### PR TITLE
Fix CJK Spacer XAML diagnostics startup race

### DIFF
--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -1869,6 +1869,10 @@ struct XamlDiagnosticsRetry {
     }
 };
 
+// Keep the full compatibility range for initial and event-driven attempts,
+// which can encounter an already-running or reused XAML core. Timed startup
+// retries only probe whether a core has become ready, so a smaller range avoids
+// repeating the expensive full scan while Explorer starts.
 constexpr int kInitialXamlDiagnosticsConnectionLimit = 10000;
 constexpr int kRetryXamlDiagnosticsConnectionLimit = 256;
 
@@ -2535,10 +2539,14 @@ DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
             ResetXamlDiagnosticsAttempts(retries);
             ++retryIndex;
             delayedRetry = true;
-        } else {
+        } else if (waitResult == WAIT_FAILED) {
             Wh_Log(L"XAML diagnostics worker wait failed: %u",
-                   waitResult == WAIT_FAILED ? GetLastError()
-                                             : ERROR_GEN_FAILURE);
+                   GetLastError());
+            break;
+        } else {
+            Wh_Log(L"XAML diagnostics worker returned unexpected wait "
+                   L"result: %u",
+                   waitResult);
             break;
         }
 

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -98,17 +98,13 @@ so another diagnostics-based customization tool, including Windows 11 Taskbar
 Styler or Windows 11 File Explorer Styler, can prevent this path from
 initializing. The mod waits for a recognized Windows.UI.Xaml or
 Microsoft.UI.Xaml host window before requesting the corresponding diagnostics
-connection. Window-creation hooks only signal a managed worker; an
-Explorer-process window scan covers hosts that already exist when the mod is
-enabled. There is no timed polling. Host notifications received during a
-connection attempt are coalesced into one follow-up attempt. Exhausting the
-connection-name walk with `ERROR_NOT_FOUND` means that the XAML endpoint isn't
-registered yet and doesn't consume the three-attempt hard-failure budget.
-Connections blocked by another diagnostics consumer aren't retried
-automatically. When an established connection is disconnected, that flavor is
-re-armed and waits for the next matching host window before reconnecting. All
-connection work runs outside the window-creation hooks and is stopped before
-the mod unloads.
+connection, and framework module loads provide a fallback signal when a host
+appears first. Connection work runs on a managed worker outside those hooks,
+and repeated unavailable endpoints or hard failures are bounded. Connections
+blocked by another diagnostics consumer aren't retried automatically. An
+established connection is re-armed after its XAML host disappears, and all
+connection work stops before the mod unloads. If the modern path's required
+hooks aren't available, enabled classic menus and tooltips remain active.
 When Taskbar Styler is configured to alert on competing XAML Diagnostics
 consumers, an intercepted connection attempt can show a confirmation dialog;
 if the tool blocks it by returning success, the walk stops and this mod marks
