### PR TITLE
Add Taskbar Count Badges mod

### DIFF
--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -1688,7 +1688,7 @@ bool HookTaskbarView(HMODULE module) {
         return true;
     }
 
-    WindhawkUtils::SYMBOL_HOOK taskbarViewDllHooks[] = {
+    WindhawkUtils::SYMBOL_HOOK taskbarViewHooks[] = {
         {
             {
                 LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateVisualStates(void))",
@@ -1711,8 +1711,8 @@ bool HookTaskbarView(HMODULE module) {
         },
     };
 
-    if (!WindhawkUtils::HookSymbols(module, taskbarViewDllHooks,
-                                    ARRAYSIZE(taskbarViewDllHooks))) {
+    if (!WindhawkUtils::HookSymbols(module, taskbarViewHooks,
+                                    ARRAYSIZE(taskbarViewHooks))) {
         g_taskbarViewHooked = false;
         Wh_Log(L"Taskbar.View hooks failed");
         return false;

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -331,14 +331,14 @@ Settings g_settings;
 // Globals
 // -----------------------------------------------------------------------------
 
-bool g_isTaskbarProcess = false;
-
 std::atomic<bool> g_taskbarViewHooked = false;
 std::atomic<bool> g_unloading = false;
 std::atomic<bool> g_recountQueued = false;
 
-winrt::Windows::UI::Core::CoreDispatcher
+[[clang::no_destroy]] winrt::Windows::UI::Core::CoreDispatcher
     g_taskbarDispatcher{nullptr};
+
+bool g_countsInitialized = false;
 
 struct TrackedButton {
     void* identity;
@@ -1257,29 +1257,29 @@ void ApplyBadgeVisualStyle(
         text.FontWeight(
             GetConfiguredFontWeight());
 
-    text.HorizontalAlignment(
-        HorizontalAlignment::Center);
+        text.HorizontalAlignment(
+            HorizontalAlignment::Center);
 
-    text.VerticalAlignment(
-        VerticalAlignment::Center);
+        text.VerticalAlignment(
+            VerticalAlignment::Center);
 
-    text.TextAlignment(
-        TextAlignment::Center);
+        text.TextAlignment(
+            TextAlignment::Center);
 
-    // Optical correction for the font baseline.
-    text.Margin(
-        Thickness{
-            0,
-            -2,
-            0,
-            0});
+        // Optical correction for the font baseline.
+        text.Margin(
+            Thickness{
+                0,
+                -2,
+                0,
+                0});
 
-    text.Text(
-        MakeNumberText(
-            count));
+        text.Text(
+            MakeNumberText(
+                count));
 
-    return;
-}
+        return;
+    }
 
     // ---------------------------------------------------------------------
     // VERTICAL DOTS
@@ -1829,14 +1829,7 @@ XamlRoot GetTaskbarXamlRoot(
         Wh_Log(
             L"Taskbar Count Badges: "
             L"couldn't detect TaskbarHost "
-            L"XAML offset");
-
-        if (hostShared[1]) {
-            g_RefCount_Decref(
-                hostShared[1]);
-        }
-
-        return nullptr;
+            L"XAML offset, using 0x48");
     }
 
 #elif defined(_M_ARM64)
@@ -2048,6 +2041,79 @@ struct IAppResolver_8 :
             void* unknown3) = 0;
 };
 
+IAppResolver_8* g_appResolver = nullptr;
+CO_MTA_USAGE_COOKIE g_appResolverMtaCookie{};
+
+bool EnsureAppResolver() {
+    if (g_appResolver) {
+        return true;
+    }
+
+    CO_MTA_USAGE_COOKIE cookie{};
+
+    bool mta =
+        SUCCEEDED(
+            CoIncrementMTAUsage(
+                &cookie));
+
+    IAppResolver_8* resolver =
+        nullptr;
+
+    HRESULT hr =
+        CoCreateInstance(
+            CLSID_StartMenuCacheAndAppResolver,
+            nullptr,
+            CLSCTX_INPROC_SERVER |
+                CLSCTX_INPROC_HANDLER,
+            IID_IAppResolver_8,
+            reinterpret_cast<void**>(
+                &resolver));
+
+    if (FAILED(
+            hr) ||
+        !resolver) {
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"AppResolver failed "
+            L"hr=0x%08X",
+            static_cast<unsigned int>(
+                hr));
+
+        if (mta) {
+            CoDecrementMTAUsage(
+                cookie);
+        }
+
+        return false;
+    }
+
+    g_appResolver =
+        resolver;
+
+    if (mta) {
+        g_appResolverMtaCookie =
+            cookie;
+    }
+
+    return true;
+}
+
+void ReleaseAppResolver() {
+    if (g_appResolver) {
+        g_appResolver->Release();
+        g_appResolver =
+            nullptr;
+    }
+
+    if (g_appResolverMtaCookie) {
+        CoDecrementMTAUsage(
+            g_appResolverMtaCookie);
+
+        g_appResolverMtaCookie =
+            nullptr;
+    }
+}
+
 // -----------------------------------------------------------------------------
 // Which HWNDs count
 // -----------------------------------------------------------------------------
@@ -2232,41 +2298,7 @@ bool BuildRealWindowCounts(
     std::unordered_set<
         std::wstring>* changedIds,
     bool initialBuild) {
-    CO_MTA_USAGE_COOKIE cookie{};
-
-    bool mta =
-        SUCCEEDED(
-            CoIncrementMTAUsage(
-                &cookie));
-
-    winrt::com_ptr<
-        IAppResolver_8>
-        resolver;
-
-    HRESULT hr =
-        CoCreateInstance(
-            CLSID_StartMenuCacheAndAppResolver,
-            nullptr,
-            CLSCTX_INPROC_SERVER |
-                CLSCTX_INPROC_HANDLER,
-            IID_IAppResolver_8,
-            resolver.put_void());
-
-    if (FAILED(
-            hr) ||
-        !resolver) {
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"AppResolver failed "
-            L"hr=0x%08X",
-            static_cast<unsigned int>(
-                hr));
-
-        if (mta) {
-            CoDecrementMTAUsage(
-                cookie);
-        }
-
+    if (!EnsureAppResolver()) {
         return false;
     }
 
@@ -2276,7 +2308,7 @@ bool BuildRealWindowCounts(
         newCounts;
 
     WindowEnumContext context{
-        resolver.get(),
+        g_appResolver,
         &newCounts,
     };
 
@@ -2285,18 +2317,13 @@ bool BuildRealWindowCounts(
         reinterpret_cast<LPARAM>(
             &context));
 
-    resolver =
-        nullptr;
-
-    if (mta) {
-        CoDecrementMTAUsage(
-            cookie);
-    }
-
     if (initialBuild) {
         g_appCounts =
             std::move(
                 newCounts);
+
+        g_countsInitialized =
+            true;
 
         size_t multiWindowApps =
             0;
@@ -2377,6 +2404,9 @@ bool BuildRealWindowCounts(
     g_appCounts =
         std::move(
             newCounts);
+
+    g_countsInitialized =
+        true;
 
     return true;
 }
@@ -2460,29 +2490,30 @@ void QueueRealWindowRecount() {
                 CoreDispatcherPriority::
                     Normal,
             []() {
+                try {
+                    if (!g_unloading) {
+                        std::unordered_set<
+                            std::wstring>
+                            changedIds;
+
+                        if (BuildRealWindowCounts(
+                                &changedIds,
+                                false) &&
+                            !changedIds.empty()) {
+                            RefreshChangedTrackedButtons(
+                                changedIds);
+                        }
+                    }
+                } catch (...) {
+                    Wh_Log(
+                        L"Taskbar Count Badges: "
+                        L"HWND recount failed");
+                }
+
+                // Keep the flag set until all enumeration and UI refresh work
+                // is complete so getter bursts collapse into one recount.
                 g_recountQueued =
                     false;
-
-                if (g_unloading) {
-                    return;
-                }
-
-                std::unordered_set<
-                    std::wstring>
-                    changedIds;
-
-                if (!BuildRealWindowCounts(
-                        &changedIds,
-                        false)) {
-                    return;
-                }
-
-                if (changedIds.empty()) {
-                    return;
-                }
-
-                RefreshChangedTrackedButtons(
-                    changedIds);
             });
     } catch (...) {
         g_recountQueued =
@@ -2544,6 +2575,12 @@ TaskListButton_UpdateVisualStates_Hook(
                 element.Dispatcher();
         }
 
+        if (!g_countsInitialized) {
+            BuildRealWindowCounts(
+                nullptr,
+                true);
+        }
+
         TrackTaskbarButton(
             element);
 
@@ -2597,33 +2634,19 @@ GetViewModelCount_Hook(
 // Apply settings live
 // -----------------------------------------------------------------------------
 
-void ApplySettingsToTaskbar() {
-    if (g_unloading ||
-        !g_taskbarDispatcher) {
+void WINAPI
+ApplySettingsOnTaskbarThread(
+    void*) {
+    if (g_unloading) {
         return;
     }
 
-    try {
-        g_taskbarDispatcher.RunAsync(
-            winrt::Windows::UI::Core::
-                CoreDispatcherPriority::
-                    Normal,
-            []() {
-                if (g_unloading) {
-                    return;
-                }
+    LoadSettings();
+    RefreshAllTrackedButtons();
 
-                RefreshAllTrackedButtons();
-
-                Wh_Log(
-                    L"Taskbar Count Badges: "
-                    L"settings applied");
-            });
-    } catch (...) {
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"failed to apply settings");
-    }
+    Wh_Log(
+        L"Taskbar Count Badges: "
+        L"settings applied");
 }
 
 // -----------------------------------------------------------------------------
@@ -2676,6 +2699,15 @@ void CleanupOnTaskbarThread() {
 
     g_trackedButtons.clear();
 
+    ReleaseAppResolver();
+
+    g_recountQueued =
+        false;
+
+    // Release the strong XAML/UI-thread object on its owning thread.
+    g_taskbarDispatcher =
+        nullptr;
+
     Wh_Log(
         L"Taskbar Count Badges: "
         L"cleanup complete");
@@ -2699,7 +2731,7 @@ bool CleanupSynchronously() {
                     winrt::Windows::UI::
                         Core::
                             CoreDispatcherPriority::
-                                High,
+                                Normal,
                     []() {
                         CleanupOnTaskbarThread();
                     });
@@ -2857,7 +2889,6 @@ LoadLibraryExW_Hook(
 
     if (module &&
         !g_unloading &&
-        g_isTaskbarProcess &&
         !g_taskbarViewHooked) {
         HMODULE taskbarView =
             GetTaskbarViewModuleHandle();
@@ -2886,23 +2917,15 @@ BOOL Wh_ModInit() {
     g_recountQueued =
         false;
 
-    LoadSettings();
+    g_countsInitialized =
+        false;
 
-    g_isTaskbarProcess =
-        FindCurrentProcessTaskbarWnd() !=
-        nullptr;
+    LoadSettings();
 
     Wh_Log(
         L"Taskbar Count Badges: "
-        L"init PID=%lu taskbar=%s",
-        GetCurrentProcessId(),
-        g_isTaskbarProcess
-            ? L"YES"
-            : L"NO");
-
-    if (!g_isTaskbarProcess) {
-        return TRUE;
-    }
+        L"init PID=%lu",
+        GetCurrentProcessId());
 
     if (!HookTaskbarDll()) {
         return FALSE;
@@ -2952,10 +2975,6 @@ void Wh_ModAfterInit() {
         L"Taskbar Count Badges: "
         L"after init");
 
-    if (!g_isTaskbarProcess) {
-        return;
-    }
-
     HWND taskbarWnd =
         FindCurrentProcessTaskbarWnd();
 
@@ -2974,13 +2993,23 @@ void Wh_ModAfterInit() {
 }
 
 void Wh_ModSettingsChanged() {
-    LoadSettings();
+    HWND taskbarWnd =
+        FindCurrentProcessTaskbarWnd();
 
-    if (!g_isTaskbarProcess) {
+    if (!taskbarWnd) {
+        // No taskbar UI exists yet, so there are no concurrent UI reads.
+        LoadSettings();
         return;
     }
 
-    ApplySettingsToTaskbar();
+    if (!RunOnTaskbarThread(
+            taskbarWnd,
+            ApplySettingsOnTaskbarThread,
+            nullptr)) {
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"failed to apply settings on taskbar thread");
+    }
 }
 
 void Wh_ModBeforeUninit() {
@@ -3006,11 +3035,11 @@ void Wh_ModUninit() {
     g_recountQueued =
         false;
 
+    g_countsInitialized =
+        false;
+
     g_appCounts.clear();
     g_trackedButtons.clear();
-
-    g_taskbarDispatcher =
-        nullptr;
 
     Wh_Log(
         L"Taskbar Count Badges: "

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -236,6 +236,7 @@ ordering, or application behavior.
 #include <cwctype>
 #include <cstdint>
 #include <limits>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -334,6 +335,7 @@ Settings g_settings;
 std::atomic<bool> g_taskbarViewHooked = false;
 std::atomic<bool> g_unloading = false;
 std::atomic<bool> g_recountQueued = false;
+std::mutex g_queueMutex;
 
 [[clang::no_destroy]] winrt::Windows::UI::Core::CoreDispatcher
     g_taskbarDispatcher{nullptr};
@@ -2043,10 +2045,23 @@ struct IAppResolver_8 :
 
 IAppResolver_8* g_appResolver = nullptr;
 CO_MTA_USAGE_COOKIE g_appResolverMtaCookie{};
+ULONGLONG g_appResolverRetryAfter = 0;
+
+// A window keeps the same app ID for its lifetime. Cache the normalized ID so
+// steady-state recounts don't repeatedly call the shell resolver for every HWND.
+std::unordered_map<HWND, std::wstring> g_appIdCache;
 
 bool EnsureAppResolver() {
     if (g_appResolver) {
         return true;
+    }
+
+    ULONGLONG now =
+        GetTickCount64();
+
+    if (now <
+        g_appResolverRetryAfter) {
+        return false;
     }
 
     CO_MTA_USAGE_COOKIE cookie{};
@@ -2084,8 +2099,16 @@ bool EnsureAppResolver() {
                 cookie);
         }
 
+        // Avoid retrying COM activation on every TaskListButton state update.
+        // A later recount can retry after this short backoff.
+        g_appResolverRetryAfter =
+            now + 5000;
+
         return false;
     }
+
+    g_appResolverRetryAfter =
+        0;
 
     g_appResolver =
         resolver;
@@ -2112,6 +2135,11 @@ void ReleaseAppResolver() {
         g_appResolverMtaCookie =
             nullptr;
     }
+
+    g_appResolverRetryAfter =
+        0;
+
+    g_appIdCache.clear();
 }
 
 // -----------------------------------------------------------------------------
@@ -2230,6 +2258,9 @@ struct WindowEnumContext {
     std::unordered_map<
         std::wstring,
         unsigned int>* counts;
+
+    std::unordered_set<HWND>*
+        seenWindows;
 };
 
 BOOL CALLBACK EnumCountableWindows(
@@ -2247,7 +2278,23 @@ BOOL CALLBACK EnumCountableWindows(
 
     if (!context ||
         !context->resolver ||
-        !context->counts) {
+        !context->counts ||
+        !context->seenWindows) {
+        return TRUE;
+    }
+
+    context->seenWindows->insert(
+        hWnd);
+
+    auto cached =
+        g_appIdCache.find(
+            hWnd);
+
+    if (cached !=
+        g_appIdCache.end()) {
+        (*context->counts)[
+            cached->second]++;
+
         return TRUE;
     }
 
@@ -2284,6 +2331,10 @@ BOOL CALLBACK EnumCountableWindows(
     CoTaskMemFree(
         appId);
 
+    g_appIdCache.emplace(
+        hWnd,
+        key);
+
     (*context->counts)[
         key]++;
 
@@ -2307,15 +2358,33 @@ bool BuildRealWindowCounts(
         unsigned int>
         newCounts;
 
+    std::unordered_set<HWND>
+        seenWindows;
+
     WindowEnumContext context{
         g_appResolver,
         &newCounts,
+        &seenWindows,
     };
 
     EnumWindows(
         EnumCountableWindows,
         reinterpret_cast<LPARAM>(
             &context));
+
+    for (auto it =
+             g_appIdCache.begin();
+         it !=
+         g_appIdCache.end();) {
+        if (!seenWindows.contains(
+                it->first)) {
+            it =
+                g_appIdCache.erase(
+                    it);
+        } else {
+            ++it;
+        }
+    }
 
     if (initialBuild) {
         g_appCounts =
@@ -2418,55 +2487,61 @@ bool BuildRealWindowCounts(
 void WINAPI
 InitializeExistingButtonsOnTaskbarThread(
     void* parameter) {
-    HWND taskbarWnd =
-        reinterpret_cast<HWND>(
-            parameter);
+    try {
+        HWND taskbarWnd =
+            reinterpret_cast<HWND>(
+                parameter);
 
-    auto xamlRoot =
-        GetTaskbarXamlRoot(
-            taskbarWnd);
+        auto xamlRoot =
+            GetTaskbarXamlRoot(
+                taskbarWnd);
 
-    if (!xamlRoot) {
+        if (!xamlRoot) {
+            Wh_Log(
+                L"Taskbar Count Badges: "
+                L"failed to get taskbar XamlRoot");
+
+            return;
+        }
+
+        auto content =
+            xamlRoot.Content()
+                .try_as<
+                    FrameworkElement>();
+
+        if (!content) {
+            Wh_Log(
+                L"Taskbar Count Badges: "
+                L"XamlRoot content unavailable");
+
+            return;
+        }
+
+        if (!g_taskbarDispatcher) {
+            g_taskbarDispatcher =
+                content.Dispatcher();
+        }
+
+        // Keep the count map on the taskbar UI thread. Live recounts and badge
+        // updates also run on this thread, avoiding concurrent map access during
+        // initialization.
+        BuildRealWindowCounts(
+            nullptr,
+            true);
+
+        int buttonCount =
+            EnumerateExistingTaskbarButtons(
+                content);
+
         Wh_Log(
             L"Taskbar Count Badges: "
-            L"failed to get taskbar XamlRoot");
-
-        return;
-    }
-
-    auto content =
-        xamlRoot.Content()
-            .try_as<
-                FrameworkElement>();
-
-    if (!content) {
+            L"initial taskbar buttons=%d",
+            buttonCount);
+    } catch (...) {
         Wh_Log(
             L"Taskbar Count Badges: "
-            L"XamlRoot content unavailable");
-
-        return;
+            L"initial taskbar UI setup failed");
     }
-
-    if (!g_taskbarDispatcher) {
-        g_taskbarDispatcher =
-            content.Dispatcher();
-    }
-
-    // Keep the count map on the taskbar UI thread. Live recounts and badge
-    // updates also run on this thread, avoiding concurrent map access during
-    // initialization.
-    BuildRealWindowCounts(
-        nullptr,
-        true);
-
-    int buttonCount =
-        EnumerateExistingTaskbarButtons(
-            content);
-
-    Wh_Log(
-        L"Taskbar Count Badges: "
-        L"initial taskbar buttons=%d",
-        buttonCount);
 }
 
 // -----------------------------------------------------------------------------
@@ -2474,6 +2549,9 @@ InitializeExistingButtonsOnTaskbarThread(
 // -----------------------------------------------------------------------------
 
 void QueueRealWindowRecount() {
+    std::lock_guard<std::mutex> guard(
+        g_queueMutex);
+
     if (g_unloading ||
         !g_taskbarDispatcher) {
         return;
@@ -2641,12 +2719,18 @@ ApplySettingsOnTaskbarThread(
         return;
     }
 
-    LoadSettings();
-    RefreshAllTrackedButtons();
+    try {
+        LoadSettings();
+        RefreshAllTrackedButtons();
 
-    Wh_Log(
-        L"Taskbar Count Badges: "
-        L"settings applied");
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"settings applied");
+    } catch (...) {
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"settings apply failed");
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -3017,8 +3101,13 @@ void Wh_ModBeforeUninit() {
         L"Taskbar Count Badges: "
         L"before uninit");
 
-    g_unloading =
-        true;
+    {
+        std::lock_guard<std::mutex> guard(
+            g_queueMutex);
+
+        g_unloading =
+            true;
+    }
 
     bool ok =
         CleanupSynchronously();
@@ -3039,6 +3128,7 @@ void Wh_ModUninit() {
         false;
 
     g_appCounts.clear();
+    g_appIdCache.clear();
     g_trackedButtons.clear();
 
     Wh_Log(

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -1687,7 +1687,7 @@ bool HookTaskbarView(HMODULE module) {
     if (g_taskbarViewHooked.exchange(true)) {
         return true;
     }
-
+// Taskbar.View.dll, ExplorerExtensions.dll
     WindhawkUtils::SYMBOL_HOOK taskbarViewHooks[] = {
         {
             {

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -1,7 +1,7 @@
 // ==WindhawkMod==
 // @id              taskbar-count-badges
 // @name            Taskbar Count Badges
-// @description     Show customizable window-count badges or vertical dots on Windows 11 taskbar.
+// @description     Show customizable per-taskbar-button window counts as badges or vertical dots on Windows 11.
 // @version         1.0.0
 // @author          digART
 // @github          https://github.com/digart11
@@ -17,9 +17,10 @@
 // the Free Software Foundation, either version 3 of the License, or
 // any later version.
 //
-// Taskbar hook, AppResolver, and taskbar XAML/UI-thread infrastructure include
-// techniques adapted from Windhawk mods by Michael Maltsev (m417z), including
-// Taskbar Labels for Windows 11 and Taskbar Tray Show on Hover.
+// Taskbar hook and taskbar XAML/UI-thread infrastructure include techniques
+// adapted from Windhawk mods by Michael Maltsev (m417z), including
+// Taskbar Labels for Windows 11, Taskbar Button Scroll, and Taskbar Tray Show
+// on Hover.
 
 
 
@@ -27,10 +28,10 @@
 /*
 # Taskbar Count Badges
 
-See how many windows are open for each app directly on the Windows 11 taskbar.
+See how many windows are represented by each app button on the Windows 11 taskbar.
 
-Taskbar Count Badges adds a small customizable indicator to taskbar app buttons
-when an app has multiple open windows. The indicator can be shown as either a
+Taskbar Count Badges adds a small customizable indicator when a taskbar app
+button represents multiple windows. The indicator can be shown as either a
 **number badge** or a compact stack of **vertical dots**.
 
 ## Screenshots
@@ -47,7 +48,7 @@ when an app has multiple open windows. The indicator can be shown as either a
 
 ### Number badge
 
-Shows the exact number of open windows for an app.
+Shows the number of windows represented by that taskbar button.
 
 The badge can be customized with:
 
@@ -69,8 +70,8 @@ Shows a minimal vertical stack of dots beside the app icon.
 
 ## Behavior
 
-By default, no indicator is shown for a single open window. The indicator appears
-when an app reaches two open windows.
+By default, no indicator is shown when a taskbar button represents a single
+window. The indicator appears when that button represents two or more windows.
 
 The minimum window count can be changed in the settings.
 
@@ -83,6 +84,11 @@ settings are applied live.
 - Supports x64 and ARM64 Windows
 - Works with multiple monitors and secondary Windows taskbars
 
+On multi-monitor systems, the count follows each individual taskbar button.
+Depending on the Windows multi-monitor taskbar configuration, the same app can
+therefore show different counts on different monitors. Moving a window between
+monitors can change the count shown on each taskbar.
+
 The mod is designed primarily for grouped/combined taskbar app buttons. When
 taskbar buttons are configured to stay uncombined, Windows can expose multiple
 buttons for the same app group, so the same app count may appear on more than
@@ -93,9 +99,9 @@ taskbar may not be compatible.
 
 ## Notes
 
-The mod counts real top-level application windows and maps them to their Windows
-application IDs. Windows shell infrastructure windows are excluded from the
-count.
+The mod uses the taskbar's own per-button grouping information instead of
+independently scanning all desktop windows. Counts therefore follow Windows
+taskbar grouping, including per-taskbar behavior on multi-monitor systems.
 
 The badge is visual only and doesn't change taskbar grouping, combining, window
 ordering, or application behavior.
@@ -212,36 +218,30 @@ ordering, or application behavior.
 */
 // ==/WindhawkModSettings==
 
+#include <windhawk_utils.h>
 #include <windows.h>
 #include <winstring.h>
-#include <windhawk_utils.h>
 
 #undef GetCurrentTime
 
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.h>
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Text.h>
-#include <winrt/Windows.UI.Xaml.h>
-#include <winrt/Windows.UI.Xaml.Automation.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Markup.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.Shapes.h>
+#include <winrt/Windows.UI.Xaml.h>
+#include <winrt/Windows.UI.h>
 #include <winrt/base.h>
 
 #include <algorithm>
 #include <atomic>
-#include <cwctype>
 #include <cstdint>
 #include <limits>
-#include <mutex>
+#include <list>
 #include <string>
-#include <unordered_map>
-#include <unordered_set>
-#include <utility>
-#include <vector>
 
 using namespace winrt::Windows::UI::Xaml;
 
@@ -281,46 +281,36 @@ enum class BadgeFontWeight {
 };
 
 struct Settings {
-    DisplayStyle displayStyle =
-        DisplayStyle::Number;
+    DisplayStyle displayStyle = DisplayStyle::Number;
 
-    BadgeShape badgeShape =
-        BadgeShape::Circle;
+    BadgeShape badgeShape = BadgeShape::Circle;
 
-    BadgePosition badgePosition =
-        BadgePosition::TopRight;
+    BadgePosition badgePosition = BadgePosition::TopRight;
 
     int badgeOffsetX = -2;
     int badgeOffsetY = -2;
 
     int badgeSize = 16;
 
-    std::wstring badgeBackgroundColor =
-        L"#D90000";
+    std::wstring badgeBackgroundColor = L"#D90000";
 
-    std::wstring badgeBorderColor =
-        L"#FFFFFF";
+    std::wstring badgeBorderColor = L"#FFFFFF";
 
     int badgeBorderThickness = 0;
 
-    std::wstring textColor =
-        L"#FFFFFF";
+    std::wstring textColor = L"#FFFFFF";
 
-    std::wstring fontFamily =
-        L"Segoe UI";
+    std::wstring fontFamily = L"Segoe UI";
 
     int fontSize = 10;
 
-    BadgeFontWeight fontWeight =
-        BadgeFontWeight::SemiBold;
+    BadgeFontWeight fontWeight = BadgeFontWeight::SemiBold;
 
-    DotPosition dotPosition =
-        DotPosition::Right;
+    DotPosition dotPosition = DotPosition::Right;
 
     int dotSize = 4;
 
-    std::wstring dotColor =
-        L"#FFFFFF";
+    std::wstring dotColor = L"#FFFFFF";
 
     int minimumCount = 2;
     int maximumNumber = 99;
@@ -334,311 +324,201 @@ Settings g_settings;
 
 std::atomic<bool> g_taskbarViewHooked = false;
 std::atomic<bool> g_unloading = false;
-std::atomic<bool> g_recountQueued = false;
-std::mutex g_queueMutex;
-
-[[clang::no_destroy]] winrt::Windows::UI::Core::CoreDispatcher
-    g_taskbarDispatcher{nullptr};
-
-bool g_countsInitialized = false;
+std::atomic<bool> g_settingsReloadPending = false;
+std::atomic<DWORD> g_taskbarThreadId = 0;
+uint64_t g_settingsGeneration = 0;
 
 struct TrackedButton {
-    void* identity;
-    std::wstring automationId;
+    void* identity = nullptr;
+    void* viewModel = nullptr;
     winrt::weak_ref<FrameworkElement> element;
+    unsigned int lastAppliedCount = std::numeric_limits<unsigned int>::max();
+    uint64_t lastSettingsGeneration = 0;
 };
 
-std::vector<TrackedButton> g_trackedButtons;
-
-// Always contains REAL HWND-derived counts.
-// ViewModelCount is only used as a change notification.
-std::unordered_map<std::wstring, unsigned int>
-    g_appCounts;
+std::list<TrackedButton> g_trackedButtons;
 
 // -----------------------------------------------------------------------------
-// taskbar.dll symbols used to access existing XamlRoot
+// Taskbar.View symbols used for direct group counts
+// -----------------------------------------------------------------------------
+
+using TryGetItemFromContainer_TaskListGroupViewModel_t =
+    void*(WINAPI*)(void** output, UIElement* container);
+TryGetItemFromContainer_TaskListGroupViewModel_t
+    TryGetItemFromContainer_TaskListGroupViewModel_Original = nullptr;
+
+using GetViewModelCount_t = HRESULT(WINAPI*)(void* pThis, unsigned int* count);
+GetViewModelCount_t GetViewModelCount_Original = nullptr;
+
+unsigned int WindowCountFromViewModelCount(unsigned int viewModelCount) {
+    // For the TaskListGroupViewModel returned for a taskbar button, Windows
+    // reports ViewModelCount one higher than the represented window count
+    // (1 window -> 2, 2 windows -> 3). Keep Windows' value untouched and
+    // normalize only the count displayed by this mod.
+    return viewModelCount > 0 ? viewModelCount - 1 : 0;
+}
+
+// -----------------------------------------------------------------------------
+// taskbar.dll symbols used to access primary and secondary XamlRoot
 // -----------------------------------------------------------------------------
 
 void* g_CTaskBand_ITaskListWndSite_vftable = nullptr;
+void* g_CSecondaryTaskBand_ITaskListWndSite_vftable = nullptr;
 
-using CTaskBand_GetTaskbarHost_t =
-    void*(__cdecl*)(
-        void* pThis,
-        void** result);
+using CTaskBand_GetTaskbarHost_t = void*(WINAPI*)(void* pThis, void** result);
+CTaskBand_GetTaskbarHost_t g_CTaskBand_GetTaskbarHost = nullptr;
 
-CTaskBand_GetTaskbarHost_t
-    g_CTaskBand_GetTaskbarHost = nullptr;
+using CSecondaryTaskBand_GetTaskbarHost_t = void*(WINAPI*)(void* pThis,
+                                                          void** result);
+CSecondaryTaskBand_GetTaskbarHost_t g_CSecondaryTaskBand_GetTaskbarHost =
+    nullptr;
 
 void* g_TaskbarHost_FrameHeight = nullptr;
 
-using RefCount_Decref_t =
-    void(__cdecl*)(
-        void* pThis);
-
-RefCount_Decref_t
-    g_RefCount_Decref = nullptr;
-
-// -----------------------------------------------------------------------------
-// COM compatibility
-// -----------------------------------------------------------------------------
-
-#if __cplusplus < 202302L
-DECLARE_HANDLE(CO_MTA_USAGE_COOKIE);
-
-WINOLEAPI CoIncrementMTAUsage(
-    CO_MTA_USAGE_COOKIE* cookie);
-
-WINOLEAPI CoDecrementMTAUsage(
-    CO_MTA_USAGE_COOKIE cookie);
-#endif
+using RefCount_Decref_t = void(WINAPI*)(void* pThis);
+RefCount_Decref_t g_RefCount_Decref = nullptr;
 
 // -----------------------------------------------------------------------------
 // Setting helpers
 // -----------------------------------------------------------------------------
 
-std::wstring ReadStringSetting(
-    PCWSTR name) {
-    PCWSTR value =
-        Wh_GetStringSetting(name);
-
-    std::wstring result =
-        value ? value : L"";
-
-    if (value) {
-        Wh_FreeStringSetting(value);
-    }
-
-    return result;
+std::wstring ReadStringSetting(PCWSTR name) {
+    auto value = WindhawkUtils::StringSetting::make(name);
+    return value.get();
 }
 
 void LoadSettings() {
     // Display ---------------------------------------------------------------
 
-    std::wstring displayStyle =
-        ReadStringSetting(
-            L"Display.style");
+    std::wstring displayStyle = ReadStringSetting(L"Display.style");
 
     g_settings.displayStyle =
-        displayStyle == L"dots"
-            ? DisplayStyle::Dots
-            : DisplayStyle::Number;
+        displayStyle == L"dots" ? DisplayStyle::Dots : DisplayStyle::Number;
 
     // Badge -----------------------------------------------------------------
 
-    std::wstring shape =
-        ReadStringSetting(
-            L"Badge.shape");
+    std::wstring shape = ReadStringSetting(L"Badge.shape");
 
     if (shape == L"square") {
-        g_settings.badgeShape =
-            BadgeShape::Square;
+        g_settings.badgeShape = BadgeShape::Square;
     } else if (shape == L"rounded") {
-        g_settings.badgeShape =
-            BadgeShape::Rounded;
+        g_settings.badgeShape = BadgeShape::Rounded;
     } else {
-        g_settings.badgeShape =
-            BadgeShape::Circle;
+        g_settings.badgeShape = BadgeShape::Circle;
     }
 
-    std::wstring position =
-        ReadStringSetting(
-            L"Badge.position");
+    std::wstring position = ReadStringSetting(L"Badge.position");
 
     if (position == L"topLeft") {
-        g_settings.badgePosition =
-            BadgePosition::TopLeft;
+        g_settings.badgePosition = BadgePosition::TopLeft;
     } else if (position == L"topCenter") {
-        g_settings.badgePosition =
-            BadgePosition::TopCenter;
+        g_settings.badgePosition = BadgePosition::TopCenter;
     } else if (position == L"bottomLeft") {
-        g_settings.badgePosition =
-            BadgePosition::BottomLeft;
+        g_settings.badgePosition = BadgePosition::BottomLeft;
     } else if (position == L"bottomCenter") {
-        g_settings.badgePosition =
-            BadgePosition::BottomCenter;
+        g_settings.badgePosition = BadgePosition::BottomCenter;
     } else if (position == L"bottomRight") {
-        g_settings.badgePosition =
-            BadgePosition::BottomRight;
+        g_settings.badgePosition = BadgePosition::BottomRight;
     } else {
-        g_settings.badgePosition =
-            BadgePosition::TopRight;
+        g_settings.badgePosition = BadgePosition::TopRight;
     }
 
-    g_settings.badgeOffsetX =
-        Wh_GetIntSetting(
-            L"Badge.offsetX");
+    g_settings.badgeOffsetX = Wh_GetIntSetting(L"Badge.offsetX");
 
-    g_settings.badgeOffsetY =
-        Wh_GetIntSetting(
-            L"Badge.offsetY");
+    g_settings.badgeOffsetY = Wh_GetIntSetting(L"Badge.offsetY");
 
-    g_settings.badgeSize =
-        std::max(
-            4,
-            Wh_GetIntSetting(
-                L"Badge.size"));
-
+    g_settings.badgeSize = std::max(4, Wh_GetIntSetting(L"Badge.size"));
 
     g_settings.badgeBackgroundColor =
-        ReadStringSetting(
-            L"Badge.backgroundColor");
+        ReadStringSetting(L"Badge.backgroundColor");
 
-    g_settings.badgeBorderColor =
-        ReadStringSetting(
-            L"Badge.borderColor");
+    g_settings.badgeBorderColor = ReadStringSetting(L"Badge.borderColor");
 
     g_settings.badgeBorderThickness =
-        std::max(
-            0,
-            Wh_GetIntSetting(
-                L"Badge.borderThickness"));
+        std::max(0, Wh_GetIntSetting(L"Badge.borderThickness"));
 
     // Text ------------------------------------------------------------------
 
-    g_settings.textColor =
-        ReadStringSetting(
-            L"Text.color");
+    g_settings.textColor = ReadStringSetting(L"Text.color");
 
-    g_settings.fontFamily =
-        ReadStringSetting(
-            L"Text.fontFamily");
+    g_settings.fontFamily = ReadStringSetting(L"Text.fontFamily");
 
     if (g_settings.fontFamily.empty()) {
-        g_settings.fontFamily =
-            L"Segoe UI";
+        g_settings.fontFamily = L"Segoe UI";
     }
 
-    g_settings.fontSize =
-        std::max(
-            1,
-            Wh_GetIntSetting(
-                L"Text.fontSize"));
+    g_settings.fontSize = std::max(1, Wh_GetIntSetting(L"Text.fontSize"));
 
-    std::wstring fontWeight =
-        ReadStringSetting(
-            L"Text.fontWeight");
+    std::wstring fontWeight = ReadStringSetting(L"Text.fontWeight");
 
     if (fontWeight == L"bold") {
-        g_settings.fontWeight =
-            BadgeFontWeight::Bold;
+        g_settings.fontWeight = BadgeFontWeight::Bold;
     } else if (fontWeight == L"normal") {
-        g_settings.fontWeight =
-            BadgeFontWeight::Normal;
+        g_settings.fontWeight = BadgeFontWeight::Normal;
     } else {
-        g_settings.fontWeight =
-            BadgeFontWeight::SemiBold;
+        g_settings.fontWeight = BadgeFontWeight::SemiBold;
     }
 
     // Vertical dots ---------------------------------------------------------
 
-    std::wstring dotPosition =
-        ReadStringSetting(
-            L"VerticalDots.position");
+    std::wstring dotPosition = ReadStringSetting(L"VerticalDots.position");
 
     g_settings.dotPosition =
-        dotPosition == L"left"
-            ? DotPosition::Left
-            : DotPosition::Right;
+        dotPosition == L"left" ? DotPosition::Left : DotPosition::Right;
 
-    g_settings.dotSize =
-        std::max(
-            2,
-            Wh_GetIntSetting(
-                L"VerticalDots.size"));
+    g_settings.dotSize = std::max(2, Wh_GetIntSetting(L"VerticalDots.size"));
 
-    g_settings.dotColor =
-        ReadStringSetting(
-            L"VerticalDots.color");
+    g_settings.dotColor = ReadStringSetting(L"VerticalDots.color");
 
     // Behavior --------------------------------------------------------------
 
     g_settings.minimumCount =
-        std::max(
-            1,
-            Wh_GetIntSetting(
-                L"Behavior.minimumCount"));
+        std::max(1, Wh_GetIntSetting(L"Behavior.minimumCount"));
 
     g_settings.maximumNumber =
-        std::max(
-            1,
-            Wh_GetIntSetting(
-                L"Behavior.maximumNumber"));
-}
+        std::max(1, Wh_GetIntSetting(L"Behavior.maximumNumber"));
 
-// -----------------------------------------------------------------------------
-// Generic helpers
-// -----------------------------------------------------------------------------
-
-std::wstring NormalizeId(
-    std::wstring value) {
-    std::transform(
-        value.begin(),
-        value.end(),
-        value.begin(),
-        [](wchar_t c) {
-            return static_cast<wchar_t>(
-                std::towlower(c));
-        });
-
-    return value;
+    ++g_settingsGeneration;
 }
 
 // -----------------------------------------------------------------------------
 // Color parsing
 // -----------------------------------------------------------------------------
 
-bool ParseHexByte(
-    wchar_t high,
-    wchar_t low,
-    BYTE* result) {
-    auto getValue =
-        [](wchar_t c) -> int {
-            if (c >= L'0' &&
-                c <= L'9') {
-                return c - L'0';
-            }
+bool ParseHexByte(wchar_t high, wchar_t low, BYTE* result) {
+    auto getValue = [](wchar_t c) -> int {
+        if (c >= L'0' && c <= L'9') {
+            return c - L'0';
+        }
 
-            c =
-                static_cast<wchar_t>(
-                    std::towupper(c));
+        c = static_cast<wchar_t>(std::towupper(c));
 
-            if (c >= L'A' &&
-                c <= L'F') {
-                return c - L'A' + 10;
-            }
+        if (c >= L'A' && c <= L'F') {
+            return c - L'A' + 10;
+        }
 
-            return -1;
-        };
+        return -1;
+    };
 
-    int highValue =
-        getValue(high);
+    int highValue = getValue(high);
 
-    int lowValue =
-        getValue(low);
+    int lowValue = getValue(low);
 
-    if (highValue < 0 ||
-        lowValue < 0) {
+    if (highValue < 0 || lowValue < 0) {
         return false;
     }
 
-    *result =
-        static_cast<BYTE>(
-            highValue * 16 +
-            lowValue);
+    *result = static_cast<BYTE>(highValue * 16 + lowValue);
 
     return true;
 }
 
-winrt::Windows::UI::Color ParseColor(
-    const std::wstring& value,
-    winrt::Windows::UI::Color fallback) {
-    std::wstring text =
-        value;
+winrt::Windows::UI::Color ParseColor(const std::wstring& value,
+                                     winrt::Windows::UI::Color fallback) {
+    std::wstring text = value;
 
-    if (!text.empty() &&
-        text[0] == L'#') {
-        text.erase(
-            text.begin());
+    if (!text.empty() && text[0] == L'#') {
+        text.erase(text.begin());
     }
 
     BYTE a = 255;
@@ -647,37 +527,16 @@ winrt::Windows::UI::Color ParseColor(
     BYTE b = 0;
 
     if (text.length() == 6) {
-        if (!ParseHexByte(
-                text[0],
-                text[1],
-                &r) ||
-            !ParseHexByte(
-                text[2],
-                text[3],
-                &g) ||
-            !ParseHexByte(
-                text[4],
-                text[5],
-                &b)) {
+        if (!ParseHexByte(text[0], text[1], &r) ||
+            !ParseHexByte(text[2], text[3], &g) ||
+            !ParseHexByte(text[4], text[5], &b)) {
             return fallback;
         }
     } else if (text.length() == 8) {
-        if (!ParseHexByte(
-                text[0],
-                text[1],
-                &a) ||
-            !ParseHexByte(
-                text[2],
-                text[3],
-                &r) ||
-            !ParseHexByte(
-                text[4],
-                text[5],
-                &g) ||
-            !ParseHexByte(
-                text[6],
-                text[7],
-                &b)) {
+        if (!ParseHexByte(text[0], text[1], &a) ||
+            !ParseHexByte(text[2], text[3], &r) ||
+            !ParseHexByte(text[4], text[5], &g) ||
+            !ParseHexByte(text[6], text[7], &b)) {
             return fallback;
         }
     } else {
@@ -694,26 +553,19 @@ winrt::Windows::UI::Color ParseColor(
     return color;
 }
 
-Media::SolidColorBrush CreateBrush(
-    const std::wstring& value,
-    winrt::Windows::UI::Color fallback) {
-    return Media::SolidColorBrush(
-        ParseColor(
-            value,
-            fallback));
+Media::SolidColorBrush CreateBrush(const std::wstring& value,
+                                   winrt::Windows::UI::Color fallback) {
+    return Media::SolidColorBrush(ParseColor(value, fallback));
 }
 
 // -----------------------------------------------------------------------------
 // Position helpers
 // -----------------------------------------------------------------------------
 
-void ApplyNumberBadgePosition(
-    Controls::Border badge) {
-    HorizontalAlignment horizontal =
-        HorizontalAlignment::Right;
+void ApplyNumberBadgePosition(Controls::Border badge) {
+    HorizontalAlignment horizontal = HorizontalAlignment::Right;
 
-    VerticalAlignment vertical =
-        VerticalAlignment::Top;
+    VerticalAlignment vertical = VerticalAlignment::Top;
 
     switch (g_settings.badgePosition) {
         case BadgePosition::TopLeft:
@@ -752,48 +604,35 @@ void ApplyNumberBadgePosition(
     badge.Margin(Thickness{});
 
     auto transform =
-        badge.RenderTransform()
-            .try_as<Media::TranslateTransform>();
+        badge.RenderTransform().try_as<Media::TranslateTransform>();
 
     if (!transform) {
-        transform =
-            Media::TranslateTransform();
+        transform = Media::TranslateTransform();
 
         badge.RenderTransform(transform);
     }
 
-    transform.X(
-        static_cast<double>(
-            g_settings.badgeOffsetX));
+    transform.X(static_cast<double>(g_settings.badgeOffsetX));
 
-    transform.Y(
-        static_cast<double>(
-            g_settings.badgeOffsetY));
+    transform.Y(static_cast<double>(g_settings.badgeOffsetY));
 }
 
-void ApplyDotPosition(
-    Controls::Border badge) {
-    badge.VerticalAlignment(
-        VerticalAlignment::Center);
+void ApplyDotPosition(Controls::Border badge) {
+    badge.VerticalAlignment(VerticalAlignment::Center);
 
     badge.Margin(Thickness{});
 
-    if (g_settings.dotPosition ==
-        DotPosition::Left) {
-        badge.HorizontalAlignment(
-            HorizontalAlignment::Left);
+    if (g_settings.dotPosition == DotPosition::Left) {
+        badge.HorizontalAlignment(HorizontalAlignment::Left);
     } else {
-        badge.HorizontalAlignment(
-            HorizontalAlignment::Right);
+        badge.HorizontalAlignment(HorizontalAlignment::Right);
     }
 
     auto transform =
-        badge.RenderTransform()
-            .try_as<Media::TranslateTransform>();
+        badge.RenderTransform().try_as<Media::TranslateTransform>();
 
     if (!transform) {
-        transform =
-            Media::TranslateTransform();
+        transform = Media::TranslateTransform();
 
         badge.RenderTransform(transform);
     }
@@ -803,11 +642,7 @@ void ApplyDotPosition(
     // Moving them outside causes the taskbar XAML to clip them.
     //
     // 2 px gives a little separation from the panel edge.
-    transform.X(
-        g_settings.dotPosition ==
-                DotPosition::Left
-            ? 2.0
-            : -2.0);
+    transform.X(g_settings.dotPosition == DotPosition::Left ? 2.0 : -2.0);
 
     transform.Y(0.0);
 }
@@ -816,8 +651,7 @@ void ApplyDotPosition(
 // Font helper
 // -----------------------------------------------------------------------------
 
-winrt::Windows::UI::Text::FontWeight
-GetConfiguredFontWeight() {
+winrt::Windows::UI::Text::FontWeight GetConfiguredFontWeight() {
     uint16_t weight = 600;
 
     switch (g_settings.fontWeight) {
@@ -836,8 +670,7 @@ GetConfiguredFontWeight() {
 
     winrt::Windows::UI::Text::FontWeight result{};
 
-    result.Weight =
-        weight;
+    result.Weight = weight;
 
     return result;
 }
@@ -850,43 +683,29 @@ HWND FindCurrentProcessTaskbarWnd() {
     HWND result = nullptr;
 
     EnumWindows(
-        [](HWND hWnd,
-           LPARAM param) -> BOOL {
+        [](HWND hWnd, LPARAM param) -> BOOL {
             DWORD pid = 0;
             WCHAR className[64] = {};
 
-            GetWindowThreadProcessId(
-                hWnd,
-                &pid);
+            GetWindowThreadProcessId(hWnd, &pid);
 
-            if (pid !=
-                GetCurrentProcessId()) {
+            if (pid != GetCurrentProcessId()) {
                 return TRUE;
             }
 
-            if (!GetClassNameW(
-                    hWnd,
-                    className,
-                    ARRAYSIZE(
-                        className))) {
+            if (!GetClassNameW(hWnd, className, ARRAYSIZE(className))) {
                 return TRUE;
             }
 
-            if (_wcsicmp(
-                    className,
-                    L"Shell_TrayWnd") !=
-                0) {
+            if (_wcsicmp(className, L"Shell_TrayWnd") != 0) {
                 return TRUE;
             }
 
-            *reinterpret_cast<HWND*>(
-                param) =
-                hWnd;
+            *reinterpret_cast<HWND*>(param) = hWnd;
 
             return FALSE;
         },
-        reinterpret_cast<LPARAM>(
-            &result));
+        reinterpret_cast<LPARAM>(&result));
 
     return result;
 }
@@ -896,14 +715,10 @@ HWND FindCurrentProcessTaskbarWnd() {
 // -----------------------------------------------------------------------------
 
 HMODULE GetTaskbarViewModuleHandle() {
-    HMODULE module =
-        GetModuleHandleW(
-            L"Taskbar.View.dll");
+    HMODULE module = GetModuleHandleW(L"Taskbar.View.dll");
 
     if (!module) {
-        module =
-            GetModuleHandleW(
-                L"ExplorerExtensions.dll");
+        module = GetModuleHandleW(L"ExplorerExtensions.dll");
     }
 
     return module;
@@ -913,38 +728,22 @@ HMODULE GetTaskbarViewModuleHandle() {
 // XAML helpers
 // -----------------------------------------------------------------------------
 
-FrameworkElement FindChildByName(
-    FrameworkElement element,
-    PCWSTR name) {
-    int count =
-        Media::VisualTreeHelper::
-            GetChildrenCount(
-                element);
+FrameworkElement FindChildByName(FrameworkElement element, PCWSTR name) {
+    int count = Media::VisualTreeHelper::GetChildrenCount(element);
 
-    for (int i = 0;
-         i < count;
-         i++) {
-        auto child =
-            Media::VisualTreeHelper::
-                GetChild(
-                    element,
-                    i)
-                    .try_as<
-                        FrameworkElement>();
+    for (int i = 0; i < count; i++) {
+        auto child = Media::VisualTreeHelper::GetChild(element, i)
+                         .try_as<FrameworkElement>();
 
         if (!child) {
             continue;
         }
 
-        if (child.Name() ==
-            name) {
+        if (child.Name() == name) {
             return child;
         }
 
-        auto result =
-            FindChildByName(
-                child,
-                name);
+        auto result = FindChildByName(child, name);
 
         if (result) {
             return result;
@@ -958,97 +757,55 @@ FrameworkElement FindChildByName(
 // Badge text / dot content
 // -----------------------------------------------------------------------------
 
-std::wstring MakeNumberText(
-    unsigned int count) {
-    if (count >
-        static_cast<unsigned int>(
-            g_settings.maximumNumber)) {
-        return std::to_wstring(
-                   g_settings.maximumNumber) +
-               L"+";
+std::wstring MakeNumberText(unsigned int count) {
+    if (count > static_cast<unsigned int>(g_settings.maximumNumber)) {
+        return std::to_wstring(g_settings.maximumNumber) + L"+";
     }
 
-    return std::to_wstring(
-        count);
+    return std::to_wstring(count);
 }
 
-unsigned int GetVisibleDotCount(
-    unsigned int count) {
+unsigned int GetVisibleDotCount(unsigned int count) {
     // Five dots means five or more windows.
-    return std::min<unsigned int>(
-        count,
-        5);
+    return std::min<unsigned int>(count, 5);
 }
 
-void RebuildDots(
-    Controls::StackPanel dotStack,
-    unsigned int count) {
+void RebuildDots(Controls::StackPanel dotStack, unsigned int count) {
     dotStack.Children().Clear();
 
-    winrt::Windows::UI::Color
-        defaultDotColor{};
+    winrt::Windows::UI::Color defaultDotColor{};
 
     defaultDotColor.A = 255;
     defaultDotColor.R = 255;
     defaultDotColor.G = 255;
     defaultDotColor.B = 255;
 
-    auto brush =
-        CreateBrush(
-            g_settings.dotColor,
-            defaultDotColor);
+    auto brush = CreateBrush(g_settings.dotColor, defaultDotColor);
 
-    unsigned int dotCount =
-        GetVisibleDotCount(
-            count);
+    unsigned int dotCount = GetVisibleDotCount(count);
 
     constexpr double kDotSpacing = 2.0;
 
-    for (unsigned int i = 0;
-         i < dotCount;
-         i++) {
+    for (unsigned int i = 0; i < dotCount; i++) {
         Controls::Border dot;
 
-        dot.Width(
-            static_cast<double>(
-                g_settings.dotSize));
+        dot.Width(static_cast<double>(g_settings.dotSize));
 
-        dot.Height(
-            static_cast<double>(
-                g_settings.dotSize));
+        dot.Height(static_cast<double>(g_settings.dotSize));
 
-        double radius =
-            static_cast<double>(
-                g_settings.dotSize) /
-            2.0;
+        double radius = static_cast<double>(g_settings.dotSize) / 2.0;
 
-        dot.CornerRadius(
-            CornerRadius{
-                radius,
-                radius,
-                radius,
-                radius});
+        dot.CornerRadius(CornerRadius{radius, radius, radius, radius});
 
-        dot.Background(
-            brush);
+        dot.Background(brush);
 
-        double topMargin =
-            i == 0
-                ? 0.0
-                : kDotSpacing;
+        double topMargin = i == 0 ? 0.0 : kDotSpacing;
 
-        dot.Margin(
-            Thickness{
-                0,
-                topMargin,
-                0,
-                0});
+        dot.Margin(Thickness{0, topMargin, 0, 0});
 
-        dot.IsHitTestVisible(
-            false);
+        dot.IsHitTestVisible(false);
 
-        dotStack.Children().Append(
-            dot);
+        dotStack.Children().Append(dot);
     }
 }
 
@@ -1056,62 +813,38 @@ void RebuildDots(
 // Apply visual style
 // -----------------------------------------------------------------------------
 
-void ApplyBadgeVisualStyle(
-    Controls::Border badge,
-    unsigned int count) {
-    auto circleVisual =
-        FindChildByName(
-            badge,
-            L"WindhawkCircleVisual")
-            .try_as<
-                Shapes::Ellipse>();
+void ApplyBadgeVisualStyle(Controls::Border badge, unsigned int count) {
+    auto circleVisual = FindChildByName(badge, L"WindhawkCircleVisual")
+                            .try_as<Shapes::Ellipse>();
 
-    auto badgeVisual =
-        FindChildByName(
-            badge,
-            L"WindhawkBadgeVisual")
-            .try_as<
-                Controls::Border>();
+    auto badgeVisual = FindChildByName(badge, L"WindhawkBadgeVisual")
+                           .try_as<Controls::Border>();
 
-    auto text =
-        FindChildByName(
-            badge,
-            L"WindhawkCountText")
-            .try_as<
-                Controls::TextBlock>();
+    auto text = FindChildByName(badge, L"WindhawkCountText")
+                    .try_as<Controls::TextBlock>();
 
-    auto dotStack =
-        FindChildByName(
-            badge,
-            L"WindhawkDotStack")
-            .try_as<
-                Controls::StackPanel>();
+    auto dotStack = FindChildByName(badge, L"WindhawkDotStack")
+                        .try_as<Controls::StackPanel>();
 
-    if (!circleVisual ||
-        !badgeVisual ||
-        !text ||
-        !dotStack) {
+    if (!circleVisual || !badgeVisual || !text || !dotStack) {
         return;
     }
 
-    winrt::Windows::UI::Color
-        defaultBackground{};
+    winrt::Windows::UI::Color defaultBackground{};
 
     defaultBackground.A = 255;
     defaultBackground.R = 217;
     defaultBackground.G = 0;
     defaultBackground.B = 0;
 
-    winrt::Windows::UI::Color
-        defaultText{};
+    winrt::Windows::UI::Color defaultText{};
 
     defaultText.A = 255;
     defaultText.R = 255;
     defaultText.G = 255;
     defaultText.B = 255;
 
-    winrt::Windows::UI::Color
-        defaultBorder{};
+    winrt::Windows::UI::Color defaultBorder{};
 
     defaultBorder.A = 255;
     defaultBorder.R = 255;
@@ -1120,165 +853,104 @@ void ApplyBadgeVisualStyle(
 
     badge.IsHitTestVisible(false);
 
-    Controls::Canvas::SetZIndex(
-        badge,
-        100);
+    Controls::Canvas::SetZIndex(badge, 100);
 
     // ---------------------------------------------------------------------
     // NUMBER BADGE
     // ---------------------------------------------------------------------
 
-    if (g_settings.displayStyle ==
-        DisplayStyle::Number) {
-        ApplyNumberBadgePosition(
-            badge);
+    if (g_settings.displayStyle == DisplayStyle::Number) {
+        ApplyNumberBadgePosition(badge);
 
-        dotStack.Visibility(
-            Visibility::Collapsed);
+        dotStack.Visibility(Visibility::Collapsed);
 
-        text.Visibility(
-            Visibility::Visible);
+        text.Visibility(Visibility::Visible);
 
-        double size =
-            static_cast<double>(
-                g_settings.badgeSize);
+        double size = static_cast<double>(g_settings.badgeSize);
 
         badge.Width(size);
         badge.Height(size);
 
         auto backgroundBrush =
-            CreateBrush(
-                g_settings.badgeBackgroundColor,
-                defaultBackground);
+            CreateBrush(g_settings.badgeBackgroundColor, defaultBackground);
 
         auto borderBrush =
-            CreateBrush(
-                g_settings.badgeBorderColor,
-                defaultBorder);
+            CreateBrush(g_settings.badgeBorderColor, defaultBorder);
 
         double borderThickness =
-            static_cast<double>(
-                g_settings.badgeBorderThickness);
+            static_cast<double>(g_settings.badgeBorderThickness);
 
-        if (g_settings.badgeShape ==
-            BadgeShape::Circle) {
-            badgeVisual.Visibility(
-                Visibility::Collapsed);
+        if (g_settings.badgeShape == BadgeShape::Circle) {
+            badgeVisual.Visibility(Visibility::Collapsed);
 
-            circleVisual.Visibility(
-                Visibility::Visible);
+            circleVisual.Visibility(Visibility::Visible);
 
             circleVisual.Width(size);
             circleVisual.Height(size);
 
-            circleVisual.Fill(
-                backgroundBrush);
+            circleVisual.Fill(backgroundBrush);
 
             if (g_settings.badgeBorderThickness > 0) {
-                circleVisual.Stroke(
-                    borderBrush);
+                circleVisual.Stroke(borderBrush);
 
-                circleVisual.StrokeThickness(
-                    borderThickness);
+                circleVisual.StrokeThickness(borderThickness);
             } else {
-                circleVisual.Stroke(
-                    nullptr);
+                circleVisual.Stroke(nullptr);
 
-                circleVisual.StrokeThickness(
-                    0);
+                circleVisual.StrokeThickness(0);
             }
         } else {
-            circleVisual.Visibility(
-                Visibility::Collapsed);
+            circleVisual.Visibility(Visibility::Collapsed);
 
-            badgeVisual.Visibility(
-                Visibility::Visible);
+            badgeVisual.Visibility(Visibility::Visible);
 
             badgeVisual.Width(size);
             badgeVisual.Height(size);
 
-            badgeVisual.HorizontalAlignment(
-                HorizontalAlignment::Center);
+            badgeVisual.HorizontalAlignment(HorizontalAlignment::Center);
 
-            badgeVisual.VerticalAlignment(
-                VerticalAlignment::Center);
+            badgeVisual.VerticalAlignment(VerticalAlignment::Center);
 
             double cornerRadius =
-                g_settings.badgeShape ==
-                        BadgeShape::Rounded
-                    ? size / 4.0
-                    : 0.0;
+                g_settings.badgeShape == BadgeShape::Rounded ? size / 4.0 : 0.0;
 
-            badgeVisual.CornerRadius(
-                CornerRadius{
-                    cornerRadius,
-                    cornerRadius,
-                    cornerRadius,
-                    cornerRadius});
+            badgeVisual.CornerRadius(CornerRadius{cornerRadius, cornerRadius,
+                                                  cornerRadius, cornerRadius});
 
-            badgeVisual.Background(
-                backgroundBrush);
+            badgeVisual.Background(backgroundBrush);
 
             if (g_settings.badgeBorderThickness > 0) {
-                badgeVisual.BorderBrush(
-                    borderBrush);
+                badgeVisual.BorderBrush(borderBrush);
 
                 badgeVisual.BorderThickness(
-                    Thickness{
-                        borderThickness,
-                        borderThickness,
-                        borderThickness,
-                        borderThickness});
+                    Thickness{borderThickness, borderThickness, borderThickness,
+                              borderThickness});
             } else {
-                badgeVisual.BorderBrush(
-                    nullptr);
+                badgeVisual.BorderBrush(nullptr);
 
-                badgeVisual.BorderThickness(
-                    Thickness{
-                        0,
-                        0,
-                        0,
-                        0});
+                badgeVisual.BorderThickness(Thickness{0, 0, 0, 0});
             }
         }
 
-        text.Foreground(
-            CreateBrush(
-                g_settings.textColor,
-                defaultText));
+        text.Foreground(CreateBrush(g_settings.textColor, defaultText));
 
-        text.FontSize(
-            static_cast<double>(
-                g_settings.fontSize));
+        text.FontSize(static_cast<double>(g_settings.fontSize));
 
         text.FontFamily(
-            Media::FontFamily(
-                winrt::hstring(
-                    g_settings.fontFamily)));
+            Media::FontFamily(winrt::hstring(g_settings.fontFamily)));
 
-        text.FontWeight(
-            GetConfiguredFontWeight());
+        text.FontWeight(GetConfiguredFontWeight());
 
-        text.HorizontalAlignment(
-            HorizontalAlignment::Center);
+        text.HorizontalAlignment(HorizontalAlignment::Center);
 
-        text.VerticalAlignment(
-            VerticalAlignment::Center);
+        text.VerticalAlignment(VerticalAlignment::Center);
 
-        text.TextAlignment(
-            TextAlignment::Center);
+        text.TextAlignment(TextAlignment::Center);
 
         // Optical correction for the font baseline.
-        text.Margin(
-            Thickness{
-                0,
-                -2,
-                0,
-                0});
+        text.Margin(Thickness{0, -2, 0, 0});
 
-        text.Text(
-            MakeNumberText(
-                count));
+        text.Text(MakeNumberText(count));
 
         return;
     }
@@ -1287,78 +959,50 @@ void ApplyBadgeVisualStyle(
     // VERTICAL DOTS
     // ---------------------------------------------------------------------
 
-    ApplyDotPosition(
-        badge);
+    ApplyDotPosition(badge);
 
-    circleVisual.Visibility(
-        Visibility::Collapsed);
+    circleVisual.Visibility(Visibility::Collapsed);
 
-    badgeVisual.Visibility(
-        Visibility::Collapsed);
+    badgeVisual.Visibility(Visibility::Collapsed);
 
-    text.Visibility(
-        Visibility::Collapsed);
+    text.Visibility(Visibility::Collapsed);
 
-    dotStack.Visibility(
-        Visibility::Visible);
+    dotStack.Visibility(Visibility::Visible);
 
-    badge.Width(
-        std::numeric_limits<double>::
-            quiet_NaN());
+    badge.Width(std::numeric_limits<double>::quiet_NaN());
 
-    badge.Height(
-        std::numeric_limits<double>::
-            quiet_NaN());
+    badge.Height(std::numeric_limits<double>::quiet_NaN());
 
-    badge.Background(
-        nullptr);
+    badge.Background(nullptr);
 
-    badge.BorderBrush(
-        nullptr);
+    badge.BorderBrush(nullptr);
 
-    badge.BorderThickness(
-        Thickness{
-            0,
-            0,
-            0,
-            0});
+    badge.BorderThickness(Thickness{0, 0, 0, 0});
 
-    dotStack.Orientation(
-        Controls::Orientation::Vertical);
+    dotStack.Orientation(Controls::Orientation::Vertical);
 
-    dotStack.HorizontalAlignment(
-        HorizontalAlignment::Center);
+    dotStack.HorizontalAlignment(HorizontalAlignment::Center);
 
-    dotStack.VerticalAlignment(
-        VerticalAlignment::Center);
+    dotStack.VerticalAlignment(VerticalAlignment::Center);
 
-    RebuildDots(
-        dotStack,
-        count);
+    RebuildDots(dotStack, count);
 }
 // -----------------------------------------------------------------------------
 // Badge
 // -----------------------------------------------------------------------------
 
-void RemoveBadgeFromPanel(
-    Controls::Panel iconPanel,
-    Controls::Border badge) {
-    auto children =
-        iconPanel.Children();
+void RemoveBadgeFromPanel(Controls::Panel iconPanel, Controls::Border badge) {
+    auto children = iconPanel.Children();
 
-    for (uint32_t i = 0;
-         i < children.Size();
-         i++) {
-        if (children.GetAt(i) ==
-            badge) {
+    for (uint32_t i = 0; i < children.Size(); i++) {
+        if (children.GetAt(i) == badge) {
             children.RemoveAt(i);
             return;
         }
     }
 }
 
-Controls::Border CreateCountBadge(
-    Controls::Panel iconPanel) {
+Controls::Border CreateCountBadge(Controls::Panel iconPanel) {
     PCWSTR xaml =
         LR"(
 <Border
@@ -1400,264 +1044,224 @@ Controls::Border CreateCountBadge(
 </Border>
 )";
 
-    auto badge =
-        Markup::XamlReader::
-            Load(xaml)
-            .as<
-                Controls::Border>();
+    auto badge = Markup::XamlReader::Load(xaml).as<Controls::Border>();
 
-    badge.IsHitTestVisible(
-        false);
+    badge.IsHitTestVisible(false);
 
-    Controls::Canvas::SetZIndex(
-        badge,
-        100);
+    Controls::Canvas::SetZIndex(badge, 100);
 
-    iconPanel.Children().Append(
-        badge);
+    iconPanel.Children().Append(badge);
 
     return badge;
 }
 
-void UpdateCountBadge(
-    FrameworkElement taskListButton,
-    unsigned int count) {
+bool UpdateCountBadge(FrameworkElement taskListButton, unsigned int count) {
     if (g_unloading) {
-        return;
+        return false;
     }
 
-    auto iconPanelElement =
-        FindChildByName(
-            taskListButton,
-            L"IconPanel");
+    auto iconPanelElement = FindChildByName(taskListButton, L"IconPanel");
 
     if (!iconPanelElement) {
-        return;
+        return false;
     }
 
-    auto iconPanel =
-        iconPanelElement
-            .try_as<
-                Controls::Panel>();
+    auto iconPanel = iconPanelElement.try_as<Controls::Panel>();
 
     if (!iconPanel) {
-        return;
+        return false;
     }
 
-    auto badge =
-        FindChildByName(
-            iconPanelElement,
-            L"WindhawkCountBadge")
-            .try_as<
-                Controls::Border>();
+    auto badge = FindChildByName(iconPanelElement, L"WindhawkCountBadge")
+                     .try_as<Controls::Border>();
 
     // Rebuild badges created by older visual-layout versions.
     if (badge) {
-        auto circleVisual =
-            FindChildByName(
-                badge,
-                L"WindhawkCircleVisual");
+        auto circleVisual = FindChildByName(badge, L"WindhawkCircleVisual");
 
-        auto badgeVisual =
-            FindChildByName(
-                badge,
-                L"WindhawkBadgeVisual");
+        auto badgeVisual = FindChildByName(badge, L"WindhawkBadgeVisual");
 
-        auto countText =
-            FindChildByName(
-                badge,
-                L"WindhawkCountText");
+        auto countText = FindChildByName(badge, L"WindhawkCountText");
 
-        auto dotStack =
-            FindChildByName(
-                badge,
-                L"WindhawkDotStack");
+        auto dotStack = FindChildByName(badge, L"WindhawkDotStack");
 
-        if (!circleVisual ||
-            !badgeVisual ||
-            !countText ||
-            !dotStack) {
-            RemoveBadgeFromPanel(
-                iconPanel,
-                badge);
+        if (!circleVisual || !badgeVisual || !countText || !dotStack) {
+            RemoveBadgeFromPanel(iconPanel, badge);
 
             badge = nullptr;
         }
     }
 
-    if (count <
-        static_cast<unsigned int>(
-            g_settings.minimumCount)) {
+    if (count < static_cast<unsigned int>(g_settings.minimumCount)) {
         if (badge) {
-            badge.Visibility(
-                Visibility::Collapsed);
+            badge.Visibility(Visibility::Collapsed);
         }
 
-        return;
+        return true;
     }
 
     if (!badge) {
-        badge =
-            CreateCountBadge(
-                iconPanel);
+        badge = CreateCountBadge(iconPanel);
     }
 
-    ApplyBadgeVisualStyle(
-        badge,
-        count);
+    ApplyBadgeVisualStyle(badge, count);
 
-    badge.Visibility(
-        Visibility::Visible);
+    badge.Visibility(Visibility::Visible);
+
+    return true;
 }
 // -----------------------------------------------------------------------------
-// Tracked buttons
+// Direct taskbar group count / tracked buttons
 // -----------------------------------------------------------------------------
 
 void PruneDeadTrackedButtons() {
-    for (auto it =
-             g_trackedButtons.begin();
-         it !=
-         g_trackedButtons.end();) {
+    for (auto it = g_trackedButtons.begin(); it != g_trackedButtons.end();) {
         if (!it->element.get()) {
-            it =
-                g_trackedButtons.erase(
-                    it);
+            it = g_trackedButtons.erase(it);
         } else {
             ++it;
         }
     }
 }
 
-void TrackTaskbarButton(
-    FrameworkElement element) {
+TrackedButton* TrackTaskbarButton(FrameworkElement element, void* viewModel) {
     PruneDeadTrackedButtons();
-    auto unknown =
-        element.as<
-            winrt::Windows::
-                Foundation::IUnknown>();
 
-    void* identity =
-        winrt::get_abi(
-            unknown);
-
-    auto automationId =
-        winrt::Windows::UI::
-            Xaml::Automation::
-                AutomationProperties::
-                    GetAutomationId(
-                        element);
-
-    if (automationId.empty()) {
-        return;
-    }
+    auto unknown = element.as<winrt::Windows::Foundation::IUnknown>();
+    void* identity = winrt::get_abi(unknown);
 
     auto existing =
-        std::find_if(
-            g_trackedButtons.begin(),
-            g_trackedButtons.end(),
-            [identity](
-                const TrackedButton& item) {
-                return item.identity ==
-                       identity;
-            });
+        std::find_if(g_trackedButtons.begin(), g_trackedButtons.end(),
+                     [identity](const TrackedButton& item) {
+                         return item.identity == identity;
+                     });
 
-    if (existing !=
-        g_trackedButtons.end()) {
-        existing->automationId =
-            automationId.c_str();
-
-        return;
+    if (existing != g_trackedButtons.end()) {
+        existing->viewModel = viewModel;
+        return &*existing;
     }
 
-    g_trackedButtons.push_back(
-        {
-            identity,
-            automationId.c_str(),
-            winrt::make_weak(
-                element),
-        });
+    g_trackedButtons.push_back({
+        .identity = identity,
+        .viewModel = viewModel,
+        .element = winrt::make_weak(element),
+    });
+
+    return &g_trackedButtons.back();
 }
 
-// -----------------------------------------------------------------------------
-// Apply cached HWND count
-// -----------------------------------------------------------------------------
+bool GetTaskbarButtonViewModelCount(FrameworkElement element,
+                                    void** viewModel,
+                                    unsigned int* count) {
+    if (!viewModel || !count ||
+        !TryGetItemFromContainer_TaskListGroupViewModel_Original ||
+        !GetViewModelCount_Original) {
+        return false;
+    }
 
-void ApplyCountToButton(
-    FrameworkElement element) {
-    auto automationId =
-        winrt::Windows::UI::
-            Xaml::Automation::
-                AutomationProperties::
-                    GetAutomationId(
-                        element);
+    *viewModel = nullptr;
+    *count = 0;
 
-    if (automationId.empty()) {
+    UIElement uiElement = element.as<UIElement>();
+    winrt::com_ptr<IUnknown> groupViewModel;
+    TryGetItemFromContainer_TaskListGroupViewModel_Original(
+        groupViewModel.put_void(), &uiElement);
+
+    if (!groupViewModel) {
+        return false;
+    }
+
+    *viewModel = groupViewModel.get();
+
+    HRESULT hr = GetViewModelCount_Original(groupViewModel.get(), count);
+    if (FAILED(hr)) {
+        return false;
+    }
+
+    *count = WindowCountFromViewModelCount(*count);
+    return true;
+}
+
+void ApplyCountToTrackedButton(TrackedButton& item, unsigned int count) {
+    uint64_t settingsGeneration = g_settingsGeneration;
+    if (item.lastAppliedCount == count &&
+        item.lastSettingsGeneration == settingsGeneration) {
         return;
     }
 
-    std::wstring key =
-        NormalizeId(
-            automationId.c_str());
-
-    unsigned int count = 0;
-
-    auto it =
-        g_appCounts.find(
-            key);
-
-    if (it !=
-        g_appCounts.end()) {
-        count =
-            it->second;
+    auto element = item.element.get();
+    if (!element) {
+        return;
     }
 
-    UpdateCountBadge(
-        element,
-        count);
+    // Mark the state before touching XAML so a synchronous re-entrant taskbar
+    // update doesn't apply the same visual change recursively. Roll it back if
+    // the visual couldn't be updated.
+    unsigned int previousCount = item.lastAppliedCount;
+    uint64_t previousGeneration = item.lastSettingsGeneration;
+    item.lastAppliedCount = count;
+    item.lastSettingsGeneration = settingsGeneration;
+
+    try {
+        if (!UpdateCountBadge(element, count)) {
+            item.lastAppliedCount = previousCount;
+            item.lastSettingsGeneration = previousGeneration;
+        }
+    } catch (...) {
+        item.lastAppliedCount = previousCount;
+        item.lastSettingsGeneration = previousGeneration;
+        throw;
+    }
+}
+
+void ApplyCountToButton(FrameworkElement element) {
+    void* viewModel = nullptr;
+    unsigned int count = 0;
+    bool haveCount =
+        GetTaskbarButtonViewModelCount(element, &viewModel, &count);
+
+    auto* tracked = TrackTaskbarButton(element, viewModel);
+    if (!tracked) {
+        return;
+    }
+
+    // A recycled/pinned button can temporarily have no group view model. Treat
+    // it as zero so a badge from the previous container contents can't remain
+    // visible.
+    ApplyCountToTrackedButton(*tracked, haveCount ? count : 0);
 }
 
 void RefreshAllTrackedButtons() {
     PruneDeadTrackedButtons();
 
-    for (auto& item :
-         g_trackedButtons) {
-        auto element =
-            item.element.get();
-
+    for (auto& item : g_trackedButtons) {
+        auto element = item.element.get();
         if (!element) {
             continue;
         }
 
-        ApplyCountToButton(
-            element);
+        void* viewModel = nullptr;
+        unsigned int count = 0;
+        bool haveCount =
+            GetTaskbarButtonViewModelCount(element, &viewModel, &count);
+        item.viewModel = viewModel;
+        ApplyCountToTrackedButton(item, haveCount ? count : 0);
     }
 }
 
-void RefreshChangedTrackedButtons(
-    const std::unordered_set<
-        std::wstring>& changedIds) {
+void RefreshTrackedButtonsForViewModel(void* viewModel, unsigned int count) {
+    DWORD taskbarThreadId = g_taskbarThreadId.load();
+    if (!viewModel || !taskbarThreadId ||
+        taskbarThreadId != GetCurrentThreadId()) {
+        return;
+    }
+
     PruneDeadTrackedButtons();
 
-    for (auto& item :
-         g_trackedButtons) {
-        std::wstring key =
-            NormalizeId(
-                item.automationId);
-
-        if (!changedIds.contains(
-                key)) {
-            continue;
+    for (auto& item : g_trackedButtons) {
+        if (item.viewModel == viewModel) {
+            ApplyCountToTrackedButton(item, count);
         }
-
-        auto element =
-            item.element.get();
-
-        if (!element) {
-            continue;
-        }
-
-        ApplyCountToButton(
-            element);
     }
 }
 
@@ -1665,8 +1269,7 @@ void RefreshChangedTrackedButtons(
 // Existing XAML tree enumeration
 // -----------------------------------------------------------------------------
 
-int EnumerateExistingTaskbarButtons(
-    FrameworkElement element) {
+int EnumerateExistingTaskbarButtons(FrameworkElement element) {
     if (!element) {
         return 0;
     }
@@ -1674,45 +1277,18 @@ int EnumerateExistingTaskbarButtons(
     int found = 0;
 
     try {
-        if (element.Name() ==
-            L"TaskListButton") {
-            if (!g_taskbarDispatcher) {
-                g_taskbarDispatcher =
-                    element.Dispatcher();
-            }
-
-            TrackTaskbarButton(
-                element);
-
-            ApplyCountToButton(
-                element);
-
-            found++;
+        if (element.Name() == L"TaskListButton") {
+            ApplyCountToButton(element);
+            ++found;
         }
 
-        int children =
-            Media::VisualTreeHelper::
-                GetChildrenCount(
-                    element);
-
-        for (int i = 0;
-             i < children;
-             i++) {
-            auto child =
-                Media::VisualTreeHelper::
-                    GetChild(
-                        element,
-                        i)
-                    .try_as<
-                        FrameworkElement>();
-
-            if (!child) {
-                continue;
+        int children = Media::VisualTreeHelper::GetChildrenCount(element);
+        for (int i = 0; i < children; ++i) {
+            auto child = Media::VisualTreeHelper::GetChild(element, i)
+                             .try_as<FrameworkElement>();
+            if (child) {
+                found += EnumerateExistingTaskbarButtons(child);
             }
-
-            found +=
-                EnumerateExistingTaskbarButtons(
-                    child);
         }
     } catch (...) {
     }
@@ -1724,195 +1300,155 @@ int EnumerateExistingTaskbarButtons(
 // Existing taskbar XamlRoot
 // -----------------------------------------------------------------------------
 
-XamlRoot GetTaskbarXamlRoot(
-    HWND taskbarWnd) {
-    if (!taskbarWnd ||
-        !g_CTaskBand_ITaskListWndSite_vftable ||
-        !g_CTaskBand_GetTaskbarHost ||
-        !g_TaskbarHost_FrameHeight ||
+XamlRoot XamlRootFromTaskbarHostSharedPtr(void* hostShared[2]) {
+    if (!hostShared[0]) {
+        if (hostShared[1]) {
+            g_RefCount_Decref(hostShared[1]);
+        }
+        return nullptr;
+    }
+
+    // Current Windows 11 TaskbarHost layout uses 0x48 on ARM64. On x64,
+    // detect the offset from TaskbarHost::FrameHeight where possible.
+    size_t elementOffset = 0x48;
+
+#if defined(_M_X64)
+    const BYTE* code = reinterpret_cast<const BYTE*>(g_TaskbarHost_FrameHeight);
+    if (code[0] == 0x48 && code[1] == 0x83 && code[2] == 0xEC &&
+        code[4] == 0x48 && code[5] == 0x83 && code[6] == 0xC1 &&
+        code[7] <= 0x7F) {
+        elementOffset = code[7];
+    } else {
+        Wh_Log(L"Couldn't detect TaskbarHost XAML offset, using 0x48");
+    }
+#elif defined(_M_ARM64)
+    // Use the known/default TaskbarHost XAML element offset.
+#else
+#error "Unsupported architecture"
+#endif
+
+    IUnknown* xamlUnknown = *reinterpret_cast<IUnknown**>(
+        reinterpret_cast<BYTE*>(hostShared[0]) + elementOffset);
+
+    FrameworkElement taskbarElement = nullptr;
+    if (xamlUnknown) {
+        xamlUnknown->QueryInterface(winrt::guid_of<FrameworkElement>(),
+                                    winrt::put_abi(taskbarElement));
+    }
+
+    XamlRoot result = taskbarElement ? taskbarElement.XamlRoot() : nullptr;
+
+    if (hostShared[1]) {
+        g_RefCount_Decref(hostShared[1]);
+    }
+
+    return result;
+}
+
+XamlRoot GetTaskbarXamlRoot(HWND taskbarWnd) {
+    if (!taskbarWnd || !g_CTaskBand_ITaskListWndSite_vftable ||
+        !g_CTaskBand_GetTaskbarHost || !g_TaskbarHost_FrameHeight ||
         !g_RefCount_Decref) {
         return nullptr;
     }
 
     HWND taskBandWnd =
-        reinterpret_cast<HWND>(
-            GetPropW(
-                taskbarWnd,
-                L"TaskbandHWND"));
-
+        reinterpret_cast<HWND>(GetPropW(taskbarWnd, L"TaskbandHWND"));
     if (!taskBandWnd) {
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"TaskbandHWND not found");
-
+        Wh_Log(L"TaskbandHWND not found");
         return nullptr;
     }
 
-    void* taskBand =
-        reinterpret_cast<void*>(
-            GetWindowLongPtrW(
-                taskBandWnd,
-                0));
-
+    void* taskBand = reinterpret_cast<void*>(GetWindowLongPtrW(taskBandWnd, 0));
     if (!taskBand) {
         return nullptr;
     }
 
-    void* site =
-        taskBand;
-
-    bool siteFound =
-        false;
-
-    for (int i = 0;
-         i < 20;
-         i++) {
-        if (*reinterpret_cast<void**>(
-                site) ==
+    void* site = taskBand;
+    bool siteFound = false;
+    for (int i = 0; i < 20; ++i) {
+        if (*reinterpret_cast<void**>(site) ==
             g_CTaskBand_ITaskListWndSite_vftable) {
-            siteFound =
-                true;
-
+            siteFound = true;
             break;
         }
-
-        site =
-            reinterpret_cast<void**>(
-                site) +
-            1;
+        site = reinterpret_cast<void**>(site) + 1;
     }
 
     if (!siteFound) {
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"ITaskListWndSite not found");
-
+        Wh_Log(L"ITaskListWndSite not found for primary taskbar");
         return nullptr;
     }
 
     void* hostShared[2] = {};
+    g_CTaskBand_GetTaskbarHost(site, hostShared);
+    return XamlRootFromTaskbarHostSharedPtr(hostShared);
+}
 
-    g_CTaskBand_GetTaskbarHost(
-        site,
-        hostShared);
-
-    if (!hostShared[0]) {
-        if (hostShared[1]) {
-            g_RefCount_Decref(
-                hostShared[1]);
-        }
-
+XamlRoot GetSecondaryTaskbarXamlRoot(HWND taskbarWnd) {
+    if (!taskbarWnd || !g_CSecondaryTaskBand_ITaskListWndSite_vftable ||
+        !g_CSecondaryTaskBand_GetTaskbarHost || !g_TaskbarHost_FrameHeight ||
+        !g_RefCount_Decref) {
         return nullptr;
     }
 
-    // Current Windows 11 TaskbarHost layout uses 0x48 on ARM64.
-    // On x64, detect the offset from TaskbarHost::FrameHeight so the mod can
-    // tolerate layout changes where possible.
-    size_t elementOffset =
-        0x48;
-
-#if defined(_M_X64)
-
-    const BYTE* code =
-        reinterpret_cast<
-            const BYTE*>(
-            g_TaskbarHost_FrameHeight);
-
-    if (code[0] == 0x48 &&
-        code[1] == 0x83 &&
-        code[2] == 0xEC &&
-        code[4] == 0x48 &&
-        code[5] == 0x83 &&
-        code[6] == 0xC1 &&
-        code[7] <= 0x7F) {
-        elementOffset =
-            code[7];
-    } else {
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"couldn't detect TaskbarHost "
-            L"XAML offset, using 0x48");
+    HWND taskBandWnd = FindWindowExW(taskbarWnd, nullptr, L"WorkerW", nullptr);
+    if (!taskBandWnd) {
+        return nullptr;
     }
 
-#elif defined(_M_ARM64)
-
-    // Use the known/default TaskbarHost XAML element offset.
-    // This follows the ARM64 fallback used by current Windhawk taskbar mods.
-
-#else
-
-#error "Unsupported architecture"
-
-#endif
-
-    IUnknown* xamlUnknown =
-        *reinterpret_cast<IUnknown**>(
-            reinterpret_cast<BYTE*>(
-                hostShared[0]) +
-            elementOffset);
-
-    FrameworkElement taskbarElement =
-        nullptr;
-
-    if (xamlUnknown) {
-        xamlUnknown->QueryInterface(
-            winrt::guid_of<
-                FrameworkElement>(),
-            winrt::put_abi(
-                taskbarElement));
+    void* taskBand = reinterpret_cast<void*>(GetWindowLongPtrW(taskBandWnd, 0));
+    if (!taskBand) {
+        return nullptr;
     }
 
-    XamlRoot result =
-        taskbarElement
-            ? taskbarElement.XamlRoot()
-            : nullptr;
-
-    if (hostShared[1]) {
-        g_RefCount_Decref(
-            hostShared[1]);
+    void* site = taskBand;
+    bool siteFound = false;
+    for (int i = 0; i < 20; ++i) {
+        if (*reinterpret_cast<void**>(site) ==
+            g_CSecondaryTaskBand_ITaskListWndSite_vftable) {
+            siteFound = true;
+            break;
+        }
+        site = reinterpret_cast<void**>(site) + 1;
     }
 
-    return result;
+    if (!siteFound) {
+        Wh_Log(L"ITaskListWndSite not found for secondary taskbar");
+        return nullptr;
+    }
+
+    void* hostShared[2] = {};
+    g_CSecondaryTaskBand_GetTaskbarHost(site, hostShared);
+    return XamlRootFromTaskbarHostSharedPtr(hostShared);
 }
 
 // -----------------------------------------------------------------------------
 // Run synchronously on taskbar UI thread
 // -----------------------------------------------------------------------------
 
-using TaskbarThreadProc =
-    void(WINAPI*)(
-        void* parameter);
+using TaskbarThreadProc = void(WINAPI*)(void* parameter);
 
-bool RunOnTaskbarThread(
-    HWND hWnd,
-    TaskbarThreadProc proc,
-    void* parameter) {
-    if (!hWnd ||
-        !proc) {
+bool RunOnTaskbarThread(HWND hWnd, TaskbarThreadProc proc, void* parameter) {
+    if (!hWnd || !proc) {
         return false;
     }
 
-    DWORD threadId =
-        GetWindowThreadProcessId(
-            hWnd,
-            nullptr);
+    DWORD threadId = GetWindowThreadProcessId(hWnd, nullptr);
 
     if (!threadId) {
         return false;
     }
 
-    if (threadId ==
-        GetCurrentThreadId()) {
-        proc(
-            parameter);
+    if (threadId == GetCurrentThreadId()) {
+        proc(parameter);
 
         return true;
     }
 
-    static UINT message =
-        RegisterWindowMessageW(
-            L"Windhawk_TaskbarCountBadges_"
-            L"RunOnTaskbarThread");
+    static UINT message = RegisterWindowMessageW(
+        L"Windhawk_TaskbarCountBadges_"
+        L"RunOnTaskbarThread");
 
     if (!message) {
         return false;
@@ -1923,42 +1459,24 @@ bool RunOnTaskbarThread(
         void* parameter;
     };
 
-    HHOOK hook =
-        SetWindowsHookExW(
-            WH_CALLWNDPROC,
-            [](int code,
-               WPARAM wParam,
-               LPARAM lParam) -> LRESULT {
-                if (code ==
-                    HC_ACTION) {
-                    auto data =
-                        reinterpret_cast<
-                            CWPSTRUCT*>(
-                            lParam);
+    HHOOK hook = SetWindowsHookExW(
+        WH_CALLWNDPROC,
+        [](int code, WPARAM wParam, LPARAM lParam) -> LRESULT {
+            if (code == HC_ACTION) {
+                auto data = reinterpret_cast<CWPSTRUCT*>(lParam);
 
-                    if (data->message ==
-                        message) {
-                        auto request =
-                            reinterpret_cast<
-                                Request*>(
-                                data->lParam);
+                if (data->message == message) {
+                    auto request = reinterpret_cast<Request*>(data->lParam);
 
-                        if (request &&
-                            request->proc) {
-                            request->proc(
-                                request->parameter);
-                        }
+                    if (request && request->proc) {
+                        request->proc(request->parameter);
                     }
                 }
+            }
 
-                return CallNextHookEx(
-                    nullptr,
-                    code,
-                    wParam,
-                    lParam);
-            },
-            nullptr,
-            threadId);
+            return CallNextHookEx(nullptr, code, wParam, lParam);
+        },
+        nullptr, threadId);
 
     if (!hook) {
         return false;
@@ -1969,513 +1487,9 @@ bool RunOnTaskbarThread(
         parameter,
     };
 
-    SendMessageW(
-        hWnd,
-        message,
-        0,
-        reinterpret_cast<LPARAM>(
-            &request));
+    SendMessageW(hWnd, message, 0, reinterpret_cast<LPARAM>(&request));
 
-    UnhookWindowsHookEx(
-        hook);
-
-    return true;
-}
-
-// -----------------------------------------------------------------------------
-// App resolver
-// -----------------------------------------------------------------------------
-
-constexpr winrt::guid
-    CLSID_StartMenuCacheAndAppResolver{
-        0x660B90C8,
-        0x73A9,
-        0x4B58,
-        {
-            0x8C,
-            0xAE,
-            0x35,
-            0x5B,
-            0x7F,
-            0x55,
-            0x34,
-            0x1B,
-        }};
-
-constexpr winrt::guid
-    IID_IAppResolver_8{
-        0xDE25675A,
-        0x72DE,
-        0x44B4,
-        {
-            0x93,
-            0x73,
-            0x05,
-            0x17,
-            0x04,
-            0x50,
-            0xC1,
-            0x40,
-        }};
-
-struct IAppResolver_8 :
-    public IUnknown {
-    virtual HRESULT STDMETHODCALLTYPE
-        GetAppIDForShortcut() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE
-        GetAppIDForShortcutObject() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE
-        GetAppIDForWindow(
-            HWND hWnd,
-            WCHAR** appId,
-            void* unknown1,
-            void* unknown2,
-            void* unknown3) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE
-        GetAppIDForProcess(
-            DWORD processId,
-            WCHAR** appId,
-            void* unknown1,
-            void* unknown2,
-            void* unknown3) = 0;
-};
-
-IAppResolver_8* g_appResolver = nullptr;
-CO_MTA_USAGE_COOKIE g_appResolverMtaCookie{};
-ULONGLONG g_appResolverRetryAfter = 0;
-
-// A window keeps the same app ID for its lifetime. Cache the normalized ID so
-// steady-state recounts don't repeatedly call the shell resolver for every HWND.
-std::unordered_map<HWND, std::wstring> g_appIdCache;
-
-bool EnsureAppResolver() {
-    if (g_appResolver) {
-        return true;
-    }
-
-    ULONGLONG now =
-        GetTickCount64();
-
-    if (now <
-        g_appResolverRetryAfter) {
-        return false;
-    }
-
-    CO_MTA_USAGE_COOKIE cookie{};
-
-    bool mta =
-        SUCCEEDED(
-            CoIncrementMTAUsage(
-                &cookie));
-
-    IAppResolver_8* resolver =
-        nullptr;
-
-    HRESULT hr =
-        CoCreateInstance(
-            CLSID_StartMenuCacheAndAppResolver,
-            nullptr,
-            CLSCTX_INPROC_SERVER |
-                CLSCTX_INPROC_HANDLER,
-            IID_IAppResolver_8,
-            reinterpret_cast<void**>(
-                &resolver));
-
-    if (FAILED(
-            hr) ||
-        !resolver) {
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"AppResolver failed "
-            L"hr=0x%08X",
-            static_cast<unsigned int>(
-                hr));
-
-        if (mta) {
-            CoDecrementMTAUsage(
-                cookie);
-        }
-
-        // Avoid retrying COM activation on every TaskListButton state update.
-        // A later recount can retry after this short backoff.
-        g_appResolverRetryAfter =
-            now + 5000;
-
-        return false;
-    }
-
-    g_appResolverRetryAfter =
-        0;
-
-    g_appResolver =
-        resolver;
-
-    if (mta) {
-        g_appResolverMtaCookie =
-            cookie;
-    }
-
-    return true;
-}
-
-void ReleaseAppResolver() {
-    if (g_appResolver) {
-        g_appResolver->Release();
-        g_appResolver =
-            nullptr;
-    }
-
-    if (g_appResolverMtaCookie) {
-        CoDecrementMTAUsage(
-            g_appResolverMtaCookie);
-
-        g_appResolverMtaCookie =
-            nullptr;
-    }
-
-    g_appResolverRetryAfter =
-        0;
-
-    g_appIdCache.clear();
-}
-
-// -----------------------------------------------------------------------------
-// Which HWNDs count
-// -----------------------------------------------------------------------------
-
-bool IsCountableWindow(
-    HWND hWnd) {
-    if (!hWnd ||
-        !IsWindowVisible(
-            hWnd)) {
-        return false;
-    }
-
-    WCHAR className[128] = {};
-
-    if (GetClassNameW(
-            hWnd,
-            className,
-            ARRAYSIZE(className))) {
-
-        // Shell/taskbar infrastructure windows.
-        // These are not real application taskbar windows.
-        if (_wcsicmp(
-                className,
-                L"Shell_TrayWnd") == 0 ||
-            _wcsicmp(
-                className,
-                L"Shell_SecondaryTrayWnd") == 0 ||
-            _wcsicmp(
-                className,
-                L"Progman") == 0 ||
-            _wcsicmp(
-                className,
-                L"WorkerW") == 0 ||
-            _wcsicmp(
-                className,
-                L"ApplicationManager_ImmersiveShellWindow") == 0) {
-            return false;
-        }
-    }
-
-    LONG_PTR exStyle =
-        GetWindowLongPtrW(
-            hWnd,
-            GWL_EXSTYLE);
-
-    if ((exStyle &
-         WS_EX_TOOLWINDOW) &&
-        !(exStyle &
-          WS_EX_APPWINDOW)) {
-        return false;
-    }
-
-    HWND owner =
-        GetWindow(
-            hWnd,
-            GW_OWNER);
-
-    if (owner &&
-        !(exStyle &
-          WS_EX_APPWINDOW)) {
-        return false;
-    }
-
-    using DwmGetWindowAttribute_t =
-        HRESULT(WINAPI*)(
-            HWND,
-            DWORD,
-            PVOID,
-            DWORD);
-
-    static DwmGetWindowAttribute_t
-        getDwmWindowAttribute = nullptr;
-
-    if (!getDwmWindowAttribute) {
-        HMODULE dwmApi =
-            GetModuleHandleW(
-                L"dwmapi.dll");
-
-        if (dwmApi) {
-            getDwmWindowAttribute =
-                reinterpret_cast<
-                    DwmGetWindowAttribute_t>(
-                    GetProcAddress(
-                        dwmApi,
-                        "DwmGetWindowAttribute"));
-        }
-    }
-
-    if (getDwmWindowAttribute) {
-        DWORD cloaked = 0;
-
-        // DWMWA_CLOAKED = 14
-        if (SUCCEEDED(
-                getDwmWindowAttribute(
-                    hWnd,
-                    14,
-                    &cloaked,
-                    sizeof(cloaked))) &&
-            cloaked) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-// -----------------------------------------------------------------------------
-// Build HWND/AppID count map
-// -----------------------------------------------------------------------------
-
-struct WindowEnumContext {
-    IAppResolver_8* resolver;
-
-    std::unordered_map<
-        std::wstring,
-        unsigned int>* counts;
-
-    std::unordered_set<HWND>*
-        seenWindows;
-};
-
-BOOL CALLBACK EnumCountableWindows(
-    HWND hWnd,
-    LPARAM param) {
-    if (!IsCountableWindow(
-            hWnd)) {
-        return TRUE;
-    }
-
-    auto context =
-        reinterpret_cast<
-            WindowEnumContext*>(
-            param);
-
-    if (!context ||
-        !context->resolver ||
-        !context->counts ||
-        !context->seenWindows) {
-        return TRUE;
-    }
-
-    context->seenWindows->insert(
-        hWnd);
-
-    auto cached =
-        g_appIdCache.find(
-            hWnd);
-
-    if (cached !=
-        g_appIdCache.end()) {
-        (*context->counts)[
-            cached->second]++;
-
-        return TRUE;
-    }
-
-    WCHAR* appId =
-        nullptr;
-
-    HRESULT hr =
-        context->resolver
-            ->GetAppIDForWindow(
-                hWnd,
-                &appId,
-                nullptr,
-                nullptr,
-                nullptr);
-
-    if (FAILED(
-            hr) ||
-        !appId ||
-        !*appId) {
-        if (appId) {
-            CoTaskMemFree(
-                appId);
-        }
-
-        return TRUE;
-    }
-
-    std::wstring key =
-        NormalizeId(
-            L"Appid: " +
-            std::wstring(
-                appId));
-
-    CoTaskMemFree(
-        appId);
-
-    g_appIdCache.emplace(
-        hWnd,
-        key);
-
-    (*context->counts)[
-        key]++;
-
-    return TRUE;
-}
-
-// -----------------------------------------------------------------------------
-// Rebuild counts
-// -----------------------------------------------------------------------------
-
-bool BuildRealWindowCounts(
-    std::unordered_set<
-        std::wstring>* changedIds,
-    bool initialBuild) {
-    if (!EnsureAppResolver()) {
-        return false;
-    }
-
-    std::unordered_map<
-        std::wstring,
-        unsigned int>
-        newCounts;
-
-    std::unordered_set<HWND>
-        seenWindows;
-
-    WindowEnumContext context{
-        g_appResolver,
-        &newCounts,
-        &seenWindows,
-    };
-
-    EnumWindows(
-        EnumCountableWindows,
-        reinterpret_cast<LPARAM>(
-            &context));
-
-    for (auto it =
-             g_appIdCache.begin();
-         it !=
-         g_appIdCache.end();) {
-        if (!seenWindows.contains(
-                it->first)) {
-            it =
-                g_appIdCache.erase(
-                    it);
-        } else {
-            ++it;
-        }
-    }
-
-    if (initialBuild) {
-        g_appCounts =
-            std::move(
-                newCounts);
-
-        g_countsInitialized =
-            true;
-
-        size_t multiWindowApps =
-            0;
-
-        for (const auto& pair :
-             g_appCounts) {
-            if (pair.second >=
-                static_cast<unsigned int>(
-                    g_settings.minimumCount)) {
-                multiWindowApps++;
-            }
-        }
-
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"initial window counts ready "
-            L"apps=%zu visible=%zu",
-            g_appCounts.size(),
-            multiWindowApps);
-
-        return true;
-    }
-
-    if (!changedIds) {
-        return false;
-    }
-
-    changedIds->clear();
-
-    for (const auto& oldPair :
-         g_appCounts) {
-        auto newIt =
-            newCounts.find(
-                oldPair.first);
-
-        unsigned int newCount =
-            newIt !=
-                    newCounts.end()
-                ? newIt->second
-                : 0;
-
-        if (oldPair.second ==
-            newCount) {
-            continue;
-        }
-
-        changedIds->insert(
-            oldPair.first);
-
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"count changed id=\"%s\" "
-            L"%u -> %u",
-            oldPair.first.c_str(),
-            oldPair.second,
-            newCount);
-    }
-
-    for (const auto& newPair :
-         newCounts) {
-        if (g_appCounts.find(
-                newPair.first) !=
-            g_appCounts.end()) {
-            continue;
-        }
-
-        changedIds->insert(
-            newPair.first);
-
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"count changed id=\"%s\" "
-            L"0 -> %u",
-            newPair.first.c_str(),
-            newPair.second);
-    }
-
-    g_appCounts =
-        std::move(
-            newCounts);
-
-    g_countsInitialized =
-        true;
+    UnhookWindowsHookEx(hook);
 
     return true;
 }
@@ -2484,122 +1498,59 @@ bool BuildRealWindowCounts(
 // Existing taskbar initialization
 // -----------------------------------------------------------------------------
 
-void WINAPI
-InitializeExistingButtonsOnTaskbarThread(
-    void* parameter) {
-    try {
-        HWND taskbarWnd =
-            reinterpret_cast<HWND>(
-                parameter);
+struct ExistingButtonsInitContext {
+    int taskbarCount = 0;
+    int buttonCount = 0;
+};
 
-        auto xamlRoot =
-            GetTaskbarXamlRoot(
-                taskbarWnd);
-
-        if (!xamlRoot) {
-            Wh_Log(
-                L"Taskbar Count Badges: "
-                L"failed to get taskbar XamlRoot");
-
-            return;
-        }
-
-        auto content =
-            xamlRoot.Content()
-                .try_as<
-                    FrameworkElement>();
-
-        if (!content) {
-            Wh_Log(
-                L"Taskbar Count Badges: "
-                L"XamlRoot content unavailable");
-
-            return;
-        }
-
-        if (!g_taskbarDispatcher) {
-            g_taskbarDispatcher =
-                content.Dispatcher();
-        }
-
-        // Keep the count map on the taskbar UI thread. Live recounts and badge
-        // updates also run on this thread, avoiding concurrent map access during
-        // initialization.
-        BuildRealWindowCounts(
-            nullptr,
-            true);
-
-        int buttonCount =
-            EnumerateExistingTaskbarButtons(
-                content);
-
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"initial taskbar buttons=%d",
-            buttonCount);
-    } catch (...) {
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"initial taskbar UI setup failed");
-    }
-}
-
-// -----------------------------------------------------------------------------
-// Recount queue
-// -----------------------------------------------------------------------------
-
-void QueueRealWindowRecount() {
-    std::lock_guard<std::mutex> guard(
-        g_queueMutex);
-
-    if (g_unloading ||
-        !g_taskbarDispatcher) {
-        return;
-    }
-
-    if (g_recountQueued.exchange(
-            true)) {
-        return;
-    }
+void WINAPI InitializeExistingButtonsOnTaskbarThread(void*) {
+    g_taskbarThreadId = GetCurrentThreadId();
+    ExistingButtonsInitContext context;
 
     try {
-        g_taskbarDispatcher.RunAsync(
-            winrt::Windows::UI::Core::
-                CoreDispatcherPriority::
-                    Normal,
-            []() {
-                try {
-                    if (!g_unloading) {
-                        std::unordered_set<
-                            std::wstring>
-                            changedIds;
+        EnumThreadWindows(
+            GetCurrentThreadId(),
+            [](HWND hWnd, LPARAM param) -> BOOL {
+                auto* context =
+                    reinterpret_cast<ExistingButtonsInitContext*>(param);
 
-                        if (BuildRealWindowCounts(
-                                &changedIds,
-                                false) &&
-                            !changedIds.empty()) {
-                            RefreshChangedTrackedButtons(
-                                changedIds);
-                        }
-                    }
-                } catch (...) {
-                    Wh_Log(
-                        L"Taskbar Count Badges: "
-                        L"HWND recount failed");
+                WCHAR className[32] = {};
+                if (!GetClassNameW(hWnd, className, ARRAYSIZE(className))) {
+                    return TRUE;
                 }
 
-                // Keep the flag set until all enumeration and UI refresh work
-                // is complete so getter bursts collapse into one recount.
-                g_recountQueued =
-                    false;
-            });
-    } catch (...) {
-        g_recountQueued =
-            false;
+                XamlRoot xamlRoot = nullptr;
+                if (_wcsicmp(className, L"Shell_TrayWnd") == 0) {
+                    xamlRoot = GetTaskbarXamlRoot(hWnd);
+                } else if (_wcsicmp(className, L"Shell_SecondaryTrayWnd") ==
+                           0) {
+                    xamlRoot = GetSecondaryTaskbarXamlRoot(hWnd);
+                } else {
+                    return TRUE;
+                }
 
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"failed to queue HWND recount");
+                if (!xamlRoot) {
+                    Wh_Log(L"Failed to get taskbar XamlRoot for %s", className);
+                    return TRUE;
+                }
+
+                auto content = xamlRoot.Content().try_as<FrameworkElement>();
+                if (!content) {
+                    Wh_Log(L"XamlRoot content unavailable for %s", className);
+                    return TRUE;
+                }
+
+                ++context->taskbarCount;
+                context->buttonCount +=
+                    EnumerateExistingTaskbarButtons(content);
+                return TRUE;
+            },
+            reinterpret_cast<LPARAM>(&context));
+
+        Wh_Log(L"Initial taskbars=%d buttons=%d", context.taskbarCount,
+               context.buttonCount);
+    } catch (...) {
+        Wh_Log(L"Initial taskbar UI setup failed");
     }
 }
 
@@ -2607,103 +1558,65 @@ void QueueRealWindowRecount() {
 // TaskListButton::UpdateVisualStates
 // -----------------------------------------------------------------------------
 
-using TaskListButton_UpdateVisualStates_t =
-    void(__cdecl*)(
-        void* pThis);
+using TaskListButton_UpdateVisualStates_t = void(__cdecl*)(void* pThis);
+TaskListButton_UpdateVisualStates_t TaskListButton_UpdateVisualStates_Original =
+    nullptr;
 
-TaskListButton_UpdateVisualStates_t
-    TaskListButton_UpdateVisualStates_Original =
-        nullptr;
-
-void __cdecl
-TaskListButton_UpdateVisualStates_Hook(
-    void* pThis) {
-    TaskListButton_UpdateVisualStates_Original(
-        pThis);
+void __cdecl TaskListButton_UpdateVisualStates_Hook(void* pThis) {
+    TaskListButton_UpdateVisualStates_Original(pThis);
 
     if (g_unloading) {
         return;
     }
 
     try {
-        void* taskListButtonIUnknownPtr =
-            reinterpret_cast<void**>(
-                pThis) +
-            3;
+        g_taskbarThreadId = GetCurrentThreadId();
+        void* taskListButtonIUnknownPtr = reinterpret_cast<void**>(pThis) + 3;
 
-        winrt::Windows::
-            Foundation::IUnknown
-                taskListButtonIUnknown;
+        winrt::Windows::Foundation::IUnknown taskListButtonIUnknown;
+        winrt::copy_from_abi(taskListButtonIUnknown, taskListButtonIUnknownPtr);
 
-        winrt::copy_from_abi(
-            taskListButtonIUnknown,
-            taskListButtonIUnknownPtr);
-
-        auto element =
-            taskListButtonIUnknown
-                .try_as<
-                    FrameworkElement>();
-
+        auto element = taskListButtonIUnknown.try_as<FrameworkElement>();
         if (!element) {
             return;
         }
 
-        if (!g_taskbarDispatcher) {
-            g_taskbarDispatcher =
-                element.Dispatcher();
+        // If a settings-change callback couldn't marshal to the taskbar thread,
+        // apply it here the next time the taskbar naturally updates a button.
+        if (g_settingsReloadPending.exchange(false)) {
+            LoadSettings();
+            RefreshAllTrackedButtons();
+            Wh_Log(L"Deferred settings applied");
         }
 
-        if (!g_countsInitialized) {
-            BuildRealWindowCounts(
-                nullptr,
-                true);
-        }
-
-        TrackTaskbarButton(
-            element);
-
-        ApplyCountToButton(
-            element);
+        ApplyCountToButton(element);
     } catch (...) {
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"TaskListButton update failed");
+        Wh_Log(L"TaskListButton update failed");
     }
 }
 
 // -----------------------------------------------------------------------------
-// ViewModelCount
-//
-// This value is NOT used as the displayed count.
-// It only tells us that taskbar group state changed.
+// TaskListGroupViewModel::get_ViewModelCount
 // -----------------------------------------------------------------------------
 
-using GetViewModelCount_t =
-    HRESULT(WINAPI*)(
-        void* pThis,
-        unsigned int* count);
+HRESULT WINAPI GetViewModelCount_Hook(void* pThis, unsigned int* count) {
+    HRESULT hr = GetViewModelCount_Original(pThis, count);
 
-GetViewModelCount_t
-    GetViewModelCount_Original =
-        nullptr;
-
-HRESULT WINAPI
-GetViewModelCount_Hook(
-    void* pThis,
-    unsigned int* count) {
-    HRESULT hr =
-        GetViewModelCount_Original(
-            pThis,
-            count);
-
-    if (FAILED(
-            hr) ||
-        !count ||
-        g_unloading) {
+    if (FAILED(hr) || !count || g_unloading) {
         return hr;
     }
 
-    QueueRealWindowRecount();
+    // pThis is the same ITaskListGroupViewModel interface returned by
+    // TryGetItemFromContainer<TaskListGroupViewModel>. Update only buttons that
+    // are backed by this group; no desktop/window enumeration is needed. Keep
+    // the original ViewModelCount untouched for Windows and normalize only the
+    // count used by the badge.
+    try {
+        RefreshTrackedButtonsForViewModel(
+            pThis, WindowCountFromViewModelCount(*count));
+    } catch (...) {
+        Wh_Log(L"ViewModel count update failed");
+    }
 
     return hr;
 }
@@ -2712,24 +1625,19 @@ GetViewModelCount_Hook(
 // Apply settings live
 // -----------------------------------------------------------------------------
 
-void WINAPI
-ApplySettingsOnTaskbarThread(
-    void*) {
+void WINAPI ApplySettingsOnTaskbarThread(void*) {
     if (g_unloading) {
         return;
     }
 
+    g_settingsReloadPending = false;
     try {
         LoadSettings();
         RefreshAllTrackedButtons();
-
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"settings applied");
+        Wh_Log(L"Settings applied");
     } catch (...) {
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"settings apply failed");
+        g_settingsReloadPending = true;
+        Wh_Log(L"Settings apply failed");
     }
 }
 
@@ -2740,144 +1648,77 @@ ApplySettingsOnTaskbarThread(
 void CleanupOnTaskbarThread() {
     PruneDeadTrackedButtons();
 
-    for (auto& item :
-         g_trackedButtons) {
-        auto element =
-            item.element.get();
-
+    for (auto& item : g_trackedButtons) {
+        auto element = item.element.get();
         if (!element) {
             continue;
         }
 
-        auto iconPanelElement =
-            FindChildByName(
-                element,
-                L"IconPanel");
-
+        auto iconPanelElement = FindChildByName(element, L"IconPanel");
         if (!iconPanelElement) {
             continue;
         }
 
-        auto iconPanel =
-            iconPanelElement
-                .try_as<
-                    Controls::Panel>();
-
+        auto iconPanel = iconPanelElement.try_as<Controls::Panel>();
         if (!iconPanel) {
             continue;
         }
 
-        auto badge =
-            FindChildByName(
-                iconPanelElement,
-                L"WindhawkCountBadge")
-                .try_as<
-                    Controls::Border>();
-
+        auto badge = FindChildByName(iconPanelElement, L"WindhawkCountBadge")
+                         .try_as<Controls::Border>();
         if (badge) {
-            RemoveBadgeFromPanel(
-                iconPanel,
-                badge);
+            RemoveBadgeFromPanel(iconPanel, badge);
         }
     }
 
     g_trackedButtons.clear();
-
-    ReleaseAppResolver();
-
-    g_recountQueued =
-        false;
-
-    // Release the strong XAML/UI-thread object on its owning thread.
-    g_taskbarDispatcher =
-        nullptr;
-
-    Wh_Log(
-        L"Taskbar Count Badges: "
-        L"cleanup complete");
+    Wh_Log(L"Cleanup complete");
 }
 
-bool CleanupSynchronously() {
-    if (!g_taskbarDispatcher) {
-        return true;
-    }
-
-    try {
-        if (g_taskbarDispatcher
-                .HasThreadAccess()) {
-            CleanupOnTaskbarThread();
-            return true;
-        }
-
-        auto operation =
-            g_taskbarDispatcher
-                .RunAsync(
-                    winrt::Windows::UI::
-                        Core::
-                            CoreDispatcherPriority::
-                                Normal,
-                    []() {
-                        CleanupOnTaskbarThread();
-                    });
-
-        operation.get();
-
-        return true;
-    } catch (...) {
-        return false;
-    }
+void WINAPI CleanupOnTaskbarThreadProc(void*) {
+    CleanupOnTaskbarThread();
 }
 
 // -----------------------------------------------------------------------------
 // Taskbar.View hooks
 // -----------------------------------------------------------------------------
 
-bool HookTaskbarView(
-    HMODULE module) {
-    if (g_taskbarViewHooked
-            .exchange(
-                true)) {
+bool HookTaskbarView(HMODULE module) {
+    if (g_taskbarViewHooked.exchange(true)) {
         return true;
     }
 
-    WindhawkUtils::SYMBOL_HOOK
-        hooks[] = {
+    WindhawkUtils::SYMBOL_HOOK taskbarViewHooks[] = {
+        {
             {
-                {
-                    LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateVisualStates(void))",
-                },
-                &TaskListButton_UpdateVisualStates_Original,
-                TaskListButton_UpdateVisualStates_Hook,
+                LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateVisualStates(void))",
             },
+            &TaskListButton_UpdateVisualStates_Original,
+            TaskListButton_UpdateVisualStates_Hook,
+        },
+        {
             {
-                {
-                    LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListGroupViewModel,struct winrt::Taskbar::ITaskListGroupViewModel>::get_ViewModelCount(unsigned int *))",
-                },
-                &GetViewModelCount_Original,
-                GetViewModelCount_Hook,
+                LR"(struct winrt::Taskbar::TaskListGroupViewModel __cdecl TryGetItemFromContainer<struct winrt::Taskbar::TaskListGroupViewModel>(struct winrt::Windows::UI::Xaml::UIElement const &))",
             },
-        };
+            &TryGetItemFromContainer_TaskListGroupViewModel_Original,
+        },
+        {
+            {
+                LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListGroupViewModel,struct winrt::Taskbar::ITaskListGroupViewModel>::get_ViewModelCount(unsigned int *))",
+            },
+            &GetViewModelCount_Original,
+            GetViewModelCount_Hook,
+        },
+    };
 
-    if (!WindhawkUtils::
-            HookSymbols(
-                module,
-                hooks,
-                ARRAYSIZE(
-                    hooks))) {
-        g_taskbarViewHooked =
-            false;
-
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"Taskbar.View hooks failed");
-
+    if (!WindhawkUtils::HookSymbols(module, taskbarViewHooks,
+                                    ARRAYSIZE(taskbarViewHooks))) {
+        g_taskbarViewHooked = false;
+        Wh_Log(L"Taskbar.View hooks failed");
         return false;
     }
 
-    Wh_Log(
-        L"Taskbar Count Badges: "
-        L"Taskbar.View hooks installed");
-
+    Wh_Log(L"Taskbar.View hooks installed");
     return true;
 }
 
@@ -2887,64 +1728,58 @@ bool HookTaskbarView(
 
 bool HookTaskbarDll() {
     HMODULE module =
-        LoadLibraryExW(
-            L"taskbar.dll",
-            nullptr,
-            LOAD_LIBRARY_SEARCH_SYSTEM32);
-
+        LoadLibraryExW(L"taskbar.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
     if (!module) {
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"taskbar.dll load failed");
-
+        Wh_Log(L"taskbar.dll load failed");
         return false;
     }
 
-    WindhawkUtils::SYMBOL_HOOK
-        hooks[] = {
+    WindhawkUtils::SYMBOL_HOOK taskbarDllHooks[] = {
+        {
             {
-                {
-                    LR"(const CTaskBand::`vftable'{for `ITaskListWndSite'})",
-                },
-                &g_CTaskBand_ITaskListWndSite_vftable,
+                LR"(const CTaskBand::`vftable'{for `ITaskListWndSite'})",
             },
+            &g_CTaskBand_ITaskListWndSite_vftable,
+        },
+        {
             {
-                {
-                    LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CTaskBand::GetTaskbarHost(void)const )",
-                },
-                &g_CTaskBand_GetTaskbarHost,
+                LR"(const CSecondaryTaskBand::`vftable'{for `ITaskListWndSite'})",
             },
+            &g_CSecondaryTaskBand_ITaskListWndSite_vftable,
+        },
+        {
             {
-                {
-                    LR"(public: int __cdecl TaskbarHost::FrameHeight(void)const )",
-                },
-                &g_TaskbarHost_FrameHeight,
+                LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CTaskBand::GetTaskbarHost(void)const )",
             },
+            &g_CTaskBand_GetTaskbarHost,
+        },
+        {
             {
-                {
-                    LR"(public: void __cdecl std::_Ref_count_base::_Decref(void))",
-                },
-                &g_RefCount_Decref,
+                LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CSecondaryTaskBand::GetTaskbarHost(void)const )",
             },
-        };
+            &g_CSecondaryTaskBand_GetTaskbarHost,
+        },
+        {
+            {
+                LR"(public: int __cdecl TaskbarHost::FrameHeight(void)const )",
+            },
+            &g_TaskbarHost_FrameHeight,
+        },
+        {
+            {
+                LR"(public: void __cdecl std::_Ref_count_base::_Decref(void))",
+            },
+            &g_RefCount_Decref,
+        },
+    };
 
-    if (!WindhawkUtils::
-            HookSymbols(
-                module,
-                hooks,
-                ARRAYSIZE(
-                    hooks))) {
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"taskbar.dll symbols failed");
-
+    if (!WindhawkUtils::HookSymbols(module, taskbarDllHooks,
+                                    ARRAYSIZE(taskbarDllHooks))) {
+        Wh_Log(L"taskbar.dll symbols failed");
         return false;
     }
 
-    Wh_Log(
-        L"Taskbar Count Badges: "
-        L"taskbar XamlRoot symbols installed");
-
+    Wh_Log(L"Taskbar XamlRoot symbols installed");
     return true;
 }
 
@@ -2952,36 +1787,18 @@ bool HookTaskbarDll() {
 // Late Taskbar.View loading
 // -----------------------------------------------------------------------------
 
-using LoadLibraryExW_t =
-    decltype(
-        &LoadLibraryExW);
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 
-LoadLibraryExW_t
-    LoadLibraryExW_Original =
-        nullptr;
+LoadLibraryExW_t LoadLibraryExW_Original = nullptr;
 
-HMODULE WINAPI
-LoadLibraryExW_Hook(
-    LPCWSTR fileName,
-    HANDLE file,
-    DWORD flags) {
-    HMODULE module =
-        LoadLibraryExW_Original(
-            fileName,
-            file,
-            flags);
+HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName, HANDLE file, DWORD flags) {
+    HMODULE module = LoadLibraryExW_Original(fileName, file, flags);
 
-    if (module &&
-        !g_unloading &&
-        !g_taskbarViewHooked) {
-        HMODULE taskbarView =
-            GetTaskbarViewModuleHandle();
+    if (module && !g_unloading && !g_taskbarViewHooked) {
+        HMODULE taskbarView = GetTaskbarViewModuleHandle();
 
-        if (taskbarView &&
-            taskbarView ==
-                module) {
-            if (HookTaskbarView(
-                    taskbarView)) {
+        if (taskbarView && taskbarView == module) {
+            if (HookTaskbarView(taskbarView)) {
                 Wh_ApplyHookOperations();
             }
         }
@@ -2995,143 +1812,92 @@ LoadLibraryExW_Hook(
 // -----------------------------------------------------------------------------
 
 BOOL Wh_ModInit() {
-    g_unloading =
-        false;
-
-    g_recountQueued =
-        false;
-
-    g_countsInitialized =
-        false;
+    g_unloading = false;
+    g_settingsReloadPending = false;
+    g_taskbarThreadId = 0;
+    g_trackedButtons.clear();
 
     LoadSettings();
-
-    Wh_Log(
-        L"Taskbar Count Badges: "
-        L"init PID=%lu",
-        GetCurrentProcessId());
+    Wh_Log(L"Init PID=%lu", GetCurrentProcessId());
 
     if (!HookTaskbarDll()) {
         return FALSE;
     }
 
-    if (HMODULE module =
-            GetTaskbarViewModuleHandle()) {
-        if (!HookTaskbarView(
-                module)) {
+    if (HMODULE module = GetTaskbarViewModuleHandle()) {
+        if (!HookTaskbarView(module)) {
             return FALSE;
         }
-
         return TRUE;
     }
 
-    HMODULE kernelBase =
-        GetModuleHandleW(
-            L"kernelbase.dll");
-
+    HMODULE kernelBase = GetModuleHandleW(L"kernelbase.dll");
     if (!kernelBase) {
         return FALSE;
     }
 
-    auto loadLibraryExW =
-        reinterpret_cast<
-            decltype(
-                &LoadLibraryExW)>(
-            GetProcAddress(
-                kernelBase,
-                "LoadLibraryExW"));
-
+    auto loadLibraryExW = reinterpret_cast<decltype(&LoadLibraryExW)>(
+        GetProcAddress(kernelBase, "LoadLibraryExW"));
     if (!loadLibraryExW) {
         return FALSE;
     }
 
-    WindhawkUtils::
-        SetFunctionHook(
-            loadLibraryExW,
-            LoadLibraryExW_Hook,
-            &LoadLibraryExW_Original);
-
+    WindhawkUtils::SetFunctionHook(loadLibraryExW, LoadLibraryExW_Hook,
+                                   &LoadLibraryExW_Original);
     return TRUE;
 }
 
 void Wh_ModAfterInit() {
-    Wh_Log(
-        L"Taskbar Count Badges: "
-        L"after init");
+    Wh_Log(L"After init");
 
-    HWND taskbarWnd =
-        FindCurrentProcessTaskbarWnd();
-
+    HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
     if (!taskbarWnd) {
         return;
     }
 
     if (!RunOnTaskbarThread(
-            taskbarWnd,
-            InitializeExistingButtonsOnTaskbarThread,
-            taskbarWnd)) {
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"initial taskbar-thread execution failed");
+            taskbarWnd, InitializeExistingButtonsOnTaskbarThread, nullptr)) {
+        Wh_Log(L"Initial taskbar-thread execution failed");
     }
 }
 
 void Wh_ModSettingsChanged() {
-    HWND taskbarWnd =
-        FindCurrentProcessTaskbarWnd();
-
+    HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
+    g_settingsReloadPending = true;
     if (!taskbarWnd) {
-        // No taskbar UI exists yet, so there are no concurrent UI reads.
-        LoadSettings();
+        // Apply on the taskbar UI thread when a button is next realized.
         return;
     }
-
-    if (!RunOnTaskbarThread(
-            taskbarWnd,
-            ApplySettingsOnTaskbarThread,
-            nullptr)) {
-        Wh_Log(
-            L"Taskbar Count Badges: "
-            L"failed to apply settings on taskbar thread");
+    if (!RunOnTaskbarThread(taskbarWnd, ApplySettingsOnTaskbarThread,
+                            nullptr)) {
+        // Don't rewrite std::wstring settings from this arbitrary callback
+        // thread. The next TaskListButton update will apply the pending change
+        // on the UI thread instead.
+        Wh_Log(L"Settings deferred until next taskbar update");
     }
 }
 
 void Wh_ModBeforeUninit() {
-    Wh_Log(
-        L"Taskbar Count Badges: "
-        L"before uninit");
+    Wh_Log(L"Before uninit");
+    g_unloading = true;
+    g_settingsReloadPending = false;
 
-    {
-        std::lock_guard<std::mutex> guard(
-            g_queueMutex);
-
-        g_unloading =
-            true;
+    HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
+    if (!taskbarWnd) {
+        // The taskbar UI is already gone, so there are no visible badges to
+        // remove.
+        return;
     }
 
-    bool ok =
-        CleanupSynchronously();
-
-    Wh_Log(
-        L"Taskbar Count Badges: "
-        L"cleanup=%s",
-        ok
-            ? L"OK"
-            : L"FAILED");
+    if (!RunOnTaskbarThread(taskbarWnd, CleanupOnTaskbarThreadProc, nullptr)) {
+        Wh_Log(L"Cleanup taskbar-thread execution failed");
+    }
 }
 
 void Wh_ModUninit() {
-    g_recountQueued =
-        false;
-
-    g_countsInitialized =
-        false;
-
-    g_appCounts.clear();
-    g_appIdCache.clear();
+    // Tracked buttons contain weak WinRT references only; releasing them here
+    // is safe even if Explorer is already tearing the taskbar down.
     g_trackedButtons.clear();
-
-    Wh_Log(
-        L"Taskbar Count Badges: "
-        L"uninit");
+    g_taskbarThreadId = 0;
+    Wh_Log(L"Uninit");
 }

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -1,0 +1,3018 @@
+// ==WindhawkMod==
+// @id              taskbar-count-badges
+// @name            Taskbar Count Badges
+// @description     Show customizable window-count badges or vertical dots on Windows 11 taskbar.
+// @version         1.0.0
+// @author          digART
+// @github          https://github.com/digart11
+// @license         GPL-3.0
+// @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject
+// ==/WindhawkMod==
+// Copyright (C) 2026 digART
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// Taskbar hook, AppResolver, and taskbar XAML/UI-thread infrastructure include
+// techniques adapted from Windhawk mods by Michael Maltsev (m417z), including
+// Taskbar Labels for Windows 11 and Taskbar Tray Show on Hover.
+
+
+
+// ==WindhawkModReadme==
+/*
+# Taskbar Count Badges
+
+See how many windows are open for each app directly on the Windows 11 taskbar.
+
+Taskbar Count Badges adds a small customizable indicator to taskbar app buttons
+when an app has multiple open windows. The indicator can be shown as either a
+**number badge** or a compact stack of **vertical dots**.
+
+## Screenshots
+
+### Customization examples
+
+![Taskbar Count Badges examples](https://raw.githubusercontent.com/digart11/TaskbarCountBadges/main/images/showcase.png)
+
+### Settings
+
+![Taskbar Count Badges settings](https://raw.githubusercontent.com/digart11/TaskbarCountBadges/main/images/settings.png)
+
+## Display styles
+
+### Number badge
+
+Shows the exact number of open windows for an app.
+
+The badge can be customized with:
+
+- Circle, rounded-square, or square shape
+- Badge size and position
+- Horizontal and vertical offsets
+- Background, text, and border colors
+- Border thickness
+- Font family, size, and weight
+- Configurable maximum number, with larger values shown using `+`
+
+### Vertical dots
+
+Shows a minimal vertical stack of dots beside the app icon.
+
+- Position the dots on the left or right
+- Change dot size and color
+- Up to five dots are shown; five dots means **five or more windows**
+
+## Behavior
+
+By default, no indicator is shown for a single open window. The indicator appears
+when an app reaches two open windows.
+
+The minimum window count can be changed in the settings.
+
+Window counts update automatically as windows are opened and closed, and
+settings are applied live.
+
+## Compatibility
+
+- Windows 11 only
+- Supports x64 and ARM64 Windows
+- Works with multiple monitors and secondary Windows taskbars
+
+The mod is designed primarily for grouped/combined taskbar app buttons. When
+taskbar buttons are configured to stay uncombined, Windows can expose multiple
+buttons for the same app group, so the same app count may appear on more than
+one button.
+
+Third-party taskbar replacements or tools that replace the native Windows 11
+taskbar may not be compatible.
+
+## Notes
+
+The mod counts real top-level application windows and maps them to their Windows
+application IDs. Windows shell infrastructure windows are excluded from the
+count.
+
+The badge is visual only and doesn't change taskbar grouping, combining, window
+ordering, or application behavior.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- Display:
+  - style: number
+    $name: Display style
+    $description: Choose how multiple open windows are shown.
+    $options:
+    - number: Number badge
+    - dots: Vertical dots
+  $name: Display
+
+- VerticalDots:
+  - position: right
+    $name: Position
+    $options:
+    - left: Left side
+    - right: Right side
+
+  - size: 4
+    $name: Dot size
+
+  - color: "#FFFFFF"
+    $name: Dot color
+  $name: Vertical dots
+  $description: These settings apply only when Display style is set to Vertical dots.
+
+- Badge:
+  - shape: circle
+    $name: Shape
+    $options:
+    - circle: Circle
+    - rounded: Rounded square
+    - square: Square
+
+  - size: 16
+    $name: Size
+    $description: Badge diameter or square size in pixels.
+
+  - position: topRight
+    $name: Position
+    $options:
+    - topLeft: Top left
+    - topCenter: Top center
+    - topRight: Top right
+    - bottomLeft: Bottom left
+    - bottomCenter: Bottom center
+    - bottomRight: Bottom right
+
+  - offsetX: -2
+    $name: Horizontal offset
+    $description: Positive moves right, negative moves left.
+
+  - offsetY: -2
+    $name: Vertical offset
+    $description: Positive moves down, negative moves up.
+
+  - backgroundColor: "#D90000"
+    $name: Background color
+
+  - borderColor: "#FFFFFF"
+    $name: Border color
+
+  - borderThickness: 0
+    $name: Border thickness
+    $description: 0 disables the border.
+  $name: Number badge
+  $description: These settings apply only when Display style is set to Number badge.
+
+- Text:
+  - color: "#FFFFFF"
+    $name: Text color
+
+  - fontFamily: "Segoe UI"
+    $name: Font family
+    $options:
+    - "Segoe UI": Segoe UI
+    - "Segoe UI Variable": Segoe UI Variable
+    - "Arial": Arial
+    - "Calibri": Calibri
+    - "Tahoma": Tahoma
+    - "Verdana": Verdana
+    - "Trebuchet MS": Trebuchet MS
+    - "Consolas": Consolas
+    - "Cascadia Code": Cascadia Code
+    - "Cascadia Mono": Cascadia Mono
+
+  - fontSize: 10
+    $name: Font size
+
+  - fontWeight: semiBold
+    $name: Font weight
+    $options:
+    - normal: Normal
+    - semiBold: Semi-bold
+    - bold: Bold
+  $name: Number text
+  $description: These settings apply only when Display style is set to Number badge.
+
+- Behavior:
+  - minimumCount: 2
+    $name: Show from window count
+    $description: Default 2 means one window has no badge or dots.
+
+  - maximumNumber: 99
+    $name: Maximum number
+    $description: Number badge only. Higher counts are shown with a plus sign, for example 99+.
+  $name: Behavior
+*/
+// ==/WindhawkModSettings==
+
+#include <windows.h>
+#include <winstring.h>
+#include <windhawk_utils.h>
+
+#undef GetCurrentTime
+
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.UI.h>
+#include <winrt/Windows.UI.Core.h>
+#include <winrt/Windows.UI.Text.h>
+#include <winrt/Windows.UI.Xaml.h>
+#include <winrt/Windows.UI.Xaml.Automation.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Markup.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
+#include <winrt/Windows.UI.Xaml.Shapes.h>
+#include <winrt/base.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cwctype>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+using namespace winrt::Windows::UI::Xaml;
+
+// -----------------------------------------------------------------------------
+// Settings
+// -----------------------------------------------------------------------------
+
+enum class DisplayStyle {
+    Number,
+    Dots,
+};
+
+enum class BadgeShape {
+    Circle,
+    Rounded,
+    Square,
+};
+
+enum class BadgePosition {
+    TopLeft,
+    TopCenter,
+    TopRight,
+    BottomLeft,
+    BottomCenter,
+    BottomRight,
+};
+
+enum class DotPosition {
+    Left,
+    Right,
+};
+
+enum class BadgeFontWeight {
+    Normal,
+    SemiBold,
+    Bold,
+};
+
+struct Settings {
+    DisplayStyle displayStyle =
+        DisplayStyle::Number;
+
+    BadgeShape badgeShape =
+        BadgeShape::Circle;
+
+    BadgePosition badgePosition =
+        BadgePosition::TopRight;
+
+    int badgeOffsetX = -2;
+    int badgeOffsetY = -2;
+
+    int badgeSize = 16;
+
+    std::wstring badgeBackgroundColor =
+        L"#D90000";
+
+    std::wstring badgeBorderColor =
+        L"#FFFFFF";
+
+    int badgeBorderThickness = 0;
+
+    std::wstring textColor =
+        L"#FFFFFF";
+
+    std::wstring fontFamily =
+        L"Segoe UI";
+
+    int fontSize = 10;
+
+    BadgeFontWeight fontWeight =
+        BadgeFontWeight::SemiBold;
+
+    DotPosition dotPosition =
+        DotPosition::Right;
+
+    int dotSize = 4;
+
+    std::wstring dotColor =
+        L"#FFFFFF";
+
+    int minimumCount = 2;
+    int maximumNumber = 99;
+};
+
+Settings g_settings;
+
+// -----------------------------------------------------------------------------
+// Globals
+// -----------------------------------------------------------------------------
+
+bool g_isTaskbarProcess = false;
+
+std::atomic<bool> g_taskbarViewHooked = false;
+std::atomic<bool> g_unloading = false;
+std::atomic<bool> g_recountQueued = false;
+
+winrt::Windows::UI::Core::CoreDispatcher
+    g_taskbarDispatcher{nullptr};
+
+struct TrackedButton {
+    void* identity;
+    std::wstring automationId;
+    winrt::weak_ref<FrameworkElement> element;
+};
+
+std::vector<TrackedButton> g_trackedButtons;
+
+// Always contains REAL HWND-derived counts.
+// ViewModelCount is only used as a change notification.
+std::unordered_map<std::wstring, unsigned int>
+    g_appCounts;
+
+// -----------------------------------------------------------------------------
+// taskbar.dll symbols used to access existing XamlRoot
+// -----------------------------------------------------------------------------
+
+void* g_CTaskBand_ITaskListWndSite_vftable = nullptr;
+
+using CTaskBand_GetTaskbarHost_t =
+    void*(__cdecl*)(
+        void* pThis,
+        void** result);
+
+CTaskBand_GetTaskbarHost_t
+    g_CTaskBand_GetTaskbarHost = nullptr;
+
+void* g_TaskbarHost_FrameHeight = nullptr;
+
+using RefCount_Decref_t =
+    void(__cdecl*)(
+        void* pThis);
+
+RefCount_Decref_t
+    g_RefCount_Decref = nullptr;
+
+// -----------------------------------------------------------------------------
+// COM compatibility
+// -----------------------------------------------------------------------------
+
+#if __cplusplus < 202302L
+DECLARE_HANDLE(CO_MTA_USAGE_COOKIE);
+
+WINOLEAPI CoIncrementMTAUsage(
+    CO_MTA_USAGE_COOKIE* cookie);
+
+WINOLEAPI CoDecrementMTAUsage(
+    CO_MTA_USAGE_COOKIE cookie);
+#endif
+
+// -----------------------------------------------------------------------------
+// Setting helpers
+// -----------------------------------------------------------------------------
+
+std::wstring ReadStringSetting(
+    PCWSTR name) {
+    PCWSTR value =
+        Wh_GetStringSetting(name);
+
+    std::wstring result =
+        value ? value : L"";
+
+    if (value) {
+        Wh_FreeStringSetting(value);
+    }
+
+    return result;
+}
+
+void LoadSettings() {
+    // Display ---------------------------------------------------------------
+
+    std::wstring displayStyle =
+        ReadStringSetting(
+            L"Display.style");
+
+    g_settings.displayStyle =
+        displayStyle == L"dots"
+            ? DisplayStyle::Dots
+            : DisplayStyle::Number;
+
+    // Badge -----------------------------------------------------------------
+
+    std::wstring shape =
+        ReadStringSetting(
+            L"Badge.shape");
+
+    if (shape == L"square") {
+        g_settings.badgeShape =
+            BadgeShape::Square;
+    } else if (shape == L"rounded") {
+        g_settings.badgeShape =
+            BadgeShape::Rounded;
+    } else {
+        g_settings.badgeShape =
+            BadgeShape::Circle;
+    }
+
+    std::wstring position =
+        ReadStringSetting(
+            L"Badge.position");
+
+    if (position == L"topLeft") {
+        g_settings.badgePosition =
+            BadgePosition::TopLeft;
+    } else if (position == L"topCenter") {
+        g_settings.badgePosition =
+            BadgePosition::TopCenter;
+    } else if (position == L"bottomLeft") {
+        g_settings.badgePosition =
+            BadgePosition::BottomLeft;
+    } else if (position == L"bottomCenter") {
+        g_settings.badgePosition =
+            BadgePosition::BottomCenter;
+    } else if (position == L"bottomRight") {
+        g_settings.badgePosition =
+            BadgePosition::BottomRight;
+    } else {
+        g_settings.badgePosition =
+            BadgePosition::TopRight;
+    }
+
+    g_settings.badgeOffsetX =
+        Wh_GetIntSetting(
+            L"Badge.offsetX");
+
+    g_settings.badgeOffsetY =
+        Wh_GetIntSetting(
+            L"Badge.offsetY");
+
+    g_settings.badgeSize =
+        std::max(
+            4,
+            Wh_GetIntSetting(
+                L"Badge.size"));
+
+
+    g_settings.badgeBackgroundColor =
+        ReadStringSetting(
+            L"Badge.backgroundColor");
+
+    g_settings.badgeBorderColor =
+        ReadStringSetting(
+            L"Badge.borderColor");
+
+    g_settings.badgeBorderThickness =
+        std::max(
+            0,
+            Wh_GetIntSetting(
+                L"Badge.borderThickness"));
+
+    // Text ------------------------------------------------------------------
+
+    g_settings.textColor =
+        ReadStringSetting(
+            L"Text.color");
+
+    g_settings.fontFamily =
+        ReadStringSetting(
+            L"Text.fontFamily");
+
+    if (g_settings.fontFamily.empty()) {
+        g_settings.fontFamily =
+            L"Segoe UI";
+    }
+
+    g_settings.fontSize =
+        std::max(
+            1,
+            Wh_GetIntSetting(
+                L"Text.fontSize"));
+
+    std::wstring fontWeight =
+        ReadStringSetting(
+            L"Text.fontWeight");
+
+    if (fontWeight == L"bold") {
+        g_settings.fontWeight =
+            BadgeFontWeight::Bold;
+    } else if (fontWeight == L"normal") {
+        g_settings.fontWeight =
+            BadgeFontWeight::Normal;
+    } else {
+        g_settings.fontWeight =
+            BadgeFontWeight::SemiBold;
+    }
+
+    // Vertical dots ---------------------------------------------------------
+
+    std::wstring dotPosition =
+        ReadStringSetting(
+            L"VerticalDots.position");
+
+    g_settings.dotPosition =
+        dotPosition == L"left"
+            ? DotPosition::Left
+            : DotPosition::Right;
+
+    g_settings.dotSize =
+        std::max(
+            2,
+            Wh_GetIntSetting(
+                L"VerticalDots.size"));
+
+    g_settings.dotColor =
+        ReadStringSetting(
+            L"VerticalDots.color");
+
+    // Behavior --------------------------------------------------------------
+
+    g_settings.minimumCount =
+        std::max(
+            1,
+            Wh_GetIntSetting(
+                L"Behavior.minimumCount"));
+
+    g_settings.maximumNumber =
+        std::max(
+            1,
+            Wh_GetIntSetting(
+                L"Behavior.maximumNumber"));
+}
+
+// -----------------------------------------------------------------------------
+// Generic helpers
+// -----------------------------------------------------------------------------
+
+std::wstring NormalizeId(
+    std::wstring value) {
+    std::transform(
+        value.begin(),
+        value.end(),
+        value.begin(),
+        [](wchar_t c) {
+            return static_cast<wchar_t>(
+                std::towlower(c));
+        });
+
+    return value;
+}
+
+// -----------------------------------------------------------------------------
+// Color parsing
+// -----------------------------------------------------------------------------
+
+bool ParseHexByte(
+    wchar_t high,
+    wchar_t low,
+    BYTE* result) {
+    auto getValue =
+        [](wchar_t c) -> int {
+            if (c >= L'0' &&
+                c <= L'9') {
+                return c - L'0';
+            }
+
+            c =
+                static_cast<wchar_t>(
+                    std::towupper(c));
+
+            if (c >= L'A' &&
+                c <= L'F') {
+                return c - L'A' + 10;
+            }
+
+            return -1;
+        };
+
+    int highValue =
+        getValue(high);
+
+    int lowValue =
+        getValue(low);
+
+    if (highValue < 0 ||
+        lowValue < 0) {
+        return false;
+    }
+
+    *result =
+        static_cast<BYTE>(
+            highValue * 16 +
+            lowValue);
+
+    return true;
+}
+
+winrt::Windows::UI::Color ParseColor(
+    const std::wstring& value,
+    winrt::Windows::UI::Color fallback) {
+    std::wstring text =
+        value;
+
+    if (!text.empty() &&
+        text[0] == L'#') {
+        text.erase(
+            text.begin());
+    }
+
+    BYTE a = 255;
+    BYTE r = 0;
+    BYTE g = 0;
+    BYTE b = 0;
+
+    if (text.length() == 6) {
+        if (!ParseHexByte(
+                text[0],
+                text[1],
+                &r) ||
+            !ParseHexByte(
+                text[2],
+                text[3],
+                &g) ||
+            !ParseHexByte(
+                text[4],
+                text[5],
+                &b)) {
+            return fallback;
+        }
+    } else if (text.length() == 8) {
+        if (!ParseHexByte(
+                text[0],
+                text[1],
+                &a) ||
+            !ParseHexByte(
+                text[2],
+                text[3],
+                &r) ||
+            !ParseHexByte(
+                text[4],
+                text[5],
+                &g) ||
+            !ParseHexByte(
+                text[6],
+                text[7],
+                &b)) {
+            return fallback;
+        }
+    } else {
+        return fallback;
+    }
+
+    winrt::Windows::UI::Color color{};
+
+    color.A = a;
+    color.R = r;
+    color.G = g;
+    color.B = b;
+
+    return color;
+}
+
+Media::SolidColorBrush CreateBrush(
+    const std::wstring& value,
+    winrt::Windows::UI::Color fallback) {
+    return Media::SolidColorBrush(
+        ParseColor(
+            value,
+            fallback));
+}
+
+// -----------------------------------------------------------------------------
+// Position helpers
+// -----------------------------------------------------------------------------
+
+void ApplyNumberBadgePosition(
+    Controls::Border badge) {
+    HorizontalAlignment horizontal =
+        HorizontalAlignment::Right;
+
+    VerticalAlignment vertical =
+        VerticalAlignment::Top;
+
+    switch (g_settings.badgePosition) {
+        case BadgePosition::TopLeft:
+            horizontal = HorizontalAlignment::Left;
+            vertical = VerticalAlignment::Top;
+            break;
+
+        case BadgePosition::TopCenter:
+            horizontal = HorizontalAlignment::Center;
+            vertical = VerticalAlignment::Top;
+            break;
+
+        case BadgePosition::TopRight:
+            horizontal = HorizontalAlignment::Right;
+            vertical = VerticalAlignment::Top;
+            break;
+
+        case BadgePosition::BottomLeft:
+            horizontal = HorizontalAlignment::Left;
+            vertical = VerticalAlignment::Bottom;
+            break;
+
+        case BadgePosition::BottomCenter:
+            horizontal = HorizontalAlignment::Center;
+            vertical = VerticalAlignment::Bottom;
+            break;
+
+        case BadgePosition::BottomRight:
+            horizontal = HorizontalAlignment::Right;
+            vertical = VerticalAlignment::Bottom;
+            break;
+    }
+
+    badge.HorizontalAlignment(horizontal);
+    badge.VerticalAlignment(vertical);
+    badge.Margin(Thickness{});
+
+    auto transform =
+        badge.RenderTransform()
+            .try_as<Media::TranslateTransform>();
+
+    if (!transform) {
+        transform =
+            Media::TranslateTransform();
+
+        badge.RenderTransform(transform);
+    }
+
+    transform.X(
+        static_cast<double>(
+            g_settings.badgeOffsetX));
+
+    transform.Y(
+        static_cast<double>(
+            g_settings.badgeOffsetY));
+}
+
+void ApplyDotPosition(
+    Controls::Border badge) {
+    badge.VerticalAlignment(
+        VerticalAlignment::Center);
+
+    badge.Margin(Thickness{});
+
+    if (g_settings.dotPosition ==
+        DotPosition::Left) {
+        badge.HorizontalAlignment(
+            HorizontalAlignment::Left);
+    } else {
+        badge.HorizontalAlignment(
+            HorizontalAlignment::Right);
+    }
+
+    auto transform =
+        badge.RenderTransform()
+            .try_as<Media::TranslateTransform>();
+
+    if (!transform) {
+        transform =
+            Media::TranslateTransform();
+
+        badge.RenderTransform(transform);
+    }
+
+    // IMPORTANT:
+    // Keep dots inside IconPanel.
+    // Moving them outside causes the taskbar XAML to clip them.
+    //
+    // 2 px gives a little separation from the panel edge.
+    transform.X(
+        g_settings.dotPosition ==
+                DotPosition::Left
+            ? 2.0
+            : -2.0);
+
+    transform.Y(0.0);
+}
+
+// -----------------------------------------------------------------------------
+// Font helper
+// -----------------------------------------------------------------------------
+
+winrt::Windows::UI::Text::FontWeight
+GetConfiguredFontWeight() {
+    uint16_t weight = 600;
+
+    switch (g_settings.fontWeight) {
+        case BadgeFontWeight::Normal:
+            weight = 400;
+            break;
+
+        case BadgeFontWeight::SemiBold:
+            weight = 600;
+            break;
+
+        case BadgeFontWeight::Bold:
+            weight = 700;
+            break;
+    }
+
+    winrt::Windows::UI::Text::FontWeight result{};
+
+    result.Weight =
+        weight;
+
+    return result;
+}
+
+// -----------------------------------------------------------------------------
+// Main taskbar HWND
+// -----------------------------------------------------------------------------
+
+HWND FindCurrentProcessTaskbarWnd() {
+    HWND result = nullptr;
+
+    EnumWindows(
+        [](HWND hWnd,
+           LPARAM param) -> BOOL {
+            DWORD pid = 0;
+            WCHAR className[64] = {};
+
+            GetWindowThreadProcessId(
+                hWnd,
+                &pid);
+
+            if (pid !=
+                GetCurrentProcessId()) {
+                return TRUE;
+            }
+
+            if (!GetClassNameW(
+                    hWnd,
+                    className,
+                    ARRAYSIZE(
+                        className))) {
+                return TRUE;
+            }
+
+            if (_wcsicmp(
+                    className,
+                    L"Shell_TrayWnd") !=
+                0) {
+                return TRUE;
+            }
+
+            *reinterpret_cast<HWND*>(
+                param) =
+                hWnd;
+
+            return FALSE;
+        },
+        reinterpret_cast<LPARAM>(
+            &result));
+
+    return result;
+}
+
+// -----------------------------------------------------------------------------
+// Taskbar.View module
+// -----------------------------------------------------------------------------
+
+HMODULE GetTaskbarViewModuleHandle() {
+    HMODULE module =
+        GetModuleHandleW(
+            L"Taskbar.View.dll");
+
+    if (!module) {
+        module =
+            GetModuleHandleW(
+                L"ExplorerExtensions.dll");
+    }
+
+    return module;
+}
+
+// -----------------------------------------------------------------------------
+// XAML helpers
+// -----------------------------------------------------------------------------
+
+FrameworkElement FindChildByName(
+    FrameworkElement element,
+    PCWSTR name) {
+    int count =
+        Media::VisualTreeHelper::
+            GetChildrenCount(
+                element);
+
+    for (int i = 0;
+         i < count;
+         i++) {
+        auto child =
+            Media::VisualTreeHelper::
+                GetChild(
+                    element,
+                    i)
+                    .try_as<
+                        FrameworkElement>();
+
+        if (!child) {
+            continue;
+        }
+
+        if (child.Name() ==
+            name) {
+            return child;
+        }
+
+        auto result =
+            FindChildByName(
+                child,
+                name);
+
+        if (result) {
+            return result;
+        }
+    }
+
+    return nullptr;
+}
+
+// -----------------------------------------------------------------------------
+// Badge text / dot content
+// -----------------------------------------------------------------------------
+
+std::wstring MakeNumberText(
+    unsigned int count) {
+    if (count >
+        static_cast<unsigned int>(
+            g_settings.maximumNumber)) {
+        return std::to_wstring(
+                   g_settings.maximumNumber) +
+               L"+";
+    }
+
+    return std::to_wstring(
+        count);
+}
+
+unsigned int GetVisibleDotCount(
+    unsigned int count) {
+    // Five dots means five or more windows.
+    return std::min<unsigned int>(
+        count,
+        5);
+}
+
+void RebuildDots(
+    Controls::StackPanel dotStack,
+    unsigned int count) {
+    dotStack.Children().Clear();
+
+    winrt::Windows::UI::Color
+        defaultDotColor{};
+
+    defaultDotColor.A = 255;
+    defaultDotColor.R = 255;
+    defaultDotColor.G = 255;
+    defaultDotColor.B = 255;
+
+    auto brush =
+        CreateBrush(
+            g_settings.dotColor,
+            defaultDotColor);
+
+    unsigned int dotCount =
+        GetVisibleDotCount(
+            count);
+
+    constexpr double kDotSpacing = 2.0;
+
+    for (unsigned int i = 0;
+         i < dotCount;
+         i++) {
+        Controls::Border dot;
+
+        dot.Width(
+            static_cast<double>(
+                g_settings.dotSize));
+
+        dot.Height(
+            static_cast<double>(
+                g_settings.dotSize));
+
+        double radius =
+            static_cast<double>(
+                g_settings.dotSize) /
+            2.0;
+
+        dot.CornerRadius(
+            CornerRadius{
+                radius,
+                radius,
+                radius,
+                radius});
+
+        dot.Background(
+            brush);
+
+        double topMargin =
+            i == 0
+                ? 0.0
+                : kDotSpacing;
+
+        dot.Margin(
+            Thickness{
+                0,
+                topMargin,
+                0,
+                0});
+
+        dot.IsHitTestVisible(
+            false);
+
+        dotStack.Children().Append(
+            dot);
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Apply visual style
+// -----------------------------------------------------------------------------
+
+void ApplyBadgeVisualStyle(
+    Controls::Border badge,
+    unsigned int count) {
+    auto circleVisual =
+        FindChildByName(
+            badge,
+            L"WindhawkCircleVisual")
+            .try_as<
+                Shapes::Ellipse>();
+
+    auto badgeVisual =
+        FindChildByName(
+            badge,
+            L"WindhawkBadgeVisual")
+            .try_as<
+                Controls::Border>();
+
+    auto text =
+        FindChildByName(
+            badge,
+            L"WindhawkCountText")
+            .try_as<
+                Controls::TextBlock>();
+
+    auto dotStack =
+        FindChildByName(
+            badge,
+            L"WindhawkDotStack")
+            .try_as<
+                Controls::StackPanel>();
+
+    if (!circleVisual ||
+        !badgeVisual ||
+        !text ||
+        !dotStack) {
+        return;
+    }
+
+    winrt::Windows::UI::Color
+        defaultBackground{};
+
+    defaultBackground.A = 255;
+    defaultBackground.R = 217;
+    defaultBackground.G = 0;
+    defaultBackground.B = 0;
+
+    winrt::Windows::UI::Color
+        defaultText{};
+
+    defaultText.A = 255;
+    defaultText.R = 255;
+    defaultText.G = 255;
+    defaultText.B = 255;
+
+    winrt::Windows::UI::Color
+        defaultBorder{};
+
+    defaultBorder.A = 255;
+    defaultBorder.R = 255;
+    defaultBorder.G = 255;
+    defaultBorder.B = 255;
+
+    badge.IsHitTestVisible(false);
+
+    Controls::Canvas::SetZIndex(
+        badge,
+        100);
+
+    // ---------------------------------------------------------------------
+    // NUMBER BADGE
+    // ---------------------------------------------------------------------
+
+    if (g_settings.displayStyle ==
+        DisplayStyle::Number) {
+        ApplyNumberBadgePosition(
+            badge);
+
+        dotStack.Visibility(
+            Visibility::Collapsed);
+
+        text.Visibility(
+            Visibility::Visible);
+
+        double size =
+            static_cast<double>(
+                g_settings.badgeSize);
+
+        badge.Width(size);
+        badge.Height(size);
+
+        auto backgroundBrush =
+            CreateBrush(
+                g_settings.badgeBackgroundColor,
+                defaultBackground);
+
+        auto borderBrush =
+            CreateBrush(
+                g_settings.badgeBorderColor,
+                defaultBorder);
+
+        double borderThickness =
+            static_cast<double>(
+                g_settings.badgeBorderThickness);
+
+        if (g_settings.badgeShape ==
+            BadgeShape::Circle) {
+            badgeVisual.Visibility(
+                Visibility::Collapsed);
+
+            circleVisual.Visibility(
+                Visibility::Visible);
+
+            circleVisual.Width(size);
+            circleVisual.Height(size);
+
+            circleVisual.Fill(
+                backgroundBrush);
+
+            if (g_settings.badgeBorderThickness > 0) {
+                circleVisual.Stroke(
+                    borderBrush);
+
+                circleVisual.StrokeThickness(
+                    borderThickness);
+            } else {
+                circleVisual.Stroke(
+                    nullptr);
+
+                circleVisual.StrokeThickness(
+                    0);
+            }
+        } else {
+            circleVisual.Visibility(
+                Visibility::Collapsed);
+
+            badgeVisual.Visibility(
+                Visibility::Visible);
+
+            badgeVisual.Width(size);
+            badgeVisual.Height(size);
+
+            badgeVisual.HorizontalAlignment(
+                HorizontalAlignment::Center);
+
+            badgeVisual.VerticalAlignment(
+                VerticalAlignment::Center);
+
+            double cornerRadius =
+                g_settings.badgeShape ==
+                        BadgeShape::Rounded
+                    ? size / 4.0
+                    : 0.0;
+
+            badgeVisual.CornerRadius(
+                CornerRadius{
+                    cornerRadius,
+                    cornerRadius,
+                    cornerRadius,
+                    cornerRadius});
+
+            badgeVisual.Background(
+                backgroundBrush);
+
+            if (g_settings.badgeBorderThickness > 0) {
+                badgeVisual.BorderBrush(
+                    borderBrush);
+
+                badgeVisual.BorderThickness(
+                    Thickness{
+                        borderThickness,
+                        borderThickness,
+                        borderThickness,
+                        borderThickness});
+            } else {
+                badgeVisual.BorderBrush(
+                    nullptr);
+
+                badgeVisual.BorderThickness(
+                    Thickness{
+                        0,
+                        0,
+                        0,
+                        0});
+            }
+        }
+
+        text.Foreground(
+            CreateBrush(
+                g_settings.textColor,
+                defaultText));
+
+        text.FontSize(
+            static_cast<double>(
+                g_settings.fontSize));
+
+        text.FontFamily(
+            Media::FontFamily(
+                winrt::hstring(
+                    g_settings.fontFamily)));
+
+        text.FontWeight(
+            GetConfiguredFontWeight());
+
+    text.HorizontalAlignment(
+        HorizontalAlignment::Center);
+
+    text.VerticalAlignment(
+        VerticalAlignment::Center);
+
+    text.TextAlignment(
+        TextAlignment::Center);
+
+    // Optical correction for the font baseline.
+    text.Margin(
+        Thickness{
+            0,
+            -2,
+            0,
+            0});
+
+    text.Text(
+        MakeNumberText(
+            count));
+
+    return;
+}
+
+    // ---------------------------------------------------------------------
+    // VERTICAL DOTS
+    // ---------------------------------------------------------------------
+
+    ApplyDotPosition(
+        badge);
+
+    circleVisual.Visibility(
+        Visibility::Collapsed);
+
+    badgeVisual.Visibility(
+        Visibility::Collapsed);
+
+    text.Visibility(
+        Visibility::Collapsed);
+
+    dotStack.Visibility(
+        Visibility::Visible);
+
+    badge.Width(
+        std::numeric_limits<double>::
+            quiet_NaN());
+
+    badge.Height(
+        std::numeric_limits<double>::
+            quiet_NaN());
+
+    badge.Background(
+        nullptr);
+
+    badge.BorderBrush(
+        nullptr);
+
+    badge.BorderThickness(
+        Thickness{
+            0,
+            0,
+            0,
+            0});
+
+    dotStack.Orientation(
+        Controls::Orientation::Vertical);
+
+    dotStack.HorizontalAlignment(
+        HorizontalAlignment::Center);
+
+    dotStack.VerticalAlignment(
+        VerticalAlignment::Center);
+
+    RebuildDots(
+        dotStack,
+        count);
+}
+// -----------------------------------------------------------------------------
+// Badge
+// -----------------------------------------------------------------------------
+
+void RemoveBadgeFromPanel(
+    Controls::Panel iconPanel,
+    Controls::Border badge) {
+    auto children =
+        iconPanel.Children();
+
+    for (uint32_t i = 0;
+         i < children.Size();
+         i++) {
+        if (children.GetAt(i) ==
+            badge) {
+            children.RemoveAt(i);
+            return;
+        }
+    }
+}
+
+Controls::Border CreateCountBadge(
+    Controls::Panel iconPanel) {
+    PCWSTR xaml =
+        LR"(
+<Border
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    Name="WindhawkCountBadge"
+    Background="Transparent"
+    HorizontalAlignment="Right"
+    VerticalAlignment="Top">
+
+    <Grid>
+
+        <Ellipse
+            Name="WindhawkCircleVisual"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Visibility="Collapsed"/>
+
+        <Border
+            Name="WindhawkBadgeVisual"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Visibility="Collapsed"/>
+
+        <TextBlock
+            Name="WindhawkCountText"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            TextAlignment="Center"/>
+
+        <StackPanel
+            Name="WindhawkDotStack"
+            Orientation="Vertical"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Visibility="Collapsed"/>
+
+    </Grid>
+
+</Border>
+)";
+
+    auto badge =
+        Markup::XamlReader::
+            Load(xaml)
+            .as<
+                Controls::Border>();
+
+    badge.IsHitTestVisible(
+        false);
+
+    Controls::Canvas::SetZIndex(
+        badge,
+        100);
+
+    iconPanel.Children().Append(
+        badge);
+
+    return badge;
+}
+
+void UpdateCountBadge(
+    FrameworkElement taskListButton,
+    unsigned int count) {
+    if (g_unloading) {
+        return;
+    }
+
+    auto iconPanelElement =
+        FindChildByName(
+            taskListButton,
+            L"IconPanel");
+
+    if (!iconPanelElement) {
+        return;
+    }
+
+    auto iconPanel =
+        iconPanelElement
+            .try_as<
+                Controls::Panel>();
+
+    if (!iconPanel) {
+        return;
+    }
+
+    auto badge =
+        FindChildByName(
+            iconPanelElement,
+            L"WindhawkCountBadge")
+            .try_as<
+                Controls::Border>();
+
+    // Rebuild badges created by older visual-layout versions.
+    if (badge) {
+        auto circleVisual =
+            FindChildByName(
+                badge,
+                L"WindhawkCircleVisual");
+
+        auto badgeVisual =
+            FindChildByName(
+                badge,
+                L"WindhawkBadgeVisual");
+
+        auto countText =
+            FindChildByName(
+                badge,
+                L"WindhawkCountText");
+
+        auto dotStack =
+            FindChildByName(
+                badge,
+                L"WindhawkDotStack");
+
+        if (!circleVisual ||
+            !badgeVisual ||
+            !countText ||
+            !dotStack) {
+            RemoveBadgeFromPanel(
+                iconPanel,
+                badge);
+
+            badge = nullptr;
+        }
+    }
+
+    if (count <
+        static_cast<unsigned int>(
+            g_settings.minimumCount)) {
+        if (badge) {
+            badge.Visibility(
+                Visibility::Collapsed);
+        }
+
+        return;
+    }
+
+    if (!badge) {
+        badge =
+            CreateCountBadge(
+                iconPanel);
+    }
+
+    ApplyBadgeVisualStyle(
+        badge,
+        count);
+
+    badge.Visibility(
+        Visibility::Visible);
+}
+// -----------------------------------------------------------------------------
+// Tracked buttons
+// -----------------------------------------------------------------------------
+
+void PruneDeadTrackedButtons() {
+    for (auto it =
+             g_trackedButtons.begin();
+         it !=
+         g_trackedButtons.end();) {
+        if (!it->element.get()) {
+            it =
+                g_trackedButtons.erase(
+                    it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+void TrackTaskbarButton(
+    FrameworkElement element) {
+    PruneDeadTrackedButtons();
+    auto unknown =
+        element.as<
+            winrt::Windows::
+                Foundation::IUnknown>();
+
+    void* identity =
+        winrt::get_abi(
+            unknown);
+
+    auto automationId =
+        winrt::Windows::UI::
+            Xaml::Automation::
+                AutomationProperties::
+                    GetAutomationId(
+                        element);
+
+    if (automationId.empty()) {
+        return;
+    }
+
+    auto existing =
+        std::find_if(
+            g_trackedButtons.begin(),
+            g_trackedButtons.end(),
+            [identity](
+                const TrackedButton& item) {
+                return item.identity ==
+                       identity;
+            });
+
+    if (existing !=
+        g_trackedButtons.end()) {
+        existing->automationId =
+            automationId.c_str();
+
+        return;
+    }
+
+    g_trackedButtons.push_back(
+        {
+            identity,
+            automationId.c_str(),
+            winrt::make_weak(
+                element),
+        });
+}
+
+// -----------------------------------------------------------------------------
+// Apply cached HWND count
+// -----------------------------------------------------------------------------
+
+void ApplyCountToButton(
+    FrameworkElement element) {
+    auto automationId =
+        winrt::Windows::UI::
+            Xaml::Automation::
+                AutomationProperties::
+                    GetAutomationId(
+                        element);
+
+    if (automationId.empty()) {
+        return;
+    }
+
+    std::wstring key =
+        NormalizeId(
+            automationId.c_str());
+
+    unsigned int count = 0;
+
+    auto it =
+        g_appCounts.find(
+            key);
+
+    if (it !=
+        g_appCounts.end()) {
+        count =
+            it->second;
+    }
+
+    UpdateCountBadge(
+        element,
+        count);
+}
+
+void RefreshAllTrackedButtons() {
+    PruneDeadTrackedButtons();
+
+    for (auto& item :
+         g_trackedButtons) {
+        auto element =
+            item.element.get();
+
+        if (!element) {
+            continue;
+        }
+
+        ApplyCountToButton(
+            element);
+    }
+}
+
+void RefreshChangedTrackedButtons(
+    const std::unordered_set<
+        std::wstring>& changedIds) {
+    PruneDeadTrackedButtons();
+
+    for (auto& item :
+         g_trackedButtons) {
+        std::wstring key =
+            NormalizeId(
+                item.automationId);
+
+        if (!changedIds.contains(
+                key)) {
+            continue;
+        }
+
+        auto element =
+            item.element.get();
+
+        if (!element) {
+            continue;
+        }
+
+        ApplyCountToButton(
+            element);
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Existing XAML tree enumeration
+// -----------------------------------------------------------------------------
+
+int EnumerateExistingTaskbarButtons(
+    FrameworkElement element) {
+    if (!element) {
+        return 0;
+    }
+
+    int found = 0;
+
+    try {
+        if (element.Name() ==
+            L"TaskListButton") {
+            if (!g_taskbarDispatcher) {
+                g_taskbarDispatcher =
+                    element.Dispatcher();
+            }
+
+            TrackTaskbarButton(
+                element);
+
+            ApplyCountToButton(
+                element);
+
+            found++;
+        }
+
+        int children =
+            Media::VisualTreeHelper::
+                GetChildrenCount(
+                    element);
+
+        for (int i = 0;
+             i < children;
+             i++) {
+            auto child =
+                Media::VisualTreeHelper::
+                    GetChild(
+                        element,
+                        i)
+                    .try_as<
+                        FrameworkElement>();
+
+            if (!child) {
+                continue;
+            }
+
+            found +=
+                EnumerateExistingTaskbarButtons(
+                    child);
+        }
+    } catch (...) {
+    }
+
+    return found;
+}
+
+// -----------------------------------------------------------------------------
+// Existing taskbar XamlRoot
+// -----------------------------------------------------------------------------
+
+XamlRoot GetTaskbarXamlRoot(
+    HWND taskbarWnd) {
+    if (!taskbarWnd ||
+        !g_CTaskBand_ITaskListWndSite_vftable ||
+        !g_CTaskBand_GetTaskbarHost ||
+        !g_TaskbarHost_FrameHeight ||
+        !g_RefCount_Decref) {
+        return nullptr;
+    }
+
+    HWND taskBandWnd =
+        reinterpret_cast<HWND>(
+            GetPropW(
+                taskbarWnd,
+                L"TaskbandHWND"));
+
+    if (!taskBandWnd) {
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"TaskbandHWND not found");
+
+        return nullptr;
+    }
+
+    void* taskBand =
+        reinterpret_cast<void*>(
+            GetWindowLongPtrW(
+                taskBandWnd,
+                0));
+
+    if (!taskBand) {
+        return nullptr;
+    }
+
+    void* site =
+        taskBand;
+
+    bool siteFound =
+        false;
+
+    for (int i = 0;
+         i < 20;
+         i++) {
+        if (*reinterpret_cast<void**>(
+                site) ==
+            g_CTaskBand_ITaskListWndSite_vftable) {
+            siteFound =
+                true;
+
+            break;
+        }
+
+        site =
+            reinterpret_cast<void**>(
+                site) +
+            1;
+    }
+
+    if (!siteFound) {
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"ITaskListWndSite not found");
+
+        return nullptr;
+    }
+
+    void* hostShared[2] = {};
+
+    g_CTaskBand_GetTaskbarHost(
+        site,
+        hostShared);
+
+    if (!hostShared[0]) {
+        if (hostShared[1]) {
+            g_RefCount_Decref(
+                hostShared[1]);
+        }
+
+        return nullptr;
+    }
+
+    // Current Windows 11 TaskbarHost layout uses 0x48 on ARM64.
+    // On x64, detect the offset from TaskbarHost::FrameHeight so the mod can
+    // tolerate layout changes where possible.
+    size_t elementOffset =
+        0x48;
+
+#if defined(_M_X64)
+
+    const BYTE* code =
+        reinterpret_cast<
+            const BYTE*>(
+            g_TaskbarHost_FrameHeight);
+
+    if (code[0] == 0x48 &&
+        code[1] == 0x83 &&
+        code[2] == 0xEC &&
+        code[4] == 0x48 &&
+        code[5] == 0x83 &&
+        code[6] == 0xC1 &&
+        code[7] <= 0x7F) {
+        elementOffset =
+            code[7];
+    } else {
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"couldn't detect TaskbarHost "
+            L"XAML offset");
+
+        if (hostShared[1]) {
+            g_RefCount_Decref(
+                hostShared[1]);
+        }
+
+        return nullptr;
+    }
+
+#elif defined(_M_ARM64)
+
+    // Use the known/default TaskbarHost XAML element offset.
+    // This follows the ARM64 fallback used by current Windhawk taskbar mods.
+
+#else
+
+#error "Unsupported architecture"
+
+#endif
+
+    IUnknown* xamlUnknown =
+        *reinterpret_cast<IUnknown**>(
+            reinterpret_cast<BYTE*>(
+                hostShared[0]) +
+            elementOffset);
+
+    FrameworkElement taskbarElement =
+        nullptr;
+
+    if (xamlUnknown) {
+        xamlUnknown->QueryInterface(
+            winrt::guid_of<
+                FrameworkElement>(),
+            winrt::put_abi(
+                taskbarElement));
+    }
+
+    XamlRoot result =
+        taskbarElement
+            ? taskbarElement.XamlRoot()
+            : nullptr;
+
+    if (hostShared[1]) {
+        g_RefCount_Decref(
+            hostShared[1]);
+    }
+
+    return result;
+}
+
+// -----------------------------------------------------------------------------
+// Run synchronously on taskbar UI thread
+// -----------------------------------------------------------------------------
+
+using TaskbarThreadProc =
+    void(WINAPI*)(
+        void* parameter);
+
+bool RunOnTaskbarThread(
+    HWND hWnd,
+    TaskbarThreadProc proc,
+    void* parameter) {
+    if (!hWnd ||
+        !proc) {
+        return false;
+    }
+
+    DWORD threadId =
+        GetWindowThreadProcessId(
+            hWnd,
+            nullptr);
+
+    if (!threadId) {
+        return false;
+    }
+
+    if (threadId ==
+        GetCurrentThreadId()) {
+        proc(
+            parameter);
+
+        return true;
+    }
+
+    static UINT message =
+        RegisterWindowMessageW(
+            L"Windhawk_TaskbarCountBadges_"
+            L"RunOnTaskbarThread");
+
+    if (!message) {
+        return false;
+    }
+
+    struct Request {
+        TaskbarThreadProc proc;
+        void* parameter;
+    };
+
+    HHOOK hook =
+        SetWindowsHookExW(
+            WH_CALLWNDPROC,
+            [](int code,
+               WPARAM wParam,
+               LPARAM lParam) -> LRESULT {
+                if (code ==
+                    HC_ACTION) {
+                    auto data =
+                        reinterpret_cast<
+                            CWPSTRUCT*>(
+                            lParam);
+
+                    if (data->message ==
+                        message) {
+                        auto request =
+                            reinterpret_cast<
+                                Request*>(
+                                data->lParam);
+
+                        if (request &&
+                            request->proc) {
+                            request->proc(
+                                request->parameter);
+                        }
+                    }
+                }
+
+                return CallNextHookEx(
+                    nullptr,
+                    code,
+                    wParam,
+                    lParam);
+            },
+            nullptr,
+            threadId);
+
+    if (!hook) {
+        return false;
+    }
+
+    Request request{
+        proc,
+        parameter,
+    };
+
+    SendMessageW(
+        hWnd,
+        message,
+        0,
+        reinterpret_cast<LPARAM>(
+            &request));
+
+    UnhookWindowsHookEx(
+        hook);
+
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+// App resolver
+// -----------------------------------------------------------------------------
+
+constexpr winrt::guid
+    CLSID_StartMenuCacheAndAppResolver{
+        0x660B90C8,
+        0x73A9,
+        0x4B58,
+        {
+            0x8C,
+            0xAE,
+            0x35,
+            0x5B,
+            0x7F,
+            0x55,
+            0x34,
+            0x1B,
+        }};
+
+constexpr winrt::guid
+    IID_IAppResolver_8{
+        0xDE25675A,
+        0x72DE,
+        0x44B4,
+        {
+            0x93,
+            0x73,
+            0x05,
+            0x17,
+            0x04,
+            0x50,
+            0xC1,
+            0x40,
+        }};
+
+struct IAppResolver_8 :
+    public IUnknown {
+    virtual HRESULT STDMETHODCALLTYPE
+        GetAppIDForShortcut() = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE
+        GetAppIDForShortcutObject() = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE
+        GetAppIDForWindow(
+            HWND hWnd,
+            WCHAR** appId,
+            void* unknown1,
+            void* unknown2,
+            void* unknown3) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE
+        GetAppIDForProcess(
+            DWORD processId,
+            WCHAR** appId,
+            void* unknown1,
+            void* unknown2,
+            void* unknown3) = 0;
+};
+
+// -----------------------------------------------------------------------------
+// Which HWNDs count
+// -----------------------------------------------------------------------------
+
+bool IsCountableWindow(
+    HWND hWnd) {
+    if (!hWnd ||
+        !IsWindowVisible(
+            hWnd)) {
+        return false;
+    }
+
+    WCHAR className[128] = {};
+
+    if (GetClassNameW(
+            hWnd,
+            className,
+            ARRAYSIZE(className))) {
+
+        // Shell/taskbar infrastructure windows.
+        // These are not real application taskbar windows.
+        if (_wcsicmp(
+                className,
+                L"Shell_TrayWnd") == 0 ||
+            _wcsicmp(
+                className,
+                L"Shell_SecondaryTrayWnd") == 0 ||
+            _wcsicmp(
+                className,
+                L"Progman") == 0 ||
+            _wcsicmp(
+                className,
+                L"WorkerW") == 0 ||
+            _wcsicmp(
+                className,
+                L"ApplicationManager_ImmersiveShellWindow") == 0) {
+            return false;
+        }
+    }
+
+    LONG_PTR exStyle =
+        GetWindowLongPtrW(
+            hWnd,
+            GWL_EXSTYLE);
+
+    if ((exStyle &
+         WS_EX_TOOLWINDOW) &&
+        !(exStyle &
+          WS_EX_APPWINDOW)) {
+        return false;
+    }
+
+    HWND owner =
+        GetWindow(
+            hWnd,
+            GW_OWNER);
+
+    if (owner &&
+        !(exStyle &
+          WS_EX_APPWINDOW)) {
+        return false;
+    }
+
+    using DwmGetWindowAttribute_t =
+        HRESULT(WINAPI*)(
+            HWND,
+            DWORD,
+            PVOID,
+            DWORD);
+
+    static DwmGetWindowAttribute_t
+        getDwmWindowAttribute = nullptr;
+
+    if (!getDwmWindowAttribute) {
+        HMODULE dwmApi =
+            GetModuleHandleW(
+                L"dwmapi.dll");
+
+        if (dwmApi) {
+            getDwmWindowAttribute =
+                reinterpret_cast<
+                    DwmGetWindowAttribute_t>(
+                    GetProcAddress(
+                        dwmApi,
+                        "DwmGetWindowAttribute"));
+        }
+    }
+
+    if (getDwmWindowAttribute) {
+        DWORD cloaked = 0;
+
+        // DWMWA_CLOAKED = 14
+        if (SUCCEEDED(
+                getDwmWindowAttribute(
+                    hWnd,
+                    14,
+                    &cloaked,
+                    sizeof(cloaked))) &&
+            cloaked) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+// Build HWND/AppID count map
+// -----------------------------------------------------------------------------
+
+struct WindowEnumContext {
+    IAppResolver_8* resolver;
+
+    std::unordered_map<
+        std::wstring,
+        unsigned int>* counts;
+};
+
+BOOL CALLBACK EnumCountableWindows(
+    HWND hWnd,
+    LPARAM param) {
+    if (!IsCountableWindow(
+            hWnd)) {
+        return TRUE;
+    }
+
+    auto context =
+        reinterpret_cast<
+            WindowEnumContext*>(
+            param);
+
+    if (!context ||
+        !context->resolver ||
+        !context->counts) {
+        return TRUE;
+    }
+
+    WCHAR* appId =
+        nullptr;
+
+    HRESULT hr =
+        context->resolver
+            ->GetAppIDForWindow(
+                hWnd,
+                &appId,
+                nullptr,
+                nullptr,
+                nullptr);
+
+    if (FAILED(
+            hr) ||
+        !appId ||
+        !*appId) {
+        if (appId) {
+            CoTaskMemFree(
+                appId);
+        }
+
+        return TRUE;
+    }
+
+    std::wstring key =
+        NormalizeId(
+            L"Appid: " +
+            std::wstring(
+                appId));
+
+    CoTaskMemFree(
+        appId);
+
+    (*context->counts)[
+        key]++;
+
+    return TRUE;
+}
+
+// -----------------------------------------------------------------------------
+// Rebuild counts
+// -----------------------------------------------------------------------------
+
+bool BuildRealWindowCounts(
+    std::unordered_set<
+        std::wstring>* changedIds,
+    bool initialBuild) {
+    CO_MTA_USAGE_COOKIE cookie{};
+
+    bool mta =
+        SUCCEEDED(
+            CoIncrementMTAUsage(
+                &cookie));
+
+    winrt::com_ptr<
+        IAppResolver_8>
+        resolver;
+
+    HRESULT hr =
+        CoCreateInstance(
+            CLSID_StartMenuCacheAndAppResolver,
+            nullptr,
+            CLSCTX_INPROC_SERVER |
+                CLSCTX_INPROC_HANDLER,
+            IID_IAppResolver_8,
+            resolver.put_void());
+
+    if (FAILED(
+            hr) ||
+        !resolver) {
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"AppResolver failed "
+            L"hr=0x%08X",
+            static_cast<unsigned int>(
+                hr));
+
+        if (mta) {
+            CoDecrementMTAUsage(
+                cookie);
+        }
+
+        return false;
+    }
+
+    std::unordered_map<
+        std::wstring,
+        unsigned int>
+        newCounts;
+
+    WindowEnumContext context{
+        resolver.get(),
+        &newCounts,
+    };
+
+    EnumWindows(
+        EnumCountableWindows,
+        reinterpret_cast<LPARAM>(
+            &context));
+
+    resolver =
+        nullptr;
+
+    if (mta) {
+        CoDecrementMTAUsage(
+            cookie);
+    }
+
+    if (initialBuild) {
+        g_appCounts =
+            std::move(
+                newCounts);
+
+        size_t multiWindowApps =
+            0;
+
+        for (const auto& pair :
+             g_appCounts) {
+            if (pair.second >=
+                static_cast<unsigned int>(
+                    g_settings.minimumCount)) {
+                multiWindowApps++;
+            }
+        }
+
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"initial window counts ready "
+            L"apps=%zu visible=%zu",
+            g_appCounts.size(),
+            multiWindowApps);
+
+        return true;
+    }
+
+    if (!changedIds) {
+        return false;
+    }
+
+    changedIds->clear();
+
+    for (const auto& oldPair :
+         g_appCounts) {
+        auto newIt =
+            newCounts.find(
+                oldPair.first);
+
+        unsigned int newCount =
+            newIt !=
+                    newCounts.end()
+                ? newIt->second
+                : 0;
+
+        if (oldPair.second ==
+            newCount) {
+            continue;
+        }
+
+        changedIds->insert(
+            oldPair.first);
+
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"count changed id=\"%s\" "
+            L"%u -> %u",
+            oldPair.first.c_str(),
+            oldPair.second,
+            newCount);
+    }
+
+    for (const auto& newPair :
+         newCounts) {
+        if (g_appCounts.find(
+                newPair.first) !=
+            g_appCounts.end()) {
+            continue;
+        }
+
+        changedIds->insert(
+            newPair.first);
+
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"count changed id=\"%s\" "
+            L"0 -> %u",
+            newPair.first.c_str(),
+            newPair.second);
+    }
+
+    g_appCounts =
+        std::move(
+            newCounts);
+
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+// Existing taskbar initialization
+// -----------------------------------------------------------------------------
+
+void WINAPI
+InitializeExistingButtonsOnTaskbarThread(
+    void* parameter) {
+    HWND taskbarWnd =
+        reinterpret_cast<HWND>(
+            parameter);
+
+    auto xamlRoot =
+        GetTaskbarXamlRoot(
+            taskbarWnd);
+
+    if (!xamlRoot) {
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"failed to get taskbar XamlRoot");
+
+        return;
+    }
+
+    auto content =
+        xamlRoot.Content()
+            .try_as<
+                FrameworkElement>();
+
+    if (!content) {
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"XamlRoot content unavailable");
+
+        return;
+    }
+
+    if (!g_taskbarDispatcher) {
+        g_taskbarDispatcher =
+            content.Dispatcher();
+    }
+
+    // Keep the count map on the taskbar UI thread. Live recounts and badge
+    // updates also run on this thread, avoiding concurrent map access during
+    // initialization.
+    BuildRealWindowCounts(
+        nullptr,
+        true);
+
+    int buttonCount =
+        EnumerateExistingTaskbarButtons(
+            content);
+
+    Wh_Log(
+        L"Taskbar Count Badges: "
+        L"initial taskbar buttons=%d",
+        buttonCount);
+}
+
+// -----------------------------------------------------------------------------
+// Recount queue
+// -----------------------------------------------------------------------------
+
+void QueueRealWindowRecount() {
+    if (g_unloading ||
+        !g_taskbarDispatcher) {
+        return;
+    }
+
+    if (g_recountQueued.exchange(
+            true)) {
+        return;
+    }
+
+    try {
+        g_taskbarDispatcher.RunAsync(
+            winrt::Windows::UI::Core::
+                CoreDispatcherPriority::
+                    Normal,
+            []() {
+                g_recountQueued =
+                    false;
+
+                if (g_unloading) {
+                    return;
+                }
+
+                std::unordered_set<
+                    std::wstring>
+                    changedIds;
+
+                if (!BuildRealWindowCounts(
+                        &changedIds,
+                        false)) {
+                    return;
+                }
+
+                if (changedIds.empty()) {
+                    return;
+                }
+
+                RefreshChangedTrackedButtons(
+                    changedIds);
+            });
+    } catch (...) {
+        g_recountQueued =
+            false;
+
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"failed to queue HWND recount");
+    }
+}
+
+// -----------------------------------------------------------------------------
+// TaskListButton::UpdateVisualStates
+// -----------------------------------------------------------------------------
+
+using TaskListButton_UpdateVisualStates_t =
+    void(__cdecl*)(
+        void* pThis);
+
+TaskListButton_UpdateVisualStates_t
+    TaskListButton_UpdateVisualStates_Original =
+        nullptr;
+
+void __cdecl
+TaskListButton_UpdateVisualStates_Hook(
+    void* pThis) {
+    TaskListButton_UpdateVisualStates_Original(
+        pThis);
+
+    if (g_unloading) {
+        return;
+    }
+
+    try {
+        void* taskListButtonIUnknownPtr =
+            reinterpret_cast<void**>(
+                pThis) +
+            3;
+
+        winrt::Windows::
+            Foundation::IUnknown
+                taskListButtonIUnknown;
+
+        winrt::copy_from_abi(
+            taskListButtonIUnknown,
+            taskListButtonIUnknownPtr);
+
+        auto element =
+            taskListButtonIUnknown
+                .try_as<
+                    FrameworkElement>();
+
+        if (!element) {
+            return;
+        }
+
+        if (!g_taskbarDispatcher) {
+            g_taskbarDispatcher =
+                element.Dispatcher();
+        }
+
+        TrackTaskbarButton(
+            element);
+
+        ApplyCountToButton(
+            element);
+    } catch (...) {
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"TaskListButton update failed");
+    }
+}
+
+// -----------------------------------------------------------------------------
+// ViewModelCount
+//
+// This value is NOT used as the displayed count.
+// It only tells us that taskbar group state changed.
+// -----------------------------------------------------------------------------
+
+using GetViewModelCount_t =
+    HRESULT(WINAPI*)(
+        void* pThis,
+        unsigned int* count);
+
+GetViewModelCount_t
+    GetViewModelCount_Original =
+        nullptr;
+
+HRESULT WINAPI
+GetViewModelCount_Hook(
+    void* pThis,
+    unsigned int* count) {
+    HRESULT hr =
+        GetViewModelCount_Original(
+            pThis,
+            count);
+
+    if (FAILED(
+            hr) ||
+        !count ||
+        g_unloading) {
+        return hr;
+    }
+
+    QueueRealWindowRecount();
+
+    return hr;
+}
+
+// -----------------------------------------------------------------------------
+// Apply settings live
+// -----------------------------------------------------------------------------
+
+void ApplySettingsToTaskbar() {
+    if (g_unloading ||
+        !g_taskbarDispatcher) {
+        return;
+    }
+
+    try {
+        g_taskbarDispatcher.RunAsync(
+            winrt::Windows::UI::Core::
+                CoreDispatcherPriority::
+                    Normal,
+            []() {
+                if (g_unloading) {
+                    return;
+                }
+
+                RefreshAllTrackedButtons();
+
+                Wh_Log(
+                    L"Taskbar Count Badges: "
+                    L"settings applied");
+            });
+    } catch (...) {
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"failed to apply settings");
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Cleanup
+// -----------------------------------------------------------------------------
+
+void CleanupOnTaskbarThread() {
+    PruneDeadTrackedButtons();
+
+    for (auto& item :
+         g_trackedButtons) {
+        auto element =
+            item.element.get();
+
+        if (!element) {
+            continue;
+        }
+
+        auto iconPanelElement =
+            FindChildByName(
+                element,
+                L"IconPanel");
+
+        if (!iconPanelElement) {
+            continue;
+        }
+
+        auto iconPanel =
+            iconPanelElement
+                .try_as<
+                    Controls::Panel>();
+
+        if (!iconPanel) {
+            continue;
+        }
+
+        auto badge =
+            FindChildByName(
+                iconPanelElement,
+                L"WindhawkCountBadge")
+                .try_as<
+                    Controls::Border>();
+
+        if (badge) {
+            RemoveBadgeFromPanel(
+                iconPanel,
+                badge);
+        }
+    }
+
+    g_trackedButtons.clear();
+
+    Wh_Log(
+        L"Taskbar Count Badges: "
+        L"cleanup complete");
+}
+
+bool CleanupSynchronously() {
+    if (!g_taskbarDispatcher) {
+        return true;
+    }
+
+    try {
+        if (g_taskbarDispatcher
+                .HasThreadAccess()) {
+            CleanupOnTaskbarThread();
+            return true;
+        }
+
+        auto operation =
+            g_taskbarDispatcher
+                .RunAsync(
+                    winrt::Windows::UI::
+                        Core::
+                            CoreDispatcherPriority::
+                                High,
+                    []() {
+                        CleanupOnTaskbarThread();
+                    });
+
+        operation.get();
+
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Taskbar.View hooks
+// -----------------------------------------------------------------------------
+
+bool HookTaskbarView(
+    HMODULE module) {
+    if (g_taskbarViewHooked
+            .exchange(
+                true)) {
+        return true;
+    }
+
+    WindhawkUtils::SYMBOL_HOOK
+        hooks[] = {
+            {
+                {
+                    LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateVisualStates(void))",
+                },
+                &TaskListButton_UpdateVisualStates_Original,
+                TaskListButton_UpdateVisualStates_Hook,
+            },
+            {
+                {
+                    LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListGroupViewModel,struct winrt::Taskbar::ITaskListGroupViewModel>::get_ViewModelCount(unsigned int *))",
+                },
+                &GetViewModelCount_Original,
+                GetViewModelCount_Hook,
+            },
+        };
+
+    if (!WindhawkUtils::
+            HookSymbols(
+                module,
+                hooks,
+                ARRAYSIZE(
+                    hooks))) {
+        g_taskbarViewHooked =
+            false;
+
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"Taskbar.View hooks failed");
+
+        return false;
+    }
+
+    Wh_Log(
+        L"Taskbar Count Badges: "
+        L"Taskbar.View hooks installed");
+
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+// taskbar.dll symbols for XamlRoot access
+// -----------------------------------------------------------------------------
+
+bool HookTaskbarDll() {
+    HMODULE module =
+        LoadLibraryExW(
+            L"taskbar.dll",
+            nullptr,
+            LOAD_LIBRARY_SEARCH_SYSTEM32);
+
+    if (!module) {
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"taskbar.dll load failed");
+
+        return false;
+    }
+
+    WindhawkUtils::SYMBOL_HOOK
+        hooks[] = {
+            {
+                {
+                    LR"(const CTaskBand::`vftable'{for `ITaskListWndSite'})",
+                },
+                &g_CTaskBand_ITaskListWndSite_vftable,
+            },
+            {
+                {
+                    LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CTaskBand::GetTaskbarHost(void)const )",
+                },
+                &g_CTaskBand_GetTaskbarHost,
+            },
+            {
+                {
+                    LR"(public: int __cdecl TaskbarHost::FrameHeight(void)const )",
+                },
+                &g_TaskbarHost_FrameHeight,
+            },
+            {
+                {
+                    LR"(public: void __cdecl std::_Ref_count_base::_Decref(void))",
+                },
+                &g_RefCount_Decref,
+            },
+        };
+
+    if (!WindhawkUtils::
+            HookSymbols(
+                module,
+                hooks,
+                ARRAYSIZE(
+                    hooks))) {
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"taskbar.dll symbols failed");
+
+        return false;
+    }
+
+    Wh_Log(
+        L"Taskbar Count Badges: "
+        L"taskbar XamlRoot symbols installed");
+
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+// Late Taskbar.View loading
+// -----------------------------------------------------------------------------
+
+using LoadLibraryExW_t =
+    decltype(
+        &LoadLibraryExW);
+
+LoadLibraryExW_t
+    LoadLibraryExW_Original =
+        nullptr;
+
+HMODULE WINAPI
+LoadLibraryExW_Hook(
+    LPCWSTR fileName,
+    HANDLE file,
+    DWORD flags) {
+    HMODULE module =
+        LoadLibraryExW_Original(
+            fileName,
+            file,
+            flags);
+
+    if (module &&
+        !g_unloading &&
+        g_isTaskbarProcess &&
+        !g_taskbarViewHooked) {
+        HMODULE taskbarView =
+            GetTaskbarViewModuleHandle();
+
+        if (taskbarView &&
+            taskbarView ==
+                module) {
+            if (HookTaskbarView(
+                    taskbarView)) {
+                Wh_ApplyHookOperations();
+            }
+        }
+    }
+
+    return module;
+}
+
+// -----------------------------------------------------------------------------
+// Lifecycle
+// -----------------------------------------------------------------------------
+
+BOOL Wh_ModInit() {
+    g_unloading =
+        false;
+
+    g_recountQueued =
+        false;
+
+    LoadSettings();
+
+    g_isTaskbarProcess =
+        FindCurrentProcessTaskbarWnd() !=
+        nullptr;
+
+    Wh_Log(
+        L"Taskbar Count Badges: "
+        L"init PID=%lu taskbar=%s",
+        GetCurrentProcessId(),
+        g_isTaskbarProcess
+            ? L"YES"
+            : L"NO");
+
+    if (!g_isTaskbarProcess) {
+        return TRUE;
+    }
+
+    if (!HookTaskbarDll()) {
+        return FALSE;
+    }
+
+    if (HMODULE module =
+            GetTaskbarViewModuleHandle()) {
+        if (!HookTaskbarView(
+                module)) {
+            return FALSE;
+        }
+
+        return TRUE;
+    }
+
+    HMODULE kernelBase =
+        GetModuleHandleW(
+            L"kernelbase.dll");
+
+    if (!kernelBase) {
+        return FALSE;
+    }
+
+    auto loadLibraryExW =
+        reinterpret_cast<
+            decltype(
+                &LoadLibraryExW)>(
+            GetProcAddress(
+                kernelBase,
+                "LoadLibraryExW"));
+
+    if (!loadLibraryExW) {
+        return FALSE;
+    }
+
+    WindhawkUtils::
+        SetFunctionHook(
+            loadLibraryExW,
+            LoadLibraryExW_Hook,
+            &LoadLibraryExW_Original);
+
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    Wh_Log(
+        L"Taskbar Count Badges: "
+        L"after init");
+
+    if (!g_isTaskbarProcess) {
+        return;
+    }
+
+    HWND taskbarWnd =
+        FindCurrentProcessTaskbarWnd();
+
+    if (!taskbarWnd) {
+        return;
+    }
+
+    if (!RunOnTaskbarThread(
+            taskbarWnd,
+            InitializeExistingButtonsOnTaskbarThread,
+            taskbarWnd)) {
+        Wh_Log(
+            L"Taskbar Count Badges: "
+            L"initial taskbar-thread execution failed");
+    }
+}
+
+void Wh_ModSettingsChanged() {
+    LoadSettings();
+
+    if (!g_isTaskbarProcess) {
+        return;
+    }
+
+    ApplySettingsToTaskbar();
+}
+
+void Wh_ModBeforeUninit() {
+    Wh_Log(
+        L"Taskbar Count Badges: "
+        L"before uninit");
+
+    g_unloading =
+        true;
+
+    bool ok =
+        CleanupSynchronously();
+
+    Wh_Log(
+        L"Taskbar Count Badges: "
+        L"cleanup=%s",
+        ok
+            ? L"OK"
+            : L"FAILED");
+}
+
+void Wh_ModUninit() {
+    g_recountQueued =
+        false;
+
+    g_appCounts.clear();
+    g_trackedButtons.clear();
+
+    g_taskbarDispatcher =
+        nullptr;
+
+    Wh_Log(
+        L"Taskbar Count Badges: "
+        L"uninit");
+}

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -1688,7 +1688,7 @@ bool HookTaskbarView(HMODULE module) {
         return true;
     }
 
-    WindhawkUtils::SYMBOL_HOOK taskbarViewHooks[] = {
+    WindhawkUtils::SYMBOL_HOOK taskbarViewDllHooks[] = {
         {
             {
                 LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateVisualStates(void))",
@@ -1711,8 +1711,8 @@ bool HookTaskbarView(HMODULE module) {
         },
     };
 
-    if (!WindhawkUtils::HookSymbols(module, taskbarViewHooks,
-                                    ARRAYSIZE(taskbarViewHooks))) {
+    if (!WindhawkUtils::HookSymbols(module, taskbarViewDllHooks,
+                                    ARRAYSIZE(taskbarViewDllHooks))) {
         g_taskbarViewHooked = false;
         Wh_Log(L"Taskbar.View hooks failed");
         return false;

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -8,7 +8,7 @@
 // @license         GPL-3.0
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lole32 -loleaut32 -lruntimeobject
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lcomctl32
 // ==/WindhawkMod==
 // Copyright (C) 2026 digART
 //
@@ -229,6 +229,7 @@ ordering, or application behavior.
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Text.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Input.h>
 #include <winrt/Windows.UI.Xaml.Markup.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.Shapes.h>
@@ -238,11 +239,14 @@ ordering, or application behavior.
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <cwctype>
 #include <limits>
 #include <list>
 #include <string>
+#include <vector>
 
 using namespace winrt::Windows::UI::Xaml;
 
@@ -330,17 +334,35 @@ std::atomic<bool> g_deferredCountRefreshQueued = false;
 std::atomic<DWORD> g_taskbarThreadId = 0;
 uint64_t g_settingsGeneration = 0;
 
-std::atomic<HHOOK> g_taskbarGetMessageHook = nullptr;
+std::atomic<HWND> g_taskbarSubclassWindow = nullptr;
 UINT g_deferredCountRefreshMessage = 0;
 
 struct TrackedButton {
     void* identity = nullptr;
     winrt::weak_ref<FrameworkElement> element;
+    winrt::weak_ref<Controls::Border> badge;
+    winrt::weak_ref<FrameworkElement> dotIcon;
+    winrt::weak_ref<Controls::Grid> dotHost;
+    winrt::weak_ref<UIElement> dotPointerSource;
+    winrt::event_token dotLayoutUpdatedToken{};
+    winrt::Windows::Foundation::IInspectable dotPointerMovedHandler{nullptr};
+    bool dotLayoutUpdatedAttached = false;
+    bool dotPointerMovedAttached = false;
     unsigned int lastAppliedCount = std::numeric_limits<unsigned int>::max();
     uint64_t lastSettingsGeneration = 0;
 };
 
 std::list<TrackedButton> g_trackedButtons;
+
+using DotAnimationClock = std::chrono::steady_clock;
+constexpr auto kDotAnimationTrackingTimeout = std::chrono::seconds(3);
+constexpr int kDotGeometryStableFrameThreshold = 12;
+
+winrt::event_token g_dotRenderingToken{};
+bool g_dotRenderingSubscribed = false;
+bool g_dotRenderingCallbackActive = false;
+int g_dotGeometryStableFrames = 0;
+DotAnimationClock::time_point g_dotAnimationLastActivity{};
 
 // -----------------------------------------------------------------------------
 // Taskbar.View symbols used for direct group counts
@@ -567,6 +589,7 @@ Media::SolidColorBrush CreateBrush(const std::wstring& value,
 // -----------------------------------------------------------------------------
 
 FrameworkElement FindChildByName(FrameworkElement element, PCWSTR name);
+unsigned int GetVisibleDotCount(unsigned int count);
 
 void ApplyNumberBadgePosition(Controls::Border badge) {
     HorizontalAlignment horizontal = HorizontalAlignment::Right;
@@ -623,10 +646,10 @@ void ApplyNumberBadgePosition(Controls::Border badge) {
     transform.Y(static_cast<double>(g_settings.badgeOffsetY));
 }
 
-void ApplyDotPosition(Controls::Border badge) {
-    badge.VerticalAlignment(VerticalAlignment::Center);
-    badge.Margin(Thickness{});
-
+bool RefreshDotPosition(Controls::Border badge,
+                        FrameworkElement icon,
+                        Controls::Grid dotHost,
+                        unsigned int count) {
     auto transform =
         badge.RenderTransform().try_as<Media::TranslateTransform>();
     if (!transform) {
@@ -634,46 +657,43 @@ void ApplyDotPosition(Controls::Border badge) {
         badge.RenderTransform(transform);
     }
 
-    // Anchor the dots to the actual app icon instead of to IconPanel's edge.
-    // IconPanel has side padding in the stock taskbar, but its geometry can be
-    // changed by taskbar layout/styling mods. Using the Icon child keeps the
-    // dots beside the icon rather than on top of it.
-    auto iconPanelElement = badge.Parent().try_as<FrameworkElement>();
-    auto icon = iconPanelElement
-                    ? FindChildByName(iconPanelElement, L"Icon")
-                    : nullptr;
+    double iconWidth = icon.ActualWidth();
+    double iconHeight = icon.ActualHeight();
+    auto iconBounds = icon.TransformToVisual(dotHost).TransformBounds(
+        winrt::Windows::Foundation::Rect{0, 0,
+                                         static_cast<float>(iconWidth),
+                                         static_cast<float>(iconHeight)});
 
-    if (icon && icon.ActualWidth() > 0) {
-        auto iconTransform = icon.TransformToVisual(iconPanelElement);
-        auto iconTopLeft = iconTransform.TransformPoint(
-            winrt::Windows::Foundation::Point{0, 0});
-        constexpr double kDotGap = 2.0;
-
-        if (g_settings.dotPosition == DotPosition::Left) {
-            // Anchor the badge's RIGHT edge to the icon's left edge. Don't
-            // assume the badge width equals dotSize: XAML layout/DPI rounding
-            // can make the realized width differ slightly.
-            badge.HorizontalAlignment(HorizontalAlignment::Right);
-            transform.X(iconTopLeft.X - iconPanelElement.ActualWidth() -
-                        kDotGap);
-        } else {
-            // Anchor the badge's LEFT edge to the icon's right edge.
-            badge.HorizontalAlignment(HorizontalAlignment::Left);
-            transform.X(iconTopLeft.X + icon.ActualWidth() + kDotGap);
-        }
-    } else {
-        // Fallback for unexpected taskbar templates where the Icon element
-        // can't be resolved. Keep the indicator inside IconPanel.
-        if (g_settings.dotPosition == DotPosition::Left) {
-            badge.HorizontalAlignment(HorizontalAlignment::Left);
-            transform.X(2.0);
-        } else {
-            badge.HorizontalAlignment(HorizontalAlignment::Right);
-            transform.X(-2.0);
-        }
+    constexpr double kDotGap = 2.0;
+    constexpr double kDotSpacing = 2.0;
+    double dotSize = static_cast<double>(g_settings.dotSize);
+    unsigned int dotCount = GetVisibleDotCount(count);
+    double dotStackHeight = dotCount * dotSize;
+    if (dotCount > 1) {
+        dotStackHeight += (dotCount - 1) * kDotSpacing;
     }
 
-    transform.Y(0.0);
+    double left = g_settings.dotPosition == DotPosition::Left
+                      ? iconBounds.X - kDotGap - dotSize
+                      : iconBounds.X + iconBounds.Width + kDotGap;
+    double top = iconBounds.Y + (iconBounds.Height - dotStackHeight) / 2.0;
+    bool changed = std::abs(transform.X() - left) > 0.01 ||
+                   std::abs(transform.Y() - top) > 0.01;
+    if (changed) {
+        transform.X(left);
+        transform.Y(top);
+    }
+    return changed;
+}
+
+void ApplyDotPosition(Controls::Border badge,
+                      FrameworkElement icon,
+                      Controls::Grid dotHost,
+                      unsigned int count) {
+    badge.HorizontalAlignment(HorizontalAlignment::Left);
+    badge.VerticalAlignment(VerticalAlignment::Top);
+    badge.Margin(Thickness{});
+    RefreshDotPosition(badge, icon, dotHost, count);
 }
 
 // -----------------------------------------------------------------------------
@@ -782,6 +802,26 @@ FrameworkElement FindChildByName(FrameworkElement element, PCWSTR name) {
     return nullptr;
 }
 
+Controls::Grid FindDotHostGrid(FrameworkElement taskListButton,
+                               FrameworkElement iconPanel) {
+    FrameworkElement current = taskListButton;
+    for (int depth = 0; current && depth < 20; depth++) {
+        if (current.Name() == L"RootGrid") {
+            auto rootGrid = current.try_as<Controls::Grid>();
+            if (rootGrid && !rootGrid.Clip() &&
+                rootGrid.ActualWidth() > iconPanel.ActualWidth()) {
+                return rootGrid;
+            }
+            return nullptr;
+        }
+
+        auto parent = Media::VisualTreeHelper::GetParent(current);
+        current = parent ? parent.try_as<FrameworkElement>() : nullptr;
+    }
+
+    return nullptr;
+}
+
 // -----------------------------------------------------------------------------
 // Badge text / dot content
 // -----------------------------------------------------------------------------
@@ -842,7 +882,10 @@ void RebuildDots(Controls::StackPanel dotStack, unsigned int count) {
 // Apply visual style
 // -----------------------------------------------------------------------------
 
-void ApplyBadgeVisualStyle(Controls::Border badge, unsigned int count) {
+void ApplyBadgeVisualStyle(Controls::Border badge,
+                           unsigned int count,
+                           FrameworkElement icon = nullptr,
+                           Controls::Grid dotHost = nullptr) {
     auto circleVisual = FindChildByName(badge, L"WindhawkCircleVisual")
                             .try_as<Shapes::Ellipse>();
 
@@ -988,8 +1031,6 @@ void ApplyBadgeVisualStyle(Controls::Border badge, unsigned int count) {
     // VERTICAL DOTS
     // ---------------------------------------------------------------------
 
-    ApplyDotPosition(badge);
-
     circleVisual.Visibility(Visibility::Collapsed);
 
     badgeVisual.Visibility(Visibility::Collapsed);
@@ -1015,20 +1056,221 @@ void ApplyBadgeVisualStyle(Controls::Border badge, unsigned int count) {
     dotStack.VerticalAlignment(VerticalAlignment::Center);
 
     RebuildDots(dotStack, count);
+    ApplyDotPosition(badge, icon, dotHost, count);
 }
 // -----------------------------------------------------------------------------
 // Badge
 // -----------------------------------------------------------------------------
 
-void RemoveBadgeFromPanel(Controls::Panel iconPanel, Controls::Border badge) {
+void RemoveBadgeFromPanel(Controls::Panel panel, Controls::Border badge) {
     uint32_t index = 0;
-    auto children = iconPanel.Children();
+    auto children = panel.Children();
     if (children.IndexOf(badge, index)) {
         children.RemoveAt(index);
     }
 }
 
-Controls::Border CreateCountBadge(Controls::Panel iconPanel) {
+void RemoveBadgeFromCurrentParent(Controls::Border badge) {
+    if (auto parent = badge.Parent().try_as<Controls::Panel>()) {
+        RemoveBadgeFromPanel(parent, badge);
+    }
+}
+
+bool HasActiveDotTracking() {
+    return std::any_of(g_trackedButtons.begin(), g_trackedButtons.end(),
+                       [](TrackedButton const& item) {
+                           return item.dotLayoutUpdatedAttached ||
+                                  item.dotPointerMovedAttached;
+                       });
+}
+
+void StopDotGeometryTracking() {
+    if (g_dotRenderingSubscribed) {
+        try {
+            Media::CompositionTarget::Rendering(g_dotRenderingToken);
+        } catch (...) {
+        }
+        g_dotRenderingToken = {};
+        g_dotRenderingSubscribed = false;
+    }
+    g_dotGeometryStableFrames = 0;
+    g_dotAnimationLastActivity = {};
+}
+
+void OnDotGeometryRendering(
+    winrt::Windows::Foundation::IInspectable const&,
+    winrt::Windows::Foundation::IInspectable const&) {
+    if (g_dotRenderingCallbackActive) {
+        return;
+    }
+    g_dotRenderingCallbackActive = true;
+    struct CallbackGuard {
+        ~CallbackGuard() {
+            g_dotRenderingCallbackActive = false;
+        }
+    } callbackGuard;
+
+    if (g_unloading || g_settings.displayStyle != DisplayStyle::Dots ||
+        !HasActiveDotTracking()) {
+        StopDotGeometryTracking();
+        return;
+    }
+
+    auto now = DotAnimationClock::now();
+    if (g_dotAnimationLastActivity != DotAnimationClock::time_point{} &&
+        now - g_dotAnimationLastActivity >= kDotAnimationTrackingTimeout) {
+        StopDotGeometryTracking();
+        return;
+    }
+
+    struct DotGeometrySnapshot {
+        winrt::weak_ref<Controls::Border> badge;
+        winrt::weak_ref<FrameworkElement> icon;
+        winrt::weak_ref<Controls::Grid> host;
+        unsigned int count;
+    };
+
+    std::vector<DotGeometrySnapshot> snapshot;
+    snapshot.reserve(g_trackedButtons.size());
+    for (auto const& item : g_trackedButtons) {
+        if (!item.dotLayoutUpdatedAttached &&
+            !item.dotPointerMovedAttached) {
+            continue;
+        }
+        snapshot.push_back({item.badge, item.dotIcon, item.dotHost,
+                            item.lastAppliedCount});
+    }
+
+    bool anyValidGeometry = false;
+    bool anyPositionChanged = false;
+    for (auto const& item : snapshot) {
+        auto badge = item.badge.get();
+        auto icon = item.icon.get();
+        auto host = item.host.get();
+        if (!badge || !icon || !host ||
+            item.count == std::numeric_limits<unsigned int>::max()) {
+            continue;
+        }
+
+        try {
+            anyPositionChanged |=
+                RefreshDotPosition(badge, icon, host, item.count);
+            anyValidGeometry = true;
+        } catch (...) {
+        }
+    }
+
+    if (!anyValidGeometry) {
+        StopDotGeometryTracking();
+        return;
+    }
+
+    g_dotGeometryStableFrames =
+        anyPositionChanged ? 0 : g_dotGeometryStableFrames + 1;
+    if (g_dotGeometryStableFrames >= kDotGeometryStableFrameThreshold) {
+        StopDotGeometryTracking();
+    }
+}
+
+void StartDotGeometryTracking() {
+    if (g_unloading || g_settings.displayStyle != DisplayStyle::Dots ||
+        !HasActiveDotTracking()) {
+        return;
+    }
+
+    g_dotAnimationLastActivity = DotAnimationClock::now();
+    g_dotGeometryStableFrames = 0;
+    if (!g_dotRenderingSubscribed) {
+        g_dotRenderingToken = Media::CompositionTarget::Rendering(
+            OnDotGeometryRendering);
+        g_dotRenderingSubscribed = true;
+    }
+}
+
+void DetachDotTrackingHandlers(TrackedButton& tracked) {
+    if (tracked.dotLayoutUpdatedAttached) {
+        if (auto icon = tracked.dotIcon.get()) {
+            try {
+                icon.LayoutUpdated(tracked.dotLayoutUpdatedToken);
+            } catch (...) {
+            }
+        }
+    }
+    if (tracked.dotPointerMovedAttached) {
+        if (auto source = tracked.dotPointerSource.get()) {
+            try {
+                source.RemoveHandler(UIElement::PointerMovedEvent(),
+                                     tracked.dotPointerMovedHandler);
+            } catch (...) {
+            }
+        }
+    }
+
+    tracked.dotIcon = {};
+    tracked.dotHost = {};
+    tracked.dotPointerSource = {};
+    tracked.dotLayoutUpdatedToken = {};
+    tracked.dotPointerMovedHandler = nullptr;
+    tracked.dotLayoutUpdatedAttached = false;
+    tracked.dotPointerMovedAttached = false;
+
+    if (!HasActiveDotTracking()) {
+        StopDotGeometryTracking();
+    }
+}
+
+void AttachDotTrackingHandlers(TrackedButton& tracked,
+                               FrameworkElement taskListButton,
+                               FrameworkElement icon,
+                               Controls::Grid dotHost) {
+    auto existingIcon = tracked.dotIcon.get();
+    auto existingHost = tracked.dotHost.get();
+    auto existingPointerSource = tracked.dotPointerSource.get();
+    if (tracked.dotLayoutUpdatedAttached &&
+        tracked.dotPointerMovedAttached && existingIcon && existingHost &&
+        existingPointerSource &&
+        winrt::get_abi(existingIcon) == winrt::get_abi(icon) &&
+        winrt::get_abi(existingHost) == winrt::get_abi(dotHost) &&
+        winrt::get_abi(existingPointerSource) ==
+            winrt::get_abi(taskListButton)) {
+        StartDotGeometryTracking();
+        return;
+    }
+
+    DetachDotTrackingHandlers(tracked);
+
+    auto pointerSource = taskListButton.try_as<UIElement>();
+    if (!pointerSource) {
+        return;
+    }
+
+    try {
+        tracked.dotIcon = winrt::make_weak(icon);
+        tracked.dotHost = winrt::make_weak(dotHost);
+        tracked.dotPointerSource = winrt::make_weak(pointerSource);
+        tracked.dotLayoutUpdatedToken = icon.LayoutUpdated(
+            [](winrt::Windows::Foundation::IInspectable const&,
+               winrt::Windows::Foundation::IInspectable const&) {
+                StartDotGeometryTracking();
+            });
+        tracked.dotLayoutUpdatedAttached = true;
+
+        tracked.dotPointerMovedHandler =
+            winrt::box_value(Input::PointerEventHandler{
+                [](winrt::Windows::Foundation::IInspectable const&,
+                   Input::PointerRoutedEventArgs const&) {
+                    StartDotGeometryTracking();
+                }});
+        pointerSource.AddHandler(UIElement::PointerMovedEvent(),
+                                 tracked.dotPointerMovedHandler, true);
+        tracked.dotPointerMovedAttached = true;
+        StartDotGeometryTracking();
+    } catch (...) {
+        DetachDotTrackingHandlers(tracked);
+    }
+}
+
+Controls::Border CreateCountBadge(Controls::Panel parent) {
     PCWSTR xaml =
         LR"(
 <Border
@@ -1076,14 +1318,20 @@ Controls::Border CreateCountBadge(Controls::Panel iconPanel) {
 
     Controls::Canvas::SetZIndex(badge, 100);
 
-    iconPanel.Children().Append(badge);
+    parent.Children().Append(badge);
 
     return badge;
 }
 
-bool UpdateCountBadge(FrameworkElement taskListButton, unsigned int count) {
+bool UpdateCountBadge(TrackedButton& tracked,
+                      FrameworkElement taskListButton,
+                      unsigned int count) {
     if (g_unloading) {
         return false;
+    }
+
+    if (g_settings.displayStyle != DisplayStyle::Dots) {
+        DetachDotTrackingHandlers(tracked);
     }
 
     auto iconPanelElement = FindChildByName(taskListButton, L"IconPanel");
@@ -1098,8 +1346,21 @@ bool UpdateCountBadge(FrameworkElement taskListButton, unsigned int count) {
         return false;
     }
 
-    auto badge = FindChildByName(iconPanelElement, L"WindhawkCountBadge")
-                     .try_as<Controls::Border>();
+    auto badge = tracked.badge.get();
+    if (badge && badge.Name() != L"WindhawkCountBadge") {
+        badge = nullptr;
+        tracked.badge = {};
+    }
+
+    auto iconPanelBadge =
+        FindChildByName(iconPanelElement, L"WindhawkCountBadge")
+            .try_as<Controls::Border>();
+    if (!badge) {
+        badge = iconPanelBadge;
+    } else if (iconPanelBadge &&
+               winrt::get_abi(iconPanelBadge) != winrt::get_abi(badge)) {
+        RemoveBadgeFromPanel(iconPanel, iconPanelBadge);
+    }
 
     // Rebuild badges created by older visual-layout versions.
     if (badge) {
@@ -1112,13 +1373,44 @@ bool UpdateCountBadge(FrameworkElement taskListButton, unsigned int count) {
         auto dotStack = FindChildByName(badge, L"WindhawkDotStack");
 
         if (!circleVisual || !badgeVisual || !countText || !dotStack) {
-            RemoveBadgeFromPanel(iconPanel, badge);
+            RemoveBadgeFromCurrentParent(badge);
 
             badge = nullptr;
+            tracked.badge = {};
         }
     }
 
+    FrameworkElement icon = nullptr;
+    Controls::Grid dotHost = nullptr;
+    Controls::Panel desiredParent = iconPanel;
+    if (g_settings.displayStyle == DisplayStyle::Dots) {
+        icon = FindChildByName(iconPanelElement, L"Icon");
+        dotHost = FindDotHostGrid(taskListButton, iconPanelElement);
+        if (!icon || icon.ActualWidth() <= 0 || icon.ActualHeight() <= 0 ||
+            !dotHost) {
+            DetachDotTrackingHandlers(tracked);
+            if (badge) {
+                badge.Visibility(Visibility::Collapsed);
+            }
+            return false;
+        }
+        desiredParent = dotHost;
+    }
+
+    if (badge) {
+        auto currentParent = badge.Parent().try_as<Controls::Panel>();
+        if (!currentParent ||
+            winrt::get_abi(currentParent) != winrt::get_abi(desiredParent)) {
+            if (currentParent) {
+                RemoveBadgeFromPanel(currentParent, badge);
+            }
+            desiredParent.Children().Append(badge);
+        }
+        tracked.badge = winrt::make_weak(badge);
+    }
+
     if (count < static_cast<unsigned int>(g_settings.minimumCount)) {
+        DetachDotTrackingHandlers(tracked);
         if (badge) {
             badge.Visibility(Visibility::Collapsed);
         }
@@ -1127,10 +1419,15 @@ bool UpdateCountBadge(FrameworkElement taskListButton, unsigned int count) {
     }
 
     if (!badge) {
-        badge = CreateCountBadge(iconPanel);
+        badge = CreateCountBadge(desiredParent);
+        tracked.badge = winrt::make_weak(badge);
     }
 
-    ApplyBadgeVisualStyle(badge, count);
+    ApplyBadgeVisualStyle(badge, count, icon, dotHost);
+
+    if (g_settings.displayStyle == DisplayStyle::Dots) {
+        AttachDotTrackingHandlers(tracked, taskListButton, icon, dotHost);
+    }
 
     badge.Visibility(Visibility::Visible);
 
@@ -1143,6 +1440,10 @@ bool UpdateCountBadge(FrameworkElement taskListButton, unsigned int count) {
 void PruneDeadTrackedButtons() {
     for (auto it = g_trackedButtons.begin(); it != g_trackedButtons.end();) {
         if (!it->element.get()) {
+            DetachDotTrackingHandlers(*it);
+            if (auto badge = it->badge.get()) {
+                RemoveBadgeFromCurrentParent(badge);
+            }
             it = g_trackedButtons.erase(it);
         } else {
             ++it;
@@ -1165,7 +1466,12 @@ TrackedButton* TrackTaskbarButton(FrameworkElement element) {
         // this identity is already gone, treat this as a fresh button and
         // reset the cached visual state.
         if (!existing->element.get()) {
+            DetachDotTrackingHandlers(*existing);
+            if (auto badge = existing->badge.get()) {
+                RemoveBadgeFromCurrentParent(badge);
+            }
             existing->element = winrt::make_weak(element);
+            existing->badge = {};
             existing->lastAppliedCount =
                 std::numeric_limits<unsigned int>::max();
             existing->lastSettingsGeneration = 0;
@@ -1230,7 +1536,7 @@ void ApplyCountToTrackedButton(TrackedButton& item, unsigned int count) {
     item.lastSettingsGeneration = settingsGeneration;
 
     try {
-        if (!UpdateCountBadge(element, count)) {
+        if (!UpdateCountBadge(item, element, count)) {
             item.lastAppliedCount = previousCount;
             item.lastSettingsGeneration = previousGeneration;
         }
@@ -1257,19 +1563,23 @@ void ApplyCountToButton(FrameworkElement element) {
 }
 
 void RefreshAllTrackedButtons() {
-    // Prune before walking. TrackTaskbarButton doesn't prune, so XAML re-entry
-    // during this loop can't erase the element currently being visited.
     PruneDeadTrackedButtons();
 
-    for (auto& item : g_trackedButtons) {
-        auto element = item.element.get();
+    std::vector<winrt::weak_ref<FrameworkElement>> buttonSnapshot;
+    buttonSnapshot.reserve(g_trackedButtons.size());
+    for (auto const& item : g_trackedButtons) {
+        buttonSnapshot.push_back(item.element);
+    }
+
+    // Refresh through the element identity instead of retaining a list
+    // iterator/reference across XAML mutations. A nested refresh can prune or
+    // otherwise update the tracked list without invalidating this snapshot.
+    for (auto const& weakElement : buttonSnapshot) {
+        auto element = weakElement.get();
         if (!element) {
             continue;
         }
-
-        unsigned int count = 0;
-        bool haveCount = GetTaskbarButtonViewModelCount(element, &count);
-        ApplyCountToTrackedButton(item, haveCount ? count : 0);
+        ApplyCountToButton(element);
     }
 }
 
@@ -1526,82 +1836,84 @@ HWND FindWindowOnThread(DWORD threadId) {
 // Deferred count refresh
 // -----------------------------------------------------------------------------
 
-LRESULT CALLBACK TaskbarGetMessageHookProc(int code,
+LRESULT CALLBACK TaskbarWindowSubclassProc(HWND hWnd,
+                                           UINT message,
                                            WPARAM wParam,
-                                           LPARAM lParam) {
-    if (code >= 0 && wParam == PM_REMOVE && lParam) {
-        auto* message = reinterpret_cast<MSG*>(lParam);
-        if (g_deferredCountRefreshMessage &&
-            message->message == g_deferredCountRefreshMessage) {
-            // Consume the private thread message. The refresh now runs from the
-            // taskbar message loop, after the ViewModel getter/layout stack has
-            // returned, so XAML isn't mutated from inside the property getter.
-            message->message = WM_NULL;
-
-            if (!g_unloading) {
-                try {
-                    RefreshAllTrackedButtons();
-                } catch (...) {
-                    Wh_Log(L"Deferred count refresh failed");
-                }
+                                           LPARAM lParam,
+                                           DWORD_PTR) {
+    if (message == g_deferredCountRefreshMessage) {
+        if (!g_unloading) {
+            try {
+                RefreshAllTrackedButtons();
+            } catch (...) {
+                Wh_Log(L"Deferred count refresh failed");
             }
-
-            // Keep the refresh marked as queued until all XAML work finishes.
-            // Any ViewModelCount reads caused by that work are collapsed into
-            // this refresh instead of scheduling a feedback-loop refresh.
-            g_deferredCountRefreshQueued = false;
         }
+
+        // Keep the refresh marked as queued until all XAML work finishes.
+        // Getter notifications caused by that work collapse into this refresh.
+        g_deferredCountRefreshQueued = false;
+        return 0;
     }
 
-    return CallNextHookEx(g_taskbarGetMessageHook.load(), code, wParam, lParam);
+    if (message == WM_NCDESTROY &&
+        g_taskbarSubclassWindow.load() == hWnd) {
+        g_taskbarSubclassWindow = nullptr;
+        g_deferredCountRefreshQueued = false;
+    }
+
+    return DefSubclassProc(hWnd, message, wParam, lParam);
 }
 
-bool EnsureDeferredCountRefreshHookOnTaskbarThread() {
-    DWORD threadId = GetCurrentThreadId();
-    HHOOK existingHook = g_taskbarGetMessageHook.load();
+bool EnsureDeferredCountRefreshSubclass() {
+    if (g_unloading) {
+        return false;
+    }
 
-    if (existingHook && g_taskbarThreadId.load() == threadId) {
+    HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
+    if (!taskbarWnd) {
+        return false;
+    }
+
+    HWND existingWindow = g_taskbarSubclassWindow.load();
+    if (existingWindow == taskbarWnd) {
+        g_taskbarThreadId =
+            GetWindowThreadProcessId(taskbarWnd, nullptr);
         return true;
     }
 
-    if (existingHook) {
-        UnhookWindowsHookEx(existingHook);
-        g_taskbarGetMessageHook = nullptr;
+    if (existingWindow) {
+        WindhawkUtils::RemoveWindowSubclassFromAnyThread(
+            existingWindow, TaskbarWindowSubclassProc);
+        g_taskbarSubclassWindow = nullptr;
     }
 
-    g_taskbarThreadId = threadId;
-
-    if (!g_deferredCountRefreshMessage) {
-        g_deferredCountRefreshMessage = RegisterWindowMessageW(
-            L"Windhawk_DeferredCountRefresh_" WH_MOD_ID);
-        if (!g_deferredCountRefreshMessage) {
-            return false;
-        }
+    if (!WindhawkUtils::SetWindowSubclassFromAnyThread(
+            taskbarWnd, TaskbarWindowSubclassProc, 0)) {
+        return false;
     }
 
-    HHOOK hook = SetWindowsHookExW(WH_GETMESSAGE, TaskbarGetMessageHookProc,
-                                   nullptr, threadId);
-    g_taskbarGetMessageHook = hook;
-    return hook != nullptr;
+    g_taskbarThreadId = GetWindowThreadProcessId(taskbarWnd, nullptr);
+    g_taskbarSubclassWindow = taskbarWnd;
+    return true;
 }
 
-void StopDeferredCountRefreshHook() {
-    HHOOK hook = g_taskbarGetMessageHook.exchange(nullptr);
-    if (hook) {
-        UnhookWindowsHookEx(hook);
-    }
-
+void StopDeferredCountRefreshSubclass() {
+    HWND taskbarWnd = g_taskbarSubclassWindow.exchange(nullptr);
     g_deferredCountRefreshQueued = false;
+    if (taskbarWnd) {
+        WindhawkUtils::RemoveWindowSubclassFromAnyThread(
+            taskbarWnd, TaskbarWindowSubclassProc);
+    }
 }
 
 void QueueDeferredCountRefresh() {
-    if (g_unloading || !g_taskbarGetMessageHook.load() ||
-        !g_deferredCountRefreshMessage) {
+    if (g_unloading || !g_deferredCountRefreshMessage) {
         return;
     }
 
-    DWORD threadId = g_taskbarThreadId.load();
-    if (!threadId || threadId != GetCurrentThreadId()) {
+    HWND taskbarWnd = g_taskbarSubclassWindow.load();
+    if (!taskbarWnd) {
         return;
     }
 
@@ -1609,7 +1921,7 @@ void QueueDeferredCountRefresh() {
         return;
     }
 
-    if (!PostThreadMessageW(threadId, g_deferredCountRefreshMessage, 0, 0)) {
+    if (!PostMessageW(taskbarWnd, g_deferredCountRefreshMessage, 0, 0)) {
         g_deferredCountRefreshQueued = false;
         Wh_Log(L"Failed to queue deferred count refresh");
     }
@@ -1625,8 +1937,8 @@ struct ExistingButtonsInitContext {
 };
 
 void WINAPI InitializeExistingButtonsOnTaskbarThread(void*) {
-    if (!EnsureDeferredCountRefreshHookOnTaskbarThread()) {
-        Wh_Log(L"Failed to install deferred count refresh hook");
+    if (!EnsureDeferredCountRefreshSubclass()) {
+        Wh_Log(L"Failed to install deferred count refresh subclass");
     }
 
     ExistingButtonsInitContext context;
@@ -1697,7 +2009,7 @@ void __cdecl TaskListButton_UpdateVisualStates_Hook(void* pThis) {
     }
 
     try {
-        EnsureDeferredCountRefreshHookOnTaskbarThread();
+        EnsureDeferredCountRefreshSubclass();
         void* taskListButtonIUnknownPtr = reinterpret_cast<void**>(pThis) + 3;
 
         winrt::Windows::Foundation::IUnknown taskListButtonIUnknown;
@@ -1717,6 +2029,9 @@ void __cdecl TaskListButton_UpdateVisualStates_Hook(void* pThis) {
         }
 
         ApplyCountToButton(element);
+        if (g_settings.displayStyle == DisplayStyle::Dots) {
+            StartDotGeometryTracking();
+        }
     } catch (...) {
         Wh_Log(L"TaskListButton update failed");
     }
@@ -1766,14 +2081,21 @@ void WINAPI ApplySettingsOnTaskbarThread(void*) {
 // -----------------------------------------------------------------------------
 
 void CleanupOnTaskbarThread() {
+    StopDotGeometryTracking();
     PruneDeadTrackedButtons();
 
     for (auto& item : g_trackedButtons) {
+        DetachDotTrackingHandlers(item);
         auto element = item.element.get();
+        auto badge = item.badge.get();
+        if (badge) {
+            RemoveBadgeFromCurrentParent(badge);
+            item.badge = {};
+        }
+
         if (!element) {
             continue;
         }
-
         auto iconPanelElement = FindChildByName(element, L"IconPanel");
         if (!iconPanelElement) {
             continue;
@@ -1784,20 +2106,16 @@ void CleanupOnTaskbarThread() {
             continue;
         }
 
-        auto badge = FindChildByName(iconPanelElement, L"WindhawkCountBadge")
-                         .try_as<Controls::Border>();
-        if (badge) {
-            RemoveBadgeFromPanel(iconPanel, badge);
+        auto iconPanelBadge =
+            FindChildByName(iconPanelElement, L"WindhawkCountBadge")
+                .try_as<Controls::Border>();
+        if (iconPanelBadge) {
+            RemoveBadgeFromPanel(iconPanel, iconPanelBadge);
         }
     }
 }
 
 void WINAPI CleanupOnTaskbarThreadProc(void*) {
-    // The WH_GETMESSAGE hook belongs to this taskbar UI thread. Remove it here
-    // synchronously so no hook callback can still be executing when the mod is
-    // unloaded.
-    StopDeferredCountRefreshHook();
-
     try {
         CleanupOnTaskbarThread();
         Wh_Log(L"Cleanup complete");
@@ -1950,8 +2268,12 @@ BOOL Wh_ModInit() {
     g_settingsReloadPending = false;
     g_deferredCountRefreshQueued = false;
     g_taskbarThreadId = 0;
-    g_taskbarGetMessageHook = nullptr;
-    g_deferredCountRefreshMessage = 0;
+    g_taskbarSubclassWindow = nullptr;
+    g_deferredCountRefreshMessage = RegisterWindowMessageW(
+        L"Windhawk_DeferredCountRefresh_" WH_MOD_ID);
+    if (!g_deferredCountRefreshMessage) {
+        return FALSE;
+    }
     g_trackedButtons.clear();
 
     LoadSettings();
@@ -2031,13 +2353,13 @@ void Wh_ModBeforeUninit() {
     Wh_Log(L"Before uninit");
     g_unloading = true;
     g_settingsReloadPending = false;
+    StopDeferredCountRefreshSubclass();
 
     DWORD taskbarThreadId = g_taskbarThreadId.load();
     HWND cleanupWnd = nullptr;
 
-    // Prefer Shell_TrayWnd while it still exists, but cleanup must not depend
-    // on it: the deferred WH_GETMESSAGE hook belongs to the taskbar UI thread
-    // and can outlive the visible taskbar window during Explorer teardown.
+    // Prefer Shell_TrayWnd while it still exists, with another window on the
+    // same taskbar UI thread as a cleanup-only fallback.
     HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
     if (taskbarWnd) {
         DWORD windowThreadId = GetWindowThreadProcessId(taskbarWnd, nullptr);
@@ -2051,15 +2373,9 @@ void Wh_ModBeforeUninit() {
     }
 
     if (!cleanupWnd) {
-        // If no deferred hook was ever installed, there is no callback that can
-        // survive the mod. Any XAML tree that has already lost all of its
-        // windows is no longer reachable for visual cleanup either.
-        if (!g_taskbarGetMessageHook.load()) {
-            g_trackedButtons.clear();
-            return;
-        }
-
-        Wh_Log(L"Couldn't find a window on the taskbar thread for cleanup");
+        // The subclass is already removed, so pending posted refresh messages
+        // are harmless. With no taskbar-thread window, XAML is unreachable.
+        g_trackedButtons.clear();
         return;
     }
 
@@ -2069,12 +2385,8 @@ void Wh_ModBeforeUninit() {
 }
 
 void Wh_ModUninit() {
-    // Normal teardown removes the long-lived hook synchronously from its own
-    // taskbar thread in CleanupOnTaskbarThreadProc. This is only a last-resort
-    // fallback for a teardown path where taskbar-thread marshalling was no
-    // longer possible.
-    if (g_taskbarGetMessageHook.load()) {
-        StopDeferredCountRefreshHook();
+    if (g_taskbarSubclassWindow.load()) {
+        StopDeferredCountRefreshSubclass();
     }
 
     // Tracked buttons contain weak WinRT references only; releasing them here

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -22,8 +22,6 @@
 // Taskbar Labels for Windows 11, Taskbar Button Scroll, and Taskbar Tray Show
 // on Hover.
 
-
-
 // ==WindhawkModReadme==
 /*
 # Taskbar Count Badges
@@ -81,7 +79,7 @@ settings are applied live.
 ## Compatibility
 
 - Windows 11 only
-- Supports x64 and ARM64 Windows
+- Supports x64 Windows
 - Works with multiple monitors and secondary Windows taskbars
 
 On multi-monitor systems, the count follows each individual taskbar button.
@@ -131,6 +129,7 @@ ordering, or application behavior.
 
   - color: "#FFFFFF"
     $name: Dot color
+    $description: Hex color in #RRGGBB or #AARRGGBB format.
   $name: Vertical dots
   $description: These settings apply only when Display style is set to Vertical dots.
 
@@ -166,9 +165,11 @@ ordering, or application behavior.
 
   - backgroundColor: "#D90000"
     $name: Background color
+    $description: Hex color in #RRGGBB or #AARRGGBB format.
 
   - borderColor: "#FFFFFF"
     $name: Border color
+    $description: Hex color in #RRGGBB or #AARRGGBB format.
 
   - borderThickness: 0
     $name: Border thickness
@@ -179,6 +180,7 @@ ordering, or application behavior.
 - Text:
   - color: "#FFFFFF"
     $name: Text color
+    $description: Hex color in #RRGGBB or #AARRGGBB format.
 
   - fontFamily: "Segoe UI"
     $name: Font family
@@ -220,17 +222,16 @@ ordering, or application behavior.
 
 #include <windhawk_utils.h>
 #include <windows.h>
-#include <winstring.h>
-
 #undef GetCurrentTime
 
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Core.h>
+#include <winrt/Windows.Foundation.Numerics.h>
 #include <winrt/Windows.UI.Text.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Input.h>
 #include <winrt/Windows.UI.Xaml.Markup.h>
+#include <winrt/Windows.UI.Xaml.Hosting.h>
+#include <winrt/Windows.UI.Composition.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.Shapes.h>
 #include <winrt/Windows.UI.Xaml.h>
@@ -239,7 +240,6 @@ ordering, or application behavior.
 
 #include <algorithm>
 #include <atomic>
-#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <cwctype>
@@ -247,6 +247,7 @@ ordering, or application behavior.
 #include <list>
 #include <optional>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 using namespace winrt::Windows::UI::Xaml;
@@ -255,18 +256,21 @@ using namespace winrt::Windows::UI::Xaml;
 // Settings
 // -----------------------------------------------------------------------------
 
-enum class DisplayStyle {
+enum class DisplayStyle
+{
     Number,
     Dots,
 };
 
-enum class BadgeShape {
+enum class BadgeShape
+{
     Circle,
     Rounded,
     Square,
 };
 
-enum class BadgePosition {
+enum class BadgePosition
+{
     TopLeft,
     TopCenter,
     TopRight,
@@ -275,18 +279,21 @@ enum class BadgePosition {
     BottomRight,
 };
 
-enum class DotPosition {
+enum class DotPosition
+{
     Left,
     Right,
 };
 
-enum class BadgeFontWeight {
+enum class BadgeFontWeight
+{
     Normal,
     SemiBold,
     Bold,
 };
 
-struct Settings {
+struct Settings
+{
     DisplayStyle displayStyle = DisplayStyle::Number;
 
     BadgeShape badgeShape = BadgeShape::Circle;
@@ -338,58 +345,45 @@ uint64_t g_settingsGeneration = 0;
 std::atomic<HWND> g_taskbarSubclassWindow = nullptr;
 UINT g_deferredCountRefreshMessage = 0;
 
-struct TrackedButton {
-    void* identity = nullptr;
+struct TrackedButton
+{
+    void *identity = nullptr;
     winrt::weak_ref<FrameworkElement> element;
     winrt::weak_ref<Controls::Border> badge;
-    winrt::weak_ref<FrameworkElement> dotIcon;
-    winrt::weak_ref<Controls::Grid> dotHost;
-    winrt::weak_ref<UIElement> dotPointerSource;
-    winrt::event_token dotLayoutUpdatedToken{};
-    winrt::Windows::Foundation::IInspectable dotPointerMovedHandler{nullptr};
-    bool dotLayoutUpdatedAttached = false;
-    bool dotPointerMovedAttached = false;
     unsigned int lastAppliedCount = std::numeric_limits<unsigned int>::max();
     uint64_t lastSettingsGeneration = 0;
 };
 
-// TrackedButton contains a strong XAML event-handler reference. Prevent the
-// container destructor from releasing thread-affine XAML objects during
-// Explorer process shutdown, where Wh_ModUninit isn't guaranteed to run.
+// Keep the tracked-button container out of CRT global destruction. It only
+// owns weak WinRT references, but explicit reset() on normal unload keeps the
+// lifetime rules simple if the tracked state grows in future revisions.
 [[clang::no_destroy]] std::optional<std::list<TrackedButton>> g_trackedButtons{
     std::in_place};
 
-std::list<TrackedButton>& TrackedButtons() {
+std::list<TrackedButton> &TrackedButtons()
+{
     return *g_trackedButtons;
 }
-
-using DotAnimationClock = std::chrono::steady_clock;
-constexpr auto kDotAnimationTrackingTimeout = std::chrono::seconds(3);
-constexpr int kDotGeometryStableFrameThreshold = 12;
-
-winrt::event_token g_dotRenderingToken{};
-bool g_dotRenderingSubscribed = false;
-bool g_dotRenderingCallbackActive = false;
-int g_dotGeometryStableFrames = 0;
-DotAnimationClock::time_point g_dotAnimationLastActivity{};
 
 // -----------------------------------------------------------------------------
 // Taskbar.View symbols used for direct group counts
 // -----------------------------------------------------------------------------
 
 using TryGetItemFromContainer_TaskListGroupViewModel_t =
-    void*(WINAPI*)(void** output, UIElement* container);
+    void *(WINAPI *)(void **output, UIElement *container);
 TryGetItemFromContainer_TaskListGroupViewModel_t
     TryGetItemFromContainer_TaskListGroupViewModel_Original = nullptr;
 
-using GetViewModelCount_t = HRESULT(WINAPI*)(void* pThis, unsigned int* count);
+using GetViewModelCount_t = HRESULT(WINAPI *)(void *pThis, unsigned int *count);
 GetViewModelCount_t GetViewModelCount_Original = nullptr;
 
-unsigned int WindowCountFromViewModelCount(unsigned int viewModelCount) {
+unsigned int WindowCountFromViewModelCount(unsigned int viewModelCount)
+{
     // For the TaskListGroupViewModel returned for a taskbar button, Windows
     // reports ViewModelCount one higher than the represented window count
-    // (1 window -> 2, 2 windows -> 3). Keep Windows' value untouched and
-    // normalize only the count displayed by this mod.
+    // (1 window -> 2, 2 windows -> 3). Verified on Windows 11 24H2. Keep
+    // Windows' value untouched and normalize only the count displayed by this
+    // mod.
     return viewModelCount > 0 ? viewModelCount - 1 : 0;
 }
 
@@ -397,32 +391,34 @@ unsigned int WindowCountFromViewModelCount(unsigned int viewModelCount) {
 // taskbar.dll symbols used to access primary and secondary XamlRoot
 // -----------------------------------------------------------------------------
 
-void* g_CTaskBand_ITaskListWndSite_vftable = nullptr;
-void* g_CSecondaryTaskBand_ITaskListWndSite_vftable = nullptr;
+void *g_CTaskBand_ITaskListWndSite_vftable = nullptr;
+void *g_CSecondaryTaskBand_ITaskListWndSite_vftable = nullptr;
 
-using CTaskBand_GetTaskbarHost_t = void*(WINAPI*)(void* pThis, void** result);
+using CTaskBand_GetTaskbarHost_t = void *(WINAPI *)(void *pThis, void **result);
 CTaskBand_GetTaskbarHost_t g_CTaskBand_GetTaskbarHost = nullptr;
 
-using CSecondaryTaskBand_GetTaskbarHost_t = void*(WINAPI*)(void* pThis,
-                                                          void** result);
+using CSecondaryTaskBand_GetTaskbarHost_t = void *(WINAPI *)(void *pThis,
+                                                             void **result);
 CSecondaryTaskBand_GetTaskbarHost_t g_CSecondaryTaskBand_GetTaskbarHost =
     nullptr;
 
-void* g_TaskbarHost_FrameHeight = nullptr;
+void *g_TaskbarHost_FrameHeight = nullptr;
 
-using RefCount_Decref_t = void(WINAPI*)(void* pThis);
+using RefCount_Decref_t = void(WINAPI *)(void *pThis);
 RefCount_Decref_t g_RefCount_Decref = nullptr;
 
 // -----------------------------------------------------------------------------
 // Setting helpers
 // -----------------------------------------------------------------------------
 
-std::wstring ReadStringSetting(PCWSTR name) {
+std::wstring ReadStringSetting(PCWSTR name)
+{
     auto value = WindhawkUtils::StringSetting::make(name);
     return value.get();
 }
 
-void LoadSettings() {
+void LoadSettings()
+{
     // Display ---------------------------------------------------------------
 
     std::wstring displayStyle = ReadStringSetting(L"Display.style");
@@ -434,27 +430,43 @@ void LoadSettings() {
 
     std::wstring shape = ReadStringSetting(L"Badge.shape");
 
-    if (shape == L"square") {
+    if (shape == L"square")
+    {
         g_settings.badgeShape = BadgeShape::Square;
-    } else if (shape == L"rounded") {
+    }
+    else if (shape == L"rounded")
+    {
         g_settings.badgeShape = BadgeShape::Rounded;
-    } else {
+    }
+    else
+    {
         g_settings.badgeShape = BadgeShape::Circle;
     }
 
     std::wstring position = ReadStringSetting(L"Badge.position");
 
-    if (position == L"topLeft") {
+    if (position == L"topLeft")
+    {
         g_settings.badgePosition = BadgePosition::TopLeft;
-    } else if (position == L"topCenter") {
+    }
+    else if (position == L"topCenter")
+    {
         g_settings.badgePosition = BadgePosition::TopCenter;
-    } else if (position == L"bottomLeft") {
+    }
+    else if (position == L"bottomLeft")
+    {
         g_settings.badgePosition = BadgePosition::BottomLeft;
-    } else if (position == L"bottomCenter") {
+    }
+    else if (position == L"bottomCenter")
+    {
         g_settings.badgePosition = BadgePosition::BottomCenter;
-    } else if (position == L"bottomRight") {
+    }
+    else if (position == L"bottomRight")
+    {
         g_settings.badgePosition = BadgePosition::BottomRight;
-    } else {
+    }
+    else
+    {
         g_settings.badgePosition = BadgePosition::TopRight;
     }
 
@@ -478,7 +490,8 @@ void LoadSettings() {
 
     g_settings.fontFamily = ReadStringSetting(L"Text.fontFamily");
 
-    if (g_settings.fontFamily.empty()) {
+    if (g_settings.fontFamily.empty())
+    {
         g_settings.fontFamily = L"Segoe UI";
     }
 
@@ -486,11 +499,16 @@ void LoadSettings() {
 
     std::wstring fontWeight = ReadStringSetting(L"Text.fontWeight");
 
-    if (fontWeight == L"bold") {
+    if (fontWeight == L"bold")
+    {
         g_settings.fontWeight = BadgeFontWeight::Bold;
-    } else if (fontWeight == L"normal") {
+    }
+    else if (fontWeight == L"normal")
+    {
         g_settings.fontWeight = BadgeFontWeight::Normal;
-    } else {
+    }
+    else
+    {
         g_settings.fontWeight = BadgeFontWeight::SemiBold;
     }
 
@@ -520,15 +538,19 @@ void LoadSettings() {
 // Color parsing
 // -----------------------------------------------------------------------------
 
-bool ParseHexByte(wchar_t high, wchar_t low, BYTE* result) {
-    auto getValue = [](wchar_t c) -> int {
-        if (c >= L'0' && c <= L'9') {
+bool ParseHexByte(wchar_t high, wchar_t low, BYTE *result)
+{
+    auto getValue = [](wchar_t c) -> int
+    {
+        if (c >= L'0' && c <= L'9')
+        {
             return c - L'0';
         }
 
         c = static_cast<wchar_t>(std::towupper(c));
 
-        if (c >= L'A' && c <= L'F') {
+        if (c >= L'A' && c <= L'F')
+        {
             return c - L'A' + 10;
         }
 
@@ -539,7 +561,8 @@ bool ParseHexByte(wchar_t high, wchar_t low, BYTE* result) {
 
     int lowValue = getValue(low);
 
-    if (highValue < 0 || lowValue < 0) {
+    if (highValue < 0 || lowValue < 0)
+    {
         return false;
     }
 
@@ -548,11 +571,13 @@ bool ParseHexByte(wchar_t high, wchar_t low, BYTE* result) {
     return true;
 }
 
-winrt::Windows::UI::Color ParseColor(const std::wstring& value,
-                                     winrt::Windows::UI::Color fallback) {
+winrt::Windows::UI::Color ParseColor(const std::wstring &value,
+                                     winrt::Windows::UI::Color fallback)
+{
     std::wstring text = value;
 
-    if (!text.empty() && text[0] == L'#') {
+    if (!text.empty() && text[0] == L'#')
+    {
         text.erase(text.begin());
     }
 
@@ -561,20 +586,27 @@ winrt::Windows::UI::Color ParseColor(const std::wstring& value,
     BYTE g = 0;
     BYTE b = 0;
 
-    if (text.length() == 6) {
+    if (text.length() == 6)
+    {
         if (!ParseHexByte(text[0], text[1], &r) ||
             !ParseHexByte(text[2], text[3], &g) ||
-            !ParseHexByte(text[4], text[5], &b)) {
+            !ParseHexByte(text[4], text[5], &b))
+        {
             return fallback;
         }
-    } else if (text.length() == 8) {
+    }
+    else if (text.length() == 8)
+    {
         if (!ParseHexByte(text[0], text[1], &a) ||
             !ParseHexByte(text[2], text[3], &r) ||
             !ParseHexByte(text[4], text[5], &g) ||
-            !ParseHexByte(text[6], text[7], &b)) {
+            !ParseHexByte(text[6], text[7], &b))
+        {
             return fallback;
         }
-    } else {
+    }
+    else
+    {
         return fallback;
     }
 
@@ -588,8 +620,9 @@ winrt::Windows::UI::Color ParseColor(const std::wstring& value,
     return color;
 }
 
-Media::SolidColorBrush CreateBrush(const std::wstring& value,
-                                   winrt::Windows::UI::Color fallback) {
+Media::SolidColorBrush CreateBrush(const std::wstring &value,
+                                   winrt::Windows::UI::Color fallback)
+{
     return Media::SolidColorBrush(ParseColor(value, fallback));
 }
 
@@ -599,42 +632,47 @@ Media::SolidColorBrush CreateBrush(const std::wstring& value,
 
 FrameworkElement FindChildByName(FrameworkElement element, PCWSTR name);
 unsigned int GetVisibleDotCount(unsigned int count);
+void StopDotPositionBinding(Controls::Border badge);
 
-void ApplyNumberBadgePosition(Controls::Border badge) {
+void ApplyNumberBadgePosition(Controls::Border badge)
+{
+    StopDotPositionBinding(badge);
+
     HorizontalAlignment horizontal = HorizontalAlignment::Right;
 
     VerticalAlignment vertical = VerticalAlignment::Top;
 
-    switch (g_settings.badgePosition) {
-        case BadgePosition::TopLeft:
-            horizontal = HorizontalAlignment::Left;
-            vertical = VerticalAlignment::Top;
-            break;
+    switch (g_settings.badgePosition)
+    {
+    case BadgePosition::TopLeft:
+        horizontal = HorizontalAlignment::Left;
+        vertical = VerticalAlignment::Top;
+        break;
 
-        case BadgePosition::TopCenter:
-            horizontal = HorizontalAlignment::Center;
-            vertical = VerticalAlignment::Top;
-            break;
+    case BadgePosition::TopCenter:
+        horizontal = HorizontalAlignment::Center;
+        vertical = VerticalAlignment::Top;
+        break;
 
-        case BadgePosition::TopRight:
-            horizontal = HorizontalAlignment::Right;
-            vertical = VerticalAlignment::Top;
-            break;
+    case BadgePosition::TopRight:
+        horizontal = HorizontalAlignment::Right;
+        vertical = VerticalAlignment::Top;
+        break;
 
-        case BadgePosition::BottomLeft:
-            horizontal = HorizontalAlignment::Left;
-            vertical = VerticalAlignment::Bottom;
-            break;
+    case BadgePosition::BottomLeft:
+        horizontal = HorizontalAlignment::Left;
+        vertical = VerticalAlignment::Bottom;
+        break;
 
-        case BadgePosition::BottomCenter:
-            horizontal = HorizontalAlignment::Center;
-            vertical = VerticalAlignment::Bottom;
-            break;
+    case BadgePosition::BottomCenter:
+        horizontal = HorizontalAlignment::Center;
+        vertical = VerticalAlignment::Bottom;
+        break;
 
-        case BadgePosition::BottomRight:
-            horizontal = HorizontalAlignment::Right;
-            vertical = VerticalAlignment::Bottom;
-            break;
+    case BadgePosition::BottomRight:
+        horizontal = HorizontalAlignment::Right;
+        vertical = VerticalAlignment::Bottom;
+        break;
     }
 
     badge.HorizontalAlignment(horizontal);
@@ -644,7 +682,8 @@ void ApplyNumberBadgePosition(Controls::Border badge) {
     auto transform =
         badge.RenderTransform().try_as<Media::TranslateTransform>();
 
-    if (!transform) {
+    if (!transform)
+    {
         transform = Media::TranslateTransform();
 
         badge.RenderTransform(transform);
@@ -655,75 +694,148 @@ void ApplyNumberBadgePosition(Controls::Border badge) {
     transform.Y(static_cast<double>(g_settings.badgeOffsetY));
 }
 
-bool RefreshDotPosition(Controls::Border badge,
-                        FrameworkElement icon,
-                        Controls::Grid dotHost,
-                        unsigned int count) {
-    auto transform =
-        badge.RenderTransform().try_as<Media::TranslateTransform>();
-    if (!transform) {
-        transform = Media::TranslateTransform();
-        badge.RenderTransform(transform);
+void StopDotPositionBinding(Controls::Border badge)
+{
+    if (!badge)
+    {
+        return;
     }
 
-    double iconWidth = icon.ActualWidth();
-    double iconHeight = icon.ActualHeight();
-    auto iconBounds = icon.TransformToVisual(dotHost).TransformBounds(
-        winrt::Windows::Foundation::Rect{0, 0,
-                                         static_cast<float>(iconWidth),
-                                         static_cast<float>(iconHeight)});
+    try
+    {
+        auto visual =
+            Hosting::ElementCompositionPreview::GetElementVisual(badge);
 
-    constexpr double kDotGap = 2.0;
-    constexpr double kDotSpacing = 2.0;
-    double dotSize = static_cast<double>(g_settings.dotSize);
-    unsigned int dotCount = GetVisibleDotCount(count);
-    double dotStackHeight = dotCount * dotSize;
-    if (dotCount > 1) {
-        dotStackHeight += (dotCount - 1) * kDotSpacing;
+        // Translation is the XAML composition hand-off property exposed on
+        // Visual.Properties after SetIsTranslationEnabled(true). Stopping the
+        // expression leaves its last animated value in that property, so a
+        // badge reparented from RootGrid back into IconPanel can otherwise
+        // remain translated away from its normal number-badge position.
+        auto properties = visual.Properties();
+        properties.StopAnimation(L"Translation");
+        properties.InsertVector3(
+            L"Translation",
+            winrt::Windows::Foundation::Numerics::float3{0.0f, 0.0f, 0.0f});
     }
-
-    double left = g_settings.dotPosition == DotPosition::Left
-                      ? iconBounds.X - kDotGap - dotSize
-                      : iconBounds.X + iconBounds.Width + kDotGap;
-    double top = iconBounds.Y + (iconBounds.Height - dotStackHeight) / 2.0;
-    bool changed = std::abs(transform.X() - left) > 0.01 ||
-                   std::abs(transform.Y() - top) > 0.01;
-    if (changed) {
-        transform.X(left);
-        transform.Y(top);
+    catch (...)
+    {
     }
-    return changed;
 }
 
-void ApplyDotPosition(Controls::Border badge,
-                      FrameworkElement icon,
-                      Controls::Grid dotHost,
-                      unsigned int count) {
-    badge.HorizontalAlignment(HorizontalAlignment::Left);
-    badge.VerticalAlignment(VerticalAlignment::Top);
-    badge.Margin(Thickness{});
-    RefreshDotPosition(badge, icon, dotHost, count);
+bool BindDotPositionExpression(Controls::Border badge,
+                               FrameworkElement icon,
+                               Controls::Grid dotHost,
+                               unsigned int count)
+{
+    if (!badge || !icon || !dotHost)
+    {
+        return false;
+    }
+
+    try
+    {
+        // The badge lives in RootGrid so it isn't clipped by IconPanel. Glue
+        // its composition Translation to the icon's visual-offset chain. The
+        // compositor evaluates this expression on the render thread, so the
+        // dots follow taskbar reordering/insertion animations without XAML
+        // LayoutUpdated/PointerMoved/Rendering callbacks into the mod image.
+        FrameworkElement hostElement = dotHost;
+        std::vector<winrt::Windows::UI::Composition::Visual> chain;
+        FrameworkElement current = icon;
+        for (int depth = 0; current && current != hostElement && depth < 20;
+             ++depth)
+        {
+            chain.push_back(
+                Hosting::ElementCompositionPreview::GetElementVisual(current));
+            auto parent = Media::VisualTreeHelper::GetParent(current);
+            current = parent ? parent.try_as<FrameworkElement>() : nullptr;
+        }
+
+        if (!current || current != hostElement || chain.empty())
+        {
+            return false;
+        }
+
+        constexpr double kDotGap = 2.0;
+        constexpr double kDotSpacing = 2.0;
+        double dotSize = static_cast<double>(g_settings.dotSize);
+        unsigned int dotCount = GetVisibleDotCount(count);
+        double stackHeight = dotCount * dotSize;
+        if (dotCount > 1)
+        {
+            stackHeight += (dotCount - 1) * kDotSpacing;
+        }
+
+        badge.HorizontalAlignment(HorizontalAlignment::Left);
+        badge.VerticalAlignment(VerticalAlignment::Top);
+        badge.Margin(Thickness{});
+        badge.RenderTransform(nullptr);
+
+        Hosting::ElementCompositionPreview::SetIsTranslationEnabled(badge,
+                                                                    true);
+        auto badgeVisual =
+            Hosting::ElementCompositionPreview::GetElementVisual(badge);
+
+        std::wstring sumX;
+        std::wstring sumY;
+        for (size_t i = 0; i < chain.size(); ++i)
+        {
+            std::wstring parameter = L"p" + std::to_wstring(i);
+            sumX += parameter + L".Offset.X + ";
+            sumY += parameter + L".Offset.Y + ";
+        }
+
+        std::wstring xAdjustment =
+            g_settings.dotPosition == DotPosition::Left
+                ? L"(-gap - dotSize)"
+                : L"(p0.Size.X + gap)";
+
+        std::wstring expression =
+            L"Vector3(" + sumX + xAdjustment + L" - self.Offset.X, " +
+            sumY + L"(p0.Size.Y - stackHeight) / 2.0f - self.Offset.Y, 0.0f)";
+
+        auto animation = badgeVisual.Compositor().CreateExpressionAnimation(
+            winrt::hstring(expression));
+        for (size_t i = 0; i < chain.size(); ++i)
+        {
+            animation.SetReferenceParameter(
+                winrt::hstring(L"p" + std::to_wstring(i)), chain[i]);
+        }
+        animation.SetScalarParameter(L"gap", static_cast<float>(kDotGap));
+        animation.SetScalarParameter(L"dotSize", static_cast<float>(dotSize));
+        animation.SetScalarParameter(L"stackHeight",
+                                     static_cast<float>(stackHeight));
+        animation.SetReferenceParameter(L"self", badgeVisual);
+        badgeVisual.Properties().StartAnimation(L"Translation", animation);
+        return true;
+    }
+    catch (...)
+    {
+        return false;
+    }
 }
 
 // -----------------------------------------------------------------------------
 // Font helper
 // -----------------------------------------------------------------------------
 
-winrt::Windows::UI::Text::FontWeight GetConfiguredFontWeight() {
+winrt::Windows::UI::Text::FontWeight GetConfiguredFontWeight()
+{
     uint16_t weight = 600;
 
-    switch (g_settings.fontWeight) {
-        case BadgeFontWeight::Normal:
-            weight = 400;
-            break;
+    switch (g_settings.fontWeight)
+    {
+    case BadgeFontWeight::Normal:
+        weight = 400;
+        break;
 
-        case BadgeFontWeight::SemiBold:
-            weight = 600;
-            break;
+    case BadgeFontWeight::SemiBold:
+        weight = 600;
+        break;
 
-        case BadgeFontWeight::Bold:
-            weight = 700;
-            break;
+    case BadgeFontWeight::Bold:
+        weight = 700;
+        break;
     }
 
     winrt::Windows::UI::Text::FontWeight result{};
@@ -737,29 +849,34 @@ winrt::Windows::UI::Text::FontWeight GetConfiguredFontWeight() {
 // Main taskbar HWND
 // -----------------------------------------------------------------------------
 
-HWND FindCurrentProcessTaskbarWnd() {
+HWND FindCurrentProcessTaskbarWnd()
+{
     HWND result = nullptr;
 
     EnumWindows(
-        [](HWND hWnd, LPARAM param) -> BOOL {
+        [](HWND hWnd, LPARAM param) -> BOOL
+        {
             DWORD pid = 0;
             WCHAR className[64] = {};
 
             GetWindowThreadProcessId(hWnd, &pid);
 
-            if (pid != GetCurrentProcessId()) {
+            if (pid != GetCurrentProcessId())
+            {
                 return TRUE;
             }
 
-            if (!GetClassNameW(hWnd, className, ARRAYSIZE(className))) {
+            if (!GetClassNameW(hWnd, className, ARRAYSIZE(className)))
+            {
                 return TRUE;
             }
 
-            if (_wcsicmp(className, L"Shell_TrayWnd") != 0) {
+            if (_wcsicmp(className, L"Shell_TrayWnd") != 0)
+            {
                 return TRUE;
             }
 
-            *reinterpret_cast<HWND*>(param) = hWnd;
+            *reinterpret_cast<HWND *>(param) = hWnd;
 
             return FALSE;
         },
@@ -772,10 +889,12 @@ HWND FindCurrentProcessTaskbarWnd() {
 // Taskbar.View module
 // -----------------------------------------------------------------------------
 
-HMODULE GetTaskbarViewModuleHandle() {
+HMODULE GetTaskbarViewModuleHandle()
+{
     HMODULE module = GetModuleHandleW(L"Taskbar.View.dll");
 
-    if (!module) {
+    if (!module)
+    {
         module = GetModuleHandleW(L"ExplorerExtensions.dll");
     }
 
@@ -786,24 +905,29 @@ HMODULE GetTaskbarViewModuleHandle() {
 // XAML helpers
 // -----------------------------------------------------------------------------
 
-FrameworkElement FindChildByName(FrameworkElement element, PCWSTR name) {
+FrameworkElement FindChildByName(FrameworkElement element, PCWSTR name)
+{
     int count = Media::VisualTreeHelper::GetChildrenCount(element);
 
-    for (int i = 0; i < count; i++) {
+    for (int i = 0; i < count; i++)
+    {
         auto child = Media::VisualTreeHelper::GetChild(element, i)
                          .try_as<FrameworkElement>();
 
-        if (!child) {
+        if (!child)
+        {
             continue;
         }
 
-        if (child.Name() == name) {
+        if (child.Name() == name)
+        {
             return child;
         }
 
         auto result = FindChildByName(child, name);
 
-        if (result) {
+        if (result)
+        {
             return result;
         }
     }
@@ -812,13 +936,17 @@ FrameworkElement FindChildByName(FrameworkElement element, PCWSTR name) {
 }
 
 Controls::Grid FindDotHostGrid(FrameworkElement taskListButton,
-                               FrameworkElement iconPanel) {
+                               FrameworkElement iconPanel)
+{
     FrameworkElement current = taskListButton;
-    for (int depth = 0; current && depth < 20; depth++) {
-        if (current.Name() == L"RootGrid") {
+    for (int depth = 0; current && depth < 20; depth++)
+    {
+        if (current.Name() == L"RootGrid")
+        {
             auto rootGrid = current.try_as<Controls::Grid>();
             if (rootGrid && !rootGrid.Clip() &&
-                rootGrid.ActualWidth() > iconPanel.ActualWidth()) {
+                rootGrid.ActualWidth() > iconPanel.ActualWidth())
+            {
                 return rootGrid;
             }
             return nullptr;
@@ -835,20 +963,24 @@ Controls::Grid FindDotHostGrid(FrameworkElement taskListButton,
 // Badge text / dot content
 // -----------------------------------------------------------------------------
 
-std::wstring MakeNumberText(unsigned int count) {
-    if (count > static_cast<unsigned int>(g_settings.maximumNumber)) {
+std::wstring MakeNumberText(unsigned int count)
+{
+    if (count > static_cast<unsigned int>(g_settings.maximumNumber))
+    {
         return std::to_wstring(g_settings.maximumNumber) + L"+";
     }
 
     return std::to_wstring(count);
 }
 
-unsigned int GetVisibleDotCount(unsigned int count) {
+unsigned int GetVisibleDotCount(unsigned int count)
+{
     // Five dots means five or more windows.
     return std::min<unsigned int>(count, 5);
 }
 
-void RebuildDots(Controls::StackPanel dotStack, unsigned int count) {
+void RebuildDots(Controls::StackPanel dotStack, unsigned int count)
+{
     dotStack.Children().Clear();
 
     winrt::Windows::UI::Color defaultDotColor{};
@@ -864,7 +996,8 @@ void RebuildDots(Controls::StackPanel dotStack, unsigned int count) {
 
     constexpr double kDotSpacing = 2.0;
 
-    for (unsigned int i = 0; i < dotCount; i++) {
+    for (unsigned int i = 0; i < dotCount; i++)
+    {
         Controls::Border dot;
 
         dot.Width(static_cast<double>(g_settings.dotSize));
@@ -891,10 +1024,11 @@ void RebuildDots(Controls::StackPanel dotStack, unsigned int count) {
 // Apply visual style
 // -----------------------------------------------------------------------------
 
-void ApplyBadgeVisualStyle(Controls::Border badge,
+bool ApplyBadgeVisualStyle(Controls::Border badge,
                            unsigned int count,
                            FrameworkElement icon = nullptr,
-                           Controls::Grid dotHost = nullptr) {
+                           Controls::Grid dotHost = nullptr)
+{
     auto circleVisual = FindChildByName(badge, L"WindhawkCircleVisual")
                             .try_as<Shapes::Ellipse>();
 
@@ -907,8 +1041,9 @@ void ApplyBadgeVisualStyle(Controls::Border badge,
     auto dotStack = FindChildByName(badge, L"WindhawkDotStack")
                         .try_as<Controls::StackPanel>();
 
-    if (!circleVisual || !badgeVisual || !text || !dotStack) {
-        return;
+    if (!circleVisual || !badgeVisual || !text || !dotStack)
+    {
+        return false;
     }
 
     winrt::Windows::UI::Color defaultBackground{};
@@ -940,7 +1075,8 @@ void ApplyBadgeVisualStyle(Controls::Border badge,
     // NUMBER BADGE
     // ---------------------------------------------------------------------
 
-    if (g_settings.displayStyle == DisplayStyle::Number) {
+    if (g_settings.displayStyle == DisplayStyle::Number)
+    {
         ApplyNumberBadgePosition(badge);
 
         dotStack.Visibility(Visibility::Collapsed);
@@ -961,7 +1097,8 @@ void ApplyBadgeVisualStyle(Controls::Border badge,
         double borderThickness =
             static_cast<double>(g_settings.badgeBorderThickness);
 
-        if (g_settings.badgeShape == BadgeShape::Circle) {
+        if (g_settings.badgeShape == BadgeShape::Circle)
+        {
             badgeVisual.Visibility(Visibility::Collapsed);
 
             circleVisual.Visibility(Visibility::Visible);
@@ -971,16 +1108,21 @@ void ApplyBadgeVisualStyle(Controls::Border badge,
 
             circleVisual.Fill(backgroundBrush);
 
-            if (g_settings.badgeBorderThickness > 0) {
+            if (g_settings.badgeBorderThickness > 0)
+            {
                 circleVisual.Stroke(borderBrush);
 
                 circleVisual.StrokeThickness(borderThickness);
-            } else {
+            }
+            else
+            {
                 circleVisual.Stroke(nullptr);
 
                 circleVisual.StrokeThickness(0);
             }
-        } else {
+        }
+        else
+        {
             circleVisual.Visibility(Visibility::Collapsed);
 
             badgeVisual.Visibility(Visibility::Visible);
@@ -1000,13 +1142,16 @@ void ApplyBadgeVisualStyle(Controls::Border badge,
 
             badgeVisual.Background(backgroundBrush);
 
-            if (g_settings.badgeBorderThickness > 0) {
+            if (g_settings.badgeBorderThickness > 0)
+            {
                 badgeVisual.BorderBrush(borderBrush);
 
                 badgeVisual.BorderThickness(
                     Thickness{borderThickness, borderThickness, borderThickness,
                               borderThickness});
-            } else {
+            }
+            else
+            {
                 badgeVisual.BorderBrush(nullptr);
 
                 badgeVisual.BorderThickness(Thickness{0, 0, 0, 0});
@@ -1033,7 +1178,7 @@ void ApplyBadgeVisualStyle(Controls::Border badge,
 
         text.Text(MakeNumberText(count));
 
-        return;
+        return true;
     }
 
     // ---------------------------------------------------------------------
@@ -1065,234 +1210,33 @@ void ApplyBadgeVisualStyle(Controls::Border badge,
     dotStack.VerticalAlignment(VerticalAlignment::Center);
 
     RebuildDots(dotStack, count);
-    ApplyDotPosition(badge, icon, dotHost, count);
+    return BindDotPositionExpression(badge, icon, dotHost, count);
 }
 // -----------------------------------------------------------------------------
 // Badge
 // -----------------------------------------------------------------------------
 
-void RemoveBadgeFromPanel(Controls::Panel panel, Controls::Border badge) {
+void RemoveBadgeFromPanel(Controls::Panel panel, Controls::Border badge)
+{
+    StopDotPositionBinding(badge);
     uint32_t index = 0;
     auto children = panel.Children();
-    if (children.IndexOf(badge, index)) {
+    if (children.IndexOf(badge, index))
+    {
         children.RemoveAt(index);
     }
 }
 
-void RemoveBadgeFromCurrentParent(Controls::Border badge) {
-    if (auto parent = badge.Parent().try_as<Controls::Panel>()) {
+void RemoveBadgeFromCurrentParent(Controls::Border badge)
+{
+    if (auto parent = badge.Parent().try_as<Controls::Panel>())
+    {
         RemoveBadgeFromPanel(parent, badge);
     }
 }
 
-bool HasActiveDotTracking() {
-    return std::any_of(TrackedButtons().begin(), TrackedButtons().end(),
-                       [](TrackedButton const& item) {
-                           return item.dotLayoutUpdatedAttached ||
-                                  item.dotPointerMovedAttached;
-                       });
-}
-
-void StopDotGeometryTracking() {
-    if (g_dotRenderingSubscribed) {
-        try {
-            Media::CompositionTarget::Rendering(g_dotRenderingToken);
-        } catch (...) {
-        }
-        g_dotRenderingToken = {};
-        g_dotRenderingSubscribed = false;
-    }
-    g_dotGeometryStableFrames = 0;
-    g_dotAnimationLastActivity = {};
-}
-
-void OnDotGeometryRendering(
-    winrt::Windows::Foundation::IInspectable const&,
-    winrt::Windows::Foundation::IInspectable const&) {
-    if (g_dotRenderingCallbackActive) {
-        return;
-    }
-    g_dotRenderingCallbackActive = true;
-    struct CallbackGuard {
-        ~CallbackGuard() {
-            g_dotRenderingCallbackActive = false;
-        }
-    } callbackGuard;
-
-    if (g_unloading || g_settings.displayStyle != DisplayStyle::Dots ||
-        !HasActiveDotTracking()) {
-        StopDotGeometryTracking();
-        return;
-    }
-
-    auto now = DotAnimationClock::now();
-    if (g_dotAnimationLastActivity != DotAnimationClock::time_point{} &&
-        now - g_dotAnimationLastActivity >= kDotAnimationTrackingTimeout) {
-        StopDotGeometryTracking();
-        return;
-    }
-
-    struct DotGeometrySnapshot {
-        winrt::weak_ref<Controls::Border> badge;
-        winrt::weak_ref<FrameworkElement> icon;
-        winrt::weak_ref<Controls::Grid> host;
-        unsigned int count;
-    };
-
-    std::vector<DotGeometrySnapshot> snapshot;
-    snapshot.reserve(TrackedButtons().size());
-    for (auto const& item : TrackedButtons()) {
-        if (!item.dotLayoutUpdatedAttached &&
-            !item.dotPointerMovedAttached) {
-            continue;
-        }
-        snapshot.push_back({item.badge, item.dotIcon, item.dotHost,
-                            item.lastAppliedCount});
-    }
-
-    bool anyValidGeometry = false;
-    bool anyPositionChanged = false;
-    for (auto const& item : snapshot) {
-        auto badge = item.badge.get();
-        auto icon = item.icon.get();
-        auto host = item.host.get();
-        if (!badge || !icon || !host ||
-            item.count == std::numeric_limits<unsigned int>::max()) {
-            continue;
-        }
-
-        try {
-            anyPositionChanged |=
-                RefreshDotPosition(badge, icon, host, item.count);
-            anyValidGeometry = true;
-        } catch (...) {
-        }
-    }
-
-    if (!anyValidGeometry) {
-        StopDotGeometryTracking();
-        return;
-    }
-
-    g_dotGeometryStableFrames =
-        anyPositionChanged ? 0 : g_dotGeometryStableFrames + 1;
-    if (g_dotGeometryStableFrames >= kDotGeometryStableFrameThreshold) {
-        StopDotGeometryTracking();
-    }
-}
-
-void StartDotGeometryTracking() {
-    if (g_unloading || g_settings.displayStyle != DisplayStyle::Dots ||
-        !HasActiveDotTracking()) {
-        return;
-    }
-
-    g_dotAnimationLastActivity = DotAnimationClock::now();
-    g_dotGeometryStableFrames = 0;
-    if (!g_dotRenderingSubscribed) {
-        g_dotRenderingToken = Media::CompositionTarget::Rendering(
-            OnDotGeometryRendering);
-        g_dotRenderingSubscribed = true;
-    }
-}
-
-void DetachDotTrackingHandlers(TrackedButton& tracked) {
-    if (tracked.dotLayoutUpdatedAttached) {
-        if (auto icon = tracked.dotIcon.get()) {
-            try {
-                icon.LayoutUpdated(tracked.dotLayoutUpdatedToken);
-            } catch (...) {
-            }
-        }
-    }
-    if (tracked.dotPointerMovedAttached) {
-        if (auto source = tracked.dotPointerSource.get()) {
-            try {
-                source.RemoveHandler(UIElement::PointerMovedEvent(),
-                                     tracked.dotPointerMovedHandler);
-            } catch (...) {
-            }
-        }
-    }
-
-    tracked.dotIcon = {};
-    tracked.dotHost = {};
-    tracked.dotPointerSource = {};
-    tracked.dotLayoutUpdatedToken = {};
-    tracked.dotPointerMovedHandler = nullptr;
-    tracked.dotLayoutUpdatedAttached = false;
-    tracked.dotPointerMovedAttached = false;
-
-    if (!HasActiveDotTracking()) {
-        StopDotGeometryTracking();
-    }
-}
-
-template <typename T, typename U>
-bool IsSameWinrtObject(T const& first, U const& second) {
-    if (!first || !second) {
-        return false;
-    }
-
-    auto firstUnknown =
-        first.template try_as<winrt::Windows::Foundation::IUnknown>();
-    auto secondUnknown =
-        second.template try_as<winrt::Windows::Foundation::IUnknown>();
-    return firstUnknown && secondUnknown &&
-           winrt::get_abi(firstUnknown) == winrt::get_abi(secondUnknown);
-}
-
-void AttachDotTrackingHandlers(TrackedButton& tracked,
-                               FrameworkElement taskListButton,
-                               FrameworkElement icon,
-                               Controls::Grid dotHost) {
-    auto existingIcon = tracked.dotIcon.get();
-    auto existingHost = tracked.dotHost.get();
-    auto existingPointerSource = tracked.dotPointerSource.get();
-    if (tracked.dotLayoutUpdatedAttached &&
-        tracked.dotPointerMovedAttached && existingIcon && existingHost &&
-        existingPointerSource &&
-        IsSameWinrtObject(existingIcon, icon) &&
-        IsSameWinrtObject(existingHost, dotHost) &&
-        IsSameWinrtObject(existingPointerSource, taskListButton)) {
-        StartDotGeometryTracking();
-        return;
-    }
-
-    DetachDotTrackingHandlers(tracked);
-
-    auto pointerSource = taskListButton.try_as<UIElement>();
-    if (!pointerSource) {
-        return;
-    }
-
-    try {
-        tracked.dotIcon = winrt::make_weak(icon);
-        tracked.dotHost = winrt::make_weak(dotHost);
-        tracked.dotPointerSource = winrt::make_weak(pointerSource);
-        tracked.dotLayoutUpdatedToken = icon.LayoutUpdated(
-            [](winrt::Windows::Foundation::IInspectable const&,
-               winrt::Windows::Foundation::IInspectable const&) {
-                StartDotGeometryTracking();
-            });
-        tracked.dotLayoutUpdatedAttached = true;
-
-        tracked.dotPointerMovedHandler =
-            winrt::box_value(Input::PointerEventHandler{
-                [](winrt::Windows::Foundation::IInspectable const&,
-                   Input::PointerRoutedEventArgs const&) {
-                    StartDotGeometryTracking();
-                }});
-        pointerSource.AddHandler(UIElement::PointerMovedEvent(),
-                                 tracked.dotPointerMovedHandler, true);
-        tracked.dotPointerMovedAttached = true;
-        StartDotGeometryTracking();
-    } catch (...) {
-        DetachDotTrackingHandlers(tracked);
-    }
-}
-
-Controls::Border CreateCountBadge(Controls::Panel parent) {
+Controls::Border CreateCountBadge(Controls::Panel parent)
+{
     PCWSTR xaml =
         LR"(
 <Border
@@ -1345,54 +1289,72 @@ Controls::Border CreateCountBadge(Controls::Panel parent) {
     return badge;
 }
 
-bool IsTrackedBadge(Controls::Border const& badge) {
-    for (auto const& item : TrackedButtons()) {
+void RemoveOrphanDotBadges(Controls::Grid const &dotHost)
+{
+    // RootGrid is shared by all taskbar buttons. Build the set once, then scan
+    // the grid, instead of rescanning the tracked list for every child.
+    std::unordered_set<void *> trackedBadgeIdentities;
+    trackedBadgeIdentities.reserve(TrackedButtons().size());
+    for (auto const &item : TrackedButtons())
+    {
         auto trackedBadge = item.badge.get();
-        if (trackedBadge && IsSameWinrtObject(trackedBadge, badge)) {
-            return true;
+        if (!trackedBadge)
+        {
+            continue;
+        }
+        auto unknown = trackedBadge.try_as<winrt::Windows::Foundation::IUnknown>();
+        if (unknown)
+        {
+            trackedBadgeIdentities.insert(winrt::get_abi(unknown));
         }
     }
-    return false;
-}
 
-void RemoveOrphanDotBadges(Controls::Grid const& dotHost) {
     auto children = dotHost.Children();
-    for (uint32_t i = children.Size(); i > 0; --i) {
+    for (uint32_t i = children.Size(); i > 0; --i)
+    {
         auto badge = children.GetAt(i - 1).try_as<Controls::Border>();
-        if (!badge || badge.Name() != L"WindhawkCountBadge" ||
-            IsTrackedBadge(badge)) {
+        if (!badge || badge.Name() != L"WindhawkCountBadge")
+        {
             continue;
         }
 
+        auto unknown = badge.try_as<winrt::Windows::Foundation::IUnknown>();
+        if (unknown && trackedBadgeIdentities.contains(winrt::get_abi(unknown)))
+        {
+            continue;
+        }
+
+        StopDotPositionBinding(badge);
         children.RemoveAt(i - 1);
     }
 }
 
-bool UpdateCountBadge(TrackedButton& tracked,
+bool UpdateCountBadge(TrackedButton &tracked,
                       FrameworkElement taskListButton,
-                      unsigned int count) {
-    if (g_unloading) {
+                      unsigned int count)
+{
+    if (g_unloading)
+    {
         return false;
-    }
-
-    if (g_settings.displayStyle != DisplayStyle::Dots) {
-        DetachDotTrackingHandlers(tracked);
     }
 
     auto iconPanelElement = FindChildByName(taskListButton, L"IconPanel");
 
-    if (!iconPanelElement) {
+    if (!iconPanelElement)
+    {
         return false;
     }
 
     auto iconPanel = iconPanelElement.try_as<Controls::Panel>();
 
-    if (!iconPanel) {
+    if (!iconPanel)
+    {
         return false;
     }
 
     auto badge = tracked.badge.get();
-    if (badge && badge.Name() != L"WindhawkCountBadge") {
+    if (badge && badge.Name() != L"WindhawkCountBadge")
+    {
         badge = nullptr;
         tracked.badge = {};
     }
@@ -1400,15 +1362,19 @@ bool UpdateCountBadge(TrackedButton& tracked,
     auto iconPanelBadge =
         FindChildByName(iconPanelElement, L"WindhawkCountBadge")
             .try_as<Controls::Border>();
-    if (!badge) {
+    if (!badge)
+    {
         badge = iconPanelBadge;
-    } else if (iconPanelBadge &&
-               winrt::get_abi(iconPanelBadge) != winrt::get_abi(badge)) {
+    }
+    else if (iconPanelBadge &&
+             winrt::get_abi(iconPanelBadge) != winrt::get_abi(badge))
+    {
         RemoveBadgeFromPanel(iconPanel, iconPanelBadge);
     }
 
     // Rebuild badges created by older visual-layout versions.
-    if (badge) {
+    if (badge)
+    {
         auto circleVisual = FindChildByName(badge, L"WindhawkCircleVisual");
 
         auto badgeVisual = FindChildByName(badge, L"WindhawkBadgeVisual");
@@ -1417,7 +1383,8 @@ bool UpdateCountBadge(TrackedButton& tracked,
 
         auto dotStack = FindChildByName(badge, L"WindhawkDotStack");
 
-        if (!circleVisual || !badgeVisual || !countText || !dotStack) {
+        if (!circleVisual || !badgeVisual || !countText || !dotStack)
+        {
             RemoveBadgeFromCurrentParent(badge);
 
             badge = nullptr;
@@ -1428,13 +1395,16 @@ bool UpdateCountBadge(TrackedButton& tracked,
     FrameworkElement icon = nullptr;
     Controls::Grid dotHost = nullptr;
     Controls::Panel desiredParent = iconPanel;
-    if (g_settings.displayStyle == DisplayStyle::Dots) {
+    if (g_settings.displayStyle == DisplayStyle::Dots)
+    {
         icon = FindChildByName(iconPanelElement, L"Icon");
         dotHost = FindDotHostGrid(taskListButton, iconPanelElement);
         if (!icon || icon.ActualWidth() <= 0 || icon.ActualHeight() <= 0 ||
-            !dotHost) {
-            DetachDotTrackingHandlers(tracked);
-            if (badge) {
+            !dotHost)
+        {
+            if (badge)
+            {
+                StopDotPositionBinding(badge);
                 badge.Visibility(Visibility::Collapsed);
             }
             return false;
@@ -1448,11 +1418,15 @@ bool UpdateCountBadge(TrackedButton& tracked,
         RemoveOrphanDotBadges(dotHost);
     }
 
-    if (badge) {
+    if (badge)
+    {
         auto currentParent = badge.Parent().try_as<Controls::Panel>();
         if (!currentParent ||
-            winrt::get_abi(currentParent) != winrt::get_abi(desiredParent)) {
-            if (currentParent) {
+            winrt::get_abi(currentParent) != winrt::get_abi(desiredParent))
+        {
+            StopDotPositionBinding(badge);
+            if (currentParent)
+            {
                 RemoveBadgeFromPanel(currentParent, badge);
             }
             desiredParent.Children().Append(badge);
@@ -1460,24 +1434,28 @@ bool UpdateCountBadge(TrackedButton& tracked,
         tracked.badge = winrt::make_weak(badge);
     }
 
-    if (count < static_cast<unsigned int>(g_settings.minimumCount)) {
-        DetachDotTrackingHandlers(tracked);
-        if (badge) {
+    if (count < static_cast<unsigned int>(g_settings.minimumCount))
+    {
+        if (badge)
+        {
+            StopDotPositionBinding(badge);
             badge.Visibility(Visibility::Collapsed);
         }
 
         return true;
     }
 
-    if (!badge) {
+    if (!badge)
+    {
         badge = CreateCountBadge(desiredParent);
         tracked.badge = winrt::make_weak(badge);
     }
 
-    ApplyBadgeVisualStyle(badge, count, icon, dotHost);
-
-    if (g_settings.displayStyle == DisplayStyle::Dots) {
-        AttachDotTrackingHandlers(tracked, taskListButton, icon, dotHost);
+    if (!ApplyBadgeVisualStyle(badge, count, icon, dotHost))
+    {
+        StopDotPositionBinding(badge);
+        badge.Visibility(Visibility::Collapsed);
+        return false;
     }
 
     badge.Visibility(Visibility::Visible);
@@ -1488,37 +1466,48 @@ bool UpdateCountBadge(TrackedButton& tracked,
 // Direct taskbar group count / tracked buttons
 // -----------------------------------------------------------------------------
 
-void PruneDeadTrackedButtons() {
-    for (auto it = TrackedButtons().begin(); it != TrackedButtons().end();) {
-        if (!it->element.get()) {
-            DetachDotTrackingHandlers(*it);
-            if (auto badge = it->badge.get()) {
+void PruneDeadTrackedButtons()
+{
+    for (auto it = TrackedButtons().begin(); it != TrackedButtons().end();)
+    {
+        if (!it->element.get())
+        {
+            if (auto badge = it->badge.get())
+            {
+                StopDotPositionBinding(badge);
                 RemoveBadgeFromCurrentParent(badge);
             }
             it = TrackedButtons().erase(it);
-        } else {
+        }
+        else
+        {
             ++it;
         }
     }
 }
 
-TrackedButton* TrackTaskbarButton(FrameworkElement element) {
+TrackedButton *TrackTaskbarButton(FrameworkElement element)
+{
     auto unknown = element.as<winrt::Windows::Foundation::IUnknown>();
-    void* identity = winrt::get_abi(unknown);
+    void *identity = winrt::get_abi(unknown);
 
     auto existing =
         std::find_if(TrackedButtons().begin(), TrackedButtons().end(),
-                     [identity](const TrackedButton& item) {
+                     [identity](const TrackedButton &item)
+                     {
                          return item.identity == identity;
                      });
 
-    if (existing != TrackedButtons().end()) {
+    if (existing != TrackedButtons().end())
+    {
         // The taskbar recycles button containers. If the previous element at
         // this identity is already gone, treat this as a fresh button and
         // reset the cached visual state.
-        if (!existing->element.get()) {
-            DetachDotTrackingHandlers(*existing);
-            if (auto badge = existing->badge.get()) {
+        if (!existing->element.get())
+        {
+            if (auto badge = existing->badge.get())
+            {
+                StopDotPositionBinding(badge);
                 RemoveBadgeFromCurrentParent(badge);
             }
             existing->element = winrt::make_weak(element);
@@ -1540,9 +1529,11 @@ TrackedButton* TrackTaskbarButton(FrameworkElement element) {
 }
 
 bool GetTaskbarButtonViewModelCount(FrameworkElement element,
-                                    unsigned int* count) {
+                                    unsigned int *count)
+{
     if (!count || !TryGetItemFromContainer_TaskListGroupViewModel_Original ||
-        !GetViewModelCount_Original) {
+        !GetViewModelCount_Original)
+    {
         return false;
     }
 
@@ -1553,12 +1544,14 @@ bool GetTaskbarButtonViewModelCount(FrameworkElement element,
     TryGetItemFromContainer_TaskListGroupViewModel_Original(
         groupViewModel.put_void(), &uiElement);
 
-    if (!groupViewModel) {
+    if (!groupViewModel)
+    {
         return false;
     }
 
     HRESULT hr = GetViewModelCount_Original(groupViewModel.get(), count);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         return false;
     }
 
@@ -1566,15 +1559,18 @@ bool GetTaskbarButtonViewModelCount(FrameworkElement element,
     return true;
 }
 
-void ApplyCountToTrackedButton(TrackedButton& item, unsigned int count) {
+void ApplyCountToTrackedButton(TrackedButton &item, unsigned int count)
+{
     uint64_t settingsGeneration = g_settingsGeneration;
     if (item.lastAppliedCount == count &&
-        item.lastSettingsGeneration == settingsGeneration) {
+        item.lastSettingsGeneration == settingsGeneration)
+    {
         return;
     }
 
     auto element = item.element.get();
-    if (!element) {
+    if (!element)
+    {
         return;
     }
 
@@ -1586,21 +1582,27 @@ void ApplyCountToTrackedButton(TrackedButton& item, unsigned int count) {
     item.lastAppliedCount = count;
     item.lastSettingsGeneration = settingsGeneration;
 
-    try {
-        if (!UpdateCountBadge(item, element, count)) {
+    try
+    {
+        if (!UpdateCountBadge(item, element, count))
+        {
             item.lastAppliedCount = previousCount;
             item.lastSettingsGeneration = previousGeneration;
         }
-    } catch (...) {
+    }
+    catch (...)
+    {
         item.lastAppliedCount = previousCount;
         item.lastSettingsGeneration = previousGeneration;
         throw;
     }
 }
 
-void ApplyCountToButton(FrameworkElement element) {
-    auto* tracked = TrackTaskbarButton(element);
-    if (!tracked) {
+void ApplyCountToButton(FrameworkElement element)
+{
+    auto *tracked = TrackTaskbarButton(element);
+    if (!tracked)
+    {
         return;
     }
 
@@ -1613,21 +1615,25 @@ void ApplyCountToButton(FrameworkElement element) {
     ApplyCountToTrackedButton(*tracked, haveCount ? count : 0);
 }
 
-void RefreshAllTrackedButtons() {
+void RefreshAllTrackedButtons()
+{
     PruneDeadTrackedButtons();
 
     std::vector<winrt::weak_ref<FrameworkElement>> buttonSnapshot;
     buttonSnapshot.reserve(TrackedButtons().size());
-    for (auto const& item : TrackedButtons()) {
+    for (auto const &item : TrackedButtons())
+    {
         buttonSnapshot.push_back(item.element);
     }
 
     // Refresh through the element identity instead of retaining a list
     // iterator/reference across XAML mutations. A nested refresh can prune or
     // otherwise update the tracked list without invalidating this snapshot.
-    for (auto const& weakElement : buttonSnapshot) {
+    for (auto const &weakElement : buttonSnapshot)
+    {
         auto element = weakElement.get();
-        if (!element) {
+        if (!element)
+        {
             continue;
         }
         ApplyCountToButton(element);
@@ -1638,28 +1644,36 @@ void RefreshAllTrackedButtons() {
 // Existing XAML tree enumeration
 // -----------------------------------------------------------------------------
 
-int EnumerateExistingTaskbarButtons(FrameworkElement element) {
-    if (!element) {
+int EnumerateExistingTaskbarButtons(FrameworkElement element)
+{
+    if (!element)
+    {
         return 0;
     }
 
     int found = 0;
 
-    try {
-        if (element.Name() == L"TaskListButton") {
+    try
+    {
+        if (element.Name() == L"TaskListButton")
+        {
             ApplyCountToButton(element);
             ++found;
         }
 
         int children = Media::VisualTreeHelper::GetChildrenCount(element);
-        for (int i = 0; i < children; ++i) {
+        for (int i = 0; i < children; ++i)
+        {
             auto child = Media::VisualTreeHelper::GetChild(element, i)
                              .try_as<FrameworkElement>();
-            if (child) {
+            if (child)
+            {
                 found += EnumerateExistingTaskbarButtons(child);
             }
         }
-    } catch (...) {
+    }
+    catch (...)
+    {
     }
 
     return found;
@@ -1669,9 +1683,12 @@ int EnumerateExistingTaskbarButtons(FrameworkElement element) {
 // Existing taskbar XamlRoot
 // -----------------------------------------------------------------------------
 
-XamlRoot XamlRootFromTaskbarHostSharedPtr(void* hostShared[2]) {
-    if (!hostShared[0]) {
-        if (hostShared[1]) {
+XamlRoot XamlRootFromTaskbarHostSharedPtr(void *hostShared[2])
+{
+    if (!hostShared[0])
+    {
+        if (hostShared[1])
+        {
             g_RefCount_Decref(hostShared[1]);
         }
         return nullptr;
@@ -1682,12 +1699,15 @@ XamlRoot XamlRootFromTaskbarHostSharedPtr(void* hostShared[2]) {
     size_t elementOffset = 0x48;
 
 #if defined(_M_X64)
-    const BYTE* code = reinterpret_cast<const BYTE*>(g_TaskbarHost_FrameHeight);
+    const BYTE *code = reinterpret_cast<const BYTE *>(g_TaskbarHost_FrameHeight);
     if (code[0] == 0x48 && code[1] == 0x83 && code[2] == 0xEC &&
         code[4] == 0x48 && code[5] == 0x83 && code[6] == 0xC1 &&
-        code[7] <= 0x7F) {
+        code[7] <= 0x7F)
+    {
         elementOffset = code[7];
-    } else {
+    }
+    else
+    {
         Wh_Log(L"Couldn't detect TaskbarHost XAML offset, using 0x48");
     }
 #elif defined(_M_ARM64)
@@ -1696,98 +1716,114 @@ XamlRoot XamlRootFromTaskbarHostSharedPtr(void* hostShared[2]) {
 #error "Unsupported architecture"
 #endif
 
-    IUnknown* xamlUnknown = *reinterpret_cast<IUnknown**>(
-        reinterpret_cast<BYTE*>(hostShared[0]) + elementOffset);
+    IUnknown *xamlUnknown = *reinterpret_cast<IUnknown **>(
+        reinterpret_cast<BYTE *>(hostShared[0]) + elementOffset);
 
     FrameworkElement taskbarElement = nullptr;
-    if (xamlUnknown) {
+    if (xamlUnknown)
+    {
         xamlUnknown->QueryInterface(winrt::guid_of<FrameworkElement>(),
                                     winrt::put_abi(taskbarElement));
     }
 
     XamlRoot result = taskbarElement ? taskbarElement.XamlRoot() : nullptr;
 
-    if (hostShared[1]) {
+    if (hostShared[1])
+    {
         g_RefCount_Decref(hostShared[1]);
     }
 
     return result;
 }
 
-XamlRoot GetTaskbarXamlRoot(HWND taskbarWnd) {
+XamlRoot GetTaskbarXamlRoot(HWND taskbarWnd)
+{
     if (!taskbarWnd || !g_CTaskBand_ITaskListWndSite_vftable ||
         !g_CTaskBand_GetTaskbarHost || !g_TaskbarHost_FrameHeight ||
-        !g_RefCount_Decref) {
+        !g_RefCount_Decref)
+    {
         return nullptr;
     }
 
     HWND taskBandWnd =
         reinterpret_cast<HWND>(GetPropW(taskbarWnd, L"TaskbandHWND"));
-    if (!taskBandWnd) {
+    if (!taskBandWnd)
+    {
         Wh_Log(L"TaskbandHWND not found");
         return nullptr;
     }
 
-    void* taskBand = reinterpret_cast<void*>(GetWindowLongPtrW(taskBandWnd, 0));
-    if (!taskBand) {
+    void *taskBand = reinterpret_cast<void *>(GetWindowLongPtrW(taskBandWnd, 0));
+    if (!taskBand)
+    {
         return nullptr;
     }
 
-    void* site = taskBand;
+    void *site = taskBand;
     bool siteFound = false;
-    for (int i = 0; i < 20; ++i) {
-        if (*reinterpret_cast<void**>(site) ==
-            g_CTaskBand_ITaskListWndSite_vftable) {
+    for (int i = 0; i < 20; ++i)
+    {
+        if (*reinterpret_cast<void **>(site) ==
+            g_CTaskBand_ITaskListWndSite_vftable)
+        {
             siteFound = true;
             break;
         }
-        site = reinterpret_cast<void**>(site) + 1;
+        site = reinterpret_cast<void **>(site) + 1;
     }
 
-    if (!siteFound) {
+    if (!siteFound)
+    {
         Wh_Log(L"ITaskListWndSite not found for primary taskbar");
         return nullptr;
     }
 
-    void* hostShared[2] = {};
+    void *hostShared[2] = {};
     g_CTaskBand_GetTaskbarHost(site, hostShared);
     return XamlRootFromTaskbarHostSharedPtr(hostShared);
 }
 
-XamlRoot GetSecondaryTaskbarXamlRoot(HWND taskbarWnd) {
+XamlRoot GetSecondaryTaskbarXamlRoot(HWND taskbarWnd)
+{
     if (!taskbarWnd || !g_CSecondaryTaskBand_ITaskListWndSite_vftable ||
         !g_CSecondaryTaskBand_GetTaskbarHost || !g_TaskbarHost_FrameHeight ||
-        !g_RefCount_Decref) {
+        !g_RefCount_Decref)
+    {
         return nullptr;
     }
 
     HWND taskBandWnd = FindWindowExW(taskbarWnd, nullptr, L"WorkerW", nullptr);
-    if (!taskBandWnd) {
+    if (!taskBandWnd)
+    {
         return nullptr;
     }
 
-    void* taskBand = reinterpret_cast<void*>(GetWindowLongPtrW(taskBandWnd, 0));
-    if (!taskBand) {
+    void *taskBand = reinterpret_cast<void *>(GetWindowLongPtrW(taskBandWnd, 0));
+    if (!taskBand)
+    {
         return nullptr;
     }
 
-    void* site = taskBand;
+    void *site = taskBand;
     bool siteFound = false;
-    for (int i = 0; i < 20; ++i) {
-        if (*reinterpret_cast<void**>(site) ==
-            g_CSecondaryTaskBand_ITaskListWndSite_vftable) {
+    for (int i = 0; i < 20; ++i)
+    {
+        if (*reinterpret_cast<void **>(site) ==
+            g_CSecondaryTaskBand_ITaskListWndSite_vftable)
+        {
             siteFound = true;
             break;
         }
-        site = reinterpret_cast<void**>(site) + 1;
+        site = reinterpret_cast<void **>(site) + 1;
     }
 
-    if (!siteFound) {
+    if (!siteFound)
+    {
         Wh_Log(L"ITaskListWndSite not found for secondary taskbar");
         return nullptr;
     }
 
-    void* hostShared[2] = {};
+    void *hostShared[2] = {};
     g_CSecondaryTaskBand_GetTaskbarHost(site, hostShared);
     return XamlRootFromTaskbarHostSharedPtr(hostShared);
 }
@@ -1796,20 +1832,24 @@ XamlRoot GetSecondaryTaskbarXamlRoot(HWND taskbarWnd) {
 // Run synchronously on taskbar UI thread
 // -----------------------------------------------------------------------------
 
-using TaskbarThreadProc = void(WINAPI*)(void* parameter);
+using TaskbarThreadProc = void(WINAPI *)(void *parameter);
 
-bool RunOnTaskbarThread(HWND hWnd, TaskbarThreadProc proc, void* parameter) {
-    if (!hWnd || !proc) {
+bool RunOnTaskbarThread(HWND hWnd, TaskbarThreadProc proc, void *parameter)
+{
+    if (!hWnd || !proc)
+    {
         return false;
     }
 
     DWORD threadId = GetWindowThreadProcessId(hWnd, nullptr);
 
-    if (!threadId) {
+    if (!threadId)
+    {
         return false;
     }
 
-    if (threadId == GetCurrentThreadId()) {
+    if (threadId == GetCurrentThreadId())
+    {
         proc(parameter);
 
         return true;
@@ -1818,25 +1858,31 @@ bool RunOnTaskbarThread(HWND hWnd, TaskbarThreadProc proc, void* parameter) {
     static UINT message =
         RegisterWindowMessageW(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
 
-    if (!message) {
+    if (!message)
+    {
         return false;
     }
 
-    struct Request {
+    struct Request
+    {
         TaskbarThreadProc proc;
-        void* parameter;
+        void *parameter;
     };
 
     HHOOK hook = SetWindowsHookExW(
         WH_CALLWNDPROC,
-        [](int code, WPARAM wParam, LPARAM lParam) -> LRESULT {
-            if (code == HC_ACTION) {
-                auto data = reinterpret_cast<CWPSTRUCT*>(lParam);
+        [](int code, WPARAM wParam, LPARAM lParam) -> LRESULT
+        {
+            if (code == HC_ACTION)
+            {
+                auto data = reinterpret_cast<CWPSTRUCT *>(lParam);
 
-                if (data->message == message) {
-                    auto request = reinterpret_cast<Request*>(data->lParam);
+                if (data->message == message)
+                {
+                    auto request = reinterpret_cast<Request *>(data->lParam);
 
-                    if (request && request->proc) {
+                    if (request && request->proc)
+                    {
                         request->proc(request->parameter);
                     }
                 }
@@ -1846,7 +1892,8 @@ bool RunOnTaskbarThread(HWND hWnd, TaskbarThreadProc proc, void* parameter) {
         },
         nullptr, threadId);
 
-    if (!hook) {
+    if (!hook)
+    {
         return false;
     }
 
@@ -1862,19 +1909,23 @@ bool RunOnTaskbarThread(HWND hWnd, TaskbarThreadProc proc, void* parameter) {
     return true;
 }
 
-HWND FindWindowOnThread(DWORD threadId) {
-    if (!threadId) {
+HWND FindWindowOnThread(DWORD threadId)
+{
+    if (!threadId)
+    {
         return nullptr;
     }
 
-    struct Context {
+    struct Context
+    {
         HWND hWnd = nullptr;
     } context;
 
     EnumThreadWindows(
         threadId,
-        [](HWND hWnd, LPARAM lParam) -> BOOL {
-            auto* context = reinterpret_cast<Context*>(lParam);
+        [](HWND hWnd, LPARAM lParam) -> BOOL
+        {
+            auto *context = reinterpret_cast<Context *>(lParam);
             context->hWnd = hWnd;
             return FALSE;
         },
@@ -1891,12 +1942,18 @@ LRESULT CALLBACK TaskbarWindowSubclassProc(HWND hWnd,
                                            UINT message,
                                            WPARAM wParam,
                                            LPARAM lParam,
-                                           DWORD_PTR) {
-    if (message == g_deferredCountRefreshMessage) {
-        if (!g_unloading) {
-            try {
+                                           DWORD_PTR)
+{
+    if (message == g_deferredCountRefreshMessage)
+    {
+        if (!g_unloading)
+        {
+            try
+            {
                 RefreshAllTrackedButtons();
-            } catch (...) {
+            }
+            catch (...)
+            {
                 Wh_Log(L"Deferred count refresh failed");
             }
         }
@@ -1908,7 +1965,8 @@ LRESULT CALLBACK TaskbarWindowSubclassProc(HWND hWnd,
     }
 
     if (message == WM_NCDESTROY &&
-        g_taskbarSubclassWindow.load() == hWnd) {
+        g_taskbarSubclassWindow.load() == hWnd)
+    {
         g_taskbarSubclassWindow = nullptr;
         g_deferredCountRefreshQueued = false;
     }
@@ -1916,8 +1974,10 @@ LRESULT CALLBACK TaskbarWindowSubclassProc(HWND hWnd,
     return DefSubclassProc(hWnd, message, wParam, lParam);
 }
 
-bool EnsureDeferredCountRefreshSubclass() {
-    if (g_unloading) {
+bool EnsureDeferredCountRefreshSubclass()
+{
+    if (g_unloading)
+    {
         return false;
     }
 
@@ -1925,17 +1985,20 @@ bool EnsureDeferredCountRefreshSubclass() {
     // subclass is still live. Avoid a desktop-wide EnumWindows sweep on every
     // TaskListButton::UpdateVisualStates call.
     HWND existingWindow = g_taskbarSubclassWindow.load();
-    if (existingWindow) {
+    if (existingWindow)
+    {
         return true;
     }
 
     HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
-    if (!taskbarWnd) {
+    if (!taskbarWnd)
+    {
         return false;
     }
 
     if (!WindhawkUtils::SetWindowSubclassFromAnyThread(
-            taskbarWnd, TaskbarWindowSubclassProc, 0)) {
+            taskbarWnd, TaskbarWindowSubclassProc, 0))
+    {
         return false;
     }
 
@@ -1944,30 +2007,37 @@ bool EnsureDeferredCountRefreshSubclass() {
     return true;
 }
 
-void StopDeferredCountRefreshSubclass() {
+void StopDeferredCountRefreshSubclass()
+{
     HWND taskbarWnd = g_taskbarSubclassWindow.exchange(nullptr);
     g_deferredCountRefreshQueued = false;
-    if (taskbarWnd) {
+    if (taskbarWnd)
+    {
         WindhawkUtils::RemoveWindowSubclassFromAnyThread(
             taskbarWnd, TaskbarWindowSubclassProc);
     }
 }
 
-void QueueDeferredCountRefresh() {
-    if (g_unloading || !g_deferredCountRefreshMessage) {
+void QueueDeferredCountRefresh()
+{
+    if (g_unloading || !g_deferredCountRefreshMessage)
+    {
         return;
     }
 
     HWND taskbarWnd = g_taskbarSubclassWindow.load();
-    if (!taskbarWnd) {
+    if (!taskbarWnd)
+    {
         return;
     }
 
-    if (g_deferredCountRefreshQueued.exchange(true)) {
+    if (g_deferredCountRefreshQueued.exchange(true))
+    {
         return;
     }
 
-    if (!PostMessageW(taskbarWnd, g_deferredCountRefreshMessage, 0, 0)) {
+    if (!PostMessageW(taskbarWnd, g_deferredCountRefreshMessage, 0, 0))
+    {
         g_deferredCountRefreshQueued = false;
         Wh_Log(L"Failed to queue deferred count refresh");
     }
@@ -1977,13 +2047,16 @@ void QueueDeferredCountRefresh() {
 // Existing taskbar initialization
 // -----------------------------------------------------------------------------
 
-struct ExistingButtonsInitContext {
+struct ExistingButtonsInitContext
+{
     int taskbarCount = 0;
     int buttonCount = 0;
 };
 
-void WINAPI InitializeExistingButtonsOnTaskbarThread(void*) {
-    if (!EnsureDeferredCountRefreshSubclass()) {
+void WINAPI InitializeExistingButtonsOnTaskbarThread(void *)
+{
+    if (!EnsureDeferredCountRefreshSubclass())
+    {
         Wh_Log(L"Failed to install deferred count refresh subclass");
     }
 
@@ -1991,33 +2064,43 @@ void WINAPI InitializeExistingButtonsOnTaskbarThread(void*) {
 
     EnumThreadWindows(
         GetCurrentThreadId(),
-        [](HWND hWnd, LPARAM param) -> BOOL {
-            try {
-                auto* context =
-                    reinterpret_cast<ExistingButtonsInitContext*>(param);
+        [](HWND hWnd, LPARAM param) -> BOOL
+        {
+            try
+            {
+                auto *context =
+                    reinterpret_cast<ExistingButtonsInitContext *>(param);
 
                 WCHAR className[32] = {};
-                if (!GetClassNameW(hWnd, className, ARRAYSIZE(className))) {
+                if (!GetClassNameW(hWnd, className, ARRAYSIZE(className)))
+                {
                     return TRUE;
                 }
 
                 XamlRoot xamlRoot = nullptr;
-                if (_wcsicmp(className, L"Shell_TrayWnd") == 0) {
+                if (_wcsicmp(className, L"Shell_TrayWnd") == 0)
+                {
                     xamlRoot = GetTaskbarXamlRoot(hWnd);
-                } else if (_wcsicmp(className, L"Shell_SecondaryTrayWnd") ==
-                           0) {
+                }
+                else if (_wcsicmp(className, L"Shell_SecondaryTrayWnd") ==
+                         0)
+                {
                     xamlRoot = GetSecondaryTaskbarXamlRoot(hWnd);
-                } else {
+                }
+                else
+                {
                     return TRUE;
                 }
 
-                if (!xamlRoot) {
+                if (!xamlRoot)
+                {
                     Wh_Log(L"Failed to get taskbar XamlRoot for %s", className);
                     return TRUE;
                 }
 
                 auto content = xamlRoot.Content().try_as<FrameworkElement>();
-                if (!content) {
+                if (!content)
+                {
                     Wh_Log(L"XamlRoot content unavailable for %s", className);
                     return TRUE;
                 }
@@ -2025,7 +2108,9 @@ void WINAPI InitializeExistingButtonsOnTaskbarThread(void*) {
                 ++context->taskbarCount;
                 context->buttonCount +=
                     EnumerateExistingTaskbarButtons(content);
-            } catch (...) {
+            }
+            catch (...)
+            {
                 // Never let a C++/WinRT exception unwind through the Win32
                 // EnumThreadWindows callback boundary.
                 Wh_Log(L"Taskbar XamlRoot enumeration failed");
@@ -2043,42 +2128,46 @@ void WINAPI InitializeExistingButtonsOnTaskbarThread(void*) {
 // TaskListButton::UpdateVisualStates
 // -----------------------------------------------------------------------------
 
-using TaskListButton_UpdateVisualStates_t = void(__cdecl*)(void* pThis);
+using TaskListButton_UpdateVisualStates_t = void(__cdecl *)(void *pThis);
 TaskListButton_UpdateVisualStates_t TaskListButton_UpdateVisualStates_Original =
     nullptr;
 
-void __cdecl TaskListButton_UpdateVisualStates_Hook(void* pThis) {
+void __cdecl TaskListButton_UpdateVisualStates_Hook(void *pThis)
+{
     TaskListButton_UpdateVisualStates_Original(pThis);
 
-    if (g_unloading) {
+    if (g_unloading)
+    {
         return;
     }
 
-    try {
+    try
+    {
         EnsureDeferredCountRefreshSubclass();
-        void* taskListButtonIUnknownPtr = reinterpret_cast<void**>(pThis) + 3;
+        void *taskListButtonIUnknownPtr = reinterpret_cast<void **>(pThis) + 3;
 
         winrt::Windows::Foundation::IUnknown taskListButtonIUnknown;
         winrt::copy_from_abi(taskListButtonIUnknown, taskListButtonIUnknownPtr);
 
         auto element = taskListButtonIUnknown.try_as<FrameworkElement>();
-        if (!element) {
+        if (!element)
+        {
             return;
         }
 
         // If a settings-change callback couldn't marshal to the taskbar thread,
         // apply it here the next time the taskbar naturally updates a button.
-        if (g_settingsReloadPending.exchange(false)) {
+        if (g_settingsReloadPending.exchange(false))
+        {
             LoadSettings();
             RefreshAllTrackedButtons();
             Wh_Log(L"Deferred settings applied");
         }
 
         ApplyCountToButton(element);
-        if (g_settings.displayStyle == DisplayStyle::Dots) {
-            StartDotGeometryTracking();
-        }
-    } catch (...) {
+    }
+    catch (...)
+    {
         Wh_Log(L"TaskListButton update failed");
     }
 }
@@ -2087,10 +2176,12 @@ void __cdecl TaskListButton_UpdateVisualStates_Hook(void* pThis) {
 // TaskListGroupViewModel::get_ViewModelCount
 // -----------------------------------------------------------------------------
 
-HRESULT WINAPI GetViewModelCount_Hook(void* pThis, unsigned int* count) {
+HRESULT WINAPI GetViewModelCount_Hook(void *pThis, unsigned int *count)
+{
     HRESULT hr = GetViewModelCount_Original(pThis, count);
 
-    if (FAILED(hr) || !count || g_unloading) {
+    if (FAILED(hr) || !count || g_unloading)
+    {
         return hr;
     }
 
@@ -2106,17 +2197,22 @@ HRESULT WINAPI GetViewModelCount_Hook(void* pThis, unsigned int* count) {
 // Apply settings live
 // -----------------------------------------------------------------------------
 
-void WINAPI ApplySettingsOnTaskbarThread(void*) {
-    if (g_unloading) {
+void WINAPI ApplySettingsOnTaskbarThread(void *)
+{
+    if (g_unloading)
+    {
         return;
     }
 
     g_settingsReloadPending = false;
-    try {
+    try
+    {
         LoadSettings();
         RefreshAllTrackedButtons();
         Wh_Log(L"Settings applied");
-    } catch (...) {
+    }
+    catch (...)
+    {
         g_settingsReloadPending = true;
         Wh_Log(L"Settings apply failed");
     }
@@ -2126,46 +2222,55 @@ void WINAPI ApplySettingsOnTaskbarThread(void*) {
 // Cleanup
 // -----------------------------------------------------------------------------
 
-void CleanupOnTaskbarThread() {
-    StopDotGeometryTracking();
+void CleanupOnTaskbarThread()
+{
     PruneDeadTrackedButtons();
 
-    for (auto& item : TrackedButtons()) {
-        DetachDotTrackingHandlers(item);
+    for (auto &item : TrackedButtons())
+    {
         auto element = item.element.get();
         auto badge = item.badge.get();
-        if (badge) {
+        if (badge)
+        {
             RemoveBadgeFromCurrentParent(badge);
             item.badge = {};
         }
 
-        if (!element) {
+        if (!element)
+        {
             continue;
         }
         auto iconPanelElement = FindChildByName(element, L"IconPanel");
-        if (!iconPanelElement) {
+        if (!iconPanelElement)
+        {
             continue;
         }
 
         auto iconPanel = iconPanelElement.try_as<Controls::Panel>();
-        if (!iconPanel) {
+        if (!iconPanel)
+        {
             continue;
         }
 
         auto iconPanelBadge =
             FindChildByName(iconPanelElement, L"WindhawkCountBadge")
                 .try_as<Controls::Border>();
-        if (iconPanelBadge) {
+        if (iconPanelBadge)
+        {
             RemoveBadgeFromPanel(iconPanel, iconPanelBadge);
         }
     }
 }
 
-void WINAPI CleanupOnTaskbarThreadProc(void*) {
-    try {
+void WINAPI CleanupOnTaskbarThreadProc(void *)
+{
+    try
+    {
         CleanupOnTaskbarThread();
         Wh_Log(L"Cleanup complete");
-    } catch (...) {
+    }
+    catch (...)
+    {
         // Never allow a C++/WinRT exception to escape through the Win32 hook
         // callback used by RunOnTaskbarThread.
         Wh_Log(L"Cleanup failed");
@@ -2181,8 +2286,10 @@ void WINAPI CleanupOnTaskbarThreadProc(void*) {
 // Taskbar.View hooks
 // -----------------------------------------------------------------------------
 
-bool HookTaskbarView(HMODULE module) {
-    if (g_taskbarViewHooked.exchange(true)) {
+bool HookTaskbarView(HMODULE module)
+{
+    if (g_taskbarViewHooked.exchange(true))
+    {
         return true;
     }
 
@@ -2211,7 +2318,8 @@ bool HookTaskbarView(HMODULE module) {
     };
 
     if (!WindhawkUtils::HookSymbols(module, taskbarViewHooks,
-                                    ARRAYSIZE(taskbarViewHooks))) {
+                                    ARRAYSIZE(taskbarViewHooks)))
+    {
         g_taskbarViewHooked = false;
         Wh_Log(L"Taskbar.View hooks failed");
         return false;
@@ -2225,10 +2333,12 @@ bool HookTaskbarView(HMODULE module) {
 // taskbar.dll symbols for XamlRoot access
 // -----------------------------------------------------------------------------
 
-bool HookTaskbarDll() {
+bool HookTaskbarDll()
+{
     HMODULE module =
         LoadLibraryExW(L"taskbar.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-    if (!module) {
+    if (!module)
+    {
         Wh_Log(L"taskbar.dll load failed");
         return false;
     }
@@ -2273,7 +2383,8 @@ bool HookTaskbarDll() {
     };
 
     if (!WindhawkUtils::HookSymbols(module, taskbarDllHooks,
-                                    ARRAYSIZE(taskbarDllHooks))) {
+                                    ARRAYSIZE(taskbarDllHooks)))
+    {
         Wh_Log(L"taskbar.dll symbols failed");
         return false;
     }
@@ -2290,14 +2401,16 @@ using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 
 LoadLibraryExW_t LoadLibraryExW_Original = nullptr;
 
-HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName, HANDLE file, DWORD flags) {
+HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName, HANDLE file, DWORD flags)
+{
     HMODULE module = LoadLibraryExW_Original(fileName, file, flags);
 
-    if (module && !g_unloading && !g_taskbarViewHooked) {
-        HMODULE taskbarView = GetTaskbarViewModuleHandle();
-
-        if (taskbarView && taskbarView == module) {
-            if (HookTaskbarView(taskbarView)) {
+    if (module && !g_unloading && !g_taskbarViewHooked)
+    {
+        if (HMODULE taskbarView = GetTaskbarViewModuleHandle())
+        {
+            if (HookTaskbarView(taskbarView))
+            {
                 Wh_ApplyHookOperations();
             }
         }
@@ -2310,7 +2423,8 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName, HANDLE file, DWORD flags) {
 // Lifecycle
 // -----------------------------------------------------------------------------
 
-BOOL Wh_ModInit() {
+BOOL Wh_ModInit()
+{
     g_unloading = false;
     g_settingsReloadPending = false;
     g_deferredCountRefreshQueued = false;
@@ -2318,37 +2432,42 @@ BOOL Wh_ModInit() {
     g_taskbarSubclassWindow = nullptr;
     g_deferredCountRefreshMessage = RegisterWindowMessageW(
         L"Windhawk_DeferredCountRefresh_" WH_MOD_ID);
-    if (!g_deferredCountRefreshMessage) {
+    if (!g_deferredCountRefreshMessage)
+    {
         return FALSE;
     }
-    if (!g_trackedButtons) {
-        g_trackedButtons.emplace();
-    } else {
-        TrackedButtons().clear();
-    }
+    g_trackedButtons.emplace();
 
     LoadSettings();
     Wh_Log(L"Init PID=%lu", GetCurrentProcessId());
 
-    if (!HookTaskbarDll()) {
-        return FALSE;
+    if (!HookTaskbarDll())
+    {
+        // These symbols are only needed for the one-time sweep of already
+        // realized taskbar buttons. The core UpdateVisualStates path can still
+        // create/update badges as buttons naturally refresh.
+        Wh_Log(L"Continuing without initial taskbar XamlRoot enumeration");
     }
 
-    if (HMODULE module = GetTaskbarViewModuleHandle()) {
-        if (!HookTaskbarView(module)) {
+    if (HMODULE module = GetTaskbarViewModuleHandle())
+    {
+        if (!HookTaskbarView(module))
+        {
             return FALSE;
         }
         return TRUE;
     }
 
     HMODULE kernelBase = GetModuleHandleW(L"kernelbase.dll");
-    if (!kernelBase) {
+    if (!kernelBase)
+    {
         return FALSE;
     }
 
     auto loadLibraryExW = reinterpret_cast<decltype(&LoadLibraryExW)>(
         GetProcAddress(kernelBase, "LoadLibraryExW"));
-    if (!loadLibraryExW) {
+    if (!loadLibraryExW)
+    {
         return FALSE;
     }
 
@@ -2357,42 +2476,53 @@ BOOL Wh_ModInit() {
     return TRUE;
 }
 
-void Wh_ModAfterInit() {
+void Wh_ModAfterInit()
+{
     Wh_Log(L"After init");
 
     // Taskbar.View can load after Wh_ModInit checked for it but before the
     // LoadLibraryExW hook becomes active. Re-check after hook operations are
     // installed so that narrow startup race can't leave the mod unhooked.
-    if (!g_taskbarViewHooked) {
-        if (HMODULE module = GetTaskbarViewModuleHandle()) {
-            if (HookTaskbarView(module)) {
+    if (!g_taskbarViewHooked)
+    {
+        if (HMODULE module = GetTaskbarViewModuleHandle())
+        {
+            if (HookTaskbarView(module))
+            {
                 Wh_ApplyHookOperations();
-            } else {
+            }
+            else
+            {
                 Wh_Log(L"Late Taskbar.View hook failed");
             }
         }
     }
 
     HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
-    if (!taskbarWnd) {
+    if (!taskbarWnd)
+    {
         return;
     }
 
     if (!RunOnTaskbarThread(
-            taskbarWnd, InitializeExistingButtonsOnTaskbarThread, nullptr)) {
+            taskbarWnd, InitializeExistingButtonsOnTaskbarThread, nullptr))
+    {
         Wh_Log(L"Initial taskbar-thread execution failed");
     }
 }
 
-void Wh_ModSettingsChanged() {
+void Wh_ModSettingsChanged()
+{
     HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
     g_settingsReloadPending = true;
-    if (!taskbarWnd) {
+    if (!taskbarWnd)
+    {
         // Apply on the taskbar UI thread when a button is next realized.
         return;
     }
     if (!RunOnTaskbarThread(taskbarWnd, ApplySettingsOnTaskbarThread,
-                            nullptr)) {
+                            nullptr))
+    {
         // Don't rewrite std::wstring settings from this arbitrary callback
         // thread. The next TaskListButton update will apply the pending change
         // on the UI thread instead.
@@ -2400,7 +2530,8 @@ void Wh_ModSettingsChanged() {
     }
 }
 
-void Wh_ModBeforeUninit() {
+void Wh_ModBeforeUninit()
+{
     Wh_Log(L"Before uninit");
     g_unloading = true;
     g_settingsReloadPending = false;
@@ -2411,55 +2542,54 @@ void Wh_ModBeforeUninit() {
     DWORD taskbarThreadId = g_taskbarThreadId.load();
     StopDeferredCountRefreshSubclass();
 
-    auto tryCleanup = [](HWND hWnd) -> bool {
+    auto tryCleanup = [](HWND hWnd) -> bool
+    {
         return hWnd &&
                RunOnTaskbarThread(hWnd, CleanupOnTaskbarThreadProc, nullptr);
     };
 
     bool cleanedUp = tryCleanup(subclassWindow);
 
-    if (!cleanedUp) {
+    if (!cleanedUp)
+    {
         HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
-        if (taskbarWnd && taskbarWnd != subclassWindow) {
+        if (taskbarWnd && taskbarWnd != subclassWindow)
+        {
             DWORD windowThreadId =
                 GetWindowThreadProcessId(taskbarWnd, nullptr);
-            if (!taskbarThreadId || windowThreadId == taskbarThreadId) {
+            if (!taskbarThreadId || windowThreadId == taskbarThreadId)
+            {
                 cleanedUp = tryCleanup(taskbarWnd);
             }
         }
     }
 
-    if (!cleanedUp && taskbarThreadId) {
+    if (!cleanedUp && taskbarThreadId)
+    {
         HWND fallbackWnd = FindWindowOnThread(taskbarThreadId);
-        if (fallbackWnd && fallbackWnd != subclassWindow) {
+        if (fallbackWnd && fallbackWnd != subclassWindow)
+        {
             cleanedUp = tryCleanup(fallbackWnd);
         }
     }
 
-    if (!cleanedUp) {
-        // Don't clear/reset the tracked container here: it owns the strong
-        // PointerMoved handler objects, and dropping them off the taskbar UI
-        // thread is unsafe. Best-effort removal of the static Rendering event
-        // avoids leaving its callback registered if the taskbar thread is
-        // already unreachable. The no_destroy container intentionally remains
-        // alive until process termination in this exceptional path.
-        try {
-            StopDotGeometryTracking();
-        } catch (...) {
-        }
+    if (!cleanedUp)
+    {
+        // Dot positioning uses compositor expressions only; there are no XAML
+        // or CompositionTarget delegates pointing into the mod image. If the
+        // taskbar thread is already unreachable, leaving the no_destroy weak
+        // tracking state and any stale visual behind is safe: no code in this
+        // DLL remains callable after unload.
         Wh_Log(L"Couldn't execute taskbar-thread cleanup");
     }
 }
 
-void Wh_ModUninit() {
-    if (g_taskbarSubclassWindow.load()) {
-        StopDeferredCountRefreshSubclass();
-    }
-
-    // Normal unload resets g_trackedButtons in CleanupOnTaskbarThreadProc after
-    // all XAML handlers are detached on the taskbar thread. If cleanup couldn't
-    // be marshalled, leave the no_destroy container intact rather than releasing
-    // thread-affine XAML handler references from this arbitrary thread.
+void Wh_ModUninit()
+{
+    // Wh_ModBeforeUninit already removes the taskbar subclass. Normal cleanup
+    // also resets g_trackedButtons on the taskbar thread; if that thread was
+    // unreachable, the no_destroy weak-reference container is intentionally
+    // left intact until process termination.
     g_taskbarThreadId = 0;
     Wh_Log(L"Uninit");
 }

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -325,12 +325,15 @@ Settings g_settings;
 std::atomic<bool> g_taskbarViewHooked = false;
 std::atomic<bool> g_unloading = false;
 std::atomic<bool> g_settingsReloadPending = false;
+std::atomic<bool> g_deferredCountRefreshQueued = false;
 std::atomic<DWORD> g_taskbarThreadId = 0;
 uint64_t g_settingsGeneration = 0;
 
+HHOOK g_taskbarGetMessageHook = nullptr;
+UINT g_deferredCountRefreshMessage = 0;
+
 struct TrackedButton {
     void* identity = nullptr;
-    void* viewModel = nullptr;
     winrt::weak_ref<FrameworkElement> element;
     unsigned int lastAppliedCount = std::numeric_limits<unsigned int>::max();
     uint64_t lastSettingsGeneration = 0;
@@ -1124,9 +1127,7 @@ void PruneDeadTrackedButtons() {
     }
 }
 
-TrackedButton* TrackTaskbarButton(FrameworkElement element, void* viewModel) {
-    PruneDeadTrackedButtons();
-
+TrackedButton* TrackTaskbarButton(FrameworkElement element) {
     auto unknown = element.as<winrt::Windows::Foundation::IUnknown>();
     void* identity = winrt::get_abi(unknown);
 
@@ -1137,13 +1138,11 @@ TrackedButton* TrackTaskbarButton(FrameworkElement element, void* viewModel) {
                      });
 
     if (existing != g_trackedButtons.end()) {
-        existing->viewModel = viewModel;
         return &*existing;
     }
 
     g_trackedButtons.push_back({
         .identity = identity,
-        .viewModel = viewModel,
         .element = winrt::make_weak(element),
     });
 
@@ -1151,15 +1150,12 @@ TrackedButton* TrackTaskbarButton(FrameworkElement element, void* viewModel) {
 }
 
 bool GetTaskbarButtonViewModelCount(FrameworkElement element,
-                                    void** viewModel,
                                     unsigned int* count) {
-    if (!viewModel || !count ||
-        !TryGetItemFromContainer_TaskListGroupViewModel_Original ||
+    if (!count || !TryGetItemFromContainer_TaskListGroupViewModel_Original ||
         !GetViewModelCount_Original) {
         return false;
     }
 
-    *viewModel = nullptr;
     *count = 0;
 
     UIElement uiElement = element.as<UIElement>();
@@ -1170,8 +1166,6 @@ bool GetTaskbarButtonViewModelCount(FrameworkElement element,
     if (!groupViewModel) {
         return false;
     }
-
-    *viewModel = groupViewModel.get();
 
     HRESULT hr = GetViewModelCount_Original(groupViewModel.get(), count);
     if (FAILED(hr)) {
@@ -1195,8 +1189,8 @@ void ApplyCountToTrackedButton(TrackedButton& item, unsigned int count) {
     }
 
     // Mark the state before touching XAML so a synchronous re-entrant taskbar
-    // update doesn't apply the same visual change recursively. Roll it back if
-    // the visual couldn't be updated.
+    // update doesn't apply the same visual change recursively. TrackTaskbarButton
+    // never erases entries, so this reference stays valid across re-entry.
     unsigned int previousCount = item.lastAppliedCount;
     uint64_t previousGeneration = item.lastSettingsGeneration;
     item.lastAppliedCount = count;
@@ -1215,15 +1209,13 @@ void ApplyCountToTrackedButton(TrackedButton& item, unsigned int count) {
 }
 
 void ApplyCountToButton(FrameworkElement element) {
-    void* viewModel = nullptr;
-    unsigned int count = 0;
-    bool haveCount =
-        GetTaskbarButtonViewModelCount(element, &viewModel, &count);
-
-    auto* tracked = TrackTaskbarButton(element, viewModel);
+    auto* tracked = TrackTaskbarButton(element);
     if (!tracked) {
         return;
     }
+
+    unsigned int count = 0;
+    bool haveCount = GetTaskbarButtonViewModelCount(element, &count);
 
     // A recycled/pinned button can temporarily have no group view model. Treat
     // it as zero so a badge from the previous container contents can't remain
@@ -1232,6 +1224,8 @@ void ApplyCountToButton(FrameworkElement element) {
 }
 
 void RefreshAllTrackedButtons() {
+    // Prune before walking. TrackTaskbarButton doesn't prune, so XAML re-entry
+    // during this loop can't erase the element currently being visited.
     PruneDeadTrackedButtons();
 
     for (auto& item : g_trackedButtons) {
@@ -1240,28 +1234,9 @@ void RefreshAllTrackedButtons() {
             continue;
         }
 
-        void* viewModel = nullptr;
         unsigned int count = 0;
-        bool haveCount =
-            GetTaskbarButtonViewModelCount(element, &viewModel, &count);
-        item.viewModel = viewModel;
+        bool haveCount = GetTaskbarButtonViewModelCount(element, &count);
         ApplyCountToTrackedButton(item, haveCount ? count : 0);
-    }
-}
-
-void RefreshTrackedButtonsForViewModel(void* viewModel, unsigned int count) {
-    DWORD taskbarThreadId = g_taskbarThreadId.load();
-    if (!viewModel || !taskbarThreadId ||
-        taskbarThreadId != GetCurrentThreadId()) {
-        return;
-    }
-
-    PruneDeadTrackedButtons();
-
-    for (auto& item : g_trackedButtons) {
-        if (item.viewModel == viewModel) {
-            ApplyCountToTrackedButton(item, count);
-        }
     }
 }
 
@@ -1495,6 +1470,93 @@ bool RunOnTaskbarThread(HWND hWnd, TaskbarThreadProc proc, void* parameter) {
 }
 
 // -----------------------------------------------------------------------------
+// Deferred count refresh
+// -----------------------------------------------------------------------------
+
+LRESULT CALLBACK TaskbarGetMessageHookProc(int code,
+                                           WPARAM wParam,
+                                           LPARAM lParam) {
+    if (code >= 0 && wParam == PM_REMOVE && lParam) {
+        auto* message = reinterpret_cast<MSG*>(lParam);
+        if (g_deferredCountRefreshMessage &&
+            message->message == g_deferredCountRefreshMessage) {
+            // Consume the private thread message. The refresh now runs from the
+            // taskbar message loop, after the ViewModel getter/layout stack has
+            // returned, so XAML isn't mutated from inside the property getter.
+            message->message = WM_NULL;
+            g_deferredCountRefreshQueued = false;
+
+            if (!g_unloading) {
+                try {
+                    RefreshAllTrackedButtons();
+                } catch (...) {
+                    Wh_Log(L"Deferred count refresh failed");
+                }
+            }
+        }
+    }
+
+    return CallNextHookEx(g_taskbarGetMessageHook, code, wParam, lParam);
+}
+
+bool EnsureDeferredCountRefreshHookOnTaskbarThread() {
+    DWORD threadId = GetCurrentThreadId();
+
+    if (g_taskbarGetMessageHook && g_taskbarThreadId.load() == threadId) {
+        return true;
+    }
+
+    if (g_taskbarGetMessageHook) {
+        UnhookWindowsHookEx(g_taskbarGetMessageHook);
+        g_taskbarGetMessageHook = nullptr;
+    }
+
+    g_taskbarThreadId = threadId;
+
+    if (!g_deferredCountRefreshMessage) {
+        g_deferredCountRefreshMessage = RegisterWindowMessageW(
+            L"Windhawk_TaskbarCountBadges_DeferredCountRefresh");
+        if (!g_deferredCountRefreshMessage) {
+            return false;
+        }
+    }
+
+    g_taskbarGetMessageHook = SetWindowsHookExW(
+        WH_GETMESSAGE, TaskbarGetMessageHookProc, nullptr, threadId);
+    return g_taskbarGetMessageHook != nullptr;
+}
+
+void StopDeferredCountRefreshHook() {
+    if (g_taskbarGetMessageHook) {
+        UnhookWindowsHookEx(g_taskbarGetMessageHook);
+        g_taskbarGetMessageHook = nullptr;
+    }
+
+    g_deferredCountRefreshQueued = false;
+}
+
+void QueueDeferredCountRefresh() {
+    if (g_unloading || !g_taskbarGetMessageHook ||
+        !g_deferredCountRefreshMessage) {
+        return;
+    }
+
+    DWORD threadId = g_taskbarThreadId.load();
+    if (!threadId || threadId != GetCurrentThreadId()) {
+        return;
+    }
+
+    if (g_deferredCountRefreshQueued.exchange(true)) {
+        return;
+    }
+
+    if (!PostThreadMessageW(threadId, g_deferredCountRefreshMessage, 0, 0)) {
+        g_deferredCountRefreshQueued = false;
+        Wh_Log(L"Failed to queue deferred count refresh");
+    }
+}
+
+// -----------------------------------------------------------------------------
 // Existing taskbar initialization
 // -----------------------------------------------------------------------------
 
@@ -1504,13 +1566,16 @@ struct ExistingButtonsInitContext {
 };
 
 void WINAPI InitializeExistingButtonsOnTaskbarThread(void*) {
-    g_taskbarThreadId = GetCurrentThreadId();
+    if (!EnsureDeferredCountRefreshHookOnTaskbarThread()) {
+        Wh_Log(L"Failed to install deferred count refresh hook");
+    }
+
     ExistingButtonsInitContext context;
 
-    try {
-        EnumThreadWindows(
-            GetCurrentThreadId(),
-            [](HWND hWnd, LPARAM param) -> BOOL {
+    EnumThreadWindows(
+        GetCurrentThreadId(),
+        [](HWND hWnd, LPARAM param) -> BOOL {
+            try {
                 auto* context =
                     reinterpret_cast<ExistingButtonsInitContext*>(param);
 
@@ -1543,15 +1608,18 @@ void WINAPI InitializeExistingButtonsOnTaskbarThread(void*) {
                 ++context->taskbarCount;
                 context->buttonCount +=
                     EnumerateExistingTaskbarButtons(content);
-                return TRUE;
-            },
-            reinterpret_cast<LPARAM>(&context));
+            } catch (...) {
+                // Never let a C++/WinRT exception unwind through the Win32
+                // EnumThreadWindows callback boundary.
+                Wh_Log(L"Taskbar XamlRoot enumeration failed");
+            }
 
-        Wh_Log(L"Initial taskbars=%d buttons=%d", context.taskbarCount,
-               context.buttonCount);
-    } catch (...) {
-        Wh_Log(L"Initial taskbar UI setup failed");
-    }
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&context));
+
+    Wh_Log(L"Initial taskbars=%d buttons=%d", context.taskbarCount,
+           context.buttonCount);
 }
 
 // -----------------------------------------------------------------------------
@@ -1570,7 +1638,9 @@ void __cdecl TaskListButton_UpdateVisualStates_Hook(void* pThis) {
     }
 
     try {
-        g_taskbarThreadId = GetCurrentThreadId();
+        if (!EnsureDeferredCountRefreshHookOnTaskbarThread()) {
+            g_taskbarThreadId = GetCurrentThreadId();
+        }
         void* taskListButtonIUnknownPtr = reinterpret_cast<void**>(pThis) + 3;
 
         winrt::Windows::Foundation::IUnknown taskListButtonIUnknown;
@@ -1606,17 +1676,10 @@ HRESULT WINAPI GetViewModelCount_Hook(void* pThis, unsigned int* count) {
         return hr;
     }
 
-    // pThis is the same ITaskListGroupViewModel interface returned by
-    // TryGetItemFromContainer<TaskListGroupViewModel>. Update only buttons that
-    // are backed by this group; no desktop/window enumeration is needed. Keep
-    // the original ViewModelCount untouched for Windows and normalize only the
-    // count used by the badge.
-    try {
-        RefreshTrackedButtonsForViewModel(
-            pThis, WindowCountFromViewModelCount(*count));
-    } catch (...) {
-        Wh_Log(L"ViewModel count update failed");
-    }
+    // Keep this bindable property getter notification-only. XAML changes are
+    // deferred to the taskbar message loop so they can't occur while the
+    // ItemsRepeater is measuring/realizing a TaskListButton.
+    QueueDeferredCountRefresh();
 
     return hr;
 }
@@ -1670,13 +1733,21 @@ void CleanupOnTaskbarThread() {
             RemoveBadgeFromPanel(iconPanel, badge);
         }
     }
-
-    g_trackedButtons.clear();
-    Wh_Log(L"Cleanup complete");
 }
 
 void WINAPI CleanupOnTaskbarThreadProc(void*) {
-    CleanupOnTaskbarThread();
+    try {
+        CleanupOnTaskbarThread();
+        Wh_Log(L"Cleanup complete");
+    } catch (...) {
+        // Never allow a C++/WinRT exception to escape through the Win32 hook
+        // callback used by RunOnTaskbarThread.
+        Wh_Log(L"Cleanup failed");
+    }
+
+    // Always drop weak references, even if part of the XAML tree was already
+    // closed while Explorer was rebuilding/shutting down.
+    g_trackedButtons.clear();
 }
 
 // -----------------------------------------------------------------------------
@@ -1687,7 +1758,8 @@ bool HookTaskbarView(HMODULE module) {
     if (g_taskbarViewHooked.exchange(true)) {
         return true;
     }
-// Taskbar.View.dll, ExplorerExtensions.dll
+
+    // Taskbar.View.dll, ExplorerExtensions.dll
     WindhawkUtils::SYMBOL_HOOK taskbarViewHooks[] = {
         {
             {
@@ -1814,7 +1886,10 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName, HANDLE file, DWORD flags) {
 BOOL Wh_ModInit() {
     g_unloading = false;
     g_settingsReloadPending = false;
+    g_deferredCountRefreshQueued = false;
     g_taskbarThreadId = 0;
+    g_taskbarGetMessageHook = nullptr;
+    g_deferredCountRefreshMessage = 0;
     g_trackedButtons.clear();
 
     LoadSettings();
@@ -1850,6 +1925,19 @@ BOOL Wh_ModInit() {
 void Wh_ModAfterInit() {
     Wh_Log(L"After init");
 
+    // Taskbar.View can load after Wh_ModInit checked for it but before the
+    // LoadLibraryExW hook becomes active. Re-check after hook operations are
+    // installed so that narrow startup race can't leave the mod unhooked.
+    if (!g_taskbarViewHooked) {
+        if (HMODULE module = GetTaskbarViewModuleHandle()) {
+            if (HookTaskbarView(module)) {
+                Wh_ApplyHookOperations();
+            } else {
+                Wh_Log(L"Late Taskbar.View hook failed");
+            }
+        }
+    }
+
     HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
     if (!taskbarWnd) {
         return;
@@ -1881,6 +1969,7 @@ void Wh_ModBeforeUninit() {
     Wh_Log(L"Before uninit");
     g_unloading = true;
     g_settingsReloadPending = false;
+    StopDeferredCountRefreshHook();
 
     HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
     if (!taskbarWnd) {
@@ -1895,6 +1984,9 @@ void Wh_ModBeforeUninit() {
 }
 
 void Wh_ModUninit() {
+    StopDeferredCountRefreshHook();
+    g_deferredCountRefreshQueued = false;
+
     // Tracked buttons contain weak WinRT references only; releasing them here
     // is safe even if Explorer is already tearing the taskbar down.
     g_trackedButtons.clear();

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -566,6 +566,8 @@ Media::SolidColorBrush CreateBrush(const std::wstring& value,
 // Position helpers
 // -----------------------------------------------------------------------------
 
+FrameworkElement FindChildByName(FrameworkElement element, PCWSTR name);
+
 void ApplyNumberBadgePosition(Controls::Border badge) {
     HorizontalAlignment horizontal = HorizontalAlignment::Right;
 
@@ -623,30 +625,53 @@ void ApplyNumberBadgePosition(Controls::Border badge) {
 
 void ApplyDotPosition(Controls::Border badge) {
     badge.VerticalAlignment(VerticalAlignment::Center);
-
     badge.Margin(Thickness{});
-
-    if (g_settings.dotPosition == DotPosition::Left) {
-        badge.HorizontalAlignment(HorizontalAlignment::Left);
-    } else {
-        badge.HorizontalAlignment(HorizontalAlignment::Right);
-    }
 
     auto transform =
         badge.RenderTransform().try_as<Media::TranslateTransform>();
-
     if (!transform) {
         transform = Media::TranslateTransform();
-
         badge.RenderTransform(transform);
     }
 
-    // IMPORTANT:
-    // Keep dots inside IconPanel.
-    // Moving them outside causes the taskbar XAML to clip them.
-    //
-    // 2 px gives a little separation from the panel edge.
-    transform.X(g_settings.dotPosition == DotPosition::Left ? 2.0 : -2.0);
+    // Anchor the dots to the actual app icon instead of to IconPanel's edge.
+    // IconPanel has side padding in the stock taskbar, but its geometry can be
+    // changed by taskbar layout/styling mods. Using the Icon child keeps the
+    // dots beside the icon rather than on top of it.
+    auto iconPanelElement = badge.Parent().try_as<FrameworkElement>();
+    auto icon = iconPanelElement
+                    ? FindChildByName(iconPanelElement, L"Icon")
+                    : nullptr;
+
+    if (icon && icon.ActualWidth() > 0) {
+        auto iconTransform = icon.TransformToVisual(iconPanelElement);
+        auto iconTopLeft = iconTransform.TransformPoint(
+            winrt::Windows::Foundation::Point{0, 0});
+        constexpr double kDotGap = 2.0;
+
+        if (g_settings.dotPosition == DotPosition::Left) {
+            // Anchor the badge's RIGHT edge to the icon's left edge. Don't
+            // assume the badge width equals dotSize: XAML layout/DPI rounding
+            // can make the realized width differ slightly.
+            badge.HorizontalAlignment(HorizontalAlignment::Right);
+            transform.X(iconTopLeft.X - iconPanelElement.ActualWidth() -
+                        kDotGap);
+        } else {
+            // Anchor the badge's LEFT edge to the icon's right edge.
+            badge.HorizontalAlignment(HorizontalAlignment::Left);
+            transform.X(iconTopLeft.X + icon.ActualWidth() + kDotGap);
+        }
+    } else {
+        // Fallback for unexpected taskbar templates where the Icon element
+        // can't be resolved. Keep the indicator inside IconPanel.
+        if (g_settings.dotPosition == DotPosition::Left) {
+            badge.HorizontalAlignment(HorizontalAlignment::Left);
+            transform.X(2.0);
+        } else {
+            badge.HorizontalAlignment(HorizontalAlignment::Right);
+            transform.X(-2.0);
+        }
+    }
 
     transform.Y(0.0);
 }
@@ -996,13 +1021,10 @@ void ApplyBadgeVisualStyle(Controls::Border badge, unsigned int count) {
 // -----------------------------------------------------------------------------
 
 void RemoveBadgeFromPanel(Controls::Panel iconPanel, Controls::Border badge) {
+    uint32_t index = 0;
     auto children = iconPanel.Children();
-
-    for (uint32_t i = 0; i < children.Size(); i++) {
-        if (children.GetAt(i) == badge) {
-            children.RemoveAt(i);
-            return;
-        }
+    if (children.IndexOf(badge, index)) {
+        children.RemoveAt(index);
     }
 }
 
@@ -1432,9 +1454,8 @@ bool RunOnTaskbarThread(HWND hWnd, TaskbarThreadProc proc, void* parameter) {
         return true;
     }
 
-    static UINT message = RegisterWindowMessageW(
-        L"Windhawk_TaskbarCountBadges_"
-        L"RunOnTaskbarThread");
+    static UINT message =
+        RegisterWindowMessageW(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
 
     if (!message) {
         return false;
@@ -1478,6 +1499,27 @@ bool RunOnTaskbarThread(HWND hWnd, TaskbarThreadProc proc, void* parameter) {
     UnhookWindowsHookEx(hook);
 
     return true;
+}
+
+HWND FindWindowOnThread(DWORD threadId) {
+    if (!threadId) {
+        return nullptr;
+    }
+
+    struct Context {
+        HWND hWnd = nullptr;
+    } context;
+
+    EnumThreadWindows(
+        threadId,
+        [](HWND hWnd, LPARAM lParam) -> BOOL {
+            auto* context = reinterpret_cast<Context*>(lParam);
+            context->hWnd = hWnd;
+            return FALSE;
+        },
+        reinterpret_cast<LPARAM>(&context));
+
+    return context.hWnd;
 }
 
 // -----------------------------------------------------------------------------
@@ -1531,7 +1573,7 @@ bool EnsureDeferredCountRefreshHookOnTaskbarThread() {
 
     if (!g_deferredCountRefreshMessage) {
         g_deferredCountRefreshMessage = RegisterWindowMessageW(
-            L"Windhawk_TaskbarCountBadges_DeferredCountRefresh");
+            L"Windhawk_DeferredCountRefresh_" WH_MOD_ID);
         if (!g_deferredCountRefreshMessage) {
             return false;
         }
@@ -1655,9 +1697,7 @@ void __cdecl TaskListButton_UpdateVisualStates_Hook(void* pThis) {
     }
 
     try {
-        if (!EnsureDeferredCountRefreshHookOnTaskbarThread()) {
-            g_taskbarThreadId = GetCurrentThreadId();
-        }
+        EnsureDeferredCountRefreshHookOnTaskbarThread();
         void* taskListButtonIUnknownPtr = reinterpret_cast<void**>(pThis) + 3;
 
         winrt::Windows::Foundation::IUnknown taskListButtonIUnknown;
@@ -1992,21 +2032,50 @@ void Wh_ModBeforeUninit() {
     g_unloading = true;
     g_settingsReloadPending = false;
 
+    DWORD taskbarThreadId = g_taskbarThreadId.load();
+    HWND cleanupWnd = nullptr;
+
+    // Prefer Shell_TrayWnd while it still exists, but cleanup must not depend
+    // on it: the deferred WH_GETMESSAGE hook belongs to the taskbar UI thread
+    // and can outlive the visible taskbar window during Explorer teardown.
     HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
-    if (!taskbarWnd) {
-        // The taskbar UI is already gone, so there are no visible badges to
-        // remove.
+    if (taskbarWnd) {
+        DWORD windowThreadId = GetWindowThreadProcessId(taskbarWnd, nullptr);
+        if (!taskbarThreadId || windowThreadId == taskbarThreadId) {
+            cleanupWnd = taskbarWnd;
+        }
+    }
+
+    if (!cleanupWnd && taskbarThreadId) {
+        cleanupWnd = FindWindowOnThread(taskbarThreadId);
+    }
+
+    if (!cleanupWnd) {
+        // If no deferred hook was ever installed, there is no callback that can
+        // survive the mod. Any XAML tree that has already lost all of its
+        // windows is no longer reachable for visual cleanup either.
+        if (!g_taskbarGetMessageHook.load()) {
+            g_trackedButtons.clear();
+            return;
+        }
+
+        Wh_Log(L"Couldn't find a window on the taskbar thread for cleanup");
         return;
     }
 
-    if (!RunOnTaskbarThread(taskbarWnd, CleanupOnTaskbarThreadProc, nullptr)) {
+    if (!RunOnTaskbarThread(cleanupWnd, CleanupOnTaskbarThreadProc, nullptr)) {
         Wh_Log(L"Cleanup taskbar-thread execution failed");
     }
 }
 
 void Wh_ModUninit() {
-    StopDeferredCountRefreshHook();
-    g_deferredCountRefreshQueued = false;
+    // Normal teardown removes the long-lived hook synchronously from its own
+    // taskbar thread in CleanupOnTaskbarThreadProc. This is only a last-resort
+    // fallback for a teardown path where taskbar-thread marshalling was no
+    // longer possible.
+    if (g_taskbarGetMessageHook.load()) {
+        StopDeferredCountRefreshHook();
+    }
 
     // Tracked buttons contain weak WinRT references only; releasing them here
     // is safe even if Explorer is already tearing the taskbar down.

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -239,6 +239,7 @@ ordering, or application behavior.
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
+#include <cwctype>
 #include <limits>
 #include <list>
 #include <string>
@@ -329,7 +330,7 @@ std::atomic<bool> g_deferredCountRefreshQueued = false;
 std::atomic<DWORD> g_taskbarThreadId = 0;
 uint64_t g_settingsGeneration = 0;
 
-HHOOK g_taskbarGetMessageHook = nullptr;
+std::atomic<HHOOK> g_taskbarGetMessageHook = nullptr;
 UINT g_deferredCountRefreshMessage = 0;
 
 struct TrackedButton {
@@ -1138,6 +1139,16 @@ TrackedButton* TrackTaskbarButton(FrameworkElement element) {
                      });
 
     if (existing != g_trackedButtons.end()) {
+        // The taskbar recycles button containers. If the previous element at
+        // this identity is already gone, treat this as a fresh button and
+        // reset the cached visual state.
+        if (!existing->element.get()) {
+            existing->element = winrt::make_weak(element);
+            existing->lastAppliedCount =
+                std::numeric_limits<unsigned int>::max();
+            existing->lastSettingsGeneration = 0;
+        }
+
         return &*existing;
     }
 
@@ -1484,7 +1495,6 @@ LRESULT CALLBACK TaskbarGetMessageHookProc(int code,
             // taskbar message loop, after the ViewModel getter/layout stack has
             // returned, so XAML isn't mutated from inside the property getter.
             message->message = WM_NULL;
-            g_deferredCountRefreshQueued = false;
 
             if (!g_unloading) {
                 try {
@@ -1493,21 +1503,27 @@ LRESULT CALLBACK TaskbarGetMessageHookProc(int code,
                     Wh_Log(L"Deferred count refresh failed");
                 }
             }
+
+            // Keep the refresh marked as queued until all XAML work finishes.
+            // Any ViewModelCount reads caused by that work are collapsed into
+            // this refresh instead of scheduling a feedback-loop refresh.
+            g_deferredCountRefreshQueued = false;
         }
     }
 
-    return CallNextHookEx(g_taskbarGetMessageHook, code, wParam, lParam);
+    return CallNextHookEx(g_taskbarGetMessageHook.load(), code, wParam, lParam);
 }
 
 bool EnsureDeferredCountRefreshHookOnTaskbarThread() {
     DWORD threadId = GetCurrentThreadId();
+    HHOOK existingHook = g_taskbarGetMessageHook.load();
 
-    if (g_taskbarGetMessageHook && g_taskbarThreadId.load() == threadId) {
+    if (existingHook && g_taskbarThreadId.load() == threadId) {
         return true;
     }
 
-    if (g_taskbarGetMessageHook) {
-        UnhookWindowsHookEx(g_taskbarGetMessageHook);
+    if (existingHook) {
+        UnhookWindowsHookEx(existingHook);
         g_taskbarGetMessageHook = nullptr;
     }
 
@@ -1521,22 +1537,23 @@ bool EnsureDeferredCountRefreshHookOnTaskbarThread() {
         }
     }
 
-    g_taskbarGetMessageHook = SetWindowsHookExW(
-        WH_GETMESSAGE, TaskbarGetMessageHookProc, nullptr, threadId);
-    return g_taskbarGetMessageHook != nullptr;
+    HHOOK hook = SetWindowsHookExW(WH_GETMESSAGE, TaskbarGetMessageHookProc,
+                                   nullptr, threadId);
+    g_taskbarGetMessageHook = hook;
+    return hook != nullptr;
 }
 
 void StopDeferredCountRefreshHook() {
-    if (g_taskbarGetMessageHook) {
-        UnhookWindowsHookEx(g_taskbarGetMessageHook);
-        g_taskbarGetMessageHook = nullptr;
+    HHOOK hook = g_taskbarGetMessageHook.exchange(nullptr);
+    if (hook) {
+        UnhookWindowsHookEx(hook);
     }
 
     g_deferredCountRefreshQueued = false;
 }
 
 void QueueDeferredCountRefresh() {
-    if (g_unloading || !g_taskbarGetMessageHook ||
+    if (g_unloading || !g_taskbarGetMessageHook.load() ||
         !g_deferredCountRefreshMessage) {
         return;
     }
@@ -1736,6 +1753,11 @@ void CleanupOnTaskbarThread() {
 }
 
 void WINAPI CleanupOnTaskbarThreadProc(void*) {
+    // The WH_GETMESSAGE hook belongs to this taskbar UI thread. Remove it here
+    // synchronously so no hook callback can still be executing when the mod is
+    // unloaded.
+    StopDeferredCountRefreshHook();
+
     try {
         CleanupOnTaskbarThread();
         Wh_Log(L"Cleanup complete");
@@ -1969,7 +1991,6 @@ void Wh_ModBeforeUninit() {
     Wh_Log(L"Before uninit");
     g_unloading = true;
     g_settingsReloadPending = false;
-    StopDeferredCountRefreshHook();
 
     HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
     if (!taskbarWnd) {

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -245,6 +245,7 @@ ordering, or application behavior.
 #include <cwctype>
 #include <limits>
 #include <list>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -352,7 +353,15 @@ struct TrackedButton {
     uint64_t lastSettingsGeneration = 0;
 };
 
-std::list<TrackedButton> g_trackedButtons;
+// TrackedButton contains a strong XAML event-handler reference. Prevent the
+// container destructor from releasing thread-affine XAML objects during
+// Explorer process shutdown, where Wh_ModUninit isn't guaranteed to run.
+[[clang::no_destroy]] std::optional<std::list<TrackedButton>> g_trackedButtons{
+    std::in_place};
+
+std::list<TrackedButton>& TrackedButtons() {
+    return *g_trackedButtons;
+}
 
 using DotAnimationClock = std::chrono::steady_clock;
 constexpr auto kDotAnimationTrackingTimeout = std::chrono::seconds(3);
@@ -1077,7 +1086,7 @@ void RemoveBadgeFromCurrentParent(Controls::Border badge) {
 }
 
 bool HasActiveDotTracking() {
-    return std::any_of(g_trackedButtons.begin(), g_trackedButtons.end(),
+    return std::any_of(TrackedButtons().begin(), TrackedButtons().end(),
                        [](TrackedButton const& item) {
                            return item.dotLayoutUpdatedAttached ||
                                   item.dotPointerMovedAttached;
@@ -1131,8 +1140,8 @@ void OnDotGeometryRendering(
     };
 
     std::vector<DotGeometrySnapshot> snapshot;
-    snapshot.reserve(g_trackedButtons.size());
-    for (auto const& item : g_trackedButtons) {
+    snapshot.reserve(TrackedButtons().size());
+    for (auto const& item : TrackedButtons()) {
         if (!item.dotLayoutUpdatedAttached &&
             !item.dotPointerMovedAttached) {
             continue;
@@ -1219,6 +1228,20 @@ void DetachDotTrackingHandlers(TrackedButton& tracked) {
     }
 }
 
+template <typename T, typename U>
+bool IsSameWinrtObject(T const& first, U const& second) {
+    if (!first || !second) {
+        return false;
+    }
+
+    auto firstUnknown =
+        first.template try_as<winrt::Windows::Foundation::IUnknown>();
+    auto secondUnknown =
+        second.template try_as<winrt::Windows::Foundation::IUnknown>();
+    return firstUnknown && secondUnknown &&
+           winrt::get_abi(firstUnknown) == winrt::get_abi(secondUnknown);
+}
+
 void AttachDotTrackingHandlers(TrackedButton& tracked,
                                FrameworkElement taskListButton,
                                FrameworkElement icon,
@@ -1229,10 +1252,9 @@ void AttachDotTrackingHandlers(TrackedButton& tracked,
     if (tracked.dotLayoutUpdatedAttached &&
         tracked.dotPointerMovedAttached && existingIcon && existingHost &&
         existingPointerSource &&
-        winrt::get_abi(existingIcon) == winrt::get_abi(icon) &&
-        winrt::get_abi(existingHost) == winrt::get_abi(dotHost) &&
-        winrt::get_abi(existingPointerSource) ==
-            winrt::get_abi(taskListButton)) {
+        IsSameWinrtObject(existingIcon, icon) &&
+        IsSameWinrtObject(existingHost, dotHost) &&
+        IsSameWinrtObject(existingPointerSource, taskListButton)) {
         StartDotGeometryTracking();
         return;
     }
@@ -1323,6 +1345,29 @@ Controls::Border CreateCountBadge(Controls::Panel parent) {
     return badge;
 }
 
+bool IsTrackedBadge(Controls::Border const& badge) {
+    for (auto const& item : TrackedButtons()) {
+        auto trackedBadge = item.badge.get();
+        if (trackedBadge && IsSameWinrtObject(trackedBadge, badge)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void RemoveOrphanDotBadges(Controls::Grid const& dotHost) {
+    auto children = dotHost.Children();
+    for (uint32_t i = children.Size(); i > 0; --i) {
+        auto badge = children.GetAt(i - 1).try_as<Controls::Border>();
+        if (!badge || badge.Name() != L"WindhawkCountBadge" ||
+            IsTrackedBadge(badge)) {
+            continue;
+        }
+
+        children.RemoveAt(i - 1);
+    }
+}
+
 bool UpdateCountBadge(TrackedButton& tracked,
                       FrameworkElement taskListButton,
                       unsigned int count) {
@@ -1395,6 +1440,12 @@ bool UpdateCountBadge(TrackedButton& tracked,
             return false;
         }
         desiredParent = dotHost;
+
+        // RootGrid is shared by taskbar buttons. Remove only Count Badges
+        // visuals that aren't owned by any current tracked button, allowing a
+        // new instance to recover from an interrupted prior cleanup without
+        // touching live badges for other buttons.
+        RemoveOrphanDotBadges(dotHost);
     }
 
     if (badge) {
@@ -1438,13 +1489,13 @@ bool UpdateCountBadge(TrackedButton& tracked,
 // -----------------------------------------------------------------------------
 
 void PruneDeadTrackedButtons() {
-    for (auto it = g_trackedButtons.begin(); it != g_trackedButtons.end();) {
+    for (auto it = TrackedButtons().begin(); it != TrackedButtons().end();) {
         if (!it->element.get()) {
             DetachDotTrackingHandlers(*it);
             if (auto badge = it->badge.get()) {
                 RemoveBadgeFromCurrentParent(badge);
             }
-            it = g_trackedButtons.erase(it);
+            it = TrackedButtons().erase(it);
         } else {
             ++it;
         }
@@ -1456,12 +1507,12 @@ TrackedButton* TrackTaskbarButton(FrameworkElement element) {
     void* identity = winrt::get_abi(unknown);
 
     auto existing =
-        std::find_if(g_trackedButtons.begin(), g_trackedButtons.end(),
+        std::find_if(TrackedButtons().begin(), TrackedButtons().end(),
                      [identity](const TrackedButton& item) {
                          return item.identity == identity;
                      });
 
-    if (existing != g_trackedButtons.end()) {
+    if (existing != TrackedButtons().end()) {
         // The taskbar recycles button containers. If the previous element at
         // this identity is already gone, treat this as a fresh button and
         // reset the cached visual state.
@@ -1480,12 +1531,12 @@ TrackedButton* TrackTaskbarButton(FrameworkElement element) {
         return &*existing;
     }
 
-    g_trackedButtons.push_back({
+    TrackedButtons().push_back({
         .identity = identity,
         .element = winrt::make_weak(element),
     });
 
-    return &g_trackedButtons.back();
+    return &TrackedButtons().back();
 }
 
 bool GetTaskbarButtonViewModelCount(FrameworkElement element,
@@ -1566,8 +1617,8 @@ void RefreshAllTrackedButtons() {
     PruneDeadTrackedButtons();
 
     std::vector<winrt::weak_ref<FrameworkElement>> buttonSnapshot;
-    buttonSnapshot.reserve(g_trackedButtons.size());
-    for (auto const& item : g_trackedButtons) {
+    buttonSnapshot.reserve(TrackedButtons().size());
+    for (auto const& item : TrackedButtons()) {
         buttonSnapshot.push_back(item.element);
     }
 
@@ -1870,22 +1921,17 @@ bool EnsureDeferredCountRefreshSubclass() {
         return false;
     }
 
-    HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
-    if (!taskbarWnd) {
-        return false;
-    }
-
+    // WM_NCDESTROY clears the cached handle, so a non-null value means the
+    // subclass is still live. Avoid a desktop-wide EnumWindows sweep on every
+    // TaskListButton::UpdateVisualStates call.
     HWND existingWindow = g_taskbarSubclassWindow.load();
-    if (existingWindow == taskbarWnd) {
-        g_taskbarThreadId =
-            GetWindowThreadProcessId(taskbarWnd, nullptr);
+    if (existingWindow) {
         return true;
     }
 
-    if (existingWindow) {
-        WindhawkUtils::RemoveWindowSubclassFromAnyThread(
-            existingWindow, TaskbarWindowSubclassProc);
-        g_taskbarSubclassWindow = nullptr;
+    HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
+    if (!taskbarWnd) {
+        return false;
     }
 
     if (!WindhawkUtils::SetWindowSubclassFromAnyThread(
@@ -2084,7 +2130,7 @@ void CleanupOnTaskbarThread() {
     StopDotGeometryTracking();
     PruneDeadTrackedButtons();
 
-    for (auto& item : g_trackedButtons) {
+    for (auto& item : TrackedButtons()) {
         DetachDotTrackingHandlers(item);
         auto element = item.element.get();
         auto badge = item.badge.get();
@@ -2125,9 +2171,10 @@ void WINAPI CleanupOnTaskbarThreadProc(void*) {
         Wh_Log(L"Cleanup failed");
     }
 
-    // Always drop weak references, even if part of the XAML tree was already
-    // closed while Explorer was rebuilding/shutting down.
-    g_trackedButtons.clear();
+    // All strong XAML handlers were detached above on the taskbar UI thread.
+    // Destroy the tracked container explicitly here instead of allowing its
+    // automatic destructor to run during process shutdown.
+    g_trackedButtons.reset();
 }
 
 // -----------------------------------------------------------------------------
@@ -2274,7 +2321,11 @@ BOOL Wh_ModInit() {
     if (!g_deferredCountRefreshMessage) {
         return FALSE;
     }
-    g_trackedButtons.clear();
+    if (!g_trackedButtons) {
+        g_trackedButtons.emplace();
+    } else {
+        TrackedButtons().clear();
+    }
 
     LoadSettings();
     Wh_Log(L"Init PID=%lu", GetCurrentProcessId());
@@ -2353,34 +2404,50 @@ void Wh_ModBeforeUninit() {
     Wh_Log(L"Before uninit");
     g_unloading = true;
     g_settingsReloadPending = false;
+
+    // Capture the subclass window before removing the subclass. It's the best
+    // cleanup target because it is known to belong to the taskbar UI thread.
+    HWND subclassWindow = g_taskbarSubclassWindow.load();
+    DWORD taskbarThreadId = g_taskbarThreadId.load();
     StopDeferredCountRefreshSubclass();
 
-    DWORD taskbarThreadId = g_taskbarThreadId.load();
-    HWND cleanupWnd = nullptr;
+    auto tryCleanup = [](HWND hWnd) -> bool {
+        return hWnd &&
+               RunOnTaskbarThread(hWnd, CleanupOnTaskbarThreadProc, nullptr);
+    };
 
-    // Prefer Shell_TrayWnd while it still exists, with another window on the
-    // same taskbar UI thread as a cleanup-only fallback.
-    HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
-    if (taskbarWnd) {
-        DWORD windowThreadId = GetWindowThreadProcessId(taskbarWnd, nullptr);
-        if (!taskbarThreadId || windowThreadId == taskbarThreadId) {
-            cleanupWnd = taskbarWnd;
+    bool cleanedUp = tryCleanup(subclassWindow);
+
+    if (!cleanedUp) {
+        HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
+        if (taskbarWnd && taskbarWnd != subclassWindow) {
+            DWORD windowThreadId =
+                GetWindowThreadProcessId(taskbarWnd, nullptr);
+            if (!taskbarThreadId || windowThreadId == taskbarThreadId) {
+                cleanedUp = tryCleanup(taskbarWnd);
+            }
         }
     }
 
-    if (!cleanupWnd && taskbarThreadId) {
-        cleanupWnd = FindWindowOnThread(taskbarThreadId);
+    if (!cleanedUp && taskbarThreadId) {
+        HWND fallbackWnd = FindWindowOnThread(taskbarThreadId);
+        if (fallbackWnd && fallbackWnd != subclassWindow) {
+            cleanedUp = tryCleanup(fallbackWnd);
+        }
     }
 
-    if (!cleanupWnd) {
-        // The subclass is already removed, so pending posted refresh messages
-        // are harmless. With no taskbar-thread window, XAML is unreachable.
-        g_trackedButtons.clear();
-        return;
-    }
-
-    if (!RunOnTaskbarThread(cleanupWnd, CleanupOnTaskbarThreadProc, nullptr)) {
-        Wh_Log(L"Cleanup taskbar-thread execution failed");
+    if (!cleanedUp) {
+        // Don't clear/reset the tracked container here: it owns the strong
+        // PointerMoved handler objects, and dropping them off the taskbar UI
+        // thread is unsafe. Best-effort removal of the static Rendering event
+        // avoids leaving its callback registered if the taskbar thread is
+        // already unreachable. The no_destroy container intentionally remains
+        // alive until process termination in this exceptional path.
+        try {
+            StopDotGeometryTracking();
+        } catch (...) {
+        }
+        Wh_Log(L"Couldn't execute taskbar-thread cleanup");
     }
 }
 
@@ -2389,9 +2456,10 @@ void Wh_ModUninit() {
         StopDeferredCountRefreshSubclass();
     }
 
-    // Tracked buttons contain weak WinRT references only; releasing them here
-    // is safe even if Explorer is already tearing the taskbar down.
-    g_trackedButtons.clear();
+    // Normal unload resets g_trackedButtons in CleanupOnTaskbarThreadProc after
+    // all XAML handlers are detached on the taskbar thread. If cleanup couldn't
+    // be marshalled, leave the no_destroy container intact rather than releasing
+    // thread-affine XAML handler references from this arbitrary thread.
     g_taskbarThreadId = 0;
     Wh_Log(L"Uninit");
 }

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -2103,9 +2103,19 @@ bool EnsureDeferredCountRefreshSubclass()
 
     g_taskbarThreadId = GetWindowThreadProcessId(taskbarWnd, nullptr);
     g_taskbarSubclassWindow = taskbarWnd;
+
+    // Wh_ModBeforeUninit may have run between the initial unloading check
+    // and subclass installation. Publish the handle first, then re-check:
+    // either the uninit thread sees the handle and removes the subclass, or
+    // this thread sees g_unloading and removes it here.
+    if (g_unloading)
+    {
+        StopDeferredCountRefreshSubclass();
+        return false;
+    }
+
     return true;
 }
-
 void StopDeferredCountRefreshSubclass()
 {
     HWND taskbarWnd = g_taskbarSubclassWindow.exchange(nullptr);

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -2757,4 +2757,3 @@ void Wh_ModUninit()
     g_taskbarThreadId = 0;
     Wh_Log(L"Uninit");
 }
-

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -79,7 +79,7 @@ settings are applied live.
 ## Compatibility
 
 - Windows 11 only
-- Supports x64 Windows
+- Supports x64 and ARM64 Windows
 - Works with multiple monitors and secondary Windows taskbars
 
 On multi-monitor systems, the count follows each individual taskbar button.
@@ -240,7 +240,6 @@ ordering, or application behavior.
 
 #include <algorithm>
 #include <atomic>
-#include <cmath>
 #include <cstdint>
 #include <cwctype>
 #include <limits>
@@ -336,6 +335,7 @@ Settings g_settings;
 // -----------------------------------------------------------------------------
 
 std::atomic<bool> g_taskbarViewHooked = false;
+std::atomic<bool> g_taskbarViewHookAttempted = false;
 std::atomic<bool> g_unloading = false;
 std::atomic<bool> g_settingsReloadPending = false;
 std::atomic<bool> g_deferredCountRefreshQueued = false;
@@ -632,12 +632,9 @@ Media::SolidColorBrush CreateBrush(const std::wstring &value,
 
 FrameworkElement FindChildByName(FrameworkElement element, PCWSTR name);
 unsigned int GetVisibleDotCount(unsigned int count);
-void StopDotPositionBinding(Controls::Border badge);
 
 void ApplyNumberBadgePosition(Controls::Border badge)
 {
-    StopDotPositionBinding(badge);
-
     HorizontalAlignment horizontal = HorizontalAlignment::Right;
 
     VerticalAlignment vertical = VerticalAlignment::Top;
@@ -706,8 +703,9 @@ void StopDotPositionBinding(Controls::Border badge)
         auto visual =
             Hosting::ElementCompositionPreview::GetElementVisual(badge);
 
-        // Number badges live in IconPanel, while dots live in RootGrid. Clear
-        // all compositor state before the visual is removed or reused.
+        // Dot badges live in RootGrid and use compositor expressions for
+        // Translation and TransformMatrix. Clear that compositor state
+        // before a dot badge is hidden or removed.
         auto properties = visual.Properties();
         properties.StopAnimation(L"Translation");
         properties.InsertVector3(
@@ -1367,7 +1365,8 @@ void RemoveOrphanDotBadges(Controls::Grid const &dotHost)
         {
             continue;
         }
-        auto unknown = trackedBadge.try_as<winrt::Windows::Foundation::IUnknown>();
+        auto unknown =
+            trackedBadge.try_as<winrt::Windows::Foundation::IUnknown>();
         if (unknown)
         {
             trackedBadgeIdentities.insert(winrt::get_abi(unknown));
@@ -1437,7 +1436,8 @@ bool UpdateCountBadge(TrackedButton &tracked,
         RemoveBadgeFromPanel(iconPanel, iconPanelBadge);
     }
 
-    // Rebuild badges created by older visual-layout versions.
+    // Recover a stale or partially-created Count Badges visual left by an
+    // interrupted prior instance before trying to reuse it.
     if (badge)
     {
         auto circleVisual = FindChildByName(badge, L"WindhawkCircleVisual");
@@ -1511,7 +1511,10 @@ bool UpdateCountBadge(TrackedButton &tracked,
     {
         if (badge)
         {
-            StopDotPositionBinding(badge);
+            if (g_settings.displayStyle == DisplayStyle::Dots)
+            {
+                StopDotPositionBinding(badge);
+            }
             badge.Visibility(Visibility::Collapsed);
         }
 
@@ -1527,7 +1530,10 @@ bool UpdateCountBadge(TrackedButton &tracked,
     if (!ApplyBadgeVisualStyle(badge, count, taskListButton, icon,
                                dotHost))
     {
-        StopDotPositionBinding(badge);
+        if (g_settings.displayStyle == DisplayStyle::Dots)
+        {
+            StopDotPositionBinding(badge);
+        }
         badge.Visibility(Visibility::Collapsed);
         return false;
     }
@@ -1786,6 +1792,10 @@ XamlRoot XamlRootFromTaskbarHostSharedPtr(void *hostShared[2])
         else
         {
             Wh_Log(L"Unsupported TaskbarHost::FrameHeight");
+            if (hostShared[1])
+            {
+                g_RefCount_Decref(hostShared[1]);
+            }
             return nullptr;
         }
     }
@@ -1808,6 +1818,10 @@ XamlRoot XamlRootFromTaskbarHostSharedPtr(void *hostShared[2])
         else
         {
             Wh_Log(L"Unsupported TaskbarHost::FrameHeight");
+            if (hostShared[1])
+            {
+                g_RefCount_Decref(hostShared[1]);
+            }
             return nullptr;
         }
     }
@@ -1852,7 +1866,8 @@ XamlRoot GetTaskbarXamlRoot(HWND taskbarWnd)
         return nullptr;
     }
 
-    void *taskBand = reinterpret_cast<void *>(GetWindowLongPtrW(taskBandWnd, 0));
+    void *taskBand =
+        reinterpret_cast<void *>(GetWindowLongPtrW(taskBandWnd, 0));
     if (!taskBand)
     {
         return nullptr;
@@ -1891,13 +1906,15 @@ XamlRoot GetSecondaryTaskbarXamlRoot(HWND taskbarWnd)
         return nullptr;
     }
 
-    HWND taskBandWnd = FindWindowExW(taskbarWnd, nullptr, L"WorkerW", nullptr);
+    HWND taskBandWnd =
+        FindWindowExW(taskbarWnd, nullptr, L"WorkerW", nullptr);
     if (!taskBandWnd)
     {
         return nullptr;
     }
 
-    void *taskBand = reinterpret_cast<void *>(GetWindowLongPtrW(taskBandWnd, 0));
+    void *taskBand =
+        reinterpret_cast<void *>(GetWindowLongPtrW(taskBandWnd, 0));
     if (!taskBand)
     {
         return nullptr;
@@ -1966,6 +1983,7 @@ bool RunOnTaskbarThread(HWND hWnd, TaskbarThreadProc proc, void *parameter)
     {
         TaskbarThreadProc proc;
         void *parameter;
+        std::atomic<bool> ran{false};
     };
 
     HHOOK hook = SetWindowsHookExW(
@@ -1978,10 +1996,12 @@ bool RunOnTaskbarThread(HWND hWnd, TaskbarThreadProc proc, void *parameter)
 
                 if (data->message == message)
                 {
-                    auto request = reinterpret_cast<Request *>(data->lParam);
+                    auto request =
+                        reinterpret_cast<Request *>(data->lParam);
 
                     if (request && request->proc)
                     {
+                        request->ran.store(true, std::memory_order_release);
                         request->proc(request->parameter);
                     }
                 }
@@ -2005,7 +2025,7 @@ bool RunOnTaskbarThread(HWND hWnd, TaskbarThreadProc proc, void *parameter)
 
     UnhookWindowsHookEx(hook);
 
-    return true;
+    return request.ran.load(std::memory_order_acquire);
 }
 
 HWND FindWindowOnThread(DWORD threadId)
@@ -2118,6 +2138,7 @@ bool EnsureDeferredCountRefreshSubclass()
 
     return true;
 }
+
 void StopDeferredCountRefreshSubclass()
 {
     HWND taskbarWnd = g_taskbarSubclassWindow.exchange(nullptr);
@@ -2166,9 +2187,22 @@ struct ExistingButtonsInitContext
 
 void WINAPI InitializeExistingButtonsOnTaskbarThread(void *)
 {
+    if (g_unloading)
+    {
+        return;
+    }
+
     if (!EnsureDeferredCountRefreshSubclass())
     {
-        Wh_Log(L"Failed to install deferred count refresh subclass");
+        if (!g_unloading)
+        {
+            Wh_Log(L"Failed to install deferred count refresh subclass");
+        }
+    }
+
+    if (g_unloading)
+    {
+        return;
     }
 
     ExistingButtonsInitContext context;
@@ -2205,14 +2239,17 @@ void WINAPI InitializeExistingButtonsOnTaskbarThread(void *)
 
                 if (!xamlRoot)
                 {
-                    Wh_Log(L"Failed to get taskbar XamlRoot for %s", className);
+                    Wh_Log(L"Failed to get taskbar XamlRoot for %s",
+                           className);
                     return TRUE;
                 }
 
-                auto content = xamlRoot.Content().try_as<FrameworkElement>();
+                auto content =
+                    xamlRoot.Content().try_as<FrameworkElement>();
                 if (!content)
                 {
-                    Wh_Log(L"XamlRoot content unavailable for %s", className);
+                    Wh_Log(L"XamlRoot content unavailable for %s",
+                           className);
                     return TRUE;
                 }
 
@@ -2255,12 +2292,20 @@ void __cdecl TaskListButton_UpdateVisualStates_Hook(void *pThis)
     try
     {
         EnsureDeferredCountRefreshSubclass();
-        void *taskListButtonIUnknownPtr = reinterpret_cast<void **>(pThis) + 3;
+        if (g_unloading)
+        {
+            return;
+        }
+
+        void *taskListButtonIUnknownPtr =
+            reinterpret_cast<void **>(pThis) + 3;
 
         winrt::Windows::Foundation::IUnknown taskListButtonIUnknown;
-        winrt::copy_from_abi(taskListButtonIUnknown, taskListButtonIUnknownPtr);
+        winrt::copy_from_abi(taskListButtonIUnknown,
+                             taskListButtonIUnknownPtr);
 
-        auto element = taskListButtonIUnknown.try_as<FrameworkElement>();
+        auto element =
+            taskListButtonIUnknown.try_as<FrameworkElement>();
         if (!element)
         {
             return;
@@ -2399,9 +2444,9 @@ void WINAPI CleanupOnTaskbarThreadProc(void *)
 
 bool HookTaskbarView(HMODULE module)
 {
-    if (g_taskbarViewHooked.exchange(true))
+    if (g_taskbarViewHookAttempted.exchange(true))
     {
-        return true;
+        return g_taskbarViewHooked.load();
     }
 
     // Taskbar.View.dll, ExplorerExtensions.dll
@@ -2431,11 +2476,11 @@ bool HookTaskbarView(HMODULE module)
     if (!WindhawkUtils::HookSymbols(module, taskbarViewHooks,
                                     ARRAYSIZE(taskbarViewHooks)))
     {
-        g_taskbarViewHooked = false;
         Wh_Log(L"Taskbar.View hooks failed");
         return false;
     }
 
+    g_taskbarViewHooked = true;
     Wh_Log(L"Taskbar.View hooks installed");
     return true;
 }
@@ -2516,7 +2561,7 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName, HANDLE file, DWORD flags)
 {
     HMODULE module = LoadLibraryExW_Original(fileName, file, flags);
 
-    if (module && !g_unloading && !g_taskbarViewHooked)
+    if (module && !g_unloading && !g_taskbarViewHookAttempted)
     {
         if (HMODULE taskbarView = GetTaskbarViewModuleHandle())
         {
@@ -2536,13 +2581,15 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName, HANDLE file, DWORD flags)
 
 BOOL Wh_ModInit()
 {
+    g_taskbarViewHooked = false;
+    g_taskbarViewHookAttempted = false;
     g_unloading = false;
     g_settingsReloadPending = false;
     g_deferredCountRefreshQueued = false;
     g_taskbarThreadId = 0;
     g_taskbarSubclassWindow = nullptr;
-    g_deferredCountRefreshMessage = RegisterWindowMessageW(
-        L"Windhawk_DeferredCountRefresh_" WH_MOD_ID);
+    g_deferredCountRefreshMessage =
+        RegisterWindowMessageW(L"Windhawk_DeferredCountRefresh_" WH_MOD_ID);
     if (!g_deferredCountRefreshMessage)
     {
         return FALSE;
@@ -2575,8 +2622,9 @@ BOOL Wh_ModInit()
         return FALSE;
     }
 
-    auto loadLibraryExW = reinterpret_cast<decltype(&LoadLibraryExW)>(
-        GetProcAddress(kernelBase, "LoadLibraryExW"));
+    auto loadLibraryExW =
+        reinterpret_cast<decltype(&LoadLibraryExW)>(
+            GetProcAddress(kernelBase, "LoadLibraryExW"));
     if (!loadLibraryExW)
     {
         return FALSE;
@@ -2594,7 +2642,7 @@ void Wh_ModAfterInit()
     // Taskbar.View can load after Wh_ModInit checked for it but before the
     // LoadLibraryExW hook becomes active. Re-check after hook operations are
     // installed so that narrow startup race can't leave the mod unhooked.
-    if (!g_taskbarViewHooked)
+    if (!g_taskbarViewHookAttempted)
     {
         if (HMODULE module = GetTaskbarViewModuleHandle())
         {
@@ -2624,6 +2672,11 @@ void Wh_ModAfterInit()
 
 void Wh_ModSettingsChanged()
 {
+    if (g_unloading)
+    {
+        return;
+    }
+
     HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
     g_settingsReloadPending = true;
     if (!taskbarWnd)
@@ -2704,3 +2757,4 @@ void Wh_ModUninit()
     g_taskbarThreadId = 0;
     Wh_Log(L"Uninit");
 }
+

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -2037,6 +2037,8 @@ HWND FindWindowOnThread(DWORD threadId)
 // Deferred count refresh
 // -----------------------------------------------------------------------------
 
+void StopDeferredCountRefreshSubclass();
+
 LRESULT CALLBACK TaskbarWindowSubclassProc(HWND hWnd,
                                            UINT message,
                                            WPARAM wParam,

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -1642,8 +1642,12 @@ bool GetTaskbarButtonViewModelCount(FrameworkElement element,
 void ApplyCountToTrackedButton(TrackedButton &item, unsigned int count)
 {
     uint64_t settingsGeneration = g_settingsGeneration;
+    bool badgeExpected =
+        count >= static_cast<unsigned int>(g_settings.minimumCount);
+
     if (item.lastAppliedCount == count &&
-        item.lastSettingsGeneration == settingsGeneration)
+        item.lastSettingsGeneration == settingsGeneration &&
+        (!badgeExpected || item.badge.get()))
     {
         return;
     }

--- a/mods/taskbar-count-badges.wh.cpp
+++ b/mods/taskbar-count-badges.wh.cpp
@@ -706,16 +706,21 @@ void StopDotPositionBinding(Controls::Border badge)
         auto visual =
             Hosting::ElementCompositionPreview::GetElementVisual(badge);
 
-        // Translation is the XAML composition hand-off property exposed on
-        // Visual.Properties after SetIsTranslationEnabled(true). Stopping the
-        // expression leaves its last animated value in that property, so a
-        // badge reparented from RootGrid back into IconPanel can otherwise
-        // remain translated away from its normal number-badge position.
+        // Number badges live in IconPanel, while dots live in RootGrid. Clear
+        // all compositor state before the visual is removed or reused.
         auto properties = visual.Properties();
         properties.StopAnimation(L"Translation");
         properties.InsertVector3(
             L"Translation",
             winrt::Windows::Foundation::Numerics::float3{0.0f, 0.0f, 0.0f});
+
+        visual.StopAnimation(L"TransformMatrix");
+        visual.TransformMatrix(
+            winrt::Windows::Foundation::Numerics::float4x4{
+                1.0f, 0.0f, 0.0f, 0.0f,
+                0.0f, 1.0f, 0.0f, 0.0f,
+                0.0f, 0.0f, 1.0f, 0.0f,
+                0.0f, 0.0f, 0.0f, 1.0f});
     }
     catch (...)
     {
@@ -723,90 +728,148 @@ void StopDotPositionBinding(Controls::Border badge)
 }
 
 bool BindDotPositionExpression(Controls::Border badge,
+                               FrameworkElement taskListButton,
                                FrameworkElement icon,
                                Controls::Grid dotHost,
                                unsigned int count)
 {
-    if (!badge || !icon || !dotHost)
+    if (!badge || !taskListButton || !icon || !dotHost)
     {
         return false;
     }
 
     try
     {
-        // The badge lives in RootGrid so it isn't clipped by IconPanel. Glue
-        // its composition Translation to the icon's visual-offset chain. The
-        // compositor evaluates this expression on the render thread, so the
-        // dots follow taskbar reordering/insertion animations without XAML
-        // LayoutUpdated/PointerMoved/Rendering callbacks into the mod image.
+        // Keep the dots in RootGrid to avoid IconPanel clipping, but make the
+        // RootGrid badge a TaskListButton-sized visual proxy. Its static
+        // placement follows the button's normal layout Offset chain, while the
+        // shell's live TaskListButton TransformMatrix is copied as a whole so
+        // the dots inherit the same taskbar animation as the real button.
         FrameworkElement hostElement = dotHost;
-        std::vector<winrt::Windows::UI::Composition::Visual> chain;
-        FrameworkElement current = icon;
+        std::vector<winrt::Windows::UI::Composition::Visual> layoutChain;
+        FrameworkElement current = taskListButton;
+
         for (int depth = 0; current && current != hostElement && depth < 20;
              ++depth)
         {
-            chain.push_back(
+            layoutChain.push_back(
                 Hosting::ElementCompositionPreview::GetElementVisual(current));
+
             auto parent = Media::VisualTreeHelper::GetParent(current);
             current = parent ? parent.try_as<FrameworkElement>() : nullptr;
         }
 
-        if (!current || current != hostElement || chain.empty())
+        if (!current || current != hostElement || layoutChain.empty())
         {
             return false;
         }
 
+        double buttonWidth = taskListButton.ActualWidth();
+        double buttonHeight = taskListButton.ActualHeight();
+        double iconWidth = icon.ActualWidth();
+        double iconHeight = icon.ActualHeight();
+
+        if (buttonWidth <= 0 || buttonHeight <= 0 ||
+            iconWidth <= 0 || iconHeight <= 0)
+        {
+            return false;
+        }
+
+        auto iconBoundsInButton =
+            icon.TransformToVisual(taskListButton)
+                .TransformBounds(winrt::Windows::Foundation::Rect{
+                    0.0f, 0.0f,
+                    static_cast<float>(iconWidth),
+                    static_cast<float>(iconHeight)});
+
         constexpr double kDotGap = 2.0;
         constexpr double kDotSpacing = 2.0;
+
         double dotSize = static_cast<double>(g_settings.dotSize);
         unsigned int dotCount = GetVisibleDotCount(count);
+
         double stackHeight = dotCount * dotSize;
         if (dotCount > 1)
         {
             stackHeight += (dotCount - 1) * kDotSpacing;
         }
 
+        auto dotStack = FindChildByName(badge, L"WindhawkDotStack")
+                            .try_as<Controls::StackPanel>();
+        if (!dotStack)
+        {
+            return false;
+        }
+
+        badge.Width(buttonWidth);
+        badge.Height(buttonHeight);
         badge.HorizontalAlignment(HorizontalAlignment::Left);
         badge.VerticalAlignment(VerticalAlignment::Top);
         badge.Margin(Thickness{});
         badge.RenderTransform(nullptr);
 
+        dotStack.HorizontalAlignment(HorizontalAlignment::Left);
+        dotStack.VerticalAlignment(VerticalAlignment::Top);
+
+        double dotX =
+            g_settings.dotPosition == DotPosition::Left
+                ? static_cast<double>(iconBoundsInButton.X) -
+                      kDotGap - dotSize
+                : static_cast<double>(iconBoundsInButton.X) +
+                      static_cast<double>(iconBoundsInButton.Width) +
+                      kDotGap;
+
+        double dotY =
+            static_cast<double>(iconBoundsInButton.Y) +
+            (static_cast<double>(iconBoundsInButton.Height) - stackHeight) /
+                2.0;
+
+        dotStack.Margin(Thickness{dotX, dotY, 0.0, 0.0});
+
         Hosting::ElementCompositionPreview::SetIsTranslationEnabled(badge,
                                                                     true);
-        auto badgeVisual =
+
+        auto proxyVisual =
             Hosting::ElementCompositionPreview::GetElementVisual(badge);
+        auto buttonVisual =
+            Hosting::ElementCompositionPreview::GetElementVisual(
+                taskListButton);
 
         std::wstring sumX;
         std::wstring sumY;
-        for (size_t i = 0; i < chain.size(); ++i)
+
+        for (size_t i = 0; i < layoutChain.size(); ++i)
         {
             std::wstring parameter = L"p" + std::to_wstring(i);
             sumX += parameter + L".Offset.X + ";
             sumY += parameter + L".Offset.Y + ";
         }
 
-        std::wstring xAdjustment =
-            g_settings.dotPosition == DotPosition::Left
-                ? L"(-gap - dotSize)"
-                : L"(p0.Size.X + gap)";
+        std::wstring translationExpression =
+            L"Vector3(" + sumX + L"0.0f - self.Offset.X, " +
+            sumY + L"0.0f - self.Offset.Y, 0.0f)";
 
-        std::wstring expression =
-            L"Vector3(" + sumX + xAdjustment + L" - self.Offset.X, " +
-            sumY + L"(p0.Size.Y - stackHeight) / 2.0f - self.Offset.Y, 0.0f)";
+        auto translationAnimation =
+            proxyVisual.Compositor().CreateExpressionAnimation(
+                winrt::hstring(translationExpression));
 
-        auto animation = badgeVisual.Compositor().CreateExpressionAnimation(
-            winrt::hstring(expression));
-        for (size_t i = 0; i < chain.size(); ++i)
+        for (size_t i = 0; i < layoutChain.size(); ++i)
         {
-            animation.SetReferenceParameter(
-                winrt::hstring(L"p" + std::to_wstring(i)), chain[i]);
+            translationAnimation.SetReferenceParameter(
+                winrt::hstring(L"p" + std::to_wstring(i)),
+                layoutChain[i]);
         }
-        animation.SetScalarParameter(L"gap", static_cast<float>(kDotGap));
-        animation.SetScalarParameter(L"dotSize", static_cast<float>(dotSize));
-        animation.SetScalarParameter(L"stackHeight",
-                                     static_cast<float>(stackHeight));
-        animation.SetReferenceParameter(L"self", badgeVisual);
-        badgeVisual.Properties().StartAnimation(L"Translation", animation);
+
+        translationAnimation.SetReferenceParameter(L"self", proxyVisual);
+        proxyVisual.Properties().StartAnimation(
+            L"Translation", translationAnimation);
+
+        auto matrixAnimation =
+            proxyVisual.Compositor().CreateExpressionAnimation(
+                L"button.TransformMatrix");
+        matrixAnimation.SetReferenceParameter(L"button", buttonVisual);
+        proxyVisual.StartAnimation(L"TransformMatrix", matrixAnimation);
+
         return true;
     }
     catch (...)
@@ -1026,6 +1089,7 @@ void RebuildDots(Controls::StackPanel dotStack, unsigned int count)
 
 bool ApplyBadgeVisualStyle(Controls::Border badge,
                            unsigned int count,
+                           FrameworkElement taskListButton = nullptr,
                            FrameworkElement icon = nullptr,
                            Controls::Grid dotHost = nullptr)
 {
@@ -1210,7 +1274,8 @@ bool ApplyBadgeVisualStyle(Controls::Border badge,
     dotStack.VerticalAlignment(VerticalAlignment::Center);
 
     RebuildDots(dotStack, count);
-    return BindDotPositionExpression(badge, icon, dotHost, count);
+    return BindDotPositionExpression(badge, taskListButton, icon, dotHost,
+                                     count);
 }
 // -----------------------------------------------------------------------------
 // Badge
@@ -1424,14 +1489,22 @@ bool UpdateCountBadge(TrackedButton &tracked,
         if (!currentParent ||
             winrt::get_abi(currentParent) != winrt::get_abi(desiredParent))
         {
+            // Number and dots intentionally use different parents. Recreate
+            // the tiny badge when crossing IconPanel <-> RootGrid so a fresh
+            // compositor Visual is used for every Number -> Dots transition.
             StopDotPositionBinding(badge);
             if (currentParent)
             {
                 RemoveBadgeFromPanel(currentParent, badge);
             }
-            desiredParent.Children().Append(badge);
+
+            badge = nullptr;
+            tracked.badge = {};
         }
-        tracked.badge = winrt::make_weak(badge);
+        else
+        {
+            tracked.badge = winrt::make_weak(badge);
+        }
     }
 
     if (count < static_cast<unsigned int>(g_settings.minimumCount))
@@ -1451,7 +1524,8 @@ bool UpdateCountBadge(TrackedButton &tracked,
         tracked.badge = winrt::make_weak(badge);
     }
 
-    if (!ApplyBadgeVisualStyle(badge, count, icon, dotHost))
+    if (!ApplyBadgeVisualStyle(badge, count, taskListButton, icon,
+                               dotHost))
     {
         StopDotPositionBinding(badge);
         badge.Visibility(Visibility::Collapsed);
@@ -1694,24 +1768,49 @@ XamlRoot XamlRootFromTaskbarHostSharedPtr(void *hostShared[2])
         return nullptr;
     }
 
-    // Current Windows 11 TaskbarHost layout uses 0x48 on ARM64. On x64,
-    // detect the offset from TaskbarHost::FrameHeight where possible.
-    size_t elementOffset = 0x48;
+    size_t elementOffset = 0;
 
 #if defined(_M_X64)
-    const BYTE *code = reinterpret_cast<const BYTE *>(g_TaskbarHost_FrameHeight);
-    if (code[0] == 0x48 && code[1] == 0x83 && code[2] == 0xEC &&
-        code[4] == 0x48 && code[5] == 0x83 && code[6] == 0xC1 &&
-        code[7] <= 0x7F)
     {
-        elementOffset = code[7];
-    }
-    else
-    {
-        Wh_Log(L"Couldn't detect TaskbarHost XAML offset, using 0x48");
+        // 48:83EC 28 | sub rsp,28
+        // 48:83C1 48 | add rcx,48
+        const BYTE *b =
+            reinterpret_cast<const BYTE *>(g_TaskbarHost_FrameHeight);
+
+        if (b[0] == 0x48 && b[1] == 0x83 && b[2] == 0xEC &&
+            b[4] == 0x48 && b[5] == 0x83 && b[6] == 0xC1 &&
+            b[7] <= 0x7F)
+        {
+            elementOffset = b[7];
+        }
+        else
+        {
+            Wh_Log(L"Unsupported TaskbarHost::FrameHeight");
+            return nullptr;
+        }
     }
 #elif defined(_M_ARM64)
-    // Use the known/default TaskbarHost XAML element offset.
+    {
+        // 7f2303d5 pacibsp
+        // fd7bbfa9 stp fp, lr, [sp, #-0x10]!
+        // fd030091 mov fp, sp
+        // 080c41f8 ldr x8, [x0, #0x10]!
+        const DWORD *p =
+            reinterpret_cast<const DWORD *>(g_TaskbarHost_FrameHeight);
+
+        if (p[0] == 0xD503237F &&
+            (p[1] & 0xFFC07FFF) == 0xA9807BFD &&
+            p[2] == 0x910003FD &&
+            (p[3] & 0xFFF00FE0) == 0xF8400C00)
+        {
+            elementOffset = (p[3] >> 12) & 0xFF;
+        }
+        else
+        {
+            Wh_Log(L"Unsupported TaskbarHost::FrameHeight");
+            return nullptr;
+        }
+    }
 #else
 #error "Unsupported architecture"
 #endif


### PR DESCRIPTION
Adds a Windows 11 taskbar mod that shows the number of open windows for each app as either a customizable number badge or vertical dots.

Features include:
- Number badges and vertical dots
- Custom shape, size, position, offsets, colors, border, and fonts
- Configurable minimum count and maximum displayed number
- Live window-count updates
- Multi-monitor support
- x64 and ARM64 support

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [x] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
