### PR TITLE
Add Photoshop Dark Menus mod

### DIFF
--- a/mods/photoshop-dark-menus.wh.cpp
+++ b/mods/photoshop-dark-menus.wh.cpp
@@ -2,37 +2,112 @@
 // @id            photoshop-dark-menus
 // @name          Photoshop Dark Menus
 // @description   Enables dark mode and custom separator colors for all menus in Adobe Photoshop.
-// @version       1.1.0
+// @version       1.2.0
 // @author        Saber Naeemi
 // @github        https://github.com/sabergraphics
 // @twitter       https://x.com/SaberNaeemi
 // @homepage      https://www.sabernaeemi.com
 // @include       Photoshop.exe
 // @compilerOptions -lUser32 -lGdi32 -lAdvapi32
-// @license       MIT
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
 /*
 # Photoshop Dark Menus
 
-Forces dark mode for all context and top menu bar dropdowns in Adobe Photoshop without permanently altering registry keys on disk.
+This Windhawk mod enables dark menus (top-bar dropdowns and context menus) in
+Adobe Photoshop on Windows 11, along with custom color settings.
 
-### Features
-- Dark backgrounds and customizable text colors across all menus.
-- Independent separator line color control (set to match menu background to hide separators).
-- Legible disabled item text styling.
-- Automatic restoration of default Windows system colors upon exiting Photoshop.
+## Screenshots
 
-### Screenshots
-![Photoshop Dark Menu Dropdown](https://raw.githubusercontent.com/sabergraphics/photoshop-dark-menus/main/images/photoshop-dark-menu-screenshot-1.png)
+![Top Bar Menu Dropdown](https://raw.githubusercontent.com/sabergraphics/photoshop-dark-menus/main/images/photoshop-dark-menu-screenshot-1.png)
 
-![Photoshop Dark Context Menu](https://raw.githubusercontent.com/sabergraphics/photoshop-dark-menus/main/images/photoshop-dark-menu-screenshot-2.png)
+![Context Menu](https://raw.githubusercontent.com/sabergraphics/photoshop-dark-menus/main/images/photoshop-dark-menu-screenshot-2.png)
+
+## How it works
+
+The mod has two theming engines, selectable in the settings.
+
+### Global system colors (default)
+
+Photoshop renders its legacy Win32 menus through the classic (unthemed) path,
+which reads the shared system color table directly — so per-process dark-mode
+techniques (`SetPreferredAppMode`, `GetSysColor` hooks) do not reach it. This
+engine updates the active Windows session palette with `SetSysColors`, which
+is the only approach found to reliably darken Photoshop's menus.
+
+**Warning:** while this mode is active, the menu/selection/3D colors change
+for *every* application on the desktop, not just Photoshop, until Photoshop
+exits. Safeguards used in this mode:
+
+- Original colors are backed up from `HKCU\Control Panel\Colors` (not from the
+  possibly-already-modified live palette), so restarts and multiple instances
+  cannot corrupt the backup.
+- Colors are restored from an `ExitProcess` teardown hook. If another
+  Photoshop instance is still running, restoration is deferred to the last
+  instance to exit, so instances no longer fight over the palette.
+- If Photoshop **hard-crashes** (faulty plugin, Force Quit via Task Manager),
+  the teardown hook cannot run and the desktop may remain dark. Launching and
+  cleanly closing Photoshop once restores the original colors.
+
+### Process-local (experimental)
+
+Everything stays inside the Photoshop process; no other application is
+affected:
+
+- Switches the process to the dark menu theme via `uxtheme`
+  (`SetPreferredAppMode` + `FlushMenuThemes`).
+- Hooks `GetSysColor` / `GetSysColorBrush` in-process, so Photoshop's legacy
+  menu drawing code picks up the custom menu, text, highlight and disabled-text
+  colors without touching the system palette.
+- Sets a custom background brush on Photoshop's menus
+  (`MENUINFO::hbrBack`, applied to submenus and to context menus via
+  `TrackPopupMenu(Ex)` hooks).
+- Hooks `PatBlt` / `FillRect`, strictly scoped to active menu windows (class
+  `#32768` or modal `GUI_INMENUMODE`), to recolor the separator lines that
+  Photoshop draws with legacy GDI calls.
+
+In testing, this mode does **not** darken Photoshop's menu backgrounds and
+text, because Photoshop's classic menu rendering bypasses the hooked user-mode
+color APIs. It is kept as an opt-in for experimentation and for setups where
+it may behave differently.
+
+## Why a standalone mod?
+
+The system-wide [Dark mode context menus](https://github.com/MGGSK/DarkMenus)
+mod darkens Win32 menus globally but does not offer per-color customization,
+and its approach alone does not cover Photoshop's legacy separator drawing.
+This mod adds fully customizable menu colors, Photoshop-scoped GDI separator
+hooks that would be unsafe in an `@include *` mod, and a global-palette
+fallback for setups where process-local theming is not sufficient.
+
+## Options
+
+- **Theming Mode**: Global system colors (default; affects the whole desktop
+  while Photoshop runs) or process-local (experimental; only affects Photoshop
+  but does not darken menus on most setups).
+- **Menu Background Color**: Background color for all menu popups (Default: `#282828`).
+- **Menu Text Color**: Text color for active items (Default: `#DCDCDC`).
+- **Highlight Background Color**: Color when hovering over an item (Default: `#505050`).
+- **Highlight Text Color**: Text color when hovering over an item (Default: `#FFFFFF`).
+- **Separator Line Color**: Color for separator lines. Set to match the background color to hide them completely (Default: `#383838`).
+- **Disabled Text Color**: Text color for disabled menu items (Default: `#808080`).
 */
 // ==/WindhawkModReadme==
 
+
 // ==WindhawkModSettings==
 /*
+- ThemingMode: systemColors
+  $name: "Theming Mode"
+  $description: >-
+    Global system colors reliably darkens Photoshop's menus but affects the
+    whole desktop while Photoshop runs. Process-local only affects Photoshop
+    but does not darken the menus on most setups, because Photoshop's menu
+    rendering reads the system color table directly.
+  $options:
+  - systemColors: "Global system colors (recommended for Photoshop)"
+  - processLocal: "Process-local (experimental)"
 - MenuBgColor: "#282828"
   $name: "Menu Background Color"
 - MenuTextColor: "#DCDCDC"
@@ -43,45 +118,82 @@ Forces dark mode for all context and top menu bar dropdowns in Adobe Photoshop w
   $name: "Highlight Text Color"
 - SeparatorColor: "#383838"
   $name: "Separator Line Color"
-  $description: "Set this to the menu background color to hide separators."
 - GrayTextColor: "#808080"
   $name: "Disabled Text Color"
 */
 // ==/WindhawkModSettings==
 
 #include <windows.h>
+#include <tlhelp32.h>
 #include <windhawk_api.h>
 #include <windhawk_utils.h>
 #include <wchar.h>
+#include <wctype.h>
+#include <vector>
+#include <mutex>
 
 constexpr int NUM_ELEMENTS = 10;
-
 const INT g_sysElements[NUM_ELEMENTS] = {
-    COLOR_MENU,
-    COLOR_MENUTEXT,
-    COLOR_HIGHLIGHT,
-    COLOR_HIGHLIGHTTEXT,
-    COLOR_BTNSHADOW,
-    COLOR_GRAYTEXT,
-    COLOR_BTNHIGHLIGHT,
-    COLOR_3DDKSHADOW,
-    COLOR_3DLIGHT,
-    COLOR_MENUBAR
+    COLOR_MENU, COLOR_MENUTEXT, COLOR_HIGHLIGHT, COLOR_HIGHLIGHTTEXT,
+    COLOR_BTNSHADOW, COLOR_GRAYTEXT, COLOR_BTNHIGHLIGHT,
+    COLOR_3DDKSHADOW, COLOR_3DLIGHT, COLOR_MENUBAR
 };
 
 COLORREF g_origColors[NUM_ELEMENTS] = {};
 bool g_hasSavedOrigColors = false;
 
+// Mode state. Written only from Windhawk callbacks (init / settings / uninit).
+bool g_processLocal = false;  // desired mode from settings
+bool g_globalActive = false;  // our SetSysColors palette is currently applied
+bool g_localActive = false;   // dark app mode is currently applied
+
+// Colors read by the in-process hooks.
+COLORREF g_colMenu = RGB(40, 40, 40);
+COLORREF g_colText = RGB(220, 220, 220);
+COLORREF g_colHighlight = RGB(80, 80, 80);
+COLORREF g_colHiText = RGB(255, 255, 255);
+COLORREF g_colGray = RGB(128, 128, 128);
+
+// Brushes are published with InterlockedExchangePointer; replaced brushes are
+// parked in g_retiredBrushes and only deleted at uninit, so painting threads
+// can never use a freed handle.
 HBRUSH g_hSeparatorBrush = nullptr;
+HBRUSH g_hMenuBrush = nullptr;
+HBRUSH g_hTextBrush = nullptr;
+HBRUSH g_hHighlightBrush = nullptr;
+HBRUSH g_hHiTextBrush = nullptr;
+HBRUSH g_hGrayBrush = nullptr;
+std::vector<HBRUSH> g_retiredBrushes;
+std::mutex g_brushMutex;
 