@@ -209,6 +205,7 @@ enum class CharacterKind {
 std::atomic_bool g_classicMenus{true};
 std::atomic_bool g_classicTooltips{true};
 std::atomic_bool g_modernUiText{false};
+std::atomic_bool g_modernUiActive{false};
 std::atomic_bool g_unicodeLettersAndDigits{true};
 
 bool IsHighSurrogate(wchar_t value) {
@@ -1873,6 +1870,7 @@ enum class XamlDiagnosticsFlavor {
 // core. Its diagnostics endpoint can still be registered slightly later.
 constexpr int kXamlDiagnosticsConnectionLimit = 10000;
 constexpr unsigned int kXamlDiagnosticsMaxAttempts = 3;
+constexpr unsigned int kXamlDiagnosticsMaxEmptyWalks = 5;
 
 struct XamlDiagnosticsConnectionState {
     std::atomic_bool connected{false};
@@ -1880,7 +1878,18 @@ struct XamlDiagnosticsConnectionState {
     std::atomic_uint requestGeneration{0};
     std::atomic_uint processedGeneration{0};
     std::atomic_uint failureCount{0};
+    std::atomic_uint emptyWalkCount{0};
 };
+
+bool CanAttemptXamlDiagnosticsConnection(
+    const XamlDiagnosticsConnectionState& state) {
+    return !state.connected.load(std::memory_order_acquire) &&
+           !state.blocked.load(std::memory_order_acquire) &&
+           state.failureCount.load(std::memory_order_acquire) <
+               kXamlDiagnosticsMaxAttempts &&
+           state.emptyWalkCount.load(std::memory_order_acquire) <
+               kXamlDiagnosticsMaxEmptyWalks;
+}
 
 bool RequestModernXamlDiagnosticsInitialization(
     XamlDiagnosticsFlavor flavor);
@@ -2389,10 +2398,7 @@ void EnsureXamlDiagnosticsConnection(
     LPCWSTR displayName,
     XamlDiagnosticsFlavor flavor) {
     if (g_stoppingModernUi.load(std::memory_order_acquire) ||
-        state.connected.load(std::memory_order_acquire) ||
-        state.blocked.load(std::memory_order_acquire) ||
-        state.failureCount.load(std::memory_order_acquire) >=
-            kXamlDiagnosticsMaxAttempts) {
+        !CanAttemptXamlDiagnosticsConnection(state)) {
         return;
     }
 
@@ -2414,6 +2420,7 @@ void EnsureXamlDiagnosticsConnection(
                 std::memory_order_acquire) > watcherGeneration) {
             state.connected.store(true, std::memory_order_release);
             state.failureCount.store(0, std::memory_order_release);
+            state.emptyWalkCount.store(0, std::memory_order_release);
             Wh_Log(L"Connected to %s diagnostics", displayName);
         } else {
             // A competing diagnostics hook can return success without
@@ -2426,10 +2433,21 @@ void EnsureXamlDiagnosticsConnection(
                    displayName);
         }
     } else if (result == HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
-        // The module exists, but no XAML core has registered a diagnostics
-        // endpoint yet. A later host notification will request another walk;
-        // don't spend the hard-failure budget on this startup state.
-        Wh_Log(L"%s diagnostics endpoint isn't registered yet", displayName);
+        const unsigned int emptyWalkCount =
+            state.emptyWalkCount.fetch_add(
+                1, std::memory_order_acq_rel) +
+            1;
+        if (emptyWalkCount >= kXamlDiagnosticsMaxEmptyWalks) {
+            Wh_Log(L"%s diagnostics endpoint remained unavailable after "
+                   L"%u full connection-name walks; stopping automatic "
+                   L"attempts",
+                   displayName, emptyWalkCount);
+        } else {
+            Wh_Log(L"%s diagnostics endpoint isn't registered yet "
+                   L"(empty walk %u/%u)",
+                   displayName, emptyWalkCount,
+                   kXamlDiagnosticsMaxEmptyWalks);
+        }
     } else if (result != HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
         const unsigned int failureCount =
             state.failureCount.fetch_add(
@@ -2515,27 +2533,8 @@ DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
                 microsoftGeneration, std::memory_order_release);
         }
 
-        // A matching host created during the walk advances its generation.
-        // It is already represented by at least one SetEvent call, but signal
-        // again after publishing the processed snapshots to make the handoff
-        // explicit and coalesce the whole burst into one follow-up attempt.
-        const bool requestAdvanced =
-            g_windowsUiXamlDiagnostics.requestGeneration.load(
-                std::memory_order_acquire) !=
-                g_windowsUiXamlDiagnostics.processedGeneration.load(
-                    std::memory_order_acquire) ||
-            g_microsoftUiXamlDiagnostics.requestGeneration.load(
-                std::memory_order_acquire) !=
-                g_microsoftUiXamlDiagnostics.processedGeneration.load(
-                    std::memory_order_acquire);
-        if (requestAdvanced) {
-            std::lock_guard<std::mutex> guard(
-                g_xamlDiagnosticsWorkerMutex);
-            if (!g_stoppingModernUi.load(std::memory_order_acquire) &&
-                g_xamlDiagnosticsWorkerWakeEvent) {
-                SetEvent(g_xamlDiagnosticsWorkerWakeEvent);
-            }
-        }
+        // A request that arrived after the snapshot already left the
+        // auto-reset event signaled, so the next wait handles its generation.
     }
 
     if (SUCCEEDED(initializeResult)) {
@@ -2565,6 +2564,7 @@ void RearmXamlDiagnosticsConnection(
 
     state->blocked.store(false, std::memory_order_release);
     state->failureCount.store(0, std::memory_order_release);
+    state->emptyWalkCount.store(0, std::memory_order_release);
     state->processedGeneration.store(
         state->requestGeneration.load(std::memory_order_acquire),
         std::memory_order_release);
@@ -2585,10 +2585,7 @@ bool RequestModernXamlDiagnosticsInitialization(
         return false;
     }
 
-    if (state->connected.load(std::memory_order_acquire) ||
-        state->blocked.load(std::memory_order_acquire) ||
-        state->failureCount.load(std::memory_order_acquire) >=
-            kXamlDiagnosticsMaxAttempts) {
+    if (!CanAttemptXamlDiagnosticsConnection(*state)) {
         return false;
     }
 
@@ -2596,10 +2593,7 @@ bool RequestModernXamlDiagnosticsInitialization(
         g_xamlDiagnosticsWorkerMutex);
     if (g_stoppingModernUi.load(std::memory_order_acquire) ||
         !g_xamlDiagnosticsWorkerWakeEvent ||
-        state->connected.load(std::memory_order_acquire) ||
-        state->blocked.load(std::memory_order_acquire) ||
-        state->failureCount.load(std::memory_order_acquire) >=
-            kXamlDiagnosticsMaxAttempts) {
+        !CanAttemptXamlDiagnosticsConnection(*state)) {
         return false;
     }
 
@@ -2610,8 +2604,6 @@ bool RequestModernXamlDiagnosticsInitialization(
         previousGeneration ==
         state->processedGeneration.load(std::memory_order_acquire);
     if (!SetEvent(g_xamlDiagnosticsWorkerWakeEvent)) {
-        state->requestGeneration.fetch_sub(
-            1, std::memory_order_acq_rel);
         Wh_Log(L"Couldn't signal the XAML diagnostics worker: %u",
                GetLastError());
         return false;
@@ -2714,10 +2706,7 @@ XamlDiagnosticsFlavor GetModernXamlHostFlavor(
 
 bool NeedsXamlDiagnosticsHostNotification(
     const XamlDiagnosticsConnectionState& state) {
-    return !state.connected.load(std::memory_order_acquire) &&
-           !state.blocked.load(std::memory_order_acquire) &&
-           state.failureCount.load(std::memory_order_acquire) <
-               kXamlDiagnosticsMaxAttempts;
+    return CanAttemptXamlDiagnosticsConnection(state);
 }
 
 bool NeedsAnyXamlDiagnosticsHostNotification() {
@@ -2728,7 +2717,8 @@ bool NeedsAnyXamlDiagnosticsHostNotification() {
 }
 
 void NotifyModernXamlHost(HWND window, LPCWSTR className = nullptr) {
-    if (!NeedsAnyXamlDiagnosticsHostNotification()) {
+    if (!g_modernUiActive.load(std::memory_order_acquire) ||
+        !NeedsAnyXamlDiagnosticsHostNotification()) {
         return;
     }
 
@@ -2787,6 +2777,64 @@ BOOL CALLBACK EnumExistingModernXamlTopLevelWindow(HWND window, LPARAM) {
 
 void DiscoverExistingModernXamlHosts() {
     EnumWindows(EnumExistingModernXamlTopLevelWindow, 0);
+}
+
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+LoadLibraryExW_t g_originalLoadLibraryExW;
+
+PCWSTR GetModuleFileNamePart(LPCWSTR path) {
+    if (!path) {
+        return nullptr;
+    }
+
+    PCWSTR fileName = wcsrchr(path, L'\\');
+    const PCWSTR forwardSlash = wcsrchr(path, L'/');
+    if (!fileName || (forwardSlash && forwardSlash > fileName)) {
+        fileName = forwardSlash;
+    }
+    return fileName ? fileName + 1 : path;
+}
+
+XamlDiagnosticsFlavor GetXamlDiagnosticsModuleFlavor(LPCWSTR path) {
+    const PCWSTR fileName = GetModuleFileNamePart(path);
+    if (!fileName) {
+        return XamlDiagnosticsFlavor::None;
+    }
+    if (_wcsicmp(fileName, L"Windows.UI.Xaml.dll") == 0) {
+        return XamlDiagnosticsFlavor::Windows;
+    }
+    if (_wcsicmp(fileName,
+                 L"Microsoft.Internal.FrameworkUdk.dll") == 0) {
+        return XamlDiagnosticsFlavor::Microsoft;
+    }
+    return XamlDiagnosticsFlavor::None;
+}
+
+bool IsModuleAlreadyLoaded(LPCWSTR path) {
+    const PCWSTR fileName = GetModuleFileNamePart(path);
+    return fileName && GetModuleHandleW(fileName) != nullptr;
+}
+
+HMODULE WINAPI LoadLibraryExWHook(LPCWSTR fileName,
+                                  HANDLE file,
+                                  DWORD flags) {
+    const XamlDiagnosticsFlavor flavor =
+        GetXamlDiagnosticsModuleFlavor(fileName);
+    const bool wasLoaded =
+        flavor != XamlDiagnosticsFlavor::None &&
+        IsModuleAlreadyLoaded(fileName);
+    HMODULE module = g_originalLoadLibraryExW(fileName, file, flags);
+    if (module && !wasLoaded &&
+        flavor != XamlDiagnosticsFlavor::None &&
+        g_modernUiActive.load(std::memory_order_acquire)) {
+        // Only wake the worker here. Diagnostics initialization must not run
+        // from a library-loading call stack.
+        if (RequestModernXamlDiagnosticsInitialization(flavor)) {
+            Wh_Log(L"Loaded XAML diagnostics module: %s",
+                   GetModuleFileNamePart(fileName));
+        }
+    }
+    return module;
 }
 
 using CreateWindowExW_t = decltype(&CreateWindowExW);
@@ -2979,6 +3027,7 @@ bool InitializeModernUi() {
         state->requestGeneration.store(0, std::memory_order_release);
         state->processedGeneration.store(0, std::memory_order_release);
         state->failureCount.store(0, std::memory_order_release);
+        state->emptyWalkCount.store(0, std::memory_order_release);
     }
     g_visualTreeWatcherGeneration.store(
         0, std::memory_order_release);
@@ -3087,6 +3136,23 @@ bool InstallHook(Function target,
     return true;
 }
 
+bool HookXamlDiagnosticsModuleLoads() {
+    HMODULE kernelBaseModule = GetModuleHandleW(L"kernelbase.dll");
+    const auto loadLibraryExW =
+        kernelBaseModule
+            ? reinterpret_cast<LoadLibraryExW_t>(
+                  GetProcAddress(kernelBaseModule, "LoadLibraryExW"))
+            : nullptr;
+    if (!loadLibraryExW) {
+        Wh_Log(L"Couldn't find kernelbase!LoadLibraryExW");
+        return false;
+    }
+
+    return InstallHook(
+        loadLibraryExW, LoadLibraryExWHook,
+        &g_originalLoadLibraryExW, L"kernelbase!LoadLibraryExW");
+}
+
 bool HookModernXamlHostCreation() {
     if (!InstallHook(
             CreateWindowExW, CreateWindowExWHook,
@@ -3097,28 +3163,29 @@ bool HookModernXamlHostCreation() {
     HMODULE user32Module = GetModuleHandleW(L"user32.dll");
     if (!user32Module) {
         Wh_Log(L"Couldn't find linked user32.dll");
-        return false;
+        return true;
     }
 
     const auto createWindowInBand =
         reinterpret_cast<CreateWindowInBand_t>(
             GetProcAddress(user32Module, "CreateWindowInBand"));
-    if (createWindowInBand &&
-        !InstallHook(
+    if (createWindowInBand) {
+        InstallHook(
             createWindowInBand, CreateWindowInBandHook,
             &g_originalCreateWindowInBand,
-            L"CreateWindowInBand")) {
-        return false;
+            L"CreateWindowInBand");
     }
 
     const auto createWindowInBandEx =
         reinterpret_cast<CreateWindowInBandEx_t>(
             GetProcAddress(user32Module, "CreateWindowInBandEx"));
-    return !createWindowInBandEx ||
-           InstallHook(
-               createWindowInBandEx, CreateWindowInBandExHook,
-               &g_originalCreateWindowInBandEx,
-               L"CreateWindowInBandEx");
+    if (createWindowInBandEx) {
+        InstallHook(
+            createWindowInBandEx, CreateWindowInBandExHook,
+            &g_originalCreateWindowInBandEx,
+            L"CreateWindowInBandEx");
+    }
+    return true;
 }
 
 bool HookClassicMenus() {
@@ -3245,6 +3312,7 @@ void LoadSettings() {
 
 BOOL Wh_ModInit() {
     LoadSettings();
+    g_modernUiActive.store(false, std::memory_order_release);
 
     const bool classicMenusEnabled =
         g_classicMenus.load(std::memory_order_relaxed);
@@ -3269,18 +3337,25 @@ BOOL Wh_ModInit() {
     }
 
     if (modernUiTextEnabled) {
-        if (!HookModernXamlHostCreation()) {
-            return FALSE;
-        }
-        if (!InitializeModernUi()) {
-            return FALSE;
+        const bool modernUiReady =
+            HookModernXamlHostCreation() &&
+            HookXamlDiagnosticsModuleLoads() &&
+            InitializeModernUi();
+        if (!modernUiReady) {
+            if (!classicMenusEnabled && !classicTooltipsEnabled) {
+                return FALSE;
+            }
+            Wh_Log(L"Modern XAML support couldn't be initialized; "
+                   L"continuing with enabled classic targets");
+        } else {
+            g_modernUiActive.store(true, std::memory_order_release);
         }
     }
 
     Wh_Log(L"Initialized (classicMenus=%d, "
            L"classicTooltips=%d, modern=%d, unicode=%d)",
            g_classicMenus.load(), g_classicTooltips.load(),
-           g_modernUiText.load(),
+           g_modernUiActive.load(),
            g_unicodeLettersAndDigits.load());
     return TRUE;
 }
@@ -3290,13 +3365,13 @@ void Wh_ModAfterInit() {
         DiscoverExistingClassicTooltipThemes();
     }
 
-    if (g_modernUiText.load(std::memory_order_relaxed)) {
+    if (g_modernUiActive.load(std::memory_order_acquire)) {
         DiscoverExistingModernXamlHosts();
     }
 }
 
 void Wh_ModBeforeUninit() {
-    if (g_modernUiText.load(std::memory_order_relaxed)) {
+    if (g_modernUiActive.load(std::memory_order_acquire)) {
         // Stop new COM callbacks and wait for the diagnostics worker before
         // Windhawk begins removing hooks. UninitializeModernUi performs the
         // owning-thread restoration after hook removal.
@@ -3311,8 +3386,9 @@ void Wh_ModUninit() {
     ClearCreatedClassicPopupMenus();
     CloseDiscoveredClassicTooltipThemes();
     ClearTrackedClassicTooltipThemes();
-    if (g_modernUiText.load(std::memory_order_relaxed)) {
+    if (g_modernUiActive.load(std::memory_order_acquire)) {
         UninitializeModernUi();
+        g_modernUiActive.store(false, std::memory_order_release);
     }
     Wh_Log(L"Uninitialized");
 }

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2704,16 +2704,9 @@ XamlDiagnosticsFlavor GetModernXamlHostFlavor(
         className, parentClassNamePointer);
 }
 
-bool NeedsXamlDiagnosticsHostNotification(
-    const XamlDiagnosticsConnectionState& state) {
-    return CanAttemptXamlDiagnosticsConnection(state);
-}
-
 bool NeedsAnyXamlDiagnosticsHostNotification() {
-    return NeedsXamlDiagnosticsHostNotification(
-               g_windowsUiXamlDiagnostics) ||
-           NeedsXamlDiagnosticsHostNotification(
-               g_microsoftUiXamlDiagnostics);
+    return CanAttemptXamlDiagnosticsConnection(g_windowsUiXamlDiagnostics) ||
+           CanAttemptXamlDiagnosticsConnection(g_microsoftUiXamlDiagnostics);
 }
 
 void NotifyModernXamlHost(HWND window, LPCWSTR className = nullptr) {
@@ -2788,10 +2781,6 @@ PCWSTR GetModuleFileNamePart(LPCWSTR path) {
     }
 
     PCWSTR fileName = wcsrchr(path, L'\\');
-    const PCWSTR forwardSlash = wcsrchr(path, L'/');
-    if (!fileName || (forwardSlash && forwardSlash > fileName)) {
-        fileName = forwardSlash;
-    }
     return fileName ? fileName + 1 : path;
 }
 
@@ -2804,7 +2793,8 @@ XamlDiagnosticsFlavor GetXamlDiagnosticsModuleFlavor(LPCWSTR path) {
         return XamlDiagnosticsFlavor::Windows;
     }
     if (_wcsicmp(fileName,
-                 L"Microsoft.Internal.FrameworkUdk.dll") == 0) {
+                 L"Microsoft.Internal.FrameworkUdk.dll") == 0 ||
+        _wcsicmp(fileName, L"CoreMessagingXP.dll") == 0) {
         return XamlDiagnosticsFlavor::Microsoft;
     }
     return XamlDiagnosticsFlavor::None;
@@ -3337,10 +3327,14 @@ BOOL Wh_ModInit() {
     }
 
     if (modernUiTextEnabled) {
-        const bool modernUiReady =
-            HookModernXamlHostCreation() &&
-            HookXamlDiagnosticsModuleLoads() &&
-            InitializeModernUi();
+        bool modernUiReady = InitializeModernUi();
+        if (modernUiReady &&
+            (!HookXamlDiagnosticsModuleLoads() ||
+             !HookModernXamlHostCreation())) {
+            UninitializeModernUi();
+            modernUiReady = false;
+        }
+
         if (!modernUiReady) {
             if (!classicMenusEnabled && !classicTooltipsEnabled) {
                 return FALSE;

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -96,14 +96,17 @@ The modern path supports both Windows.UI.Xaml and Microsoft.UI.Xaml content
 hosted by Explorer. Each named XAML Diagnostics connection allows one consumer,
 so another diagnostics-based customization tool, including Windows 11 Taskbar
 Styler or Windows 11 File Explorer Styler, can prevent this path from
-initializing. If Explorer's diagnostics endpoint isn't ready yet, the mod
-retries for about one minute during startup. Afterwards, it retries only when a
-relevant XAML module loads or an established connection is disconnected.
-Connections blocked by another diagnostics consumer aren't retried
-automatically. All connection work runs outside the Windows loader path and is
-stopped before the mod unloads.
+initializing. The mod waits for a recognized Windows.UI.Xaml or
+Microsoft.UI.Xaml host window before requesting the corresponding diagnostics
+connection. Window-creation hooks only signal a managed worker; an
+Explorer-process window scan covers hosts that already exist when the mod is
+enabled. There is no timed polling. Connections blocked by another diagnostics
+consumer aren't retried automatically, while an established connection being
+disconnected is retried. All connection work runs outside the window-creation
+hooks and is stopped before the mod unloads.
 When Taskbar Styler is configured to alert on competing XAML Diagnostics
-consumers, enabling this path can show its confirmation dialog.
+consumers, enabling this path can show one or more confirmation dialogs while
+the connection-name walk skips names that are already in use.
 The mod is injected only into `explorer.exe`. Start, Search, and some shell
 flyouts hosted by `StartMenuExperienceHost.exe`, `SearchHost.exe`, or
 `ShellExperienceHost.exe` are outside its scope.
@@ -1860,24 +1863,13 @@ enum class XamlDiagnosticsFlavor {
     Microsoft,
 };
 
-struct XamlDiagnosticsRetry {
-    bool windows = false;
-    bool microsoft = false;
+// A recognized host window means the corresponding XAML core is ready, so the
+// compatibility walk normally stops at its first free connection name.
+constexpr int kXamlDiagnosticsConnectionLimit = 10000;
 
-    explicit operator bool() const {
-        return windows || microsoft;
-    }
-};
-
-// Keep the full compatibility range for initial and event-driven attempts,
-// which can encounter an already-running or reused XAML core. Timed startup
-// retries only probe whether a core has become ready, so a smaller range avoids
-// repeating the expensive full scan while Explorer starts.
-constexpr int kInitialXamlDiagnosticsConnectionLimit = 10000;
-constexpr int kRetryXamlDiagnosticsConnectionLimit = 256;
-
-void RequestModernXamlDiagnosticsInitialization(
-    XamlDiagnosticsFlavor retryFlavor = XamlDiagnosticsFlavor::None);
+bool RequestModernXamlDiagnosticsInitialization(
+    XamlDiagnosticsFlavor flavor,
+    bool reconnect = false);
 
 extern std::atomic_bool g_windowsUiXamlDiagnosticsConnected;
 extern std::atomic_bool g_microsoftUiXamlDiagnosticsConnected;
@@ -2213,7 +2205,7 @@ public:
                 !g_stoppingModernUi.load(
                     std::memory_order_relaxed)) {
                 RequestModernXamlDiagnosticsInitialization(
-                    disconnectedFlavor);
+                    disconnectedFlavor, true);
             }
             return S_OK;
         }
@@ -2325,23 +2317,21 @@ namespace {
 using InitializeXamlDiagnosticsEx_t =
     decltype(&InitializeXamlDiagnosticsEx);
 
-std::mutex g_xamlDiagnosticsInitializationMutex;
 std::atomic_bool g_windowsUiXamlDiagnosticsConnected{false};
 std::atomic_bool g_microsoftUiXamlDiagnosticsConnected{false};
 std::atomic_bool g_windowsUiXamlDiagnosticsAttempted{false};
 std::atomic_bool g_microsoftUiXamlDiagnosticsAttempted{false};
-std::atomic_bool g_xamlDiagnosticsRequestPending{false};
+std::atomic_bool g_windowsUiXamlDiagnosticsRequestPending{false};
+std::atomic_bool g_microsoftUiXamlDiagnosticsRequestPending{false};
 std::mutex g_xamlDiagnosticsWorkerMutex;
 HANDLE g_xamlDiagnosticsWorkerThread;
 HANDLE g_xamlDiagnosticsWorkerWakeEvent;
-thread_local bool g_loadingXamlDiagnostics;
 thread_local XamlDiagnosticsFlavor g_connectingXamlDiagnostics =
     XamlDiagnosticsFlavor::None;
 
 HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
                               LPCWSTR connectionPrefix,
-                              XamlDiagnosticsFlavor flavor,
-                              int connectionLimit) {
+                              XamlDiagnosticsFlavor flavor) {
     const auto initialize =
         reinterpret_cast<InitializeXamlDiagnosticsEx_t>(
             GetProcAddress(xamlModule,
@@ -2364,7 +2354,9 @@ HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
     }
 
     HRESULT result = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
-    for (int index = 1; index <= connectionLimit; ++index) {
+    for (int index = 1;
+         index <= kXamlDiagnosticsConnectionLimit;
+         ++index) {
         if (g_stoppingModernUi.load(std::memory_order_acquire)) {
             return HRESULT_FROM_WIN32(ERROR_CANCELLED);
         }
@@ -2387,25 +2379,14 @@ HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
     return result;
 }
 
-XamlDiagnosticsRetry EnsureModernXamlDiagnostics(bool delayedRetry) {
-    XamlDiagnosticsRetry retries;
-    const int connectionLimit =
-        delayedRetry ? kRetryXamlDiagnosticsConnectionLimit
-                     : kInitialXamlDiagnosticsConnectionLimit;
-    if (g_stoppingModernUi.load(std::memory_order_acquire) ||
-        g_loadingXamlDiagnostics) {
-        return retries;
-    }
-
-    ScopedBoolValue loadingGuard(g_loadingXamlDiagnostics, true);
-
-    std::lock_guard<std::mutex> guard(
-        g_xamlDiagnosticsInitializationMutex);
+void EnsureModernXamlDiagnostics(bool requestWindows,
+                                 bool requestMicrosoft) {
     if (g_stoppingModernUi.load(std::memory_order_acquire)) {
-        return retries;
+        return;
     }
 
-    if (!g_windowsUiXamlDiagnosticsConnected.load(
+    if (requestWindows &&
+        !g_windowsUiXamlDiagnosticsConnected.load(
             std::memory_order_acquire) &&
         !g_windowsUiXamlDiagnosticsAttempted.load(
             std::memory_order_acquire)) {
@@ -2418,7 +2399,7 @@ XamlDiagnosticsRetry EnsureModernXamlDiagnostics(bool delayedRetry) {
                     std::memory_order_acquire);
             const HRESULT result = InjectXamlDiagnostics(
                 module, L"VisualDiagConnection",
-                XamlDiagnosticsFlavor::Windows, connectionLimit);
+                XamlDiagnosticsFlavor::Windows);
             if (SUCCEEDED(result) &&
                 !g_stoppingModernUi.load(std::memory_order_acquire) &&
                 g_visualTreeWatcherGeneration.load(
@@ -2431,9 +2412,6 @@ XamlDiagnosticsRetry EnsureModernXamlDiagnostics(bool delayedRetry) {
                 Wh_Log(L"Windows.UI.Xaml diagnostics returned success "
                        L"without creating a watcher; another diagnostics "
                        L"tool probably blocked the connection");
-            } else if (result ==
-                       HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
-                retries.windows = true;
             } else if (result !=
                        HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
                 Wh_Log(L"Windows.UI.Xaml diagnostics failed: "
@@ -2442,7 +2420,8 @@ XamlDiagnosticsRetry EnsureModernXamlDiagnostics(bool delayedRetry) {
         }
     }
 
-    if (!g_microsoftUiXamlDiagnosticsConnected.load(
+    if (requestMicrosoft &&
+        !g_microsoftUiXamlDiagnosticsConnected.load(
             std::memory_order_acquire) &&
         !g_microsoftUiXamlDiagnosticsAttempted.load(
             std::memory_order_acquire)) {
@@ -2455,7 +2434,7 @@ XamlDiagnosticsRetry EnsureModernXamlDiagnostics(bool delayedRetry) {
                     std::memory_order_acquire);
             const HRESULT result = InjectXamlDiagnostics(
                 module, L"WinUIVisualDiagConnection",
-                XamlDiagnosticsFlavor::Microsoft, connectionLimit);
+                XamlDiagnosticsFlavor::Microsoft);
             if (SUCCEEDED(result) &&
                 !g_stoppingModernUi.load(std::memory_order_acquire) &&
                 g_visualTreeWatcherGeneration.load(
@@ -2468,9 +2447,6 @@ XamlDiagnosticsRetry EnsureModernXamlDiagnostics(bool delayedRetry) {
                 Wh_Log(L"Microsoft.UI.Xaml diagnostics returned success "
                        L"without creating a watcher; another diagnostics "
                        L"tool probably blocked the connection");
-            } else if (result ==
-                       HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
-                retries.microsoft = true;
             } else if (result !=
                        HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
                 Wh_Log(L"Microsoft.UI.Xaml diagnostics failed: "
@@ -2478,90 +2454,37 @@ XamlDiagnosticsRetry EnsureModernXamlDiagnostics(bool delayedRetry) {
             }
         }
     }
-    return retries;
-}
-
-void ResetXamlDiagnosticsAttempts(XamlDiagnosticsRetry retries) {
-    if (retries.windows) {
-        g_windowsUiXamlDiagnosticsAttempted.store(
-            false, std::memory_order_release);
-    }
-    if (retries.microsoft) {
-        g_microsoftUiXamlDiagnosticsAttempted.store(
-            false, std::memory_order_release);
-    }
-}
-
-bool NeedsXamlDiagnosticsConnection() {
-    return (!g_windowsUiXamlDiagnosticsConnected.load(
-                 std::memory_order_acquire) &&
-            !g_windowsUiXamlDiagnosticsAttempted.load(
-                std::memory_order_acquire) &&
-            GetModuleHandleW(L"Windows.UI.Xaml.dll")) ||
-           (!g_microsoftUiXamlDiagnosticsConnected.load(
-                 std::memory_order_acquire) &&
-            !g_microsoftUiXamlDiagnosticsAttempted.load(
-                std::memory_order_acquire) &&
-            GetModuleHandleW(L"Microsoft.Internal.FrameworkUdk.dll"));
 }
 
 DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
     const HANDLE wakeEvent = static_cast<HANDLE>(parameter);
     const HRESULT initializeResult =
         CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-    constexpr DWORD retryDelaysMs[] = {
-        1000, 2000, 5000, 10000, 20000, 30000};
-    XamlDiagnosticsRetry retries;
-    size_t retryIndex = 0;
     for (;;) {
-        const DWORD waitTimeout =
-            !retries
-                ? INFINITE
-                : retryDelaysMs[retryIndex];
         const DWORD waitResult =
-            WaitForSingleObject(wakeEvent, waitTimeout);
+            WaitForSingleObject(wakeEvent, INFINITE);
         if (g_stoppingModernUi.load(std::memory_order_acquire)) {
             break;
         }
 
-        bool delayedRetry = false;
-        if (waitResult == WAIT_OBJECT_0) {
-            if (!g_xamlDiagnosticsRequestPending.exchange(
-                    false, std::memory_order_acq_rel)) {
-                continue;
-            }
-            // An explicit wake is a genuine new opportunity. Preserve all
-            // pending flavors and intentionally restart their backoff ladder.
-            ResetXamlDiagnosticsAttempts(retries);
-            retryIndex = 0;
-        } else if (waitResult == WAIT_TIMEOUT &&
-                   retries) {
-            ResetXamlDiagnosticsAttempts(retries);
-            ++retryIndex;
-            delayedRetry = true;
-        } else if (waitResult == WAIT_FAILED) {
-            Wh_Log(L"XAML diagnostics worker wait failed: %u",
-                   GetLastError());
-            break;
-        } else {
-            Wh_Log(L"XAML diagnostics worker returned unexpected wait "
-                   L"result: %u",
-                   waitResult);
+        if (waitResult != WAIT_OBJECT_0) {
+            Wh_Log(L"XAML diagnostics worker wait failed: "
+                   L"result=%u, error=%u",
+                   waitResult, GetLastError());
             break;
         }
 
-        retries = EnsureModernXamlDiagnostics(delayedRetry);
-        if (retries) {
-            if (retryIndex < ARRAYSIZE(retryDelaysMs)) {
-                Wh_Log(L"XAML diagnostics isn't ready; retrying in %u ms",
-                       retryDelaysMs[retryIndex]);
-            } else {
-                Wh_Log(L"XAML diagnostics remained unavailable after "
-                       L"startup retries");
-                retries = {};
-                retryIndex = 0;
-            }
+        const bool requestWindows =
+            g_windowsUiXamlDiagnosticsRequestPending.exchange(
+                false, std::memory_order_acq_rel);
+        const bool requestMicrosoft =
+            g_microsoftUiXamlDiagnosticsRequestPending.exchange(
+                false, std::memory_order_acq_rel);
+        if (!requestWindows && !requestMicrosoft) {
+            continue;
         }
+
+        EnsureModernXamlDiagnostics(requestWindows, requestMicrosoft);
     }
 
     if (SUCCEEDED(initializeResult)) {
@@ -2570,40 +2493,55 @@ DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
     return 0;
 }
 
-void RequestModernXamlDiagnosticsInitialization(
-    XamlDiagnosticsFlavor retryFlavor) {
+bool RequestModernXamlDiagnosticsInitialization(
+    XamlDiagnosticsFlavor flavor,
+    bool reconnect) {
     if (g_stoppingModernUi.load(std::memory_order_acquire)) {
-        return;
+        return false;
     }
 
-    // A new XAML module load or a previously established connection being
-    // torn down is an explicit retry opportunity.
-    if (retryFlavor == XamlDiagnosticsFlavor::Windows) {
-        g_windowsUiXamlDiagnosticsAttempted.store(
-            false, std::memory_order_release);
-    } else if (retryFlavor == XamlDiagnosticsFlavor::Microsoft) {
-        g_microsoftUiXamlDiagnosticsAttempted.store(
-            false, std::memory_order_release);
+    std::atomic_bool* connected;
+    std::atomic_bool* attempted;
+    std::atomic_bool* pending;
+    if (flavor == XamlDiagnosticsFlavor::Windows) {
+        connected = &g_windowsUiXamlDiagnosticsConnected;
+        attempted = &g_windowsUiXamlDiagnosticsAttempted;
+        pending = &g_windowsUiXamlDiagnosticsRequestPending;
+    } else if (flavor == XamlDiagnosticsFlavor::Microsoft) {
+        connected = &g_microsoftUiXamlDiagnosticsConnected;
+        attempted = &g_microsoftUiXamlDiagnosticsAttempted;
+        pending = &g_microsoftUiXamlDiagnosticsRequestPending;
+    } else {
+        return false;
     }
 
-    // Once all currently loaded XAML diagnostics connections are established,
-    // avoid scheduling another attempt until SetSite(nullptr) explicitly marks
-    // one as disconnected.
-    if (!NeedsXamlDiagnosticsConnection()) {
-        return;
+    if (reconnect) {
+        attempted->store(false, std::memory_order_release);
+    }
+    if (connected->load(std::memory_order_acquire) ||
+        attempted->load(std::memory_order_acquire)) {
+        return false;
     }
 
-    g_xamlDiagnosticsRequestPending.store(
-        true, std::memory_order_release);
+    if (pending->exchange(true, std::memory_order_acq_rel)) {
+        return false;
+    }
 
     std::lock_guard<std::mutex> guard(
         g_xamlDiagnosticsWorkerMutex);
     if (g_stoppingModernUi.load(std::memory_order_acquire) ||
         !g_xamlDiagnosticsWorkerWakeEvent) {
-        return;
+        pending->store(false, std::memory_order_release);
+        return false;
     }
 
-    SetEvent(g_xamlDiagnosticsWorkerWakeEvent);
+    if (!SetEvent(g_xamlDiagnosticsWorkerWakeEvent)) {
+        pending->store(false, std::memory_order_release);
+        Wh_Log(L"Couldn't signal the XAML diagnostics worker: %u",
+               GetLastError());
+        return false;
+    }
+    return true;
 }
 
 void StopModernXamlDiagnosticsWorker() {
@@ -2632,87 +2570,183 @@ void StopModernXamlDiagnosticsWorker() {
     if (wakeEvent) {
         CloseHandle(wakeEvent);
     }
-    g_xamlDiagnosticsRequestPending.store(
+    g_windowsUiXamlDiagnosticsRequestPending.store(
+        false, std::memory_order_release);
+    g_microsoftUiXamlDiagnosticsRequestPending.store(
         false, std::memory_order_release);
 }
 
-using LoadLibraryExW_t = decltype(&LoadLibraryExW);
-LoadLibraryExW_t g_originalLoadLibraryExW;
-
-PCWSTR GetModuleFileNamePart(LPCWSTR path) {
-    if (!path) {
-        return nullptr;
-    }
-
-    PCWSTR fileName = wcsrchr(path, L'\\');
-    return fileName ? fileName + 1 : path;
-}
-
-XamlDiagnosticsFlavor GetXamlDiagnosticsTriggerFlavor(LPCWSTR path) {
-    const PCWSTR fileName = GetModuleFileNamePart(path);
-    if (!fileName) {
+XamlDiagnosticsFlavor GetModernXamlHostFlavor(LPCWSTR className) {
+    if (!className) {
         return XamlDiagnosticsFlavor::None;
     }
 
-    if (_wcsicmp(fileName, L"Windows.UI.Xaml.dll") == 0) {
+    if (_wcsicmp(
+            className,
+            L"Windows.UI.Composition.DesktopWindowContentBridge") == 0 ||
+        _wcsicmp(className, L"XamlExplorerHostIslandWindow") == 0) {
         return XamlDiagnosticsFlavor::Windows;
     }
-    if (_wcsicmp(fileName,
-                 L"Microsoft.Internal.FrameworkUdk.dll") == 0) {
+    if (_wcsicmp(
+            className, L"XamlExplorerHostIslandWindow_WASDK") == 0) {
         return XamlDiagnosticsFlavor::Microsoft;
     }
     return XamlDiagnosticsFlavor::None;
 }
 
-bool IsXamlDiagnosticsTriggerModule(LPCWSTR path) {
-    const PCWSTR fileName = GetModuleFileNamePart(path);
-    return GetXamlDiagnosticsTriggerFlavor(path) !=
-               XamlDiagnosticsFlavor::None ||
-           (fileName && _wcsicmp(fileName, L"CoreMessagingXP.dll") == 0);
-}
-
-bool IsXamlDiagnosticsTriggerModuleLoaded(LPCWSTR path) {
-    const PCWSTR fileName = GetModuleFileNamePart(path);
-    if (!fileName) {
-        return false;
-    }
-
-    return GetModuleHandleW(fileName) != nullptr;
-}
-
-HMODULE WINAPI LoadLibraryExWHook(LPCWSTR fileName,
-                                  HANDLE file,
-                                  DWORD flags) {
-    const bool triggerModule =
-        IsXamlDiagnosticsTriggerModule(fileName);
-    const XamlDiagnosticsFlavor triggerFlavor =
-        GetXamlDiagnosticsTriggerFlavor(fileName);
-    const bool triggerModuleWasLoaded =
-        triggerModule &&
-        IsXamlDiagnosticsTriggerModuleLoaded(fileName);
-    HMODULE module =
-        g_originalLoadLibraryExW(fileName, file, flags);
-    if (module &&
-        g_modernUiText.load(std::memory_order_relaxed) &&
-        triggerModule) {
-        // Don't load the TAP or activate COM while the caller might hold the
-        // Windows loader lock.
-        RequestModernXamlDiagnosticsInitialization(
-            !triggerModuleWasLoaded
-                ? triggerFlavor
-                : XamlDiagnosticsFlavor::None);
-    }
-    return module;
-}
-
 bool IsModernXamlHostClassName(LPCWSTR className) {
-    return className &&
-           (_wcsicmp(
-                className,
-                L"Windows.UI.Composition.DesktopWindowContentBridge") == 0 ||
-            _wcsicmp(className, L"XamlExplorerHostIslandWindow") == 0 ||
-            _wcsicmp(
-                className, L"XamlExplorerHostIslandWindow_WASDK") == 0);
+    return GetModernXamlHostFlavor(className) !=
+           XamlDiagnosticsFlavor::None;
+}
+
+void NotifyModernXamlHost(HWND window, LPCWSTR className = nullptr) {
+    wchar_t resolvedClassName[128];
+    if (!className || IS_INTRESOURCE(className)) {
+        if (GetClassNameW(window, resolvedClassName,
+                          ARRAYSIZE(resolvedClassName)) <= 0) {
+            return;
+        }
+        className = resolvedClassName;
+    }
+
+    const XamlDiagnosticsFlavor flavor =
+        GetModernXamlHostFlavor(className);
+    if (flavor == XamlDiagnosticsFlavor::None) {
+        return;
+    }
+
+    // Only signal the worker here. XAML Diagnostics and COM initialization
+    // must not run inside a window-creation hook.
+    if (RequestModernXamlDiagnosticsInitialization(flavor)) {
+        Wh_Log(L"Found XAML host window: %s", className);
+    }
+}
+
+BOOL CALLBACK EnumExistingModernXamlHostWindow(HWND window, LPARAM) {
+    DWORD processId;
+    if (GetWindowThreadProcessId(window, &processId) &&
+        processId == GetCurrentProcessId()) {
+        NotifyModernXamlHost(window);
+    }
+    return TRUE;
+}
+
+BOOL CALLBACK EnumExistingModernXamlTopLevelWindow(HWND window, LPARAM) {
+    DWORD processId;
+    if (!GetWindowThreadProcessId(window, &processId) ||
+        processId != GetCurrentProcessId()) {
+        return TRUE;
+    }
+
+    NotifyModernXamlHost(window);
+    EnumChildWindows(window, EnumExistingModernXamlHostWindow, 0);
+    return TRUE;
+}
+
+void DiscoverExistingModernXamlHosts() {
+    EnumWindows(EnumExistingModernXamlTopLevelWindow, 0);
+}
+
+using CreateWindowExW_t = decltype(&CreateWindowExW);
+CreateWindowExW_t g_originalCreateWindowExW;
+
+HWND WINAPI CreateWindowExWHook(DWORD extendedStyle,
+                                LPCWSTR className,
+                                LPCWSTR windowName,
+                                DWORD style,
+                                int x,
+                                int y,
+                                int width,
+                                int height,
+                                HWND parent,
+                                HMENU menu,
+                                HINSTANCE instance,
+                                LPVOID parameter) {
+    HWND window = g_originalCreateWindowExW(
+        extendedStyle, className, windowName, style, x, y, width, height,
+        parent, menu, instance, parameter);
+    if (window) {
+        NotifyModernXamlHost(window, className);
+    }
+    return window;
+}
+
+using CreateWindowInBand_t = HWND(WINAPI*)(
+    DWORD extendedStyle,
+    LPCWSTR className,
+    LPCWSTR windowName,
+    DWORD style,
+    int x,
+    int y,
+    int width,
+    int height,
+    HWND parent,
+    HMENU menu,
+    HINSTANCE instance,
+    LPVOID parameter,
+    DWORD band);
+CreateWindowInBand_t g_originalCreateWindowInBand;
+
+HWND WINAPI CreateWindowInBandHook(DWORD extendedStyle,
+                                   LPCWSTR className,
+                                   LPCWSTR windowName,
+                                   DWORD style,
+                                   int x,
+                                   int y,
+                                   int width,
+                                   int height,
+                                   HWND parent,
+                                   HMENU menu,
+                                   HINSTANCE instance,
+                                   LPVOID parameter,
+                                   DWORD band) {
+    HWND window = g_originalCreateWindowInBand(
+        extendedStyle, className, windowName, style, x, y, width, height,
+        parent, menu, instance, parameter, band);
+    if (window) {
+        NotifyModernXamlHost(window, className);
+    }
+    return window;
+}
+
+using CreateWindowInBandEx_t = HWND(WINAPI*)(
+    DWORD extendedStyle,
+    LPCWSTR className,
+    LPCWSTR windowName,
+    DWORD style,
+    int x,
+    int y,
+    int width,
+    int height,
+    HWND parent,
+    HMENU menu,
+    HINSTANCE instance,
+    LPVOID parameter,
+    DWORD band,
+    DWORD typeFlags);
+CreateWindowInBandEx_t g_originalCreateWindowInBandEx;
+
+HWND WINAPI CreateWindowInBandExHook(DWORD extendedStyle,
+                                     LPCWSTR className,
+                                     LPCWSTR windowName,
+                                     DWORD style,
+                                     int x,
+                                     int y,
+                                     int width,
+                                     int height,
+                                     HWND parent,
+                                     HMENU menu,
+                                     HINSTANCE instance,
+                                     LPVOID parameter,
+                                     DWORD band,
+                                     DWORD typeFlags) {
+    HWND window = g_originalCreateWindowInBandEx(
+        extendedStyle, className, windowName, style, x, y, width, height,
+        parent, menu, instance, parameter, band, typeFlags);
+    if (window) {
+        NotifyModernXamlHost(window, className);
+    }
+    return window;
 }
 
 using RunFromWindowThreadProc_t = void(WINAPI*)(PVOID parameter);
@@ -2803,7 +2837,9 @@ bool InitializeModernUi() {
         false, std::memory_order_release);
     g_microsoftUiXamlDiagnosticsAttempted.store(
         false, std::memory_order_release);
-    g_xamlDiagnosticsRequestPending.store(
+    g_windowsUiXamlDiagnosticsRequestPending.store(
+        false, std::memory_order_release);
+    g_microsoftUiXamlDiagnosticsRequestPending.store(
         false, std::memory_order_release);
     g_visualTreeWatcherGeneration.store(
         0, std::memory_order_release);
@@ -2910,6 +2946,40 @@ bool InstallHook(Function target,
     }
 
     return true;
+}
+
+bool HookModernXamlHostCreation() {
+    if (!InstallHook(
+            CreateWindowExW, CreateWindowExWHook,
+            &g_originalCreateWindowExW, L"CreateWindowExW")) {
+        return false;
+    }
+
+    HMODULE user32Module = GetModuleHandleW(L"user32.dll");
+    if (!user32Module) {
+        Wh_Log(L"Couldn't find linked user32.dll");
+        return false;
+    }
+
+    const auto createWindowInBand =
+        reinterpret_cast<CreateWindowInBand_t>(
+            GetProcAddress(user32Module, "CreateWindowInBand"));
+    if (createWindowInBand &&
+        !InstallHook(
+            createWindowInBand, CreateWindowInBandHook,
+            &g_originalCreateWindowInBand,
+            L"CreateWindowInBand")) {
+        return false;
+    }
+
+    const auto createWindowInBandEx =
+        reinterpret_cast<CreateWindowInBandEx_t>(
+            GetProcAddress(user32Module, "CreateWindowInBandEx"));
+    return !createWindowInBandEx ||
+           InstallHook(
+               createWindowInBandEx, CreateWindowInBandExHook,
+               &g_originalCreateWindowInBandEx,
+               L"CreateWindowInBandEx");
 }
 
 bool HookClassicMenus() {
@@ -3060,23 +3130,7 @@ BOOL Wh_ModInit() {
     }
 
     if (modernUiTextEnabled) {
-        HMODULE kernelBaseModule =
-            GetModuleHandleW(L"kernelbase.dll");
-        const auto loadLibraryExW =
-            kernelBaseModule
-                ? reinterpret_cast<LoadLibraryExW_t>(
-                      GetProcAddress(kernelBaseModule,
-                                     "LoadLibraryExW"))
-                : nullptr;
-        if (loadLibraryExW) {
-            if (!InstallHook(
-                    loadLibraryExW, LoadLibraryExWHook,
-                    &g_originalLoadLibraryExW,
-                    L"kernelbase!LoadLibraryExW")) {
-                return FALSE;
-            }
-        } else {
-            Wh_Log(L"Couldn't find kernelbase!LoadLibraryExW");
+        if (!HookModernXamlHostCreation()) {
             return FALSE;
         }
         if (!InitializeModernUi()) {
@@ -3098,7 +3152,7 @@ void Wh_ModAfterInit() {
     }
 
     if (g_modernUiText.load(std::memory_order_relaxed)) {
-        RequestModernXamlDiagnosticsInitialization();
+        DiscoverExistingModernXamlHosts();
     }
 }
 

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -100,10 +100,12 @@ initializing. The mod waits for a recognized Windows.UI.Xaml or
 Microsoft.UI.Xaml host window before requesting the corresponding diagnostics
 connection. Window-creation hooks only signal a managed worker; an
 Explorer-process window scan covers hosts that already exist when the mod is
-enabled. There is no timed polling. Connections blocked by another diagnostics
-consumer aren't retried automatically, while an established connection being
-disconnected is retried. All connection work runs outside the window-creation
-hooks and is stopped before the mod unloads.
+enabled. There is no timed polling. A hard connection failure can be retried by
+later matching host-window notifications, with at most three attempts per XAML
+flavor. Connections blocked by another diagnostics consumer aren't retried
+automatically, while an established connection being disconnected resets the
+attempt budget for that flavor. All connection work runs outside the
+window-creation hooks and is stopped before the mod unloads.
 When Taskbar Styler is configured to alert on competing XAML Diagnostics
 consumers, enabling this path can show one or more confirmation dialogs while
 the connection-name walk skips names that are already in use.
@@ -1866,15 +1868,21 @@ enum class XamlDiagnosticsFlavor {
 // A recognized host window means the corresponding XAML core is ready, so the
 // compatibility walk normally stops at its first free connection name.
 constexpr int kXamlDiagnosticsConnectionLimit = 10000;
+constexpr unsigned int kXamlDiagnosticsMaxAttempts = 3;
+
+struct XamlDiagnosticsConnectionState {
+    std::atomic_bool connected{false};
+    std::atomic_bool blocked{false};
+    std::atomic_bool requestPending{false};
+    std::atomic_uint failureCount{0};
+};
 
 bool RequestModernXamlDiagnosticsInitialization(
     XamlDiagnosticsFlavor flavor,
     bool reconnect = false);
 
-extern std::atomic_bool g_windowsUiXamlDiagnosticsConnected;
-extern std::atomic_bool g_microsoftUiXamlDiagnosticsConnected;
-extern std::atomic_bool g_windowsUiXamlDiagnosticsAttempted;
-extern std::atomic_bool g_microsoftUiXamlDiagnosticsAttempted;
+extern XamlDiagnosticsConnectionState g_windowsUiXamlDiagnostics;
+extern XamlDiagnosticsConnectionState g_microsoftUiXamlDiagnostics;
 extern thread_local XamlDiagnosticsFlavor g_connectingXamlDiagnostics;
 
 struct XamlWatcherThreadNode {
@@ -2194,11 +2202,11 @@ public:
             m_flavor = XamlDiagnosticsFlavor::None;
             if (disconnectedFlavor ==
                 XamlDiagnosticsFlavor::Windows) {
-                g_windowsUiXamlDiagnosticsConnected.store(
+                g_windowsUiXamlDiagnostics.connected.store(
                     false, std::memory_order_release);
             } else if (disconnectedFlavor ==
                        XamlDiagnosticsFlavor::Microsoft) {
-                g_microsoftUiXamlDiagnosticsConnected.store(
+                g_microsoftUiXamlDiagnostics.connected.store(
                     false, std::memory_order_release);
             }
             if (disconnectedFlavor != XamlDiagnosticsFlavor::None &&
@@ -2317,12 +2325,8 @@ namespace {
 using InitializeXamlDiagnosticsEx_t =
     decltype(&InitializeXamlDiagnosticsEx);
 
-std::atomic_bool g_windowsUiXamlDiagnosticsConnected{false};
-std::atomic_bool g_microsoftUiXamlDiagnosticsConnected{false};
-std::atomic_bool g_windowsUiXamlDiagnosticsAttempted{false};
-std::atomic_bool g_microsoftUiXamlDiagnosticsAttempted{false};
-std::atomic_bool g_windowsUiXamlDiagnosticsRequestPending{false};
-std::atomic_bool g_microsoftUiXamlDiagnosticsRequestPending{false};
+XamlDiagnosticsConnectionState g_windowsUiXamlDiagnostics;
+XamlDiagnosticsConnectionState g_microsoftUiXamlDiagnostics;
 std::mutex g_xamlDiagnosticsWorkerMutex;
 HANDLE g_xamlDiagnosticsWorkerThread;
 HANDLE g_xamlDiagnosticsWorkerWakeEvent;
@@ -2379,80 +2383,73 @@ HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
     return result;
 }
 
-void EnsureModernXamlDiagnostics(bool requestWindows,
-                                 bool requestMicrosoft) {
-    if (g_stoppingModernUi.load(std::memory_order_acquire)) {
+void EnsureXamlDiagnosticsConnection(
+    XamlDiagnosticsConnectionState& state,
+    LPCWSTR moduleName,
+    LPCWSTR connectionPrefix,
+    LPCWSTR displayName,
+    XamlDiagnosticsFlavor flavor) {
+    if (g_stoppingModernUi.load(std::memory_order_acquire) ||
+        state.connected.load(std::memory_order_acquire) ||
+        state.blocked.load(std::memory_order_acquire) ||
+        state.failureCount.load(std::memory_order_acquire) >=
+            kXamlDiagnosticsMaxAttempts) {
         return;
     }
 
-    if (requestWindows &&
-        !g_windowsUiXamlDiagnosticsConnected.load(
-            std::memory_order_acquire) &&
-        !g_windowsUiXamlDiagnosticsAttempted.load(
-            std::memory_order_acquire)) {
-        if (HMODULE module =
-                GetModuleHandleW(L"Windows.UI.Xaml.dll")) {
-            g_windowsUiXamlDiagnosticsAttempted.store(
-                true, std::memory_order_release);
-            const uint64_t watcherGeneration =
-                g_visualTreeWatcherGeneration.load(
-                    std::memory_order_acquire);
-            const HRESULT result = InjectXamlDiagnostics(
-                module, L"VisualDiagConnection",
-                XamlDiagnosticsFlavor::Windows);
-            if (SUCCEEDED(result) &&
-                !g_stoppingModernUi.load(std::memory_order_acquire) &&
-                g_visualTreeWatcherGeneration.load(
-                    std::memory_order_acquire) >
-                    watcherGeneration) {
-                g_windowsUiXamlDiagnosticsConnected.store(
-                    true, std::memory_order_release);
-                Wh_Log(L"Connected to Windows.UI.Xaml diagnostics");
-            } else if (SUCCEEDED(result)) {
-                Wh_Log(L"Windows.UI.Xaml diagnostics returned success "
-                       L"without creating a watcher; another diagnostics "
-                       L"tool probably blocked the connection");
-            } else if (result !=
-                       HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
-                Wh_Log(L"Windows.UI.Xaml diagnostics failed: "
-                       L"0x%08X", result);
-            }
-        }
+    HMODULE module = GetModuleHandleW(moduleName);
+    if (!module) {
+        return;
     }
 
-    if (requestMicrosoft &&
-        !g_microsoftUiXamlDiagnosticsConnected.load(
-            std::memory_order_acquire) &&
-        !g_microsoftUiXamlDiagnosticsAttempted.load(
-            std::memory_order_acquire)) {
-        if (HMODULE module = GetModuleHandleW(
-                L"Microsoft.Internal.FrameworkUdk.dll")) {
-            g_microsoftUiXamlDiagnosticsAttempted.store(
-                true, std::memory_order_release);
-            const uint64_t watcherGeneration =
-                g_visualTreeWatcherGeneration.load(
-                    std::memory_order_acquire);
-            const HRESULT result = InjectXamlDiagnostics(
-                module, L"WinUIVisualDiagConnection",
-                XamlDiagnosticsFlavor::Microsoft);
-            if (SUCCEEDED(result) &&
-                !g_stoppingModernUi.load(std::memory_order_acquire) &&
-                g_visualTreeWatcherGeneration.load(
-                    std::memory_order_acquire) >
-                    watcherGeneration) {
-                g_microsoftUiXamlDiagnosticsConnected.store(
-                    true, std::memory_order_release);
-                Wh_Log(L"Connected to Microsoft.UI.Xaml diagnostics");
-            } else if (SUCCEEDED(result)) {
-                Wh_Log(L"Microsoft.UI.Xaml diagnostics returned success "
-                       L"without creating a watcher; another diagnostics "
-                       L"tool probably blocked the connection");
-            } else if (result !=
-                       HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
-                Wh_Log(L"Microsoft.UI.Xaml diagnostics failed: "
-                       L"0x%08X", result);
-            }
+    const uint64_t watcherGeneration =
+        g_visualTreeWatcherGeneration.load(std::memory_order_acquire);
+    const HRESULT result = InjectXamlDiagnostics(
+        module, connectionPrefix, flavor);
+    if (SUCCEEDED(result)) {
+        if (g_stoppingModernUi.load(std::memory_order_acquire)) {
+            return;
         }
+        if (g_visualTreeWatcherGeneration.load(
+                std::memory_order_acquire) > watcherGeneration) {
+            state.connected.store(true, std::memory_order_release);
+            state.failureCount.store(0, std::memory_order_release);
+            Wh_Log(L"Connected to %s diagnostics", displayName);
+        } else {
+            // A competing diagnostics hook can return success without
+            // allowing this TAP to create a watcher. Don't prompt or probe
+            // again.
+            state.blocked.store(true, std::memory_order_release);
+            Wh_Log(L"%s diagnostics returned success without creating a "
+                   L"watcher; another diagnostics tool probably blocked "
+                   L"the connection",
+                   displayName);
+        }
+    } else if (result != HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
+        const unsigned int failureCount =
+            state.failureCount.fetch_add(
+                1, std::memory_order_acq_rel) +
+            1;
+        Wh_Log(L"%s diagnostics attempt %u/%u failed: 0x%08X",
+               displayName, failureCount,
+               kXamlDiagnosticsMaxAttempts, result);
+    }
+}
+
+void EnsureModernXamlDiagnostics(bool requestWindows,
+                                 bool requestMicrosoft) {
+    if (requestWindows) {
+        EnsureXamlDiagnosticsConnection(
+            g_windowsUiXamlDiagnostics,
+            L"Windows.UI.Xaml.dll", L"VisualDiagConnection",
+            L"Windows.UI.Xaml", XamlDiagnosticsFlavor::Windows);
+    }
+    if (requestMicrosoft) {
+        EnsureXamlDiagnosticsConnection(
+            g_microsoftUiXamlDiagnostics,
+            L"Microsoft.Internal.FrameworkUdk.dll",
+            L"WinUIVisualDiagConnection", L"Microsoft.UI.Xaml",
+            XamlDiagnosticsFlavor::Microsoft);
     }
 }
 
@@ -2475,10 +2472,10 @@ DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
         }
 
         const bool requestWindows =
-            g_windowsUiXamlDiagnosticsRequestPending.exchange(
+            g_windowsUiXamlDiagnostics.requestPending.exchange(
                 false, std::memory_order_acq_rel);
         const bool requestMicrosoft =
-            g_microsoftUiXamlDiagnosticsRequestPending.exchange(
+            g_microsoftUiXamlDiagnostics.requestPending.exchange(
                 false, std::memory_order_acq_rel);
         if (!requestWindows && !requestMicrosoft) {
             continue;
@@ -2500,30 +2497,28 @@ bool RequestModernXamlDiagnosticsInitialization(
         return false;
     }
 
-    std::atomic_bool* connected;
-    std::atomic_bool* attempted;
-    std::atomic_bool* pending;
+    XamlDiagnosticsConnectionState* state;
     if (flavor == XamlDiagnosticsFlavor::Windows) {
-        connected = &g_windowsUiXamlDiagnosticsConnected;
-        attempted = &g_windowsUiXamlDiagnosticsAttempted;
-        pending = &g_windowsUiXamlDiagnosticsRequestPending;
+        state = &g_windowsUiXamlDiagnostics;
     } else if (flavor == XamlDiagnosticsFlavor::Microsoft) {
-        connected = &g_microsoftUiXamlDiagnosticsConnected;
-        attempted = &g_microsoftUiXamlDiagnosticsAttempted;
-        pending = &g_microsoftUiXamlDiagnosticsRequestPending;
+        state = &g_microsoftUiXamlDiagnostics;
     } else {
         return false;
     }
 
     if (reconnect) {
-        attempted->store(false, std::memory_order_release);
+        state->blocked.store(false, std::memory_order_release);
+        state->failureCount.store(0, std::memory_order_release);
     }
-    if (connected->load(std::memory_order_acquire) ||
-        attempted->load(std::memory_order_acquire)) {
+    if (state->connected.load(std::memory_order_acquire) ||
+        state->blocked.load(std::memory_order_acquire) ||
+        state->failureCount.load(std::memory_order_acquire) >=
+            kXamlDiagnosticsMaxAttempts) {
         return false;
     }
 
-    if (pending->exchange(true, std::memory_order_acq_rel)) {
+    if (state->requestPending.exchange(
+            true, std::memory_order_acq_rel)) {
         return false;
     }
 
@@ -2531,12 +2526,12 @@ bool RequestModernXamlDiagnosticsInitialization(
         g_xamlDiagnosticsWorkerMutex);
     if (g_stoppingModernUi.load(std::memory_order_acquire) ||
         !g_xamlDiagnosticsWorkerWakeEvent) {
-        pending->store(false, std::memory_order_release);
+        state->requestPending.store(false, std::memory_order_release);
         return false;
     }
 
     if (!SetEvent(g_xamlDiagnosticsWorkerWakeEvent)) {
-        pending->store(false, std::memory_order_release);
+        state->requestPending.store(false, std::memory_order_release);
         Wh_Log(L"Couldn't signal the XAML diagnostics worker: %u",
                GetLastError());
         return false;
@@ -2570,33 +2565,89 @@ void StopModernXamlDiagnosticsWorker() {
     if (wakeEvent) {
         CloseHandle(wakeEvent);
     }
-    g_windowsUiXamlDiagnosticsRequestPending.store(
+    g_windowsUiXamlDiagnostics.requestPending.store(
         false, std::memory_order_release);
-    g_microsoftUiXamlDiagnosticsRequestPending.store(
+    g_microsoftUiXamlDiagnostics.requestPending.store(
         false, std::memory_order_release);
 }
 
-XamlDiagnosticsFlavor GetModernXamlHostFlavor(LPCWSTR className) {
+XamlDiagnosticsFlavor ClassifyModernXamlHost(
+    LPCWSTR className,
+    LPCWSTR parentClassName = nullptr) {
     if (!className) {
         return XamlDiagnosticsFlavor::None;
     }
 
-    if (_wcsicmp(
-            className,
-            L"Windows.UI.Composition.DesktopWindowContentBridge") == 0 ||
-        _wcsicmp(className, L"XamlExplorerHostIslandWindow") == 0) {
+    if (_wcsicmp(className, L"XamlExplorerHostIslandWindow") == 0 ||
+        (_wcsicmp(
+             className,
+             L"Windows.UI.Composition.DesktopWindowContentBridge") == 0 &&
+         parentClassName &&
+         _wcsicmp(parentClassName, L"Shell_TrayWnd") == 0)) {
         return XamlDiagnosticsFlavor::Windows;
     }
-    if (_wcsicmp(
-            className, L"XamlExplorerHostIslandWindow_WASDK") == 0) {
+    if (_wcsicmp(className, L"CabinetWClass") == 0 ||
+        _wcsicmp(
+             className, L"XamlExplorerHostIslandWindow_WASDK") == 0) {
         return XamlDiagnosticsFlavor::Microsoft;
     }
     return XamlDiagnosticsFlavor::None;
 }
 
 bool IsModernXamlHostClassName(LPCWSTR className) {
-    return GetModernXamlHostFlavor(className) !=
-           XamlDiagnosticsFlavor::None;
+    return className &&
+           (_wcsicmp(className, L"CabinetWClass") == 0 ||
+            _wcsicmp(className, L"XamlExplorerHostIslandWindow") == 0 ||
+            _wcsicmp(
+                className, L"XamlExplorerHostIslandWindow_WASDK") == 0 ||
+            _wcsicmp(
+                className,
+                L"Windows.UI.Composition.DesktopWindowContentBridge") == 0);
+}
+
+XamlDiagnosticsFlavor GetModernXamlHostFlavor(
+    HWND window,
+    LPCWSTR className = nullptr) {
+    wchar_t resolvedClassName[128];
+    if (!className || IS_INTRESOURCE(className)) {
+        if (GetClassNameW(window, resolvedClassName,
+                          ARRAYSIZE(resolvedClassName)) <= 0) {
+            return XamlDiagnosticsFlavor::None;
+        }
+        className = resolvedClassName;
+    }
+
+    wchar_t parentClassName[128];
+    LPCWSTR parentClassNamePointer = nullptr;
+    if (_wcsicmp(
+            className,
+            L"Windows.UI.Composition.DesktopWindowContentBridge") == 0) {
+        const HWND parent = GetParent(window);
+        if (parent &&
+            GetClassNameW(parent, parentClassName,
+                          ARRAYSIZE(parentClassName)) > 0) {
+            parentClassNamePointer = parentClassName;
+        }
+    }
+
+    return ClassifyModernXamlHost(
+        className, parentClassNamePointer);
+}
+
+bool NeedsXamlDiagnosticsHostNotification(
+    const XamlDiagnosticsConnectionState& state) {
+    return !state.connected.load(std::memory_order_acquire) &&
+           !state.blocked.load(std::memory_order_acquire) &&
+           !state.requestPending.load(std::memory_order_acquire) &&
+           state.failureCount.load(std::memory_order_acquire) <
+               kXamlDiagnosticsMaxAttempts;
+}
+
+bool NeedsAnyXamlDiagnosticsHostNotification() {
+    return NeedsXamlDiagnosticsHostNotification(
+               g_windowsUiXamlDiagnostics) ||
+           NeedsXamlDiagnosticsHostNotification(
+               g_microsoftUiXamlDiagnostics);
 }
 
 void NotifyModernXamlHost(HWND window, LPCWSTR className = nullptr) {
@@ -2610,7 +2661,7 @@ void NotifyModernXamlHost(HWND window, LPCWSTR className = nullptr) {
     }
 
     const XamlDiagnosticsFlavor flavor =
-        GetModernXamlHostFlavor(className);
+        GetModernXamlHostFlavor(window, className);
     if (flavor == XamlDiagnosticsFlavor::None) {
         return;
     }
@@ -2623,15 +2674,23 @@ void NotifyModernXamlHost(HWND window, LPCWSTR className = nullptr) {
 }
 
 BOOL CALLBACK EnumExistingModernXamlHostWindow(HWND window, LPARAM) {
+    if (!NeedsAnyXamlDiagnosticsHostNotification()) {
+        return FALSE;
+    }
+
     DWORD processId;
     if (GetWindowThreadProcessId(window, &processId) &&
         processId == GetCurrentProcessId()) {
         NotifyModernXamlHost(window);
     }
-    return TRUE;
+    return NeedsAnyXamlDiagnosticsHostNotification();
 }
 
 BOOL CALLBACK EnumExistingModernXamlTopLevelWindow(HWND window, LPARAM) {
+    if (!NeedsAnyXamlDiagnosticsHostNotification()) {
+        return FALSE;
+    }
+
     DWORD processId;
     if (!GetWindowThreadProcessId(window, &processId) ||
         processId != GetCurrentProcessId()) {
@@ -2639,8 +2698,10 @@ BOOL CALLBACK EnumExistingModernXamlTopLevelWindow(HWND window, LPARAM) {
     }
 
     NotifyModernXamlHost(window);
-    EnumChildWindows(window, EnumExistingModernXamlHostWindow, 0);
-    return TRUE;
+    if (NeedsAnyXamlDiagnosticsHostNotification()) {
+        EnumChildWindows(window, EnumExistingModernXamlHostWindow, 0);
+    }
+    return NeedsAnyXamlDiagnosticsHostNotification();
 }
 
 void DiscoverExistingModernXamlHosts() {
@@ -2829,18 +2890,14 @@ HWND FindWindowForThread(DWORD threadId) {
 
 bool InitializeModernUi() {
     g_stoppingModernUi.store(true, std::memory_order_release);
-    g_windowsUiXamlDiagnosticsConnected.store(
-        false, std::memory_order_release);
-    g_microsoftUiXamlDiagnosticsConnected.store(
-        false, std::memory_order_release);
-    g_windowsUiXamlDiagnosticsAttempted.store(
-        false, std::memory_order_release);
-    g_microsoftUiXamlDiagnosticsAttempted.store(
-        false, std::memory_order_release);
-    g_windowsUiXamlDiagnosticsRequestPending.store(
-        false, std::memory_order_release);
-    g_microsoftUiXamlDiagnosticsRequestPending.store(
-        false, std::memory_order_release);
+    for (XamlDiagnosticsConnectionState* state : {
+             &g_windowsUiXamlDiagnostics,
+             &g_microsoftUiXamlDiagnostics}) {
+        state->connected.store(false, std::memory_order_release);
+        state->blocked.store(false, std::memory_order_release);
+        state->requestPending.store(false, std::memory_order_release);
+        state->failureCount.store(0, std::memory_order_release);
+    }
     g_visualTreeWatcherGeneration.store(
         0, std::memory_order_release);
     {

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -103,9 +103,10 @@ Explorer-process window scan covers hosts that already exist when the mod is
 enabled. There is no timed polling. A hard connection failure can be retried by
 later matching host-window notifications, with at most three attempts per XAML
 flavor. Connections blocked by another diagnostics consumer aren't retried
-automatically, while an established connection being disconnected resets the
-attempt budget for that flavor. All connection work runs outside the
-window-creation hooks and is stopped before the mod unloads.
+automatically. When an established connection is disconnected, that flavor is
+re-armed and waits for the next matching host window before reconnecting. All
+connection work runs outside the window-creation hooks and is stopped before
+the mod unloads.
 When Taskbar Styler is configured to alert on competing XAML Diagnostics
 consumers, enabling this path can show one or more confirmation dialogs while
 the connection-name walk skips names that are already in use.
@@ -1878,8 +1879,9 @@ struct XamlDiagnosticsConnectionState {
 };
 
 bool RequestModernXamlDiagnosticsInitialization(
-    XamlDiagnosticsFlavor flavor,
-    bool reconnect = false);
+    XamlDiagnosticsFlavor flavor);
+void RearmXamlDiagnosticsConnection(
+    XamlDiagnosticsFlavor flavor);
 
 extern XamlDiagnosticsConnectionState g_windowsUiXamlDiagnostics;
 extern XamlDiagnosticsConnectionState g_microsoftUiXamlDiagnostics;
@@ -2200,20 +2202,13 @@ public:
             const XamlDiagnosticsFlavor disconnectedFlavor =
                 m_flavor;
             m_flavor = XamlDiagnosticsFlavor::None;
-            if (disconnectedFlavor ==
-                XamlDiagnosticsFlavor::Windows) {
-                g_windowsUiXamlDiagnostics.connected.store(
-                    false, std::memory_order_release);
-            } else if (disconnectedFlavor ==
-                       XamlDiagnosticsFlavor::Microsoft) {
-                g_microsoftUiXamlDiagnostics.connected.store(
-                    false, std::memory_order_release);
-            }
             if (disconnectedFlavor != XamlDiagnosticsFlavor::None &&
                 !g_stoppingModernUi.load(
                     std::memory_order_relaxed)) {
-                RequestModernXamlDiagnosticsInitialization(
-                    disconnectedFlavor, true);
+                // A disconnect means the old core is going away. Re-arm the
+                // flavor, but wait for the next matching host window before
+                // requesting another connection.
+                RearmXamlDiagnosticsConnection(disconnectedFlavor);
             }
             return S_OK;
         }
@@ -2399,6 +2394,7 @@ void EnsureXamlDiagnosticsConnection(
 
     HMODULE module = GetModuleHandleW(moduleName);
     if (!module) {
+        Wh_Log(L"%s diagnostics module isn't loaded yet", displayName);
         return;
     }
 
@@ -2471,17 +2467,28 @@ DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
             break;
         }
 
+        // Keep requestPending set throughout the connection attempt. Matching
+        // host windows created in the same startup burst are then coalesced
+        // instead of immediately consuming the remaining attempt budget.
         const bool requestWindows =
-            g_windowsUiXamlDiagnostics.requestPending.exchange(
-                false, std::memory_order_acq_rel);
+            g_windowsUiXamlDiagnostics.requestPending.load(
+                std::memory_order_acquire);
         const bool requestMicrosoft =
-            g_microsoftUiXamlDiagnostics.requestPending.exchange(
-                false, std::memory_order_acq_rel);
+            g_microsoftUiXamlDiagnostics.requestPending.load(
+                std::memory_order_acquire);
         if (!requestWindows && !requestMicrosoft) {
             continue;
         }
 
         EnsureModernXamlDiagnostics(requestWindows, requestMicrosoft);
+        if (requestWindows) {
+            g_windowsUiXamlDiagnostics.requestPending.store(
+                false, std::memory_order_release);
+        }
+        if (requestMicrosoft) {
+            g_microsoftUiXamlDiagnostics.requestPending.store(
+                false, std::memory_order_release);
+        }
     }
 
     if (SUCCEEDED(initializeResult)) {
@@ -2490,26 +2497,42 @@ DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
     return 0;
 }
 
+XamlDiagnosticsConnectionState* GetXamlDiagnosticsConnectionState(
+    XamlDiagnosticsFlavor flavor) {
+    if (flavor == XamlDiagnosticsFlavor::Windows) {
+        return &g_windowsUiXamlDiagnostics;
+    }
+    if (flavor == XamlDiagnosticsFlavor::Microsoft) {
+        return &g_microsoftUiXamlDiagnostics;
+    }
+    return nullptr;
+}
+
+void RearmXamlDiagnosticsConnection(
+    XamlDiagnosticsFlavor flavor) {
+    XamlDiagnosticsConnectionState* state =
+        GetXamlDiagnosticsConnectionState(flavor);
+    if (!state) {
+        return;
+    }
+
+    state->connected.store(false, std::memory_order_release);
+    state->blocked.store(false, std::memory_order_release);
+    state->failureCount.store(0, std::memory_order_release);
+}
+
 bool RequestModernXamlDiagnosticsInitialization(
-    XamlDiagnosticsFlavor flavor,
-    bool reconnect) {
+    XamlDiagnosticsFlavor flavor) {
     if (g_stoppingModernUi.load(std::memory_order_acquire)) {
         return false;
     }
 
-    XamlDiagnosticsConnectionState* state;
-    if (flavor == XamlDiagnosticsFlavor::Windows) {
-        state = &g_windowsUiXamlDiagnostics;
-    } else if (flavor == XamlDiagnosticsFlavor::Microsoft) {
-        state = &g_microsoftUiXamlDiagnostics;
-    } else {
+    XamlDiagnosticsConnectionState* state =
+        GetXamlDiagnosticsConnectionState(flavor);
+    if (!state) {
         return false;
     }
 
-    if (reconnect) {
-        state->blocked.store(false, std::memory_order_release);
-        state->failureCount.store(0, std::memory_order_release);
-    }
     if (state->connected.load(std::memory_order_acquire) ||
         state->blocked.load(std::memory_order_acquire) ||
         state->failureCount.load(std::memory_order_acquire) >=
@@ -2579,6 +2602,7 @@ XamlDiagnosticsFlavor ClassifyModernXamlHost(
     }
 
     if (_wcsicmp(className, L"XamlExplorerHostIslandWindow") == 0 ||
+        _wcsicmp(className, L"Shell_InputSwitchTopLevelWindow") == 0 ||
         (_wcsicmp(
              className,
              L"Windows.UI.Composition.DesktopWindowContentBridge") == 0 &&
@@ -2595,14 +2619,17 @@ XamlDiagnosticsFlavor ClassifyModernXamlHost(
 }
 
 bool IsModernXamlHostClassName(LPCWSTR className) {
-    return className &&
-           (_wcsicmp(className, L"CabinetWClass") == 0 ||
-            _wcsicmp(className, L"XamlExplorerHostIslandWindow") == 0 ||
-            _wcsicmp(
-                className, L"XamlExplorerHostIslandWindow_WASDK") == 0 ||
-            _wcsicmp(
-                className,
-                L"Windows.UI.Composition.DesktopWindowContentBridge") == 0);
+    if (!className) {
+        return false;
+    }
+
+    // A bridge needs its parent to determine whether it is a supported host,
+    // but it is still a useful dispatch window during per-thread cleanup.
+    return ClassifyModernXamlHost(className) !=
+               XamlDiagnosticsFlavor::None ||
+           _wcsicmp(
+               className,
+               L"Windows.UI.Composition.DesktopWindowContentBridge") == 0;
 }
 
 XamlDiagnosticsFlavor GetModernXamlHostFlavor(
@@ -2651,6 +2678,10 @@ bool NeedsAnyXamlDiagnosticsHostNotification() {
 }
 
 void NotifyModernXamlHost(HWND window, LPCWSTR className = nullptr) {
+    if (!NeedsAnyXamlDiagnosticsHostNotification()) {
+        return;
+    }
+
     wchar_t resolvedClassName[128];
     if (!className || IS_INTRESOURCE(className)) {
         if (GetClassNameW(window, resolvedClassName,

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -96,15 +96,12 @@ The modern path supports both Windows.UI.Xaml and Microsoft.UI.Xaml content
 hosted by Explorer. Each named XAML Diagnostics connection allows one consumer,
 so another diagnostics-based customization tool, including Windows 11 Taskbar
 Styler or Windows 11 File Explorer Styler, can prevent this path from
-initializing. The mod waits for a recognized Windows.UI.Xaml or
-Microsoft.UI.Xaml host window before requesting the corresponding diagnostics
-connection, and framework module loads provide a fallback signal when a host
-appears first. Connection work runs on a managed worker outside those hooks,
-and repeated unavailable endpoints or hard failures are bounded. Connections
-blocked by another diagnostics consumer aren't retried automatically. An
-established connection is re-armed after its XAML host disappears, and all
-connection work stops before the mod unloads. If the modern path's required
-hooks aren't available, enabled classic menus and tooltips remain active.
+initializing. The mod waits until supported XAML UI appears before connecting.
+Temporarily unavailable connections are retried with bounded pauses, while
+repeated hard failures are abandoned. Connections blocked by another
+diagnostics consumer aren't retried automatically. An established connection
+can be restored after its XAML host disappears. If the modern path can't be
+initialized, enabled classic menus and tooltips remain active.
 When Taskbar Styler is configured to alert on competing XAML Diagnostics
 consumers, an intercepted connection attempt can show a confirmation dialog;
 if the tool blocks it by returning success, the walk stops and this mod marks
@@ -1866,11 +1863,14 @@ enum class XamlDiagnosticsFlavor {
     Microsoft,
 };
 
-// A recognized host window is a readiness signal for the corresponding XAML
-// core. Its diagnostics endpoint can still be registered slightly later.
-constexpr int kXamlDiagnosticsConnectionLimit = 10000;
+// DXamlCore allocates dense low connection indices. A larger walk only
+// multiplies probes while no diagnostics endpoint is registered.
+constexpr int kXamlDiagnosticsConnectionLimit = 64;
 constexpr unsigned int kXamlDiagnosticsMaxAttempts = 3;
+// Pause after five empty walks in one startup burst. A later host or module
+// event can resume probing after this cooldown.
 constexpr unsigned int kXamlDiagnosticsMaxEmptyWalks = 5;
+constexpr uint64_t kXamlDiagnosticsEmptyWalkCooldownMilliseconds = 30'000;
 
 struct XamlDiagnosticsConnectionState {
     std::atomic_bool connected{false};
@@ -1879,16 +1879,50 @@ struct XamlDiagnosticsConnectionState {
     std::atomic_uint processedGeneration{0};
     std::atomic_uint failureCount{0};
     std::atomic_uint emptyWalkCount{0};
+    std::atomic_uint64_t lastEmptyWalkTick{0};
 };
 
+bool HasXamlDiagnosticsEmptyWalkBudget(
+    const XamlDiagnosticsConnectionState& state,
+    uint64_t currentTick = GetTickCount64()) {
+    if (state.emptyWalkCount.load(std::memory_order_acquire) <
+        kXamlDiagnosticsMaxEmptyWalks) {
+        return true;
+    }
+
+    const uint64_t lastEmptyWalkTick =
+        state.lastEmptyWalkTick.load(std::memory_order_acquire);
+    return currentTick >= lastEmptyWalkTick &&
+           currentTick - lastEmptyWalkTick >=
+               kXamlDiagnosticsEmptyWalkCooldownMilliseconds;
+}
+
 bool CanAttemptXamlDiagnosticsConnection(
-    const XamlDiagnosticsConnectionState& state) {
+    const XamlDiagnosticsConnectionState& state,
+    uint64_t currentTick = GetTickCount64()) {
     return !state.connected.load(std::memory_order_acquire) &&
            !state.blocked.load(std::memory_order_acquire) &&
            state.failureCount.load(std::memory_order_acquire) <
                kXamlDiagnosticsMaxAttempts &&
-           state.emptyWalkCount.load(std::memory_order_acquire) <
-               kXamlDiagnosticsMaxEmptyWalks;
+           HasXamlDiagnosticsEmptyWalkBudget(state, currentTick);
+}
+
+bool RefreshXamlDiagnosticsEmptyWalkBudget(
+    XamlDiagnosticsConnectionState& state,
+    uint64_t currentTick) {
+    if (!HasXamlDiagnosticsEmptyWalkBudget(state, currentTick)) {
+        return false;
+    }
+    if (state.emptyWalkCount.load(std::memory_order_acquire) <
+        kXamlDiagnosticsMaxEmptyWalks) {
+        return true;
+    }
+
+    state.lastEmptyWalkTick.store(0, std::memory_order_relaxed);
+    state.emptyWalkCount.store(0, std::memory_order_release);
+    Wh_Log(L"Resuming XAML diagnostics probes after the empty-walk "
+           L"cooldown");
+    return true;
 }
 
 bool RequestModernXamlDiagnosticsInitialization(
@@ -2421,6 +2455,7 @@ void EnsureXamlDiagnosticsConnection(
             state.connected.store(true, std::memory_order_release);
             state.failureCount.store(0, std::memory_order_release);
             state.emptyWalkCount.store(0, std::memory_order_release);
+            state.lastEmptyWalkTick.store(0, std::memory_order_release);
             Wh_Log(L"Connected to %s diagnostics", displayName);
         } else {
             // A competing diagnostics hook can return success without
@@ -2433,15 +2468,19 @@ void EnsureXamlDiagnosticsConnection(
                    displayName);
         }
     } else if (result == HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
+        state.lastEmptyWalkTick.store(
+            GetTickCount64(), std::memory_order_release);
         const unsigned int emptyWalkCount =
             state.emptyWalkCount.fetch_add(
                 1, std::memory_order_acq_rel) +
             1;
         if (emptyWalkCount >= kXamlDiagnosticsMaxEmptyWalks) {
             Wh_Log(L"%s diagnostics endpoint remained unavailable after "
-                   L"%u full connection-name walks; stopping automatic "
-                   L"attempts",
-                   displayName, emptyWalkCount);
+                   L"%u connection-name walks; pausing automatic attempts "
+                   L"for %u seconds",
+                   displayName, emptyWalkCount,
+                   static_cast<unsigned int>(
+                       kXamlDiagnosticsEmptyWalkCooldownMilliseconds / 1000));
         } else {
             Wh_Log(L"%s diagnostics endpoint isn't registered yet "
                    L"(empty walk %u/%u)",
@@ -2565,6 +2604,7 @@ void RearmXamlDiagnosticsConnection(
     state->blocked.store(false, std::memory_order_release);
     state->failureCount.store(0, std::memory_order_release);
     state->emptyWalkCount.store(0, std::memory_order_release);
+    state->lastEmptyWalkTick.store(0, std::memory_order_release);
     state->processedGeneration.store(
         state->requestGeneration.load(std::memory_order_acquire),
         std::memory_order_release);
@@ -2591,9 +2631,11 @@ bool RequestModernXamlDiagnosticsInitialization(
 
     std::lock_guard<std::mutex> guard(
         g_xamlDiagnosticsWorkerMutex);
+    const uint64_t currentTick = GetTickCount64();
     if (g_stoppingModernUi.load(std::memory_order_acquire) ||
         !g_xamlDiagnosticsWorkerWakeEvent ||
-        !CanAttemptXamlDiagnosticsConnection(*state)) {
+        !RefreshXamlDiagnosticsEmptyWalkBudget(*state, currentTick) ||
+        !CanAttemptXamlDiagnosticsConnection(*state, currentTick)) {
         return false;
     }
 
@@ -2670,7 +2712,7 @@ XamlDiagnosticsFlavor ClassifyModernXamlHost(
     return XamlDiagnosticsFlavor::None;
 }
 
-bool IsModernXamlHostClassName(LPCWSTR className) {
+bool IsModernUiDispatchWindowClassName(LPCWSTR className) {
     if (!className) {
         return false;
     }
@@ -2732,7 +2774,9 @@ void NotifyModernXamlHost(HWND window, LPCWSTR className = nullptr) {
 
     // Only signal the worker here. XAML Diagnostics and COM initialization
     // must not run inside a window-creation hook.
-    if (RequestModernXamlDiagnosticsInitialization(flavor)) {
+    const bool queuedFirstRequest =
+        RequestModernXamlDiagnosticsInitialization(flavor);
+    if (queuedFirstRequest) {
         Wh_Log(L"Found XAML host window: %s", className);
     }
 }
@@ -2747,7 +2791,7 @@ BOOL CALLBACK EnumExistingModernXamlHostWindow(HWND window, LPARAM) {
         processId == GetCurrentProcessId()) {
         NotifyModernXamlHost(window);
     }
-    return NeedsAnyXamlDiagnosticsHostNotification();
+    return TRUE;
 }
 
 BOOL CALLBACK EnumExistingModernXamlTopLevelWindow(HWND window, LPARAM) {
@@ -2762,10 +2806,8 @@ BOOL CALLBACK EnumExistingModernXamlTopLevelWindow(HWND window, LPARAM) {
     }
 
     NotifyModernXamlHost(window);
-    if (NeedsAnyXamlDiagnosticsHostNotification()) {
-        EnumChildWindows(window, EnumExistingModernXamlHostWindow, 0);
-    }
-    return NeedsAnyXamlDiagnosticsHostNotification();
+    EnumChildWindows(window, EnumExistingModernXamlHostWindow, 0);
+    return TRUE;
 }
 
 void DiscoverExistingModernXamlHosts() {
@@ -2819,7 +2861,9 @@ HMODULE WINAPI LoadLibraryExWHook(LPCWSTR fileName,
         g_modernUiActive.load(std::memory_order_acquire)) {
         // Only wake the worker here. Diagnostics initialization must not run
         // from a library-loading call stack.
-        if (RequestModernXamlDiagnosticsInitialization(flavor)) {
+        const bool queuedFirstRequest =
+            RequestModernXamlDiagnosticsInitialization(flavor);
+        if (queuedFirstRequest) {
             Wh_Log(L"Loaded XAML diagnostics module: %s",
                    GetModuleFileNamePart(fileName));
         }
@@ -2982,7 +3026,7 @@ bool RunFromWindowThread(HWND window,
 HWND FindWindowForThread(DWORD threadId) {
     struct FindWindowParameter {
         HWND first = nullptr;
-        HWND xamlHost = nullptr;
+        HWND preferred = nullptr;
     } parameter;
 
     EnumThreadWindows(
@@ -2996,15 +3040,15 @@ HWND FindWindowForThread(DWORD threadId) {
             wchar_t className[128];
             if (GetClassNameW(
                     window, className, ARRAYSIZE(className)) > 0 &&
-                IsModernXamlHostClassName(className)) {
-                state->xamlHost = window;
+                IsModernUiDispatchWindowClassName(className)) {
+                state->preferred = window;
                 return FALSE;
             }
 
             return TRUE;
         },
         reinterpret_cast<LPARAM>(&parameter));
-    return parameter.xamlHost ? parameter.xamlHost : parameter.first;
+    return parameter.preferred ? parameter.preferred : parameter.first;
 }
 
 bool InitializeModernUi() {
@@ -3018,6 +3062,7 @@ bool InitializeModernUi() {
         state->processedGeneration.store(0, std::memory_order_release);
         state->failureCount.store(0, std::memory_order_release);
         state->emptyWalkCount.store(0, std::memory_order_release);
+        state->lastEmptyWalkTick.store(0, std::memory_order_release);
     }
     g_visualTreeWatcherGeneration.store(
         0, std::memory_order_release);
@@ -3092,9 +3137,9 @@ void UninitializeModernUi() {
             continue;
         }
 
-        // Prefer an Explorer/taskbar XAML host window. If the host was
-        // replaced, the helper still falls back to another window on the same
-        // UI thread so cleanup can run on the owning thread.
+        // Prefer a window associated with supported modern UI. If it was
+        // replaced, fall back to another window on the same UI thread so
+        // cleanup can still run on the owning thread.
         const HWND window = FindWindowForThread(threadId);
         if (!window ||
             !IsRegisteredThreadAlive(threadId, creationTime) ||
@@ -3151,10 +3196,6 @@ bool HookModernXamlHostCreation() {
     }
 
     HMODULE user32Module = GetModuleHandleW(L"user32.dll");
-    if (!user32Module) {
-        Wh_Log(L"Couldn't find linked user32.dll");
-        return true;
-    }
 
     const auto createWindowInBand =
         reinterpret_cast<CreateWindowInBand_t>(

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips; modern XAML UI is opt-in and best-effort because it may conflict with other XAML Diagnostics mods
-// @version         0.1.27
+// @version         0.1.28
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -99,7 +99,9 @@ Styler or Windows 11 File Explorer Styler, can prevent this path from
 initializing. Connection attempts are scheduled outside the Windows loader
   path; one managed worker retains requests that arrive while it is running,
   tracks the Windows.UI.Xaml and Microsoft.UI.Xaml connections independently,
-  and retries only the connection that was lost. It doesn't add a module
+  retries `ERROR_NOT_FOUND` during concurrent Explorer startup with bounded,
+  interruptible backoff, and later retries only the connection that was lost.
+  It doesn't add a module
   reference: the worker is signaled to stop and joined before Windhawk removes
   hooks. Asynchronous visual-tree watcher setup threads are tracked by handle
   and joined at the same point, so the engine's single module reference remains
@@ -108,9 +110,9 @@ initializing. Connection attempts are scheduled outside the Windows loader
   `LoadLibraryExW` hook covers modules loaded later, including the
   `CoreMessagingXP.dll` static-import path used by
   `Microsoft.Internal.FrameworkUdk.dll`.
-  If a connection attempt is denied or otherwise fails, a newly loaded XAML
-  module or an established connection being disconnected provides the next
-  retry opportunity.
+  A connection blocked with a successful return isn't retried automatically;
+  after startup backoff is exhausted, a newly loaded XAML module or an
+  established connection being disconnected provides the next opportunity.
 When Taskbar Styler is configured to alert on competing XAML Diagnostics
 consumers, enabling this path can show its confirmation dialog.
 The mod is injected only into `explorer.exe`. Start, Search, and some shell
@@ -1869,6 +1871,25 @@ enum class XamlDiagnosticsFlavor {
     Microsoft,
 };
 
+enum class XamlDiagnosticsRetry : unsigned char {
+    None = 0,
+    Windows = 1,
+    Microsoft = 2,
+};
+
+XamlDiagnosticsRetry operator|(XamlDiagnosticsRetry left,
+                               XamlDiagnosticsRetry right) {
+    return static_cast<XamlDiagnosticsRetry>(
+        static_cast<unsigned char>(left) |
+        static_cast<unsigned char>(right));
+}
+
+bool HasXamlDiagnosticsRetry(XamlDiagnosticsRetry retries,
+                             XamlDiagnosticsRetry flavor) {
+    return (static_cast<unsigned char>(retries) &
+            static_cast<unsigned char>(flavor)) != 0;
+}
+
 void RequestModernXamlDiagnosticsInitialization(
     XamlDiagnosticsFlavor retryFlavor = XamlDiagnosticsFlavor::None);
 
@@ -2379,10 +2400,11 @@ HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
     return result;
 }
 
-void EnsureModernXamlDiagnostics() {
+XamlDiagnosticsRetry EnsureModernXamlDiagnostics() {
+    XamlDiagnosticsRetry retries = XamlDiagnosticsRetry::None;
     if (g_stoppingModernUi.load(std::memory_order_acquire) ||
         g_loadingXamlDiagnostics) {
-        return;
+        return retries;
     }
 
     ScopedBoolValue loadingGuard(g_loadingXamlDiagnostics, true);
@@ -2390,7 +2412,7 @@ void EnsureModernXamlDiagnostics() {
     std::lock_guard<std::mutex> guard(
         g_xamlDiagnosticsInitializationMutex);
     if (g_stoppingModernUi.load(std::memory_order_acquire)) {
-        return;
+        return retries;
     }
 
     if (!g_windowsUiXamlDiagnosticsConnected.load(
@@ -2419,10 +2441,11 @@ void EnsureModernXamlDiagnostics() {
                 Wh_Log(L"Windows.UI.Xaml diagnostics returned success "
                        L"without creating a watcher; another diagnostics "
                        L"tool probably blocked the connection");
+            } else if (result ==
+                       HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
+                retries = retries | XamlDiagnosticsRetry::Windows;
             } else if (result !=
-                           HRESULT_FROM_WIN32(ERROR_NOT_FOUND) &&
-                       result !=
-                           HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
+                       HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
                 Wh_Log(L"Windows.UI.Xaml diagnostics failed: "
                        L"0x%08X", result);
             }
@@ -2455,14 +2478,29 @@ void EnsureModernXamlDiagnostics() {
                 Wh_Log(L"Microsoft.UI.Xaml diagnostics returned success "
                        L"without creating a watcher; another diagnostics "
                        L"tool probably blocked the connection");
+            } else if (result ==
+                       HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
+                retries = retries | XamlDiagnosticsRetry::Microsoft;
             } else if (result !=
-                           HRESULT_FROM_WIN32(ERROR_NOT_FOUND) &&
-                       result !=
-                           HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
+                       HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
                 Wh_Log(L"Microsoft.UI.Xaml diagnostics failed: "
                        L"0x%08X", result);
             }
         }
+    }
+    return retries;
+}
+
+void ResetXamlDiagnosticsAttempts(XamlDiagnosticsRetry retries) {
+    if (HasXamlDiagnosticsRetry(
+            retries, XamlDiagnosticsRetry::Windows)) {
+        g_windowsUiXamlDiagnosticsAttempted.store(
+            false, std::memory_order_release);
+    }
+    if (HasXamlDiagnosticsRetry(
+            retries, XamlDiagnosticsRetry::Microsoft)) {
+        g_microsoftUiXamlDiagnosticsAttempted.store(
+            false, std::memory_order_release);
     }
 }
 
@@ -2483,17 +2521,52 @@ DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
     const HANDLE wakeEvent = static_cast<HANDLE>(parameter);
     const HRESULT initializeResult =
         CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    constexpr DWORD retryDelaysMs[] = {
+        1000, 2000, 5000, 10000, 20000, 30000};
+    XamlDiagnosticsRetry retries = XamlDiagnosticsRetry::None;
+    size_t retryIndex = 0;
     for (;;) {
-        const DWORD waitResult = WaitForSingleObject(wakeEvent, INFINITE);
-        if (waitResult != WAIT_OBJECT_0 ||
-            g_stoppingModernUi.load(std::memory_order_acquire)) {
+        const DWORD waitTimeout =
+            retries == XamlDiagnosticsRetry::None
+                ? INFINITE
+                : retryDelaysMs[retryIndex];
+        const DWORD waitResult =
+            WaitForSingleObject(wakeEvent, waitTimeout);
+        if (g_stoppingModernUi.load(std::memory_order_acquire)) {
             break;
         }
 
-        while (!g_stoppingModernUi.load(std::memory_order_acquire) &&
-               g_xamlDiagnosticsRequestPending.exchange(
-                   false, std::memory_order_acq_rel)) {
-            EnsureModernXamlDiagnostics();
+        if (waitResult == WAIT_OBJECT_0) {
+            if (!g_xamlDiagnosticsRequestPending.exchange(
+                    false, std::memory_order_acq_rel)) {
+                continue;
+            }
+            // Preserve a scheduled startup retry when another flavor or a
+            // reconnect request wakes the worker in the meantime.
+            ResetXamlDiagnosticsAttempts(retries);
+            retryIndex = 0;
+        } else if (waitResult == WAIT_TIMEOUT &&
+                   retries != XamlDiagnosticsRetry::None) {
+            ResetXamlDiagnosticsAttempts(retries);
+            ++retryIndex;
+        } else {
+            Wh_Log(L"XAML diagnostics worker wait failed: %u",
+                   waitResult == WAIT_FAILED ? GetLastError()
+                                             : ERROR_GEN_FAILURE);
+            break;
+        }
+
+        retries = EnsureModernXamlDiagnostics();
+        if (retries != XamlDiagnosticsRetry::None) {
+            if (retryIndex < ARRAYSIZE(retryDelaysMs)) {
+                Wh_Log(L"XAML diagnostics isn't ready; retrying in %u ms",
+                       retryDelaysMs[retryIndex]);
+            } else {
+                Wh_Log(L"XAML diagnostics remained unavailable after "
+                       L"startup retries");
+                retries = XamlDiagnosticsRetry::None;
+                retryIndex = 0;
+            }
         }
     }
 
@@ -2520,7 +2593,7 @@ void RequestModernXamlDiagnosticsInitialization(
     }
 
     // Once all currently loaded XAML diagnostics connections are established,
-    // avoid creating another worker until SetSite(nullptr) explicitly marks
+    // avoid scheduling another attempt until SetSite(nullptr) explicitly marks
     // one as disconnected.
     if (!NeedsXamlDiagnosticsConnection()) {
         return;

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -97,11 +97,13 @@ hosted by Explorer. Each named XAML Diagnostics connection allows one consumer,
 so another diagnostics-based customization tool, including Windows 11 Taskbar
 Styler or Windows 11 File Explorer Styler, can prevent this path from
 initializing. The mod waits until supported XAML UI appears before connecting.
-Temporarily unavailable connections are retried with bounded pauses, while
-repeated hard failures are abandoned. Connections blocked by another
-diagnostics consumer aren't retried automatically. An established connection
-can be restored after its XAML host disappears. If the modern path can't be
-initialized, enabled classic menus and tooltips remain active.
+Temporarily unavailable connections are retried with bounded pauses; after
+those automatic retries are exhausted, a later host window or module load can
+still trigger another attempt. Repeated hard failures are abandoned.
+Connections blocked by another diagnostics consumer aren't retried
+automatically. An established connection can be restored after its XAML host
+disappears. If the modern path can't be initialized, enabled classic menus and
+tooltips remain active.
 When Taskbar Styler is configured to alert on competing XAML Diagnostics
 consumers, an intercepted connection attempt can show a confirmation dialog;
 if the tool blocks it by returning success, the walk stops and this mod marks
@@ -1868,9 +1870,13 @@ enum class XamlDiagnosticsFlavor {
 constexpr int kXamlDiagnosticsConnectionLimit = 64;
 constexpr unsigned int kXamlDiagnosticsMaxAttempts = 3;
 // Pause after five empty walks in one startup burst. A later host or module
-// event can resume probing after this cooldown.
+// event, or the cooldown expiring, can resume probing.
 constexpr unsigned int kXamlDiagnosticsMaxEmptyWalks = 5;
 constexpr uint64_t kXamlDiagnosticsEmptyWalkCooldownMilliseconds = 30'000;
+// The worker retries a cooling-down flavor on its own after each cooldown, but
+// stops after this many rounds so a permanently absent XAML core doesn't turn
+// into an endless 30-second polling loop.
+constexpr unsigned int kXamlDiagnosticsMaxCooldownRetries = 3;
 
 struct XamlDiagnosticsConnectionState {
     std::atomic_bool connected{false};
@@ -1879,6 +1885,7 @@ struct XamlDiagnosticsConnectionState {
     std::atomic_uint processedGeneration{0};
     std::atomic_uint failureCount{0};
     std::atomic_uint emptyWalkCount{0};
+    std::atomic_uint cooldownRetryCount{0};
     std::atomic_uint64_t lastEmptyWalkTick{0};
 };
 
@@ -1907,6 +1914,14 @@ bool CanAttemptXamlDiagnosticsConnection(
            HasXamlDiagnosticsEmptyWalkBudget(state, currentTick);
 }
 
+bool IsXamlDiagnosticsFlavorCoolingDown(
+    const XamlDiagnosticsConnectionState& state,
+    uint64_t currentTick = GetTickCount64()) {
+    return state.emptyWalkCount.load(std::memory_order_acquire) >=
+               kXamlDiagnosticsMaxEmptyWalks &&
+           !HasXamlDiagnosticsEmptyWalkBudget(state, currentTick);
+}
+
 bool RefreshXamlDiagnosticsEmptyWalkBudget(
     XamlDiagnosticsConnectionState& state,
     uint64_t currentTick) {
@@ -1918,8 +1933,9 @@ bool RefreshXamlDiagnosticsEmptyWalkBudget(
         return true;
     }
 
-    state.lastEmptyWalkTick.store(0, std::memory_order_relaxed);
+    state.lastEmptyWalkTick.store(0, std::memory_order_release);
     state.emptyWalkCount.store(0, std::memory_order_release);
+    state.cooldownRetryCount.store(0, std::memory_order_release);
     Wh_Log(L"Resuming XAML diagnostics probes after the empty-walk "
            L"cooldown");
     return true;
@@ -2383,20 +2399,23 @@ HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
             GetProcAddress(xamlModule,
                            "InitializeXamlDiagnosticsEx"));
     if (!initialize) {
-        return HRESULT_FROM_WIN32(GetLastError());
+        return HRESULT_FROM_WIN32(ERROR_PROC_NOT_FOUND);
     }
 
     const HMODULE module = GetCurrentModuleHandle();
     if (!module) {
-        return HRESULT_FROM_WIN32(GetLastError());
+        return HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND);
     }
 
     wchar_t modulePath[MAX_PATH];
     const DWORD pathLength =
         GetModuleFileNameW(module, modulePath,
                            ARRAYSIZE(modulePath));
-    if (!pathLength || pathLength == ARRAYSIZE(modulePath)) {
-        return HRESULT_FROM_WIN32(GetLastError());
+    if (!pathLength) {
+        return E_FAIL;
+    }
+    if (pathLength == ARRAYSIZE(modulePath)) {
+        return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
     }
 
     HRESULT result = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
@@ -2455,6 +2474,7 @@ void EnsureXamlDiagnosticsConnection(
             state.connected.store(true, std::memory_order_release);
             state.failureCount.store(0, std::memory_order_release);
             state.emptyWalkCount.store(0, std::memory_order_release);
+            state.cooldownRetryCount.store(0, std::memory_order_release);
             state.lastEmptyWalkTick.store(0, std::memory_order_release);
             Wh_Log(L"Connected to %s diagnostics", displayName);
         } else {
@@ -2515,15 +2535,91 @@ void EnsureModernXamlDiagnostics(bool requestWindows,
     }
 }
 
+bool AnyXamlDiagnosticsFlavorCoolingDown(uint64_t currentTick) {
+    return IsXamlDiagnosticsFlavorCoolingDown(
+               g_windowsUiXamlDiagnostics, currentTick) ||
+           IsXamlDiagnosticsFlavorCoolingDown(
+               g_microsoftUiXamlDiagnostics, currentTick);
+}
+
+DWORD XamlDiagnosticsWorkerTimeout(uint64_t currentTick) {
+    if (!AnyXamlDiagnosticsFlavorCoolingDown(currentTick)) {
+        return INFINITE;
+    }
+
+    DWORD timeout = INFINITE;
+    for (const XamlDiagnosticsConnectionState* state : {
+             &g_windowsUiXamlDiagnostics,
+             &g_microsoftUiXamlDiagnostics}) {
+        if (!IsXamlDiagnosticsFlavorCoolingDown(*state, currentTick)) {
+            continue;
+        }
+
+        const uint64_t lastEmptyWalkTick =
+            state->lastEmptyWalkTick.load(std::memory_order_acquire);
+        const uint64_t elapsed =
+            currentTick >= lastEmptyWalkTick
+                ? currentTick - lastEmptyWalkTick
+                : 0;
+        const uint64_t remaining =
+            kXamlDiagnosticsEmptyWalkCooldownMilliseconds - elapsed;
+        const DWORD candidate =
+            static_cast<DWORD>(remaining > 0 ? remaining : 1);
+        if (candidate < timeout) {
+            timeout = candidate;
+        }
+    }
+    return timeout;
+}
+
+void RetryXamlDiagnosticsAfterCooldown() {
+    const uint64_t currentTick = GetTickCount64();
+    for (XamlDiagnosticsConnectionState* state : {
+             &g_windowsUiXamlDiagnostics,
+             &g_microsoftUiXamlDiagnostics}) {
+        if (!CanAttemptXamlDiagnosticsConnection(*state, currentTick) ||
+            state->cooldownRetryCount.load(std::memory_order_acquire) >=
+                kXamlDiagnosticsMaxCooldownRetries) {
+            continue;
+        }
+
+        // The cooldown elapsed without a new host or module event, so retry
+        // this flavor once. Count the retry before the attempt; a successful
+        // connection resets the count.
+        state->cooldownRetryCount.fetch_add(1, std::memory_order_acq_rel);
+        const LPCWSTR displayName =
+            state == &g_windowsUiXamlDiagnostics ? L"Windows.UI.Xaml"
+                                                 : L"Microsoft.UI.Xaml";
+        Wh_Log(L"Retrying %s diagnostics after the empty-walk cooldown",
+               displayName);
+        if (state == &g_windowsUiXamlDiagnostics) {
+            EnsureXamlDiagnosticsConnection(
+                *state, L"Windows.UI.Xaml.dll", L"VisualDiagConnection",
+                L"Windows.UI.Xaml", XamlDiagnosticsFlavor::Windows);
+        } else {
+            EnsureXamlDiagnosticsConnection(
+                *state, L"Microsoft.Internal.FrameworkUdk.dll",
+                L"WinUIVisualDiagConnection", L"Microsoft.UI.Xaml",
+                XamlDiagnosticsFlavor::Microsoft);
+        }
+    }
+}
+
 DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
     const HANDLE wakeEvent = static_cast<HANDLE>(parameter);
     const HRESULT initializeResult =
         CoInitializeEx(nullptr, COINIT_MULTITHREADED);
     for (;;) {
-        const DWORD waitResult =
-            WaitForSingleObject(wakeEvent, INFINITE);
+        const uint64_t waitStartedTick = GetTickCount64();
+        const DWORD waitResult = WaitForSingleObject(
+            wakeEvent, XamlDiagnosticsWorkerTimeout(waitStartedTick));
         if (g_stoppingModernUi.load(std::memory_order_acquire)) {
             break;
+        }
+
+        if (waitResult == WAIT_TIMEOUT) {
+            RetryXamlDiagnosticsAfterCooldown();
+            continue;
         }
 
         if (waitResult != WAIT_OBJECT_0) {
@@ -2604,6 +2700,7 @@ void RearmXamlDiagnosticsConnection(
     state->blocked.store(false, std::memory_order_release);
     state->failureCount.store(0, std::memory_order_release);
     state->emptyWalkCount.store(0, std::memory_order_release);
+    state->cooldownRetryCount.store(0, std::memory_order_release);
     state->lastEmptyWalkTick.store(0, std::memory_order_release);
     state->processedGeneration.store(
         state->requestGeneration.load(std::memory_order_acquire),
@@ -2782,6 +2879,8 @@ void NotifyModernXamlHost(HWND window, LPCWSTR className = nullptr) {
 }
 
 BOOL CALLBACK EnumExistingModernXamlHostWindow(HWND window, LPARAM) {
+    // Stop only this top-level window's child walk; EnumWindows continues with
+    // the next top-level window.
     if (!NeedsAnyXamlDiagnosticsHostNotification()) {
         return FALSE;
     }
@@ -2795,6 +2894,7 @@ BOOL CALLBACK EnumExistingModernXamlHostWindow(HWND window, LPARAM) {
 }
 
 BOOL CALLBACK EnumExistingModernXamlTopLevelWindow(HWND window, LPARAM) {
+    // Stop the whole EnumWindows walk once no flavor can accept a notification.
     if (!NeedsAnyXamlDiagnosticsHostNotification()) {
         return FALSE;
     }
@@ -3062,6 +3162,7 @@ bool InitializeModernUi() {
         state->processedGeneration.store(0, std::memory_order_release);
         state->failureCount.store(0, std::memory_order_release);
         state->emptyWalkCount.store(0, std::memory_order_release);
+        state->cooldownRetryCount.store(0, std::memory_order_release);
         state->lastEmptyWalkTick.store(0, std::memory_order_release);
     }
     g_visualTreeWatcherGeneration.store(

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -100,16 +100,19 @@ initializing. The mod waits for a recognized Windows.UI.Xaml or
 Microsoft.UI.Xaml host window before requesting the corresponding diagnostics
 connection. Window-creation hooks only signal a managed worker; an
 Explorer-process window scan covers hosts that already exist when the mod is
-enabled. There is no timed polling. A hard connection failure can be retried by
-later matching host-window notifications, with at most three attempts per XAML
-flavor. Connections blocked by another diagnostics consumer aren't retried
+enabled. There is no timed polling. Host notifications received during a
+connection attempt are coalesced into one follow-up attempt. Exhausting the
+connection-name walk with `ERROR_NOT_FOUND` means that the XAML endpoint isn't
+registered yet and doesn't consume the three-attempt hard-failure budget.
+Connections blocked by another diagnostics consumer aren't retried
 automatically. When an established connection is disconnected, that flavor is
 re-armed and waits for the next matching host window before reconnecting. All
 connection work runs outside the window-creation hooks and is stopped before
 the mod unloads.
 When Taskbar Styler is configured to alert on competing XAML Diagnostics
-consumers, enabling this path can show one or more confirmation dialogs while
-the connection-name walk skips names that are already in use.
+consumers, an intercepted connection attempt can show a confirmation dialog;
+if the tool blocks it by returning success, the walk stops and this mod marks
+that flavor as blocked.
 The mod is injected only into `explorer.exe`. Start, Search, and some shell
 flyouts hosted by `StartMenuExperienceHost.exe`, `SearchHost.exe`, or
 `ShellExperienceHost.exe` are outside its scope.
@@ -1866,15 +1869,16 @@ enum class XamlDiagnosticsFlavor {
     Microsoft,
 };
 
-// A recognized host window means the corresponding XAML core is ready, so the
-// compatibility walk normally stops at its first free connection name.
+// A recognized host window is a readiness signal for the corresponding XAML
+// core. Its diagnostics endpoint can still be registered slightly later.
 constexpr int kXamlDiagnosticsConnectionLimit = 10000;
 constexpr unsigned int kXamlDiagnosticsMaxAttempts = 3;
 
 struct XamlDiagnosticsConnectionState {
     std::atomic_bool connected{false};
     std::atomic_bool blocked{false};
-    std::atomic_bool requestPending{false};
+    std::atomic_uint requestGeneration{0};
+    std::atomic_uint processedGeneration{0};
     std::atomic_uint failureCount{0};
 };
 
@@ -2421,6 +2425,11 @@ void EnsureXamlDiagnosticsConnection(
                    L"the connection",
                    displayName);
         }
+    } else if (result == HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
+        // The module exists, but no XAML core has registered a diagnostics
+        // endpoint yet. A later host notification will request another walk;
+        // don't spend the hard-failure budget on this startup state.
+        Wh_Log(L"%s diagnostics endpoint isn't registered yet", displayName);
     } else if (result != HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
         const unsigned int failureCount =
             state.failureCount.fetch_add(
@@ -2467,14 +2476,30 @@ DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
             break;
         }
 
-        // Keep requestPending set throughout the connection attempt. Matching
-        // host windows created in the same startup burst are then coalesced
-        // instead of immediately consuming the remaining attempt budget.
+        unsigned int windowsGeneration;
+        unsigned int microsoftGeneration;
+        {
+            // RequestModernXamlDiagnosticsInitialization increments a
+            // generation and signals the event while holding this mutex.
+            // Taking the mutex here ensures the snapshot includes the
+            // generation associated with the wake-up.
+            std::lock_guard<std::mutex> guard(
+                g_xamlDiagnosticsWorkerMutex);
+            windowsGeneration =
+                g_windowsUiXamlDiagnostics.requestGeneration.load(
+                    std::memory_order_acquire);
+            microsoftGeneration =
+                g_microsoftUiXamlDiagnostics.requestGeneration.load(
+                    std::memory_order_acquire);
+        }
+
         const bool requestWindows =
-            g_windowsUiXamlDiagnostics.requestPending.load(
+            windowsGeneration !=
+            g_windowsUiXamlDiagnostics.processedGeneration.load(
                 std::memory_order_acquire);
         const bool requestMicrosoft =
-            g_microsoftUiXamlDiagnostics.requestPending.load(
+            microsoftGeneration !=
+            g_microsoftUiXamlDiagnostics.processedGeneration.load(
                 std::memory_order_acquire);
         if (!requestWindows && !requestMicrosoft) {
             continue;
@@ -2482,12 +2507,34 @@ DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
 
         EnsureModernXamlDiagnostics(requestWindows, requestMicrosoft);
         if (requestWindows) {
-            g_windowsUiXamlDiagnostics.requestPending.store(
-                false, std::memory_order_release);
+            g_windowsUiXamlDiagnostics.processedGeneration.store(
+                windowsGeneration, std::memory_order_release);
         }
         if (requestMicrosoft) {
-            g_microsoftUiXamlDiagnostics.requestPending.store(
-                false, std::memory_order_release);
+            g_microsoftUiXamlDiagnostics.processedGeneration.store(
+                microsoftGeneration, std::memory_order_release);
+        }
+
+        // A matching host created during the walk advances its generation.
+        // It is already represented by at least one SetEvent call, but signal
+        // again after publishing the processed snapshots to make the handoff
+        // explicit and coalesce the whole burst into one follow-up attempt.
+        const bool requestAdvanced =
+            g_windowsUiXamlDiagnostics.requestGeneration.load(
+                std::memory_order_acquire) !=
+                g_windowsUiXamlDiagnostics.processedGeneration.load(
+                    std::memory_order_acquire) ||
+            g_microsoftUiXamlDiagnostics.requestGeneration.load(
+                std::memory_order_acquire) !=
+                g_microsoftUiXamlDiagnostics.processedGeneration.load(
+                    std::memory_order_acquire);
+        if (requestAdvanced) {
+            std::lock_guard<std::mutex> guard(
+                g_xamlDiagnosticsWorkerMutex);
+            if (!g_stoppingModernUi.load(std::memory_order_acquire) &&
+                g_xamlDiagnosticsWorkerWakeEvent) {
+                SetEvent(g_xamlDiagnosticsWorkerWakeEvent);
+            }
         }
     }
 
@@ -2516,9 +2563,14 @@ void RearmXamlDiagnosticsConnection(
         return;
     }
 
-    state->connected.store(false, std::memory_order_release);
     state->blocked.store(false, std::memory_order_release);
     state->failureCount.store(0, std::memory_order_release);
+    state->processedGeneration.store(
+        state->requestGeneration.load(std::memory_order_acquire),
+        std::memory_order_release);
+    // Publish the disconnected state last. A new host notification can only
+    // enqueue a generation after the old generations have been synchronized.
+    state->connected.store(false, std::memory_order_release);
 }
 
 bool RequestModernXamlDiagnosticsInitialization(
@@ -2540,26 +2592,31 @@ bool RequestModernXamlDiagnosticsInitialization(
         return false;
     }
 
-    if (state->requestPending.exchange(
-            true, std::memory_order_acq_rel)) {
-        return false;
-    }
-
     std::lock_guard<std::mutex> guard(
         g_xamlDiagnosticsWorkerMutex);
     if (g_stoppingModernUi.load(std::memory_order_acquire) ||
-        !g_xamlDiagnosticsWorkerWakeEvent) {
-        state->requestPending.store(false, std::memory_order_release);
+        !g_xamlDiagnosticsWorkerWakeEvent ||
+        state->connected.load(std::memory_order_acquire) ||
+        state->blocked.load(std::memory_order_acquire) ||
+        state->failureCount.load(std::memory_order_acquire) >=
+            kXamlDiagnosticsMaxAttempts) {
         return false;
     }
 
+    const unsigned int previousGeneration =
+        state->requestGeneration.fetch_add(
+            1, std::memory_order_acq_rel);
+    const bool firstPendingRequest =
+        previousGeneration ==
+        state->processedGeneration.load(std::memory_order_acquire);
     if (!SetEvent(g_xamlDiagnosticsWorkerWakeEvent)) {
-        state->requestPending.store(false, std::memory_order_release);
+        state->requestGeneration.fetch_sub(
+            1, std::memory_order_acq_rel);
         Wh_Log(L"Couldn't signal the XAML diagnostics worker: %u",
                GetLastError());
         return false;
     }
-    return true;
+    return firstPendingRequest;
 }
 
 void StopModernXamlDiagnosticsWorker() {
@@ -2588,10 +2645,13 @@ void StopModernXamlDiagnosticsWorker() {
     if (wakeEvent) {
         CloseHandle(wakeEvent);
     }
-    g_windowsUiXamlDiagnostics.requestPending.store(
-        false, std::memory_order_release);
-    g_microsoftUiXamlDiagnostics.requestPending.store(
-        false, std::memory_order_release);
+    for (XamlDiagnosticsConnectionState* state : {
+             &g_windowsUiXamlDiagnostics,
+             &g_microsoftUiXamlDiagnostics}) {
+        state->processedGeneration.store(
+            state->requestGeneration.load(std::memory_order_acquire),
+            std::memory_order_release);
+    }
 }
 
 XamlDiagnosticsFlavor ClassifyModernXamlHost(
@@ -2634,16 +2694,7 @@ bool IsModernXamlHostClassName(LPCWSTR className) {
 
 XamlDiagnosticsFlavor GetModernXamlHostFlavor(
     HWND window,
-    LPCWSTR className = nullptr) {
-    wchar_t resolvedClassName[128];
-    if (!className || IS_INTRESOURCE(className)) {
-        if (GetClassNameW(window, resolvedClassName,
-                          ARRAYSIZE(resolvedClassName)) <= 0) {
-            return XamlDiagnosticsFlavor::None;
-        }
-        className = resolvedClassName;
-    }
-
+    LPCWSTR className) {
     wchar_t parentClassName[128];
     LPCWSTR parentClassNamePointer = nullptr;
     if (_wcsicmp(
@@ -2665,7 +2716,6 @@ bool NeedsXamlDiagnosticsHostNotification(
     const XamlDiagnosticsConnectionState& state) {
     return !state.connected.load(std::memory_order_acquire) &&
            !state.blocked.load(std::memory_order_acquire) &&
-           !state.requestPending.load(std::memory_order_acquire) &&
            state.failureCount.load(std::memory_order_acquire) <
                kXamlDiagnosticsMaxAttempts;
 }
@@ -2926,7 +2976,8 @@ bool InitializeModernUi() {
              &g_microsoftUiXamlDiagnostics}) {
         state->connected.store(false, std::memory_order_release);
         state->blocked.store(false, std::memory_order_release);
-        state->requestPending.store(false, std::memory_order_release);
+        state->requestGeneration.store(0, std::memory_order_release);
+        state->processedGeneration.store(0, std::memory_order_release);
         state->failureCount.store(0, std::memory_order_release);
     }
     g_visualTreeWatcherGeneration.store(

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -96,23 +96,12 @@ The modern path supports both Windows.UI.Xaml and Microsoft.UI.Xaml content
 hosted by Explorer. Each named XAML Diagnostics connection allows one consumer,
 so another diagnostics-based customization tool, including Windows 11 Taskbar
 Styler or Windows 11 File Explorer Styler, can prevent this path from
-initializing. Connection attempts are scheduled outside the Windows loader
-  path; one managed worker retains requests that arrive while it is running,
-  tracks the Windows.UI.Xaml and Microsoft.UI.Xaml connections independently,
-  retries `ERROR_NOT_FOUND` during concurrent Explorer startup with bounded,
-  interruptible backoff, and later retries only the connection that was lost.
-  It doesn't add a module
-  reference: the worker is signaled to stop and joined before Windhawk removes
-  hooks. Asynchronous visual-tree watcher setup threads are tracked by handle
-  and joined at the same point, so the engine's single module reference remains
-  sufficient.
-  `Wh_ModAfterInit` covers XAML modules that are already loaded, while the
-  `LoadLibraryExW` hook covers modules loaded later, including the
-  `CoreMessagingXP.dll` static-import path used by
-  `Microsoft.Internal.FrameworkUdk.dll`.
-  A connection blocked with a successful return isn't retried automatically;
-  after startup backoff is exhausted, a newly loaded XAML module or an
-  established connection being disconnected provides the next opportunity.
+initializing. If Explorer's diagnostics endpoint isn't ready yet, the mod
+retries for about one minute during startup. Afterwards, it retries only when a
+relevant XAML module loads or an established connection is disconnected.
+Connections blocked by another diagnostics consumer aren't retried
+automatically. All connection work runs outside the Windows loader path and is
+stopped before the mod unloads.
 When Taskbar Styler is configured to alert on competing XAML Diagnostics
 consumers, enabling this path can show its confirmation dialog.
 The mod is injected only into `explorer.exe`. Start, Search, and some shell
@@ -1871,24 +1860,17 @@ enum class XamlDiagnosticsFlavor {
     Microsoft,
 };
 
-enum class XamlDiagnosticsRetry : unsigned char {
-    None = 0,
-    Windows = 1,
-    Microsoft = 2,
+struct XamlDiagnosticsRetry {
+    bool windows = false;
+    bool microsoft = false;
+
+    explicit operator bool() const {
+        return windows || microsoft;
+    }
 };
 
-XamlDiagnosticsRetry operator|(XamlDiagnosticsRetry left,
-                               XamlDiagnosticsRetry right) {
-    return static_cast<XamlDiagnosticsRetry>(
-        static_cast<unsigned char>(left) |
-        static_cast<unsigned char>(right));
-}
-
-bool HasXamlDiagnosticsRetry(XamlDiagnosticsRetry retries,
-                             XamlDiagnosticsRetry flavor) {
-    return (static_cast<unsigned char>(retries) &
-            static_cast<unsigned char>(flavor)) != 0;
-}
+constexpr int kInitialXamlDiagnosticsConnectionLimit = 10000;
+constexpr int kRetryXamlDiagnosticsConnectionLimit = 256;
 
 void RequestModernXamlDiagnosticsInitialization(
     XamlDiagnosticsFlavor retryFlavor = XamlDiagnosticsFlavor::None);
@@ -2354,7 +2336,8 @@ thread_local XamlDiagnosticsFlavor g_connectingXamlDiagnostics =
 
 HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
                               LPCWSTR connectionPrefix,
-                              XamlDiagnosticsFlavor flavor) {
+                              XamlDiagnosticsFlavor flavor,
+                              int connectionLimit) {
     const auto initialize =
         reinterpret_cast<InitializeXamlDiagnosticsEx_t>(
             GetProcAddress(xamlModule,
@@ -2377,7 +2360,7 @@ HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
     }
 
     HRESULT result = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
-    for (int index = 1; index <= 10000; ++index) {
+    for (int index = 1; index <= connectionLimit; ++index) {
         if (g_stoppingModernUi.load(std::memory_order_acquire)) {
             return HRESULT_FROM_WIN32(ERROR_CANCELLED);
         }
@@ -2400,8 +2383,11 @@ HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
     return result;
 }
 
-XamlDiagnosticsRetry EnsureModernXamlDiagnostics() {
-    XamlDiagnosticsRetry retries = XamlDiagnosticsRetry::None;
+XamlDiagnosticsRetry EnsureModernXamlDiagnostics(bool delayedRetry) {
+    XamlDiagnosticsRetry retries;
+    const int connectionLimit =
+        delayedRetry ? kRetryXamlDiagnosticsConnectionLimit
+                     : kInitialXamlDiagnosticsConnectionLimit;
     if (g_stoppingModernUi.load(std::memory_order_acquire) ||
         g_loadingXamlDiagnostics) {
         return retries;
@@ -2428,7 +2414,7 @@ XamlDiagnosticsRetry EnsureModernXamlDiagnostics() {
                     std::memory_order_acquire);
             const HRESULT result = InjectXamlDiagnostics(
                 module, L"VisualDiagConnection",
-                XamlDiagnosticsFlavor::Windows);
+                XamlDiagnosticsFlavor::Windows, connectionLimit);
             if (SUCCEEDED(result) &&
                 !g_stoppingModernUi.load(std::memory_order_acquire) &&
                 g_visualTreeWatcherGeneration.load(
@@ -2443,7 +2429,7 @@ XamlDiagnosticsRetry EnsureModernXamlDiagnostics() {
                        L"tool probably blocked the connection");
             } else if (result ==
                        HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
-                retries = retries | XamlDiagnosticsRetry::Windows;
+                retries.windows = true;
             } else if (result !=
                        HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
                 Wh_Log(L"Windows.UI.Xaml diagnostics failed: "
@@ -2465,7 +2451,7 @@ XamlDiagnosticsRetry EnsureModernXamlDiagnostics() {
                     std::memory_order_acquire);
             const HRESULT result = InjectXamlDiagnostics(
                 module, L"WinUIVisualDiagConnection",
-                XamlDiagnosticsFlavor::Microsoft);
+                XamlDiagnosticsFlavor::Microsoft, connectionLimit);
             if (SUCCEEDED(result) &&
                 !g_stoppingModernUi.load(std::memory_order_acquire) &&
                 g_visualTreeWatcherGeneration.load(
@@ -2480,7 +2466,7 @@ XamlDiagnosticsRetry EnsureModernXamlDiagnostics() {
                        L"tool probably blocked the connection");
             } else if (result ==
                        HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
-                retries = retries | XamlDiagnosticsRetry::Microsoft;
+                retries.microsoft = true;
             } else if (result !=
                        HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
                 Wh_Log(L"Microsoft.UI.Xaml diagnostics failed: "
@@ -2492,13 +2478,11 @@ XamlDiagnosticsRetry EnsureModernXamlDiagnostics() {
 }
 
 void ResetXamlDiagnosticsAttempts(XamlDiagnosticsRetry retries) {
-    if (HasXamlDiagnosticsRetry(
-            retries, XamlDiagnosticsRetry::Windows)) {
+    if (retries.windows) {
         g_windowsUiXamlDiagnosticsAttempted.store(
             false, std::memory_order_release);
     }
-    if (HasXamlDiagnosticsRetry(
-            retries, XamlDiagnosticsRetry::Microsoft)) {
+    if (retries.microsoft) {
         g_microsoftUiXamlDiagnosticsAttempted.store(
             false, std::memory_order_release);
     }
@@ -2523,11 +2507,11 @@ DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
         CoInitializeEx(nullptr, COINIT_MULTITHREADED);
     constexpr DWORD retryDelaysMs[] = {
         1000, 2000, 5000, 10000, 20000, 30000};
-    XamlDiagnosticsRetry retries = XamlDiagnosticsRetry::None;
+    XamlDiagnosticsRetry retries;
     size_t retryIndex = 0;
     for (;;) {
         const DWORD waitTimeout =
-            retries == XamlDiagnosticsRetry::None
+            !retries
                 ? INFINITE
                 : retryDelaysMs[retryIndex];
         const DWORD waitResult =
@@ -2536,19 +2520,21 @@ DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
             break;
         }
 
+        bool delayedRetry = false;
         if (waitResult == WAIT_OBJECT_0) {
             if (!g_xamlDiagnosticsRequestPending.exchange(
                     false, std::memory_order_acq_rel)) {
                 continue;
             }
-            // Preserve a scheduled startup retry when another flavor or a
-            // reconnect request wakes the worker in the meantime.
+            // An explicit wake is a genuine new opportunity. Preserve all
+            // pending flavors and intentionally restart their backoff ladder.
             ResetXamlDiagnosticsAttempts(retries);
             retryIndex = 0;
         } else if (waitResult == WAIT_TIMEOUT &&
-                   retries != XamlDiagnosticsRetry::None) {
+                   retries) {
             ResetXamlDiagnosticsAttempts(retries);
             ++retryIndex;
+            delayedRetry = true;
         } else {
             Wh_Log(L"XAML diagnostics worker wait failed: %u",
                    waitResult == WAIT_FAILED ? GetLastError()
@@ -2556,15 +2542,15 @@ DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
             break;
         }
 
-        retries = EnsureModernXamlDiagnostics();
-        if (retries != XamlDiagnosticsRetry::None) {
+        retries = EnsureModernXamlDiagnostics(delayedRetry);
+        if (retries) {
             if (retryIndex < ARRAYSIZE(retryDelaysMs)) {
                 Wh_Log(L"XAML diagnostics isn't ready; retrying in %u ms",
                        retryDelaysMs[retryIndex]);
             } else {
                 Wh_Log(L"XAML diagnostics remained unavailable after "
                        L"startup retries");
-                retries = XamlDiagnosticsRetry::None;
+                retries = {};
                 retryIndex = 0;
             }
         }

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -96,12 +96,13 @@ The modern path supports both Windows.UI.Xaml and Microsoft.UI.Xaml content
 hosted by Explorer. Each named XAML Diagnostics connection allows one consumer,
 so another diagnostics-based customization tool, including Windows 11 Taskbar
 Styler or Windows 11 File Explorer Styler, can prevent this path from
-initializing. The mod waits until supported XAML UI appears before connecting,
-retries when another host window or framework module appears, gives up after
-repeated hard failures, and doesn't retry while another diagnostics tool holds
-the connection. An established connection can be restored after its XAML host
-disappears. If the modern path can't be initialized, enabled classic menus and
-tooltips remain active.
+initializing. The mod waits until supported XAML UI appears before connecting;
+framework module loads only ask the worker to rescan existing hosts and never
+probe connection names from the loader call stack. It gives up after repeated
+hard failures or empty walks, and doesn't retry while another diagnostics tool
+holds the connection. An established connection can be restored after its XAML
+host disappears. If the modern path can't be initialized, enabled classic menus
+and tooltips remain active.
 When Taskbar Styler is configured to alert on competing XAML Diagnostics
 consumers, an intercepted connection attempt can show a confirmation dialog;
 if the tool blocks it by returning success, the walk stops and this mod marks
@@ -1877,9 +1878,9 @@ constexpr unsigned int kXamlDiagnosticsMaxEmptyWalks = 3;
 struct XamlDiagnosticsConnectionState {
     std::atomic_bool connected{false};
     std::atomic_bool blocked{false};
-    // Set by a host-window or module-load trigger to queue a worker attempt,
-    // and cleared by the worker when it picks the attempt up. Triggers that
-    // arrive while an attempt is in flight coalesce into the next one.
+    // Set by a host-window trigger to queue a worker attempt, and cleared by
+    // the worker when it picks the attempt up. Triggers that arrive while an
+    // attempt is in flight coalesce into the next one.
     std::atomic_bool pending{false};
     std::atomic_uint failureCount{0};
     std::atomic_uint emptyWalkCount{0};
@@ -1897,6 +1898,7 @@ bool CanAttemptXamlDiagnosticsConnection(
 
 bool RequestModernXamlDiagnosticsInitialization(
     XamlDiagnosticsFlavor flavor);
+void DiscoverExistingModernXamlHosts();
 void RearmXamlDiagnosticsConnection(
     XamlDiagnosticsFlavor flavor);
 
@@ -2352,6 +2354,7 @@ XamlDiagnosticsConnectionState g_microsoftUiXamlDiagnostics;
 std::mutex g_xamlDiagnosticsWorkerMutex;
 HANDLE g_xamlDiagnosticsWorkerThread;
 HANDLE g_xamlDiagnosticsWorkerWakeEvent;
+std::atomic_bool g_xamlDiagnosticsHostDiscoveryPending{false};
 thread_local XamlDiagnosticsFlavor g_connectingXamlDiagnostics =
     XamlDiagnosticsFlavor::None;
 
@@ -2525,15 +2528,25 @@ DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
         }
 
         // Each pending flag was stored with release ordering before its
-        // SetEvent, so the exchange observes every request that preceded the
-        // wake-up. A request that arrives while an attempt is in flight
-        // re-signals the event and is picked up on the next iteration.
+        // SetEvent, so the exchanges observe every request that preceded the
+        // wake-up. A request that arrives while work is in flight re-signals
+        // the event and is picked up on the next iteration.
+        const bool discoverHosts =
+            g_xamlDiagnosticsHostDiscoveryPending.exchange(
+                false, std::memory_order_acq_rel);
         const bool requestWindows =
             g_windowsUiXamlDiagnostics.pending.exchange(
                 false, std::memory_order_acq_rel);
         const bool requestMicrosoft =
             g_microsoftUiXamlDiagnostics.pending.exchange(
                 false, std::memory_order_acq_rel);
+
+        if (discoverHosts) {
+            // Module-load hooks only arm discovery. Enumerating windows here
+            // keeps that work out of the loader call stack, and a connection
+            // walk is queued only when a supported host actually exists.
+            DiscoverExistingModernXamlHosts();
+        }
         if (!requestWindows && !requestMicrosoft) {
             continue;
         }
@@ -2601,10 +2614,50 @@ bool RequestModernXamlDiagnosticsInitialization(
 
     // Store the request before signaling, so the worker's exchange observes
     // it when the event wakes the worker.
-    state->pending.store(true, std::memory_order_release);
+    const bool wasPending = state->pending.exchange(
+        true, std::memory_order_acq_rel);
     if (!SetEvent(g_xamlDiagnosticsWorkerWakeEvent)) {
+        const DWORD error = GetLastError();
+        if (!wasPending) {
+            state->pending.store(false, std::memory_order_release);
+        }
         Wh_Log(L"Couldn't signal the XAML diagnostics worker: %u",
-               GetLastError());
+               error);
+        return false;
+    }
+    return true;
+}
+
+bool RequestModernXamlHostDiscovery(
+    XamlDiagnosticsFlavor flavor) {
+    if (g_stoppingModernUi.load(std::memory_order_acquire)) {
+        return false;
+    }
+
+    XamlDiagnosticsConnectionState* state =
+        GetXamlDiagnosticsConnectionState(flavor);
+    if (!state || !CanAttemptXamlDiagnosticsConnection(*state)) {
+        return false;
+    }
+
+    std::lock_guard<std::mutex> guard(
+        g_xamlDiagnosticsWorkerMutex);
+    if (g_stoppingModernUi.load(std::memory_order_acquire) ||
+        !g_xamlDiagnosticsWorkerWakeEvent ||
+        !CanAttemptXamlDiagnosticsConnection(*state)) {
+        return false;
+    }
+
+    const bool wasPending =
+        g_xamlDiagnosticsHostDiscoveryPending.exchange(
+            true, std::memory_order_acq_rel);
+    if (!SetEvent(g_xamlDiagnosticsWorkerWakeEvent)) {
+        const DWORD error = GetLastError();
+        if (!wasPending) {
+            g_xamlDiagnosticsHostDiscoveryPending.store(
+                false, std::memory_order_release);
+        }
+        Wh_Log(L"Couldn't signal XAML host discovery: %u", error);
         return false;
     }
     return true;
@@ -2641,6 +2694,8 @@ void StopModernXamlDiagnosticsWorker() {
              &g_microsoftUiXamlDiagnostics}) {
         state->pending.store(false, std::memory_order_release);
     }
+    g_xamlDiagnosticsHostDiscoveryPending.store(
+        false, std::memory_order_release);
 }
 
 XamlDiagnosticsFlavor ClassifyModernXamlHost(
@@ -2822,10 +2877,11 @@ HMODULE WINAPI LoadLibraryExWHook(LPCWSTR fileName,
     if (module && !wasLoaded &&
         flavor != XamlDiagnosticsFlavor::None &&
         g_modernUiActive.load(std::memory_order_acquire)) {
-        // Only wake the worker here. Diagnostics initialization must not run
-        // from a library-loading call stack.
-        if (RequestModernXamlDiagnosticsInitialization(flavor)) {
-            Wh_Log(L"Loaded XAML diagnostics module: %s",
+        // A module load only asks the worker to rescan existing hosts. It
+        // must not enumerate windows or probe connection names from this
+        // library-loading call stack.
+        if (RequestModernXamlHostDiscovery(flavor)) {
+            Wh_Log(L"Loaded XAML diagnostics module; rescanning hosts: %s",
                    GetModuleFileNamePart(fileName));
         }
     }
@@ -3023,6 +3079,8 @@ bool InitializeModernUi() {
         state->failureCount.store(0, std::memory_order_release);
         state->emptyWalkCount.store(0, std::memory_order_release);
     }
+    g_xamlDiagnosticsHostDiscoveryPending.store(
+        false, std::memory_order_release);
     g_visualTreeWatcherGeneration.store(
         0, std::memory_order_release);
     g_tapSiteGeneration.store(

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -96,13 +96,10 @@ The modern path supports both Windows.UI.Xaml and Microsoft.UI.Xaml content
 hosted by Explorer. Each named XAML Diagnostics connection allows one consumer,
 so another diagnostics-based customization tool, including Windows 11 Taskbar
 Styler or Windows 11 File Explorer Styler, can prevent this path from
-initializing. The mod waits until supported XAML UI appears before connecting.
-Temporarily unavailable connections are retried when another host window or
-framework module appears; a burst of empty probes pauses attempts for a short
-time, and the next host or module event resumes them. Repeated hard failures
-are abandoned.
-Connections blocked by another diagnostics consumer aren't retried
-automatically. An established connection can be restored after its XAML host
+initializing. The mod waits until supported XAML UI appears before connecting,
+retries when another host window or framework module appears, gives up after
+repeated hard failures, and doesn't retry while another diagnostics tool holds
+the connection. An established connection can be restored after its XAML host
 disappears. If the modern path can't be initialized, enabled classic menus and
 tooltips remain active.
 When Taskbar Styler is configured to alert on competing XAML Diagnostics
@@ -1866,17 +1863,16 @@ enum class XamlDiagnosticsFlavor {
     Microsoft,
 };
 
-// DXamlCore allocates dense low connection indices. A larger walk only
-// multiplies probes while no diagnostics endpoint is registered, and with
-// Taskbar Styler or File Explorer Styler in alert mode each probe can raise
-// a modal dialog, so the bound stays small.
-constexpr int kXamlDiagnosticsConnectionLimit = 8;
+// The diagnostics endpoint name embeds a process-lifetime core ordinal that is
+// never reused, so a live endpoint can sit at a high index; the walk matches
+// the range the reference mods use. The cost of a failed walk is bounded by
+// kXamlDiagnosticsMaxEmptyWalks instead of the index range.
+constexpr int kXamlDiagnosticsConnectionLimit = 10000;
 constexpr unsigned int kXamlDiagnosticsMaxAttempts = 3;
-// Pause after five empty walks in one startup burst. A later host or module
-// event, or the cooldown window elapsing before one arrives, can resume
-// probing.
-constexpr unsigned int kXamlDiagnosticsMaxEmptyWalks = 5;
-constexpr uint64_t kXamlDiagnosticsEmptyWalkCooldownMilliseconds = 30'000;
+// Give up on a flavor after a few empty walks in one session. The latch is
+// cleared only when an established connection disconnects, so a flavor that
+// never registers an endpoint probes a bounded number of times per session.
+constexpr unsigned int kXamlDiagnosticsMaxEmptyWalks = 3;
 
 struct XamlDiagnosticsConnectionState {
     std::atomic_bool connected{false};
@@ -1887,55 +1883,19 @@ struct XamlDiagnosticsConnectionState {
     std::atomic_bool pending{false};
     std::atomic_uint failureCount{0};
     std::atomic_uint emptyWalkCount{0};
-    std::atomic_uint64_t lastEmptyWalkTick{0};
 };
 
-bool HasXamlDiagnosticsEmptyWalkBudget(
-    const XamlDiagnosticsConnectionState& state,
-    uint64_t currentTick) {
-    if (state.emptyWalkCount.load(std::memory_order_acquire) <
-        kXamlDiagnosticsMaxEmptyWalks) {
-        return true;
-    }
-
-    const uint64_t lastEmptyWalkTick =
-        state.lastEmptyWalkTick.load(std::memory_order_acquire);
-    return currentTick >= lastEmptyWalkTick &&
-           currentTick - lastEmptyWalkTick >=
-               kXamlDiagnosticsEmptyWalkCooldownMilliseconds;
-}
-
 bool CanAttemptXamlDiagnosticsConnection(
-    const XamlDiagnosticsConnectionState& state,
-    uint64_t currentTick) {
+    const XamlDiagnosticsConnectionState& state) {
     return !state.connected.load(std::memory_order_acquire) &&
            !state.blocked.load(std::memory_order_acquire) &&
            state.failureCount.load(std::memory_order_acquire) <
                kXamlDiagnosticsMaxAttempts &&
-           HasXamlDiagnosticsEmptyWalkBudget(state, currentTick);
+           state.emptyWalkCount.load(std::memory_order_acquire) <
+               kXamlDiagnosticsMaxEmptyWalks;
 }
 
-bool RefreshXamlDiagnosticsEmptyWalkBudget(
-    XamlDiagnosticsConnectionState& state,
-    uint64_t currentTick,
-    LPCWSTR displayName) {
-    if (!HasXamlDiagnosticsEmptyWalkBudget(state, currentTick)) {
-        return false;
-    }
-    if (state.emptyWalkCount.load(std::memory_order_acquire) <
-        kXamlDiagnosticsMaxEmptyWalks) {
-        return true;
-    }
-
-    state.lastEmptyWalkTick.store(0, std::memory_order_release);
-    state.emptyWalkCount.store(0, std::memory_order_release);
-    Wh_Log(L"Resuming %s diagnostics probes after the empty-walk "
-           L"cooldown",
-           displayName);
-    return true;
-}
-
-void RequestModernXamlDiagnosticsInitialization(
+bool RequestModernXamlDiagnosticsInitialization(
     XamlDiagnosticsFlavor flavor);
 void RearmXamlDiagnosticsConnection(
     XamlDiagnosticsFlavor flavor);
@@ -2455,7 +2415,7 @@ void EnsureXamlDiagnosticsConnection(
     LPCWSTR displayName,
     XamlDiagnosticsFlavor flavor) {
     if (g_stoppingModernUi.load(std::memory_order_acquire) ||
-        !CanAttemptXamlDiagnosticsConnection(state, GetTickCount64())) {
+        !CanAttemptXamlDiagnosticsConnection(state)) {
         return;
     }
 
@@ -2480,7 +2440,6 @@ void EnsureXamlDiagnosticsConnection(
             state.connected.store(true, std::memory_order_release);
             state.failureCount.store(0, std::memory_order_release);
             state.emptyWalkCount.store(0, std::memory_order_release);
-            state.lastEmptyWalkTick.store(0, std::memory_order_release);
             Wh_Log(L"Connected to %s diagnostics", displayName);
         } else if (g_tapSiteGeneration.load(
                        std::memory_order_acquire) > siteGeneration) {
@@ -2505,19 +2464,15 @@ void EnsureXamlDiagnosticsConnection(
                    displayName);
         }
     } else if (result == HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
-        state.lastEmptyWalkTick.store(
-            GetTickCount64(), std::memory_order_release);
         const unsigned int emptyWalkCount =
             state.emptyWalkCount.fetch_add(
                 1, std::memory_order_acq_rel) +
             1;
         if (emptyWalkCount >= kXamlDiagnosticsMaxEmptyWalks) {
             Wh_Log(L"%s diagnostics endpoint remained unavailable after "
-                   L"%u connection-name walks; pausing probe attempts "
-                   L"for %u seconds",
-                   displayName, emptyWalkCount,
-                   static_cast<unsigned int>(
-                       kXamlDiagnosticsEmptyWalkCooldownMilliseconds / 1000));
+                   L"%u connection-name walks; not probing again until "
+                   L"a disconnect",
+                   displayName, emptyWalkCount);
         } else {
             Wh_Log(L"%s diagnostics endpoint isn't registered yet "
                    L"(empty walk %u/%u)",
@@ -2614,42 +2569,34 @@ void RearmXamlDiagnosticsConnection(
     state->blocked.store(false, std::memory_order_release);
     state->failureCount.store(0, std::memory_order_release);
     state->emptyWalkCount.store(0, std::memory_order_release);
-    state->lastEmptyWalkTick.store(0, std::memory_order_release);
     state->pending.store(false, std::memory_order_release);
     // Publish the disconnected state last. A new host notification can only
     // enqueue a request after the state has been re-armed.
     state->connected.store(false, std::memory_order_release);
 }
 
-void RequestModernXamlDiagnosticsInitialization(
+bool RequestModernXamlDiagnosticsInitialization(
     XamlDiagnosticsFlavor flavor) {
     if (g_stoppingModernUi.load(std::memory_order_acquire)) {
-        return;
+        return false;
     }
 
     XamlDiagnosticsConnectionState* state =
         GetXamlDiagnosticsConnectionState(flavor);
     if (!state) {
-        return;
+        return false;
     }
 
-    const uint64_t currentTick = GetTickCount64();
-    if (!CanAttemptXamlDiagnosticsConnection(*state, currentTick)) {
-        return;
+    if (!CanAttemptXamlDiagnosticsConnection(*state)) {
+        return false;
     }
 
-    const LPCWSTR displayName =
-        flavor == XamlDiagnosticsFlavor::Windows
-            ? L"Windows.UI.Xaml"
-            : L"Microsoft.UI.Xaml";
     std::lock_guard<std::mutex> guard(
         g_xamlDiagnosticsWorkerMutex);
     if (g_stoppingModernUi.load(std::memory_order_acquire) ||
         !g_xamlDiagnosticsWorkerWakeEvent ||
-        !RefreshXamlDiagnosticsEmptyWalkBudget(
-            *state, currentTick, displayName) ||
-        !CanAttemptXamlDiagnosticsConnection(*state, currentTick)) {
-        return;
+        !CanAttemptXamlDiagnosticsConnection(*state)) {
+        return false;
     }
 
     // Store the request before signaling, so the worker's exchange observes
@@ -2658,7 +2605,9 @@ void RequestModernXamlDiagnosticsInitialization(
     if (!SetEvent(g_xamlDiagnosticsWorkerWakeEvent)) {
         Wh_Log(L"Couldn't signal the XAML diagnostics worker: %u",
                GetLastError());
+        return false;
     }
+    return true;
 }
 
 void StopModernXamlDiagnosticsWorker() {
@@ -2753,11 +2702,8 @@ XamlDiagnosticsFlavor GetModernXamlHostFlavor(
 }
 
 bool NeedsAnyXamlDiagnosticsHostNotification() {
-    const uint64_t currentTick = GetTickCount64();
-    return CanAttemptXamlDiagnosticsConnection(
-               g_windowsUiXamlDiagnostics, currentTick) ||
-           CanAttemptXamlDiagnosticsConnection(
-               g_microsoftUiXamlDiagnostics, currentTick);
+    return CanAttemptXamlDiagnosticsConnection(g_windowsUiXamlDiagnostics) ||
+           CanAttemptXamlDiagnosticsConnection(g_microsoftUiXamlDiagnostics);
 }
 
 void NotifyModernXamlHost(HWND window, LPCWSTR className = nullptr) {
@@ -2783,8 +2729,9 @@ void NotifyModernXamlHost(HWND window, LPCWSTR className = nullptr) {
 
     // Only signal the worker here. XAML Diagnostics and COM initialization
     // must not run inside a window-creation hook.
-    RequestModernXamlDiagnosticsInitialization(flavor);
-    Wh_Log(L"Found XAML host window: %s", className);
+    if (RequestModernXamlDiagnosticsInitialization(flavor)) {
+        Wh_Log(L"Found XAML host window: %s", className);
+    }
 }
 
 BOOL CALLBACK EnumExistingModernXamlHostWindow(HWND window, LPARAM) {
@@ -2877,9 +2824,10 @@ HMODULE WINAPI LoadLibraryExWHook(LPCWSTR fileName,
         g_modernUiActive.load(std::memory_order_acquire)) {
         // Only wake the worker here. Diagnostics initialization must not run
         // from a library-loading call stack.
-        RequestModernXamlDiagnosticsInitialization(flavor);
-        Wh_Log(L"Loaded XAML diagnostics module: %s",
-               GetModuleFileNamePart(fileName));
+        if (RequestModernXamlDiagnosticsInitialization(flavor)) {
+            Wh_Log(L"Loaded XAML diagnostics module: %s",
+                   GetModuleFileNamePart(fileName));
+        }
     }
     return module;
 }
@@ -3074,7 +3022,6 @@ bool InitializeModernUi() {
         state->pending.store(false, std::memory_order_release);
         state->failureCount.store(0, std::memory_order_release);
         state->emptyWalkCount.store(0, std::memory_order_release);
-        state->lastEmptyWalkTick.store(0, std::memory_order_release);
     }
     g_visualTreeWatcherGeneration.store(
         0, std::memory_order_release);

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -96,13 +96,11 @@ The modern path supports both Windows.UI.Xaml and Microsoft.UI.Xaml content
 hosted by Explorer. Each named XAML Diagnostics connection allows one consumer,
 so another diagnostics-based customization tool, including Windows 11 Taskbar
 Styler or Windows 11 File Explorer Styler, can prevent this path from
-initializing. The mod waits until supported XAML UI appears before connecting;
-framework module loads only ask the worker to rescan existing hosts and never
-probe connection names from the loader call stack. It gives up after repeated
-hard failures or empty walks, and doesn't retry while another diagnostics tool
-holds the connection. An established connection can be restored after its XAML
-host disappears. If the modern path can't be initialized, enabled classic menus
-and tooltips remain active.
+initializing. The mod connects when supported XAML UI appears, gives up after
+repeated failures, and doesn't retry while another diagnostics tool holds the
+connection. An established connection can be restored after its XAML host
+disappears. If the modern path can't be initialized, enabled classic menus and
+tooltips remain active.
 When Taskbar Styler is configured to alert on competing XAML Diagnostics
 consumers, an intercepted connection attempt can show a confirmation dialog;
 if the tool blocks it by returning success, the walk stops and this mod marks
@@ -2527,26 +2525,27 @@ DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
             break;
         }
 
+        // Run discovery before consuming flavor requests so a matching host
+        // coalesces into this iteration instead of scheduling a duplicate
+        // connection walk for the next one.
+        if (g_xamlDiagnosticsHostDiscoveryPending.exchange(
+                false, std::memory_order_acq_rel)) {
+            // Module-load hooks only arm discovery. Enumerating windows here
+            // keeps that work out of the loader call stack, and a connection
+            // walk is queued only when a supported host actually exists.
+            DiscoverExistingModernXamlHosts();
+        }
+
         // Each pending flag was stored with release ordering before its
         // SetEvent, so the exchanges observe every request that preceded the
         // wake-up. A request that arrives while work is in flight re-signals
         // the event and is picked up on the next iteration.
-        const bool discoverHosts =
-            g_xamlDiagnosticsHostDiscoveryPending.exchange(
-                false, std::memory_order_acq_rel);
         const bool requestWindows =
             g_windowsUiXamlDiagnostics.pending.exchange(
                 false, std::memory_order_acq_rel);
         const bool requestMicrosoft =
             g_microsoftUiXamlDiagnostics.pending.exchange(
                 false, std::memory_order_acq_rel);
-
-        if (discoverHosts) {
-            // Module-load hooks only arm discovery. Enumerating windows here
-            // keeps that work out of the loader call stack, and a connection
-            // walk is queued only when a supported host actually exists.
-            DiscoverExistingModernXamlHosts();
-        }
         if (!requestWindows && !requestMicrosoft) {
             continue;
         }

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -1866,8 +1866,10 @@ enum class XamlDiagnosticsFlavor {
 };
 
 // DXamlCore allocates dense low connection indices. A larger walk only
-// multiplies probes while no diagnostics endpoint is registered.
-constexpr int kXamlDiagnosticsConnectionLimit = 64;
+// multiplies probes while no diagnostics endpoint is registered, and with
+// Taskbar Styler or File Explorer Styler in alert mode each probe can raise
+// a modal dialog, so the bound stays small.
+constexpr int kXamlDiagnosticsConnectionLimit = 8;
 constexpr unsigned int kXamlDiagnosticsMaxAttempts = 3;
 // Pause after five empty walks in one startup burst. A later host or module
 // event, or the cooldown expiring, can resume probing.
@@ -1891,7 +1893,7 @@ struct XamlDiagnosticsConnectionState {
 
 bool HasXamlDiagnosticsEmptyWalkBudget(
     const XamlDiagnosticsConnectionState& state,
-    uint64_t currentTick = GetTickCount64()) {
+    uint64_t currentTick) {
     if (state.emptyWalkCount.load(std::memory_order_acquire) <
         kXamlDiagnosticsMaxEmptyWalks) {
         return true;
@@ -1906,7 +1908,7 @@ bool HasXamlDiagnosticsEmptyWalkBudget(
 
 bool CanAttemptXamlDiagnosticsConnection(
     const XamlDiagnosticsConnectionState& state,
-    uint64_t currentTick = GetTickCount64()) {
+    uint64_t currentTick) {
     return !state.connected.load(std::memory_order_acquire) &&
            !state.blocked.load(std::memory_order_acquire) &&
            state.failureCount.load(std::memory_order_acquire) <
@@ -1916,7 +1918,7 @@ bool CanAttemptXamlDiagnosticsConnection(
 
 bool IsXamlDiagnosticsFlavorCoolingDown(
     const XamlDiagnosticsConnectionState& state,
-    uint64_t currentTick = GetTickCount64()) {
+    uint64_t currentTick) {
     return state.emptyWalkCount.load(std::memory_order_acquire) >=
                kXamlDiagnosticsMaxEmptyWalks &&
            !HasXamlDiagnosticsEmptyWalkBudget(state, currentTick);
@@ -1941,7 +1943,7 @@ bool RefreshXamlDiagnosticsEmptyWalkBudget(
     return true;
 }
 
-bool RequestModernXamlDiagnosticsInitialization(
+void RequestModernXamlDiagnosticsInitialization(
     XamlDiagnosticsFlavor flavor);
 void RearmXamlDiagnosticsConnection(
     XamlDiagnosticsFlavor flavor);
@@ -2451,7 +2453,7 @@ void EnsureXamlDiagnosticsConnection(
     LPCWSTR displayName,
     XamlDiagnosticsFlavor flavor) {
     if (g_stoppingModernUi.load(std::memory_order_acquire) ||
-        !CanAttemptXamlDiagnosticsConnection(state)) {
+        !CanAttemptXamlDiagnosticsConnection(state, GetTickCount64())) {
         return;
     }
 
@@ -2716,44 +2718,38 @@ void RearmXamlDiagnosticsConnection(
     state->connected.store(false, std::memory_order_release);
 }
 
-bool RequestModernXamlDiagnosticsInitialization(
+void RequestModernXamlDiagnosticsInitialization(
     XamlDiagnosticsFlavor flavor) {
     if (g_stoppingModernUi.load(std::memory_order_acquire)) {
-        return false;
+        return;
     }
 
     XamlDiagnosticsConnectionState* state =
         GetXamlDiagnosticsConnectionState(flavor);
     if (!state) {
-        return false;
+        return;
     }
 
-    if (!CanAttemptXamlDiagnosticsConnection(*state)) {
-        return false;
+    const uint64_t currentTick = GetTickCount64();
+    if (!CanAttemptXamlDiagnosticsConnection(*state, currentTick)) {
+        return;
     }
 
     std::lock_guard<std::mutex> guard(
         g_xamlDiagnosticsWorkerMutex);
-    const uint64_t currentTick = GetTickCount64();
     if (g_stoppingModernUi.load(std::memory_order_acquire) ||
         !g_xamlDiagnosticsWorkerWakeEvent ||
         !RefreshXamlDiagnosticsEmptyWalkBudget(*state, currentTick) ||
         !CanAttemptXamlDiagnosticsConnection(*state, currentTick)) {
-        return false;
+        return;
     }
 
-    const unsigned int previousGeneration =
-        state->requestGeneration.fetch_add(
-            1, std::memory_order_acq_rel);
-    const bool firstPendingRequest =
-        previousGeneration ==
-        state->processedGeneration.load(std::memory_order_acquire);
+    state->requestGeneration.fetch_add(
+        1, std::memory_order_acq_rel);
     if (!SetEvent(g_xamlDiagnosticsWorkerWakeEvent)) {
         Wh_Log(L"Couldn't signal the XAML diagnostics worker: %u",
                GetLastError());
-        return false;
     }
-    return firstPendingRequest;
 }
 
 void StopModernXamlDiagnosticsWorker() {
@@ -2850,8 +2846,11 @@ XamlDiagnosticsFlavor GetModernXamlHostFlavor(
 }
 
 bool NeedsAnyXamlDiagnosticsHostNotification() {
-    return CanAttemptXamlDiagnosticsConnection(g_windowsUiXamlDiagnostics) ||
-           CanAttemptXamlDiagnosticsConnection(g_microsoftUiXamlDiagnostics);
+    const uint64_t currentTick = GetTickCount64();
+    return CanAttemptXamlDiagnosticsConnection(
+               g_windowsUiXamlDiagnostics, currentTick) ||
+           CanAttemptXamlDiagnosticsConnection(
+               g_microsoftUiXamlDiagnostics, currentTick);
 }
 
 void NotifyModernXamlHost(HWND window, LPCWSTR className = nullptr) {
@@ -2877,11 +2876,8 @@ void NotifyModernXamlHost(HWND window, LPCWSTR className = nullptr) {
 
     // Only signal the worker here. XAML Diagnostics and COM initialization
     // must not run inside a window-creation hook.
-    const bool queuedFirstRequest =
-        RequestModernXamlDiagnosticsInitialization(flavor);
-    if (queuedFirstRequest) {
-        Wh_Log(L"Found XAML host window: %s", className);
-    }
+    RequestModernXamlDiagnosticsInitialization(flavor);
+    Wh_Log(L"Found XAML host window: %s", className);
 }
 
 BOOL CALLBACK EnumExistingModernXamlHostWindow(HWND window, LPARAM) {
@@ -2967,12 +2963,9 @@ HMODULE WINAPI LoadLibraryExWHook(LPCWSTR fileName,
         g_modernUiActive.load(std::memory_order_acquire)) {
         // Only wake the worker here. Diagnostics initialization must not run
         // from a library-loading call stack.
-        const bool queuedFirstRequest =
-            RequestModernXamlDiagnosticsInitialization(flavor);
-        if (queuedFirstRequest) {
-            Wh_Log(L"Loaded XAML diagnostics module: %s",
-                   GetModuleFileNamePart(fileName));
-        }
+        RequestModernXamlDiagnosticsInitialization(flavor);
+        Wh_Log(L"Loaded XAML diagnostics module: %s",
+               GetModuleFileNamePart(fileName));
     }
     return module;
 }
@@ -3303,25 +3296,26 @@ bool HookModernXamlHostCreation() {
     }
 
     HMODULE user32Module = GetModuleHandleW(L"user32.dll");
+    if (user32Module) {
+        const auto createWindowInBand =
+            reinterpret_cast<CreateWindowInBand_t>(
+                GetProcAddress(user32Module, "CreateWindowInBand"));
+        if (createWindowInBand) {
+            InstallHook(
+                createWindowInBand, CreateWindowInBandHook,
+                &g_originalCreateWindowInBand,
+                L"CreateWindowInBand");
+        }
 
-    const auto createWindowInBand =
-        reinterpret_cast<CreateWindowInBand_t>(
-            GetProcAddress(user32Module, "CreateWindowInBand"));
-    if (createWindowInBand) {
-        InstallHook(
-            createWindowInBand, CreateWindowInBandHook,
-            &g_originalCreateWindowInBand,
-            L"CreateWindowInBand");
-    }
-
-    const auto createWindowInBandEx =
-        reinterpret_cast<CreateWindowInBandEx_t>(
-            GetProcAddress(user32Module, "CreateWindowInBandEx"));
-    if (createWindowInBandEx) {
-        InstallHook(
-            createWindowInBandEx, CreateWindowInBandExHook,
-            &g_originalCreateWindowInBandEx,
-            L"CreateWindowInBandEx");
+        const auto createWindowInBandEx =
+            reinterpret_cast<CreateWindowInBandEx_t>(
+                GetProcAddress(user32Module, "CreateWindowInBandEx"));
+        if (createWindowInBandEx) {
+            InstallHook(
+                createWindowInBandEx, CreateWindowInBandExHook,
+                &g_originalCreateWindowInBandEx,
+                L"CreateWindowInBandEx");
+        }
     }
     return true;
 }

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2577,7 +2577,13 @@ void RetryXamlDiagnosticsAfterCooldown() {
     for (XamlDiagnosticsConnectionState* state : {
              &g_windowsUiXamlDiagnostics,
              &g_microsoftUiXamlDiagnostics}) {
-        if (!CanAttemptXamlDiagnosticsConnection(*state, currentTick) ||
+        // Only a flavor that exhausted its empty-walk budget scheduled this
+        // timeout; one that hasn't is still waiting for its first host or
+        // module trigger, and probing it here would spend its walk budget on
+        // a connection nothing asked for.
+        if (state->emptyWalkCount.load(std::memory_order_acquire) <
+                kXamlDiagnosticsMaxEmptyWalks ||
+            !CanAttemptXamlDiagnosticsConnection(*state, currentTick) ||
             state->cooldownRetryCount.load(std::memory_order_acquire) >=
                 kXamlDiagnosticsMaxCooldownRetries) {
             continue;

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -97,9 +97,10 @@ hosted by Explorer. Each named XAML Diagnostics connection allows one consumer,
 so another diagnostics-based customization tool, including Windows 11 Taskbar
 Styler or Windows 11 File Explorer Styler, can prevent this path from
 initializing. The mod waits until supported XAML UI appears before connecting.
-Temporarily unavailable connections are retried with bounded pauses; after
-those automatic retries are exhausted, a later host window or module load can
-still trigger another attempt. Repeated hard failures are abandoned.
+Temporarily unavailable connections are retried when another host window or
+framework module appears; a burst of empty probes pauses attempts for a short
+time, and the next host or module event resumes them. Repeated hard failures
+are abandoned.
 Connections blocked by another diagnostics consumer aren't retried
 automatically. An established connection can be restored after its XAML host
 disappears. If the modern path can't be initialized, enabled classic menus and
@@ -1872,22 +1873,20 @@ enum class XamlDiagnosticsFlavor {
 constexpr int kXamlDiagnosticsConnectionLimit = 8;
 constexpr unsigned int kXamlDiagnosticsMaxAttempts = 3;
 // Pause after five empty walks in one startup burst. A later host or module
-// event, or the cooldown expiring, can resume probing.
+// event, or the cooldown window elapsing before one arrives, can resume
+// probing.
 constexpr unsigned int kXamlDiagnosticsMaxEmptyWalks = 5;
 constexpr uint64_t kXamlDiagnosticsEmptyWalkCooldownMilliseconds = 30'000;
-// The worker retries a cooling-down flavor on its own after each cooldown, but
-// stops after this many rounds so a permanently absent XAML core doesn't turn
-// into an endless 30-second polling loop.
-constexpr unsigned int kXamlDiagnosticsMaxCooldownRetries = 3;
 
 struct XamlDiagnosticsConnectionState {
     std::atomic_bool connected{false};
     std::atomic_bool blocked{false};
-    std::atomic_uint requestGeneration{0};
-    std::atomic_uint processedGeneration{0};
+    // Set by a host-window or module-load trigger to queue a worker attempt,
+    // and cleared by the worker when it picks the attempt up. Triggers that
+    // arrive while an attempt is in flight coalesce into the next one.
+    std::atomic_bool pending{false};
     std::atomic_uint failureCount{0};
     std::atomic_uint emptyWalkCount{0};
-    std::atomic_uint cooldownRetryCount{0};
     std::atomic_uint64_t lastEmptyWalkTick{0};
 };
 
@@ -1916,17 +1915,10 @@ bool CanAttemptXamlDiagnosticsConnection(
            HasXamlDiagnosticsEmptyWalkBudget(state, currentTick);
 }
 
-bool IsXamlDiagnosticsFlavorCoolingDown(
-    const XamlDiagnosticsConnectionState& state,
-    uint64_t currentTick) {
-    return state.emptyWalkCount.load(std::memory_order_acquire) >=
-               kXamlDiagnosticsMaxEmptyWalks &&
-           !HasXamlDiagnosticsEmptyWalkBudget(state, currentTick);
-}
-
 bool RefreshXamlDiagnosticsEmptyWalkBudget(
     XamlDiagnosticsConnectionState& state,
-    uint64_t currentTick) {
+    uint64_t currentTick,
+    LPCWSTR displayName) {
     if (!HasXamlDiagnosticsEmptyWalkBudget(state, currentTick)) {
         return false;
     }
@@ -1937,9 +1929,9 @@ bool RefreshXamlDiagnosticsEmptyWalkBudget(
 
     state.lastEmptyWalkTick.store(0, std::memory_order_release);
     state.emptyWalkCount.store(0, std::memory_order_release);
-    state.cooldownRetryCount.store(0, std::memory_order_release);
-    Wh_Log(L"Resuming XAML diagnostics probes after the empty-walk "
-           L"cooldown");
+    Wh_Log(L"Resuming %s diagnostics probes after the empty-walk "
+           L"cooldown",
+           displayName);
     return true;
 }
 
@@ -2221,6 +2213,10 @@ std::optional<std::vector<winrt::com_ptr<VisualTreeWatcher>>>
         g_visualTreeWatchers{std::in_place};
 std::atomic_bool g_stoppingModernUi{false};
 std::atomic_uint64_t g_visualTreeWatcherGeneration;
+// Bumped whenever the XAML core hands this module's TAP a site. Lets the
+// connection attempt tell "the TAP ran but failed to create a watcher" apart
+// from "a competing consumer returned success without loading the TAP".
+std::atomic_uint64_t g_tapSiteGeneration;
 
 bool RemoveVisualTreeWatcher(VisualTreeWatcher* watcher) {
     std::lock_guard<std::mutex> guard(g_visualTreeWatchersMutex);
@@ -2282,6 +2278,12 @@ public:
             XamlDiagnosticsFlavor::None) {
             m_flavor = g_connectingXamlDiagnostics;
         }
+
+        // Count the site handoff so EnsureXamlDiagnosticsConnection can
+        // distinguish a watcher-creation failure on our side from a competing
+        // consumer that never loads this TAP.
+        g_tapSiteGeneration.fetch_add(
+            1, std::memory_order_release);
 
         // Balance the reference added when XAML Diagnostics loads this module.
         if (HMODULE module = GetCurrentModuleHandle()) {
@@ -2465,6 +2467,8 @@ void EnsureXamlDiagnosticsConnection(
 
     const uint64_t watcherGeneration =
         g_visualTreeWatcherGeneration.load(std::memory_order_acquire);
+    const uint64_t siteGeneration =
+        g_tapSiteGeneration.load(std::memory_order_acquire);
     const HRESULT result = InjectXamlDiagnostics(
         module, connectionPrefix, flavor);
     if (SUCCEEDED(result)) {
@@ -2476,13 +2480,24 @@ void EnsureXamlDiagnosticsConnection(
             state.connected.store(true, std::memory_order_release);
             state.failureCount.store(0, std::memory_order_release);
             state.emptyWalkCount.store(0, std::memory_order_release);
-            state.cooldownRetryCount.store(0, std::memory_order_release);
             state.lastEmptyWalkTick.store(0, std::memory_order_release);
             Wh_Log(L"Connected to %s diagnostics", displayName);
+        } else if (g_tapSiteGeneration.load(
+                       std::memory_order_acquire) > siteGeneration) {
+            // The endpoint loaded this module and called SetSite, but no
+            // watcher was created — a failure on our side, so keep it
+            // retryable like a hard failure.
+            const unsigned int failureCount =
+                state.failureCount.fetch_add(
+                    1, std::memory_order_acq_rel) +
+                1;
+            Wh_Log(L"%s diagnostics returned success but couldn't create "
+                   L"a watcher (attempt %u/%u)",
+                   displayName, failureCount,
+                   kXamlDiagnosticsMaxAttempts);
         } else {
             // A competing diagnostics hook can return success without
-            // allowing this TAP to create a watcher. Don't prompt or probe
-            // again.
+            // loading this TAP. Don't prompt or probe again.
             state.blocked.store(true, std::memory_order_release);
             Wh_Log(L"%s diagnostics returned success without creating a "
                    L"watcher; another diagnostics tool probably blocked "
@@ -2498,7 +2513,7 @@ void EnsureXamlDiagnosticsConnection(
             1;
         if (emptyWalkCount >= kXamlDiagnosticsMaxEmptyWalks) {
             Wh_Log(L"%s diagnostics endpoint remained unavailable after "
-                   L"%u connection-name walks; pausing automatic attempts "
+                   L"%u connection-name walks; pausing probe attempts "
                    L"for %u seconds",
                    displayName, emptyWalkCount,
                    static_cast<unsigned int>(
@@ -2537,97 +2552,14 @@ void EnsureModernXamlDiagnostics(bool requestWindows,
     }
 }
 
-bool AnyXamlDiagnosticsFlavorCoolingDown(uint64_t currentTick) {
-    return IsXamlDiagnosticsFlavorCoolingDown(
-               g_windowsUiXamlDiagnostics, currentTick) ||
-           IsXamlDiagnosticsFlavorCoolingDown(
-               g_microsoftUiXamlDiagnostics, currentTick);
-}
-
-DWORD XamlDiagnosticsWorkerTimeout(uint64_t currentTick) {
-    if (!AnyXamlDiagnosticsFlavorCoolingDown(currentTick)) {
-        return INFINITE;
-    }
-
-    DWORD timeout = INFINITE;
-    for (const XamlDiagnosticsConnectionState* state : {
-             &g_windowsUiXamlDiagnostics,
-             &g_microsoftUiXamlDiagnostics}) {
-        if (!IsXamlDiagnosticsFlavorCoolingDown(*state, currentTick)) {
-            continue;
-        }
-
-        const uint64_t lastEmptyWalkTick =
-            state->lastEmptyWalkTick.load(std::memory_order_acquire);
-        const uint64_t elapsed =
-            currentTick >= lastEmptyWalkTick
-                ? currentTick - lastEmptyWalkTick
-                : 0;
-        const uint64_t remaining =
-            kXamlDiagnosticsEmptyWalkCooldownMilliseconds - elapsed;
-        const DWORD candidate =
-            static_cast<DWORD>(remaining > 0 ? remaining : 1);
-        if (candidate < timeout) {
-            timeout = candidate;
-        }
-    }
-    return timeout;
-}
-
-void RetryXamlDiagnosticsAfterCooldown() {
-    const uint64_t currentTick = GetTickCount64();
-    for (XamlDiagnosticsConnectionState* state : {
-             &g_windowsUiXamlDiagnostics,
-             &g_microsoftUiXamlDiagnostics}) {
-        // Only a flavor that exhausted its empty-walk budget scheduled this
-        // timeout; one that hasn't is still waiting for its first host or
-        // module trigger, and probing it here would spend its walk budget on
-        // a connection nothing asked for.
-        if (state->emptyWalkCount.load(std::memory_order_acquire) <
-                kXamlDiagnosticsMaxEmptyWalks ||
-            !CanAttemptXamlDiagnosticsConnection(*state, currentTick) ||
-            state->cooldownRetryCount.load(std::memory_order_acquire) >=
-                kXamlDiagnosticsMaxCooldownRetries) {
-            continue;
-        }
-
-        // The cooldown elapsed without a new host or module event, so retry
-        // this flavor once. Count the retry before the attempt; a successful
-        // connection resets the count.
-        state->cooldownRetryCount.fetch_add(1, std::memory_order_acq_rel);
-        const LPCWSTR displayName =
-            state == &g_windowsUiXamlDiagnostics ? L"Windows.UI.Xaml"
-                                                 : L"Microsoft.UI.Xaml";
-        Wh_Log(L"Retrying %s diagnostics after the empty-walk cooldown",
-               displayName);
-        if (state == &g_windowsUiXamlDiagnostics) {
-            EnsureXamlDiagnosticsConnection(
-                *state, L"Windows.UI.Xaml.dll", L"VisualDiagConnection",
-                L"Windows.UI.Xaml", XamlDiagnosticsFlavor::Windows);
-        } else {
-            EnsureXamlDiagnosticsConnection(
-                *state, L"Microsoft.Internal.FrameworkUdk.dll",
-                L"WinUIVisualDiagConnection", L"Microsoft.UI.Xaml",
-                XamlDiagnosticsFlavor::Microsoft);
-        }
-    }
-}
-
 DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
     const HANDLE wakeEvent = static_cast<HANDLE>(parameter);
     const HRESULT initializeResult =
         CoInitializeEx(nullptr, COINIT_MULTITHREADED);
     for (;;) {
-        const uint64_t waitStartedTick = GetTickCount64();
-        const DWORD waitResult = WaitForSingleObject(
-            wakeEvent, XamlDiagnosticsWorkerTimeout(waitStartedTick));
+        const DWORD waitResult = WaitForSingleObject(wakeEvent, INFINITE);
         if (g_stoppingModernUi.load(std::memory_order_acquire)) {
             break;
-        }
-
-        if (waitResult == WAIT_TIMEOUT) {
-            RetryXamlDiagnosticsAfterCooldown();
-            continue;
         }
 
         if (waitResult != WAIT_OBJECT_0) {
@@ -2637,47 +2569,21 @@ DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
             break;
         }
 
-        unsigned int windowsGeneration;
-        unsigned int microsoftGeneration;
-        {
-            // RequestModernXamlDiagnosticsInitialization increments a
-            // generation and signals the event while holding this mutex.
-            // Taking the mutex here ensures the snapshot includes the
-            // generation associated with the wake-up.
-            std::lock_guard<std::mutex> guard(
-                g_xamlDiagnosticsWorkerMutex);
-            windowsGeneration =
-                g_windowsUiXamlDiagnostics.requestGeneration.load(
-                    std::memory_order_acquire);
-            microsoftGeneration =
-                g_microsoftUiXamlDiagnostics.requestGeneration.load(
-                    std::memory_order_acquire);
-        }
-
+        // Each pending flag was stored with release ordering before its
+        // SetEvent, so the exchange observes every request that preceded the
+        // wake-up. A request that arrives while an attempt is in flight
+        // re-signals the event and is picked up on the next iteration.
         const bool requestWindows =
-            windowsGeneration !=
-            g_windowsUiXamlDiagnostics.processedGeneration.load(
-                std::memory_order_acquire);
+            g_windowsUiXamlDiagnostics.pending.exchange(
+                false, std::memory_order_acq_rel);
         const bool requestMicrosoft =
-            microsoftGeneration !=
-            g_microsoftUiXamlDiagnostics.processedGeneration.load(
-                std::memory_order_acquire);
+            g_microsoftUiXamlDiagnostics.pending.exchange(
+                false, std::memory_order_acq_rel);
         if (!requestWindows && !requestMicrosoft) {
             continue;
         }
 
         EnsureModernXamlDiagnostics(requestWindows, requestMicrosoft);
-        if (requestWindows) {
-            g_windowsUiXamlDiagnostics.processedGeneration.store(
-                windowsGeneration, std::memory_order_release);
-        }
-        if (requestMicrosoft) {
-            g_microsoftUiXamlDiagnostics.processedGeneration.store(
-                microsoftGeneration, std::memory_order_release);
-        }
-
-        // A request that arrived after the snapshot already left the
-        // auto-reset event signaled, so the next wait handles its generation.
     }
 
     if (SUCCEEDED(initializeResult)) {
@@ -2708,13 +2614,10 @@ void RearmXamlDiagnosticsConnection(
     state->blocked.store(false, std::memory_order_release);
     state->failureCount.store(0, std::memory_order_release);
     state->emptyWalkCount.store(0, std::memory_order_release);
-    state->cooldownRetryCount.store(0, std::memory_order_release);
     state->lastEmptyWalkTick.store(0, std::memory_order_release);
-    state->processedGeneration.store(
-        state->requestGeneration.load(std::memory_order_acquire),
-        std::memory_order_release);
+    state->pending.store(false, std::memory_order_release);
     // Publish the disconnected state last. A new host notification can only
-    // enqueue a generation after the old generations have been synchronized.
+    // enqueue a request after the state has been re-armed.
     state->connected.store(false, std::memory_order_release);
 }
 
@@ -2735,17 +2638,23 @@ void RequestModernXamlDiagnosticsInitialization(
         return;
     }
 
+    const LPCWSTR displayName =
+        flavor == XamlDiagnosticsFlavor::Windows
+            ? L"Windows.UI.Xaml"
+            : L"Microsoft.UI.Xaml";
     std::lock_guard<std::mutex> guard(
         g_xamlDiagnosticsWorkerMutex);
     if (g_stoppingModernUi.load(std::memory_order_acquire) ||
         !g_xamlDiagnosticsWorkerWakeEvent ||
-        !RefreshXamlDiagnosticsEmptyWalkBudget(*state, currentTick) ||
+        !RefreshXamlDiagnosticsEmptyWalkBudget(
+            *state, currentTick, displayName) ||
         !CanAttemptXamlDiagnosticsConnection(*state, currentTick)) {
         return;
     }
 
-    state->requestGeneration.fetch_add(
-        1, std::memory_order_acq_rel);
+    // Store the request before signaling, so the worker's exchange observes
+    // it when the event wakes the worker.
+    state->pending.store(true, std::memory_order_release);
     if (!SetEvent(g_xamlDiagnosticsWorkerWakeEvent)) {
         Wh_Log(L"Couldn't signal the XAML diagnostics worker: %u",
                GetLastError());
@@ -2781,9 +2690,7 @@ void StopModernXamlDiagnosticsWorker() {
     for (XamlDiagnosticsConnectionState* state : {
              &g_windowsUiXamlDiagnostics,
              &g_microsoftUiXamlDiagnostics}) {
-        state->processedGeneration.store(
-            state->requestGeneration.load(std::memory_order_acquire),
-            std::memory_order_release);
+        state->pending.store(false, std::memory_order_release);
     }
 }
 
@@ -2908,7 +2815,14 @@ BOOL CALLBACK EnumExistingModernXamlTopLevelWindow(HWND window, LPARAM) {
     }
 
     NotifyModernXamlHost(window);
-    EnumChildWindows(window, EnumExistingModernXamlHostWindow, 0);
+
+    // Only the taskbar's DesktopWindowContentBridge can match as a child, so
+    // the child walk is restricted to the tray window.
+    wchar_t className[128];
+    if (GetClassNameW(window, className, ARRAYSIZE(className)) > 0 &&
+        _wcsicmp(className, L"Shell_TrayWnd") == 0) {
+        EnumChildWindows(window, EnumExistingModernXamlHostWindow, 0);
+    }
     return TRUE;
 }
 
@@ -3157,14 +3071,14 @@ bool InitializeModernUi() {
              &g_microsoftUiXamlDiagnostics}) {
         state->connected.store(false, std::memory_order_release);
         state->blocked.store(false, std::memory_order_release);
-        state->requestGeneration.store(0, std::memory_order_release);
-        state->processedGeneration.store(0, std::memory_order_release);
+        state->pending.store(false, std::memory_order_release);
         state->failureCount.store(0, std::memory_order_release);
         state->emptyWalkCount.store(0, std::memory_order_release);
-        state->cooldownRetryCount.store(0, std::memory_order_release);
         state->lastEmptyWalkTick.store(0, std::memory_order_release);
     }
     g_visualTreeWatcherGeneration.store(
+        0, std::memory_order_release);
+    g_tapSiteGeneration.store(
         0, std::memory_order_release);
     {
         std::lock_guard<std::mutex> guard(


### PR DESCRIPTION
## Summary

Fix a confirmed startup race in the opt-in modern XAML path. When Explorer, Windhawk, and notification-area applications start concurrently, a diagnostics attempt can run before the corresponding XAML core is ready. The previous one-shot attempt then remains disabled until a mod reload.

The modern diagnostics path now:

- reacts to matching XAML host-window creation through narrowly filtered `CreateWindowExW`, `CreateWindowInBand`, and `CreateWindowInBandEx` hooks instead of DLL-load timing or timed polling;
- scans existing top-level and child windows in the current Explorer process from `Wh_ModAfterInit`, stopping once both XAML flavors are already queued or no longer need a trigger;
- maps `XamlExplorerHostIslandWindow` and a taskbar-owned `Windows.UI.Composition.DesktopWindowContentBridge` to Windows.UI.Xaml, and maps `CabinetWClass` plus `XamlExplorerHostIslandWindow_WASDK` to Microsoft.UI.Xaml;
- only signals a managed worker from window hooks, keeping COM activation and XAML Diagnostics work outside window-creation call stacks;
- coalesces Windows.UI.Xaml and Microsoft.UI.Xaml requests independently;
- allows hard connection failures to be retried by later matching host-window notifications, with at most three attempts per flavor;
- suppresses further attempts when a diagnostics call succeeds without creating a watcher, avoiding repeated conflicts with another Diagnostics consumer;
- resets only the affected flavor's attempt budget when an established connection disconnects;
- stops and joins the worker before unload, preserving the existing thread-lifetime guarantees.

The connection-name walk matches the range the reference mods use (up to 10,000 names), because the endpoint name embeds a process-lifetime core ordinal that is never reused and a live endpoint can sit at a high index. The cost of a failed walk is bounded by the walk count instead: after three empty walks in a session a flavor stops probing until an established connection disconnects. The walk runs only after a matching host-window or framework-module trigger indicates that the corresponding core should be ready.

## Verification

- Reproduced with Windhawk and NetEase UU Remote starting automatically.
- Confirmed that the tray tooltip uses the modern XAML path.
- Manually verified in Windhawk that host-window-driven initialization fixes the cold-start failure without toggling the mod setting.
- Compiled successfully for x86-64 and ARM64 after the latest trigger and retry-state changes.
- Local CJKSpacer spacing and lifecycle regression tests pass.
- Both maintained source copies are identical and `git diff --check` passes.

This update was implemented with AI assistance and manually verified on the affected system.


