### PR TITLE
Start button always on the left v1.3.2

### DIFF
--- a/mods/taskbar-start-button-position.wh.cpp
+++ b/mods/taskbar-start-button-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-start-button-position
 // @name            Start button always on the left
 // @description     Forces the Start button to be on the left of the taskbar, even when taskbar icons are centered, with an option to also move the search and task view buttons (Windows 11 only)
-// @version         1.3.1
+// @version         1.3.2
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -10,7 +10,7 @@
 // @include         StartMenuExperienceHost.exe
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -ldwmapi -lole32 -loleaut32 -lruntimeobject -lshcore
+// @compilerOptions -ldwmapi -lole32 -loleaut32 -lruntimeobject
 // ==/WindhawkMod==
 
 // Source code is published under The GNU General Public License v3.0.
@@ -43,15 +43,24 @@ _Start button, search and task view buttons on the left_
 
 // ==WindhawkModSettings==
 /*
+- otherSystemButtonsOnTheLeft: false
+  $name: Move other system buttons to the left
+  $description: >-
+    In addition to the Start button, also move the search and task view buttons
+    to the left, keeping only the app icons centered.
 - startMenuOnTheLeft: true
   $name: Start menu on the left
   $description: >-
     Make the start menu open on the left even if taskbar icons are centered.
-- otherSystemButtonsOnTheLeft: false
-  $name: Move other system buttons to the left
+- searchMenuPositionInAllCases: false
+  $name: Position the search menu in all cases
   $description: >-
-    In addition to the start button, also move the search and task view buttons
-    to the left, keeping only the app icons centered.
+    By default, the search menu is only repositioned when it's opened from the
+    Start menu, not when it's opened in other ways, such as with the Win+S
+    shortcut or the taskbar search icon. Enable this option to reposition it in
+    all cases.
+
+    Only applies when the "Start menu on the left" option is enabled.
 */
 // ==/WindhawkModSettings==
 
@@ -59,6 +68,8 @@ _Start button, search and task view buttons on the left_
 
 #include <atomic>
 #include <functional>
+#include <limits>
+#include <optional>
 #include <string>
 
 #include <dwmapi.h>