-COLORREF ParseHexColor(const PCWSTR hexStr, COLORREF defaultColor) {
-    if (!hexStr || wcslen(hexStr) < 7 || hexStr[0] != L'#')
+HMODULE g_hUxtheme = nullptr;
+enum class PreferredAppMode { Default, AllowDark, ForceDark, ForceLight, Max };
+using SetPreferredAppMode_t = PreferredAppMode(WINAPI*)(PreferredAppMode);
+using FlushMenuThemes_t = void(WINAPI*)();
+
+COLORREF ParseHexColor(PCWSTR hexStr, COLORREF defaultColor) {
+    if (!hexStr) {
+        Wh_Log(L"ParseHexColor: Null string, using default.");
         return defaultColor;
-
-    unsigned int r = 0, g = 0, b = 0;
-    if (swscanf_s(hexStr + 1, L"%02x%02x%02x", &r, &g, &b) == 3) {
-        return RGB(r, g, b);
     }
+
+    const wchar_t* p = hexStr;
+    if (*p == L'#') p++; // allow with or without #
+
+    size_t len = wcslen(p);
+    bool allHex = len > 0;
+    for (size_t i = 0; i < len && allHex; i++) {
+        if (!iswxdigit(p[i])) allHex = false;
+    }
+
+    unsigned int r, g, b;
+    if (allHex && len == 6 && swscanf_s(p, L"%02x%02x%02x", &r, &g, &b) == 3) {
+        return RGB(r, g, b);
+    } else if (allHex && len == 3 && swscanf_s(p, L"%1x%1x%1x", &r, &g, &b) == 3) {
+        return RGB(r * 17, g * 17, b * 17); // expand short hex
+    }
+
+    Wh_Log(L"ParseHexColor: Invalid format '%s', using default.", hexStr);
     return defaultColor;
 }
 
@@ -104,19 +216,56 @@ COLORREF GetColorFromRegistry(int sysElement, COLORREF liveColorFallback) {
         HKEY hKey;
         if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Control Panel\\Colors", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
             wchar_t buffer[64] = {0};
-            DWORD bufferSize = sizeof(buffer);
-            if (RegQueryValueExW(hKey, valueName, nullptr, nullptr, (LPBYTE)buffer, &bufferSize) == ERROR_SUCCESS) {
-                int r, g, b;
-                if (swscanf_s(buffer, L"%d %d %d", &r, &g, &b) == 3) {
-                    RegCloseKey(hKey);
-                    return RGB(r, g, b);
+            DWORD bufferSize = sizeof(buffer) - sizeof(WCHAR);
+            DWORD type = 0;
+
+            if (RegQueryValueExW(hKey, valueName, nullptr, &type, (LPBYTE)buffer, &bufferSize) == ERROR_SUCCESS) {
+                if (type == REG_SZ) {
+                    buffer[bufferSize / sizeof(WCHAR)] = L'\0';
+                    int r, g, b;
+                    if (swscanf_s(buffer, L"%d %d %d", &r, &g, &b) == 3 &&
+                        r >= 0 && r <= 255 && g >= 0 && g <= 255 && b >= 0 && b <= 255) {
+                        RegCloseKey(hKey);
+                        return RGB(r, g, b);
+                    }
                 }
             }
             RegCloseKey(hKey);
         }
     }
+    Wh_Log(L"Failed to read %s from registry. Falling back to live color.", valueName ? valueName : L"unknown");
     return liveColorFallback;
 }
+
+void PublishBrush(HBRUSH* pSlot, COLORREF color) {
+    HBRUSH hNew = CreateSolidBrush(color);
+    HBRUSH hOld = (HBRUSH)InterlockedExchangePointer((PVOID*)pSlot, hNew);
+    if (hOld) {
+        std::lock_guard<std::mutex> lock(g_brushMutex);
+        g_retiredBrushes.push_back(hOld);
+    }
+}
+
+void LoadSettings() {
+    WindhawkUtils::StringSetting mode = WindhawkUtils::StringSetting::make(L"ThemingMode");
+    g_processLocal = wcscmp(mode.get(), L"systemColors") != 0;
+
+    g_colMenu      = ParseHexColor(WindhawkUtils::StringSetting::make(L"MenuBgColor").get(), RGB(40, 40, 40));
+    g_colText      = ParseHexColor(WindhawkUtils::StringSetting::make(L"MenuTextColor").get(), RGB(220, 220, 220));
+    g_colHighlight = ParseHexColor(WindhawkUtils::StringSetting::make(L"HighlightBgColor").get(), RGB(80, 80, 80));
+    g_colHiText    = ParseHexColor(WindhawkUtils::StringSetting::make(L"HighlightTextColor").get(), RGB(255, 255, 255));
+    g_colGray      = ParseHexColor(WindhawkUtils::StringSetting::make(L"GrayTextColor").get(), RGB(128, 128, 128));
+    COLORREF colSep = ParseHexColor(WindhawkUtils::StringSetting::make(L"SeparatorColor").get(), RGB(56, 56, 56));
+
+    PublishBrush(&g_hSeparatorBrush, colSep);
+    PublishBrush(&g_hMenuBrush, g_colMenu);
+    PublishBrush(&g_hTextBrush, g_colText);
+    PublishBrush(&g_hHighlightBrush, g_colHighlight);
+    PublishBrush(&g_hHiTextBrush, g_colHiText);
+    PublishBrush(&g_hGrayBrush, g_colGray);
+}
+
+// ----- Global system colors engine (legacy fallback) -----
 
 void SaveOriginalColors() {
     if (g_hasSavedOrigColors) return;
@@ -129,141 +278,268 @@ void SaveOriginalColors() {
 void ApplyDarkSystemColors() {
     SaveOriginalColors();
 
-    COLORREF colMenu      = ParseHexColor(WindhawkUtils::StringSetting::make(L"MenuBgColor").get(), RGB(40, 40, 40));
-    COLORREF colText      = ParseHexColor(WindhawkUtils::StringSetting::make(L"MenuTextColor").get(), RGB(220, 220, 220));
-    COLORREF colHighlight = ParseHexColor(WindhawkUtils::StringSetting::make(L"HighlightBgColor").get(), RGB(80, 80, 80));
-    COLORREF colHiText    = ParseHexColor(WindhawkUtils::StringSetting::make(L"HighlightTextColor").get(), RGB(255, 255, 255));
-    COLORREF colSep       = ParseHexColor(WindhawkUtils::StringSetting::make(L"SeparatorColor").get(), RGB(56, 56, 56));
-    COLORREF colGray      = ParseHexColor(WindhawkUtils::StringSetting::make(L"GrayTextColor").get(), RGB(128, 128, 128));
-
-    HBRUSH hNewSepBrush = CreateSolidBrush(colSep);
-    HBRUSH hOldSepBrush = (HBRUSH)InterlockedExchangePointer((PVOID*)&g_hSeparatorBrush, hNewSepBrush);
-    if (hOldSepBrush) DeleteObject(hOldSepBrush);
-
     COLORREF darkColors[NUM_ELEMENTS] = {
-        colMenu,      // COLOR_MENU
-        colText,      // COLOR_MENUTEXT
-        colHighlight, // COLOR_HIGHLIGHT
-        colHiText,    // COLOR_HIGHLIGHTTEXT
-        colMenu,      // COLOR_BTNSHADOW
-        colGray,      // COLOR_GRAYTEXT
-        colMenu,      // COLOR_BTNHIGHLIGHT
-        colMenu,      // COLOR_3DDKSHADOW
-        colMenu,      // COLOR_3DLIGHT
-        colMenu       // COLOR_MENUBAR
+        g_colMenu, g_colText, g_colHighlight, g_colHiText,
+        g_colMenu, g_colGray, g_colMenu, g_colMenu, g_colMenu, g_colMenu
     };
 
     SetSysColors(NUM_ELEMENTS, g_sysElements, darkColors);
 }
 
-void RestoreOriginalColors() {
-    if (g_hasSavedOrigColors) {
-        SetSysColors(NUM_ELEMENTS, g_sysElements, g_origColors);
+bool AnotherPhotoshopInstanceRunning() {
+    wchar_t path[MAX_PATH];
+    if (!GetModuleFileNameW(nullptr, path, ARRAYSIZE(path))) return false;
+    const wchar_t* exe = wcsrchr(path, L'\\');
+    exe = exe ? exe + 1 : path;
+
+    HANDLE hSnap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (hSnap == INVALID_HANDLE_VALUE) return false;
+
+    bool found = false;
+    DWORD myPid = GetCurrentProcessId();
+    PROCESSENTRY32W pe = { sizeof(pe) };
+    if (Process32FirstW(hSnap, &pe)) {
+        do {
+            if (pe.th32ProcessID != myPid && _wcsicmp(pe.szExeFile, exe) == 0) {
+                found = true;
+                break;
+            }
+        } while (Process32NextW(hSnap, &pe));
     }
-    HBRUSH hOldBrush = (HBRUSH)InterlockedExchangePointer((PVOID*)&g_hSeparatorBrush, nullptr);
-    if (hOldBrush) DeleteObject(hOldBrush);
+    CloseHandle(hSnap);
+    return found;
 }
 
-// -------------------------------------------------------------------------
-// Hooks
-// -------------------------------------------------------------------------
+// force=false defers restoration to the last running Photoshop instance.
+void RestoreOriginalColors(bool force) {
+    if (!g_hasSavedOrigColors) return;
+    if (!force && AnotherPhotoshopInstanceRunning()) {
+        Wh_Log(L"Another Photoshop instance is running; deferring color restoration to it.");
+        return;
+    }
+    SetSysColors(NUM_ELEMENTS, g_sysElements, g_origColors);
+}
 
-// Safely determines if the drawing is happening for a menu, 
-// even if a memory DC (double-buffering) is being used.
+// ----- Process-local engine -----
+
+void EnableDarkAppMode(bool enable) {
+    if (!g_hUxtheme) {
+        g_hUxtheme = LoadLibraryExW(L"uxtheme.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    }
+    if (!g_hUxtheme) {
+        Wh_Log(L"Failed to load uxtheme.dll");
+        return;
+    }
+
+    auto pSetPreferredAppMode = (SetPreferredAppMode_t)(void*)GetProcAddress(g_hUxtheme, MAKEINTRESOURCEA(135));
+    auto pFlushMenuThemes = (FlushMenuThemes_t)(void*)GetProcAddress(g_hUxtheme, MAKEINTRESOURCEA(136));
+    if (!pSetPreferredAppMode || !pFlushMenuThemes) {
+        Wh_Log(L"uxtheme dark mode ordinals not available on this Windows build.");
+        return;
+    }
+
+    pSetPreferredAppMode(enable ? PreferredAppMode::ForceDark : PreferredAppMode::Default);
+    pFlushMenuThemes();
+}
+
+void ApplyMenuBackground(HMENU hMenu, HBRUSH hBrush) {
+    MENUINFO mi = { sizeof(mi) };
+    mi.fMask = MIM_BACKGROUND | MIM_APPLYTOSUBMENUS;
+    mi.hbrBack = hBrush;
+    SetMenuInfo(hMenu, &mi);
+}
+
+BOOL CALLBACK StampMenuBackgroundsProc(HWND hWnd, LPARAM lParam) {
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hWnd, &pid);
+    if (pid == GetCurrentProcessId()) {
+        HMENU hMenu = GetMenu(hWnd);
+        if (hMenu) ApplyMenuBackground(hMenu, (HBRUSH)lParam);
+    }
+    return TRUE;
+}
+
+// Stamps (or clears, with nullptr) the background brush on the menu bars of
+// all top-level windows of this process, including their submenus.
+void StampMenuBackgrounds(HBRUSH hBrush) {
+    EnumWindows(StampMenuBackgroundsProc, (LPARAM)hBrush);
+}
+
 bool IsMenuContext(HDC hdc) {
     HWND hWnd = WindowFromDC(hdc);
     if (hWnd) {
-        // Direct drawing to a real window
         WCHAR cls[16];
-        if (GetClassNameW(hWnd, cls, ARRAYSIZE(cls)) && wcscmp(cls, L"#32768") == 0) {
-            return true;
-        }
+        if (GetClassNameW(hWnd, cls, ARRAYSIZE(cls)) && wcscmp(cls, L"#32768") == 0) return true;
         return false;
-    } 
-    
-    // If hWnd is NULL, it is likely a Memory DC used for double-buffering.
-    // Check if the current thread is actively displaying a menu.
+    }
     if (GetObjectType(hdc) == OBJ_MEMDC) {
         GUITHREADINFO gti = { sizeof(GUITHREADINFO) };
         if (GetGUIThreadInfo(GetCurrentThreadId(), &gti)) {
-            if (gti.flags & GUI_INMENUMODE) {
-                return true;
-            }
+            if (gti.flags & GUI_INMENUMODE) return true;
         }
     }
-    
     return false;
 }
 
-using PatBlt_t = BOOL (WINAPI*)(HDC hdc, int x, int y, int w, int h, DWORD rop);
-PatBlt_t PatBlt_Original = nullptr;
+// Hooks
 
+decltype(&GetSysColor) GetSysColor_Original;
+DWORD WINAPI GetSysColor_Hook(int nIndex) {
+    if (g_processLocal) {
+        switch (nIndex) {
+            case COLOR_MENU:
+            case COLOR_MENUBAR:       return g_colMenu;
+            case COLOR_MENUTEXT:      return g_colText;
+            case COLOR_HIGHLIGHT:     return g_colHighlight;
+            case COLOR_HIGHLIGHTTEXT: return g_colHiText;
+            case COLOR_GRAYTEXT:      return g_colGray;
+        }
+    }
+    return GetSysColor_Original(nIndex);
+}
+
+decltype(&GetSysColorBrush) GetSysColorBrush_Original;
+HBRUSH WINAPI GetSysColorBrush_Hook(int nIndex) {
+    if (g_processLocal) {
+        HBRUSH hBrush = nullptr;
+        switch (nIndex) {
+            case COLOR_MENU:
+            case COLOR_MENUBAR:       hBrush = g_hMenuBrush; break;
+            case COLOR_MENUTEXT:      hBrush = g_hTextBrush; break;
+            case COLOR_HIGHLIGHT:     hBrush = g_hHighlightBrush; break;
+            case COLOR_HIGHLIGHTTEXT: hBrush = g_hHiTextBrush; break;
+            case COLOR_GRAYTEXT:      hBrush = g_hGrayBrush; break;
+        }
+        if (hBrush) return hBrush;
+    }
+    return GetSysColorBrush_Original(nIndex);
+}
+
+decltype(&TrackPopupMenu) TrackPopupMenu_Original;
+BOOL WINAPI TrackPopupMenu_Hook(HMENU hMenu, UINT uFlags, int x, int y, int nReserved, HWND hWnd, const RECT* prcRect) {
+    if (g_processLocal && g_hMenuBrush) ApplyMenuBackground(hMenu, g_hMenuBrush);
+    return TrackPopupMenu_Original(hMenu, uFlags, x, y, nReserved, hWnd, prcRect);
+}
+
+decltype(&TrackPopupMenuEx) TrackPopupMenuEx_Original;
+BOOL WINAPI TrackPopupMenuEx_Hook(HMENU hMenu, UINT uFlags, int x, int y, HWND hWnd, LPTPMPARAMS lptpm) {
+    if (g_processLocal && g_hMenuBrush) ApplyMenuBackground(hMenu, g_hMenuBrush);
+    return TrackPopupMenuEx_Original(hMenu, uFlags, x, y, hWnd, lptpm);
+}
+
+decltype(&PatBlt) PatBlt_Original;
 BOOL WINAPI PatBlt_Hook(HDC hdc, int x, int y, int w, int h, DWORD rop) {
-    HBRUSH hBrush = g_hSeparatorBrush; 
-    if (rop == PATCOPY && (h == 1 || h == 2) && w > 20 && hBrush && IsMenuContext(hdc)) {
-        HBRUSH hOldBrush = (HBRUSH)SelectObject(hdc, hBrush);
-        BOOL bRes = PatBlt_Original(hdc, x, y, w, h, rop);
-        SelectObject(hdc, hOldBrush);
-        return bRes;
+    HBRUSH hBrush = g_hSeparatorBrush;
+    if (rop == PATCOPY && (h == 1 || h == 2) && w > 20 && hBrush) {
+        if (IsMenuContext(hdc)) {
+            HBRUSH hOldBrush = (HBRUSH)SelectObject(hdc, hBrush);
+            BOOL bRes = PatBlt_Original(hdc, x, y, w, h, rop);
+            SelectObject(hdc, hOldBrush);
+            return bRes;
+        }
     }
     return PatBlt_Original(hdc, x, y, w, h, rop);
 }
 
-using FillRect_t = int (WINAPI*)(HDC hdc, const RECT *lprc, HBRUSH hbr);
-FillRect_t FillRect_Original = nullptr;
-
+decltype(&FillRect) FillRect_Original;
 int WINAPI FillRect_Hook(HDC hdc, const RECT *lprc, HBRUSH hbr) {
-    HBRUSH hBrush = g_hSeparatorBrush; 
-    if (lprc && hBrush && IsMenuContext(hdc)) {
+    HBRUSH hBrush = g_hSeparatorBrush;
+    if (lprc && hBrush) {
         int h = lprc->bottom - lprc->top;
         int w = lprc->right - lprc->left;
         if ((h == 1 || h == 2) && w > 20) {
-            return FillRect_Original(hdc, lprc, hBrush);
+            if (IsMenuContext(hdc)) {
+                return FillRect_Original(hdc, lprc, hBrush);
+            }
         }
     }
     return FillRect_Original(hdc, lprc, hbr);
 }
 
-using ExitProcess_t = void (WINAPI*)(UINT uExitCode);
-ExitProcess_t ExitProcess_Original = nullptr;
-
-void WINAPI ExitProcess_Hook(UINT uExitCode) {
-    RestoreOriginalColors();
+decltype(&ExitProcess) ExitProcess_Original;
+__declspec(noreturn) void WINAPI ExitProcess_Hook(UINT uExitCode) {
+    if (g_globalActive) RestoreOriginalColors(false);
     ExitProcess_Original(uExitCode);
 }
 
-// -------------------------------------------------------------------------
 // Windhawk Events
-// -------------------------------------------------------------------------
 
 void Wh_ModSettingsChanged() {
-    ApplyDarkSystemColors();
+    bool wasGlobal = g_globalActive;
+    bool wasLocal = g_localActive;
+
+    LoadSettings();
+
+    if (g_processLocal) {
+        if (wasGlobal) {
+            RestoreOriginalColors(true);
+            g_globalActive = false;
+        }
+        EnableDarkAppMode(true);
+        StampMenuBackgrounds(g_hMenuBrush);
+        g_localActive = true;
+    } else {
+        if (wasLocal) {
+            StampMenuBackgrounds(nullptr);
+            EnableDarkAppMode(false);
+            g_localActive = false;
+        }
+        ApplyDarkSystemColors();
+        g_globalActive = true;
+    }
 }
 
 BOOL Wh_ModInit() {
-    ApplyDarkSystemColors();
+    LoadSettings();
 
-    HMODULE hGdi32 = GetModuleHandleW(L"gdi32.dll");
-    if (hGdi32) {
-        void* pPatBlt = (void*)GetProcAddress(hGdi32, "PatBlt");
-        if (pPatBlt) Wh_SetFunctionHook(pPatBlt, (void*)PatBlt_Hook, (void**)&PatBlt_Original);
+    if (g_processLocal) {
+        EnableDarkAppMode(true);
+        StampMenuBackgrounds(g_hMenuBrush);
+        g_localActive = true;
+    } else {
+        ApplyDarkSystemColors();
+        g_globalActive = true;
     }
 
-    HMODULE hUser32 = GetModuleHandleW(L"user32.dll");
-    if (hUser32) {
-        void* pFillRect = (void*)GetProcAddress(hUser32, "FillRect");
-        if (pFillRect) Wh_SetFunctionHook(pFillRect, (void*)FillRect_Hook, (void**)&FillRect_Original);
-    }
-
-    HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
-    if (hKernel32) {
-        void* pExitProcess = (void*)GetProcAddress(hKernel32, "ExitProcess");
-        if (pExitProcess) Wh_SetFunctionHook(pExitProcess, (void*)ExitProcess_Hook, (void**)&ExitProcess_Original);
-    }
+    if (!WindhawkUtils::SetFunctionHook(GetSysColor, GetSysColor_Hook, &GetSysColor_Original)) Wh_Log(L"Failed to hook GetSysColor");
+    if (!WindhawkUtils::SetFunctionHook(GetSysColorBrush, GetSysColorBrush_Hook, &GetSysColorBrush_Original)) Wh_Log(L"Failed to hook GetSysColorBrush");
+    if (!WindhawkUtils::SetFunctionHook(TrackPopupMenu, TrackPopupMenu_Hook, &TrackPopupMenu_Original)) Wh_Log(L"Failed to hook TrackPopupMenu");
+    if (!WindhawkUtils::SetFunctionHook(TrackPopupMenuEx, TrackPopupMenuEx_Hook, &TrackPopupMenuEx_Original)) Wh_Log(L"Failed to hook TrackPopupMenuEx");
+    if (!WindhawkUtils::SetFunctionHook(PatBlt, PatBlt_Hook, &PatBlt_Original)) Wh_Log(L"Failed to hook PatBlt");
+    if (!WindhawkUtils::SetFunctionHook(FillRect, FillRect_Hook, &FillRect_Original)) Wh_Log(L"Failed to hook FillRect");
+    if (!WindhawkUtils::SetFunctionHook(ExitProcess, ExitProcess_Hook, &ExitProcess_Original)) Wh_Log(L"Failed to hook ExitProcess");
 
     return TRUE;
 }
 
 void Wh_ModUninit() {
-    RestoreOriginalColors();
+    if (g_globalActive) {
+        // The mod is being unloaded everywhere, so restore unconditionally;
+        // concurrent instances all write the same registry-derived originals.
+        RestoreOriginalColors(true);
+        g_globalActive = false;
+    }
+    if (g_localActive) {
+        StampMenuBackgrounds(nullptr);
+        EnableDarkAppMode(false);
+        g_localActive = false;
+    }
+
+    HBRUSH* slots[] = {
+        &g_hSeparatorBrush, &g_hMenuBrush, &g_hTextBrush,
+        &g_hHighlightBrush, &g_hHiTextBrush, &g_hGrayBrush
+    };
+    for (HBRUSH* pSlot : slots) {
+        HBRUSH hBrush = (HBRUSH)InterlockedExchangePointer((PVOID*)pSlot, nullptr);
+        if (hBrush) DeleteObject(hBrush);
+    }
+
+    std::lock_guard<std::mutex> lock(g_brushMutex);
+    for (HBRUSH b : g_retiredBrushes) DeleteObject(b);
+    g_retiredBrushes.clear();
+
+    if (g_hUxtheme) {
+        FreeLibrary(g_hUxtheme);
+        g_hUxtheme = nullptr;
+    }
 }

--- a/mods/photoshop-dark-menus.wh.cpp
+++ b/mods/photoshop-dark-menus.wh.cpp
@@ -1,0 +1,195 @@
+// ==WindhawkMod==
+// @id                photoshop-dark-menus
+// @name              Photoshop Dark Menus
+// @description       Enables dark mode and custom separator colors for all menus in Adobe Photoshop.
+// @version           1.0.0
+// @author            Saber Naeemi
+// @github          https://github.com/sabergraphics
+// @twitter         https://x.com/SaberNaeemi
+// @homepage        https://www.sabernaeemi.com
+// @include           Photoshop.exe
+// @compilerOptions   -lUser32 -lGdi32
+// @license      MIT
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Photoshop Dark Menus
+
+Forces dark mode for all context and top menu bar dropdowns in Adobe Photoshop without permanently altering registry keys on disk.
+
+### Features
+- Dark backgrounds and customizable text colors across all menus.
+- Independent separator line color control (set to match menu background to hide separators).
+- Legible disabled item text styling.
+- Automatic restoration of default Windows system colors upon exiting Photoshop.
+
+### Screenshots
+![Photoshop Dark Menu Dropdown](images/photoshop-dark-menu-screenshot-1.png)
+
+![Photoshop Dark Context Menu](imagesphotoshop-dark-menu-screenshot-2.png)
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- MenuBgColor: "#282828"
+  $name: "Menu Background Color"
+- MenuTextColor: "#DCDCDC"
+  $name: "Menu Text Color"
+- HighlightBgColor: "#505050"
+  $name: "Highlight Background Color"
+- SeparatorColor: "#383838"
+  $name: "Separator Line Color (Set same as Menu Background Color to hide)"
+- GrayTextColor: "#808080"
+  $name: "Disabled Text Color"
+*/
+// ==/WindhawkModSettings==
+
+#include <windows.h>
+#include <windhawk_api.h>
+#include <windhawk_utils.h>
+#include <wchar.h>
+
+constexpr int NUM_ELEMENTS = 10;
+
+const INT g_sysElements[NUM_ELEMENTS] = {
+    COLOR_MENU,
+    COLOR_MENUTEXT,
+    COLOR_HIGHLIGHT,
+    COLOR_HIGHLIGHTTEXT,
+    COLOR_BTNSHADOW,
+    COLOR_GRAYTEXT,
+    COLOR_BTNHIGHLIGHT,
+    COLOR_3DDKSHADOW,
+    COLOR_3DLIGHT,
+    COLOR_MENUBAR
+};
+
+COLORREF g_origColors[NUM_ELEMENTS] = {};
+bool g_hasSavedOrigColors = false;
+
+HBRUSH g_hSeparatorBrush = nullptr;
+
+COLORREF ParseHexColor(const PCWSTR hexStr, COLORREF defaultColor) {
+    if (!hexStr || wcslen(hexStr) < 7 || hexStr[0] != L'#')
+        return defaultColor;
+
+    unsigned int r = 0, g = 0, b = 0;
+    if (swscanf_s(hexStr + 1, L"%02x%02x%02x", &r, &g, &b) == 3) {
+        return RGB(r, g, b);
+    }
+    return defaultColor;
+}
+
+void SaveOriginalColors() {
+    if (g_hasSavedOrigColors) return;
+
+    for (int i = 0; i < NUM_ELEMENTS; i++) {
+        g_origColors[i] = GetSysColor(g_sysElements[i]);
+    }
+    g_hasSavedOrigColors = true;
+}
+
+void ApplyDarkSystemColors() {
+    SaveOriginalColors();
+
+    if (g_hSeparatorBrush) DeleteObject(g_hSeparatorBrush);
+
+    const PCWSTR bgStr        = Wh_GetStringSetting(L"MenuBgColor");
+    const PCWSTR textStr      = Wh_GetStringSetting(L"MenuTextColor");
+    const PCWSTR highlightStr = Wh_GetStringSetting(L"HighlightBgColor");
+    const PCWSTR sepStr       = Wh_GetStringSetting(L"SeparatorColor");
+    const PCWSTR grayStr      = Wh_GetStringSetting(L"GrayTextColor");
+
+    COLORREF colMenu      = ParseHexColor(bgStr,        RGB(40, 40, 40));
+    COLORREF colText      = ParseHexColor(textStr,      RGB(220, 220, 220));
+    COLORREF colHighlight = ParseHexColor(highlightStr, RGB(80, 80, 80));
+    COLORREF colSep       = ParseHexColor(sepStr,        RGB(56, 56, 56));
+    COLORREF colGray      = ParseHexColor(grayStr,      RGB(128, 128, 128));
+
+    Wh_FreeStringSetting(bgStr);
+    Wh_FreeStringSetting(textStr);
+    Wh_FreeStringSetting(highlightStr);
+    Wh_FreeStringSetting(sepStr);
+    Wh_FreeStringSetting(grayStr);
+
+    g_hSeparatorBrush = CreateSolidBrush(colSep);
+
+    COLORREF darkColors[NUM_ELEMENTS] = {
+        colMenu,
+        colText,
+        colHighlight,
+        RGB(255, 255, 255),
+        colMenu,
+        colGray,
+        colMenu,
+        colMenu,
+        colMenu,
+        colMenu
+    };
+
+    SetSysColors(NUM_ELEMENTS, g_sysElements, darkColors);
+}
+
+void RestoreOriginalColors() {
+    if (g_hasSavedOrigColors) {
+        SetSysColors(NUM_ELEMENTS, g_sysElements, g_origColors);
+    }
+    if (g_hSeparatorBrush) DeleteObject(g_hSeparatorBrush);
+}
+
+using PatBlt_t = BOOL (WINAPI*)(HDC hdc, int x, int y, int w, int h, DWORD rop);
+PatBlt_t PatBlt_Original = nullptr;
+
+BOOL WINAPI PatBlt_Hook(HDC hdc, int x, int y, int w, int h, DWORD rop) {
+    if ((h == 1 || h == 2) && w > 20 && g_hSeparatorBrush) {
+        HBRUSH hOldBrush = (HBRUSH)SelectObject(hdc, g_hSeparatorBrush);
+        BOOL bRes = PatBlt_Original(hdc, x, y, w, h, rop);
+        SelectObject(hdc, hOldBrush);
+        return bRes;
+    }
+    return PatBlt_Original(hdc, x, y, w, h, rop);
+}
+
+using FillRect_t = int (WINAPI*)(HDC hdc, const RECT *lprc, HBRUSH hbr);
+FillRect_t FillRect_Original = nullptr;
+
+int WINAPI FillRect_Hook(HDC hdc, const RECT *lprc, HBRUSH hbr) {
+    if (lprc && g_hSeparatorBrush) {
+        int h = lprc->bottom - lprc->top;
+        int w = lprc->right - lprc->left;
+        if ((h == 1 || h == 2) && w > 20) {
+            return FillRect_Original(hdc, lprc, g_hSeparatorBrush);
+        }
+    }
+    return FillRect_Original(hdc, lprc, hbr);
+}
+
+void Wh_ModSettingsChanged() {
+    ApplyDarkSystemColors();
+}
+
+BOOL Wh_ModInit() {
+    Wh_Log(L"Initializing Photoshop Dark Menus");
+    ApplyDarkSystemColors();
+
+    HMODULE hGdi32 = GetModuleHandleW(L"gdi32.dll");
+    if (hGdi32) {
+        void* pPatBlt = (void*)GetProcAddress(hGdi32, "PatBlt");
+        if (pPatBlt) WindhawkUtils::SetFunctionHook(pPatBlt, (void*)PatBlt_Hook, (void**)&PatBlt_Original);
+    }
+
+    HMODULE hUser32 = GetModuleHandleW(L"user32.dll");
+    if (hUser32) {
+        void* pFillRect = (void*)GetProcAddress(hUser32, "FillRect");
+        if (pFillRect) WindhawkUtils::SetFunctionHook(pFillRect, (void*)FillRect_Hook, (void**)&FillRect_Original);
+    }
+
+    return TRUE;
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L"Restoring original system palette colors");
+    RestoreOriginalColors();
+}

--- a/mods/photoshop-dark-menus.wh.cpp
+++ b/mods/photoshop-dark-menus.wh.cpp
@@ -1,15 +1,15 @@
 // ==WindhawkMod==
-// @id                photoshop-dark-menus
-// @name              Photoshop Dark Menus
-// @description       Enables dark mode and custom separator colors for all menus in Adobe Photoshop.
-// @version           1.0.0
-// @author            Saber Naeemi
-// @github          https://github.com/sabergraphics
-// @twitter         https://x.com/SaberNaeemi
-// @homepage        https://www.sabernaeemi.com
-// @include           Photoshop.exe
-// @compilerOptions   -lUser32 -lGdi32
-// @license      MIT
+// @id            photoshop-dark-menus
+// @name          Photoshop Dark Menus
+// @description   Enables dark mode and custom separator colors for all menus in Adobe Photoshop.
+// @version       1.1.0
+// @author        Saber Naeemi
+// @github        https://github.com/sabergraphics
+// @twitter       https://x.com/SaberNaeemi
+// @homepage      https://www.sabernaeemi.com
+// @include       Photoshop.exe
+// @compilerOptions -lUser32 -lGdi32 -lAdvapi32
+// @license       MIT
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -25,9 +25,9 @@ Forces dark mode for all context and top menu bar dropdowns in Adobe Photoshop w
 - Automatic restoration of default Windows system colors upon exiting Photoshop.
 
 ### Screenshots
-![Photoshop Dark Menu Dropdown](images/photoshop-dark-menu-screenshot-1.png)
+![Photoshop Dark Menu Dropdown](https://raw.githubusercontent.com/sabergraphics/photoshop-dark-menus/main/images/photoshop-dark-menu-screenshot-1.png)
 
-![Photoshop Dark Context Menu](imagesphotoshop-dark-menu-screenshot-2.png)
+![Photoshop Dark Context Menu](https://raw.githubusercontent.com/sabergraphics/photoshop-dark-menus/main/images/photoshop-dark-menu-screenshot-2.png)
 */
 // ==/WindhawkModReadme==
 
@@ -39,8 +39,11 @@ Forces dark mode for all context and top menu bar dropdowns in Adobe Photoshop w
   $name: "Menu Text Color"
 - HighlightBgColor: "#505050"
   $name: "Highlight Background Color"
+- HighlightTextColor: "#FFFFFF"
+  $name: "Highlight Text Color"
 - SeparatorColor: "#383838"
-  $name: "Separator Line Color (Set same as Menu Background Color to hide)"
+  $name: "Separator Line Color"
+  $description: "Set this to the menu background color to hide separators."
 - GrayTextColor: "#808080"
   $name: "Disabled Text Color"
 */
@@ -82,11 +85,43 @@ COLORREF ParseHexColor(const PCWSTR hexStr, COLORREF defaultColor) {
     return defaultColor;
 }
 
+COLORREF GetColorFromRegistry(int sysElement, COLORREF liveColorFallback) {
+    const wchar_t* valueName = nullptr;
+    switch (sysElement) {
+        case COLOR_MENU: valueName = L"Menu"; break;
+        case COLOR_MENUTEXT: valueName = L"MenuText"; break;
+        case COLOR_HIGHLIGHT: valueName = L"Hilight"; break;
+        case COLOR_HIGHLIGHTTEXT: valueName = L"HilightText"; break;
+        case COLOR_BTNSHADOW: valueName = L"ButtonShadow"; break;
+        case COLOR_GRAYTEXT: valueName = L"GrayText"; break;
+        case COLOR_BTNHIGHLIGHT: valueName = L"ButtonHilight"; break;
+        case COLOR_3DDKSHADOW: valueName = L"ButtonDkShadow"; break;
+        case COLOR_3DLIGHT: valueName = L"ButtonLight"; break;
+        case COLOR_MENUBAR: valueName = L"MenuBar"; break;
+    }
+
+    if (valueName) {
+        HKEY hKey;
+        if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Control Panel\\Colors", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
+            wchar_t buffer[64] = {0};
+            DWORD bufferSize = sizeof(buffer);
+            if (RegQueryValueExW(hKey, valueName, nullptr, nullptr, (LPBYTE)buffer, &bufferSize) == ERROR_SUCCESS) {
+                int r, g, b;
+                if (swscanf_s(buffer, L"%d %d %d", &r, &g, &b) == 3) {
+                    RegCloseKey(hKey);
+                    return RGB(r, g, b);
+                }
+            }
+            RegCloseKey(hKey);
+        }
+    }
+    return liveColorFallback;
+}
+
 void SaveOriginalColors() {
     if (g_hasSavedOrigColors) return;
-
     for (int i = 0; i < NUM_ELEMENTS; i++) {
-        g_origColors[i] = GetSysColor(g_sysElements[i]);
+        g_origColors[i] = GetColorFromRegistry(g_sysElements[i], GetSysColor(g_sysElements[i]));
     }
     g_hasSavedOrigColors = true;
 }
@@ -94,39 +129,28 @@ void SaveOriginalColors() {
 void ApplyDarkSystemColors() {
     SaveOriginalColors();
 
-    if (g_hSeparatorBrush) DeleteObject(g_hSeparatorBrush);
+    COLORREF colMenu      = ParseHexColor(WindhawkUtils::StringSetting::make(L"MenuBgColor").get(), RGB(40, 40, 40));
+    COLORREF colText      = ParseHexColor(WindhawkUtils::StringSetting::make(L"MenuTextColor").get(), RGB(220, 220, 220));
+    COLORREF colHighlight = ParseHexColor(WindhawkUtils::StringSetting::make(L"HighlightBgColor").get(), RGB(80, 80, 80));
+    COLORREF colHiText    = ParseHexColor(WindhawkUtils::StringSetting::make(L"HighlightTextColor").get(), RGB(255, 255, 255));
+    COLORREF colSep       = ParseHexColor(WindhawkUtils::StringSetting::make(L"SeparatorColor").get(), RGB(56, 56, 56));
+    COLORREF colGray      = ParseHexColor(WindhawkUtils::StringSetting::make(L"GrayTextColor").get(), RGB(128, 128, 128));
 
-    const PCWSTR bgStr        = Wh_GetStringSetting(L"MenuBgColor");
-    const PCWSTR textStr      = Wh_GetStringSetting(L"MenuTextColor");
-    const PCWSTR highlightStr = Wh_GetStringSetting(L"HighlightBgColor");
-    const PCWSTR sepStr       = Wh_GetStringSetting(L"SeparatorColor");
-    const PCWSTR grayStr      = Wh_GetStringSetting(L"GrayTextColor");
-
-    COLORREF colMenu      = ParseHexColor(bgStr,        RGB(40, 40, 40));
-    COLORREF colText      = ParseHexColor(textStr,      RGB(220, 220, 220));
-    COLORREF colHighlight = ParseHexColor(highlightStr, RGB(80, 80, 80));
-    COLORREF colSep       = ParseHexColor(sepStr,        RGB(56, 56, 56));
-    COLORREF colGray      = ParseHexColor(grayStr,      RGB(128, 128, 128));
-
-    Wh_FreeStringSetting(bgStr);
-    Wh_FreeStringSetting(textStr);
-    Wh_FreeStringSetting(highlightStr);
-    Wh_FreeStringSetting(sepStr);
-    Wh_FreeStringSetting(grayStr);
-
-    g_hSeparatorBrush = CreateSolidBrush(colSep);
+    HBRUSH hNewSepBrush = CreateSolidBrush(colSep);
+    HBRUSH hOldSepBrush = (HBRUSH)InterlockedExchangePointer((PVOID*)&g_hSeparatorBrush, hNewSepBrush);
+    if (hOldSepBrush) DeleteObject(hOldSepBrush);
 
     COLORREF darkColors[NUM_ELEMENTS] = {
-        colMenu,
-        colText,
-        colHighlight,
-        RGB(255, 255, 255),
-        colMenu,
-        colGray,
-        colMenu,
-        colMenu,
-        colMenu,
-        colMenu
+        colMenu,      // COLOR_MENU
+        colText,      // COLOR_MENUTEXT
+        colHighlight, // COLOR_HIGHLIGHT
+        colHiText,    // COLOR_HIGHLIGHTTEXT
+        colMenu,      // COLOR_BTNSHADOW
+        colGray,      // COLOR_GRAYTEXT
+        colMenu,      // COLOR_BTNHIGHLIGHT
+        colMenu,      // COLOR_3DDKSHADOW
+        colMenu,      // COLOR_3DLIGHT
+        colMenu       // COLOR_MENUBAR
     };
 
     SetSysColors(NUM_ELEMENTS, g_sysElements, darkColors);
@@ -136,15 +160,48 @@ void RestoreOriginalColors() {
     if (g_hasSavedOrigColors) {
         SetSysColors(NUM_ELEMENTS, g_sysElements, g_origColors);
     }
-    if (g_hSeparatorBrush) DeleteObject(g_hSeparatorBrush);
+    HBRUSH hOldBrush = (HBRUSH)InterlockedExchangePointer((PVOID*)&g_hSeparatorBrush, nullptr);
+    if (hOldBrush) DeleteObject(hOldBrush);
+}
+
+// -------------------------------------------------------------------------
+// Hooks
+// -------------------------------------------------------------------------
+
+// Safely determines if the drawing is happening for a menu, 
+// even if a memory DC (double-buffering) is being used.
+bool IsMenuContext(HDC hdc) {
+    HWND hWnd = WindowFromDC(hdc);
+    if (hWnd) {
+        // Direct drawing to a real window
+        WCHAR cls[16];
+        if (GetClassNameW(hWnd, cls, ARRAYSIZE(cls)) && wcscmp(cls, L"#32768") == 0) {
+            return true;
+        }
+        return false;
+    } 
+    
+    // If hWnd is NULL, it is likely a Memory DC used for double-buffering.
+    // Check if the current thread is actively displaying a menu.
+    if (GetObjectType(hdc) == OBJ_MEMDC) {
+        GUITHREADINFO gti = { sizeof(GUITHREADINFO) };
+        if (GetGUIThreadInfo(GetCurrentThreadId(), &gti)) {
+            if (gti.flags & GUI_INMENUMODE) {
+                return true;
+            }
+        }
+    }
+    
+    return false;
 }
 
 using PatBlt_t = BOOL (WINAPI*)(HDC hdc, int x, int y, int w, int h, DWORD rop);
 PatBlt_t PatBlt_Original = nullptr;
 
 BOOL WINAPI PatBlt_Hook(HDC hdc, int x, int y, int w, int h, DWORD rop) {
-    if ((h == 1 || h == 2) && w > 20 && g_hSeparatorBrush) {
-        HBRUSH hOldBrush = (HBRUSH)SelectObject(hdc, g_hSeparatorBrush);
+    HBRUSH hBrush = g_hSeparatorBrush; 
+    if (rop == PATCOPY && (h == 1 || h == 2) && w > 20 && hBrush && IsMenuContext(hdc)) {
+        HBRUSH hOldBrush = (HBRUSH)SelectObject(hdc, hBrush);
         BOOL bRes = PatBlt_Original(hdc, x, y, w, h, rop);
         SelectObject(hdc, hOldBrush);
         return bRes;
@@ -156,40 +213,57 @@ using FillRect_t = int (WINAPI*)(HDC hdc, const RECT *lprc, HBRUSH hbr);
 FillRect_t FillRect_Original = nullptr;
 
 int WINAPI FillRect_Hook(HDC hdc, const RECT *lprc, HBRUSH hbr) {
-    if (lprc && g_hSeparatorBrush) {
+    HBRUSH hBrush = g_hSeparatorBrush; 
+    if (lprc && hBrush && IsMenuContext(hdc)) {
         int h = lprc->bottom - lprc->top;
         int w = lprc->right - lprc->left;
         if ((h == 1 || h == 2) && w > 20) {
-            return FillRect_Original(hdc, lprc, g_hSeparatorBrush);
+            return FillRect_Original(hdc, lprc, hBrush);
         }
     }
     return FillRect_Original(hdc, lprc, hbr);
 }
+
+using ExitProcess_t = void (WINAPI*)(UINT uExitCode);
+ExitProcess_t ExitProcess_Original = nullptr;
+
+void WINAPI ExitProcess_Hook(UINT uExitCode) {
+    RestoreOriginalColors();
+    ExitProcess_Original(uExitCode);
+}
+
+// -------------------------------------------------------------------------
+// Windhawk Events
+// -------------------------------------------------------------------------
 
 void Wh_ModSettingsChanged() {
     ApplyDarkSystemColors();
 }
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"Initializing Photoshop Dark Menus");
     ApplyDarkSystemColors();
 
     HMODULE hGdi32 = GetModuleHandleW(L"gdi32.dll");
     if (hGdi32) {
         void* pPatBlt = (void*)GetProcAddress(hGdi32, "PatBlt");
-        if (pPatBlt) WindhawkUtils::SetFunctionHook(pPatBlt, (void*)PatBlt_Hook, (void**)&PatBlt_Original);
+        if (pPatBlt) Wh_SetFunctionHook(pPatBlt, (void*)PatBlt_Hook, (void**)&PatBlt_Original);
     }
 
     HMODULE hUser32 = GetModuleHandleW(L"user32.dll");
     if (hUser32) {
         void* pFillRect = (void*)GetProcAddress(hUser32, "FillRect");
-        if (pFillRect) WindhawkUtils::SetFunctionHook(pFillRect, (void*)FillRect_Hook, (void**)&FillRect_Original);
+        if (pFillRect) Wh_SetFunctionHook(pFillRect, (void*)FillRect_Hook, (void**)&FillRect_Original);
+    }
+
+    HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
+    if (hKernel32) {
+        void* pExitProcess = (void*)GetProcAddress(hKernel32, "ExitProcess");
+        if (pExitProcess) Wh_SetFunctionHook(pExitProcess, (void*)ExitProcess_Hook, (void**)&ExitProcess_Original);
     }
 
     return TRUE;
 }
 
 void Wh_ModUninit() {
-    Wh_Log(L"Restoring original system palette colors");
     RestoreOriginalColors();
 }

--- a/mods/photoshop-dark-menus.wh.cpp
+++ b/mods/photoshop-dark-menus.wh.cpp
@@ -425,6 +425,12 @@ bool IsMenuPopupWindow(HWND hWnd) {
     return GetClassNameW(hWnd, cls, ARRAYSIZE(cls)) && wcscmp(cls, L"#32768") == 0;
 }
 
+// The system reuses menu popup windows, so a subclassed popup can still be
+// alive when the mod unloads - and its window procedure would then point into
+// an unloaded DLL. Track them and remove each subclass at uninit.
+std::unordered_set<HWND> g_subclassedPopups;
+std::mutex g_subclassedPopupsMutex;
+
 // Subclassing the popup rather than watching messages from a hook: WM_PAINT is
 // posted, not sent, so a WH_CALLWNDPROCRET hook never sees it, and a popup that
 // repaints that way would keep the system frame.
@@ -433,6 +439,11 @@ LRESULT CALLBACK MenuPopupSubclassProc(HWND hWnd,
                                        WPARAM wParam,
                                        LPARAM lParam,
                                        DWORD_PTR dwRefData) {
+    if (uMsg == WM_NCDESTROY) {
+        std::lock_guard<std::mutex> lock(g_subclassedPopupsMutex);
+        g_subclassedPopups.erase(hWnd);
+    }
+
     LRESULT result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
 
     switch (uMsg) {
@@ -460,7 +471,10 @@ LRESULT CALLBACK CbtProcHook(int code, WPARAM wParam, LPARAM lParam) {
     if (code == HCBT_CREATEWND) {
         HWND hWnd = (HWND)wParam;
         if (IsMenuPopupWindow(hWnd) && g_hBorderBrush.load(std::memory_order_acquire)) {
-            if (!WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, MenuPopupSubclassProc, 0)) {
+            if (WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, MenuPopupSubclassProc, 0)) {
+                std::lock_guard<std::mutex> lock(g_subclassedPopupsMutex);
+                g_subclassedPopups.insert(hWnd);
+            } else {
                 DBG(L"Failed to subclass menu popup %p; it keeps the system frame.", hWnd);
             }
         }
@@ -635,7 +649,18 @@ void Wh_ModUninit() {
         UnhookWindowsHookEx(tl_cbtHook);
         tl_cbtHook = nullptr;
     }
-    WindhawkUtils::RemoveAllWindowSubclasses();
+    // Not WindhawkUtils::RemoveAllWindowSubclasses(), which needs Windhawk 1.8.
+    {
+        std::vector<HWND> popups;
+        {
+            std::lock_guard<std::mutex> lock(g_subclassedPopupsMutex);
+            popups.assign(g_subclassedPopups.begin(), g_subclassedPopups.end());
+            g_subclassedPopups.clear();
+        }
+        for (HWND hWnd : popups) {
+            WindhawkUtils::RemoveWindowSubclassFromAnyThread(hWnd, MenuPopupSubclassProc);
+        }
+    }
 
     // Undo the background brush stamped on Photoshop's menus, so disabling the
     // mod restores the normal menus without restarting the application.

--- a/mods/photoshop-dark-menus.wh.cpp
+++ b/mods/photoshop-dark-menus.wh.cpp
@@ -2,7 +2,7 @@
 // @id            photoshop-dark-menus
 // @name          Photoshop Dark Menus
 // @description   Enables dark mode and custom colors for all menus in Adobe Photoshop.
-// @version       2.0.0
+// @version       1.0.0
 // @author        Saber Naeemi
 // @github        https://github.com/sabergraphics
 // @twitter       https://x.com/SaberNaeemi
@@ -60,14 +60,13 @@ So every pixel of a menu item is reachable from inside the process:
 
 ## Options
 
-- **Menu Background Color**: Background color for all menu popups (Default: `#282828`).
+- **Menu Background Color**: Background color for all menu popups (Default: `#2D2D2D`).
 - **Menu Text Color**: Text color for active items (Default: `#DCDCDC`).
 - **Highlight Background Color**: Color when hovering over an item (Default: `#505050`).
 - **Highlight Text Color**: Text color when hovering over an item (Default: `#FFFFFF`).
 - **Separator Line Color**: Color for separator lines. Set to match the background color to hide them completely (Default: `#383838`).
 - **Disabled Text Color**: Text color for disabled menu items (Default: `#808080`).
-- **Border Color**: Color of the popup frame. Leave empty to keep the system frame (Default: `#282828`).
-- **Debug Logging**: Diagnostic logging, off by default.
+- **Border Color**: Color of the popup frame. Leave empty to keep the system frame (Default: `#2D2D2D`).
 
 ## Scope
 
@@ -75,29 +74,16 @@ The menu bar itself (File, Edit, Image, ...) is drawn by Photoshop's own UI
 framework and already follows Photoshop's interface theme; this mod covers the
 dropdown popups and context menus.
 
-## Changelog
-
-### 2.0.0
-- Replaced the global `SetSysColors` engine with a fully process-local one.
-  Nothing outside Photoshop changes any more, and with it went the registry
-  backup, the `RtlExitUserProcess` teardown, crash recovery, the multi-instance
-  semaphore and the two-engine setting.
-- `FillRect` now re-resolves system color pseudo-handles, which is what actually
-  reaches Photoshop's item backgrounds and hover highlight.
-- System color overrides are scoped to open menus, so Photoshop's dialogs and
-  panels keep the system colors.
-- The popup frame is repainted from a subclass on the popup, with a new border
-  color setting.
-- Menus stamped with the background brush are restored when the mod is
-  unloaded, so disabling the mod brings the normal menus back without
-  restarting Photoshop.
+Menus that Windows pops up through its own internal paths, without going through
+the exported `TrackPopupMenu` / `TrackPopupMenuEx` - a window's system menu, for
+example - are outside the reach of an in-process hook and keep the system colors.
 */
 // ==/WindhawkModReadme==
 
 
 // ==WindhawkModSettings==
 /*
-- MenuBgColor: "#282828"
+- MenuBgColor: "#2D2D2D"
   $name: "Menu Background Color"
 - MenuTextColor: "#DCDCDC"
   $name: "Menu Text Color"
@@ -110,15 +96,11 @@ dropdown popups and context menus.
   $description: Set this to the menu background color to hide separators.
 - GrayTextColor: "#808080"
   $name: "Disabled Text Color"
-- BorderColor: "#282828"
+- BorderColor: "#2D2D2D"
   $name: "Border Color"
   $description: >-
     Color of the popup frame, which the system draws from the 3D colors. Leave
     empty to keep the system frame.
-- DebugLogging: false
-  $name: "Debug Logging"
-  $description: >-
-    Logs menu drawing diagnostics. Leave off for normal use.
 */
 // ==/WindhawkModSettings==
 
@@ -138,7 +120,7 @@ dropdown popups and context menus.
 // ---------------------------------------------------------------------------
 
 // Colors read by the in-process hooks.
-std::atomic<COLORREF> g_colMenu{RGB(40, 40, 40)};
+std::atomic<COLORREF> g_colMenu{RGB(45, 45, 45)};
 std::atomic<COLORREF> g_colText{RGB(220, 220, 220)};
 std::atomic<COLORREF> g_colHighlight{RGB(80, 80, 80)};
 std::atomic<COLORREF> g_colHiText{RGB(255, 255, 255)};
@@ -156,11 +138,12 @@ std::atomic<HBRUSH> g_hBorderBrush{nullptr};
 std::vector<HBRUSH> g_retiredBrushes;
 std::mutex g_brushMutex;
 
-std::atomic<bool> g_debugLog{false};
-
-// Number of menu tracking calls currently on the stack. The hot GDI hooks bail
-// out on a single relaxed load when no menu is up.
-std::atomic<int> g_menuDepth{0};
+// Number of menu tracking calls currently on this thread's stack. A menu is
+// modal on the thread that opened it: the popup window, the WM_DRAWITEM painting
+// into the per-item memory DCs and the popup's own repaints all happen there. So
+// the state is thread-local, which keeps a menu on the UI thread from recoloring
+// another thread's drawing, and makes the hot path a plain TLS read.
+thread_local int tl_menuDepth = 0;
 
 // Set while this thread is painting on the mod's behalf, so our own drawing
 // does not re-enter the hooks.
@@ -169,9 +152,35 @@ thread_local bool tl_inOurPaint = false;
 // Hooks installed for the duration of a menu, on the menu's own thread.
 thread_local HHOOK tl_msgHook = nullptr;
 thread_local HHOOK tl_cbtHook = nullptr;
-thread_local int tl_menuHookDepth = 0;
 
-#define DBG(...) do { if (g_debugLog.load(std::memory_order_relaxed)) Wh_Log(__VA_ARGS__); } while (0)
+// Unlike the mod's function hooks, SetWindowsHookEx hooks are not removed by the
+// Windhawk engine, and their procedures live in the mod image - so one still
+// registered when the image is unmapped calls into freed memory on the next
+// message for that thread. The handles are tracked globally because Wh_ModUninit
+// never runs on the thread that installed them: while a menu is up that thread
+// is blocked in the modal menu loop. UnhookWindowsHookEx is not thread-affine,
+// so the handles can be released from any thread in the process.
+std::unordered_set<HHOOK> g_winHooks;
+std::mutex g_winHooksMutex;
+
+void TrackWinHook(HHOOK hHook) {
+    if (!hHook) return;
+
+    std::lock_guard<std::mutex> lock(g_winHooksMutex);
+    g_winHooks.insert(hHook);
+}
+
+// Releasing a handle Wh_ModUninit already dropped is harmless: the call just
+// fails on a handle that is no longer registered.
+void ReleaseWinHook(HHOOK hHook) {
+    if (!hHook) return;
+
+    {
+        std::lock_guard<std::mutex> lock(g_winHooksMutex);
+        g_winHooks.erase(hHook);
+    }
+    UnhookWindowsHookEx(hHook);
+}
 
 // ---------------------------------------------------------------------------
 // Settings
@@ -227,9 +236,7 @@ void PublishSolidBrush(std::atomic<HBRUSH>* pSlot, COLORREF color) {
 }
 
 void LoadSettings() {
-    g_debugLog.store(Wh_GetIntSetting(L"DebugLogging") != 0, std::memory_order_relaxed);
-
-    COLORREF colMenu  = ParseHexColorOr(WindhawkUtils::StringSetting::make(L"MenuBgColor").get(), RGB(40, 40, 40));
+    COLORREF colMenu  = ParseHexColorOr(WindhawkUtils::StringSetting::make(L"MenuBgColor").get(), RGB(45, 45, 45));
     COLORREF colText  = ParseHexColorOr(WindhawkUtils::StringSetting::make(L"MenuTextColor").get(), RGB(220, 220, 220));
     COLORREF colHigh  = ParseHexColorOr(WindhawkUtils::StringSetting::make(L"HighlightBgColor").get(), RGB(80, 80, 80));
     COLORREF colHiTxt = ParseHexColorOr(WindhawkUtils::StringSetting::make(L"HighlightTextColor").get(), RGB(255, 255, 255));
@@ -263,13 +270,15 @@ void LoadSettings() {
 // ---------------------------------------------------------------------------
 
 inline bool MenuIsOpen() {
-    return g_menuDepth.load(std::memory_order_relaxed) > 0;
+    return tl_menuDepth > 0;
 }
 
 // Photoshop paints menu items into per-item memory DCs while the popup is being
 // laid out, and directly onto the popup's own window DC when an item is
-// re-drawn on hover. Both are only reached while a menu is up, which the caller
-// has already established with MenuIsOpen().
+// re-drawn on hover. The memory DC fallback matches any memory DC, so it leans
+// on the caller having established MenuIsOpen() first - which is thread-local,
+// i.e. this thread is the one inside the modal menu loop and is not drawing
+// anything else.
 bool IsMenuContext(HDC hdc) {
     HWND hWnd = WindowFromDC(hdc);
     if (hWnd) {
@@ -331,15 +340,26 @@ void ApplyMenuBackground(HMENU hMenu) {
     HBRUSH hBrush = g_hMenuBrush.load(std::memory_order_acquire);
     if (!hMenu || !hBrush) return;
 
+    // The cap is checked before stamping, not after: a menu that is stamped but
+    // not recorded would stay dark for the life of the process, which is the one
+    // thing the tracking exists to prevent.
+    {
+        std::lock_guard<std::mutex> lock(g_stampedMenusMutex);
+        if (g_stampedMenus.size() >= kMaxTrackedMenus && !g_stampedMenus.contains(hMenu)) {
+            return;
+        }
+    }
+
     MENUINFO mi = { sizeof(mi) };
     mi.fMask = MIM_BACKGROUND | MIM_APPLYTOSUBMENUS;
     mi.hbrBack = hBrush;
     if (!SetMenuInfo(hMenu, &mi)) return;
 
+    // SetMenuInfo can reach a menu owned by another thread, so it is called
+    // outside the lock; two threads racing past the check can leave the set one
+    // entry over the cap, which is harmless.
     std::lock_guard<std::mutex> lock(g_stampedMenusMutex);
-    if (g_stampedMenus.size() < kMaxTrackedMenus) {
-        g_stampedMenus.insert(hMenu);
-    }
+    g_stampedMenus.insert(hMenu);
 }
 
 // MIM_APPLYTOSUBMENUS propagates the cleared brush down each menu tree, so
@@ -392,6 +412,12 @@ int GetPopupFrameWidth(HWND hWnd, const RECT& windowRect) {
 // offscreen and blitted (WM_PRINT / WM_NCUAHDRAWFRAME carry that DC in wParam),
 // so painting on the window DC instead would just be overwritten by the blit.
 void PaintPopupBorder(HWND hWnd, HDC hdcTarget) {
+    // Popups are subclassed unconditionally and the system reuses them, so a
+    // popup can be shown again later by a menu this mod doesn't theme - one that
+    // never went through TrackPopupMenu(Ex). Painting only while this thread is
+    // tracking a menu keeps the dark frame off an otherwise untouched menu.
+    if (!MenuIsOpen()) return;
+
     HBRUSH hBorder = g_hBorderBrush.load(std::memory_order_acquire);
     if (!hBorder) return;
 
@@ -465,18 +491,35 @@ LRESULT CALLBACK MenuPopupSubclassProc(HWND hWnd,
     return result;
 }
 
-// Catches the popup at creation, which is the only reliable moment: it exists
-// on this thread and has not painted yet.
+// Subclassed even when Border Color is empty, and regardless of whether a menu
+// is up: the system reuses menu popup windows, so a popup passed over here is
+// never revisited, and setting a border color later would silently do nothing
+// for the rest of the session. PaintPopupBorder returns immediately when there
+// is no border brush.
+void SubclassPopup(HWND hWnd) {
+    {
+        std::lock_guard<std::mutex> lock(g_subclassedPopupsMutex);
+        if (g_subclassedPopups.contains(hWnd)) return;
+    }
+
+    // Not subclassed under the lock: from another thread the helper gets there
+    // with a SendMessage, and the subclass procedure takes the same lock on
+    // WM_NCDESTROY.
+    if (WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, MenuPopupSubclassProc, 0)) {
+        std::lock_guard<std::mutex> lock(g_subclassedPopupsMutex);
+        g_subclassedPopups.insert(hWnd);
+    } else {
+        Wh_Log(L"Failed to subclass menu popup %p; it keeps the system frame.", hWnd);
+    }
+}
+
+// Catches a popup at creation, before it has painted. Popups that already exist
+// are picked up by the sweep in EnterMenu.
 LRESULT CALLBACK CbtProcHook(int code, WPARAM wParam, LPARAM lParam) {
     if (code == HCBT_CREATEWND) {
         HWND hWnd = (HWND)wParam;
-        if (IsMenuPopupWindow(hWnd) && g_hBorderBrush.load(std::memory_order_acquire)) {
-            if (WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, MenuPopupSubclassProc, 0)) {
-                std::lock_guard<std::mutex> lock(g_subclassedPopupsMutex);
-                g_subclassedPopups.insert(hWnd);
-            } else {
-                DBG(L"Failed to subclass menu popup %p; it keeps the system frame.", hWnd);
-            }
+        if (IsMenuPopupWindow(hWnd)) {
+            SubclassPopup(hWnd);
         }
     }
     return CallNextHookEx(nullptr, code, wParam, lParam);
@@ -493,39 +536,43 @@ LRESULT CALLBACK CallWndRetProcHook(int code, WPARAM wParam, LPARAM lParam) {
     return CallNextHookEx(nullptr, code, wParam, lParam);
 }
 
-// Menus are modal, so the hook only exists while one is up. Nested tracking
-// calls (submenus opened via TrackPopupMenu) share the outermost hook.
+// Menus are modal, so the hooks only exist while one is up. Nested tracking
+// calls (submenus opened via TrackPopupMenu) share the outermost hooks.
 void EnterMenu(HMENU hMenu) {
-    g_menuDepth.fetch_add(1, std::memory_order_relaxed);
+    bool outermost = (tl_menuDepth++ == 0);
     ApplyMenuBackground(hMenu);
+    if (!outermost) return;
 
-    if (tl_menuHookDepth++ == 0) {
-        DWORD tid = GetCurrentThreadId();
-        tl_msgHook = SetWindowsHookExW(WH_CALLWNDPROCRET, CallWndRetProcHook, nullptr, tid);
-        tl_cbtHook = SetWindowsHookExW(WH_CBT, CbtProcHook, nullptr, tid);
-        if (!tl_msgHook || !tl_cbtHook) {
-            Wh_Log(L"SetWindowsHookEx failed (%u); popup border and submenu "
-                   L"backgrounds fall back to the system's.", GetLastError());
-        }
+    DWORD tid = GetCurrentThreadId();
+    tl_msgHook = SetWindowsHookExW(WH_CALLWNDPROCRET, CallWndRetProcHook, nullptr, tid);
+    tl_cbtHook = SetWindowsHookExW(WH_CBT, CbtProcHook, nullptr, tid);
+    TrackWinHook(tl_msgHook);
+    TrackWinHook(tl_cbtHook);
+    if (!tl_msgHook || !tl_cbtHook) {
+        Wh_Log(L"SetWindowsHookEx failed (%u); popup border and submenu "
+               L"backgrounds fall back to the system's.", GetLastError());
     }
+
+    // Popup windows this thread already has, which CbtProcHook by definition
+    // never sees: the system caches and reuses them, so every popup from a menu
+    // opened before the mod was enabled - the usual way a mod is first tried -
+    // would otherwise keep the system frame for the rest of the session.
+    EnumThreadWindows(tid, [](HWND hWnd, LPARAM) WINAPI -> BOOL {
+        if (IsMenuPopupWindow(hWnd)) {
+            SubclassPopup(hWnd);
+        }
+        return TRUE;
+    }, 0);
 }
 
 void LeaveMenu() {
-    if (--tl_menuHookDepth <= 0) {
-        tl_menuHookDepth = 0;
-        if (tl_msgHook) {
-            UnhookWindowsHookEx(tl_msgHook);
-            tl_msgHook = nullptr;
-        }
-        if (tl_cbtHook) {
-            UnhookWindowsHookEx(tl_cbtHook);
-            tl_cbtHook = nullptr;
-        }
-    }
+    if (--tl_menuDepth > 0) return;
 
-    if (g_menuDepth.fetch_sub(1, std::memory_order_relaxed) <= 0) {
-        g_menuDepth.store(0, std::memory_order_relaxed);
-    }
+    tl_menuDepth = 0;
+    ReleaseWinHook(tl_msgHook);
+    tl_msgHook = nullptr;
+    ReleaseWinHook(tl_cbtHook);
+    tl_cbtHook = nullptr;
 }
 
 // ---------------------------------------------------------------------------
@@ -587,7 +634,7 @@ int WINAPI FillRect_Hook(HDC hdc, const RECT* lprc, HBRUSH hbr) {
     if (sysIndex <= (ULONG_PTR)COLOR_MENUBAR) {
         HBRUSH ours = BrushForSysColor((int)sysIndex);
         if (ours && IsMenuContext(hdc)) {
-            DBG(L"FillRect: system color %d -> mod color, %dx%d", (int)sysIndex, w, h);
+            Wh_Log(L"FillRect: system color %d -> mod color, %dx%d", (int)sysIndex, w, h);
             return FillRect_Original(hdc, lprc, ours);
         }
         return FillRect_Original(hdc, lprc, hbr);
@@ -595,7 +642,7 @@ int WINAPI FillRect_Hook(HDC hdc, const RECT* lprc, HBRUSH hbr) {
 
     HBRUSH hSep = g_hSeparatorBrush.load(std::memory_order_acquire);
     if (hSep && IsSeparatorGeometry(hdc, w, h) && IsMenuContext(hdc)) {
-        DBG(L"FillRect: separator %dx%d recolored", w, h);
+        Wh_Log(L"FillRect: separator %dx%d recolored", w, h);
         return FillRect_Original(hdc, lprc, hSep);
     }
 
@@ -641,14 +688,20 @@ BOOL Wh_ModInit() {
 }
 
 void Wh_ModUninit() {
-    if (tl_msgHook) {
-        UnhookWindowsHookEx(tl_msgHook);
-        tl_msgHook = nullptr;
+    // The message hooks belong to whichever Photoshop thread had a menu up, not
+    // to this one, so they are released through the global set - see g_winHooks.
+    {
+        std::vector<HHOOK> hooks;
+        {
+            std::lock_guard<std::mutex> lock(g_winHooksMutex);
+            hooks.assign(g_winHooks.begin(), g_winHooks.end());
+            g_winHooks.clear();
+        }
+        for (HHOOK hHook : hooks) {
+            UnhookWindowsHookEx(hHook);
+        }
     }
-    if (tl_cbtHook) {
-        UnhookWindowsHookEx(tl_cbtHook);
-        tl_cbtHook = nullptr;
-    }
+
     // Not WindhawkUtils::RemoveAllWindowSubclasses(), which needs Windhawk 1.8.
     {
         std::vector<HWND> popups;

--- a/mods/photoshop-dark-menus.wh.cpp
+++ b/mods/photoshop-dark-menus.wh.cpp
@@ -1,14 +1,14 @@
 // ==WindhawkMod==
 // @id            photoshop-dark-menus
 // @name          Photoshop Dark Menus
-// @description   Enables dark mode and custom separator colors for all menus in Adobe Photoshop.
-// @version       1.2.0
+// @description   Enables dark mode and custom colors for all menus in Adobe Photoshop.
+// @version       2.0.0
 // @author        Saber Naeemi
 // @github        https://github.com/sabergraphics
 // @twitter       https://x.com/SaberNaeemi
 // @homepage      https://www.sabernaeemi.com
 // @include       Photoshop.exe
-// @compilerOptions -lUser32 -lGdi32 -lAdvapi32
+// @compilerOptions -lUser32 -lGdi32 -lComctl32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -16,7 +16,10 @@
 # Photoshop Dark Menus
 
 This Windhawk mod enables dark menus (top-bar dropdowns and context menus) in
-Adobe Photoshop on Windows 11, along with custom color settings.
+Adobe Photoshop on Windows, with fully customizable colors.
+
+Everything happens inside the Photoshop process. No system colors are changed,
+no other application is affected, and nothing has to be restored on exit.
 
 ## Screenshots
 
@@ -26,88 +29,74 @@ Adobe Photoshop on Windows 11, along with custom color settings.
 
 ## How it works
 
-The mod has two theming engines, selectable in the settings.
+Photoshop's menus look like classic unthemed Win32 menus, but they are not:
+Photoshop **owner-draws every menu item itself** through `AdobeOwl.dll`, using
+plain GDI, inside its own process. Instrumenting a live Photoshop shows the
+menu popups going up via `TrackPopupMenuEx` and every item being painted with:
 
-### Global system colors (default)
+- `FillRect(hdc, &rc, (HBRUSH)(COLOR_MENU + 1))` for the item background, and
+  `(HBRUSH)(COLOR_HIGHLIGHT + 1)` for the hovered item. These **system color
+  pseudo-handles** are resolved inside `user32` from shared memory, so they
+  bypass `GetSysColor` and `GetSysColorBrush` hooks entirely - which is why
+  earlier per-process attempts appeared to do nothing.
+- `GetSysColor(COLOR_MENUTEXT / COLOR_GRAYTEXT / COLOR_HIGHLIGHTTEXT)` for text.
+- Its own 1px `FillRect` for separator lines.
 
-Photoshop renders its legacy Win32 menus through the classic (unthemed) path,
-which reads the shared system color table directly — so per-process dark-mode
-techniques (`SetPreferredAppMode`, `GetSysColor` hooks) do not reach it. This
-engine updates the active Windows session palette with `SetSysColors`, which
-is the only approach found to reliably darken Photoshop's menus.
+So every pixel of a menu item is reachable from inside the process:
 
-**Warning:** while this mode is active, the menu/selection/3D colors change
-for *every* application on the desktop, not just Photoshop, until Photoshop
-exits. Safeguards used in this mode:
-
-- Original colors are backed up from `HKCU\Control Panel\Colors` (not from the
-  possibly-already-modified live palette), so restarts and multiple instances
-  cannot corrupt the backup.
-- Colors are restored from an `ExitProcess` teardown hook. If another
-  Photoshop instance is still running, restoration is deferred to the last
-  instance to exit, so instances no longer fight over the palette.
-- If Photoshop **hard-crashes** (faulty plugin, Force Quit via Task Manager),
-  the teardown hook cannot run and the desktop may remain dark. Launching and
-  cleanly closing Photoshop once restores the original colors.
-
-### Process-local (experimental)
-
-Everything stays inside the Photoshop process; no other application is
-affected:
-
-- Switches the process to the dark menu theme via `uxtheme`
-  (`SetPreferredAppMode` + `FlushMenuThemes`).
-- Hooks `GetSysColor` / `GetSysColorBrush` in-process, so Photoshop's legacy
-  menu drawing code picks up the custom menu, text, highlight and disabled-text
-  colors without touching the system palette.
-- Sets a custom background brush on Photoshop's menus
-  (`MENUINFO::hbrBack`, applied to submenus and to context menus via
-  `TrackPopupMenu(Ex)` hooks).
-- Hooks `PatBlt` / `FillRect`, strictly scoped to active menu windows (class
-  `#32768` or modal `GUI_INMENUMODE`), to recolor the separator lines that
-  Photoshop draws with legacy GDI calls.
-
-In testing, this mode does **not** darken Photoshop's menu backgrounds and
-text, because Photoshop's classic menu rendering bypasses the hooked user-mode
-color APIs. It is kept as an opt-in for experimentation and for setups where
-it may behave differently.
-
-## Why a standalone mod?
-
-The system-wide [Dark mode context menus](https://github.com/MGGSK/DarkMenus)
-mod darkens Win32 menus globally but does not offer per-color customization,
-and its approach alone does not cover Photoshop's legacy separator drawing.
-This mod adds fully customizable menu colors, Photoshop-scoped GDI separator
-hooks that would be unsafe in an `@include *` mod, and a global-palette
-fallback for setups where process-local theming is not sufficient.
+- `FillRect` / `PatBlt` are hooked and, while a menu is up, sys-color
+  pseudo-handles are re-resolved through this mod's own color table, and 1px
+  fills inside a menu DC are recolored to the separator color.
+- `GetSysColor` / `GetSysColorBrush` are hooked for the menu color indices, but
+  **only while a menu is open**, so Photoshop's dialogs, panels and lists keep
+  the system colors.
+- `MENUINFO::hbrBack` is stamped on each popup (and its submenus) at
+  `WM_INITMENUPOPUP`, covering the popup background that the system paints
+  around the owner-drawn items.
+- The popup's non-client frame is the one part drawn kernel-side, from the 3D
+  colors, where no user-mode hook can reach it - so the popup is subclassed at
+  creation and the frame is repainted with the border color after it. Set
+  **Border Color** empty to leave the system frame alone.
 
 ## Options
 
-- **Theming Mode**: Global system colors (default; affects the whole desktop
-  while Photoshop runs) or process-local (experimental; only affects Photoshop
-  but does not darken menus on most setups).
 - **Menu Background Color**: Background color for all menu popups (Default: `#282828`).
 - **Menu Text Color**: Text color for active items (Default: `#DCDCDC`).
 - **Highlight Background Color**: Color when hovering over an item (Default: `#505050`).
 - **Highlight Text Color**: Text color when hovering over an item (Default: `#FFFFFF`).
 - **Separator Line Color**: Color for separator lines. Set to match the background color to hide them completely (Default: `#383838`).
 - **Disabled Text Color**: Text color for disabled menu items (Default: `#808080`).
+- **Border Color**: Color of the popup frame. Leave empty to keep the system frame (Default: `#282828`).
+- **Debug Logging**: Diagnostic logging, off by default.
+
+## Scope
+
+The menu bar itself (File, Edit, Image, ...) is drawn by Photoshop's own UI
+framework and already follows Photoshop's interface theme; this mod covers the
+dropdown popups and context menus.
+
+## Changelog
+
+### 2.0.0
+- Replaced the global `SetSysColors` engine with a fully process-local one.
+  Nothing outside Photoshop changes any more, and with it went the registry
+  backup, the `RtlExitUserProcess` teardown, crash recovery, the multi-instance
+  semaphore and the two-engine setting.
+- `FillRect` now re-resolves system color pseudo-handles, which is what actually
+  reaches Photoshop's item backgrounds and hover highlight.
+- System color overrides are scoped to open menus, so Photoshop's dialogs and
+  panels keep the system colors.
+- The popup frame is repainted from a subclass on the popup, with a new border
+  color setting.
+- Menus stamped with the background brush are restored when the mod is
+  unloaded, so disabling the mod brings the normal menus back without
+  restarting Photoshop.
 */
 // ==/WindhawkModReadme==
 
 
 // ==WindhawkModSettings==
 /*
-- ThemingMode: systemColors
-  $name: "Theming Mode"
-  $description: >-
-    Global system colors reliably darkens Photoshop's menus but affects the
-    whole desktop while Photoshop runs. Process-local only affects Photoshop
-    but does not darken the menus on most setups, because Photoshop's menu
-    rendering reads the system color table directly.
-  $options:
-  - systemColors: "Global system colors (recommended for Photoshop)"
-  - processLocal: "Process-local (experimental)"
 - MenuBgColor: "#282828"
   $name: "Menu Background Color"
 - MenuTextColor: "#DCDCDC"
@@ -118,428 +107,550 @@ fallback for setups where process-local theming is not sufficient.
   $name: "Highlight Text Color"
 - SeparatorColor: "#383838"
   $name: "Separator Line Color"
+  $description: Set this to the menu background color to hide separators.
 - GrayTextColor: "#808080"
   $name: "Disabled Text Color"
+- BorderColor: "#282828"
+  $name: "Border Color"
+  $description: >-
+    Color of the popup frame, which the system draws from the 3D colors. Leave
+    empty to keep the system frame.
+- DebugLogging: false
+  $name: "Debug Logging"
+  $description: >-
+    Logs menu drawing diagnostics. Leave off for normal use.
 */
 // ==/WindhawkModSettings==
 
 #include <windows.h>
-#include <tlhelp32.h>
+#include <commctrl.h>
 #include <windhawk_api.h>
 #include <windhawk_utils.h>
 #include <wchar.h>
 #include <wctype.h>
-#include <vector>
+#include <atomic>
 #include <mutex>
+#include <unordered_set>
+#include <vector>
 
-constexpr int NUM_ELEMENTS = 10;
-const INT g_sysElements[NUM_ELEMENTS] = {
-    COLOR_MENU, COLOR_MENUTEXT, COLOR_HIGHLIGHT, COLOR_HIGHLIGHTTEXT,
-    COLOR_BTNSHADOW, COLOR_GRAYTEXT, COLOR_BTNHIGHLIGHT,
-    COLOR_3DDKSHADOW, COLOR_3DLIGHT, COLOR_MENUBAR
-};
-
-COLORREF g_origColors[NUM_ELEMENTS] = {};
-bool g_hasSavedOrigColors = false;
-
-// Mode state. Written only from Windhawk callbacks (init / settings / uninit).
-bool g_processLocal = false;  // desired mode from settings
-bool g_globalActive = false;  // our SetSysColors palette is currently applied
-bool g_localActive = false;   // dark app mode is currently applied
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
 
 // Colors read by the in-process hooks.
-COLORREF g_colMenu = RGB(40, 40, 40);
-COLORREF g_colText = RGB(220, 220, 220);
-COLORREF g_colHighlight = RGB(80, 80, 80);
-COLORREF g_colHiText = RGB(255, 255, 255);
-COLORREF g_colGray = RGB(128, 128, 128);
+std::atomic<COLORREF> g_colMenu{RGB(40, 40, 40)};
+std::atomic<COLORREF> g_colText{RGB(220, 220, 220)};
+std::atomic<COLORREF> g_colHighlight{RGB(80, 80, 80)};
+std::atomic<COLORREF> g_colHiText{RGB(255, 255, 255)};
+std::atomic<COLORREF> g_colGray{RGB(128, 128, 128)};
 
-// Brushes are published with InterlockedExchangePointer; replaced brushes are
-// parked in g_retiredBrushes and only deleted at uninit, so painting threads
-// can never use a freed handle.
-HBRUSH g_hSeparatorBrush = nullptr;
-HBRUSH g_hMenuBrush = nullptr;
-HBRUSH g_hTextBrush = nullptr;
-HBRUSH g_hHighlightBrush = nullptr;
-HBRUSH g_hHiTextBrush = nullptr;
-HBRUSH g_hGrayBrush = nullptr;
+// Brushes are published with an atomic exchange and never deleted - see the
+// note in Wh_ModUninit.
+std::atomic<HBRUSH> g_hMenuBrush{nullptr};
+std::atomic<HBRUSH> g_hTextBrush{nullptr};
+std::atomic<HBRUSH> g_hHighlightBrush{nullptr};
+std::atomic<HBRUSH> g_hHiTextBrush{nullptr};
+std::atomic<HBRUSH> g_hGrayBrush{nullptr};
+std::atomic<HBRUSH> g_hSeparatorBrush{nullptr};
+std::atomic<HBRUSH> g_hBorderBrush{nullptr};
 std::vector<HBRUSH> g_retiredBrushes;
 std::mutex g_brushMutex;
 
-HMODULE g_hUxtheme = nullptr;
-enum class PreferredAppMode { Default, AllowDark, ForceDark, ForceLight, Max };
-using SetPreferredAppMode_t = PreferredAppMode(WINAPI*)(PreferredAppMode);
-using FlushMenuThemes_t = void(WINAPI*)();
+std::atomic<bool> g_debugLog{false};
 
-COLORREF ParseHexColor(PCWSTR hexStr, COLORREF defaultColor) {
-    if (!hexStr) {
-        Wh_Log(L"ParseHexColor: Null string, using default.");
-        return defaultColor;
-    }
+// Number of menu tracking calls currently on the stack. The hot GDI hooks bail
+// out on a single relaxed load when no menu is up.
+std::atomic<int> g_menuDepth{0};
+
+// Set while this thread is painting on the mod's behalf, so our own drawing
+// does not re-enter the hooks.
+thread_local bool tl_inOurPaint = false;
+
+// Hooks installed for the duration of a menu, on the menu's own thread.
+thread_local HHOOK tl_msgHook = nullptr;
+thread_local HHOOK tl_cbtHook = nullptr;
+thread_local int tl_menuHookDepth = 0;
+
+#define DBG(...) do { if (g_debugLog.load(std::memory_order_relaxed)) Wh_Log(__VA_ARGS__); } while (0)
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+// Returns false for an empty string, so a setting can mean "leave it alone".
+bool ParseHexColor(PCWSTR hexStr, COLORREF* pOut) {
+    if (!hexStr) return false;
 
     const wchar_t* p = hexStr;
-    if (*p == L'#') p++; // allow with or without #
+    while (*p == L' ') p++;
+    if (*p == L'#') p++;
 
     size_t len = wcslen(p);
-    bool allHex = len > 0;
+    while (len > 0 && p[len - 1] == L' ') len--;
+    if (len == 0) return false;
+
+    bool allHex = true;
     for (size_t i = 0; i < len && allHex; i++) {
         if (!iswxdigit(p[i])) allHex = false;
     }
 
     unsigned int r, g, b;
     if (allHex && len == 6 && swscanf_s(p, L"%02x%02x%02x", &r, &g, &b) == 3) {
-        return RGB(r, g, b);
-    } else if (allHex && len == 3 && swscanf_s(p, L"%1x%1x%1x", &r, &g, &b) == 3) {
-        return RGB(r * 17, g * 17, b * 17); // expand short hex
+        *pOut = RGB(r, g, b);
+        return true;
+    }
+    if (allHex && len == 3 && swscanf_s(p, L"%1x%1x%1x", &r, &g, &b) == 3) {
+        *pOut = RGB(r * 17, g * 17, b * 17);  // expand short hex
+        return true;
     }
 
-    Wh_Log(L"ParseHexColor: Invalid format '%s', using default.", hexStr);
-    return defaultColor;
+    Wh_Log(L"ParseHexColor: invalid format '%s', using default.", hexStr);
+    return false;
 }
 
-COLORREF GetColorFromRegistry(int sysElement, COLORREF liveColorFallback) {
-    const wchar_t* valueName = nullptr;
-    switch (sysElement) {
-        case COLOR_MENU: valueName = L"Menu"; break;
-        case COLOR_MENUTEXT: valueName = L"MenuText"; break;
-        case COLOR_HIGHLIGHT: valueName = L"Hilight"; break;
-        case COLOR_HIGHLIGHTTEXT: valueName = L"HilightText"; break;
-        case COLOR_BTNSHADOW: valueName = L"ButtonShadow"; break;
-        case COLOR_GRAYTEXT: valueName = L"GrayText"; break;
-        case COLOR_BTNHIGHLIGHT: valueName = L"ButtonHilight"; break;
-        case COLOR_3DDKSHADOW: valueName = L"ButtonDkShadow"; break;
-        case COLOR_3DLIGHT: valueName = L"ButtonLight"; break;
-        case COLOR_MENUBAR: valueName = L"MenuBar"; break;
-    }
-
-    if (valueName) {
-        HKEY hKey;
-        if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Control Panel\\Colors", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
-            wchar_t buffer[64] = {0};
-            DWORD bufferSize = sizeof(buffer) - sizeof(WCHAR);
-            DWORD type = 0;
-
-            if (RegQueryValueExW(hKey, valueName, nullptr, &type, (LPBYTE)buffer, &bufferSize) == ERROR_SUCCESS) {
-                if (type == REG_SZ) {
-                    buffer[bufferSize / sizeof(WCHAR)] = L'\0';
-                    int r, g, b;
-                    if (swscanf_s(buffer, L"%d %d %d", &r, &g, &b) == 3 &&
-                        r >= 0 && r <= 255 && g >= 0 && g <= 255 && b >= 0 && b <= 255) {
-                        RegCloseKey(hKey);
-                        return RGB(r, g, b);
-                    }
-                }
-            }
-            RegCloseKey(hKey);
-        }
-    }
-    Wh_Log(L"Failed to read %s from registry. Falling back to live color.", valueName ? valueName : L"unknown");
-    return liveColorFallback;
+COLORREF ParseHexColorOr(PCWSTR hexStr, COLORREF defaultColor) {
+    COLORREF c;
+    return ParseHexColor(hexStr, &c) ? c : defaultColor;
 }
 
-void PublishBrush(HBRUSH* pSlot, COLORREF color) {
-    HBRUSH hNew = CreateSolidBrush(color);
-    HBRUSH hOld = (HBRUSH)InterlockedExchangePointer((PVOID*)pSlot, hNew);
+void PublishBrush(std::atomic<HBRUSH>* pSlot, HBRUSH hNew) {
+    HBRUSH hOld = pSlot->exchange(hNew, std::memory_order_release);
     if (hOld) {
         std::lock_guard<std::mutex> lock(g_brushMutex);
         g_retiredBrushes.push_back(hOld);
     }
 }
 
+void PublishSolidBrush(std::atomic<HBRUSH>* pSlot, COLORREF color) {
+    HBRUSH hNew = CreateSolidBrush(color);
+    if (hNew) PublishBrush(pSlot, hNew);
+}
+
 void LoadSettings() {
-    WindhawkUtils::StringSetting mode = WindhawkUtils::StringSetting::make(L"ThemingMode");
-    g_processLocal = wcscmp(mode.get(), L"systemColors") != 0;
+    g_debugLog.store(Wh_GetIntSetting(L"DebugLogging") != 0, std::memory_order_relaxed);
 
-    g_colMenu      = ParseHexColor(WindhawkUtils::StringSetting::make(L"MenuBgColor").get(), RGB(40, 40, 40));
-    g_colText      = ParseHexColor(WindhawkUtils::StringSetting::make(L"MenuTextColor").get(), RGB(220, 220, 220));
-    g_colHighlight = ParseHexColor(WindhawkUtils::StringSetting::make(L"HighlightBgColor").get(), RGB(80, 80, 80));
-    g_colHiText    = ParseHexColor(WindhawkUtils::StringSetting::make(L"HighlightTextColor").get(), RGB(255, 255, 255));
-    g_colGray      = ParseHexColor(WindhawkUtils::StringSetting::make(L"GrayTextColor").get(), RGB(128, 128, 128));
-    COLORREF colSep = ParseHexColor(WindhawkUtils::StringSetting::make(L"SeparatorColor").get(), RGB(56, 56, 56));
+    COLORREF colMenu  = ParseHexColorOr(WindhawkUtils::StringSetting::make(L"MenuBgColor").get(), RGB(40, 40, 40));
+    COLORREF colText  = ParseHexColorOr(WindhawkUtils::StringSetting::make(L"MenuTextColor").get(), RGB(220, 220, 220));
+    COLORREF colHigh  = ParseHexColorOr(WindhawkUtils::StringSetting::make(L"HighlightBgColor").get(), RGB(80, 80, 80));
+    COLORREF colHiTxt = ParseHexColorOr(WindhawkUtils::StringSetting::make(L"HighlightTextColor").get(), RGB(255, 255, 255));
+    COLORREF colGray  = ParseHexColorOr(WindhawkUtils::StringSetting::make(L"GrayTextColor").get(), RGB(128, 128, 128));
+    COLORREF colSep   = ParseHexColorOr(WindhawkUtils::StringSetting::make(L"SeparatorColor").get(), RGB(56, 56, 56));
 
-    PublishBrush(&g_hSeparatorBrush, colSep);
-    PublishBrush(&g_hMenuBrush, g_colMenu);
-    PublishBrush(&g_hTextBrush, g_colText);
-    PublishBrush(&g_hHighlightBrush, g_colHighlight);
-    PublishBrush(&g_hHiTextBrush, g_colHiText);
-    PublishBrush(&g_hGrayBrush, g_colGray);
-}
+    g_colMenu.store(colMenu, std::memory_order_relaxed);
+    g_colText.store(colText, std::memory_order_relaxed);
+    g_colHighlight.store(colHigh, std::memory_order_relaxed);
+    g_colHiText.store(colHiTxt, std::memory_order_relaxed);
+    g_colGray.store(colGray, std::memory_order_relaxed);
 
-// ----- Global system colors engine (legacy fallback) -----
+    PublishSolidBrush(&g_hMenuBrush, colMenu);
+    PublishSolidBrush(&g_hTextBrush, colText);
+    PublishSolidBrush(&g_hHighlightBrush, colHigh);
+    PublishSolidBrush(&g_hHiTextBrush, colHiTxt);
+    PublishSolidBrush(&g_hGrayBrush, colGray);
+    PublishSolidBrush(&g_hSeparatorBrush, colSep);
 
-void SaveOriginalColors() {
-    if (g_hasSavedOrigColors) return;
-    for (int i = 0; i < NUM_ELEMENTS; i++) {
-        g_origColors[i] = GetColorFromRegistry(g_sysElements[i], GetSysColor(g_sysElements[i]));
+    // Empty means "keep the system frame".
+    COLORREF colBorder;
+    if (ParseHexColor(WindhawkUtils::StringSetting::make(L"BorderColor").get(), &colBorder)) {
+        PublishSolidBrush(&g_hBorderBrush, colBorder);
+    } else {
+        PublishBrush(&g_hBorderBrush, nullptr);
     }
-    g_hasSavedOrigColors = true;
 }
 
-void ApplyDarkSystemColors() {
-    SaveOriginalColors();
+// ---------------------------------------------------------------------------
+// Menu scoping
+// ---------------------------------------------------------------------------
 
-    COLORREF darkColors[NUM_ELEMENTS] = {
-        g_colMenu, g_colText, g_colHighlight, g_colHiText,
-        g_colMenu, g_colGray, g_colMenu, g_colMenu, g_colMenu, g_colMenu
-    };
-
-    SetSysColors(NUM_ELEMENTS, g_sysElements, darkColors);
+inline bool MenuIsOpen() {
+    return g_menuDepth.load(std::memory_order_relaxed) > 0;
 }
 
-bool AnotherPhotoshopInstanceRunning() {
-    wchar_t path[MAX_PATH];
-    if (!GetModuleFileNameW(nullptr, path, ARRAYSIZE(path))) return false;
-    const wchar_t* exe = wcsrchr(path, L'\\');
-    exe = exe ? exe + 1 : path;
-
-    HANDLE hSnap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-    if (hSnap == INVALID_HANDLE_VALUE) return false;
-
-    bool found = false;
-    DWORD myPid = GetCurrentProcessId();
-    PROCESSENTRY32W pe = { sizeof(pe) };
-    if (Process32FirstW(hSnap, &pe)) {
-        do {
-            if (pe.th32ProcessID != myPid && _wcsicmp(pe.szExeFile, exe) == 0) {
-                found = true;
-                break;
-            }
-        } while (Process32NextW(hSnap, &pe));
-    }
-    CloseHandle(hSnap);
-    return found;
-}
-
-// force=false defers restoration to the last running Photoshop instance.
-void RestoreOriginalColors(bool force) {
-    if (!g_hasSavedOrigColors) return;
-    if (!force && AnotherPhotoshopInstanceRunning()) {
-        Wh_Log(L"Another Photoshop instance is running; deferring color restoration to it.");
-        return;
-    }
-    SetSysColors(NUM_ELEMENTS, g_sysElements, g_origColors);
-}
-
-// ----- Process-local engine -----
-
-void EnableDarkAppMode(bool enable) {
-    if (!g_hUxtheme) {
-        g_hUxtheme = LoadLibraryExW(L"uxtheme.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-    }
-    if (!g_hUxtheme) {
-        Wh_Log(L"Failed to load uxtheme.dll");
-        return;
-    }
-
-    auto pSetPreferredAppMode = (SetPreferredAppMode_t)(void*)GetProcAddress(g_hUxtheme, MAKEINTRESOURCEA(135));
-    auto pFlushMenuThemes = (FlushMenuThemes_t)(void*)GetProcAddress(g_hUxtheme, MAKEINTRESOURCEA(136));
-    if (!pSetPreferredAppMode || !pFlushMenuThemes) {
-        Wh_Log(L"uxtheme dark mode ordinals not available on this Windows build.");
-        return;
-    }
-
-    pSetPreferredAppMode(enable ? PreferredAppMode::ForceDark : PreferredAppMode::Default);
-    pFlushMenuThemes();
-}
-
-void ApplyMenuBackground(HMENU hMenu, HBRUSH hBrush) {
-    MENUINFO mi = { sizeof(mi) };
-    mi.fMask = MIM_BACKGROUND | MIM_APPLYTOSUBMENUS;
-    mi.hbrBack = hBrush;
-    SetMenuInfo(hMenu, &mi);
-}
-
-BOOL CALLBACK StampMenuBackgroundsProc(HWND hWnd, LPARAM lParam) {
-    DWORD pid = 0;
-    GetWindowThreadProcessId(hWnd, &pid);
-    if (pid == GetCurrentProcessId()) {
-        HMENU hMenu = GetMenu(hWnd);
-        if (hMenu) ApplyMenuBackground(hMenu, (HBRUSH)lParam);
-    }
-    return TRUE;
-}
-
-// Stamps (or clears, with nullptr) the background brush on the menu bars of
-// all top-level windows of this process, including their submenus.
-void StampMenuBackgrounds(HBRUSH hBrush) {
-    EnumWindows(StampMenuBackgroundsProc, (LPARAM)hBrush);
-}
-
+// Photoshop paints menu items into per-item memory DCs while the popup is being
+// laid out, and directly onto the popup's own window DC when an item is
+// re-drawn on hover. Both are only reached while a menu is up, which the caller
+// has already established with MenuIsOpen().
 bool IsMenuContext(HDC hdc) {
     HWND hWnd = WindowFromDC(hdc);
     if (hWnd) {
         WCHAR cls[16];
-        if (GetClassNameW(hWnd, cls, ARRAYSIZE(cls)) && wcscmp(cls, L"#32768") == 0) return true;
-        return false;
+        return GetClassNameW(hWnd, cls, ARRAYSIZE(cls)) && wcscmp(cls, L"#32768") == 0;
     }
-    if (GetObjectType(hdc) == OBJ_MEMDC) {
-        GUITHREADINFO gti = { sizeof(GUITHREADINFO) };
-        if (GetGUIThreadInfo(GetCurrentThreadId(), &gti)) {
-            if (gti.flags & GUI_INMENUMODE) return true;
-        }
+    return GetObjectType(hdc) == OBJ_MEMDC;
+}
+
+// Our color for a system color index, or nullptr / false if we don't override it.
+//
+// The frame's 3D colors (COLOR_BTNSHADOW and friends) are deliberately not
+// listed: the popup frame is drawn kernel-side and never reaches a user-mode
+// GDI call, so overriding them here would change nothing - it is repainted in
+// the popup's subclass instead.
+HBRUSH BrushForSysColor(int nIndex) {
+    switch (nIndex) {
+        case COLOR_MENU:
+        case COLOR_MENUBAR:       return g_hMenuBrush.load(std::memory_order_acquire);
+        case COLOR_MENUTEXT:      return g_hTextBrush.load(std::memory_order_acquire);
+        case COLOR_HIGHLIGHT:     return g_hHighlightBrush.load(std::memory_order_acquire);
+        case COLOR_HIGHLIGHTTEXT: return g_hHiTextBrush.load(std::memory_order_acquire);
+        case COLOR_GRAYTEXT:      return g_hGrayBrush.load(std::memory_order_acquire);
+    }
+    return nullptr;
+}
+
+bool ColorForSysColor(int nIndex, COLORREF* pOut) {
+    switch (nIndex) {
+        case COLOR_MENU:
+        case COLOR_MENUBAR:       *pOut = g_colMenu.load(std::memory_order_relaxed); return true;
+        case COLOR_MENUTEXT:      *pOut = g_colText.load(std::memory_order_relaxed); return true;
+        case COLOR_HIGHLIGHT:     *pOut = g_colHighlight.load(std::memory_order_relaxed); return true;
+        case COLOR_HIGHLIGHTTEXT: *pOut = g_colHiText.load(std::memory_order_relaxed); return true;
+        case COLOR_GRAYTEXT:      *pOut = g_colGray.load(std::memory_order_relaxed); return true;
     }
     return false;
 }
 
+// Separator geometry scales with DPI; 1px at 100% is often 2-3px at 175%.
+bool IsSeparatorGeometry(HDC hdc, int w, int h) {
+    int dpi = GetDeviceCaps(hdc, LOGPIXELSY);
+    if (dpi <= 0) dpi = 96;
+    return h >= 1 && h <= MulDiv(3, dpi, 96) && w > MulDiv(20, dpi, 96);
+}
+
+// A background brush set on a menu is state on the menu object, not on a hook,
+// so it outlives the mod: without clearing it, disabling the mod leaves every
+// area the system fills from hbrBack - gaps, margins, separator bands - dark
+// until Photoshop restarts. Remember what we stamped so it can be undone.
+//
+// Photoshop keeps a bounded set of menus, but they can be rebuilt over a long
+// session, so the set is capped rather than allowed to grow without limit.
+constexpr size_t kMaxTrackedMenus = 1024;
+std::unordered_set<HMENU> g_stampedMenus;
+std::mutex g_stampedMenusMutex;
+
+void ApplyMenuBackground(HMENU hMenu) {
+    HBRUSH hBrush = g_hMenuBrush.load(std::memory_order_acquire);
+    if (!hMenu || !hBrush) return;
+
+    MENUINFO mi = { sizeof(mi) };
+    mi.fMask = MIM_BACKGROUND | MIM_APPLYTOSUBMENUS;
+    mi.hbrBack = hBrush;
+    if (!SetMenuInfo(hMenu, &mi)) return;
+
+    std::lock_guard<std::mutex> lock(g_stampedMenusMutex);
+    if (g_stampedMenus.size() < kMaxTrackedMenus) {
+        g_stampedMenus.insert(hMenu);
+    }
+}
+
+// MIM_APPLYTOSUBMENUS propagates the cleared brush down each menu tree, so
+// submenus that were stamped but never opened are covered too.
+void RestoreStampedMenus() {
+    std::vector<HMENU> menus;
+    {
+        std::lock_guard<std::mutex> lock(g_stampedMenusMutex);
+        menus.assign(g_stampedMenus.begin(), g_stampedMenus.end());
+        g_stampedMenus.clear();
+    }
+
+    // SetMenuInfo can reach a menu owned by another thread, so it is called
+    // with the lock released.
+    for (HMENU hMenu : menus) {
+        MENUINFO mi = { sizeof(mi) };
+        mi.fMask = MIM_BACKGROUND | MIM_APPLYTOSUBMENUS;
+        mi.hbrBack = nullptr;
+        SetMenuInfo(hMenu, &mi);
+    }
+}
+
+// Width of the non-client frame, i.e. how much of the window rect the system
+// paints from the 3D colors.
+int GetPopupFrameWidth(HWND hWnd, const RECT& windowRect) {
+    RECT client;
+    POINT origin = { 0, 0 };
+    if (!GetClientRect(hWnd, &client) || !ClientToScreen(hWnd, &origin)) return 1;
+
+    int left = origin.x - windowRect.left;
+    int top = origin.y - windowRect.top;
+    int right = windowRect.right - (origin.x + (client.right - client.left));
+    int bottom = windowRect.bottom - (origin.y + (client.bottom - client.top));
+
+    int frame = left;
+    if (top > frame) frame = top;
+    if (right > frame) frame = right;
+    if (bottom > frame) frame = bottom;
+
+    if (frame < 1) frame = 1;
+    if (frame > 4) frame = 4;
+    return frame;
+}
+
+// The popup's non-client frame is drawn by the system from COLOR_3DDKSHADOW /
+// COLOR_BTNHIGHLIGHT, which no process-local hook can change - so repaint it
+// once the system is done with it.
+//
+// hdcTarget is the DC the system rendered the popup into. Menus are drawn
+// offscreen and blitted (WM_PRINT / WM_NCUAHDRAWFRAME carry that DC in wParam),
+// so painting on the window DC instead would just be overwritten by the blit.
+void PaintPopupBorder(HWND hWnd, HDC hdcTarget) {
+    HBRUSH hBorder = g_hBorderBrush.load(std::memory_order_acquire);
+    if (!hBorder) return;
+
+    RECT windowRect;
+    if (!GetWindowRect(hWnd, &windowRect)) return;
+
+    int frame = GetPopupFrameWidth(hWnd, windowRect);
+
+    RECT rc = windowRect;
+    OffsetRect(&rc, -rc.left, -rc.top);
+    if (rc.right <= 0 || rc.bottom <= 0) return;
+
+    HDC hdc = hdcTarget ? hdcTarget : GetWindowDC(hWnd);
+    if (!hdc) return;
+
+    tl_inOurPaint = true;
+    for (int i = 0; i < frame && rc.right > rc.left && rc.bottom > rc.top; i++) {
+        FrameRect(hdc, &rc, hBorder);
+        InflateRect(&rc, -1, -1);
+    }
+    tl_inOurPaint = false;
+
+    if (!hdcTarget) ReleaseDC(hWnd, hdc);
+}
+
+// Undocumented: sent to a window to paint its frame into the DC in wParam.
+constexpr UINT WM_NCUAHDRAWFRAME = 0x00AF;
+
+bool IsMenuPopupWindow(HWND hWnd) {
+    WCHAR cls[16];
+    return GetClassNameW(hWnd, cls, ARRAYSIZE(cls)) && wcscmp(cls, L"#32768") == 0;
+}
+
+// Subclassing the popup rather than watching messages from a hook: WM_PAINT is
+// posted, not sent, so a WH_CALLWNDPROCRET hook never sees it, and a popup that
+// repaints that way would keep the system frame.
+LRESULT CALLBACK MenuPopupSubclassProc(HWND hWnd,
+                                       UINT uMsg,
+                                       WPARAM wParam,
+                                       LPARAM lParam,
+                                       DWORD_PTR dwRefData) {
+    LRESULT result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
+
+    switch (uMsg) {
+        // wParam carries the DC the popup was rendered into.
+        case WM_PRINT:
+        case WM_NCUAHDRAWFRAME:
+            PaintPopupBorder(hWnd, (HDC)wParam);
+            break;
+
+        // Painted on the window's own DC. WM_ERASEBKGND's DC is client
+        // relative, so the frame goes on the window DC in every one of these.
+        case WM_PAINT:
+        case WM_NCPAINT:
+        case WM_ERASEBKGND:
+            PaintPopupBorder(hWnd, nullptr);
+            break;
+    }
+
+    return result;
+}
+
+// Catches the popup at creation, which is the only reliable moment: it exists
+// on this thread and has not painted yet.
+LRESULT CALLBACK CbtProcHook(int code, WPARAM wParam, LPARAM lParam) {
+    if (code == HCBT_CREATEWND) {
+        HWND hWnd = (HWND)wParam;
+        if (IsMenuPopupWindow(hWnd) && g_hBorderBrush.load(std::memory_order_acquire)) {
+            if (!WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, MenuPopupSubclassProc, 0)) {
+                DBG(L"Failed to subclass menu popup %p; it keeps the system frame.", hWnd);
+            }
+        }
+    }
+    return CallNextHookEx(nullptr, code, wParam, lParam);
+}
+
+// Runs on the menu's own thread, after the window has handled the message.
+LRESULT CALLBACK CallWndRetProcHook(int code, WPARAM wParam, LPARAM lParam) {
+    if (code == HC_ACTION && lParam) {
+        auto* ret = (CWPRETSTRUCT*)lParam;
+        if (ret->message == WM_INITMENUPOPUP) {
+            ApplyMenuBackground((HMENU)ret->wParam);
+        }
+    }
+    return CallNextHookEx(nullptr, code, wParam, lParam);
+}
+
+// Menus are modal, so the hook only exists while one is up. Nested tracking
+// calls (submenus opened via TrackPopupMenu) share the outermost hook.
+void EnterMenu(HMENU hMenu) {
+    g_menuDepth.fetch_add(1, std::memory_order_relaxed);
+    ApplyMenuBackground(hMenu);
+
+    if (tl_menuHookDepth++ == 0) {
+        DWORD tid = GetCurrentThreadId();
+        tl_msgHook = SetWindowsHookExW(WH_CALLWNDPROCRET, CallWndRetProcHook, nullptr, tid);
+        tl_cbtHook = SetWindowsHookExW(WH_CBT, CbtProcHook, nullptr, tid);
+        if (!tl_msgHook || !tl_cbtHook) {
+            Wh_Log(L"SetWindowsHookEx failed (%u); popup border and submenu "
+                   L"backgrounds fall back to the system's.", GetLastError());
+        }
+    }
+}
+
+void LeaveMenu() {
+    if (--tl_menuHookDepth <= 0) {
+        tl_menuHookDepth = 0;
+        if (tl_msgHook) {
+            UnhookWindowsHookEx(tl_msgHook);
+            tl_msgHook = nullptr;
+        }
+        if (tl_cbtHook) {
+            UnhookWindowsHookEx(tl_cbtHook);
+            tl_cbtHook = nullptr;
+        }
+    }
+
+    if (g_menuDepth.fetch_sub(1, std::memory_order_relaxed) <= 0) {
+        g_menuDepth.store(0, std::memory_order_relaxed);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Hooks
+// ---------------------------------------------------------------------------
+
+decltype(&TrackPopupMenu) TrackPopupMenu_Original;
+BOOL WINAPI TrackPopupMenu_Hook(HMENU hMenu, UINT uFlags, int x, int y,
+                                int nReserved, HWND hWnd, const RECT* prcRect) {
+    EnterMenu(hMenu);
+    BOOL bRes = TrackPopupMenu_Original(hMenu, uFlags, x, y, nReserved, hWnd, prcRect);
+    LeaveMenu();
+    return bRes;
+}
+
+decltype(&TrackPopupMenuEx) TrackPopupMenuEx_Original;
+BOOL WINAPI TrackPopupMenuEx_Hook(HMENU hMenu, UINT uFlags, int x, int y,
+                                  HWND hWnd, LPTPMPARAMS lptpm) {
+    EnterMenu(hMenu);
+    BOOL bRes = TrackPopupMenuEx_Original(hMenu, uFlags, x, y, hWnd, lptpm);
+    LeaveMenu();
+    return bRes;
+}
 
 decltype(&GetSysColor) GetSysColor_Original;
 DWORD WINAPI GetSysColor_Hook(int nIndex) {
-    if (g_processLocal) {
-        switch (nIndex) {
-            case COLOR_MENU:
-            case COLOR_MENUBAR:       return g_colMenu;
-            case COLOR_MENUTEXT:      return g_colText;
-            case COLOR_HIGHLIGHT:     return g_colHighlight;
-            case COLOR_HIGHLIGHTTEXT: return g_colHiText;
-            case COLOR_GRAYTEXT:      return g_colGray;
-        }
+    COLORREF color;
+    if (MenuIsOpen() && !tl_inOurPaint && ColorForSysColor(nIndex, &color)) {
+        return color;
     }
     return GetSysColor_Original(nIndex);
 }
 
 decltype(&GetSysColorBrush) GetSysColorBrush_Original;
 HBRUSH WINAPI GetSysColorBrush_Hook(int nIndex) {
-    if (g_processLocal) {
-        HBRUSH hBrush = nullptr;
-        switch (nIndex) {
-            case COLOR_MENU:
-            case COLOR_MENUBAR:       hBrush = g_hMenuBrush; break;
-            case COLOR_MENUTEXT:      hBrush = g_hTextBrush; break;
-            case COLOR_HIGHLIGHT:     hBrush = g_hHighlightBrush; break;
-            case COLOR_HIGHLIGHTTEXT: hBrush = g_hHiTextBrush; break;
-            case COLOR_GRAYTEXT:      hBrush = g_hGrayBrush; break;
-        }
+    if (MenuIsOpen() && !tl_inOurPaint) {
+        HBRUSH hBrush = BrushForSysColor(nIndex);
+        // Callers may cache this handle for the process lifetime, so the
+        // brushes it hands out can never be deleted. See Wh_ModUninit.
         if (hBrush) return hBrush;
     }
     return GetSysColorBrush_Original(nIndex);
 }
 
-decltype(&TrackPopupMenu) TrackPopupMenu_Original;
-BOOL WINAPI TrackPopupMenu_Hook(HMENU hMenu, UINT uFlags, int x, int y, int nReserved, HWND hWnd, const RECT* prcRect) {
-    if (g_processLocal && g_hMenuBrush) ApplyMenuBackground(hMenu, g_hMenuBrush);
-    return TrackPopupMenu_Original(hMenu, uFlags, x, y, nReserved, hWnd, prcRect);
-}
+decltype(&FillRect) FillRect_Original;
+int WINAPI FillRect_Hook(HDC hdc, const RECT* lprc, HBRUSH hbr) {
+    if (!MenuIsOpen() || tl_inOurPaint || !lprc) {
+        return FillRect_Original(hdc, lprc, hbr);
+    }
 
-decltype(&TrackPopupMenuEx) TrackPopupMenuEx_Original;
-BOOL WINAPI TrackPopupMenuEx_Hook(HMENU hMenu, UINT uFlags, int x, int y, HWND hWnd, LPTPMPARAMS lptpm) {
-    if (g_processLocal && g_hMenuBrush) ApplyMenuBackground(hMenu, g_hMenuBrush);
-    return TrackPopupMenuEx_Original(hMenu, uFlags, x, y, hWnd, lptpm);
+    // Photoshop fills item backgrounds with a system color pseudo-handle -
+    // (HBRUSH)(COLOR_MENU + 1) and (HBRUSH)(COLOR_HIGHLIGHT + 1). user32
+    // resolves those from shared memory, so the GetSysColorBrush hook never
+    // sees them; re-resolve them here instead.
+    int w = lprc->right - lprc->left;
+    int h = lprc->bottom - lprc->top;
+
+    ULONG_PTR sysIndex = (ULONG_PTR)hbr - 1;
+    if (sysIndex <= (ULONG_PTR)COLOR_MENUBAR) {
+        HBRUSH ours = BrushForSysColor((int)sysIndex);
+        if (ours && IsMenuContext(hdc)) {
+            DBG(L"FillRect: system color %d -> mod color, %dx%d", (int)sysIndex, w, h);
+            return FillRect_Original(hdc, lprc, ours);
+        }
+        return FillRect_Original(hdc, lprc, hbr);
+    }
+
+    HBRUSH hSep = g_hSeparatorBrush.load(std::memory_order_acquire);
+    if (hSep && IsSeparatorGeometry(hdc, w, h) && IsMenuContext(hdc)) {
+        DBG(L"FillRect: separator %dx%d recolored", w, h);
+        return FillRect_Original(hdc, lprc, hSep);
+    }
+
+    return FillRect_Original(hdc, lprc, hbr);
 }
 
 decltype(&PatBlt) PatBlt_Original;
 BOOL WINAPI PatBlt_Hook(HDC hdc, int x, int y, int w, int h, DWORD rop) {
-    HBRUSH hBrush = g_hSeparatorBrush;
-    if (rop == PATCOPY && (h == 1 || h == 2) && w > 20 && hBrush) {
-        if (IsMenuContext(hdc)) {
-            HBRUSH hOldBrush = (HBRUSH)SelectObject(hdc, hBrush);
-            BOOL bRes = PatBlt_Original(hdc, x, y, w, h, rop);
-            SelectObject(hdc, hOldBrush);
-            return bRes;
-        }
+    if (!MenuIsOpen() || tl_inOurPaint || rop != PATCOPY) {
+        return PatBlt_Original(hdc, x, y, w, h, rop);
     }
+
+    HBRUSH hSep = g_hSeparatorBrush.load(std::memory_order_acquire);
+    if (hSep && IsSeparatorGeometry(hdc, w, h) && IsMenuContext(hdc)) {
+        HBRUSH hOldBrush = (HBRUSH)SelectObject(hdc, hSep);
+        BOOL bRes = PatBlt_Original(hdc, x, y, w, h, rop);
+        SelectObject(hdc, hOldBrush);
+        return bRes;
+    }
+
     return PatBlt_Original(hdc, x, y, w, h, rop);
 }
 
-decltype(&FillRect) FillRect_Original;
-int WINAPI FillRect_Hook(HDC hdc, const RECT *lprc, HBRUSH hbr) {
-    HBRUSH hBrush = g_hSeparatorBrush;
-    if (lprc && hBrush) {
-        int h = lprc->bottom - lprc->top;
-        int w = lprc->right - lprc->left;
-        if ((h == 1 || h == 2) && w > 20) {
-            if (IsMenuContext(hdc)) {
-                return FillRect_Original(hdc, lprc, hBrush);
-            }
-        }
-    }
-    return FillRect_Original(hdc, lprc, hbr);
-}
-
-decltype(&ExitProcess) ExitProcess_Original;
-__declspec(noreturn) void WINAPI ExitProcess_Hook(UINT uExitCode) {
-    if (g_globalActive) RestoreOriginalColors(false);
-    ExitProcess_Original(uExitCode);
-}
-
-// Windhawk Events
+// ---------------------------------------------------------------------------
+// Windhawk events
+// ---------------------------------------------------------------------------
 
 void Wh_ModSettingsChanged() {
-    bool wasGlobal = g_globalActive;
-    bool wasLocal = g_localActive;
-
     LoadSettings();
-
-    if (g_processLocal) {
-        if (wasGlobal) {
-            RestoreOriginalColors(true);
-            g_globalActive = false;
-        }
-        EnableDarkAppMode(true);
-        StampMenuBackgrounds(g_hMenuBrush);
-        g_localActive = true;
-    } else {
-        if (wasLocal) {
-            StampMenuBackgrounds(nullptr);
-            EnableDarkAppMode(false);
-            g_localActive = false;
-        }
-        ApplyDarkSystemColors();
-        g_globalActive = true;
-    }
 }
 
 BOOL Wh_ModInit() {
     LoadSettings();
 
-    if (g_processLocal) {
-        EnableDarkAppMode(true);
-        StampMenuBackgrounds(g_hMenuBrush);
-        g_localActive = true;
-    } else {
-        ApplyDarkSystemColors();
-        g_globalActive = true;
-    }
-
-    if (!WindhawkUtils::SetFunctionHook(GetSysColor, GetSysColor_Hook, &GetSysColor_Original)) Wh_Log(L"Failed to hook GetSysColor");
-    if (!WindhawkUtils::SetFunctionHook(GetSysColorBrush, GetSysColorBrush_Hook, &GetSysColorBrush_Original)) Wh_Log(L"Failed to hook GetSysColorBrush");
     if (!WindhawkUtils::SetFunctionHook(TrackPopupMenu, TrackPopupMenu_Hook, &TrackPopupMenu_Original)) Wh_Log(L"Failed to hook TrackPopupMenu");
     if (!WindhawkUtils::SetFunctionHook(TrackPopupMenuEx, TrackPopupMenuEx_Hook, &TrackPopupMenuEx_Original)) Wh_Log(L"Failed to hook TrackPopupMenuEx");
-    if (!WindhawkUtils::SetFunctionHook(PatBlt, PatBlt_Hook, &PatBlt_Original)) Wh_Log(L"Failed to hook PatBlt");
+    if (!WindhawkUtils::SetFunctionHook(GetSysColor, GetSysColor_Hook, &GetSysColor_Original)) Wh_Log(L"Failed to hook GetSysColor");
+    if (!WindhawkUtils::SetFunctionHook(GetSysColorBrush, GetSysColorBrush_Hook, &GetSysColorBrush_Original)) Wh_Log(L"Failed to hook GetSysColorBrush");
     if (!WindhawkUtils::SetFunctionHook(FillRect, FillRect_Hook, &FillRect_Original)) Wh_Log(L"Failed to hook FillRect");
-    if (!WindhawkUtils::SetFunctionHook(ExitProcess, ExitProcess_Hook, &ExitProcess_Original)) Wh_Log(L"Failed to hook ExitProcess");
+    if (!WindhawkUtils::SetFunctionHook(PatBlt, PatBlt_Hook, &PatBlt_Original)) Wh_Log(L"Failed to hook PatBlt");
 
     return TRUE;
 }
 
 void Wh_ModUninit() {
-    if (g_globalActive) {
-        // The mod is being unloaded everywhere, so restore unconditionally;
-        // concurrent instances all write the same registry-derived originals.
-        RestoreOriginalColors(true);
-        g_globalActive = false;
+    if (tl_msgHook) {
+        UnhookWindowsHookEx(tl_msgHook);
+        tl_msgHook = nullptr;
     }
-    if (g_localActive) {
-        StampMenuBackgrounds(nullptr);
-        EnableDarkAppMode(false);
-        g_localActive = false;
+    if (tl_cbtHook) {
+        UnhookWindowsHookEx(tl_cbtHook);
+        tl_cbtHook = nullptr;
     }
+    WindhawkUtils::RemoveAllWindowSubclasses();
 
-    HBRUSH* slots[] = {
-        &g_hSeparatorBrush, &g_hMenuBrush, &g_hTextBrush,
-        &g_hHighlightBrush, &g_hHiTextBrush, &g_hGrayBrush
-    };
-    for (HBRUSH* pSlot : slots) {
-        HBRUSH hBrush = (HBRUSH)InterlockedExchangePointer((PVOID*)pSlot, nullptr);
-        if (hBrush) DeleteObject(hBrush);
-    }
+    // Undo the background brush stamped on Photoshop's menus, so disabling the
+    // mod restores the normal menus without restarting the application.
+    RestoreStampedMenus();
 
-    std::lock_guard<std::mutex> lock(g_brushMutex);
-    for (HBRUSH b : g_retiredBrushes) DeleteObject(b);
-    g_retiredBrushes.clear();
-
-    if (g_hUxtheme) {
-        FreeLibrary(g_hUxtheme);
-        g_hUxtheme = nullptr;
+    // The brushes are deliberately NOT deleted.
+    //
+    // Two paths hand these handles to Photoshop and neither can be reclaimed:
+    // MENUINFO::hbrBack on menus that outlive the mod, and GetSysColorBrush
+    // return values, which callers are entitled to cache for the process
+    // lifetime. Deleting them means Photoshop eventually paints with a freed -
+    // possibly recycled - GDI handle. A handful of brushes for the remaining
+    // lifetime of the process is a trivial cost next to a crash in the host.
+    {
+        std::lock_guard<std::mutex> lock(g_brushMutex);
+        g_retiredBrushes.clear();
     }
 }


### PR DESCRIPTION
### Summary
This PR adds the **Photoshop Dark Menus** mod (`photoshop-dark-menus`), which enables dark mode for all context menus and top menu bar dropdowns in Adobe Photoshop.

![Top Bar Menu Dropdown](https://raw.githubusercontent.com/sabergraphics/photoshop-dark-menus/main/images/photoshop-dark-menu-screenshot-1.png)

![Context Menu](https://raw.githubusercontent.com/sabergraphics/photoshop-dark-menus/main/images/photoshop-dark-menu-screenshot-2.png)

### Mod Info & Repository
- **Mod ID:** `photoshop-dark-menus`
- **Target Process:** `Photoshop.exe`
- **Source Repository:** https://github.com/sabergraphics/photoshop-dark-menus

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [x] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