@@ -85,8 +96,9 @@ _Start button, search and task view buttons on the left_
 using namespace winrt::Windows::UI::Xaml;
 
 struct {
-    bool startMenuOnTheLeft;
     bool otherSystemButtonsOnTheLeft;
+    bool startMenuOnTheLeft;
+    bool searchMenuPositionInAllCases;
 } g_settings;
 
 enum class Target {
@@ -264,13 +276,12 @@ bool IsPinnedClusterButton(SystemButton button) {
            (button == SystemButton::Search || button == SystemButton::TaskView);
 }
 
-// The width of a cluster button. The search button's own ActualWidth is
-// unreliable while collapsed (the negative right margin reinforces its old
-// width), so use its content child's DesiredSize. Start and task view are
-// fixed-width, so ActualWidth is fine.
+// The width a cluster button takes up when it's not collapsed. ActualWidth
+// can't be used: it includes the collapse margin (-width), so it never drops
+// below it and grows on every layout pass. The content child's DesiredSize
+// doesn't depend on the button's own margin.
 double GetClusterButtonWidth(FrameworkElement element) {
-    if (IdentifySystemButton(element) == SystemButton::Search &&
-        Media::VisualTreeHelper::GetChildrenCount(element) > 0) {
+    if (Media::VisualTreeHelper::GetChildrenCount(element) > 0) {
         auto child = Media::VisualTreeHelper::GetChild(element, 0)
                          .try_as<FrameworkElement>();
         if (child) {
@@ -322,7 +333,7 @@ void UpdatePinnedSystemButtonMargin(FrameworkElement element) {
     }
 
     auto taskbarFrameRepeater =
-        Media::VisualTreeHelper::GetParent(element).as<FrameworkElement>();
+        Media::VisualTreeHelper::GetParent(element).try_as<FrameworkElement>();
     if (!taskbarFrameRepeater) {
         return;
     }
@@ -390,7 +401,7 @@ void UpdateWidgetLeftMargin(FrameworkElement element) {
     }
 
     auto taskbarFrameRepeater =
-        Media::VisualTreeHelper::GetParent(element).as<FrameworkElement>();
+        Media::VisualTreeHelper::GetParent(element).try_as<FrameworkElement>();
     if (!taskbarFrameRepeater) {
         return;
     }
@@ -756,7 +767,10 @@ HRESULT WINAPI IUIElement_Arrange_Hook(void* pThis,
     }
 
     auto taskbarFrameRepeater =
-        Media::VisualTreeHelper::GetParent(element).as<FrameworkElement>();
+        Media::VisualTreeHelper::GetParent(element).try_as<FrameworkElement>();
+    if (!taskbarFrameRepeater) {
+        return original();
+    }
 
     // Find the widgets button at its left-pinned position (offset matches its
     // margin). When present, it sits right of the start button (or cluster) and
@@ -879,22 +893,24 @@ void WINAPI ExperienceToggleButton_UpdateButtonPadding_Hook(void* pThis) {
     }
 }
 
-// The start button context menu is centered over the start button or aligned
-// to its leading edge depending on the taskbar alignment (TaskbarFrame's
+// The start button context menu is centered over the start button or aligned to
+// its leading edge depending on the taskbar alignment (TaskbarFrame's
 // Alignment, where Left=0 and Center=1). Both the placement mode and the anchor
 // position are derived from it. With the start button forced to the left, the
 // menu should align to the button's leading edge, so report left alignment
 // while the menu is being shown, letting the taskbar's own left-alignment code
 // position the menu.
-using TaskbarFrame_Alignment_t = int(WINAPI*)(void* pThis);
-TaskbarFrame_Alignment_t TaskbarFrame_Alignment_Original;
-int WINAPI TaskbarFrame_Alignment_Hook(void* pThis) {
-    if (!g_unloading && g_settings.startMenuOnTheLeft &&
+using TaskbarFrame_get_Alignment_t = HRESULT(WINAPI*)(void* pThis,
+                                                      int* alignment);
+TaskbarFrame_get_Alignment_t TaskbarFrame_get_Alignment_Original;
+HRESULT WINAPI TaskbarFrame_get_Alignment_Hook(void* pThis, int* alignment) {
+    HRESULT hr = TaskbarFrame_get_Alignment_Original(pThis, alignment);
+    if (SUCCEEDED(hr) && !g_unloading && g_settings.startMenuOnTheLeft &&
         g_inShowStartButtonContextMenu) {
-        return 0;  // TaskbarAlignment::Left
+        *alignment = 0;  // TaskbarAlignment::Left
     }
 
-    return TaskbarFrame_Alignment_Original(pThis);
+    return hr;
 }
 
 // The alignment above is read while the context menu coroutine resumes (after
@@ -964,9 +980,9 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
             ExperienceToggleButton_UpdateButtonPadding_Hook,
         },
         {
-            {LR"(public: enum winrt::WindowsUdk::UI::Shell::TaskbarAlignment __cdecl winrt::Taskbar::implementation::TaskbarFrame::Alignment(void)const )"},
-            &TaskbarFrame_Alignment_Original,
-            TaskbarFrame_Alignment_Hook,
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarFrame,struct winrt::Taskbar::ITaskbarFrame>::get_Alignment(int *))"},
+            &TaskbarFrame_get_Alignment_Original,
+            TaskbarFrame_get_Alignment_Hook,
         },
         {
             {LR"(static  winrt::Taskbar::implementation::ContextMenus::ShowStartButtonContextMenuAsync$_ResumeCoro$1())"},
@@ -1132,7 +1148,8 @@ HRESULT WINAPI DwmSetWindowAttribute_Hook(HWND hwnd,
         // Only change x.
         int xNew;
 
-        if (g_settings.startMenuOnTheLeft && !cloak && IsStartMenuOpen()) {
+        if (g_settings.startMenuOnTheLeft && !cloak &&
+            (g_settings.searchMenuPositionInAllCases || IsStartMenuOpen())) {
             // Not centered or already changed.
             if (x == monitorInfo.rcWork.left) {
                 return original();
@@ -1488,9 +1505,11 @@ void RestoreMenuPositions() {
 }
 
 void LoadSettings() {
-    g_settings.startMenuOnTheLeft = Wh_GetIntSetting(L"startMenuOnTheLeft");
     g_settings.otherSystemButtonsOnTheLeft =
         Wh_GetIntSetting(L"otherSystemButtonsOnTheLeft");
+    g_settings.startMenuOnTheLeft = Wh_GetIntSetting(L"startMenuOnTheLeft");
+    g_settings.searchMenuPositionInAllCases =
+        Wh_GetIntSetting(L"searchMenuPositionInAllCases");
 }
 
 BOOL Wh_ModInit() {


### PR DESCRIPTION
* Added an option to position the search menu in all cases. By default, the search menu is only repositioned when it's opened from the Start menu, not when it's opened in other ways, such as with the Win+S shortcut or the taskbar search icon.
* Fixed an issue with the Start button moving to the right in some cases.
* Improved compatibility with older Windows 11 versions.