### PR TITLE
Add Start Button Replacer mod

### DIFF
--- a/mods/start-button-replacer.wh.cpp
+++ b/mods/start-button-replacer.wh.cpp
@@ -83,7 +83,9 @@ the pressed duration. Set a duration to `0` to switch instantly.
 
 For crisp results, use a square image with transparency. Keep animated GIFs
 reasonably small, such as 64x64 or 128x128. The displayed size is independent
-from the source image resolution.
+from the source image resolution. Image files must be no larger than 8 MiB and
+must be stored on a fixed local drive. Network, mapped, removable and optical
+drives aren't read from Explorer's taskbar UI thread.
 */
 // ==/WindhawkModReadme==
 
@@ -91,11 +93,11 @@ from the source image resolution.
 /*
 - images:
   - imageSource: ""
-    $name: Image source
+    $name: Image source (necessary)
     $description: >-
-      Absolute local path or path containing environment variables. Supports
-      PNG, JPG and animated GIF. This is the normal image and the final fallback
-      for every other state.
+      Absolute path on a fixed local drive, or a path containing environment
+      variables. Supports PNG, JPG and animated GIF files up to 8 MiB. This is
+      the normal image and the final fallback for every other state.
   - hoverImageSource: ""
     $name: Hover image source
     $description: >-
@@ -113,9 +115,13 @@ from the source image resolution.
       pressed image is used, followed by the hover image and normal image.
   - iconSize: 34
     $name: Icon size
-    $description: Displayed size in device-independent pixels, from 8 to 128.
+    $description: >-
+      Displayed size in device-independent pixels, from 8 to 128. The default is
+      34.
   $name: Images
-  $description: Configure the replacement images and their displayed size.
+  $description: >-
+    Configure the replacement images and their displayed size. Image files on
+    network, mapped, removable and optical drives aren't supported.
 
 - imageAnimation:
   - gifPlayback: hover
@@ -130,44 +136,55 @@ from the source image resolution.
     $name: Hover crossfade duration
     $description: >-
       Crossfade duration in milliseconds when entering or leaving the hover
-      state. Set to 0 to switch images instantly.
+      state. Set to 0 to switch images instantly. The default is 120.
   - pressedFadeDuration: 80
     $name: Pressed and activated crossfade duration
     $description: >-
       Crossfade duration in milliseconds when entering or leaving the pressed
-      or activated state. Set to 0 to switch images instantly.
+      or activated state. Set to 0 to switch images instantly. The default is
+      80.
   $name: Image animation
   $description: Configure animated GIF playback and crossfades between images.
 
 - hoverEffects:
   - hoverScale: 115
     $name: Scale
-    $description: Icon scale as a percentage while hovering. 100 keeps its size.
+    $description: >-
+      Icon scale as a percentage while hovering. 100 keeps its size. The default
+      is 115.
   - hoverRotation: 4
     $name: Rotation
-    $description: Rotation in degrees while hovering. 0 disables rotation.
+    $description: >-
+      Rotation in degrees while hovering. 0 disables rotation. The default is 4.
   - hoverOpacity: 100
     $name: Opacity
-    $description: Icon opacity as a percentage while hovering.
+    $description: >-
+      Icon opacity as a percentage while hovering. The default is 100.
   - hoverDuration: 120
     $name: Transition duration
-    $description: Effect transition duration in milliseconds.
+    $description: >-
+      Effect transition duration in milliseconds. The default is 120.
   $name: Hover effects
   $description: Configure the visual effect applied while hovering.
 
 - pressedEffects:
   - pressedScale: 95
     $name: Scale
-    $description: Icon scale as a percentage while pressed. 100 keeps its size.
+    $description: >-
+      Icon scale as a percentage while pressed. 100 keeps its size. The default
+      is 95.
   - pressedRotation: -4
     $name: Rotation
-    $description: Rotation in degrees while pressed. 0 disables rotation.
+    $description: >-
+      Rotation in degrees while pressed. 0 disables rotation. The default is -4.
   - pressedOpacity: 100
     $name: Opacity
-    $description: Icon opacity as a percentage while pressed.
+    $description: >-
+      Icon opacity as a percentage while pressed. The default is 100.
   - pressedDuration: 80
     $name: Transition duration
-    $description: Effect transition duration in milliseconds.
+    $description: >-
+      Effect transition duration in milliseconds. The default is 80.
   $name: Pressed effects
   $description: Configure the visual effect applied while pressing the button.
 
@@ -176,7 +193,7 @@ from the source image resolution.
     $name: Release duration
     $description: >-
       Effect transition duration in milliseconds when the pointer leaves or the
-      button is released.
+      button is released. The default is 140.
   - respectSystemAnimations: true
     $name: Respect Windows animation setting
     $description: >-
@@ -271,6 +288,7 @@ enum class IconState : size_t {
 };
 
 constexpr size_t kIconStateCount = static_cast<size_t>(IconState::Count);
+constexpr uint64_t kMaximumImageFileSize = 8ULL * 1024 * 1024;
 
 struct ModSettings {
     std::wstring imageSource;
@@ -1779,9 +1797,43 @@ size_t GetTrackedInstanceCount() {
 // Bitmap/image loading
 // -----------------------------------------------------------------------------
 
+bool IsFixedLocalImagePath(const std::wstring& path) {
+    // Accept ordinary drive-letter paths and their extended-length form. UNC,
+    // device, relative and volume-GUID paths are intentionally rejected before
+    // CreateFileW can block Explorer's taskbar UI thread on external storage.
+    size_t driveOffset = 0;
+
+    if (path.compare(0, 4, L"\\\\?\\") == 0) {
+        driveOffset = 4;
+    }
+
+    if (path.size() < driveOffset + 3) {
+        return false;
+    }
+
+    wchar_t driveLetter = path[driveOffset];
+    bool isDriveLetter =
+        (driveLetter >= L'A' && driveLetter <= L'Z') ||
+        (driveLetter >= L'a' && driveLetter <= L'z');
+
+    if (!isDriveLetter || path[driveOffset + 1] != L':' ||
+        (path[driveOffset + 2] != L'\\' &&
+         path[driveOffset + 2] != L'/')) {
+        return false;
+    }
+
+    wchar_t driveRoot[] = {driveLetter, L':', L'\\', L'\0'};
+
+    return GetDriveTypeW(driveRoot) == DRIVE_FIXED;
+}
+
 HRESULT CreateMemoryBackedStreamFromFile(
     const std::wstring& path,
     wss::IRandomAccessStream& randomAccessStream) {
+    if (!IsFixedLocalImagePath(path)) {
+        return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+    }
+
     HANDLE file =
         CreateFileW(path.c_str(), GENERIC_READ,
                     FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
@@ -1794,6 +1846,17 @@ HRESULT CreateMemoryBackedStreamFromFile(
 
     std::unique_ptr<void, decltype(&CloseHandle)> fileOwner(file, CloseHandle);
 
+    LARGE_INTEGER fileSize{};
+
+    if (!GetFileSizeEx(file, &fileSize)) {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    if (fileSize.QuadPart < 0 ||
+        static_cast<uint64_t>(fileSize.QuadPart) > kMaximumImageFileSize) {
+        return HRESULT_FROM_WIN32(ERROR_FILE_TOO_LARGE);
+    }
+
     winrt::com_ptr<IStream> memoryStream;
     HRESULT hr = CreateStreamOnHGlobal(nullptr, TRUE, memoryStream.put());
 
@@ -1802,6 +1865,7 @@ HRESULT CreateMemoryBackedStreamFromFile(
     }
 
     std::array<BYTE, 64 * 1024> buffer;
+    uint64_t totalBytesRead = 0;
 
     while (true) {
         DWORD bytesRead = 0;
@@ -1814,6 +1878,12 @@ HRESULT CreateMemoryBackedStreamFromFile(
         if (bytesRead == 0) {
             break;
         }
+
+        if (totalBytesRead > kMaximumImageFileSize - bytesRead) {
+            return HRESULT_FROM_WIN32(ERROR_FILE_TOO_LARGE);
+        }
+
+        totalBytesRead += bytesRead;
 
         ULONG bytesWritten = 0;
         hr = memoryStream->Write(buffer.data(), bytesRead, &bytesWritten);
@@ -1931,6 +2001,16 @@ bool LoadImageResource(const std::shared_ptr<StartIconInstance>& instance,
             return false;
         }
 
+        if (!IsFixedLocalImagePath(path)) {
+            resource.failed = true;
+
+            Wh_Log(L"Reading %s image \"%s\" was refused: the source must "
+                   L"be on a fixed local drive",
+                   IconStateName(state), path.c_str());
+
+            return false;
+        }
+
         wss::IRandomAccessStream stream{nullptr};
 
         HRESULT hr = CreateMemoryBackedStreamFromFile(path, stream);
@@ -1938,16 +2018,22 @@ bool LoadImageResource(const std::shared_ptr<StartIconInstance>& instance,
         if (FAILED(hr) || !stream) {
             resource.failed = true;
 
-            Wh_Log(L"Reading %s image \"%s\" failed: 0x%08X",
-                   IconStateName(state), path.c_str(), hr);
+            if (hr == HRESULT_FROM_WIN32(ERROR_FILE_TOO_LARGE)) {
+                Wh_Log(L"Reading %s image \"%s\" was refused: the file "
+                       L"exceeds the 8 MiB limit",
+                       IconStateName(state), path.c_str());
+            } else {
+                Wh_Log(L"Reading %s image \"%s\" failed: 0x%08X",
+                       IconStateName(state), path.c_str(), hr);
+            }
 
             return false;
         }
 
         resource.memoryStream = stream;
 
-        // Asynchronous decoding prevents larger animated GIFs from blocking
-        // Explorer's taskbar UI thread.
+        // SetSourceAsync decodes the bounded in-memory copy asynchronously. The
+        // source file itself was read synchronously above.
         resource.loadAction = bitmap.SetSourceAsync(stream);
 
         return true;
@@ -3102,6 +3188,13 @@ BOOL Wh_ModInit() {
     g_unloading = false;
 
     StoreSettings(LoadSettings());
+
+    if (IsBlank(GetSettingsSnapshot().imageSource)) {
+        Wh_Log(L"No image source is configured; leaving the stock Start icon "
+               L"unchanged");
+
+        return FALSE;
+    }
 
     if (!HookTaskbarDllSymbols()) {
         return FALSE;

--- a/mods/start-button-replacer.wh.cpp
+++ b/mods/start-button-replacer.wh.cpp
@@ -7,7 +7,7 @@
 // @github          https://github.com/EnderDragonEP
 // @twitter         https://twitter.com/NoobieNoodle89
 // @include         explorer.exe
-// @architecture    amd64
+// @architecture    x86-64
 // @compilerOptions -lole32 -loleaut32 -lruntimeobject -lshcore
 // @license         GPL-3.0-only
 // ==/WindhawkMod==
@@ -3246,8 +3246,14 @@ XamlRootFromTaskbarHostSharedPtr(
             L"Unrecognized TaskbarHost::FrameHeight; using fallback offset 0x48");
     }
 
+#elif defined(_M_ARM64)
+
+    // The x64 instruction pattern above doesn't apply to ARM64. Use the
+    // established TaskbarHost layout fallback used by Windhawk's current
+    // Windows 11 taskbar mods.
+
 #else
-#error This version of the mod currently supports x86-64 only.
+#error Unsupported architecture.
 #endif
 
     auto* taskbarElementIUnknown =

--- a/mods/start-button-replacer.wh.cpp
+++ b/mods/start-button-replacer.wh.cpp
@@ -1,0 +1,3912 @@
+// ==WindhawkMod==
+// @id              start-button-replacer
+// @name            Start Button Replacer
+// @description     Replace the Windows 11 Start button icon with a custom PNG, JPG or GIF image
+// @version         0.12.1
+// @author          Ender
+// @github          https://github.com/EnderDragonEP
+// @twitter         https://twitter.com/NoobieNoodle89
+// @include         explorer.exe
+// @architecture    amd64
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lshcore
+// @license         GPL-3.0-only
+// ==/WindhawkMod==
+
+// Source code is published under the GNU General Public License v3.0 only.
+//
+// The TaskbarHost/XamlRoot discovery technique is based on the technique used
+// by Windhawk's official Windows 11 taskbar mods by m417z.
+//
+// This mod:
+//   * Finds the Windows 11 Start button.
+//   * Keeps all original Start button behavior intact.
+//   * Makes the stock Start icon transparent.
+//   * Inserts two layered Windows.UI.Xaml.Controls.Image elements.
+//   * Supports PNG/JPG/GIF.
+//   * Supports local absolute paths and HTTP/HTTPS URLs.
+//   * Supports animated GIF playback.
+//   * Supports crossfading normal, hover and pressed images.
+//   * Supports hover/press scale, rotation and opacity effects.
+
+// ==WindhawkModReadme==
+/*
+# Start Button Replacer
+
+Replaces the icon inside the Windows 11 Start button with a custom PNG, JPG or
+GIF image. Animated GIF playback and hover/pressed effects are optional
+features.
+
+Only the icon is replaced. Windows continues to handle clicking, keyboard
+navigation, accessibility and Start menu activation.
+
+## Image sources
+
+Local files:
+
+    C:\Users\YourName\Pictures\start.png
+
+Environment variables are supported:
+
+    %USERPROFILE%\Pictures\start.jpg
+
+HTTP/HTTPS URLs are also supported:
+
+    https://example.com/start.gif
+
+## Animated GIF playback
+
+- Always
+- Hover
+- Pressed
+- Stopped
+
+## Effects
+
+Separate scale, rotation and opacity settings are available for hover and
+pressed states.
+
+## Separate state images
+
+The main **Image source** is always the normal image. Add a hover, pressed or
+activated image source to enable that state automatically. The activated image
+is shown while the Start menu is open. If it is blank or unavailable, activated
+falls back to the pressed image, then the hover image, then the main image.
+Other blank or unavailable state images fall back to the main image.
+
+While the Start menu is shown, pressing the button temporarily uses the pressed
+state. The activated state resumes on release and otherwise takes priority over
+the hover state.
+
+State images crossfade whenever their applicable duration is greater than zero.
+Hover transitions use the hover duration; pressed and activated transitions use
+the pressed duration. Set a duration to `0` to switch instantly.
+
+## Notes
+
+For crisp results, use a square image with transparency. Keep animated GIFs
+reasonably small, such as 64x64 or 128x128. The displayed size is independent
+from the source image resolution.
+*/
+// ==/WindhawkModReadme==
+
+
+// ==WindhawkModSettings==
+/*
+- imageSource: ""
+  $name: Image source
+  $description: >-
+    Absolute local path, path containing environment variables, or HTTP/HTTPS
+    URL. Supports PNG, JPG and animated GIF. This is always the normal image and
+    is also the fallback for other states.
+
+- hoverImageSource: ""
+  $name: Hover image source
+  $description: >-
+    Image shown while hovering. Leave blank to use the normal image.
+
+- pressedImageSource: ""
+  $name: Pressed image source
+  $description: >-
+    Image shown while pressed. Leave blank to use the normal image.
+
+- activatedImageSource: ""
+  $name: Activated image source
+  $description: >-
+    Image shown while the Start menu is open. If blank or unavailable, uses the
+    pressed image, then the hover image, then the normal image.
+
+- hoverFadeDuration: 120
+  $name: Hover crossfade duration
+  $description: >-
+    Fade duration in milliseconds when entering or leaving the hover state. Set
+    to 0 to switch instantly.
+
+- pressedFadeDuration: 80
+  $name: Pressed crossfade duration
+  $description: >-
+    Fade duration in milliseconds when entering or leaving the pressed or
+    activated state. Set to 0 to switch instantly.
+
+- iconSize: 24
+  $name: Icon size
+  $description: Displayed icon size in device-independent pixels.
+
+- gifPlayback: always
+  $name: GIF playback
+  $description: Controls when an animated GIF is playing.
+  $options:
+  - always: Always
+  - hover: Only while hovering
+  - pressed: Only while pressed
+  - stopped: Never / first frame
+
+- hoverScale: 115
+  $name: Hover scale
+  $description: Scale percentage while the mouse is over the Start button.
+
+- hoverRotation: 4
+  $name: Hover rotation
+  $description: Rotation in degrees while hovering.
+
+- hoverOpacity: 100
+  $name: Hover opacity
+  $description: Opacity percentage while hovering.
+
+- hoverDuration: 120
+  $name: Hover animation duration
+  $description: Duration in milliseconds.
+
+- pressedScale: 88
+  $name: Pressed scale
+  $description: Scale percentage while the Start button is pressed.
+
+- pressedRotation: -4
+  $name: Pressed rotation
+  $description: Rotation in degrees while pressed.
+
+- pressedOpacity: 90
+  $name: Pressed opacity
+  $description: Opacity percentage while pressed.
+
+- pressedDuration: 80
+  $name: Pressed animation duration
+  $description: Duration in milliseconds.
+
+- releaseDuration: 140
+  $name: Release animation duration
+  $description: Duration used when returning from pressed/hover state.
+
+- respectSystemAnimations: true
+  $name: Respect Windows animation setting
+  $description: >-
+    Stop GIF playback and make transitions instant when Windows animation
+    effects are disabled.
+*/
+// ==/WindhawkModSettings==
+
+
+#include <windhawk_utils.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <shcore.h>
+
+#undef GetCurrentTime
+
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Storage.Streams.h>
+#include <winrt/Windows.UI.Composition.h>
+#include <winrt/Windows.UI.ViewManagement.h>
+#include <winrt/Windows.UI.Xaml.Automation.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Windows.UI.Xaml.Hosting.h>
+#include <winrt/Windows.UI.Xaml.Input.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
+#include <winrt/Windows.UI.Xaml.Media.Imaging.h>
+#include <winrt/Windows.UI.Xaml.h>
+
+
+namespace wf =
+    winrt::Windows::Foundation;
+
+namespace wss =
+    winrt::Windows::Storage::Streams;
+
+namespace wuc =
+    winrt::Windows::UI::Composition;
+
+namespace wuv =
+    winrt::Windows::UI::ViewManagement;
+
+namespace wux =
+    winrt::Windows::UI::Xaml;
+
+namespace wuxa =
+    winrt::Windows::UI::Xaml::Automation;
+
+namespace wuxc =
+    winrt::Windows::UI::Xaml::Controls;
+
+namespace wuxcp =
+    winrt::Windows::UI::Xaml::Controls::Primitives;
+
+namespace wuxh =
+    winrt::Windows::UI::Xaml::Hosting;
+
+namespace wuxi =
+    winrt::Windows::UI::Xaml::Input;
+
+namespace wuxm =
+    winrt::Windows::UI::Xaml::Media;
+
+namespace wuxmi =
+    winrt::Windows::UI::Xaml::Media::Imaging;
+
+
+// -----------------------------------------------------------------------------
+// Settings
+// -----------------------------------------------------------------------------
+
+enum class GifPlaybackMode {
+    Always,
+    Hover,
+    Pressed,
+    Stopped,
+};
+
+enum class GifAnimationStatus {
+    Unknown,
+    NotAnimated,
+    Playing,
+    Stopped,
+    SystemAnimationsDisabled,
+};
+
+enum class IconState : size_t {
+    Normal,
+    Hover,
+    Pressed,
+    Activated,
+    Count,
+};
+
+constexpr size_t kIconStateCount =
+    static_cast<size_t>(IconState::Count);
+
+struct ModSettings {
+    std::wstring imageSource;
+
+    std::wstring hoverImageSource;
+    std::wstring pressedImageSource;
+    std::wstring activatedImageSource;
+
+    int hoverFadeDuration = 120;
+    int pressedFadeDuration = 80;
+
+    int iconSize = 24;
+
+    GifPlaybackMode gifPlayback =
+        GifPlaybackMode::Always;
+
+    double hoverScale = 1.15;
+    double hoverRotation = 4.0;
+    double hoverOpacity = 1.0;
+    int hoverDuration = 120;
+
+    double pressedScale = 0.88;
+    double pressedRotation = -4.0;
+    double pressedOpacity = 0.90;
+    int pressedDuration = 80;
+
+    int releaseDuration = 140;
+
+    bool respectSystemAnimations = true;
+};
+
+ModSettings g_settings;
+
+std::atomic<bool> g_unloading = false;
+
+
+// -----------------------------------------------------------------------------
+// Start icon instance
+// -----------------------------------------------------------------------------
+
+struct ImageResource {
+    wuxmi::BitmapImage bitmap{nullptr};
+
+    // Keep local file streams alive while their bitmaps exist.
+    wss::IRandomAccessStream localStream{nullptr};
+    wf::IAsyncAction loadAction{nullptr};
+
+    winrt::event_token imageOpenedToken{};
+    winrt::event_token imageFailedToken{};
+
+    bool imageOpenedAttached = false;
+    bool imageFailedAttached = false;
+    bool failed = false;
+};
+
+struct StartIconInstance {
+    DWORD threadId = 0;
+
+    winrt::weak_ref<wux::FrameworkElement> startButton;
+    winrt::weak_ref<wux::FrameworkElement> stockIcon;
+    winrt::weak_ref<wuxc::Panel> hostPanel;
+    winrt::weak_ref<wuxc::Grid> customImageHost;
+    winrt::weak_ref<wuxc::Image> customImage;
+    winrt::weak_ref<wuxc::Image> transitionImage;
+
+    double originalStockOpacity = 1.0;
+
+    std::array<ImageResource, kIconStateCount>
+        imageResources;
+
+    // Multiple logical states can share one decoded image resource when their
+    // configured sources are identical.
+    std::array<size_t, kIconStateCount>
+        imageResourceIndexByState{0, 1, 2, 3};
+
+    size_t activeImageIndex = 0;
+    bool activeImageSet = false;
+    size_t activeLayerIndex = 0;
+    IconState requestedState = IconState::Normal;
+    bool requestedStateSet = false;
+    IconState displayedState = IconState::Normal;
+    bool displayedStateSet = false;
+
+    GifAnimationStatus loggedGifStatus =
+        GifAnimationStatus::Unknown;
+    GifPlaybackMode loggedGifMode =
+        GifPlaybackMode::Always;
+    IconState loggedGifState = IconState::Normal;
+    size_t loggedGifResourceIndex = 0;
+    bool gifStatusLogged = false;
+
+    bool hovering = false;
+    bool pressed = false;
+    bool activated = false;
+
+    int64_t pressedStateCallbackToken = 0;
+    bool pressedStateCallbackRegistered = false;
+
+    int64_t activatedStateCallbackToken = 0;
+    bool activatedStateCallbackRegistered = false;
+
+    wf::IInspectable pointerEnteredHandler{nullptr};
+    wf::IInspectable pointerExitedHandler{nullptr};
+    wf::IInspectable pointerPressedHandler{nullptr};
+    wf::IInspectable pointerReleasedHandler{nullptr};
+    wf::IInspectable pointerCanceledHandler{nullptr};
+    wf::IInspectable pointerCaptureLostHandler{nullptr};
+
+    bool pointerEventsAttached = false;
+};
+
+std::vector<std::shared_ptr<StartIconInstance>> g_instances;
+
+
+// -----------------------------------------------------------------------------
+// Utility
+// -----------------------------------------------------------------------------
+
+std::wstring GetStringSetting(const wchar_t* name) {
+    PCWSTR value = Wh_GetStringSetting(name);
+
+    std::wstring result =
+        value ? value : L"";
+
+    if (value) {
+        Wh_FreeStringSetting(value);
+    }
+
+    return result;
+}
+
+bool EqualsIgnoreCase(
+    const std::wstring& a,
+    const wchar_t* b)
+{
+    return _wcsicmp(a.c_str(), b) == 0;
+}
+
+bool StartsWithIgnoreCase(
+    const std::wstring& value,
+    const wchar_t* prefix)
+{
+    size_t prefixLength = wcslen(prefix);
+
+    if (value.length() < prefixLength) {
+        return false;
+    }
+
+    return _wcsnicmp(
+               value.c_str(),
+               prefix,
+               prefixLength) == 0;
+}
+
+bool IsHttpUrl(const std::wstring& source) {
+    return StartsWithIgnoreCase(
+               source,
+               L"http://") ||
+           StartsWithIgnoreCase(
+               source,
+               L"https://");
+}
+
+std::wstring ExpandPath(
+    const std::wstring& source)
+{
+    if (source.empty()) {
+        return source;
+    }
+
+    DWORD required =
+        ExpandEnvironmentStringsW(
+            source.c_str(),
+            nullptr,
+            0);
+
+    if (!required) {
+        return source;
+    }
+
+    std::wstring result(
+        required,
+        L'\0');
+
+    DWORD written =
+        ExpandEnvironmentStringsW(
+            source.c_str(),
+            result.data(),
+            required);
+
+    if (!written ||
+        written > required)
+    {
+        return source;
+    }
+
+    if (!result.empty() &&
+        result.back() == L'\0')
+    {
+        result.pop_back();
+    }
+
+    return result;
+}
+
+void LoadSettings() {
+    g_settings.imageSource =
+        GetStringSetting(L"imageSource");
+
+    g_settings.hoverImageSource =
+        GetStringSetting(
+            L"hoverImageSource");
+
+    g_settings.pressedImageSource =
+        GetStringSetting(
+            L"pressedImageSource");
+
+    g_settings.activatedImageSource =
+        GetStringSetting(
+            L"activatedImageSource");
+
+    g_settings.hoverFadeDuration =
+        std::clamp(
+            Wh_GetIntSetting(
+                L"hoverFadeDuration"),
+            0,
+            5000);
+
+    g_settings.pressedFadeDuration =
+        std::clamp(
+            Wh_GetIntSetting(
+                L"pressedFadeDuration"),
+            0,
+            5000);
+
+    g_settings.iconSize =
+        std::clamp(
+            Wh_GetIntSetting(L"iconSize"),
+            8,
+            128);
+
+    std::wstring playback =
+        GetStringSetting(L"gifPlayback");
+
+    if (EqualsIgnoreCase(
+            playback,
+            L"hover"))
+    {
+        g_settings.gifPlayback =
+            GifPlaybackMode::Hover;
+    }
+    else if (EqualsIgnoreCase(
+                 playback,
+                 L"pressed"))
+    {
+        g_settings.gifPlayback =
+            GifPlaybackMode::Pressed;
+    }
+    else if (EqualsIgnoreCase(
+                 playback,
+                 L"stopped"))
+    {
+        g_settings.gifPlayback =
+            GifPlaybackMode::Stopped;
+    }
+    else
+    {
+        g_settings.gifPlayback =
+            GifPlaybackMode::Always;
+    }
+
+    g_settings.hoverScale =
+        std::clamp(
+            Wh_GetIntSetting(
+                L"hoverScale"),
+            10,
+            500) /
+        100.0;
+
+    g_settings.hoverRotation =
+        std::clamp(
+            Wh_GetIntSetting(
+                L"hoverRotation"),
+            -360,
+            360);
+
+    g_settings.hoverOpacity =
+        std::clamp(
+            Wh_GetIntSetting(
+                L"hoverOpacity"),
+            0,
+            100) /
+        100.0;
+
+    g_settings.hoverDuration =
+        std::clamp(
+            Wh_GetIntSetting(
+                L"hoverDuration"),
+            0,
+            5000);
+
+    g_settings.pressedScale =
+        std::clamp(
+            Wh_GetIntSetting(
+                L"pressedScale"),
+            10,
+            500) /
+        100.0;
+
+    g_settings.pressedRotation =
+        std::clamp(
+            Wh_GetIntSetting(
+                L"pressedRotation"),
+            -360,
+            360);
+
+    g_settings.pressedOpacity =
+        std::clamp(
+            Wh_GetIntSetting(
+                L"pressedOpacity"),
+            0,
+            100) /
+        100.0;
+
+    g_settings.pressedDuration =
+        std::clamp(
+            Wh_GetIntSetting(
+                L"pressedDuration"),
+            0,
+            5000);
+
+    g_settings.releaseDuration =
+        std::clamp(
+            Wh_GetIntSetting(
+                L"releaseDuration"),
+            0,
+            5000);
+
+    g_settings.respectSystemAnimations =
+        Wh_GetIntSetting(
+            L"respectSystemAnimations") != 0;
+}
+
+
+// -----------------------------------------------------------------------------
+// Windows animation accessibility setting
+// -----------------------------------------------------------------------------
+
+bool MotionAllowed() {
+    if (!g_settings.respectSystemAnimations) {
+        return true;
+    }
+
+    try {
+        wuv::UISettings uiSettings;
+
+        return uiSettings.AnimationsEnabled();
+    }
+    catch (...) {
+        return true;
+    }
+}
+
+
+// -----------------------------------------------------------------------------
+// Composition effects
+// -----------------------------------------------------------------------------
+
+void SetVisualImmediately(
+    const wuc::Visual& visual,
+    float scale,
+    float rotation,
+    float opacity)
+{
+    visual.StopAnimation(L"Scale");
+    visual.StopAnimation(
+        L"RotationAngleInDegrees");
+    visual.StopAnimation(L"Opacity");
+
+    visual.Scale({
+        scale,
+        scale,
+        1.0f
+    });
+
+    visual.RotationAngleInDegrees(
+        rotation);
+
+    visual.Opacity(opacity);
+}
+
+void AnimateVisual(
+    const wux::FrameworkElement& element,
+    float scale,
+    float rotation,
+    float opacity,
+    int durationMs)
+{
+    if (!element) {
+        return;
+    }
+
+    try {
+        auto visual =
+            wuxh::ElementCompositionPreview::
+                GetElementVisual(element);
+
+        if (!visual) {
+            return;
+        }
+
+        float width =
+            static_cast<float>(
+                element.ActualWidth());
+
+        float height =
+            static_cast<float>(
+                element.ActualHeight());
+
+        if (width <= 0) {
+            width =
+                static_cast<float>(
+                    g_settings.iconSize);
+        }
+
+        if (height <= 0) {
+            height =
+                static_cast<float>(
+                    g_settings.iconSize);
+        }
+
+        visual.CenterPoint({
+            width / 2.0f,
+            height / 2.0f,
+            0.0f
+        });
+
+        if (!MotionAllowed() ||
+            durationMs <= 0)
+        {
+            SetVisualImmediately(
+                visual,
+                scale,
+                rotation,
+                opacity);
+
+            return;
+        }
+
+        auto compositor =
+            visual.Compositor();
+
+        auto easing =
+            compositor
+                .CreateCubicBezierEasingFunction(
+                    {
+                        0.20f,
+                        0.00f
+                    },
+                    {
+                        0.00f,
+                        1.00f
+                    });
+
+        // Scale.
+        {
+            auto animation =
+                compositor
+                    .CreateVector3KeyFrameAnimation();
+
+            animation.InsertKeyFrame(
+                1.0f,
+                {
+                    scale,
+                    scale,
+                    1.0f
+                },
+                easing);
+
+            animation.Duration(
+                std::chrono::milliseconds(
+                    durationMs));
+
+            visual.StartAnimation(
+                L"Scale",
+                animation);
+        }
+
+        // Rotation.
+        {
+            auto animation =
+                compositor
+                    .CreateScalarKeyFrameAnimation();
+
+            animation.InsertKeyFrame(
+                1.0f,
+                rotation,
+                easing);
+
+            animation.Duration(
+                std::chrono::milliseconds(
+                    durationMs));
+
+            visual.StartAnimation(
+                L"RotationAngleInDegrees",
+                animation);
+        }
+
+        // Opacity.
+        {
+            auto animation =
+                compositor
+                    .CreateScalarKeyFrameAnimation();
+
+            animation.InsertKeyFrame(
+                1.0f,
+                opacity,
+                easing);
+
+            animation.Duration(
+                std::chrono::milliseconds(
+                    durationMs));
+
+            visual.StartAnimation(
+                L"Opacity",
+                animation);
+        }
+    }
+    catch (const winrt::hresult_error& e) {
+        Wh_Log(
+            L"AnimateVisual failed: 0x%08X %s",
+            e.code().value,
+            e.message().c_str());
+    }
+}
+
+
+// -----------------------------------------------------------------------------
+// GIF playback
+// -----------------------------------------------------------------------------
+
+size_t IconStateIndex(IconState state) {
+    return static_cast<size_t>(state);
+}
+
+const wchar_t* IconStateName(IconState state) {
+    switch (state) {
+        case IconState::Normal:
+            return L"normal";
+
+        case IconState::Hover:
+            return L"hover";
+
+        case IconState::Pressed:
+            return L"pressed";
+
+        case IconState::Activated:
+            return L"activated";
+
+        default:
+            return L"unknown";
+    }
+}
+
+IconState GetCurrentIconState(
+    const std::shared_ptr<
+        StartIconInstance>& instance)
+{
+    if (instance && instance->pressed) {
+        return IconState::Pressed;
+    }
+
+    if (instance && instance->activated) {
+        return IconState::Activated;
+    }
+
+    if (instance && instance->hovering) {
+        return IconState::Hover;
+    }
+
+    return IconState::Normal;
+}
+
+std::wstring GetImageSourceForState(
+    IconState state)
+{
+    if (state == IconState::Normal) {
+        return g_settings.imageSource;
+    }
+
+    switch (state) {
+        case IconState::Hover:
+            return g_settings.hoverImageSource;
+
+        case IconState::Pressed:
+            return g_settings.pressedImageSource;
+
+        case IconState::Activated:
+            return g_settings.activatedImageSource;
+
+        default:
+            return L"";
+    }
+}
+
+bool ImageResourceAvailable(
+    const ImageResource& resource)
+{
+    return resource.bitmap &&
+        !resource.failed;
+}
+
+wuxc::Image GetImageLayer(
+    const std::shared_ptr<
+        StartIconInstance>& instance,
+    size_t layerIndex)
+{
+    if (!instance) {
+        return nullptr;
+    }
+
+    return layerIndex == 0
+        ? instance->customImage.get()
+        : instance->transitionImage.get();
+}
+
+bool ImageSourcesEqual(
+    const std::wstring& first,
+    const std::wstring& second)
+{
+    if (first.empty() || second.empty()) {
+        return false;
+    }
+
+    if (first == second) {
+        return true;
+    }
+
+    // URL paths can be case-sensitive. Local Windows paths are not, and
+    // environment variables should be compared after expansion.
+    if (IsHttpUrl(first) ||
+        IsHttpUrl(second))
+    {
+        return false;
+    }
+
+    std::wstring expandedFirst =
+        ExpandPath(first);
+    std::wstring expandedSecond =
+        ExpandPath(second);
+
+    return _wcsicmp(
+               expandedFirst.c_str(),
+               expandedSecond.c_str()) == 0;
+}
+
+void SetImageLayerOpacity(
+    const wuxc::Image& image,
+    float opacity)
+{
+    if (!image) {
+        return;
+    }
+
+    try {
+        auto visual =
+            wuxh::ElementCompositionPreview::
+                GetElementVisual(image);
+
+        if (!visual) {
+            return;
+        }
+
+        visual.StopAnimation(L"Opacity");
+        visual.Opacity(opacity);
+    }
+    catch (...) {
+    }
+}
+
+const wchar_t* GifPlaybackModeName(
+    GifPlaybackMode mode)
+{
+    switch (mode) {
+        case GifPlaybackMode::Always:
+            return L"always";
+
+        case GifPlaybackMode::Hover:
+            return L"hover";
+
+        case GifPlaybackMode::Pressed:
+            return L"pressed";
+
+        case GifPlaybackMode::Stopped:
+            return L"never/first-frame";
+
+        default:
+            return L"unknown";
+    }
+}
+
+const wchar_t* GifAnimationStatusName(
+    GifAnimationStatus status)
+{
+    switch (status) {
+        case GifAnimationStatus::NotAnimated:
+            return L"not-animated";
+
+        case GifAnimationStatus::Playing:
+            return L"playing";
+
+        case GifAnimationStatus::Stopped:
+            return L"stopped";
+
+        case GifAnimationStatus::
+                 SystemAnimationsDisabled:
+            return L"stopped-system-animations-disabled";
+
+        default:
+            return L"unknown";
+    }
+}
+
+void AnimateImageLayerOpacity(
+    const wuxc::Image& image,
+    float fromOpacity,
+    float toOpacity,
+    int durationMs)
+{
+    if (!image) {
+        return;
+    }
+
+    if (!MotionAllowed() ||
+        durationMs <= 0)
+    {
+        SetImageLayerOpacity(
+            image,
+            toOpacity);
+        return;
+    }
+
+    try {
+        auto visual =
+            wuxh::ElementCompositionPreview::
+                GetElementVisual(image);
+
+        if (!visual) {
+            return;
+        }
+
+        visual.StopAnimation(L"Opacity");
+        visual.Opacity(fromOpacity);
+
+        auto compositor =
+            visual.Compositor();
+
+        auto easing =
+            compositor
+                .CreateCubicBezierEasingFunction(
+                    {0.20f, 0.00f},
+                    {0.00f, 1.00f});
+
+        auto animation =
+            compositor
+                .CreateScalarKeyFrameAnimation();
+
+        animation.InsertKeyFrame(
+            0.0f,
+            fromOpacity);
+
+        animation.InsertKeyFrame(
+            1.0f,
+            toOpacity,
+            easing);
+
+        animation.Duration(
+            std::chrono::milliseconds(
+                durationMs));
+
+        visual.StartAnimation(
+            L"Opacity",
+            animation);
+    }
+    catch (...) {
+        SetImageLayerOpacity(
+            image,
+            toOpacity);
+    }
+}
+
+int GetStateCrossfadeDuration(
+    const std::shared_ptr<
+        StartIconInstance>& instance,
+    IconState nextState)
+{
+    if (!instance) {
+        return 0;
+    }
+
+    if (nextState == IconState::Pressed ||
+        nextState == IconState::Activated ||
+        (instance->displayedStateSet &&
+         (instance->displayedState ==
+              IconState::Pressed ||
+          instance->displayedState ==
+              IconState::Activated)))
+    {
+        return g_settings.pressedFadeDuration;
+    }
+
+    return g_settings.hoverFadeDuration;
+}
+
+bool UpdateDisplayedImage(
+    const std::shared_ptr<
+        StartIconInstance>& instance)
+{
+    if (!instance) {
+        return false;
+    }
+
+    auto firstLayer =
+        GetImageLayer(instance, 0);
+    auto secondLayer =
+        GetImageLayer(instance, 1);
+
+    if (!firstLayer || !secondLayer) {
+        return false;
+    }
+
+    auto setStockOpacity =
+        [&](double opacity)
+        {
+            auto stockIcon =
+                instance->stockIcon.get();
+
+            if (stockIcon) {
+                try {
+                    stockIcon.Opacity(opacity);
+                }
+                catch (...) {
+                }
+            }
+        };
+
+    IconState desiredState =
+        GetCurrentIconState(instance);
+
+    size_t normalIndex =
+        IconStateIndex(
+            IconState::Normal);
+
+    size_t selectedIndex = normalIndex;
+    IconState selectedState =
+        IconState::Normal;
+
+    auto selectIfAvailable =
+        [&](IconState state)
+        {
+            size_t stateIndex =
+                instance
+                    ->imageResourceIndexByState[
+                        IconStateIndex(state)];
+
+            if (!ImageResourceAvailable(
+                    instance
+                        ->imageResources[stateIndex]))
+            {
+                return false;
+            }
+
+            selectedIndex = stateIndex;
+            selectedState = state;
+            return true;
+        };
+
+    if (desiredState ==
+        IconState::Activated)
+    {
+        if (!selectIfAvailable(
+                IconState::Activated) &&
+            !selectIfAvailable(
+                IconState::Pressed) &&
+            !selectIfAvailable(
+                IconState::Hover))
+        {
+            selectIfAvailable(
+                IconState::Normal);
+        }
+    }
+    else if (!selectIfAvailable(
+                 desiredState))
+    {
+        selectIfAvailable(
+            IconState::Normal);
+    }
+
+    auto& selectedResource =
+        instance
+            ->imageResources[selectedIndex];
+
+    bool selectionChanged =
+        !instance->requestedStateSet ||
+        instance->requestedState !=
+            desiredState ||
+        !instance->displayedStateSet ||
+        instance->displayedState !=
+            selectedState;
+
+    instance->requestedState =
+        desiredState;
+    instance->requestedStateSet = true;
+
+    if (selectionChanged) {
+        Wh_Log(
+            L"Start icon state: requested=%s selected=%s",
+            IconStateName(desiredState),
+            IconStateName(selectedState));
+    }
+
+    if (!ImageResourceAvailable(
+            selectedResource))
+    {
+        for (size_t layerIndex = 0;
+             layerIndex < 2;
+             layerIndex++)
+        {
+            auto layer =
+                GetImageLayer(
+                    instance,
+                    layerIndex);
+
+            try {
+                layer.Source(
+                    wuxm::ImageSource{nullptr});
+            }
+            catch (...) {
+            }
+
+            SetImageLayerOpacity(
+                layer,
+                0.0f);
+        }
+
+        instance->activeImageSet = false;
+        instance->displayedState =
+            IconState::Normal;
+        instance->displayedStateSet = true;
+
+        setStockOpacity(
+            instance->originalStockOpacity);
+
+        return false;
+    }
+
+    if (instance->activeImageSet &&
+        instance->activeImageIndex ==
+            selectedIndex)
+    {
+        instance->displayedState =
+            selectedState;
+        instance->displayedStateSet = true;
+        setStockOpacity(0.0);
+        return true;
+    }
+
+    try {
+        if (!instance->activeImageSet) {
+            firstLayer.Source(
+                selectedResource.bitmap);
+
+            SetImageLayerOpacity(
+                firstLayer,
+                1.0f);
+            SetImageLayerOpacity(
+                secondLayer,
+                0.0f);
+
+            instance->activeLayerIndex = 0;
+        }
+        else {
+            size_t outgoingLayerIndex =
+                instance->activeLayerIndex;
+            size_t incomingLayerIndex =
+                1 - outgoingLayerIndex;
+
+            auto outgoingLayer =
+                GetImageLayer(
+                    instance,
+                    outgoingLayerIndex);
+            auto incomingLayer =
+                GetImageLayer(
+                    instance,
+                    incomingLayerIndex);
+
+            incomingLayer.Source(
+                selectedResource.bitmap);
+
+            int fadeDuration =
+                GetStateCrossfadeDuration(
+                    instance,
+                    selectedState);
+
+            AnimateImageLayerOpacity(
+                outgoingLayer,
+                1.0f,
+                0.0f,
+                fadeDuration);
+
+            AnimateImageLayerOpacity(
+                incomingLayer,
+                0.0f,
+                1.0f,
+                fadeDuration);
+
+            instance->activeLayerIndex =
+                incomingLayerIndex;
+        }
+
+        instance->activeImageIndex =
+            selectedIndex;
+        instance->activeImageSet = true;
+        instance->displayedState =
+            selectedState;
+        instance->displayedStateSet = true;
+
+        setStockOpacity(0.0);
+
+        return true;
+    }
+    catch (const winrt::hresult_error& e) {
+        Wh_Log(
+            L"Switching Start image failed: 0x%08X %s",
+            e.code().value,
+            e.message().c_str());
+    }
+    catch (...) {
+        Wh_Log(
+            L"Switching Start image failed");
+    }
+
+    instance->activeImageSet = false;
+    setStockOpacity(
+        instance->originalStockOpacity);
+
+    return false;
+}
+
+void LogGifAnimationStatus(
+    const std::shared_ptr<
+        StartIconInstance>& instance,
+    GifAnimationStatus status)
+{
+    if (!instance ||
+        !instance->activeImageSet)
+    {
+        return;
+    }
+
+    IconState state =
+        instance->displayedStateSet
+            ? instance->displayedState
+            : GetCurrentIconState(instance);
+
+    if (instance->gifStatusLogged &&
+        instance->loggedGifStatus == status &&
+        instance->loggedGifMode ==
+            g_settings.gifPlayback &&
+        instance->loggedGifState == state &&
+        instance->loggedGifResourceIndex ==
+            instance->activeImageIndex)
+    {
+        return;
+    }
+
+    instance->loggedGifStatus = status;
+    instance->loggedGifMode =
+        g_settings.gifPlayback;
+    instance->loggedGifState = state;
+    instance->loggedGifResourceIndex =
+        instance->activeImageIndex;
+    instance->gifStatusLogged = true;
+
+    IconState resourceState =
+        instance->activeImageIndex <
+            kIconStateCount
+            ? static_cast<IconState>(
+                  instance->activeImageIndex)
+            : IconState::Normal;
+
+    Wh_Log(
+        L"Icon Status: state=%s resource=%s mode=%s status=%s",
+        IconStateName(state),
+        IconStateName(resourceState),
+        GifPlaybackModeName(
+            g_settings.gifPlayback),
+        GifAnimationStatusName(status));
+}
+
+void UpdateGifPlayback(
+    const std::shared_ptr<
+        StartIconInstance>& instance)
+{
+    if (!instance)
+    {
+        return;
+    }
+
+    for (size_t i = 0;
+         i < kIconStateCount;
+         i++)
+    {
+        auto& resource =
+            instance->imageResources[i];
+
+        if (!resource.bitmap ||
+            (instance->activeImageSet &&
+             instance->activeImageIndex == i))
+        {
+            continue;
+        }
+
+        try {
+            resource.bitmap.Stop();
+        }
+        catch (...) {
+        }
+    }
+
+    if (!instance->activeImageSet) {
+        return;
+    }
+
+    auto& activeResource =
+        instance->imageResources[
+            instance->activeImageIndex];
+
+    if (!ImageResourceAvailable(
+            activeResource))
+    {
+        return;
+    }
+
+    try {
+        if (!activeResource
+                 .bitmap
+                 .IsAnimatedBitmap())
+        {
+            LogGifAnimationStatus(
+                instance,
+                GifAnimationStatus::NotAnimated);
+            return;
+        }
+
+        if (!MotionAllowed()) {
+            activeResource.bitmap.Stop();
+
+            LogGifAnimationStatus(
+                instance,
+                GifAnimationStatus::
+                    SystemAnimationsDisabled);
+            return;
+        }
+
+        bool play = false;
+
+        switch (
+            g_settings.gifPlayback)
+        {
+            case GifPlaybackMode::Always:
+                play = true;
+                break;
+
+            case GifPlaybackMode::Hover:
+                play =
+                    instance->hovering;
+                break;
+
+            case GifPlaybackMode::Pressed:
+                play =
+                    instance->pressed;
+                break;
+
+            case GifPlaybackMode::Stopped:
+                play = false;
+                break;
+        }
+
+        if (play) {
+            activeResource.bitmap.Play();
+
+            LogGifAnimationStatus(
+                instance,
+                GifAnimationStatus::Playing);
+        }
+        else {
+            activeResource.bitmap.Stop();
+
+            LogGifAnimationStatus(
+                instance,
+                GifAnimationStatus::Stopped);
+        }
+    }
+    catch (...) {
+        // Non-animated images or images that
+        // haven't finished loading yet can
+        // simply ignore playback control.
+    }
+}
+
+
+// -----------------------------------------------------------------------------
+// Visual states
+// -----------------------------------------------------------------------------
+
+void ApplyNormalState(
+    const std::shared_ptr<
+        StartIconInstance>& instance,
+    int duration)
+{
+    auto imageHost =
+        instance->customImageHost.get();
+
+    if (!imageHost) {
+        return;
+    }
+
+    AnimateVisual(
+        imageHost,
+        1.0f,
+        0.0f,
+        1.0f,
+        duration);
+}
+
+void ApplyHoverState(
+    const std::shared_ptr<
+        StartIconInstance>& instance,
+    int duration)
+{
+    auto imageHost =
+        instance->customImageHost.get();
+
+    if (!imageHost) {
+        return;
+    }
+
+    AnimateVisual(
+        imageHost,
+        static_cast<float>(
+            g_settings.hoverScale),
+        static_cast<float>(
+            g_settings.hoverRotation),
+        static_cast<float>(
+            g_settings.hoverOpacity),
+        duration);
+}
+
+void ApplyPressedState(
+    const std::shared_ptr<
+        StartIconInstance>& instance,
+    int duration)
+{
+    auto imageHost =
+        instance->customImageHost.get();
+
+    if (!imageHost) {
+        return;
+    }
+
+    AnimateVisual(
+        imageHost,
+        static_cast<float>(
+            g_settings.pressedScale),
+        static_cast<float>(
+            g_settings.pressedRotation),
+        static_cast<float>(
+            g_settings.pressedOpacity),
+        duration);
+}
+
+void ApplyCurrentState(
+    const std::shared_ptr<
+        StartIconInstance>& instance,
+    int duration)
+{
+    if (!instance) {
+        return;
+    }
+
+    if (!UpdateDisplayedImage(instance)) {
+        return;
+    }
+
+    if (instance->pressed) {
+        ApplyPressedState(
+            instance,
+            duration);
+    }
+    else if (instance->hovering) {
+        ApplyHoverState(
+            instance,
+            duration);
+    }
+    else {
+        ApplyNormalState(
+            instance,
+            duration);
+    }
+
+    UpdateGifPlayback(instance);
+}
+
+void SetPressedState(
+    const std::shared_ptr<
+        StartIconInstance>& instance,
+    bool pressed)
+{
+    if (!instance ||
+        instance->pressed == pressed)
+    {
+        return;
+    }
+
+    instance->pressed = pressed;
+
+    if (pressed) {
+        Wh_Log(
+            L"Start button: PRESSED");
+    }
+    else {
+        Wh_Log(
+            L"Start button: RELEASED");
+    }
+
+    ApplyCurrentState(
+        instance,
+        pressed
+            ? g_settings.pressedDuration
+            : g_settings.releaseDuration);
+}
+
+bool IsToggleButtonChecked(
+    const wuxcp::ToggleButton& toggleButton)
+{
+    if (!toggleButton) {
+        return false;
+    }
+
+    auto isChecked =
+        toggleButton.IsChecked();
+
+    return isChecked &&
+        isChecked.Value();
+}
+
+void SetActivatedState(
+    const std::shared_ptr<
+        StartIconInstance>& instance,
+    bool activated)
+{
+    if (!instance ||
+        instance->activated == activated)
+    {
+        return;
+    }
+
+    instance->activated = activated;
+
+    if (activated) {
+        Wh_Log(L"Start menu: SHOWN");
+    }
+    else {
+        Wh_Log(L"Start menu: HIDDEN");
+    }
+
+    UpdateDisplayedImage(instance);
+    UpdateGifPlayback(instance);
+}
+
+
+// -----------------------------------------------------------------------------
+// XAML tree search
+// -----------------------------------------------------------------------------
+
+wux::FrameworkElement FindElementRecursive(
+    const wux::DependencyObject& root,
+    const std::function<
+        bool(
+            const wux::FrameworkElement&)>&
+        callback)
+{
+    if (!root) {
+        return nullptr;
+    }
+
+    int childrenCount = 0;
+
+    try {
+        childrenCount =
+            wuxm::VisualTreeHelper::
+                GetChildrenCount(root);
+    }
+    catch (...) {
+        return nullptr;
+    }
+
+    for (int i = 0;
+         i < childrenCount;
+         i++)
+    {
+        wux::DependencyObject child{
+            nullptr
+        };
+
+        try {
+            child =
+                wuxm::VisualTreeHelper::
+                    GetChild(
+                        root,
+                        i);
+        }
+        catch (...) {
+            continue;
+        }
+
+        if (!child) {
+            continue;
+        }
+
+        auto frameworkElement =
+            child.try_as<
+                wux::FrameworkElement>();
+
+        if (frameworkElement) {
+            try {
+                if (callback(
+                        frameworkElement))
+                {
+                    return frameworkElement;
+                }
+            }
+            catch (...) {
+            }
+        }
+
+        auto recursiveResult =
+            FindElementRecursive(
+                child,
+                callback);
+
+        if (recursiveResult) {
+            return recursiveResult;
+        }
+    }
+
+    return nullptr;
+}
+
+wux::FrameworkElement FindStartButton(
+    const wux::FrameworkElement& root)
+{
+    return FindElementRecursive(
+        root,
+        [](const wux::FrameworkElement&
+               element)
+        {
+            try {
+                auto automationId =
+                    wuxa::AutomationProperties::
+                        GetAutomationId(
+                            element);
+
+                if (automationId ==
+                    L"StartButton")
+                {
+                    return true;
+                }
+            }
+            catch (...) {
+            }
+
+            return false;
+        });
+}
+
+wux::FrameworkElement FindStockStartIcon(
+    const wux::FrameworkElement&
+        startButton)
+{
+    // Preferred match:
+    //
+    // Microsoft.UI.Xaml.Controls
+    //     .AnimatedVisualPlayer#Icon
+
+    auto exact =
+        FindElementRecursive(
+            startButton,
+            [](const wux::FrameworkElement&
+                   element)
+            {
+                try {
+                    if (element.Name() !=
+                        L"Icon")
+                    {
+                        return false;
+                    }
+
+                    std::wstring className =
+                        winrt::get_class_name(
+                            element)
+                            .c_str();
+
+                    return className.find(
+                               L"AnimatedVisualPlayer") !=
+                           std::wstring::npos;
+                }
+                catch (...) {
+                    return false;
+                }
+            });
+
+    if (exact) {
+        return exact;
+    }
+
+    // Fallback for future Windows builds:
+    // accept a descendant named Icon.
+    return FindElementRecursive(
+        startButton,
+        [](const wux::FrameworkElement&
+               element)
+        {
+            try {
+                return element.Name() ==
+                       L"Icon";
+            }
+            catch (...) {
+                return false;
+            }
+        });
+}
+
+wuxc::Panel FindHostPanel(
+    const wux::FrameworkElement&
+        stockIcon,
+    const wux::FrameworkElement&
+        startButton)
+{
+    wux::DependencyObject current =
+        stockIcon;
+
+    while (current) {
+        try {
+            current =
+                wuxm::VisualTreeHelper::
+                    GetParent(current);
+        }
+        catch (...) {
+            return nullptr;
+        }
+
+        if (!current) {
+            return nullptr;
+        }
+
+        auto panel =
+            current.try_as<wuxc::Panel>();
+
+        if (panel) {
+            return panel;
+        }
+
+        auto frameworkElement =
+            current.try_as<
+                wux::FrameworkElement>();
+
+        if (frameworkElement &&
+            frameworkElement ==
+                startButton)
+        {
+            break;
+        }
+    }
+
+    return nullptr;
+}
+
+
+// -----------------------------------------------------------------------------
+// Instance management
+// -----------------------------------------------------------------------------
+
+void PruneDeadInstances() {
+    g_instances.erase(
+        std::remove_if(
+            g_instances.begin(),
+            g_instances.end(),
+            [](const auto& instance)
+            {
+                if (!instance) {
+                    return true;
+                }
+
+                return
+                    !instance
+                         ->startButton
+                         .get();
+            }),
+        g_instances.end());
+}
+
+bool AlreadyAttached(
+    const wux::FrameworkElement&
+        startButton)
+{
+    PruneDeadInstances();
+
+    for (const auto& instance :
+         g_instances)
+    {
+        auto existingButton =
+            instance
+                ->startButton
+                .get();
+
+        if (existingButton &&
+            existingButton ==
+                startButton)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void RemoveCustomImage(
+    const std::shared_ptr<
+        StartIconInstance>& instance)
+{
+    auto panel =
+        instance->hostPanel.get();
+
+    auto imageHost =
+        instance->customImageHost.get();
+
+    if (!panel ||
+        !imageHost)
+    {
+        return;
+    }
+
+    try {
+        auto children =
+            panel.Children();
+
+        for (uint32_t i = 0;
+             i < children.Size();
+             i++)
+        {
+            auto child =
+                children.GetAt(i);
+
+            if (child == imageHost) {
+                children.RemoveAt(i);
+                break;
+            }
+        }
+    }
+    catch (...) {
+    }
+}
+
+void DetachInstance(
+    const std::shared_ptr<
+        StartIconInstance>& instance)
+{
+    if (!instance) {
+        return;
+    }
+
+    auto startButton =
+        instance->startButton.get();
+
+    if (startButton &&
+        instance->pressedStateCallbackRegistered)
+    {
+        try {
+            auto buttonBase =
+                startButton.try_as<
+                    wuxcp::ButtonBase>();
+
+            if (buttonBase) {
+                buttonBase
+                    .UnregisterPropertyChangedCallback(
+                        wuxcp::ButtonBase::
+                            IsPressedProperty(),
+                        instance
+                            ->pressedStateCallbackToken);
+            }
+        }
+        catch (const winrt::hresult_error& e) {
+            Wh_Log(
+                L"Removing pressed-state callback failed: 0x%08X %s",
+                e.code().value,
+                e.message().c_str());
+        }
+        catch (...) {
+        }
+
+        instance->pressedStateCallbackToken = 0;
+        instance->pressedStateCallbackRegistered = false;
+    }
+    else if (!startButton) {
+        instance->pressedStateCallbackToken = 0;
+        instance->pressedStateCallbackRegistered = false;
+    }
+
+    if (startButton &&
+        instance->activatedStateCallbackRegistered)
+    {
+        try {
+            auto toggleButton =
+                startButton.try_as<
+                    wuxcp::ToggleButton>();
+
+            if (toggleButton) {
+                toggleButton
+                    .UnregisterPropertyChangedCallback(
+                        wuxcp::ToggleButton::
+                            IsCheckedProperty(),
+                        instance
+                            ->activatedStateCallbackToken);
+            }
+        }
+        catch (const winrt::hresult_error& e) {
+            Wh_Log(
+                L"Removing activated-state callback failed: 0x%08X %s",
+                e.code().value,
+                e.message().c_str());
+        }
+        catch (...) {
+        }
+
+        instance->activatedStateCallbackToken = 0;
+        instance->activatedStateCallbackRegistered = false;
+    }
+    else if (!startButton) {
+        instance->activatedStateCallbackToken = 0;
+        instance->activatedStateCallbackRegistered = false;
+    }
+
+    if (startButton &&
+    instance->pointerEventsAttached)
+    {
+        auto removeHandler =
+            [&](const wux::RoutedEvent& routedEvent,
+                wf::IInspectable& handler,
+                const wchar_t* eventName)
+            {
+                if (!handler) {
+                    return;
+                }
+
+                try {
+                    startButton.RemoveHandler(
+                        routedEvent,
+                        handler);
+                }
+                catch (const winrt::hresult_error& e) {
+                    Wh_Log(
+                        L"Removing %s handler failed: 0x%08X %s",
+                        eventName,
+                        e.code().value,
+                        e.message().c_str());
+                }
+                catch (...) {
+                    Wh_Log(
+                        L"Removing %s handler failed",
+                        eventName);
+                }
+
+                handler = nullptr;
+            };
+
+        removeHandler(
+            wux::UIElement::
+                PointerEnteredEvent(),
+            instance->pointerEnteredHandler,
+            L"PointerEntered");
+
+        removeHandler(
+            wux::UIElement::
+                PointerExitedEvent(),
+            instance->pointerExitedHandler,
+            L"PointerExited");
+
+        removeHandler(
+            wux::UIElement::
+                PointerPressedEvent(),
+            instance->pointerPressedHandler,
+            L"PointerPressed");
+
+        removeHandler(
+            wux::UIElement::
+                PointerReleasedEvent(),
+            instance->pointerReleasedHandler,
+            L"PointerReleased");
+
+        removeHandler(
+            wux::UIElement::
+                PointerCanceledEvent(),
+            instance->pointerCanceledHandler,
+            L"PointerCanceled");
+
+        removeHandler(
+            wux::UIElement::
+                PointerCaptureLostEvent(),
+            instance->pointerCaptureLostHandler,
+            L"PointerCaptureLost");
+
+        instance->pointerEventsAttached = false;
+    }
+    else if (!startButton) {
+        instance->pointerEnteredHandler = nullptr;
+        instance->pointerExitedHandler = nullptr;
+        instance->pointerPressedHandler = nullptr;
+        instance->pointerReleasedHandler = nullptr;
+        instance->pointerCanceledHandler = nullptr;
+        instance->pointerCaptureLostHandler = nullptr;
+        instance->pointerEventsAttached = false;
+    }
+
+    for (size_t i = 0;
+         i < kIconStateCount;
+         i++)
+    {
+        auto& resource =
+            instance->imageResources[i];
+
+        if (resource.bitmap &&
+            resource.imageOpenedAttached)
+        {
+            try {
+                resource.bitmap.ImageOpened(
+                    resource.imageOpenedToken);
+            }
+            catch (const winrt::hresult_error& e) {
+                Wh_Log(
+                    L"Removing %s ImageOpened handler failed: 0x%08X %s",
+                    IconStateName(
+                        static_cast<IconState>(i)),
+                    e.code().value,
+                    e.message().c_str());
+            }
+            catch (...) {
+                Wh_Log(
+                    L"Removing %s ImageOpened handler failed",
+                    IconStateName(
+                        static_cast<IconState>(i)));
+            }
+
+            resource.imageOpenedAttached = false;
+        }
+
+        if (resource.bitmap &&
+            resource.imageFailedAttached)
+        {
+            try {
+                resource.bitmap.ImageFailed(
+                    resource.imageFailedToken);
+            }
+            catch (const winrt::hresult_error& e) {
+                Wh_Log(
+                    L"Removing %s ImageFailed handler failed: 0x%08X %s",
+                    IconStateName(
+                        static_cast<IconState>(i)),
+                    e.code().value,
+                    e.message().c_str());
+            }
+            catch (...) {
+                Wh_Log(
+                    L"Removing %s ImageFailed handler failed",
+                    IconStateName(
+                        static_cast<IconState>(i)));
+            }
+
+            resource.imageFailedAttached = false;
+        }
+
+        try {
+            if (resource.bitmap) {
+                resource.bitmap.Stop();
+            }
+        }
+        catch (...) {
+        }
+
+        resource.loadAction = nullptr;
+        resource.localStream = nullptr;
+        resource.bitmap = nullptr;
+        resource.failed = false;
+    }
+
+    instance->activeImageSet = false;
+    instance->requestedStateSet = false;
+    instance->displayedStateSet = false;
+    instance->gifStatusLogged = false;
+
+    auto imageHost =
+        instance->customImageHost.get();
+
+    if (imageHost) {
+        try {
+            auto visual =
+                wuxh::ElementCompositionPreview::
+                    GetElementVisual(imageHost);
+
+            if (visual) {
+                visual.StopAnimation(
+                    L"Scale");
+
+                visual.StopAnimation(
+                    L"RotationAngleInDegrees");
+
+                visual.StopAnimation(
+                    L"Opacity");
+            }
+        }
+        catch (...) {
+        }
+    }
+
+    for (size_t layerIndex = 0;
+         layerIndex < 2;
+         layerIndex++)
+    {
+        auto layer =
+            GetImageLayer(
+                instance,
+                layerIndex);
+
+        if (!layer) {
+            continue;
+        }
+
+        try {
+            auto visual =
+                wuxh::ElementCompositionPreview::
+                    GetElementVisual(layer);
+
+            if (visual) {
+                visual.StopAnimation(
+                    L"Opacity");
+            }
+        }
+        catch (...) {
+        }
+    }
+
+    RemoveCustomImage(instance);
+
+    auto stockIcon =
+        instance->stockIcon.get();
+
+    if (stockIcon) {
+        try {
+            stockIcon.Opacity(
+                instance
+                    ->originalStockOpacity);
+        }
+        catch (...) {
+        }
+    }
+
+}
+
+void DetachAllForCurrentThread() {
+    DWORD threadId =
+        GetCurrentThreadId();
+
+    for (auto it =
+             g_instances.begin();
+         it != g_instances.end();)
+    {
+        auto instance = *it;
+
+        if (!instance ||
+            instance->threadId ==
+                threadId ||
+            !instance
+                 ->startButton
+                 .get())
+        {
+            if (instance &&
+                instance->threadId ==
+                    threadId)
+            {
+                DetachInstance(
+                    instance);
+            }
+
+            it =
+                g_instances.erase(it);
+        }
+        else {
+            ++it;
+        }
+    }
+}
+
+
+// -----------------------------------------------------------------------------
+// Bitmap/image loading
+// -----------------------------------------------------------------------------
+
+bool LoadImageResource(
+    const std::shared_ptr<
+        StartIconInstance>& instance,
+    IconState state,
+    const std::wstring& source)
+{
+    if (!instance || source.empty()) {
+        return false;
+    }
+
+    size_t stateIndex =
+        IconStateIndex(state);
+
+    auto& resource =
+        instance->imageResources[stateIndex];
+
+    try {
+        wuxmi::BitmapImage bitmap;
+
+        // Only the currently displayed GIF should run. Playback is updated
+        // after every state change and when decoding completes.
+        bitmap.AutoPlay(false);
+
+        resource.bitmap = bitmap;
+        resource.failed = false;
+
+        std::weak_ptr<StartIconInstance>
+            weakInstance = instance;
+
+        resource.imageOpenedToken =
+            bitmap.ImageOpened(
+                [weakInstance, stateIndex](
+                    const wf::IInspectable&,
+                    const wux::RoutedEventArgs&)
+                {
+                    auto instance =
+                        weakInstance.lock();
+
+                    if (!instance) {
+                        return;
+                    }
+
+                    auto state =
+                        static_cast<IconState>(
+                            stateIndex);
+
+                    Wh_Log(
+                        L"Custom Start %s image loaded",
+                        IconStateName(state));
+
+                    UpdateDisplayedImage(instance);
+                    UpdateGifPlayback(instance);
+                });
+
+        resource.imageOpenedAttached = true;
+
+        resource.imageFailedToken =
+            bitmap.ImageFailed(
+                [weakInstance, stateIndex](
+                    const wf::IInspectable&,
+                    const wux::ExceptionRoutedEventArgs&
+                        args)
+                {
+                    auto instance =
+                        weakInstance.lock();
+
+                    if (!instance) {
+                        return;
+                    }
+
+                    auto& resource =
+                        instance
+                            ->imageResources[stateIndex];
+
+                    resource.failed = true;
+
+                    auto state =
+                        static_cast<IconState>(
+                            stateIndex);
+
+                    Wh_Log(
+                        L"Custom Start %s image failed: %s",
+                        IconStateName(state),
+                        args
+                            .ErrorMessage()
+                            .c_str());
+
+                    UpdateDisplayedImage(instance);
+                    UpdateGifPlayback(instance);
+                });
+
+        resource.imageFailedAttached = true;
+
+        if (IsHttpUrl(source)) {
+            bitmap.UriSource(
+                wf::Uri(source));
+
+            return true;
+        }
+
+        std::wstring path =
+            ExpandPath(source);
+
+        if (path.empty()) {
+            resource.failed = true;
+            return false;
+        }
+
+        wss::IRandomAccessStream stream{
+            nullptr
+        };
+
+        winrt::guid streamGuid =
+            winrt::guid_of<
+                wss::IRandomAccessStream>();
+
+        HRESULT hr =
+            CreateRandomAccessStreamOnFile(
+                path.c_str(),
+                GENERIC_READ,
+                reinterpret_cast<
+                    const IID&>(
+                    streamGuid),
+                reinterpret_cast<
+                    void**>(
+                    winrt::put_abi(
+                        stream)));
+
+        if (FAILED(hr) || !stream) {
+            resource.failed = true;
+
+            Wh_Log(
+                L"Opening %s image \"%s\" failed: 0x%08X",
+                IconStateName(state),
+                path.c_str(),
+                hr);
+
+            return false;
+        }
+
+        resource.localStream = stream;
+
+        // Asynchronous decoding prevents larger animated GIFs from blocking
+        // Explorer's taskbar UI thread.
+        resource.loadAction =
+            bitmap.SetSourceAsync(stream);
+
+        return true;
+    }
+    catch (const winrt::hresult_error& e) {
+        resource.failed = true;
+
+        Wh_Log(
+            L"Loading %s image failed: 0x%08X %s",
+            IconStateName(state),
+            e.code().value,
+            e.message().c_str());
+    }
+    catch (...) {
+        resource.failed = true;
+
+        Wh_Log(
+            L"Loading %s image failed with unknown exception",
+            IconStateName(state));
+    }
+
+    return false;
+}
+
+bool LoadImages(
+    const std::shared_ptr<
+        StartIconInstance>& instance)
+{
+    if (!instance) {
+        return false;
+    }
+
+    std::array<std::wstring, kIconStateCount>
+        sources;
+
+    for (size_t i = 0;
+         i < kIconStateCount;
+         i++)
+    {
+        instance
+            ->imageResourceIndexByState[i] = i;
+
+        sources[i] =
+            GetImageSourceForState(
+                static_cast<IconState>(i));
+    }
+
+    if (!LoadImageResource(
+            instance,
+            IconState::Normal,
+            sources[IconStateIndex(
+                IconState::Normal)]))
+    {
+        return false;
+    }
+
+    for (size_t stateIndex = 1;
+         stateIndex < kIconStateCount;
+         stateIndex++)
+    {
+        IconState state =
+            static_cast<IconState>(
+                stateIndex);
+
+        if (sources[stateIndex].empty()) {
+            continue;
+        }
+
+        bool reusedResource = false;
+
+        for (size_t previousIndex = 0;
+             previousIndex < stateIndex;
+             previousIndex++)
+        {
+            if (!ImageSourcesEqual(
+                    sources[stateIndex],
+                    sources[previousIndex]))
+            {
+                continue;
+            }
+
+            instance
+                ->imageResourceIndexByState[stateIndex] =
+                instance
+                    ->imageResourceIndexByState[
+                        previousIndex];
+
+            Wh_Log(
+                L"The %s image reuses the %s image resource",
+                IconStateName(state),
+                IconStateName(
+                    static_cast<IconState>(
+                        previousIndex)));
+
+            reusedResource = true;
+            break;
+        }
+
+        if (reusedResource) {
+            continue;
+        }
+
+        if (!LoadImageResource(
+                instance,
+                state,
+                sources[stateIndex]))
+        {
+            Wh_Log(
+                L"The %s image is unavailable; using its fallback",
+                IconStateName(state));
+        }
+    }
+
+    return true;
+}
+
+
+// -----------------------------------------------------------------------------
+// Interaction state setup
+// -----------------------------------------------------------------------------
+
+void AttachPointerEvents(
+    const std::shared_ptr<StartIconInstance>& instance,
+    const wux::FrameworkElement& startButton)
+{
+    std::weak_ptr<StartIconInstance>
+        weakInstance = instance;
+
+    // Mark cleanup as necessary before the first registration so a failure in
+    // the middle of this function can still remove every handler added so far.
+    instance->pointerEventsAttached = true;
+
+    //
+    // POINTER ENTERED
+    //
+    instance->pointerEnteredHandler =
+        winrt::box_value(
+            wuxi::PointerEventHandler(
+                [weakInstance](
+                    const wf::IInspectable&,
+                    const wuxi::PointerRoutedEventArgs&)
+                {
+                    auto instance =
+                        weakInstance.lock();
+
+                    if (!instance) {
+                        return;
+                    }
+
+                    instance->hovering = true;
+
+                    ApplyCurrentState(
+                        instance,
+                        instance->pressed
+                            ? g_settings
+                                  .pressedDuration
+                            : g_settings
+                                  .hoverDuration);
+                }));
+
+    startButton.AddHandler(
+        wux::UIElement::PointerEnteredEvent(),
+        instance->pointerEnteredHandler,
+        true);
+
+
+    //
+    // POINTER EXITED
+    //
+    instance->pointerExitedHandler =
+        winrt::box_value(
+            wuxi::PointerEventHandler(
+                [weakInstance](
+                    const wf::IInspectable&,
+                    const wuxi::PointerRoutedEventArgs&)
+                {
+                    auto instance =
+                        weakInstance.lock();
+
+                    if (!instance) {
+                        return;
+                    }
+
+                    instance->hovering = false;
+
+                    // PointerPressed and PointerReleased aren't guaranteed to
+                    // occur in pairs. ButtonBase tracks this itself; the raw
+                    // fallback must treat PointerExited as an end condition.
+                    if (!instance
+                             ->pressedStateCallbackRegistered)
+                    {
+                        instance->pressed = false;
+                    }
+
+                    ApplyCurrentState(
+                        instance,
+                        g_settings.releaseDuration);
+                }));
+
+    startButton.AddHandler(
+        wux::UIElement::PointerExitedEvent(),
+        instance->pointerExitedHandler,
+        true);
+
+    // The Start control is a ButtonBase on supported Windows 11 builds.
+    // Observe its own pressed state instead of reconstructing that state from
+    // routed pointer events which the control class handles internally.
+    try {
+        auto buttonBase =
+            startButton.try_as<
+                wuxcp::ButtonBase>();
+
+        if (buttonBase) {
+            instance->pressedStateCallbackToken =
+                buttonBase
+                    .RegisterPropertyChangedCallback(
+                        wuxcp::ButtonBase::
+                            IsPressedProperty(),
+                        wux::DependencyPropertyChangedCallback(
+                            [weakInstance](
+                                const wux::DependencyObject& sender,
+                                const wux::DependencyProperty&)
+                            {
+                                auto instance =
+                                    weakInstance.lock();
+
+                                auto buttonBase =
+                                    sender.try_as<
+                                        wuxcp::ButtonBase>();
+
+                                if (!instance ||
+                                    !buttonBase)
+                                {
+                                    return;
+                                }
+
+                                SetPressedState(
+                                    instance,
+                                    buttonBase.IsPressed());
+                            }));
+
+            instance->pressedStateCallbackRegistered =
+                true;
+
+            instance->pressed =
+                buttonBase.IsPressed();
+
+            Wh_Log(
+                L"Start button pressed state is tracked "
+                L"through ButtonBase::IsPressed");
+        }
+    }
+    catch (const winrt::hresult_error& e) {
+        Wh_Log(
+            L"Registering ButtonBase::IsPressed callback failed: 0x%08X %s",
+            e.code().value,
+            e.message().c_str());
+    }
+    catch (...) {
+    }
+
+    // Taskbar.ExperienceToggleButton derives from ToggleButton. Its checked
+    // state follows whether the Start menu is currently shown.
+    try {
+        auto toggleButton =
+            startButton.try_as<
+                wuxcp::ToggleButton>();
+
+        if (toggleButton) {
+            instance->activatedStateCallbackToken =
+                toggleButton
+                    .RegisterPropertyChangedCallback(
+                        wuxcp::ToggleButton::
+                            IsCheckedProperty(),
+                        wux::DependencyPropertyChangedCallback(
+                            [weakInstance](
+                                const wux::DependencyObject& sender,
+                                const wux::DependencyProperty&)
+                            {
+                                auto instance =
+                                    weakInstance.lock();
+
+                                auto toggleButton =
+                                    sender.try_as<
+                                        wuxcp::ToggleButton>();
+
+                                if (!instance ||
+                                    !toggleButton)
+                                {
+                                    return;
+                                }
+
+                                SetActivatedState(
+                                    instance,
+                                    IsToggleButtonChecked(
+                                        toggleButton));
+                            }));
+
+            instance->activatedStateCallbackRegistered =
+                true;
+
+            instance->activated =
+                IsToggleButtonChecked(
+                    toggleButton);
+
+            Wh_Log(
+                L"Start menu visibility is tracked through "
+                L"ToggleButton::IsChecked");
+        }
+    }
+    catch (const winrt::hresult_error& e) {
+        Wh_Log(
+            L"Registering ToggleButton::IsChecked callback failed: 0x%08X %s",
+            e.code().value,
+            e.message().c_str());
+    }
+    catch (...) {
+    }
+
+    if (!instance->pressedStateCallbackRegistered) {
+        Wh_Log(
+            L"ButtonBase pressed-state callback is unavailable; "
+            L"using routed-pointer fallback");
+
+
+    //
+    // POINTER PRESSED
+    //
+    instance->pointerPressedHandler =
+        winrt::box_value(
+            wuxi::PointerEventHandler(
+                [weakInstance](
+                    const wf::IInspectable&,
+                    const wuxi::PointerRoutedEventArgs&)
+                {
+                    auto instance =
+                        weakInstance.lock();
+
+                    if (!instance) {
+                        return;
+                    }
+
+                    SetPressedState(
+                        instance,
+                        true);
+
+                    //
+                    // IMPORTANT:
+                    // Don't call args.Handled(true).
+                    //
+                    // Explorer still needs to receive
+                    // the event normally.
+                    //
+                }));
+
+    //
+    // The third argument is critical.
+    //
+    // ButtonBase normally marks PointerPressed
+    // as handled. true means our handler still
+    // receives the routed event.
+    //
+    startButton.AddHandler(
+        wux::UIElement::PointerPressedEvent(),
+        instance->pointerPressedHandler,
+        true);
+
+
+    //
+    // POINTER RELEASED
+    //
+    instance->pointerReleasedHandler =
+        winrt::box_value(
+            wuxi::PointerEventHandler(
+                [weakInstance](
+                    const wf::IInspectable&,
+                    const wuxi::PointerRoutedEventArgs&)
+                {
+                    auto instance =
+                        weakInstance.lock();
+
+                    if (!instance) {
+                        return;
+                    }
+
+                    SetPressedState(
+                        instance,
+                        false);
+                }));
+
+    startButton.AddHandler(
+        wux::UIElement::PointerReleasedEvent(),
+        instance->pointerReleasedHandler,
+        true);
+
+
+    //
+    // POINTER CANCELED
+    //
+    instance->pointerCanceledHandler =
+        winrt::box_value(
+            wuxi::PointerEventHandler(
+                [weakInstance](
+                    const wf::IInspectable&,
+                    const wuxi::PointerRoutedEventArgs&)
+                {
+                    auto instance =
+                        weakInstance.lock();
+
+                    if (!instance) {
+                        return;
+                    }
+
+                    Wh_Log(
+                        L"Start button: CANCELED");
+
+                    SetPressedState(
+                        instance,
+                        false);
+                }));
+
+    startButton.AddHandler(
+        wux::UIElement::PointerCanceledEvent(),
+        instance->pointerCanceledHandler,
+        true);
+
+
+    //
+    // POINTER CAPTURE LOST
+    //
+    instance->pointerCaptureLostHandler =
+        winrt::box_value(
+            wuxi::PointerEventHandler(
+                [weakInstance](
+                    const wf::IInspectable&,
+                    const wuxi::PointerRoutedEventArgs&)
+                {
+                    auto instance =
+                        weakInstance.lock();
+
+                    if (!instance) {
+                        return;
+                    }
+
+                    Wh_Log(
+                        L"Start button: CAPTURE LOST");
+
+                    SetPressedState(
+                        instance,
+                        false);
+                }));
+
+    startButton.AddHandler(
+        wux::UIElement::PointerCaptureLostEvent(),
+        instance->pointerCaptureLostHandler,
+        true);
+
+    }
+
+    Wh_Log(
+        L"Start button pointer handlers attached");
+}
+
+// -----------------------------------------------------------------------------
+// Install replacement into a Start button
+// -----------------------------------------------------------------------------
+
+bool AttachToStartButton(
+    const wux::FrameworkElement&
+        startButton)
+{
+    if (!startButton) {
+        return false;
+    }
+
+    if (GetImageSourceForState(
+            IconState::Normal)
+            .empty())
+    {
+        Wh_Log(
+            L"Image source is empty; leaving stock Start icon unchanged");
+
+        return true;
+    }
+
+    if (AlreadyAttached(startButton)) {
+        return true;
+    }
+
+    auto stockIcon =
+        FindStockStartIcon(
+            startButton);
+
+    if (!stockIcon) {
+        Wh_Log(
+            L"Couldn't find Start AnimatedVisualPlayer#Icon");
+
+        return false;
+    }
+
+    auto hostPanel =
+        FindHostPanel(
+            stockIcon,
+            startButton);
+
+    if (!hostPanel) {
+        Wh_Log(
+            L"Couldn't find a panel which can host the custom Start image");
+
+        return false;
+    }
+
+    std::shared_ptr<StartIconInstance>
+        instance;
+
+    try {
+        double originalStockOpacity =
+            stockIcon.Opacity();
+
+        instance =
+            std::make_shared<
+                StartIconInstance>();
+
+        instance->threadId =
+            GetCurrentThreadId();
+
+        instance->startButton =
+            winrt::make_weak(
+                startButton);
+
+        instance->stockIcon =
+            winrt::make_weak(
+                stockIcon);
+
+        instance->hostPanel =
+            winrt::make_weak(
+                hostPanel);
+
+        instance->originalStockOpacity =
+            originalStockOpacity;
+
+        wuxc::Grid imageHost;
+
+        imageHost.Width(
+            g_settings.iconSize);
+
+        imageHost.Height(
+            g_settings.iconSize);
+
+        imageHost.HorizontalAlignment(
+            wux::HorizontalAlignment::
+                Center);
+
+        imageHost.VerticalAlignment(
+            wux::VerticalAlignment::
+                Center);
+
+        imageHost.IsHitTestVisible(
+            false);
+
+        wuxc::Image customImage;
+        wuxc::Image transitionImage;
+
+        auto configureImageLayer =
+            [](const wuxc::Image& image)
+            {
+                image.HorizontalAlignment(
+                    wux::HorizontalAlignment::
+                        Stretch);
+
+                image.VerticalAlignment(
+                    wux::VerticalAlignment::
+                        Stretch);
+
+                image.Stretch(
+                    wuxm::Stretch::Uniform);
+
+                image.IsHitTestVisible(false);
+            };
+
+        configureImageLayer(customImage);
+        configureImageLayer(transitionImage);
+
+        imageHost.Children().Append(
+            customImage);
+
+        imageHost.Children().Append(
+            transitionImage);
+
+        // Put the image above the stock
+        // AnimatedVisualPlayer.
+        wuxc::Canvas::SetZIndex(
+            imageHost,
+            10000);
+
+        instance->customImageHost =
+            winrt::make_weak(
+                imageHost);
+
+        instance->customImage =
+            winrt::make_weak(
+                customImage);
+
+        instance->transitionImage =
+            winrt::make_weak(
+                transitionImage);
+
+        hostPanel
+            .Children()
+            .Append(imageHost);
+
+        AttachPointerEvents(
+            instance,
+            startButton);
+
+        if (!LoadImages(instance))
+        {
+            DetachInstance(instance);
+
+            Wh_Log(
+                L"Failed to load custom image; keeping stock icon");
+
+            return false;
+        }
+
+        // Preserve the original icon in layout,
+        // but don't render it.
+        stockIcon.Opacity(0.0);
+
+        ApplyCurrentState(
+            instance,
+            0);
+
+        g_instances.push_back(
+            instance);
+
+        Wh_Log(
+            L"Custom Start icon attached");
+
+        return true;
+    }
+    catch (const winrt::hresult_error& e) {
+        DetachInstance(instance);
+
+        Wh_Log(
+            L"AttachToStartButton failed: 0x%08X %s",
+            e.code().value,
+            e.message().c_str());
+
+        return false;
+    }
+    catch (...) {
+        DetachInstance(instance);
+
+        Wh_Log(
+            L"AttachToStartButton failed with an unknown exception");
+
+        return false;
+    }
+}
+
+
+// -----------------------------------------------------------------------------
+// Apply to XamlRoot
+// -----------------------------------------------------------------------------
+
+bool ApplyToXamlRoot(
+    const wux::XamlRoot& xamlRoot)
+{
+    if (!xamlRoot) {
+        return false;
+    }
+
+    try {
+        auto content =
+            xamlRoot
+                .Content()
+                .try_as<
+                    wux::FrameworkElement>();
+
+        if (!content) {
+            Wh_Log(
+                L"XamlRoot content isn't a FrameworkElement");
+
+            return false;
+        }
+
+        auto startButton =
+            FindStartButton(content);
+
+        if (!startButton) {
+            Wh_Log(
+                L"Couldn't find AutomationId=StartButton");
+
+            return false;
+        }
+
+        return AttachToStartButton(
+            startButton);
+    }
+    catch (const winrt::hresult_error& e) {
+        Wh_Log(
+            L"ApplyToXamlRoot failed: 0x%08X %s",
+            e.code().value,
+            e.message().c_str());
+
+        return false;
+    }
+}
+
+
+// -----------------------------------------------------------------------------
+// taskbar.dll internals
+//
+// This is the same general TaskbarHost/XamlRoot approach used by current
+// Windhawk Windows 11 taskbar mods.
+// -----------------------------------------------------------------------------
+
+void*
+    CTaskBand_ITaskListWndSite_vftable;
+
+void*
+    CSecondaryTaskBand_ITaskListWndSite_vftable;
+
+
+using CTaskBand_GetTaskbarHost_t =
+    void* (WINAPI*)(
+        void* pThis,
+        void** result);
+
+CTaskBand_GetTaskbarHost_t
+    CTaskBand_GetTaskbarHost_Original;
+
+
+using CSecondaryTaskBand_GetTaskbarHost_t =
+    void* (WINAPI*)(
+        void* pThis,
+        void** result);
+
+CSecondaryTaskBand_GetTaskbarHost_t
+    CSecondaryTaskBand_GetTaskbarHost_Original;
+
+
+void*
+    TaskbarHost_FrameHeight_Original;
+
+
+using RefCountDecref_t =
+    void (WINAPI*)(
+        void* pThis);
+
+RefCountDecref_t
+    RefCountDecref_Original;
+
+
+// -----------------------------------------------------------------------------
+// Extract XamlRoot from TaskbarHost
+// -----------------------------------------------------------------------------
+
+wux::XamlRoot
+XamlRootFromTaskbarHostSharedPtr(
+    void* sharedPtr[2])
+{
+    if (!sharedPtr[0] &&
+        !sharedPtr[1])
+    {
+        return nullptr;
+    }
+
+    size_t taskbarElementOffset =
+        0x48;
+
+#if defined(_M_X64)
+
+    // Current taskbar.dll builds generally make
+    // TaskbarHost::FrameHeight access a member
+    // at the same offset as the taskbar XAML
+    // element reference. Derive that offset from
+    // the function rather than hard-coding it
+    // whenever possible.
+    const BYTE* code =
+        reinterpret_cast<const BYTE*>(
+            TaskbarHost_FrameHeight_Original);
+
+    if (code &&
+        code[0] == 0x48 &&
+        code[1] == 0x83 &&
+        code[2] == 0xEC &&
+        code[4] == 0x48 &&
+        code[5] == 0x83 &&
+        code[6] == 0xC1 &&
+        code[7] <= 0x7F)
+    {
+        taskbarElementOffset =
+            code[7];
+    }
+    else {
+        Wh_Log(
+            L"Unrecognized TaskbarHost::FrameHeight; using fallback offset 0x48");
+    }
+
+#else
+#error This version of the mod currently supports x86-64 only.
+#endif
+
+    auto* taskbarElementIUnknown =
+        *reinterpret_cast<IUnknown**>(
+            reinterpret_cast<BYTE*>(
+                sharedPtr[0]) +
+            taskbarElementOffset);
+
+    wux::FrameworkElement
+        taskbarElement{nullptr};
+
+    if (taskbarElementIUnknown) {
+        taskbarElementIUnknown
+            ->QueryInterface(
+                winrt::guid_of<
+                    wux::FrameworkElement>(),
+                winrt::put_abi(
+                    taskbarElement));
+    }
+
+    wux::XamlRoot result{nullptr};
+
+    if (taskbarElement) {
+        result =
+            taskbarElement.XamlRoot();
+    }
+
+    if (sharedPtr[1] &&
+        RefCountDecref_Original)
+    {
+        RefCountDecref_Original(
+            sharedPtr[1]);
+    }
+
+    return result;
+}
+
+
+// -----------------------------------------------------------------------------
+// Primary taskbar XamlRoot
+// -----------------------------------------------------------------------------
+
+wux::XamlRoot GetTaskbarXamlRoot(
+    HWND taskbarWnd)
+{
+    HWND taskSwitchWnd =
+        reinterpret_cast<HWND>(
+            GetProp(
+                taskbarWnd,
+                L"TaskbandHWND"));
+
+    if (!taskSwitchWnd) {
+        return nullptr;
+    }
+
+    void* taskBand =
+        reinterpret_cast<void*>(
+            GetWindowLongPtr(
+                taskSwitchWnd,
+                0));
+
+    if (!taskBand) {
+        return nullptr;
+    }
+
+    void* interfacePointer =
+        taskBand;
+
+    for (int i = 0;
+         i < 20;
+         i++)
+    {
+        if (*reinterpret_cast<void**>(
+                interfacePointer) ==
+            CTaskBand_ITaskListWndSite_vftable)
+        {
+            break;
+        }
+
+        interfacePointer =
+            reinterpret_cast<void**>(
+                interfacePointer) +
+            1;
+
+        if (i == 19) {
+            return nullptr;
+        }
+    }
+
+    void* sharedPtr[2]{};
+
+    CTaskBand_GetTaskbarHost_Original(
+        interfacePointer,
+        sharedPtr);
+
+    return
+        XamlRootFromTaskbarHostSharedPtr(
+            sharedPtr);
+}
+
+
+// -----------------------------------------------------------------------------
+// Secondary taskbar XamlRoot
+// -----------------------------------------------------------------------------
+
+wux::XamlRoot
+GetSecondaryTaskbarXamlRoot(
+    HWND secondaryTaskbarWnd)
+{
+    HWND taskSwitchWnd =
+        FindWindowEx(
+            secondaryTaskbarWnd,
+            nullptr,
+            L"WorkerW",
+            nullptr);
+
+    if (!taskSwitchWnd) {
+        return nullptr;
+    }
+
+    void* taskBand =
+        reinterpret_cast<void*>(
+            GetWindowLongPtr(
+                taskSwitchWnd,
+                0));
+
+    if (!taskBand) {
+        return nullptr;
+    }
+
+    void* interfacePointer =
+        taskBand;
+
+    for (int i = 0;
+         i < 20;
+         i++)
+    {
+        if (*reinterpret_cast<void**>(
+                interfacePointer) ==
+            CSecondaryTaskBand_ITaskListWndSite_vftable)
+        {
+            break;
+        }
+
+        interfacePointer =
+            reinterpret_cast<void**>(
+                interfacePointer) +
+            1;
+
+        if (i == 19) {
+            return nullptr;
+        }
+    }
+
+    void* sharedPtr[2]{};
+
+    CSecondaryTaskBand_GetTaskbarHost_Original(
+        interfacePointer,
+        sharedPtr);
+
+    return
+        XamlRootFromTaskbarHostSharedPtr(
+            sharedPtr);
+}
+
+
+// -----------------------------------------------------------------------------
+// Run code on taskbar UI thread
+// -----------------------------------------------------------------------------
+
+using RunFromWindowThreadProc_t =
+    void (WINAPI*)(void* parameter);
+
+bool RunFromWindowThread(
+    HWND window,
+    RunFromWindowThreadProc_t proc,
+    void* procParam)
+{
+    static const UINT
+        registeredMessage =
+            RegisterWindowMessage(
+                L"Windhawk_RunFromWindowThread_"
+                WH_MOD_ID);
+
+    struct RunParam {
+        RunFromWindowThreadProc_t proc;
+        void* param;
+    };
+
+    DWORD threadId =
+        GetWindowThreadProcessId(
+            window,
+            nullptr);
+
+    if (!threadId) {
+        return false;
+    }
+
+    if (threadId ==
+        GetCurrentThreadId())
+    {
+        proc(procParam);
+        return true;
+    }
+
+    HHOOK hook =
+        SetWindowsHookEx(
+            WH_CALLWNDPROC,
+            [](int code,
+               WPARAM wParam,
+               LPARAM lParam)
+                -> LRESULT
+            {
+                if (code ==
+                    HC_ACTION)
+                {
+                    const CWPSTRUCT* cwp =
+                        reinterpret_cast<
+                            const CWPSTRUCT*>(
+                            lParam);
+
+                    if (cwp->message ==
+                        registeredMessage)
+                    {
+                        auto* parameter =
+                            reinterpret_cast<
+                                RunParam*>(
+                                cwp->lParam);
+
+                        parameter->proc(
+                            parameter
+                                ->param);
+                    }
+                }
+
+                return CallNextHookEx(
+                    nullptr,
+                    code,
+                    wParam,
+                    lParam);
+            },
+            nullptr,
+            threadId);
+
+    if (!hook) {
+        return false;
+    }
+
+    RunParam parameter{
+        proc,
+        procParam
+    };
+
+    SendMessage(
+        window,
+        registeredMessage,
+        0,
+        reinterpret_cast<LPARAM>(
+            &parameter));
+
+    UnhookWindowsHookEx(hook);
+
+    return true;
+}
+
+
+// -----------------------------------------------------------------------------
+// Taskbar discovery
+// -----------------------------------------------------------------------------
+
+HWND FindCurrentProcessTaskbarWnd() {
+    HWND result = nullptr;
+
+    EnumWindows(
+        [](HWND window,
+           LPARAM param)
+            -> BOOL
+        {
+            DWORD processId = 0;
+
+            GetWindowThreadProcessId(
+                window,
+                &processId);
+
+            if (processId !=
+                GetCurrentProcessId())
+            {
+                return TRUE;
+            }
+
+            wchar_t className[64]{};
+
+            if (!GetClassNameW(
+                    window,
+                    className,
+                    ARRAYSIZE(className)))
+            {
+                return TRUE;
+            }
+
+            if (_wcsicmp(
+                    className,
+                    L"Shell_TrayWnd") ==
+                0)
+            {
+                *reinterpret_cast<HWND*>(
+                    param) =
+                    window;
+
+                return FALSE;
+            }
+
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(
+            &result));
+
+    return result;
+}
+
+
+// -----------------------------------------------------------------------------
+// Apply/remove on taskbar thread
+// -----------------------------------------------------------------------------
+
+void ApplyFromTaskbarThread(
+    bool mainTaskbarOnly = false)
+{
+    EnumThreadWindows(
+        GetCurrentThreadId(),
+        [](HWND window,
+           LPARAM param)
+            -> BOOL
+        {
+            bool mainOnly =
+                param != 0;
+
+            wchar_t className[64]{};
+
+            if (!GetClassNameW(
+                    window,
+                    className,
+                    ARRAYSIZE(className)))
+            {
+                return TRUE;
+            }
+
+            wux::XamlRoot xamlRoot{
+                nullptr
+            };
+
+            if (_wcsicmp(
+                    className,
+                    L"Shell_TrayWnd") ==
+                0)
+            {
+                xamlRoot =
+                    GetTaskbarXamlRoot(
+                        window);
+            }
+            else if (
+                !mainOnly &&
+                _wcsicmp(
+                    className,
+                    L"Shell_SecondaryTrayWnd") ==
+                    0)
+            {
+                xamlRoot =
+                    GetSecondaryTaskbarXamlRoot(
+                        window);
+            }
+            else {
+                return TRUE;
+            }
+
+            if (!xamlRoot) {
+                Wh_Log(
+                    L"Couldn't obtain taskbar XamlRoot");
+
+                return TRUE;
+            }
+
+            ApplyToXamlRoot(
+                xamlRoot);
+
+            return TRUE;
+        },
+        static_cast<LPARAM>(
+            mainTaskbarOnly));
+}
+
+void RebuildFromTaskbarThread() {
+    DetachAllForCurrentThread();
+
+    if (!g_unloading) {
+        ApplyFromTaskbarThread();
+    }
+}
+
+void ApplyFromAnyThread(
+    HWND taskbarWnd)
+{
+    RunFromWindowThread(
+        taskbarWnd,
+        [](void*)
+        {
+            ApplyFromTaskbarThread();
+        },
+        nullptr);
+}
+
+void RebuildFromAnyThread(
+    HWND taskbarWnd)
+{
+    RunFromWindowThread(
+        taskbarWnd,
+        [](void*)
+        {
+            RebuildFromTaskbarThread();
+        },
+        nullptr);
+}
+
+
+// -----------------------------------------------------------------------------
+// Taskbar creation hooks
+// -----------------------------------------------------------------------------
+
+using TrayUI_StartTaskbar_t =
+    void (WINAPI*)(void* pThis);
+
+TrayUI_StartTaskbar_t
+    TrayUI_StartTaskbar_Original;
+
+void WINAPI TrayUI_StartTaskbar_Hook(
+    void* pThis)
+{
+    TrayUI_StartTaskbar_Original(
+        pThis);
+
+    if (!g_unloading) {
+        ApplyFromTaskbarThread(
+            true);
+    }
+}
+
+
+using CSecondaryTray_GetTrayWindow_t =
+    HWND (WINAPI*)(void* pThis);
+
+CSecondaryTray_GetTrayWindow_t
+    CSecondaryTray_GetTrayWindow_Original;
+
+
+using CSecondaryTray_InitModelAndHost_t =
+    void (WINAPI*)(
+        void* pThis,
+        void* taskbarModel);
+
+CSecondaryTray_InitModelAndHost_t
+    CSecondaryTray_InitModelAndHost_Original;
+
+void WINAPI
+CSecondaryTray_InitModelAndHost_Hook(
+    void* pThis,
+    void* taskbarModel)
+{
+    CSecondaryTray_InitModelAndHost_Original(
+        pThis,
+        taskbarModel);
+
+    if (g_unloading) {
+        return;
+    }
+
+    HWND taskbarWnd =
+        CSecondaryTray_GetTrayWindow_Original(
+            pThis);
+
+    if (!taskbarWnd) {
+        return;
+    }
+
+    auto xamlRoot =
+        GetSecondaryTaskbarXamlRoot(
+            taskbarWnd);
+
+    if (xamlRoot) {
+        ApplyToXamlRoot(
+            xamlRoot);
+    }
+}
+
+
+// -----------------------------------------------------------------------------
+// Symbol hooks
+// -----------------------------------------------------------------------------
+
+bool HookTaskbarDllSymbols() {
+    HMODULE taskbarDll =
+        LoadLibraryExW(
+            L"taskbar.dll",
+            nullptr,
+            LOAD_LIBRARY_SEARCH_SYSTEM32);
+
+    if (!taskbarDll) {
+        Wh_Log(
+            L"Failed to load taskbar.dll");
+
+        return false;
+    }
+
+    WindhawkUtils::SYMBOL_HOOK
+        hooks[] = {
+
+        {
+            {
+                LR"(const CTaskBand::`vftable'{for `ITaskListWndSite'})"
+            },
+            &CTaskBand_ITaskListWndSite_vftable,
+        },
+
+        {
+            {
+                LR"(const CSecondaryTaskBand::`vftable'{for `ITaskListWndSite'})"
+            },
+            &CSecondaryTaskBand_ITaskListWndSite_vftable,
+        },
+
+        {
+            {
+                LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CTaskBand::GetTaskbarHost(void)const )"
+            },
+            &CTaskBand_GetTaskbarHost_Original,
+        },
+
+        {
+            {
+                LR"(public: int __cdecl TaskbarHost::FrameHeight(void)const )"
+            },
+            &TaskbarHost_FrameHeight_Original,
+        },
+
+        {
+            {
+                LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CSecondaryTaskBand::GetTaskbarHost(void)const )"
+            },
+            &CSecondaryTaskBand_GetTaskbarHost_Original,
+        },
+
+        {
+            {
+                LR"(public: void __cdecl std::_Ref_count_base::_Decref(void))"
+            },
+            &RefCountDecref_Original,
+        },
+
+        {
+            {
+                LR"(public: virtual void __cdecl TrayUI::StartTaskbar(void))"
+            },
+            &TrayUI_StartTaskbar_Original,
+            TrayUI_StartTaskbar_Hook,
+        },
+
+        {
+            {
+                LR"(public: virtual struct HWND__ * __cdecl CSecondaryTray::GetTrayWindow(void))"
+            },
+            &CSecondaryTray_GetTrayWindow_Original,
+        },
+
+        {
+            {
+                LR"(public: virtual void __cdecl CSecondaryTray::InitModelAndHost(struct winrt::WindowsUdk::UI::Shell::TaskbarModel))"
+            },
+            &CSecondaryTray_InitModelAndHost_Original,
+            CSecondaryTray_InitModelAndHost_Hook,
+        },
+    };
+
+    if (!WindhawkUtils::HookSymbols(
+            taskbarDll,
+            hooks,
+            ARRAYSIZE(hooks)))
+    {
+        Wh_Log(
+            L"Failed to resolve taskbar.dll symbols");
+
+        return false;
+    }
+
+    return true;
+}
+
+
+// -----------------------------------------------------------------------------
+// Windhawk lifecycle
+// -----------------------------------------------------------------------------
+
+BOOL Wh_ModInit() {
+    Wh_Log(
+        L"Start Button Replacer initializing");
+
+    g_unloading = false;
+
+    LoadSettings();
+
+    if (!HookTaskbarDllSymbols()) {
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    Wh_Log(
+        L"Start Button Replacer applying");
+
+    HWND taskbarWnd =
+        FindCurrentProcessTaskbarWnd();
+
+    if (taskbarWnd) {
+        ApplyFromAnyThread(
+            taskbarWnd);
+    }
+}
+
+void Wh_ModBeforeUninit() {
+    Wh_Log(
+        L"Start Button Replacer restoring stock icon");
+
+    g_unloading = true;
+
+    HWND taskbarWnd =
+        FindCurrentProcessTaskbarWnd();
+
+    if (taskbarWnd) {
+        RebuildFromAnyThread(
+            taskbarWnd);
+    }
+}
+
+void Wh_ModUninit() {
+    Wh_Log(
+        L"Start Button Replacer unloaded");
+}
+
+void Wh_ModSettingsChanged() {
+    Wh_Log(
+        L"Start Button Replacer settings changed");
+
+    LoadSettings();
+
+    HWND taskbarWnd =
+        FindCurrentProcessTaskbarWnd();
+
+    if (taskbarWnd) {
+        RebuildFromAnyThread(
+            taskbarWnd);
+    }
+}

--- a/mods/start-button-replacer.wh.cpp
+++ b/mods/start-button-replacer.wh.cpp
@@ -209,7 +209,6 @@ from the source image resolution.
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.UI.Composition.h>
-#include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Xaml.Automation.Peers.h>
 #include <winrt/Windows.UI.Xaml.Automation.h>
 #include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
@@ -225,8 +224,6 @@ namespace wf = winrt::Windows::Foundation;
 namespace wss = winrt::Windows::Storage::Streams;
 
 namespace wuc = winrt::Windows::UI::Composition;
-
-namespace wuic = winrt::Windows::UI::Core;
 
 namespace wux = winrt::Windows::UI::Xaml;
 
@@ -331,7 +328,6 @@ struct ImageResource {
 
 struct StartIconInstance {
     DWORD threadId = 0;
-    wuic::CoreDispatcher dispatcher{nullptr};
     ModSettings settings;
 
     winrt::weak_ref<wux::FrameworkElement> startButton;
@@ -386,16 +382,12 @@ struct StartIconInstance {
 
 std::mutex g_instancesMutex;
 
+// StartIconInstance owns XAML images and callback delegates. Suppress automatic
+// destruction during Explorer process shutdown; controlled unload removes the
+// callbacks and releases every instance synchronously on its taskbar UI thread.
 [[clang::no_destroy]] std::optional<
     std::vector<std::shared_ptr<StartIconInstance>>>
     g_instances{std::in_place};
-
-// If an owning XAML dispatcher is already unavailable during a controlled
-// unload, releasing the instance from Windhawk's engine thread would violate
-// XAML thread affinity. Intentionally leak such exceptional instances instead.
-[[clang::no_destroy]] std::optional<
-    std::vector<std::shared_ptr<StartIconInstance>>>
-    g_abandonedInstances{std::in_place};
 
 // -----------------------------------------------------------------------------
 // Utility
@@ -1723,7 +1715,6 @@ void DetachInstance(const std::shared_ptr<StartIconInstance>& instance) {
     instance->customImageHost = {};
     instance->customImage = {};
     instance->transitionImage = {};
-    instance->dispatcher = nullptr;
 }
 
 void DetachAllForCurrentThread() {
@@ -1753,6 +1744,14 @@ void DetachAllForCurrentThread() {
 
             ++it;
         }
+
+        // During controlled unload, the last taskbar UI thread to remove its
+        // instances also destroys the now-empty container. Instance objects
+        // themselves remain in the local vector below until DetachInstance has
+        // released all XAML references and callbacks on this owning thread.
+        if (g_unloading && g_instances->empty()) {
+            g_instances.reset();
+        }
     }
 
     for (const auto& instance : instances) {
@@ -1760,128 +1759,20 @@ void DetachAllForCurrentThread() {
     }
 }
 
-std::vector<std::shared_ptr<StartIconInstance>> TakeAllInstancesForShutdown() {
+void BeginInstanceShutdown() {
     std::lock_guard<std::mutex> lock(g_instancesMutex);
 
     g_unloading = true;
 
-    std::vector<std::shared_ptr<StartIconInstance>> instances;
-
-    if (g_instances) {
-        instances = std::move(*g_instances);
+    if (g_instances && g_instances->empty()) {
         g_instances.reset();
     }
-
-    return instances;
 }
 
-void AbandonInstances(
-    const std::vector<std::shared_ptr<StartIconInstance>>& instances) {
-    if (instances.empty()) {
-        return;
-    }
-
+size_t GetTrackedInstanceCount() {
     std::lock_guard<std::mutex> lock(g_instancesMutex);
 
-    if (g_abandonedInstances) {
-        g_abandonedInstances->insert(g_abandonedInstances->end(),
-                                     instances.begin(), instances.end());
-    }
-}
-
-void DetachInstancesOnOwningThreads(
-    std::vector<std::shared_ptr<StartIconInstance>>& instances) {
-    if (instances.empty()) {
-        return;
-    }
-
-    std::shared_ptr<void> cleanupFinished(
-        CreateEventW(nullptr, TRUE, FALSE, nullptr), [](HANDLE eventHandle) {
-            if (eventHandle) {
-                CloseHandle(eventHandle);
-            }
-        });
-
-    if (!cleanupFinished) {
-        Wh_Log(L"Creating the XAML cleanup event failed: 0x%08X",
-               GetLastError());
-        AbandonInstances(instances);
-        return;
-    }
-
-    auto pending = std::make_shared<std::atomic<size_t>>(0);
-    std::vector<std::shared_ptr<StartIconInstance>> failedInstances;
-    std::mutex failedInstancesMutex;
-
-    auto recordFailure =
-        [&failedInstances, &failedInstancesMutex](
-            const std::shared_ptr<StartIconInstance>& instance) {
-            std::lock_guard<std::mutex> lock(failedInstancesMutex);
-            failedInstances.push_back(instance);
-        };
-
-    auto signalCompletion = [pending, cleanupFinished]() {
-        if (pending->fetch_sub(1) == 1) {
-            SetEvent(cleanupFinished.get());
-        }
-    };
-
-    for (const auto& instance : instances) {
-        if (!instance || instance->detached) {
-            continue;
-        }
-
-        auto dispatcher = instance->dispatcher;
-
-        if (!dispatcher) {
-            recordFailure(instance);
-            continue;
-        }
-
-        try {
-            if (dispatcher.HasThreadAccess()) {
-                DetachInstance(instance);
-                continue;
-            }
-
-            if (pending->fetch_add(1) == 0) {
-                ResetEvent(cleanupFinished.get());
-            }
-
-            try {
-                dispatcher.RunAsync(
-                    wuic::CoreDispatcherPriority::High,
-                    [instance, signalCompletion, recordFailure]() {
-                        try {
-                            DetachInstance(instance);
-                        } catch (...) {
-                            Wh_Log(
-                                L"Unexpected exception while detaching a Start "
-                                L"icon instance");
-                            recordFailure(instance);
-                        }
-
-                        signalCompletion();
-                    });
-            } catch (...) {
-                signalCompletion();
-                throw;
-            }
-        } catch (const winrt::hresult_error& e) {
-            Wh_Log(L"Dispatching Start icon cleanup failed: 0x%08X %s",
-                   e.code().value, e.message().c_str());
-            recordFailure(instance);
-        } catch (...) {
-            Wh_Log(L"Dispatching Start icon cleanup failed");
-            recordFailure(instance);
-        }
-    }
-
-    if (pending->load() > 0) {
-        WaitForSingleObject(cleanupFinished.get(), INFINITE);
-    }
-
-    AbandonInstances(failedInstances);
+    return g_instances ? g_instances->size() : 0;
 }
 
 // -----------------------------------------------------------------------------
@@ -2446,8 +2337,6 @@ bool AttachToStartButton(const wux::FrameworkElement& startButton) {
 
         instance->threadId = GetCurrentThreadId();
 
-        instance->dispatcher = startButton.Dispatcher();
-
         instance->settings = std::move(settings);
 
         instance->startButton = winrt::make_weak(startButton);
@@ -2459,8 +2348,8 @@ bool AttachToStartButton(const wux::FrameworkElement& startButton) {
         instance->originalStockOpacity = originalStockOpacity;
 
         // Register before adding XAML elements or callbacks. If unload starts
-        // concurrently, its dispatcher barrier will run after this UI-thread
-        // callback and will see everything that needs to be detached.
+        // concurrently, its synchronous taskbar-thread callback runs after
+        // this UI-thread work and sees everything that needs to be detached.
         if (!RegisterInstance(instance)) {
             return false;
         }
@@ -2630,7 +2519,7 @@ wux::XamlRoot XamlRootFromTaskbarHostSharedPtr(void* sharedPtr[2]) {
         return nullptr;
     }
 
-    size_t taskbarElementOffset = 0x48;
+    size_t taskbarElementOffset = 0x10;
 
 #if defined(_M_X64)
 
@@ -2658,9 +2547,26 @@ wux::XamlRoot XamlRootFromTaskbarHostSharedPtr(void* sharedPtr[2]) {
 
 #elif defined(_M_ARM64)
 
-    // The x64 instruction pattern above doesn't apply to ARM64. Use the
-    // established TaskbarHost layout fallback used by Windhawk's current
-    // Windows 11 taskbar mods.
+    // 7f2303d5 pacibsp
+    // fd7bbfa9 stp     fp, lr, [sp, #-0x10]!
+    // fd030091 mov     fp, sp
+    // 080c41f8 ldr     x8, [x0, #0x10]!
+    const DWORD* code =
+        reinterpret_cast<const DWORD*>(TaskbarHost_FrameHeight_Original);
+
+    if (code && code[0] == 0xD503237F &&
+        (code[1] & 0xFFC07FFF) == 0xA9807BFD &&
+        code[2] == 0x910003FD &&
+        (code[3] & 0xFFF00FE0) == 0xF8400C00) {
+        taskbarElementOffset = (code[3] >> 12) & 0xFF;
+    } else {
+        Wh_Log(
+            L"Unrecognized TaskbarHost::FrameHeight; refusing an unsafe "
+            L"TaskbarHost layout fallback");
+
+        releaseSharedPtr();
+        return nullptr;
+    }
 
 #else
 #error Unsupported architecture.
@@ -2785,6 +2691,7 @@ bool RunFromWindowThread(HWND window,
     struct RunParam {
         RunFromWindowThreadProc_t proc;
         void* param;
+        std::atomic<bool> invoked{false};
     };
 
     DWORD threadId = GetWindowThreadProcessId(window, nullptr);
@@ -2809,6 +2716,7 @@ bool RunFromWindowThread(HWND window,
                     auto* parameter = reinterpret_cast<RunParam*>(cwp->lParam);
 
                     parameter->proc(parameter->param);
+                    parameter->invoked.store(true);
                 }
             }
 
@@ -2827,7 +2735,7 @@ bool RunFromWindowThread(HWND window,
 
     UnhookWindowsHookEx(hook);
 
-    return true;
+    return parameter.invoked.load();
 }
 
 // -----------------------------------------------------------------------------
@@ -2950,6 +2858,10 @@ void WINAPI ApplyAllTaskbarsProc(void*) {
 
 void WINAPI RebuildAllTaskbarsProc(void*) {
     RebuildFromTaskbarThread();
+}
+
+void WINAPI DetachAllTaskbarsProc(void*) {
+    DetachAllForCurrentThread();
 }
 
 // -----------------------------------------------------------------------------
@@ -3240,9 +3152,30 @@ void Wh_ModAfterInit() {
 void Wh_ModBeforeUninit() {
     Wh_Log(L"Start Button Replacer restoring stock icon");
 
-    auto instances = TakeAllInstancesForShutdown();
+    BeginInstanceShutdown();
 
-    DetachInstancesOnOwningThreads(instances);
+    // Run synchronously on each owning taskbar UI thread. Unlike a queued
+    // CoreDispatcher callback, this has completed before RunFromWindowThread
+    // returns, so no handler implemented by this DLL remains queued or
+    // registered when controlled unload continues.
+    RunOnAllTaskbarThreads(DetachAllTaskbarsProc, nullptr);
+
+    // A taskbar window can be recreated while windows are being enumerated.
+    // Retry once if the first pass didn't visit every tracked UI thread.
+    size_t remainingInstances = GetTrackedInstanceCount();
+
+    if (remainingInstances != 0) {
+        Wh_Log(L"%zu Start icon instance(s) remained after cleanup; retrying",
+               remainingInstances);
+
+        RunOnAllTaskbarThreads(DetachAllTaskbarsProc, nullptr);
+        remainingInstances = GetTrackedInstanceCount();
+    }
+
+    if (remainingInstances != 0) {
+        Wh_Log(L"Critical: %zu Start icon instance(s) couldn't be detached",
+               remainingInstances);
+    }
 }
 
 void Wh_ModUninit() {

--- a/mods/start-button-replacer.wh.cpp
+++ b/mods/start-button-replacer.wh.cpp
@@ -96,7 +96,7 @@ at the same path, reload the mod if the previous image remains visible.
 // ==WindhawkModSettings==
 /*
 - images:
-  - imageSource: ""
+  - imageSource: "https://raw.githubusercontent.com/EnderDragonEP/asset/main/windhawk-mods/start-button-replacer/gecko/normal-hover.gif"
     $name: Image source (necessary)
     $description: >-
       Absolute file path, path containing environment variables, or HTTP/HTTPS
@@ -107,12 +107,12 @@ at the same path, reload the mod if the previous image remains visible.
     $description: >-
       Image shown while the pointer is over the Start button. Leave blank to use
       the normal image.
-  - pressedImageSource: ""
+  - pressedImageSource: "https://raw.githubusercontent.com/EnderDragonEP/asset/main/windhawk-mods/start-button-replacer/gecko/pressed.png"
     $name: Pressed image source
     $description: >-
       Image shown while the Start button is pressed. Leave blank to use the
       normal image.
-  - activatedImageSource: ""
+  - activatedImageSource: "https://raw.githubusercontent.com/EnderDragonEP/asset/main/windhawk-mods/start-button-replacer/gecko/activated.png"
     $name: Activated image source
     $description: >-
       Image shown while the Start menu is open. If blank or unavailable, the

--- a/mods/start-button-replacer.wh.cpp
+++ b/mods/start-button-replacer.wh.cpp
@@ -23,7 +23,7 @@
 //   * Makes the stock Start icon transparent.
 //   * Inserts two layered Windows.UI.Xaml.Controls.Image elements.
 //   * Supports PNG/JPG/GIF.
-//   * Supports local absolute paths and paths with environment variables.
+//   * Supports local absolute paths, environment variables and HTTP/HTTPS URLs.
 //   * Supports animated GIF playback.
 //   * Supports crossfading normal, hover and pressed images.
 //   * Supports hover/press scale, rotation and opacity effects.
@@ -50,6 +50,10 @@ Local files:
 Environment variables are supported:
 
     %USERPROFILE%\Pictures\start.jpg
+
+HTTP/HTTPS URLs are also supported:
+
+    https://example.com/start.gif
 
 ## Animated GIF playback
 
@@ -95,9 +99,9 @@ at the same path, reload the mod if the previous image remains visible.
   - imageSource: ""
     $name: Image source (necessary)
     $description: >-
-      Absolute file path, or a path containing environment variables. Supports
-      PNG, JPG and animated GIF. This is the normal image and the final fallback
-      for every other state.
+      Absolute file path, path containing environment variables, or HTTP/HTTPS
+      URL. Supports PNG, JPG and animated GIF. This is the normal image and the
+      final fallback for every other state.
   - hoverImageSource: ""
     $name: Hover image source
     $description: >-
@@ -416,6 +420,18 @@ bool EqualsIgnoreCase(const std::wstring& a, const wchar_t* b) {
 
 bool IsBlank(const std::wstring& value) {
     return value.find_first_not_of(L" \t\r\n") == std::wstring::npos;
+}
+
+bool StartsWithIgnoreCase(const std::wstring& value, const wchar_t* prefix) {
+    size_t prefixLength = wcslen(prefix);
+
+    return value.length() >= prefixLength &&
+           _wcsnicmp(value.c_str(), prefix, prefixLength) == 0;
+}
+
+bool IsHttpUrl(const std::wstring& source) {
+    return StartsWithIgnoreCase(source, L"http://") ||
+           StartsWithIgnoreCase(source, L"https://");
 }
 
 std::wstring ExpandPath(const std::wstring& source) {
@@ -740,6 +756,12 @@ bool ImageSourcesEqual(const std::wstring& first, const std::wstring& second) {
 
     if (first == second) {
         return true;
+    }
+
+    // URL paths can be case-sensitive. Only reuse URL resources when the
+    // configured strings match exactly.
+    if (IsHttpUrl(first) || IsHttpUrl(second)) {
+        return false;
     }
 
     std::wstring expandedFirst = ExpandPath(first);
@@ -1890,16 +1912,19 @@ bool LoadImageResource(const std::shared_ptr<StartIconInstance>& instance,
 
         resource.imageFailedAttached = true;
 
-        std::wstring path = ExpandPath(source);
+        // Preserve URLs exactly, including percent-encoded content. Environment
+        // variable expansion applies only to local file paths.
+        std::wstring resolvedSource =
+            IsHttpUrl(source) ? source : ExpandPath(source);
 
-        if (path.empty()) {
+        if (resolvedSource.empty()) {
             resource.failed = true;
             return false;
         }
 
         // UriSource lets XAML retrieve and decode the image asynchronously.
         // ImageOpened and ImageFailed above report completion.
-        bitmap.UriSource(wf::Uri(path));
+        bitmap.UriSource(wf::Uri(resolvedSource));
 
         auto imageHost = instance->customImageHost.get();
 

--- a/mods/start-button-replacer.wh.cpp
+++ b/mods/start-button-replacer.wh.cpp
@@ -23,7 +23,7 @@
 //   * Makes the stock Start icon transparent.
 //   * Inserts two layered Windows.UI.Xaml.Controls.Image elements.
 //   * Supports PNG/JPG/GIF.
-//   * Supports local absolute paths and HTTP/HTTPS URLs.
+//   * Supports local absolute paths and paths with environment variables.
 //   * Supports animated GIF playback.
 //   * Supports crossfading normal, hover and pressed images.
 //   * Supports hover/press scale, rotation and opacity effects.
@@ -36,7 +36,7 @@ Replaces the icon inside the Windows 11 Start button with a custom PNG, JPG or
 GIF image. Animated GIF playback and hover/pressed effects are optional
 features.
 
-![preview-gifs](https://raw.githubusercontent.com/EnderDragonEP/asset/main/windhawk-mods/start-button-replacer/preview-1.gif)
+![preview](https://raw.githubusercontent.com/EnderDragonEP/asset/main/windhawk-mods/start-button-replacer/preview-1.gif)
 
 Only the icon is replaced. Windows continues to handle clicking, keyboard
 navigation, accessibility and Start menu activation.
@@ -50,10 +50,6 @@ Local files:
 Environment variables are supported:
 
     %USERPROFILE%\Pictures\start.jpg
-
-HTTP/HTTPS URLs are also supported:
-
-    https://example.com/start.gif
 
 ## Animated GIF playback
 
@@ -91,101 +87,105 @@ from the source image resolution.
 */
 // ==/WindhawkModReadme==
 
-
 // ==WindhawkModSettings==
 /*
-- imageSource: ""
-  $name: Image source
-  $description: >-
-    Absolute local path, path containing environment variables, or HTTP/HTTPS
-    URL. Supports PNG, JPG and animated GIF. This is always the normal image and
-    is also the fallback for other states.
+- images:
+  - imageSource: ""
+    $name: Image source
+    $description: >-
+      Absolute local path or path containing environment variables. Supports
+      PNG, JPG and animated GIF. This is the normal image and the final fallback
+      for every other state.
+  - hoverImageSource: ""
+    $name: Hover image source
+    $description: >-
+      Image shown while the pointer is over the Start button. Leave blank to use
+      the normal image.
+  - pressedImageSource: ""
+    $name: Pressed image source
+    $description: >-
+      Image shown while the Start button is pressed. Leave blank to use the
+      normal image.
+  - activatedImageSource: ""
+    $name: Activated image source
+    $description: >-
+      Image shown while the Start menu is open. If blank or unavailable, the
+      pressed image is used, followed by the hover image and normal image.
+  - iconSize: 34
+    $name: Icon size
+    $description: Displayed size in device-independent pixels, from 8 to 128.
+  $name: Images
+  $description: Configure the replacement images and their displayed size.
 
-- hoverImageSource: ""
-  $name: Hover image source
-  $description: >-
-    Image shown while hovering. Leave blank to use the normal image.
+- imageAnimation:
+  - gifPlayback: hover
+    $name: GIF playback
+    $description: Choose when the currently displayed animated GIF plays.
+    $options:
+    - always: Always
+    - hover: Only while hovering
+    - pressed: Only while pressed
+    - stopped: Never / first frame
+  - hoverFadeDuration: 120
+    $name: Hover crossfade duration
+    $description: >-
+      Crossfade duration in milliseconds when entering or leaving the hover
+      state. Set to 0 to switch images instantly.
+  - pressedFadeDuration: 80
+    $name: Pressed and activated crossfade duration
+    $description: >-
+      Crossfade duration in milliseconds when entering or leaving the pressed
+      or activated state. Set to 0 to switch images instantly.
+  $name: Image animation
+  $description: Configure animated GIF playback and crossfades between images.
 
-- pressedImageSource: ""
-  $name: Pressed image source
-  $description: >-
-    Image shown while pressed. Leave blank to use the normal image.
+- hoverEffects:
+  - hoverScale: 115
+    $name: Scale
+    $description: Icon scale as a percentage while hovering. 100 keeps its size.
+  - hoverRotation: 4
+    $name: Rotation
+    $description: Rotation in degrees while hovering. 0 disables rotation.
+  - hoverOpacity: 100
+    $name: Opacity
+    $description: Icon opacity as a percentage while hovering.
+  - hoverDuration: 120
+    $name: Transition duration
+    $description: Effect transition duration in milliseconds.
+  $name: Hover effects
+  $description: Configure the visual effect applied while hovering.
 
-- activatedImageSource: ""
-  $name: Activated image source
-  $description: >-
-    Image shown while the Start menu is open. If blank or unavailable, uses the
-    pressed image, then the hover image, then the normal image.
+- pressedEffects:
+  - pressedScale: 95
+    $name: Scale
+    $description: Icon scale as a percentage while pressed. 100 keeps its size.
+  - pressedRotation: -4
+    $name: Rotation
+    $description: Rotation in degrees while pressed. 0 disables rotation.
+  - pressedOpacity: 100
+    $name: Opacity
+    $description: Icon opacity as a percentage while pressed.
+  - pressedDuration: 80
+    $name: Transition duration
+    $description: Effect transition duration in milliseconds.
+  $name: Pressed effects
+  $description: Configure the visual effect applied while pressing the button.
 
-- hoverFadeDuration: 120
-  $name: Hover crossfade duration
-  $description: >-
-    Fade duration in milliseconds when entering or leaving the hover state. Set
-    to 0 to switch instantly.
-
-- pressedFadeDuration: 80
-  $name: Pressed crossfade duration
-  $description: >-
-    Fade duration in milliseconds when entering or leaving the pressed or
-    activated state. Set to 0 to switch instantly.
-
-- iconSize: 24
-  $name: Icon size
-  $description: Displayed icon size in device-independent pixels.
-
-- gifPlayback: always
-  $name: GIF playback
-  $description: Controls when an animated GIF is playing.
-  $options:
-  - always: Always
-  - hover: Only while hovering
-  - pressed: Only while pressed
-  - stopped: Never / first frame
-
-- hoverScale: 115
-  $name: Hover scale
-  $description: Scale percentage while the mouse is over the Start button.
-
-- hoverRotation: 4
-  $name: Hover rotation
-  $description: Rotation in degrees while hovering.
-
-- hoverOpacity: 100
-  $name: Hover opacity
-  $description: Opacity percentage while hovering.
-
-- hoverDuration: 120
-  $name: Hover animation duration
-  $description: Duration in milliseconds.
-
-- pressedScale: 88
-  $name: Pressed scale
-  $description: Scale percentage while the Start button is pressed.
-
-- pressedRotation: -4
-  $name: Pressed rotation
-  $description: Rotation in degrees while pressed.
-
-- pressedOpacity: 90
-  $name: Pressed opacity
-  $description: Opacity percentage while pressed.
-
-- pressedDuration: 80
-  $name: Pressed animation duration
-  $description: Duration in milliseconds.
-
-- releaseDuration: 140
-  $name: Release animation duration
-  $description: Duration used when returning from pressed/hover state.
-
-- respectSystemAnimations: true
-  $name: Respect Windows animation setting
-  $description: >-
-    Stop GIF playback and make transitions instant when Windows animation
-    effects are disabled.
+- animationBehavior:
+  - releaseDuration: 140
+    $name: Release duration
+    $description: >-
+      Effect transition duration in milliseconds when the pointer leaves or the
+      button is released.
+  - respectSystemAnimations: true
+    $name: Respect Windows animation setting
+    $description: >-
+      Stop GIF playback and make all transitions instant when animation effects
+      are disabled in Windows.
+  $name: Animation behavior
+  $description: Configure shared animation and accessibility behavior.
 */
 // ==/WindhawkModSettings==
-
 
 #include <windhawk_utils.h>
 
@@ -196,6 +196,8 @@ from the source image resolution.
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -203,57 +205,46 @@ from the source image resolution.
 
 #undef GetCurrentTime
 
-#include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.UI.Composition.h>
-#include <winrt/Windows.UI.ViewManagement.h>
+#include <winrt/Windows.UI.Core.h>
+#include <winrt/Windows.UI.Xaml.Automation.Peers.h>
 #include <winrt/Windows.UI.Xaml.Automation.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
 #include <winrt/Windows.UI.Xaml.Input.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.Media.Imaging.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.h>
 
+namespace wf = winrt::Windows::Foundation;
 
-namespace wf =
-    winrt::Windows::Foundation;
+namespace wss = winrt::Windows::Storage::Streams;
 
-namespace wss =
-    winrt::Windows::Storage::Streams;
+namespace wuc = winrt::Windows::UI::Composition;
 
-namespace wuc =
-    winrt::Windows::UI::Composition;
+namespace wuic = winrt::Windows::UI::Core;
 
-namespace wuv =
-    winrt::Windows::UI::ViewManagement;
+namespace wux = winrt::Windows::UI::Xaml;
 
-namespace wux =
-    winrt::Windows::UI::Xaml;
+namespace wuxa = winrt::Windows::UI::Xaml::Automation;
 
-namespace wuxa =
-    winrt::Windows::UI::Xaml::Automation;
+namespace wuxap = winrt::Windows::UI::Xaml::Automation::Peers;
 
-namespace wuxc =
-    winrt::Windows::UI::Xaml::Controls;
+namespace wuxc = winrt::Windows::UI::Xaml::Controls;
 
-namespace wuxcp =
-    winrt::Windows::UI::Xaml::Controls::Primitives;
+namespace wuxcp = winrt::Windows::UI::Xaml::Controls::Primitives;
 
-namespace wuxh =
-    winrt::Windows::UI::Xaml::Hosting;
+namespace wuxh = winrt::Windows::UI::Xaml::Hosting;
 
-namespace wuxi =
-    winrt::Windows::UI::Xaml::Input;
+namespace wuxi = winrt::Windows::UI::Xaml::Input;
 
-namespace wuxm =
-    winrt::Windows::UI::Xaml::Media;
+namespace wuxm = winrt::Windows::UI::Xaml::Media;
 
-namespace wuxmi =
-    winrt::Windows::UI::Xaml::Media::Imaging;
-
+namespace wuxmi = winrt::Windows::UI::Xaml::Media::Imaging;
 
 // -----------------------------------------------------------------------------
 // Settings
@@ -282,8 +273,7 @@ enum class IconState : size_t {
     Count,
 };
 
-constexpr size_t kIconStateCount =
-    static_cast<size_t>(IconState::Count);
+constexpr size_t kIconStateCount = static_cast<size_t>(IconState::Count);
 
 struct ModSettings {
     std::wstring imageSource;
@@ -297,17 +287,16 @@ struct ModSettings {
 
     int iconSize = 24;
 
-    GifPlaybackMode gifPlayback =
-        GifPlaybackMode::Always;
+    GifPlaybackMode gifPlayback = GifPlaybackMode::Always;
 
-    double hoverScale = 1.15;
-    double hoverRotation = 4.0;
+    double hoverScale = 1.0;
+    double hoverRotation = 0.0;
     double hoverOpacity = 1.0;
     int hoverDuration = 120;
 
-    double pressedScale = 0.88;
-    double pressedRotation = -4.0;
-    double pressedOpacity = 0.90;
+    double pressedScale = 1.0;
+    double pressedRotation = 0.0;
+    double pressedOpacity = 1.0;
     int pressedDuration = 80;
 
     int releaseDuration = 140;
@@ -316,9 +305,9 @@ struct ModSettings {
 };
 
 ModSettings g_settings;
+std::mutex g_settingsMutex;
 
 std::atomic<bool> g_unloading = false;
-
 
 // -----------------------------------------------------------------------------
 // Start icon instance
@@ -327,8 +316,8 @@ std::atomic<bool> g_unloading = false;
 struct ImageResource {
     wuxmi::BitmapImage bitmap{nullptr};
 
-    // Keep local file streams alive while their bitmaps exist.
-    wss::IRandomAccessStream localStream{nullptr};
+    // The source file is copied to memory so the file itself isn't kept open.
+    wss::IRandomAccessStream memoryStream{nullptr};
     wf::IAsyncAction loadAction{nullptr};
 
     winrt::event_token imageOpenedToken{};
@@ -336,11 +325,14 @@ struct ImageResource {
 
     bool imageOpenedAttached = false;
     bool imageFailedAttached = false;
+    bool opened = false;
     bool failed = false;
 };
 
 struct StartIconInstance {
     DWORD threadId = 0;
+    wuic::CoreDispatcher dispatcher{nullptr};
+    ModSettings settings;
 
     winrt::weak_ref<wux::FrameworkElement> startButton;
     winrt::weak_ref<wux::FrameworkElement> stockIcon;
@@ -351,13 +343,11 @@ struct StartIconInstance {
 
     double originalStockOpacity = 1.0;
 
-    std::array<ImageResource, kIconStateCount>
-        imageResources;
+    std::array<ImageResource, kIconStateCount> imageResources;
 
     // Multiple logical states can share one decoded image resource when their
     // configured sources are identical.
-    std::array<size_t, kIconStateCount>
-        imageResourceIndexByState{0, 1, 2, 3};
+    std::array<size_t, kIconStateCount> imageResourceIndexByState{0, 1, 2, 3};
 
     size_t activeImageIndex = 0;
     bool activeImageSet = false;
@@ -367,10 +357,8 @@ struct StartIconInstance {
     IconState displayedState = IconState::Normal;
     bool displayedStateSet = false;
 
-    GifAnimationStatus loggedGifStatus =
-        GifAnimationStatus::Unknown;
-    GifPlaybackMode loggedGifMode =
-        GifPlaybackMode::Always;
+    GifAnimationStatus loggedGifStatus = GifAnimationStatus::Unknown;
+    GifPlaybackMode loggedGifMode = GifPlaybackMode::Always;
     IconState loggedGifState = IconState::Normal;
     size_t loggedGifResourceIndex = 0;
     bool gifStatusLogged = false;
@@ -393,433 +381,277 @@ struct StartIconInstance {
     wf::IInspectable pointerCaptureLostHandler{nullptr};
 
     bool pointerEventsAttached = false;
+    bool detached = false;
 };
 
-std::vector<std::shared_ptr<StartIconInstance>> g_instances;
+std::mutex g_instancesMutex;
 
+[[clang::no_destroy]] std::optional<
+    std::vector<std::shared_ptr<StartIconInstance>>>
+    g_instances{std::in_place};
+
+// If an owning XAML dispatcher is already unavailable during a controlled
+// unload, releasing the instance from Windhawk's engine thread would violate
+// XAML thread affinity. Intentionally leak such exceptional instances instead.
+[[clang::no_destroy]] std::optional<
+    std::vector<std::shared_ptr<StartIconInstance>>>
+    g_abandonedInstances{std::in_place};
 
 // -----------------------------------------------------------------------------
 // Utility
 // -----------------------------------------------------------------------------
 
 std::wstring GetStringSetting(const wchar_t* name) {
-    PCWSTR value = Wh_GetStringSetting(name);
+    auto value = WindhawkUtils::StringSetting::make(name);
 
-    std::wstring result =
-        value ? value : L"";
-
-    if (value) {
-        Wh_FreeStringSetting(value);
-    }
-
-    return result;
+    return value.get() ? value.get() : L"";
 }
 
-bool EqualsIgnoreCase(
-    const std::wstring& a,
-    const wchar_t* b)
-{
+bool EqualsIgnoreCase(const std::wstring& a, const wchar_t* b) {
     return _wcsicmp(a.c_str(), b) == 0;
 }
 
-bool StartsWithIgnoreCase(
-    const std::wstring& value,
-    const wchar_t* prefix)
-{
-    size_t prefixLength = wcslen(prefix);
-
-    if (value.length() < prefixLength) {
-        return false;
-    }
-
-    return _wcsnicmp(
-               value.c_str(),
-               prefix,
-               prefixLength) == 0;
+bool IsBlank(const std::wstring& value) {
+    return value.find_first_not_of(L" \t\r\n") == std::wstring::npos;
 }
 
-bool IsHttpUrl(const std::wstring& source) {
-    return StartsWithIgnoreCase(
-               source,
-               L"http://") ||
-           StartsWithIgnoreCase(
-               source,
-               L"https://");
-}
-
-std::wstring ExpandPath(
-    const std::wstring& source)
-{
+std::wstring ExpandPath(const std::wstring& source) {
     if (source.empty()) {
         return source;
     }
 
-    DWORD required =
-        ExpandEnvironmentStringsW(
-            source.c_str(),
-            nullptr,
-            0);
+    DWORD required = ExpandEnvironmentStringsW(source.c_str(), nullptr, 0);
 
     if (!required) {
         return source;
     }
 
-    std::wstring result(
-        required,
-        L'\0');
+    std::wstring result(required, L'\0');
 
     DWORD written =
-        ExpandEnvironmentStringsW(
-            source.c_str(),
-            result.data(),
-            required);
+        ExpandEnvironmentStringsW(source.c_str(), result.data(), required);
 
-    if (!written ||
-        written > required)
-    {
+    if (!written || written > required) {
         return source;
     }
 
-    if (!result.empty() &&
-        result.back() == L'\0')
-    {
+    if (!result.empty() && result.back() == L'\0') {
         result.pop_back();
     }
 
     return result;
 }
 
-void LoadSettings() {
-    g_settings.imageSource =
-        GetStringSetting(L"imageSource");
+ModSettings LoadSettings() {
+    ModSettings settings;
 
-    g_settings.hoverImageSource =
-        GetStringSetting(
-            L"hoverImageSource");
+    settings.imageSource = GetStringSetting(L"images.imageSource");
 
-    g_settings.pressedImageSource =
-        GetStringSetting(
-            L"pressedImageSource");
+    settings.hoverImageSource =
+        GetStringSetting(L"images.hoverImageSource");
 
-    g_settings.activatedImageSource =
-        GetStringSetting(
-            L"activatedImageSource");
+    settings.pressedImageSource =
+        GetStringSetting(L"images.pressedImageSource");
 
-    g_settings.hoverFadeDuration =
-        std::clamp(
-            Wh_GetIntSetting(
-                L"hoverFadeDuration"),
-            0,
-            5000);
+    settings.activatedImageSource =
+        GetStringSetting(L"images.activatedImageSource");
 
-    g_settings.pressedFadeDuration =
-        std::clamp(
-            Wh_GetIntSetting(
-                L"pressedFadeDuration"),
-            0,
-            5000);
+    settings.hoverFadeDuration =
+        std::clamp(Wh_GetIntSetting(L"imageAnimation.hoverFadeDuration"), 0,
+                   5000);
 
-    g_settings.iconSize =
-        std::clamp(
-            Wh_GetIntSetting(L"iconSize"),
-            8,
-            128);
+    settings.pressedFadeDuration =
+        std::clamp(Wh_GetIntSetting(L"imageAnimation.pressedFadeDuration"), 0,
+                   5000);
+
+    settings.iconSize =
+        std::clamp(Wh_GetIntSetting(L"images.iconSize"), 8, 128);
 
     std::wstring playback =
-        GetStringSetting(L"gifPlayback");
+        GetStringSetting(L"imageAnimation.gifPlayback");
 
-    if (EqualsIgnoreCase(
-            playback,
-            L"hover"))
-    {
-        g_settings.gifPlayback =
-            GifPlaybackMode::Hover;
-    }
-    else if (EqualsIgnoreCase(
-                 playback,
-                 L"pressed"))
-    {
-        g_settings.gifPlayback =
-            GifPlaybackMode::Pressed;
-    }
-    else if (EqualsIgnoreCase(
-                 playback,
-                 L"stopped"))
-    {
-        g_settings.gifPlayback =
-            GifPlaybackMode::Stopped;
-    }
-    else
-    {
-        g_settings.gifPlayback =
-            GifPlaybackMode::Always;
+    if (EqualsIgnoreCase(playback, L"hover")) {
+        settings.gifPlayback = GifPlaybackMode::Hover;
+    } else if (EqualsIgnoreCase(playback, L"pressed")) {
+        settings.gifPlayback = GifPlaybackMode::Pressed;
+    } else if (EqualsIgnoreCase(playback, L"stopped")) {
+        settings.gifPlayback = GifPlaybackMode::Stopped;
+    } else {
+        settings.gifPlayback = GifPlaybackMode::Always;
     }
 
-    g_settings.hoverScale =
-        std::clamp(
-            Wh_GetIntSetting(
-                L"hoverScale"),
-            10,
-            500) /
+    settings.hoverScale =
+        std::clamp(Wh_GetIntSetting(L"hoverEffects.hoverScale"), 10, 500) /
         100.0;
 
-    g_settings.hoverRotation =
-        std::clamp(
-            Wh_GetIntSetting(
-                L"hoverRotation"),
-            -360,
-            360);
+    settings.hoverRotation =
+        std::clamp(Wh_GetIntSetting(L"hoverEffects.hoverRotation"), -360,
+                   360);
 
-    g_settings.hoverOpacity =
-        std::clamp(
-            Wh_GetIntSetting(
-                L"hoverOpacity"),
-            0,
-            100) /
+    settings.hoverOpacity =
+        std::clamp(Wh_GetIntSetting(L"hoverEffects.hoverOpacity"), 0, 100) /
         100.0;
 
-    g_settings.hoverDuration =
-        std::clamp(
-            Wh_GetIntSetting(
-                L"hoverDuration"),
-            0,
-            5000);
+    settings.hoverDuration =
+        std::clamp(Wh_GetIntSetting(L"hoverEffects.hoverDuration"), 0, 5000);
 
-    g_settings.pressedScale =
-        std::clamp(
-            Wh_GetIntSetting(
-                L"pressedScale"),
-            10,
-            500) /
+    settings.pressedScale =
+        std::clamp(Wh_GetIntSetting(L"pressedEffects.pressedScale"), 10, 500) /
         100.0;
 
-    g_settings.pressedRotation =
-        std::clamp(
-            Wh_GetIntSetting(
-                L"pressedRotation"),
-            -360,
-            360);
+    settings.pressedRotation =
+        std::clamp(Wh_GetIntSetting(L"pressedEffects.pressedRotation"), -360,
+                   360);
 
-    g_settings.pressedOpacity =
-        std::clamp(
-            Wh_GetIntSetting(
-                L"pressedOpacity"),
-            0,
-            100) /
+    settings.pressedOpacity =
+        std::clamp(Wh_GetIntSetting(L"pressedEffects.pressedOpacity"), 0,
+                   100) /
         100.0;
 
-    g_settings.pressedDuration =
-        std::clamp(
-            Wh_GetIntSetting(
-                L"pressedDuration"),
-            0,
-            5000);
+    settings.pressedDuration =
+        std::clamp(Wh_GetIntSetting(L"pressedEffects.pressedDuration"), 0,
+                   5000);
 
-    g_settings.releaseDuration =
-        std::clamp(
-            Wh_GetIntSetting(
-                L"releaseDuration"),
-            0,
-            5000);
+    settings.releaseDuration =
+        std::clamp(Wh_GetIntSetting(L"animationBehavior.releaseDuration"), 0,
+                   5000);
 
-    g_settings.respectSystemAnimations =
-        Wh_GetIntSetting(
-            L"respectSystemAnimations") != 0;
+    settings.respectSystemAnimations =
+        Wh_GetIntSetting(L"animationBehavior.respectSystemAnimations") != 0;
+
+    return settings;
 }
 
+void StoreSettings(ModSettings settings) {
+    std::lock_guard<std::mutex> lock(g_settingsMutex);
+
+    g_settings = std::move(settings);
+}
+
+ModSettings GetSettingsSnapshot() {
+    std::lock_guard<std::mutex> lock(g_settingsMutex);
+
+    return g_settings;
+}
 
 // -----------------------------------------------------------------------------
 // Windows animation accessibility setting
 // -----------------------------------------------------------------------------
 
-bool MotionAllowed() {
-    if (!g_settings.respectSystemAnimations) {
+bool MotionAllowed(const ModSettings& settings) {
+    if (!settings.respectSystemAnimations) {
         return true;
     }
 
-    try {
-        wuv::UISettings uiSettings;
+    BOOL animationsEnabled = TRUE;
 
-        return uiSettings.AnimationsEnabled();
-    }
-    catch (...) {
+    if (!SystemParametersInfoW(SPI_GETCLIENTAREAANIMATION, 0,
+                               &animationsEnabled, 0)) {
         return true;
     }
+
+    return animationsEnabled != FALSE;
 }
-
 
 // -----------------------------------------------------------------------------
 // Composition effects
 // -----------------------------------------------------------------------------
 
-void SetVisualImmediately(
-    const wuc::Visual& visual,
-    float scale,
-    float rotation,
-    float opacity)
-{
+void SetVisualImmediately(const wuc::Visual& visual,
+                          float scale,
+                          float rotation,
+                          float opacity) {
     visual.StopAnimation(L"Scale");
-    visual.StopAnimation(
-        L"RotationAngleInDegrees");
+    visual.StopAnimation(L"RotationAngleInDegrees");
     visual.StopAnimation(L"Opacity");
 
-    visual.Scale({
-        scale,
-        scale,
-        1.0f
-    });
+    visual.Scale({scale, scale, 1.0f});
 
-    visual.RotationAngleInDegrees(
-        rotation);
+    visual.RotationAngleInDegrees(rotation);
 
     visual.Opacity(opacity);
 }
 
-void AnimateVisual(
-    const wux::FrameworkElement& element,
-    float scale,
-    float rotation,
-    float opacity,
-    int durationMs)
-{
+void AnimateVisual(const wux::FrameworkElement& element,
+                   const ModSettings& settings,
+                   float scale,
+                   float rotation,
+                   float opacity,
+                   int durationMs) {
     if (!element) {
         return;
     }
 
     try {
         auto visual =
-            wuxh::ElementCompositionPreview::
-                GetElementVisual(element);
+            wuxh::ElementCompositionPreview::GetElementVisual(element);
 
         if (!visual) {
             return;
         }
 
-        float width =
-            static_cast<float>(
-                element.ActualWidth());
+        float width = static_cast<float>(element.ActualWidth());
 
-        float height =
-            static_cast<float>(
-                element.ActualHeight());
+        float height = static_cast<float>(element.ActualHeight());
 
         if (width <= 0) {
-            width =
-                static_cast<float>(
-                    g_settings.iconSize);
+            width = static_cast<float>(settings.iconSize);
         }
 
         if (height <= 0) {
-            height =
-                static_cast<float>(
-                    g_settings.iconSize);
+            height = static_cast<float>(settings.iconSize);
         }
 
-        visual.CenterPoint({
-            width / 2.0f,
-            height / 2.0f,
-            0.0f
-        });
+        visual.CenterPoint({width / 2.0f, height / 2.0f, 0.0f});
 
-        if (!MotionAllowed() ||
-            durationMs <= 0)
-        {
-            SetVisualImmediately(
-                visual,
-                scale,
-                rotation,
-                opacity);
+        if (!MotionAllowed(settings) || durationMs <= 0) {
+            SetVisualImmediately(visual, scale, rotation, opacity);
 
             return;
         }
 
-        auto compositor =
-            visual.Compositor();
+        auto compositor = visual.Compositor();
 
-        auto easing =
-            compositor
-                .CreateCubicBezierEasingFunction(
-                    {
-                        0.20f,
-                        0.00f
-                    },
-                    {
-                        0.00f,
-                        1.00f
-                    });
+        auto easing = compositor.CreateCubicBezierEasingFunction(
+            {0.20f, 0.00f}, {0.00f, 1.00f});
 
         // Scale.
         {
-            auto animation =
-                compositor
-                    .CreateVector3KeyFrameAnimation();
+            auto animation = compositor.CreateVector3KeyFrameAnimation();
 
-            animation.InsertKeyFrame(
-                1.0f,
-                {
-                    scale,
-                    scale,
-                    1.0f
-                },
-                easing);
+            animation.InsertKeyFrame(1.0f, {scale, scale, 1.0f}, easing);
 
-            animation.Duration(
-                std::chrono::milliseconds(
-                    durationMs));
+            animation.Duration(std::chrono::milliseconds(durationMs));
 
-            visual.StartAnimation(
-                L"Scale",
-                animation);
+            visual.StartAnimation(L"Scale", animation);
         }
 
         // Rotation.
         {
-            auto animation =
-                compositor
-                    .CreateScalarKeyFrameAnimation();
+            auto animation = compositor.CreateScalarKeyFrameAnimation();
 
-            animation.InsertKeyFrame(
-                1.0f,
-                rotation,
-                easing);
+            animation.InsertKeyFrame(1.0f, rotation, easing);
 
-            animation.Duration(
-                std::chrono::milliseconds(
-                    durationMs));
+            animation.Duration(std::chrono::milliseconds(durationMs));
 
-            visual.StartAnimation(
-                L"RotationAngleInDegrees",
-                animation);
+            visual.StartAnimation(L"RotationAngleInDegrees", animation);
         }
 
         // Opacity.
         {
-            auto animation =
-                compositor
-                    .CreateScalarKeyFrameAnimation();
+            auto animation = compositor.CreateScalarKeyFrameAnimation();
 
-            animation.InsertKeyFrame(
-                1.0f,
-                opacity,
-                easing);
+            animation.InsertKeyFrame(1.0f, opacity, easing);
 
-            animation.Duration(
-                std::chrono::milliseconds(
-                    durationMs));
+            animation.Duration(std::chrono::milliseconds(durationMs));
 
-            visual.StartAnimation(
-                L"Opacity",
-                animation);
+            visual.StartAnimation(L"Opacity", animation);
         }
-    }
-    catch (const winrt::hresult_error& e) {
-        Wh_Log(
-            L"AnimateVisual failed: 0x%08X %s",
-            e.code().value,
-            e.message().c_str());
+    } catch (const winrt::hresult_error& e) {
+        Wh_Log(L"AnimateVisual failed: 0x%08X %s", e.code().value,
+               e.message().c_str());
     }
 }
-
 
 // -----------------------------------------------------------------------------
 // GIF playback
@@ -849,9 +681,7 @@ const wchar_t* IconStateName(IconState state) {
 }
 
 IconState GetCurrentIconState(
-    const std::shared_ptr<
-        StartIconInstance>& instance)
-{
+    const std::shared_ptr<StartIconInstance>& instance) {
     if (instance && instance->pressed) {
         return IconState::Pressed;
     }
@@ -867,53 +697,42 @@ IconState GetCurrentIconState(
     return IconState::Normal;
 }
 
-std::wstring GetImageSourceForState(
-    IconState state)
-{
+std::wstring GetImageSourceForState(const ModSettings& settings,
+                                    IconState state) {
     if (state == IconState::Normal) {
-        return g_settings.imageSource;
+        return settings.imageSource;
     }
 
     switch (state) {
         case IconState::Hover:
-            return g_settings.hoverImageSource;
+            return settings.hoverImageSource;
 
         case IconState::Pressed:
-            return g_settings.pressedImageSource;
+            return settings.pressedImageSource;
 
         case IconState::Activated:
-            return g_settings.activatedImageSource;
+            return settings.activatedImageSource;
 
         default:
             return L"";
     }
 }
 
-bool ImageResourceAvailable(
-    const ImageResource& resource)
-{
-    return resource.bitmap &&
-        !resource.failed;
+bool ImageResourceAvailable(const ImageResource& resource) {
+    return resource.bitmap && resource.opened && !resource.failed;
 }
 
-wuxc::Image GetImageLayer(
-    const std::shared_ptr<
-        StartIconInstance>& instance,
-    size_t layerIndex)
-{
+wuxc::Image GetImageLayer(const std::shared_ptr<StartIconInstance>& instance,
+                          size_t layerIndex) {
     if (!instance) {
         return nullptr;
     }
 
-    return layerIndex == 0
-        ? instance->customImage.get()
-        : instance->transitionImage.get();
+    return layerIndex == 0 ? instance->customImage.get()
+                           : instance->transitionImage.get();
 }
 
-bool ImageSourcesEqual(
-    const std::wstring& first,
-    const std::wstring& second)
-{
+bool ImageSourcesEqual(const std::wstring& first, const std::wstring& second) {
     if (first.empty() || second.empty()) {
         return false;
     }
@@ -922,36 +741,19 @@ bool ImageSourcesEqual(
         return true;
     }
 
-    // URL paths can be case-sensitive. Local Windows paths are not, and
-    // environment variables should be compared after expansion.
-    if (IsHttpUrl(first) ||
-        IsHttpUrl(second))
-    {
-        return false;
-    }
+    std::wstring expandedFirst = ExpandPath(first);
+    std::wstring expandedSecond = ExpandPath(second);
 
-    std::wstring expandedFirst =
-        ExpandPath(first);
-    std::wstring expandedSecond =
-        ExpandPath(second);
-
-    return _wcsicmp(
-               expandedFirst.c_str(),
-               expandedSecond.c_str()) == 0;
+    return _wcsicmp(expandedFirst.c_str(), expandedSecond.c_str()) == 0;
 }
 
-void SetImageLayerOpacity(
-    const wuxc::Image& image,
-    float opacity)
-{
+void SetImageLayerOpacity(const wuxc::Image& image, float opacity) {
     if (!image) {
         return;
     }
 
     try {
-        auto visual =
-            wuxh::ElementCompositionPreview::
-                GetElementVisual(image);
+        auto visual = wuxh::ElementCompositionPreview::GetElementVisual(image);
 
         if (!visual) {
             return;
@@ -959,14 +761,11 @@ void SetImageLayerOpacity(
 
         visual.StopAnimation(L"Opacity");
         visual.Opacity(opacity);
-    }
-    catch (...) {
+    } catch (...) {
     }
 }
 
-const wchar_t* GifPlaybackModeName(
-    GifPlaybackMode mode)
-{
+const wchar_t* GifPlaybackModeName(GifPlaybackMode mode) {
     switch (mode) {
         case GifPlaybackMode::Always:
             return L"always";
@@ -985,9 +784,7 @@ const wchar_t* GifPlaybackModeName(
     }
 }
 
-const wchar_t* GifAnimationStatusName(
-    GifAnimationStatus status)
-{
+const wchar_t* GifAnimationStatusName(GifAnimationStatus status) {
     switch (status) {
         case GifAnimationStatus::NotAnimated:
             return L"not-animated";
@@ -998,8 +795,7 @@ const wchar_t* GifAnimationStatusName(
         case GifAnimationStatus::Stopped:
             return L"stopped";
 
-        case GifAnimationStatus::
-                 SystemAnimationsDisabled:
+        case GifAnimationStatus::SystemAnimationsDisabled:
             return L"stopped-system-animations-disabled";
 
         default:
@@ -1007,29 +803,22 @@ const wchar_t* GifAnimationStatusName(
     }
 }
 
-void AnimateImageLayerOpacity(
-    const wuxc::Image& image,
-    float fromOpacity,
-    float toOpacity,
-    int durationMs)
-{
+void AnimateImageLayerOpacity(const wuxc::Image& image,
+                              const ModSettings& settings,
+                              float fromOpacity,
+                              float toOpacity,
+                              int durationMs) {
     if (!image) {
         return;
     }
 
-    if (!MotionAllowed() ||
-        durationMs <= 0)
-    {
-        SetImageLayerOpacity(
-            image,
-            toOpacity);
+    if (!MotionAllowed(settings) || durationMs <= 0) {
+        SetImageLayerOpacity(image, toOpacity);
         return;
     }
 
     try {
-        auto visual =
-            wuxh::ElementCompositionPreview::
-                GetElementVisual(image);
+        auto visual = wuxh::ElementCompositionPreview::GetElementVisual(image);
 
         if (!visual) {
             return;
@@ -1038,214 +827,134 @@ void AnimateImageLayerOpacity(
         visual.StopAnimation(L"Opacity");
         visual.Opacity(fromOpacity);
 
-        auto compositor =
-            visual.Compositor();
+        auto compositor = visual.Compositor();
 
-        auto easing =
-            compositor
-                .CreateCubicBezierEasingFunction(
-                    {0.20f, 0.00f},
-                    {0.00f, 1.00f});
+        auto easing = compositor.CreateCubicBezierEasingFunction(
+            {0.20f, 0.00f}, {0.00f, 1.00f});
 
-        auto animation =
-            compositor
-                .CreateScalarKeyFrameAnimation();
+        auto animation = compositor.CreateScalarKeyFrameAnimation();
 
-        animation.InsertKeyFrame(
-            0.0f,
-            fromOpacity);
+        animation.InsertKeyFrame(0.0f, fromOpacity);
 
-        animation.InsertKeyFrame(
-            1.0f,
-            toOpacity,
-            easing);
+        animation.InsertKeyFrame(1.0f, toOpacity, easing);
 
-        animation.Duration(
-            std::chrono::milliseconds(
-                durationMs));
+        animation.Duration(std::chrono::milliseconds(durationMs));
 
-        visual.StartAnimation(
-            L"Opacity",
-            animation);
-    }
-    catch (...) {
-        SetImageLayerOpacity(
-            image,
-            toOpacity);
+        visual.StartAnimation(L"Opacity", animation);
+    } catch (...) {
+        SetImageLayerOpacity(image, toOpacity);
     }
 }
 
 int GetStateCrossfadeDuration(
-    const std::shared_ptr<
-        StartIconInstance>& instance,
-    IconState nextState)
-{
+    const std::shared_ptr<StartIconInstance>& instance,
+    IconState nextState) {
     if (!instance) {
         return 0;
     }
 
-    if (nextState == IconState::Pressed ||
-        nextState == IconState::Activated ||
+    if (nextState == IconState::Pressed || nextState == IconState::Activated ||
         (instance->displayedStateSet &&
-         (instance->displayedState ==
-              IconState::Pressed ||
-          instance->displayedState ==
-              IconState::Activated)))
-    {
-        return g_settings.pressedFadeDuration;
+         (instance->displayedState == IconState::Pressed ||
+          instance->displayedState == IconState::Activated))) {
+        return instance->settings.pressedFadeDuration;
     }
 
-    return g_settings.hoverFadeDuration;
+    return instance->settings.hoverFadeDuration;
 }
 
-bool UpdateDisplayedImage(
-    const std::shared_ptr<
-        StartIconInstance>& instance)
-{
+bool UpdateDisplayedImage(const std::shared_ptr<StartIconInstance>& instance) {
     if (!instance) {
         return false;
     }
 
-    auto firstLayer =
-        GetImageLayer(instance, 0);
-    auto secondLayer =
-        GetImageLayer(instance, 1);
+    auto firstLayer = GetImageLayer(instance, 0);
+    auto secondLayer = GetImageLayer(instance, 1);
 
     if (!firstLayer || !secondLayer) {
         return false;
     }
 
-    auto setStockOpacity =
-        [&](double opacity)
-        {
-            auto stockIcon =
-                instance->stockIcon.get();
+    auto setStockOpacity = [&](double opacity) {
+        auto stockIcon = instance->stockIcon.get();
 
-            if (stockIcon) {
-                try {
-                    stockIcon.Opacity(opacity);
-                }
-                catch (...) {
-                }
+        if (stockIcon) {
+            try {
+                stockIcon.Opacity(opacity);
+            } catch (...) {
             }
-        };
+        }
+    };
 
-    IconState desiredState =
-        GetCurrentIconState(instance);
+    IconState desiredState = GetCurrentIconState(instance);
 
-    size_t normalIndex =
-        IconStateIndex(
-            IconState::Normal);
+    size_t normalIndex = IconStateIndex(IconState::Normal);
 
     size_t selectedIndex = normalIndex;
-    IconState selectedState =
-        IconState::Normal;
+    IconState selectedState = IconState::Normal;
 
-    auto selectIfAvailable =
-        [&](IconState state)
-        {
-            size_t stateIndex =
-                instance
-                    ->imageResourceIndexByState[
-                        IconStateIndex(state)];
+    auto selectIfAvailable = [&](IconState state) {
+        size_t stateIndex =
+            instance->imageResourceIndexByState[IconStateIndex(state)];
 
-            if (!ImageResourceAvailable(
-                    instance
-                        ->imageResources[stateIndex]))
-            {
-                return false;
-            }
-
-            selectedIndex = stateIndex;
-            selectedState = state;
-            return true;
-        };
-
-    if (desiredState ==
-        IconState::Activated)
-    {
-        if (!selectIfAvailable(
-                IconState::Activated) &&
-            !selectIfAvailable(
-                IconState::Pressed) &&
-            !selectIfAvailable(
-                IconState::Hover))
-        {
-            selectIfAvailable(
-                IconState::Normal);
+        if (!ImageResourceAvailable(instance->imageResources[stateIndex])) {
+            return false;
         }
+
+        selectedIndex = stateIndex;
+        selectedState = state;
+        return true;
+    };
+
+    if (desiredState == IconState::Activated) {
+        if (!selectIfAvailable(IconState::Activated) &&
+            !selectIfAvailable(IconState::Pressed) &&
+            !selectIfAvailable(IconState::Hover)) {
+            selectIfAvailable(IconState::Normal);
+        }
+    } else if (!selectIfAvailable(desiredState)) {
+        selectIfAvailable(IconState::Normal);
     }
-    else if (!selectIfAvailable(
-                 desiredState))
-    {
-        selectIfAvailable(
-            IconState::Normal);
-    }
 
-    auto& selectedResource =
-        instance
-            ->imageResources[selectedIndex];
+    auto& selectedResource = instance->imageResources[selectedIndex];
 
-    bool selectionChanged =
-        !instance->requestedStateSet ||
-        instance->requestedState !=
-            desiredState ||
-        !instance->displayedStateSet ||
-        instance->displayedState !=
-            selectedState;
+    bool selectionChanged = !instance->requestedStateSet ||
+                            instance->requestedState != desiredState ||
+                            !instance->displayedStateSet ||
+                            instance->displayedState != selectedState;
 
-    instance->requestedState =
-        desiredState;
+    instance->requestedState = desiredState;
     instance->requestedStateSet = true;
 
     if (selectionChanged) {
-        Wh_Log(
-            L"Start icon state: requested=%s selected=%s",
-            IconStateName(desiredState),
-            IconStateName(selectedState));
+        Wh_Log(L"Start icon state: requested=%s selected=%s",
+               IconStateName(desiredState), IconStateName(selectedState));
     }
 
-    if (!ImageResourceAvailable(
-            selectedResource))
-    {
-        for (size_t layerIndex = 0;
-             layerIndex < 2;
-             layerIndex++)
-        {
-            auto layer =
-                GetImageLayer(
-                    instance,
-                    layerIndex);
+    if (!ImageResourceAvailable(selectedResource)) {
+        for (size_t layerIndex = 0; layerIndex < 2; layerIndex++) {
+            auto layer = GetImageLayer(instance, layerIndex);
 
             try {
-                layer.Source(
-                    wuxm::ImageSource{nullptr});
-            }
-            catch (...) {
+                layer.Source(wuxm::ImageSource{nullptr});
+            } catch (...) {
             }
 
-            SetImageLayerOpacity(
-                layer,
-                0.0f);
+            SetImageLayerOpacity(layer, 0.0f);
         }
 
         instance->activeImageSet = false;
-        instance->displayedState =
-            IconState::Normal;
+        instance->displayedState = IconState::Normal;
         instance->displayedStateSet = true;
 
-        setStockOpacity(
-            instance->originalStockOpacity);
+        setStockOpacity(instance->originalStockOpacity);
 
         return false;
     }
 
     if (instance->activeImageSet &&
-        instance->activeImageIndex ==
-            selectedIndex)
-    {
-        instance->displayedState =
-            selectedState;
+        instance->activeImageIndex == selectedIndex) {
+        instance->displayedState = selectedState;
         instance->displayedStateSet = true;
         setStockOpacity(0.0);
         return true;
@@ -1253,164 +962,104 @@ bool UpdateDisplayedImage(
 
     try {
         if (!instance->activeImageSet) {
-            firstLayer.Source(
-                selectedResource.bitmap);
+            firstLayer.Source(selectedResource.bitmap);
 
-            SetImageLayerOpacity(
-                firstLayer,
-                1.0f);
-            SetImageLayerOpacity(
-                secondLayer,
-                0.0f);
+            SetImageLayerOpacity(firstLayer, 1.0f);
+            SetImageLayerOpacity(secondLayer, 0.0f);
 
             instance->activeLayerIndex = 0;
-        }
-        else {
-            size_t outgoingLayerIndex =
-                instance->activeLayerIndex;
-            size_t incomingLayerIndex =
-                1 - outgoingLayerIndex;
+        } else {
+            size_t outgoingLayerIndex = instance->activeLayerIndex;
+            size_t incomingLayerIndex = 1 - outgoingLayerIndex;
 
-            auto outgoingLayer =
-                GetImageLayer(
-                    instance,
-                    outgoingLayerIndex);
-            auto incomingLayer =
-                GetImageLayer(
-                    instance,
-                    incomingLayerIndex);
+            auto outgoingLayer = GetImageLayer(instance, outgoingLayerIndex);
+            auto incomingLayer = GetImageLayer(instance, incomingLayerIndex);
 
-            incomingLayer.Source(
-                selectedResource.bitmap);
+            incomingLayer.Source(selectedResource.bitmap);
 
             int fadeDuration =
-                GetStateCrossfadeDuration(
-                    instance,
-                    selectedState);
+                GetStateCrossfadeDuration(instance, selectedState);
 
-            AnimateImageLayerOpacity(
-                outgoingLayer,
-                1.0f,
-                0.0f,
-                fadeDuration);
+            AnimateImageLayerOpacity(outgoingLayer, instance->settings, 1.0f,
+                                     0.0f, fadeDuration);
 
-            AnimateImageLayerOpacity(
-                incomingLayer,
-                0.0f,
-                1.0f,
-                fadeDuration);
+            AnimateImageLayerOpacity(incomingLayer, instance->settings, 0.0f,
+                                     1.0f, fadeDuration);
 
-            instance->activeLayerIndex =
-                incomingLayerIndex;
+            instance->activeLayerIndex = incomingLayerIndex;
         }
 
-        instance->activeImageIndex =
-            selectedIndex;
+        instance->activeImageIndex = selectedIndex;
         instance->activeImageSet = true;
-        instance->displayedState =
-            selectedState;
+        instance->displayedState = selectedState;
         instance->displayedStateSet = true;
 
         setStockOpacity(0.0);
 
         return true;
-    }
-    catch (const winrt::hresult_error& e) {
-        Wh_Log(
-            L"Switching Start image failed: 0x%08X %s",
-            e.code().value,
-            e.message().c_str());
-    }
-    catch (...) {
-        Wh_Log(
-            L"Switching Start image failed");
+    } catch (const winrt::hresult_error& e) {
+        Wh_Log(L"Switching Start image failed: 0x%08X %s", e.code().value,
+               e.message().c_str());
+    } catch (...) {
+        Wh_Log(L"Switching Start image failed");
     }
 
     instance->activeImageSet = false;
-    setStockOpacity(
-        instance->originalStockOpacity);
+    setStockOpacity(instance->originalStockOpacity);
 
     return false;
 }
 
-void LogGifAnimationStatus(
-    const std::shared_ptr<
-        StartIconInstance>& instance,
-    GifAnimationStatus status)
-{
-    if (!instance ||
-        !instance->activeImageSet)
-    {
+void LogGifAnimationStatus(const std::shared_ptr<StartIconInstance>& instance,
+                           GifAnimationStatus status) {
+    if (!instance || !instance->activeImageSet) {
         return;
     }
 
-    IconState state =
-        instance->displayedStateSet
-            ? instance->displayedState
-            : GetCurrentIconState(instance);
+    IconState state = instance->displayedStateSet
+                          ? instance->displayedState
+                          : GetCurrentIconState(instance);
 
-    if (instance->gifStatusLogged &&
-        instance->loggedGifStatus == status &&
-        instance->loggedGifMode ==
-            g_settings.gifPlayback &&
+    if (instance->gifStatusLogged && instance->loggedGifStatus == status &&
+        instance->loggedGifMode == instance->settings.gifPlayback &&
         instance->loggedGifState == state &&
-        instance->loggedGifResourceIndex ==
-            instance->activeImageIndex)
-    {
+        instance->loggedGifResourceIndex == instance->activeImageIndex) {
         return;
     }
 
     instance->loggedGifStatus = status;
-    instance->loggedGifMode =
-        g_settings.gifPlayback;
+    instance->loggedGifMode = instance->settings.gifPlayback;
     instance->loggedGifState = state;
-    instance->loggedGifResourceIndex =
-        instance->activeImageIndex;
+    instance->loggedGifResourceIndex = instance->activeImageIndex;
     instance->gifStatusLogged = true;
 
     IconState resourceState =
-        instance->activeImageIndex <
-            kIconStateCount
-            ? static_cast<IconState>(
-                  instance->activeImageIndex)
+        instance->activeImageIndex < kIconStateCount
+            ? static_cast<IconState>(instance->activeImageIndex)
             : IconState::Normal;
 
-    Wh_Log(
-        L"Icon Status: state=%s resource=%s mode=%s status=%s",
-        IconStateName(state),
-        IconStateName(resourceState),
-        GifPlaybackModeName(
-            g_settings.gifPlayback),
-        GifAnimationStatusName(status));
+    Wh_Log(L"Icon Status: state=%s resource=%s mode=%s status=%s",
+           IconStateName(state), IconStateName(resourceState),
+           GifPlaybackModeName(instance->settings.gifPlayback),
+           GifAnimationStatusName(status));
 }
 
-void UpdateGifPlayback(
-    const std::shared_ptr<
-        StartIconInstance>& instance)
-{
-    if (!instance)
-    {
+void UpdateGifPlayback(const std::shared_ptr<StartIconInstance>& instance) {
+    if (!instance) {
         return;
     }
 
-    for (size_t i = 0;
-         i < kIconStateCount;
-         i++)
-    {
-        auto& resource =
-            instance->imageResources[i];
+    for (size_t i = 0; i < kIconStateCount; i++) {
+        auto& resource = instance->imageResources[i];
 
         if (!resource.bitmap ||
-            (instance->activeImageSet &&
-             instance->activeImageIndex == i))
-        {
+            (instance->activeImageSet && instance->activeImageIndex == i)) {
             continue;
         }
 
         try {
             resource.bitmap.Stop();
-        }
-        catch (...) {
+        } catch (...) {
         }
     }
 
@@ -1418,54 +1067,39 @@ void UpdateGifPlayback(
         return;
     }
 
-    auto& activeResource =
-        instance->imageResources[
-            instance->activeImageIndex];
+    auto& activeResource = instance->imageResources[instance->activeImageIndex];
 
-    if (!ImageResourceAvailable(
-            activeResource))
-    {
+    if (!ImageResourceAvailable(activeResource)) {
         return;
     }
 
     try {
-        if (!activeResource
-                 .bitmap
-                 .IsAnimatedBitmap())
-        {
-            LogGifAnimationStatus(
-                instance,
-                GifAnimationStatus::NotAnimated);
+        if (!activeResource.bitmap.IsAnimatedBitmap()) {
+            LogGifAnimationStatus(instance, GifAnimationStatus::NotAnimated);
             return;
         }
 
-        if (!MotionAllowed()) {
+        if (!MotionAllowed(instance->settings)) {
             activeResource.bitmap.Stop();
 
-            LogGifAnimationStatus(
-                instance,
-                GifAnimationStatus::
-                    SystemAnimationsDisabled);
+            LogGifAnimationStatus(instance,
+                                  GifAnimationStatus::SystemAnimationsDisabled);
             return;
         }
 
         bool play = false;
 
-        switch (
-            g_settings.gifPlayback)
-        {
+        switch (instance->settings.gifPlayback) {
             case GifPlaybackMode::Always:
                 play = true;
                 break;
 
             case GifPlaybackMode::Hover:
-                play =
-                    instance->hovering;
+                play = instance->hovering;
                 break;
 
             case GifPlaybackMode::Pressed:
-                play =
-                    instance->pressed;
+                play = instance->pressed;
                 break;
 
             case GifPlaybackMode::Stopped:
@@ -1476,101 +1110,66 @@ void UpdateGifPlayback(
         if (play) {
             activeResource.bitmap.Play();
 
-            LogGifAnimationStatus(
-                instance,
-                GifAnimationStatus::Playing);
-        }
-        else {
+            LogGifAnimationStatus(instance, GifAnimationStatus::Playing);
+        } else {
             activeResource.bitmap.Stop();
 
-            LogGifAnimationStatus(
-                instance,
-                GifAnimationStatus::Stopped);
+            LogGifAnimationStatus(instance, GifAnimationStatus::Stopped);
         }
-    }
-    catch (...) {
+    } catch (...) {
         // Non-animated images or images that
         // haven't finished loading yet can
         // simply ignore playback control.
     }
 }
 
-
 // -----------------------------------------------------------------------------
 // Visual states
 // -----------------------------------------------------------------------------
 
-void ApplyNormalState(
-    const std::shared_ptr<
-        StartIconInstance>& instance,
-    int duration)
-{
-    auto imageHost =
-        instance->customImageHost.get();
+void ApplyNormalState(const std::shared_ptr<StartIconInstance>& instance,
+                      int duration) {
+    auto imageHost = instance->customImageHost.get();
 
     if (!imageHost) {
         return;
     }
 
-    AnimateVisual(
-        imageHost,
-        1.0f,
-        0.0f,
-        1.0f,
-        duration);
+    AnimateVisual(imageHost, instance->settings, 1.0f, 0.0f, 1.0f, duration);
 }
 
-void ApplyHoverState(
-    const std::shared_ptr<
-        StartIconInstance>& instance,
-    int duration)
-{
-    auto imageHost =
-        instance->customImageHost.get();
+void ApplyHoverState(const std::shared_ptr<StartIconInstance>& instance,
+                     int duration) {
+    auto imageHost = instance->customImageHost.get();
 
     if (!imageHost) {
         return;
     }
 
-    AnimateVisual(
-        imageHost,
-        static_cast<float>(
-            g_settings.hoverScale),
-        static_cast<float>(
-            g_settings.hoverRotation),
-        static_cast<float>(
-            g_settings.hoverOpacity),
-        duration);
+    AnimateVisual(imageHost, instance->settings,
+                  static_cast<float>(instance->settings.hoverScale),
+                  static_cast<float>(instance->settings.hoverRotation),
+                  static_cast<float>(instance->settings.hoverOpacity),
+                  duration);
 }
 
-void ApplyPressedState(
-    const std::shared_ptr<
-        StartIconInstance>& instance,
-    int duration)
-{
-    auto imageHost =
-        instance->customImageHost.get();
+void ApplyPressedState(const std::shared_ptr<StartIconInstance>& instance,
+                       int duration) {
+    auto imageHost = instance->customImageHost.get();
 
     if (!imageHost) {
         return;
     }
 
-    AnimateVisual(
-        imageHost,
-        static_cast<float>(
-            g_settings.pressedScale),
-        static_cast<float>(
-            g_settings.pressedRotation),
-        static_cast<float>(
-            g_settings.pressedOpacity),
-        duration);
+    AnimateVisual(imageHost, instance->settings,
+                  static_cast<float>(instance->settings.pressedScale),
+                  static_cast<float>(instance->settings.pressedRotation),
+                  static_cast<float>(instance->settings.pressedOpacity),
+                  duration);
 }
 
-void ApplyCurrentState(
-    const std::shared_ptr<
-        StartIconInstance>& instance,
-    int duration)
-{
+void ApplyCurrentState(const std::shared_ptr<StartIconInstance>& instance,
+                       int duration) {
     if (!instance) {
         return;
     }
@@ -1580,75 +1179,47 @@ void ApplyCurrentState(
     }
 
     if (instance->pressed) {
-        ApplyPressedState(
-            instance,
-            duration);
-    }
-    else if (instance->hovering) {
-        ApplyHoverState(
-            instance,
-            duration);
-    }
-    else {
-        ApplyNormalState(
-            instance,
-            duration);
+        ApplyPressedState(instance, duration);
+    } else if (instance->hovering) {
+        ApplyHoverState(instance, duration);
+    } else {
+        ApplyNormalState(instance, duration);
     }
 
     UpdateGifPlayback(instance);
 }
 
-void SetPressedState(
-    const std::shared_ptr<
-        StartIconInstance>& instance,
-    bool pressed)
-{
-    if (!instance ||
-        instance->pressed == pressed)
-    {
+void SetPressedState(const std::shared_ptr<StartIconInstance>& instance,
+                     bool pressed) {
+    if (!instance || g_unloading || instance->pressed == pressed) {
         return;
     }
 
     instance->pressed = pressed;
 
     if (pressed) {
-        Wh_Log(
-            L"Start button: PRESSED");
-    }
-    else {
-        Wh_Log(
-            L"Start button: RELEASED");
+        Wh_Log(L"Start button: PRESSED");
+    } else {
+        Wh_Log(L"Start button: RELEASED");
     }
 
-    ApplyCurrentState(
-        instance,
-        pressed
-            ? g_settings.pressedDuration
-            : g_settings.releaseDuration);
+    ApplyCurrentState(instance, pressed ? instance->settings.pressedDuration
+                                        : instance->settings.releaseDuration);
 }
 
-bool IsToggleButtonChecked(
-    const wuxcp::ToggleButton& toggleButton)
-{
+bool IsToggleButtonChecked(const wuxcp::ToggleButton& toggleButton) {
     if (!toggleButton) {
         return false;
     }
 
-    auto isChecked =
-        toggleButton.IsChecked();
+    auto isChecked = toggleButton.IsChecked();
 
-    return isChecked &&
-        isChecked.Value();
+    return isChecked && isChecked.Value();
 }
 
-void SetActivatedState(
-    const std::shared_ptr<
-        StartIconInstance>& instance,
-    bool activated)
-{
-    if (!instance ||
-        instance->activated == activated)
-    {
+void SetActivatedState(const std::shared_ptr<StartIconInstance>& instance,
+                       bool activated) {
+    if (!instance || g_unloading || instance->activated == activated) {
         return;
     }
 
@@ -1656,8 +1227,7 @@ void SetActivatedState(
 
     if (activated) {
         Wh_Log(L"Start menu: SHOWN");
-    }
-    else {
+    } else {
         Wh_Log(L"Start menu: HIDDEN");
     }
 
@@ -1665,18 +1235,13 @@ void SetActivatedState(
     UpdateGifPlayback(instance);
 }
 
-
 // -----------------------------------------------------------------------------
 // XAML tree search
 // -----------------------------------------------------------------------------
 
 wux::FrameworkElement FindElementRecursive(
     const wux::DependencyObject& root,
-    const std::function<
-        bool(
-            const wux::FrameworkElement&)>&
-        callback)
-{
+    const std::function<bool(const wux::FrameworkElement&)>& callback) {
     if (!root) {
         return nullptr;
     }
@@ -1684,30 +1249,17 @@ wux::FrameworkElement FindElementRecursive(
     int childrenCount = 0;
 
     try {
-        childrenCount =
-            wuxm::VisualTreeHelper::
-                GetChildrenCount(root);
-    }
-    catch (...) {
+        childrenCount = wuxm::VisualTreeHelper::GetChildrenCount(root);
+    } catch (...) {
         return nullptr;
     }
 
-    for (int i = 0;
-         i < childrenCount;
-         i++)
-    {
-        wux::DependencyObject child{
-            nullptr
-        };
+    for (int i = 0; i < childrenCount; i++) {
+        wux::DependencyObject child{nullptr};
 
         try {
-            child =
-                wuxm::VisualTreeHelper::
-                    GetChild(
-                        root,
-                        i);
-        }
-        catch (...) {
+            child = wuxm::VisualTreeHelper::GetChild(root, i);
+        } catch (...) {
             continue;
         }
 
@@ -1715,26 +1267,18 @@ wux::FrameworkElement FindElementRecursive(
             continue;
         }
 
-        auto frameworkElement =
-            child.try_as<
-                wux::FrameworkElement>();
+        auto frameworkElement = child.try_as<wux::FrameworkElement>();
 
         if (frameworkElement) {
             try {
-                if (callback(
-                        frameworkElement))
-                {
+                if (callback(frameworkElement)) {
                     return frameworkElement;
                 }
-            }
-            catch (...) {
+            } catch (...) {
             }
         }
 
-        auto recursiveResult =
-            FindElementRecursive(
-                child,
-                callback);
+        auto recursiveResult = FindElementRecursive(child, callback);
 
         if (recursiveResult) {
             return recursiveResult;
@@ -1744,106 +1288,62 @@ wux::FrameworkElement FindElementRecursive(
     return nullptr;
 }
 
-wux::FrameworkElement FindStartButton(
-    const wux::FrameworkElement& root)
-{
-    return FindElementRecursive(
-        root,
-        [](const wux::FrameworkElement&
-               element)
-        {
-            try {
-                auto automationId =
-                    wuxa::AutomationProperties::
-                        GetAutomationId(
-                            element);
+wux::FrameworkElement FindStartButton(const wux::FrameworkElement& root) {
+    return FindElementRecursive(root, [](const wux::FrameworkElement& element) {
+        try {
+            auto automationId =
+                wuxa::AutomationProperties::GetAutomationId(element);
 
-                if (automationId ==
-                    L"StartButton")
-                {
-                    return true;
-                }
+            if (automationId == L"StartButton") {
+                return true;
             }
-            catch (...) {
-            }
+        } catch (...) {
+        }
 
-            return false;
-        });
+        return false;
+    });
 }
 
 wux::FrameworkElement FindStockStartIcon(
-    const wux::FrameworkElement&
-        startButton)
-{
+    const wux::FrameworkElement& startButton) {
     // Preferred match:
     //
     // Microsoft.UI.Xaml.Controls
     //     .AnimatedVisualPlayer#Icon
 
-    auto exact =
-        FindElementRecursive(
-            startButton,
-            [](const wux::FrameworkElement&
-                   element)
-            {
-                try {
-                    if (element.Name() !=
-                        L"Icon")
-                    {
-                        return false;
-                    }
-
-                    std::wstring className =
-                        winrt::get_class_name(
-                            element)
-                            .c_str();
-
-                    return className.find(
-                               L"AnimatedVisualPlayer") !=
-                           std::wstring::npos;
-                }
-                catch (...) {
+    auto exact = FindElementRecursive(
+        startButton, [](const wux::FrameworkElement& element) {
+            try {
+                if (element.Name() != L"Icon") {
                     return false;
                 }
-            });
+
+                std::wstring className = winrt::get_class_name(element).c_str();
+
+                return className.find(L"AnimatedVisualPlayer") !=
+                       std::wstring::npos;
+            } catch (...) {
+                return false;
+            }
+        });
 
     if (exact) {
         return exact;
     }
 
-    // Fallback for future Windows builds:
-    // accept a descendant named Icon.
-    return FindElementRecursive(
-        startButton,
-        [](const wux::FrameworkElement&
-               element)
-        {
-            try {
-                return element.Name() ==
-                       L"Icon";
-            }
-            catch (...) {
-                return false;
-            }
-        });
+    // Fail closed on unknown Windows layouts. Hiding an arbitrary descendant
+    // named "Icon" can make the Start button unusable after a Windows update.
+    return nullptr;
 }
 
-wuxc::Panel FindHostPanel(
-    const wux::FrameworkElement&
-        stockIcon,
-    const wux::FrameworkElement&
-        startButton)
-{
-    wux::DependencyObject current =
-        stockIcon;
+wuxc::Panel FindHostPanel(const wux::FrameworkElement& stockIcon,
+                          const wux::FrameworkElement& startButton) {
+    wux::DependencyObject current = stockIcon;
 
     while (current) {
         try {
-            current =
-                wuxm::VisualTreeHelper::
-                    GetParent(current);
-        }
-        catch (...) {
+            current = wuxm::VisualTreeHelper::GetParent(current);
+        } catch (...) {
             return nullptr;
         }
 
@@ -1851,21 +1351,15 @@ wuxc::Panel FindHostPanel(
             return nullptr;
         }
 
-        auto panel =
-            current.try_as<wuxc::Panel>();
+        auto panel = current.try_as<wuxc::Panel>();
 
         if (panel) {
             return panel;
         }
 
-        auto frameworkElement =
-            current.try_as<
-                wux::FrameworkElement>();
+        auto frameworkElement = current.try_as<wux::FrameworkElement>();
 
-        if (frameworkElement &&
-            frameworkElement ==
-                startButton)
-        {
+        if (frameworkElement && frameworkElement == startButton) {
             break;
         }
     }
@@ -1873,48 +1367,64 @@ wuxc::Panel FindHostPanel(
     return nullptr;
 }
 
-
 // -----------------------------------------------------------------------------
 // Instance management
 // -----------------------------------------------------------------------------
 
-void PruneDeadInstances() {
-    g_instances.erase(
-        std::remove_if(
-            g_instances.begin(),
-            g_instances.end(),
-            [](const auto& instance)
-            {
-                if (!instance) {
-                    return true;
-                }
+void DetachInstance(const std::shared_ptr<StartIconInstance>& instance);
 
-                return
-                    !instance
-                         ->startButton
-                         .get();
-            }),
-        g_instances.end());
+void PruneDeadInstancesForCurrentThread() {
+    DWORD threadId = GetCurrentThreadId();
+    std::vector<std::shared_ptr<StartIconInstance>> deadInstances;
+
+    {
+        std::lock_guard<std::mutex> lock(g_instancesMutex);
+
+        if (!g_instances) {
+            return;
+        }
+
+        for (auto it = g_instances->begin(); it != g_instances->end();) {
+            auto instance = *it;
+
+            if (!instance) {
+                it = g_instances->erase(it);
+                continue;
+            }
+
+            if (instance->threadId == threadId &&
+                !instance->startButton.get()) {
+                deadInstances.push_back(instance);
+                it = g_instances->erase(it);
+                continue;
+            }
+
+            ++it;
+        }
+    }
+
+    for (const auto& instance : deadInstances) {
+        DetachInstance(instance);
+    }
 }
 
-bool AlreadyAttached(
-    const wux::FrameworkElement&
-        startButton)
-{
-    PruneDeadInstances();
+bool AlreadyAttached(const wux::FrameworkElement& startButton) {
+    PruneDeadInstancesForCurrentThread();
 
-    for (const auto& instance :
-         g_instances)
-    {
-        auto existingButton =
-            instance
-                ->startButton
-                .get();
+    std::lock_guard<std::mutex> lock(g_instancesMutex);
 
-        if (existingButton &&
-            existingButton ==
-                startButton)
-        {
+    if (!g_instances) {
+        return false;
+    }
+
+    for (const auto& instance : *g_instances) {
+        if (!instance || instance->threadId != GetCurrentThreadId()) {
+            continue;
+        }
+
+        auto existingButton = instance->startButton.get();
+
+        if (existingButton && existingButton == startButton) {
             return true;
         }
     }
@@ -1922,194 +1432,183 @@ bool AlreadyAttached(
     return false;
 }
 
-void RemoveCustomImage(
-    const std::shared_ptr<
-        StartIconInstance>& instance)
-{
-    auto panel =
-        instance->hostPanel.get();
+bool RegisterInstance(const std::shared_ptr<StartIconInstance>& instance) {
+    std::lock_guard<std::mutex> lock(g_instancesMutex);
 
-    auto imageHost =
-        instance->customImageHost.get();
+    if (g_unloading || !g_instances) {
+        return false;
+    }
 
-    if (!panel ||
-        !imageHost)
+    g_instances->push_back(instance);
+    return true;
+}
+
+void UnregisterInstance(const std::shared_ptr<StartIconInstance>& instance) {
+    std::lock_guard<std::mutex> lock(g_instancesMutex);
+
+    if (!g_instances) {
+        return;
+    }
+
+    g_instances->erase(
+        std::remove(g_instances->begin(), g_instances->end(), instance),
+        g_instances->end());
+}
+
+void DetachInstanceForStartButton(
+    const wux::FrameworkElement& startButton) {
+    std::vector<std::shared_ptr<StartIconInstance>> instances;
+
     {
+        std::lock_guard<std::mutex> lock(g_instancesMutex);
+
+        if (!g_instances) {
+            return;
+        }
+
+        for (auto it = g_instances->begin(); it != g_instances->end();) {
+            auto instance = *it;
+
+            if (!instance || instance->threadId != GetCurrentThreadId()) {
+                ++it;
+                continue;
+            }
+
+            auto existingButton = instance->startButton.get();
+
+            if (existingButton && existingButton == startButton) {
+                instances.push_back(instance);
+                it = g_instances->erase(it);
+                continue;
+            }
+
+            ++it;
+        }
+    }
+
+    for (const auto& instance : instances) {
+        DetachInstance(instance);
+    }
+}
+
+void RemoveCustomImage(const std::shared_ptr<StartIconInstance>& instance) {
+    auto panel = instance->hostPanel.get();
+
+    auto imageHost = instance->customImageHost.get();
+
+    if (!panel || !imageHost) {
         return;
     }
 
     try {
-        auto children =
-            panel.Children();
+        auto children = panel.Children();
 
-        for (uint32_t i = 0;
-             i < children.Size();
-             i++)
-        {
-            auto child =
-                children.GetAt(i);
+        for (uint32_t i = 0; i < children.Size(); i++) {
+            auto child = children.GetAt(i);
 
             if (child == imageHost) {
                 children.RemoveAt(i);
                 break;
             }
         }
-    }
-    catch (...) {
+    } catch (...) {
     }
 }
 
-void DetachInstance(
-    const std::shared_ptr<
-        StartIconInstance>& instance)
-{
-    if (!instance) {
+void DetachInstance(const std::shared_ptr<StartIconInstance>& instance) {
+    if (!instance || instance->detached) {
         return;
     }
 
-    auto startButton =
-        instance->startButton.get();
+    instance->detached = true;
 
-    if (startButton &&
-        instance->pressedStateCallbackRegistered)
-    {
+    auto startButton = instance->startButton.get();
+
+    if (startButton && instance->pressedStateCallbackRegistered) {
         try {
-            auto buttonBase =
-                startButton.try_as<
-                    wuxcp::ButtonBase>();
+            auto buttonBase = startButton.try_as<wuxcp::ButtonBase>();
 
             if (buttonBase) {
-                buttonBase
-                    .UnregisterPropertyChangedCallback(
-                        wuxcp::ButtonBase::
-                            IsPressedProperty(),
-                        instance
-                            ->pressedStateCallbackToken);
+                buttonBase.UnregisterPropertyChangedCallback(
+                    wuxcp::ButtonBase::IsPressedProperty(),
+                    instance->pressedStateCallbackToken);
             }
-        }
-        catch (const winrt::hresult_error& e) {
-            Wh_Log(
-                L"Removing pressed-state callback failed: 0x%08X %s",
-                e.code().value,
-                e.message().c_str());
-        }
-        catch (...) {
+        } catch (const winrt::hresult_error& e) {
+            Wh_Log(L"Removing pressed-state callback failed: 0x%08X %s",
+                   e.code().value, e.message().c_str());
+        } catch (...) {
         }
 
         instance->pressedStateCallbackToken = 0;
         instance->pressedStateCallbackRegistered = false;
-    }
-    else if (!startButton) {
+    } else if (!startButton) {
         instance->pressedStateCallbackToken = 0;
         instance->pressedStateCallbackRegistered = false;
     }
 
-    if (startButton &&
-        instance->activatedStateCallbackRegistered)
-    {
+    if (startButton && instance->activatedStateCallbackRegistered) {
         try {
-            auto toggleButton =
-                startButton.try_as<
-                    wuxcp::ToggleButton>();
+            auto toggleButton = startButton.try_as<wuxcp::ToggleButton>();
 
             if (toggleButton) {
-                toggleButton
-                    .UnregisterPropertyChangedCallback(
-                        wuxcp::ToggleButton::
-                            IsCheckedProperty(),
-                        instance
-                            ->activatedStateCallbackToken);
+                toggleButton.UnregisterPropertyChangedCallback(
+                    wuxcp::ToggleButton::IsCheckedProperty(),
+                    instance->activatedStateCallbackToken);
             }
-        }
-        catch (const winrt::hresult_error& e) {
-            Wh_Log(
-                L"Removing activated-state callback failed: 0x%08X %s",
-                e.code().value,
-                e.message().c_str());
-        }
-        catch (...) {
+        } catch (const winrt::hresult_error& e) {
+            Wh_Log(L"Removing activated-state callback failed: 0x%08X %s",
+                   e.code().value, e.message().c_str());
+        } catch (...) {
         }
 
         instance->activatedStateCallbackToken = 0;
         instance->activatedStateCallbackRegistered = false;
-    }
-    else if (!startButton) {
+    } else if (!startButton) {
         instance->activatedStateCallbackToken = 0;
         instance->activatedStateCallbackRegistered = false;
     }
 
-    if (startButton &&
-    instance->pointerEventsAttached)
-    {
-        auto removeHandler =
-            [&](const wux::RoutedEvent& routedEvent,
-                wf::IInspectable& handler,
-                const wchar_t* eventName)
-            {
-                if (!handler) {
-                    return;
-                }
+    if (startButton && instance->pointerEventsAttached) {
+        auto removeHandler = [&](const wux::RoutedEvent& routedEvent,
+                                 wf::IInspectable& handler,
+                                 const wchar_t* eventName) {
+            if (!handler) {
+                return;
+            }
 
-                try {
-                    startButton.RemoveHandler(
-                        routedEvent,
-                        handler);
-                }
-                catch (const winrt::hresult_error& e) {
-                    Wh_Log(
-                        L"Removing %s handler failed: 0x%08X %s",
-                        eventName,
-                        e.code().value,
-                        e.message().c_str());
-                }
-                catch (...) {
-                    Wh_Log(
-                        L"Removing %s handler failed",
-                        eventName);
-                }
+            try {
+                startButton.RemoveHandler(routedEvent, handler);
+            } catch (const winrt::hresult_error& e) {
+                Wh_Log(L"Removing %s handler failed: 0x%08X %s", eventName,
+                       e.code().value, e.message().c_str());
+            } catch (...) {
+                Wh_Log(L"Removing %s handler failed", eventName);
+            }
 
-                handler = nullptr;
-            };
+            handler = nullptr;
+        };
 
-        removeHandler(
-            wux::UIElement::
-                PointerEnteredEvent(),
-            instance->pointerEnteredHandler,
-            L"PointerEntered");
+        removeHandler(wux::UIElement::PointerEnteredEvent(),
+                      instance->pointerEnteredHandler, L"PointerEntered");
 
-        removeHandler(
-            wux::UIElement::
-                PointerExitedEvent(),
-            instance->pointerExitedHandler,
-            L"PointerExited");
+        removeHandler(wux::UIElement::PointerExitedEvent(),
+                      instance->pointerExitedHandler, L"PointerExited");
 
-        removeHandler(
-            wux::UIElement::
-                PointerPressedEvent(),
-            instance->pointerPressedHandler,
-            L"PointerPressed");
+        removeHandler(wux::UIElement::PointerPressedEvent(),
+                      instance->pointerPressedHandler, L"PointerPressed");
 
-        removeHandler(
-            wux::UIElement::
-                PointerReleasedEvent(),
-            instance->pointerReleasedHandler,
-            L"PointerReleased");
+        removeHandler(wux::UIElement::PointerReleasedEvent(),
+                      instance->pointerReleasedHandler, L"PointerReleased");
 
-        removeHandler(
-            wux::UIElement::
-                PointerCanceledEvent(),
-            instance->pointerCanceledHandler,
-            L"PointerCanceled");
+        removeHandler(wux::UIElement::PointerCanceledEvent(),
+                      instance->pointerCanceledHandler, L"PointerCanceled");
 
-        removeHandler(
-            wux::UIElement::
-                PointerCaptureLostEvent(),
-            instance->pointerCaptureLostHandler,
-            L"PointerCaptureLost");
+        removeHandler(wux::UIElement::PointerCaptureLostEvent(),
+                      instance->pointerCaptureLostHandler,
+                      L"PointerCaptureLost");
 
         instance->pointerEventsAttached = false;
-    }
-    else if (!startButton) {
+    } else if (!startButton) {
         instance->pointerEnteredHandler = nullptr;
         instance->pointerExitedHandler = nullptr;
         instance->pointerPressedHandler = nullptr;
@@ -2119,58 +1618,34 @@ void DetachInstance(
         instance->pointerEventsAttached = false;
     }
 
-    for (size_t i = 0;
-         i < kIconStateCount;
-         i++)
-    {
-        auto& resource =
-            instance->imageResources[i];
+    for (size_t i = 0; i < kIconStateCount; i++) {
+        auto& resource = instance->imageResources[i];
 
-        if (resource.bitmap &&
-            resource.imageOpenedAttached)
-        {
+        if (resource.bitmap && resource.imageOpenedAttached) {
             try {
-                resource.bitmap.ImageOpened(
-                    resource.imageOpenedToken);
-            }
-            catch (const winrt::hresult_error& e) {
-                Wh_Log(
-                    L"Removing %s ImageOpened handler failed: 0x%08X %s",
-                    IconStateName(
-                        static_cast<IconState>(i)),
-                    e.code().value,
-                    e.message().c_str());
-            }
-            catch (...) {
-                Wh_Log(
-                    L"Removing %s ImageOpened handler failed",
-                    IconStateName(
-                        static_cast<IconState>(i)));
+                resource.bitmap.ImageOpened(resource.imageOpenedToken);
+            } catch (const winrt::hresult_error& e) {
+                Wh_Log(L"Removing %s ImageOpened handler failed: 0x%08X %s",
+                       IconStateName(static_cast<IconState>(i)), e.code().value,
+                       e.message().c_str());
+            } catch (...) {
+                Wh_Log(L"Removing %s ImageOpened handler failed",
+                       IconStateName(static_cast<IconState>(i)));
             }
 
             resource.imageOpenedAttached = false;
         }
 
-        if (resource.bitmap &&
-            resource.imageFailedAttached)
-        {
+        if (resource.bitmap && resource.imageFailedAttached) {
             try {
-                resource.bitmap.ImageFailed(
-                    resource.imageFailedToken);
-            }
-            catch (const winrt::hresult_error& e) {
-                Wh_Log(
-                    L"Removing %s ImageFailed handler failed: 0x%08X %s",
-                    IconStateName(
-                        static_cast<IconState>(i)),
-                    e.code().value,
-                    e.message().c_str());
-            }
-            catch (...) {
-                Wh_Log(
-                    L"Removing %s ImageFailed handler failed",
-                    IconStateName(
-                        static_cast<IconState>(i)));
+                resource.bitmap.ImageFailed(resource.imageFailedToken);
+            } catch (const winrt::hresult_error& e) {
+                Wh_Log(L"Removing %s ImageFailed handler failed: 0x%08X %s",
+                       IconStateName(static_cast<IconState>(i)), e.code().value,
+                       e.message().c_str());
+            } catch (...) {
+                Wh_Log(L"Removing %s ImageFailed handler failed",
+                       IconStateName(static_cast<IconState>(i)));
             }
 
             resource.imageFailedAttached = false;
@@ -2180,13 +1655,13 @@ void DetachInstance(
             if (resource.bitmap) {
                 resource.bitmap.Stop();
             }
-        }
-        catch (...) {
+        } catch (...) {
         }
 
         resource.loadAction = nullptr;
-        resource.localStream = nullptr;
+        resource.memoryStream = nullptr;
         resource.bitmap = nullptr;
+        resource.opened = false;
         resource.failed = false;
     }
 
@@ -2195,38 +1670,26 @@ void DetachInstance(
     instance->displayedStateSet = false;
     instance->gifStatusLogged = false;
 
-    auto imageHost =
-        instance->customImageHost.get();
+    auto imageHost = instance->customImageHost.get();
 
     if (imageHost) {
         try {
             auto visual =
-                wuxh::ElementCompositionPreview::
-                    GetElementVisual(imageHost);
+                wuxh::ElementCompositionPreview::GetElementVisual(imageHost);
 
             if (visual) {
-                visual.StopAnimation(
-                    L"Scale");
+                visual.StopAnimation(L"Scale");
 
-                visual.StopAnimation(
-                    L"RotationAngleInDegrees");
+                visual.StopAnimation(L"RotationAngleInDegrees");
 
-                visual.StopAnimation(
-                    L"Opacity");
+                visual.StopAnimation(L"Opacity");
             }
-        }
-        catch (...) {
+        } catch (...) {
         }
     }
 
-    for (size_t layerIndex = 0;
-         layerIndex < 2;
-         layerIndex++)
-    {
-        auto layer =
-            GetImageLayer(
-                instance,
-                layerIndex);
+    for (size_t layerIndex = 0; layerIndex < 2; layerIndex++) {
+        auto layer = GetImageLayer(instance, layerIndex);
 
         if (!layer) {
             continue;
@@ -2234,89 +1697,274 @@ void DetachInstance(
 
         try {
             auto visual =
-                wuxh::ElementCompositionPreview::
-                    GetElementVisual(layer);
+                wuxh::ElementCompositionPreview::GetElementVisual(layer);
 
             if (visual) {
-                visual.StopAnimation(
-                    L"Opacity");
+                visual.StopAnimation(L"Opacity");
             }
-        }
-        catch (...) {
+        } catch (...) {
         }
     }
 
     RemoveCustomImage(instance);
 
-    auto stockIcon =
-        instance->stockIcon.get();
+    auto stockIcon = instance->stockIcon.get();
 
     if (stockIcon) {
         try {
-            stockIcon.Opacity(
-                instance
-                    ->originalStockOpacity);
-        }
-        catch (...) {
+            stockIcon.Opacity(instance->originalStockOpacity);
+        } catch (...) {
         }
     }
 
+    instance->startButton = {};
+    instance->stockIcon = {};
+    instance->hostPanel = {};
+    instance->customImageHost = {};
+    instance->customImage = {};
+    instance->transitionImage = {};
+    instance->dispatcher = nullptr;
 }
 
 void DetachAllForCurrentThread() {
-    DWORD threadId =
-        GetCurrentThreadId();
+    DWORD threadId = GetCurrentThreadId();
+    std::vector<std::shared_ptr<StartIconInstance>> instances;
 
-    for (auto it =
-             g_instances.begin();
-         it != g_instances.end();)
     {
-        auto instance = *it;
+        std::lock_guard<std::mutex> lock(g_instancesMutex);
 
-        if (!instance ||
-            instance->threadId ==
-                threadId ||
-            !instance
-                 ->startButton
-                 .get())
-        {
-            if (instance &&
-                instance->threadId ==
-                    threadId)
-            {
-                DetachInstance(
-                    instance);
+        if (!g_instances) {
+            return;
+        }
+
+        for (auto it = g_instances->begin(); it != g_instances->end();) {
+            auto instance = *it;
+
+            if (!instance) {
+                it = g_instances->erase(it);
+                continue;
             }
 
-            it =
-                g_instances.erase(it);
-        }
-        else {
+            if (instance->threadId == threadId) {
+                instances.push_back(instance);
+                it = g_instances->erase(it);
+                continue;
+            }
+
             ++it;
         }
     }
+
+    for (const auto& instance : instances) {
+        DetachInstance(instance);
+    }
 }
 
+std::vector<std::shared_ptr<StartIconInstance>> TakeAllInstancesForShutdown() {
+    std::lock_guard<std::mutex> lock(g_instancesMutex);
+
+    g_unloading = true;
+
+    std::vector<std::shared_ptr<StartIconInstance>> instances;
+
+    if (g_instances) {
+        instances = std::move(*g_instances);
+        g_instances.reset();
+    }
+
+    return instances;
+}
+
+void AbandonInstances(
+    const std::vector<std::shared_ptr<StartIconInstance>>& instances) {
+    if (instances.empty()) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(g_instancesMutex);
+
+    if (g_abandonedInstances) {
+        g_abandonedInstances->insert(g_abandonedInstances->end(),
+                                     instances.begin(), instances.end());
+    }
+}
+
+void DetachInstancesOnOwningThreads(
+    std::vector<std::shared_ptr<StartIconInstance>>& instances) {
+    if (instances.empty()) {
+        return;
+    }
+
+    std::shared_ptr<void> cleanupFinished(
+        CreateEventW(nullptr, TRUE, FALSE, nullptr), [](HANDLE eventHandle) {
+            if (eventHandle) {
+                CloseHandle(eventHandle);
+            }
+        });
+
+    if (!cleanupFinished) {
+        Wh_Log(L"Creating the XAML cleanup event failed: 0x%08X",
+               GetLastError());
+        AbandonInstances(instances);
+        return;
+    }
+
+    auto pending = std::make_shared<std::atomic<size_t>>(0);
+    std::vector<std::shared_ptr<StartIconInstance>> failedInstances;
+    std::mutex failedInstancesMutex;
+
+    auto recordFailure =
+        [&failedInstances, &failedInstancesMutex](
+            const std::shared_ptr<StartIconInstance>& instance) {
+            std::lock_guard<std::mutex> lock(failedInstancesMutex);
+            failedInstances.push_back(instance);
+        };
+
+    auto signalCompletion = [pending, cleanupFinished]() {
+        if (pending->fetch_sub(1) == 1) {
+            SetEvent(cleanupFinished.get());
+        }
+    };
+
+    for (const auto& instance : instances) {
+        if (!instance || instance->detached) {
+            continue;
+        }
+
+        auto dispatcher = instance->dispatcher;
+
+        if (!dispatcher) {
+            recordFailure(instance);
+            continue;
+        }
+
+        try {
+            if (dispatcher.HasThreadAccess()) {
+                DetachInstance(instance);
+                continue;
+            }
+
+            if (pending->fetch_add(1) == 0) {
+                ResetEvent(cleanupFinished.get());
+            }
+
+            try {
+                dispatcher.RunAsync(
+                    wuic::CoreDispatcherPriority::High,
+                    [instance, signalCompletion, recordFailure]() {
+                        try {
+                            DetachInstance(instance);
+                        } catch (...) {
+                            Wh_Log(
+                                L"Unexpected exception while detaching a Start "
+                                L"icon instance");
+                            recordFailure(instance);
+                        }
+
+                        signalCompletion();
+                    });
+            } catch (...) {
+                signalCompletion();
+                throw;
+            }
+        } catch (const winrt::hresult_error& e) {
+            Wh_Log(L"Dispatching Start icon cleanup failed: 0x%08X %s",
+                   e.code().value, e.message().c_str());
+            recordFailure(instance);
+        } catch (...) {
+            Wh_Log(L"Dispatching Start icon cleanup failed");
+            recordFailure(instance);
+        }
+    }
+
+    if (pending->load() > 0) {
+        WaitForSingleObject(cleanupFinished.get(), INFINITE);
+    }
+
+    AbandonInstances(failedInstances);
+}
 
 // -----------------------------------------------------------------------------
 // Bitmap/image loading
 // -----------------------------------------------------------------------------
 
-bool LoadImageResource(
-    const std::shared_ptr<
-        StartIconInstance>& instance,
-    IconState state,
-    const std::wstring& source)
-{
+HRESULT CreateMemoryBackedStreamFromFile(
+    const std::wstring& path,
+    wss::IRandomAccessStream& randomAccessStream) {
+    HANDLE file =
+        CreateFileW(path.c_str(), GENERIC_READ,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                    nullptr, OPEN_EXISTING,
+                    FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, nullptr);
+
+    if (file == INVALID_HANDLE_VALUE) {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    std::unique_ptr<void, decltype(&CloseHandle)> fileOwner(file, CloseHandle);
+
+    winrt::com_ptr<IStream> memoryStream;
+    HRESULT hr = CreateStreamOnHGlobal(nullptr, TRUE, memoryStream.put());
+
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    std::array<BYTE, 64 * 1024> buffer;
+
+    while (true) {
+        DWORD bytesRead = 0;
+
+        if (!ReadFile(file, buffer.data(), static_cast<DWORD>(buffer.size()),
+                      &bytesRead, nullptr)) {
+            return HRESULT_FROM_WIN32(GetLastError());
+        }
+
+        if (bytesRead == 0) {
+            break;
+        }
+
+        ULONG bytesWritten = 0;
+        hr = memoryStream->Write(buffer.data(), bytesRead, &bytesWritten);
+
+        if (FAILED(hr)) {
+            return hr;
+        }
+
+        if (bytesWritten != bytesRead) {
+            return STG_E_MEDIUMFULL;
+        }
+    }
+
+    // Close the source file before XAML starts decoding. The user can replace
+    // or delete it while the mod remains enabled.
+    fileOwner.reset();
+
+    LARGE_INTEGER beginning{};
+    hr = memoryStream->Seek(beginning, STREAM_SEEK_SET, nullptr);
+
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    winrt::guid streamGuid = winrt::guid_of<wss::IRandomAccessStream>();
+
+    return CreateRandomAccessStreamOverStream(
+        memoryStream.get(), BSOS_DEFAULT,
+        reinterpret_cast<const IID&>(streamGuid),
+        reinterpret_cast<void**>(winrt::put_abi(randomAccessStream)));
+}
+
+bool LoadImageResource(const std::shared_ptr<StartIconInstance>& instance,
+                       IconState state,
+                       const std::wstring& source) {
     if (!instance || source.empty()) {
         return false;
     }
 
-    size_t stateIndex =
-        IconStateIndex(state);
+    size_t stateIndex = IconStateIndex(state);
 
-    auto& resource =
-        instance->imageResources[stateIndex];
+    auto& resource = instance->imageResources[stateIndex];
 
     try {
         wuxmi::BitmapImage bitmap;
@@ -2326,190 +1974,128 @@ bool LoadImageResource(
         bitmap.AutoPlay(false);
 
         resource.bitmap = bitmap;
+        resource.opened = false;
         resource.failed = false;
 
-        std::weak_ptr<StartIconInstance>
-            weakInstance = instance;
+        std::weak_ptr<StartIconInstance> weakInstance = instance;
 
-        resource.imageOpenedToken =
-            bitmap.ImageOpened(
-                [weakInstance, stateIndex](
-                    const wf::IInspectable&,
-                    const wux::RoutedEventArgs&)
-                {
-                    auto instance =
-                        weakInstance.lock();
+        resource.imageOpenedToken = bitmap.ImageOpened(
+            [weakInstance, stateIndex](const wf::IInspectable&,
+                                       const wux::RoutedEventArgs&) {
+                auto instance = weakInstance.lock();
 
-                    if (!instance) {
-                        return;
-                    }
+                if (!instance) {
+                    return;
+                }
 
-                    auto state =
-                        static_cast<IconState>(
-                            stateIndex);
+                auto& resource = instance->imageResources[stateIndex];
 
-                    Wh_Log(
-                        L"Custom Start %s image loaded",
-                        IconStateName(state));
+                resource.opened = true;
+                resource.failed = false;
+                resource.loadAction = nullptr;
+                resource.memoryStream = nullptr;
 
-                    UpdateDisplayedImage(instance);
-                    UpdateGifPlayback(instance);
-                });
+                auto state = static_cast<IconState>(stateIndex);
+
+                Wh_Log(L"Custom Start %s image loaded", IconStateName(state));
+
+                UpdateDisplayedImage(instance);
+                UpdateGifPlayback(instance);
+            });
 
         resource.imageOpenedAttached = true;
 
         resource.imageFailedToken =
-            bitmap.ImageFailed(
-                [weakInstance, stateIndex](
-                    const wf::IInspectable&,
-                    const wux::ExceptionRoutedEventArgs&
-                        args)
-                {
-                    auto instance =
-                        weakInstance.lock();
+            bitmap.ImageFailed([weakInstance, stateIndex](
+                                   const wf::IInspectable&,
+                                   const wux::ExceptionRoutedEventArgs& args) {
+                auto instance = weakInstance.lock();
 
-                    if (!instance) {
-                        return;
-                    }
+                if (!instance) {
+                    return;
+                }
 
-                    auto& resource =
-                        instance
-                            ->imageResources[stateIndex];
+                auto& resource = instance->imageResources[stateIndex];
 
-                    resource.failed = true;
+                resource.opened = false;
+                resource.failed = true;
+                resource.loadAction = nullptr;
+                resource.memoryStream = nullptr;
 
-                    auto state =
-                        static_cast<IconState>(
-                            stateIndex);
+                auto state = static_cast<IconState>(stateIndex);
 
-                    Wh_Log(
-                        L"Custom Start %s image failed: %s",
-                        IconStateName(state),
-                        args
-                            .ErrorMessage()
-                            .c_str());
+                Wh_Log(L"Custom Start %s image failed: %s",
+                       IconStateName(state), args.ErrorMessage().c_str());
 
-                    UpdateDisplayedImage(instance);
-                    UpdateGifPlayback(instance);
-                });
+                UpdateDisplayedImage(instance);
+                UpdateGifPlayback(instance);
+            });
 
         resource.imageFailedAttached = true;
 
-        if (IsHttpUrl(source)) {
-            bitmap.UriSource(
-                wf::Uri(source));
-
-            return true;
-        }
-
-        std::wstring path =
-            ExpandPath(source);
+        std::wstring path = ExpandPath(source);
 
         if (path.empty()) {
             resource.failed = true;
             return false;
         }
 
-        wss::IRandomAccessStream stream{
-            nullptr
-        };
+        wss::IRandomAccessStream stream{nullptr};
 
-        winrt::guid streamGuid =
-            winrt::guid_of<
-                wss::IRandomAccessStream>();
-
-        HRESULT hr =
-            CreateRandomAccessStreamOnFile(
-                path.c_str(),
-                GENERIC_READ,
-                reinterpret_cast<
-                    const IID&>(
-                    streamGuid),
-                reinterpret_cast<
-                    void**>(
-                    winrt::put_abi(
-                        stream)));
+        HRESULT hr = CreateMemoryBackedStreamFromFile(path, stream);
 
         if (FAILED(hr) || !stream) {
             resource.failed = true;
 
-            Wh_Log(
-                L"Opening %s image \"%s\" failed: 0x%08X",
-                IconStateName(state),
-                path.c_str(),
-                hr);
+            Wh_Log(L"Reading %s image \"%s\" failed: 0x%08X",
+                   IconStateName(state), path.c_str(), hr);
 
             return false;
         }
 
-        resource.localStream = stream;
+        resource.memoryStream = stream;
 
         // Asynchronous decoding prevents larger animated GIFs from blocking
         // Explorer's taskbar UI thread.
-        resource.loadAction =
-            bitmap.SetSourceAsync(stream);
+        resource.loadAction = bitmap.SetSourceAsync(stream);
 
         return true;
-    }
-    catch (const winrt::hresult_error& e) {
+    } catch (const winrt::hresult_error& e) {
         resource.failed = true;
 
-        Wh_Log(
-            L"Loading %s image failed: 0x%08X %s",
-            IconStateName(state),
-            e.code().value,
-            e.message().c_str());
-    }
-    catch (...) {
+        Wh_Log(L"Loading %s image failed: 0x%08X %s", IconStateName(state),
+               e.code().value, e.message().c_str());
+    } catch (...) {
         resource.failed = true;
 
-        Wh_Log(
-            L"Loading %s image failed with unknown exception",
-            IconStateName(state));
+        Wh_Log(L"Loading %s image failed with unknown exception",
+               IconStateName(state));
     }
 
     return false;
 }
 
-bool LoadImages(
-    const std::shared_ptr<
-        StartIconInstance>& instance)
-{
+bool LoadImages(const std::shared_ptr<StartIconInstance>& instance) {
     if (!instance) {
         return false;
     }
 
-    std::array<std::wstring, kIconStateCount>
-        sources;
+    std::array<std::wstring, kIconStateCount> sources;
 
-    for (size_t i = 0;
-         i < kIconStateCount;
-         i++)
-    {
-        instance
-            ->imageResourceIndexByState[i] = i;
+    for (size_t i = 0; i < kIconStateCount; i++) {
+        instance->imageResourceIndexByState[i] = i;
 
-        sources[i] =
-            GetImageSourceForState(
-                static_cast<IconState>(i));
+        sources[i] = GetImageSourceForState(instance->settings,
+                                            static_cast<IconState>(i));
     }
 
-    if (!LoadImageResource(
-            instance,
-            IconState::Normal,
-            sources[IconStateIndex(
-                IconState::Normal)]))
-    {
+    if (!LoadImageResource(instance, IconState::Normal,
+                           sources[IconStateIndex(IconState::Normal)])) {
         return false;
     }
 
-    for (size_t stateIndex = 1;
-         stateIndex < kIconStateCount;
-         stateIndex++)
-    {
-        IconState state =
-            static_cast<IconState>(
-                stateIndex);
+    for (size_t stateIndex = 1; stateIndex < kIconStateCount; stateIndex++) {
+        IconState state = static_cast<IconState>(stateIndex);
 
         if (sources[stateIndex].empty()) {
             continue;
@@ -2517,29 +2103,19 @@ bool LoadImages(
 
         bool reusedResource = false;
 
-        for (size_t previousIndex = 0;
-             previousIndex < stateIndex;
-             previousIndex++)
-        {
-            if (!ImageSourcesEqual(
-                    sources[stateIndex],
-                    sources[previousIndex]))
-            {
+        for (size_t previousIndex = 0; previousIndex < stateIndex;
+             previousIndex++) {
+            if (!ImageSourcesEqual(sources[stateIndex],
+                                   sources[previousIndex])) {
                 continue;
             }
 
-            instance
-                ->imageResourceIndexByState[stateIndex] =
-                instance
-                    ->imageResourceIndexByState[
-                        previousIndex];
+            instance->imageResourceIndexByState[stateIndex] =
+                instance->imageResourceIndexByState[previousIndex];
 
-            Wh_Log(
-                L"The %s image reuses the %s image resource",
-                IconStateName(state),
-                IconStateName(
-                    static_cast<IconState>(
-                        previousIndex)));
+            Wh_Log(L"The %s image reuses the %s image resource",
+                   IconStateName(state),
+                   IconStateName(static_cast<IconState>(previousIndex)));
 
             reusedResource = true;
             break;
@@ -2549,31 +2125,22 @@ bool LoadImages(
             continue;
         }
 
-        if (!LoadImageResource(
-                instance,
-                state,
-                sources[stateIndex]))
-        {
-            Wh_Log(
-                L"The %s image is unavailable; using its fallback",
-                IconStateName(state));
+        if (!LoadImageResource(instance, state, sources[stateIndex])) {
+            Wh_Log(L"The %s image is unavailable; using its fallback",
+                   IconStateName(state));
         }
     }
 
     return true;
 }
 
-
 // -----------------------------------------------------------------------------
 // Interaction state setup
 // -----------------------------------------------------------------------------
 
-void AttachPointerEvents(
-    const std::shared_ptr<StartIconInstance>& instance,
-    const wux::FrameworkElement& startButton)
-{
-    std::weak_ptr<StartIconInstance>
-        weakInstance = instance;
+void AttachPointerEvents(const std::shared_ptr<StartIconInstance>& instance,
+                         const wux::FrameworkElement& startButton) {
+    std::weak_ptr<StartIconInstance> weakInstance = instance;
 
     // Mark cleanup as necessary before the first registration so a failure in
     // the middle of this function can still remove every handler added so far.
@@ -2582,188 +2149,130 @@ void AttachPointerEvents(
     //
     // POINTER ENTERED
     //
-    instance->pointerEnteredHandler =
-        winrt::box_value(
-            wuxi::PointerEventHandler(
-                [weakInstance](
-                    const wf::IInspectable&,
-                    const wuxi::PointerRoutedEventArgs&)
-                {
-                    auto instance =
-                        weakInstance.lock();
+    instance->pointerEnteredHandler = winrt::box_value(
+        wuxi::PointerEventHandler([weakInstance](
+                                      const wf::IInspectable&,
+                                      const wuxi::PointerRoutedEventArgs&) {
+            auto instance = weakInstance.lock();
 
-                    if (!instance) {
-                        return;
-                    }
+            if (!instance) {
+                return;
+            }
 
-                    instance->hovering = true;
+            instance->hovering = true;
 
-                    ApplyCurrentState(
-                        instance,
-                        instance->pressed
-                            ? g_settings
-                                  .pressedDuration
-                            : g_settings
-                                  .hoverDuration);
-                }));
+            ApplyCurrentState(instance, instance->pressed
+                                            ? instance->settings.pressedDuration
+                                            : instance->settings.hoverDuration);
+        }));
 
-    startButton.AddHandler(
-        wux::UIElement::PointerEnteredEvent(),
-        instance->pointerEnteredHandler,
-        true);
-
+    startButton.AddHandler(wux::UIElement::PointerEnteredEvent(),
+                           instance->pointerEnteredHandler, true);
 
     //
     // POINTER EXITED
     //
-    instance->pointerExitedHandler =
-        winrt::box_value(
-            wuxi::PointerEventHandler(
-                [weakInstance](
-                    const wf::IInspectable&,
-                    const wuxi::PointerRoutedEventArgs&)
-                {
-                    auto instance =
-                        weakInstance.lock();
+    instance->pointerExitedHandler = winrt::box_value(wuxi::PointerEventHandler(
+        [weakInstance](const wf::IInspectable&,
+                       const wuxi::PointerRoutedEventArgs&) {
+            auto instance = weakInstance.lock();
 
-                    if (!instance) {
-                        return;
-                    }
+            if (!instance) {
+                return;
+            }
 
-                    instance->hovering = false;
+            instance->hovering = false;
 
-                    // PointerPressed and PointerReleased aren't guaranteed to
-                    // occur in pairs. ButtonBase tracks this itself; the raw
-                    // fallback must treat PointerExited as an end condition.
-                    if (!instance
-                             ->pressedStateCallbackRegistered)
-                    {
-                        instance->pressed = false;
-                    }
+            // PointerPressed and PointerReleased aren't guaranteed to
+            // occur in pairs. ButtonBase tracks this itself; the raw
+            // fallback must treat PointerExited as an end condition.
+            if (!instance->pressedStateCallbackRegistered) {
+                instance->pressed = false;
+            }
 
-                    ApplyCurrentState(
-                        instance,
-                        g_settings.releaseDuration);
-                }));
+            ApplyCurrentState(instance, instance->settings.releaseDuration);
+        }));
 
-    startButton.AddHandler(
-        wux::UIElement::PointerExitedEvent(),
-        instance->pointerExitedHandler,
-        true);
+    startButton.AddHandler(wux::UIElement::PointerExitedEvent(),
+                           instance->pointerExitedHandler, true);
 
     // The Start control is a ButtonBase on supported Windows 11 builds.
     // Observe its own pressed state instead of reconstructing that state from
     // routed pointer events which the control class handles internally.
     try {
-        auto buttonBase =
-            startButton.try_as<
-                wuxcp::ButtonBase>();
+        auto buttonBase = startButton.try_as<wuxcp::ButtonBase>();
 
         if (buttonBase) {
             instance->pressedStateCallbackToken =
-                buttonBase
-                    .RegisterPropertyChangedCallback(
-                        wuxcp::ButtonBase::
-                            IsPressedProperty(),
-                        wux::DependencyPropertyChangedCallback(
-                            [weakInstance](
-                                const wux::DependencyObject& sender,
-                                const wux::DependencyProperty&)
-                            {
-                                auto instance =
-                                    weakInstance.lock();
+                buttonBase.RegisterPropertyChangedCallback(
+                    wuxcp::ButtonBase::IsPressedProperty(),
+                    wux::DependencyPropertyChangedCallback(
+                        [weakInstance](const wux::DependencyObject& sender,
+                                       const wux::DependencyProperty&) {
+                            auto instance = weakInstance.lock();
 
-                                auto buttonBase =
-                                    sender.try_as<
-                                        wuxcp::ButtonBase>();
+                            auto buttonBase =
+                                sender.try_as<wuxcp::ButtonBase>();
 
-                                if (!instance ||
-                                    !buttonBase)
-                                {
-                                    return;
-                                }
+                            if (!instance || !buttonBase) {
+                                return;
+                            }
 
-                                SetPressedState(
-                                    instance,
-                                    buttonBase.IsPressed());
-                            }));
+                            SetPressedState(instance, buttonBase.IsPressed());
+                        }));
 
-            instance->pressedStateCallbackRegistered =
-                true;
+            instance->pressedStateCallbackRegistered = true;
 
-            instance->pressed =
-                buttonBase.IsPressed();
+            instance->pressed = buttonBase.IsPressed();
 
             Wh_Log(
                 L"Start button pressed state is tracked "
                 L"through ButtonBase::IsPressed");
         }
-    }
-    catch (const winrt::hresult_error& e) {
-        Wh_Log(
-            L"Registering ButtonBase::IsPressed callback failed: 0x%08X %s",
-            e.code().value,
-            e.message().c_str());
-    }
-    catch (...) {
+    } catch (const winrt::hresult_error& e) {
+        Wh_Log(L"Registering ButtonBase::IsPressed callback failed: 0x%08X %s",
+               e.code().value, e.message().c_str());
+    } catch (...) {
     }
 
     // Taskbar.ExperienceToggleButton derives from ToggleButton. Its checked
     // state follows whether the Start menu is currently shown.
     try {
-        auto toggleButton =
-            startButton.try_as<
-                wuxcp::ToggleButton>();
+        auto toggleButton = startButton.try_as<wuxcp::ToggleButton>();
 
         if (toggleButton) {
             instance->activatedStateCallbackToken =
-                toggleButton
-                    .RegisterPropertyChangedCallback(
-                        wuxcp::ToggleButton::
-                            IsCheckedProperty(),
-                        wux::DependencyPropertyChangedCallback(
-                            [weakInstance](
-                                const wux::DependencyObject& sender,
-                                const wux::DependencyProperty&)
-                            {
-                                auto instance =
-                                    weakInstance.lock();
+                toggleButton.RegisterPropertyChangedCallback(
+                    wuxcp::ToggleButton::IsCheckedProperty(),
+                    wux::DependencyPropertyChangedCallback(
+                        [weakInstance](const wux::DependencyObject& sender,
+                                       const wux::DependencyProperty&) {
+                            auto instance = weakInstance.lock();
 
-                                auto toggleButton =
-                                    sender.try_as<
-                                        wuxcp::ToggleButton>();
+                            auto toggleButton =
+                                sender.try_as<wuxcp::ToggleButton>();
 
-                                if (!instance ||
-                                    !toggleButton)
-                                {
-                                    return;
-                                }
+                            if (!instance || !toggleButton) {
+                                return;
+                            }
 
-                                SetActivatedState(
-                                    instance,
-                                    IsToggleButtonChecked(
-                                        toggleButton));
-                            }));
+                            SetActivatedState(
+                                instance, IsToggleButtonChecked(toggleButton));
+                        }));
 
-            instance->activatedStateCallbackRegistered =
-                true;
+            instance->activatedStateCallbackRegistered = true;
 
-            instance->activated =
-                IsToggleButtonChecked(
-                    toggleButton);
+            instance->activated = IsToggleButtonChecked(toggleButton);
 
             Wh_Log(
                 L"Start menu visibility is tracked through "
                 L"ToggleButton::IsChecked");
         }
-    }
-    catch (const winrt::hresult_error& e) {
+    } catch (const winrt::hresult_error& e) {
         Wh_Log(
             L"Registering ToggleButton::IsChecked callback failed: 0x%08X %s",
-            e.code().value,
-            e.message().c_str());
-    }
-    catch (...) {
+            e.code().value, e.message().c_str());
+    } catch (...) {
     }
 
     if (!instance->pressedStateCallbackRegistered) {
@@ -2771,27 +2280,20 @@ void AttachPointerEvents(
             L"ButtonBase pressed-state callback is unavailable; "
             L"using routed-pointer fallback");
 
-
-    //
-    // POINTER PRESSED
-    //
-    instance->pointerPressedHandler =
-        winrt::box_value(
-            wuxi::PointerEventHandler(
-                [weakInstance](
-                    const wf::IInspectable&,
-                    const wuxi::PointerRoutedEventArgs&)
-                {
-                    auto instance =
-                        weakInstance.lock();
+        //
+        // POINTER PRESSED
+        //
+        instance->pointerPressedHandler =
+            winrt::box_value(wuxi::PointerEventHandler(
+                [weakInstance](const wf::IInspectable&,
+                               const wuxi::PointerRoutedEventArgs&) {
+                    auto instance = weakInstance.lock();
 
                     if (!instance) {
                         return;
                     }
 
-                    SetPressedState(
-                        instance,
-                        true);
+                    SetPressedState(instance, true);
 
                     //
                     // IMPORTANT:
@@ -2802,132 +2304,115 @@ void AttachPointerEvents(
                     //
                 }));
 
-    //
-    // The third argument is critical.
-    //
-    // ButtonBase normally marks PointerPressed
-    // as handled. true means our handler still
-    // receives the routed event.
-    //
-    startButton.AddHandler(
-        wux::UIElement::PointerPressedEvent(),
-        instance->pointerPressedHandler,
-        true);
+        //
+        // The third argument is critical.
+        //
+        // ButtonBase normally marks PointerPressed
+        // as handled. true means our handler still
+        // receives the routed event.
+        //
+        startButton.AddHandler(wux::UIElement::PointerPressedEvent(),
+                               instance->pointerPressedHandler, true);
 
-
-    //
-    // POINTER RELEASED
-    //
-    instance->pointerReleasedHandler =
-        winrt::box_value(
-            wuxi::PointerEventHandler(
-                [weakInstance](
-                    const wf::IInspectable&,
-                    const wuxi::PointerRoutedEventArgs&)
-                {
-                    auto instance =
-                        weakInstance.lock();
+        //
+        // POINTER RELEASED
+        //
+        instance->pointerReleasedHandler =
+            winrt::box_value(wuxi::PointerEventHandler(
+                [weakInstance](const wf::IInspectable&,
+                               const wuxi::PointerRoutedEventArgs&) {
+                    auto instance = weakInstance.lock();
 
                     if (!instance) {
                         return;
                     }
 
-                    SetPressedState(
-                        instance,
-                        false);
+                    SetPressedState(instance, false);
                 }));
 
-    startButton.AddHandler(
-        wux::UIElement::PointerReleasedEvent(),
-        instance->pointerReleasedHandler,
-        true);
+        startButton.AddHandler(wux::UIElement::PointerReleasedEvent(),
+                               instance->pointerReleasedHandler, true);
 
-
-    //
-    // POINTER CANCELED
-    //
-    instance->pointerCanceledHandler =
-        winrt::box_value(
-            wuxi::PointerEventHandler(
-                [weakInstance](
-                    const wf::IInspectable&,
-                    const wuxi::PointerRoutedEventArgs&)
-                {
-                    auto instance =
-                        weakInstance.lock();
+        //
+        // POINTER CANCELED
+        //
+        instance->pointerCanceledHandler =
+            winrt::box_value(wuxi::PointerEventHandler(
+                [weakInstance](const wf::IInspectable&,
+                               const wuxi::PointerRoutedEventArgs&) {
+                    auto instance = weakInstance.lock();
 
                     if (!instance) {
                         return;
                     }
 
-                    Wh_Log(
-                        L"Start button: CANCELED");
+                    Wh_Log(L"Start button: CANCELED");
 
-                    SetPressedState(
-                        instance,
-                        false);
+                    SetPressedState(instance, false);
                 }));
 
-    startButton.AddHandler(
-        wux::UIElement::PointerCanceledEvent(),
-        instance->pointerCanceledHandler,
-        true);
+        startButton.AddHandler(wux::UIElement::PointerCanceledEvent(),
+                               instance->pointerCanceledHandler, true);
 
-
-    //
-    // POINTER CAPTURE LOST
-    //
-    instance->pointerCaptureLostHandler =
-        winrt::box_value(
-            wuxi::PointerEventHandler(
-                [weakInstance](
-                    const wf::IInspectable&,
-                    const wuxi::PointerRoutedEventArgs&)
-                {
-                    auto instance =
-                        weakInstance.lock();
+        //
+        // POINTER CAPTURE LOST
+        //
+        instance->pointerCaptureLostHandler =
+            winrt::box_value(wuxi::PointerEventHandler(
+                [weakInstance](const wf::IInspectable&,
+                               const wuxi::PointerRoutedEventArgs&) {
+                    auto instance = weakInstance.lock();
 
                     if (!instance) {
                         return;
                     }
 
-                    Wh_Log(
-                        L"Start button: CAPTURE LOST");
+                    Wh_Log(L"Start button: CAPTURE LOST");
 
-                    SetPressedState(
-                        instance,
-                        false);
+                    SetPressedState(instance, false);
                 }));
 
-    startButton.AddHandler(
-        wux::UIElement::PointerCaptureLostEvent(),
-        instance->pointerCaptureLostHandler,
-        true);
-
+        startButton.AddHandler(wux::UIElement::PointerCaptureLostEvent(),
+                               instance->pointerCaptureLostHandler, true);
     }
 
-    Wh_Log(
-        L"Start button pointer handlers attached");
+    Wh_Log(L"Start button pointer handlers attached");
 }
 
 // -----------------------------------------------------------------------------
 // Install replacement into a Start button
 // -----------------------------------------------------------------------------
 
-bool AttachToStartButton(
-    const wux::FrameworkElement&
-        startButton)
-{
-    if (!startButton) {
+bool AttachToStartButton(const wux::FrameworkElement& startButton) {
+    if (!startButton || g_unloading) {
         return false;
     }
 
-    if (GetImageSourceForState(
-            IconState::Normal)
-            .empty())
-    {
-        Wh_Log(
-            L"Image source is empty; leaving stock Start icon unchanged");
+    ModSettings settings = GetSettingsSnapshot();
+
+    if (IsBlank(GetImageSourceForState(settings, IconState::Normal))) {
+        // An earlier build or an interrupted hot reload might have left the
+        // stock element transparent. Remove any tracked replacement first,
+        // then explicitly make the vanilla icon visible.
+        DetachInstanceForStartButton(startButton);
+
+        auto stockIcon = FindStockStartIcon(startButton);
+
+        if (!stockIcon) {
+            Wh_Log(L"Image source is empty, but the stock Start icon wasn't "
+                   L"found");
+            return false;
+        }
+
+        try {
+            stockIcon.Opacity(1.0);
+        } catch (const winrt::hresult_error& e) {
+            Wh_Log(L"Restoring the stock Start icon failed: 0x%08X %s",
+                   e.code().value, e.message().c_str());
+            return false;
+        }
+
+        Wh_Log(L"Image source is empty; using the stock Start icon");
 
         return true;
     }
@@ -2936,227 +2421,170 @@ bool AttachToStartButton(
         return true;
     }
 
-    auto stockIcon =
-        FindStockStartIcon(
-            startButton);
+    auto stockIcon = FindStockStartIcon(startButton);
 
     if (!stockIcon) {
-        Wh_Log(
-            L"Couldn't find Start AnimatedVisualPlayer#Icon");
+        Wh_Log(L"Couldn't find Start AnimatedVisualPlayer#Icon");
 
         return false;
     }
 
-    auto hostPanel =
-        FindHostPanel(
-            stockIcon,
-            startButton);
+    auto hostPanel = FindHostPanel(stockIcon, startButton);
 
     if (!hostPanel) {
-        Wh_Log(
-            L"Couldn't find a panel which can host the custom Start image");
+        Wh_Log(L"Couldn't find a panel which can host the custom Start image");
 
         return false;
     }
 
-    std::shared_ptr<StartIconInstance>
-        instance;
+    std::shared_ptr<StartIconInstance> instance;
 
     try {
-        double originalStockOpacity =
-            stockIcon.Opacity();
+        double originalStockOpacity = stockIcon.Opacity();
 
-        instance =
-            std::make_shared<
-                StartIconInstance>();
+        instance = std::make_shared<StartIconInstance>();
 
-        instance->threadId =
-            GetCurrentThreadId();
+        instance->threadId = GetCurrentThreadId();
 
-        instance->startButton =
-            winrt::make_weak(
-                startButton);
+        instance->dispatcher = startButton.Dispatcher();
 
-        instance->stockIcon =
-            winrt::make_weak(
-                stockIcon);
+        instance->settings = std::move(settings);
 
-        instance->hostPanel =
-            winrt::make_weak(
-                hostPanel);
+        instance->startButton = winrt::make_weak(startButton);
 
-        instance->originalStockOpacity =
-            originalStockOpacity;
+        instance->stockIcon = winrt::make_weak(stockIcon);
+
+        instance->hostPanel = winrt::make_weak(hostPanel);
+
+        instance->originalStockOpacity = originalStockOpacity;
+
+        // Register before adding XAML elements or callbacks. If unload starts
+        // concurrently, its dispatcher barrier will run after this UI-thread
+        // callback and will see everything that needs to be detached.
+        if (!RegisterInstance(instance)) {
+            return false;
+        }
 
         wuxc::Grid imageHost;
 
-        imageHost.Width(
-            g_settings.iconSize);
+        imageHost.Width(instance->settings.iconSize);
 
-        imageHost.Height(
-            g_settings.iconSize);
+        imageHost.Height(instance->settings.iconSize);
 
-        imageHost.HorizontalAlignment(
-            wux::HorizontalAlignment::
-                Center);
+        imageHost.HorizontalAlignment(wux::HorizontalAlignment::Center);
 
-        imageHost.VerticalAlignment(
-            wux::VerticalAlignment::
-                Center);
+        imageHost.VerticalAlignment(wux::VerticalAlignment::Center);
 
-        imageHost.IsHitTestVisible(
-            false);
+        imageHost.IsHitTestVisible(false);
+
+        wuxa::AutomationProperties::SetAccessibilityView(
+            imageHost, wuxap::AccessibilityView::Raw);
 
         wuxc::Image customImage;
         wuxc::Image transitionImage;
 
-        auto configureImageLayer =
-            [](const wuxc::Image& image)
-            {
-                image.HorizontalAlignment(
-                    wux::HorizontalAlignment::
-                        Stretch);
+        auto configureImageLayer = [](const wuxc::Image& image) {
+            image.HorizontalAlignment(wux::HorizontalAlignment::Stretch);
 
-                image.VerticalAlignment(
-                    wux::VerticalAlignment::
-                        Stretch);
+            image.VerticalAlignment(wux::VerticalAlignment::Stretch);
 
-                image.Stretch(
-                    wuxm::Stretch::Uniform);
+            image.Stretch(wuxm::Stretch::Uniform);
 
-                image.IsHitTestVisible(false);
-            };
+            image.IsHitTestVisible(false);
+
+            wuxa::AutomationProperties::SetAccessibilityView(
+                image, wuxap::AccessibilityView::Raw);
+        };
 
         configureImageLayer(customImage);
         configureImageLayer(transitionImage);
 
-        imageHost.Children().Append(
-            customImage);
+        imageHost.Children().Append(customImage);
 
-        imageHost.Children().Append(
-            transitionImage);
+        imageHost.Children().Append(transitionImage);
 
         // Put the image above the stock
         // AnimatedVisualPlayer.
-        wuxc::Canvas::SetZIndex(
-            imageHost,
-            10000);
+        wuxc::Canvas::SetZIndex(imageHost, 10000);
 
-        instance->customImageHost =
-            winrt::make_weak(
-                imageHost);
+        instance->customImageHost = winrt::make_weak(imageHost);
 
-        instance->customImage =
-            winrt::make_weak(
-                customImage);
+        instance->customImage = winrt::make_weak(customImage);
 
-        instance->transitionImage =
-            winrt::make_weak(
-                transitionImage);
+        instance->transitionImage = winrt::make_weak(transitionImage);
 
-        hostPanel
-            .Children()
-            .Append(imageHost);
+        hostPanel.Children().Append(imageHost);
 
-        AttachPointerEvents(
-            instance,
-            startButton);
+        AttachPointerEvents(instance, startButton);
 
-        if (!LoadImages(instance))
-        {
+        if (!LoadImages(instance)) {
+            UnregisterInstance(instance);
             DetachInstance(instance);
 
-            Wh_Log(
-                L"Failed to load custom image; keeping stock icon");
+            Wh_Log(L"Failed to load custom image; keeping stock icon");
 
             return false;
         }
 
-        // Preserve the original icon in layout,
-        // but don't render it.
-        stockIcon.Opacity(0.0);
+        // UpdateDisplayedImage keeps the stock icon visible until ImageOpened
+        // confirms that the normal replacement decoded successfully.
+        ApplyCurrentState(instance, 0);
 
-        ApplyCurrentState(
-            instance,
-            0);
-
-        g_instances.push_back(
-            instance);
-
-        Wh_Log(
-            L"Custom Start icon attached");
+        Wh_Log(L"Custom Start icon attached");
 
         return true;
-    }
-    catch (const winrt::hresult_error& e) {
+    } catch (const winrt::hresult_error& e) {
+        UnregisterInstance(instance);
         DetachInstance(instance);
 
-        Wh_Log(
-            L"AttachToStartButton failed: 0x%08X %s",
-            e.code().value,
-            e.message().c_str());
+        Wh_Log(L"AttachToStartButton failed: 0x%08X %s", e.code().value,
+               e.message().c_str());
 
         return false;
-    }
-    catch (...) {
+    } catch (...) {
+        UnregisterInstance(instance);
         DetachInstance(instance);
 
-        Wh_Log(
-            L"AttachToStartButton failed with an unknown exception");
+        Wh_Log(L"AttachToStartButton failed with an unknown exception");
 
         return false;
     }
 }
-
 
 // -----------------------------------------------------------------------------
 // Apply to XamlRoot
 // -----------------------------------------------------------------------------
 
-bool ApplyToXamlRoot(
-    const wux::XamlRoot& xamlRoot)
-{
+bool ApplyToXamlRoot(const wux::XamlRoot& xamlRoot) {
     if (!xamlRoot) {
         return false;
     }
 
     try {
-        auto content =
-            xamlRoot
-                .Content()
-                .try_as<
-                    wux::FrameworkElement>();
+        auto content = xamlRoot.Content().try_as<wux::FrameworkElement>();
 
         if (!content) {
-            Wh_Log(
-                L"XamlRoot content isn't a FrameworkElement");
+            Wh_Log(L"XamlRoot content isn't a FrameworkElement");
 
             return false;
         }
 
-        auto startButton =
-            FindStartButton(content);
+        auto startButton = FindStartButton(content);
 
         if (!startButton) {
-            Wh_Log(
-                L"Couldn't find AutomationId=StartButton");
+            Wh_Log(L"Couldn't find AutomationId=StartButton");
 
             return false;
         }
 
-        return AttachToStartButton(
-            startButton);
-    }
-    catch (const winrt::hresult_error& e) {
-        Wh_Log(
-            L"ApplyToXamlRoot failed: 0x%08X %s",
-            e.code().value,
-            e.message().c_str());
+        return AttachToStartButton(startButton);
+    } catch (const winrt::hresult_error& e) {
+        Wh_Log(L"ApplyToXamlRoot failed: 0x%08X %s", e.code().value,
+               e.message().c_str());
 
         return false;
     }
 }
-
 
 // -----------------------------------------------------------------------------
 // taskbar.dll internals
@@ -3165,59 +2593,44 @@ bool ApplyToXamlRoot(
 // Windhawk Windows 11 taskbar mods.
 // -----------------------------------------------------------------------------
 
-void*
-    CTaskBand_ITaskListWndSite_vftable;
+void* CTaskBand_ITaskListWndSite_vftable;
 
-void*
-    CSecondaryTaskBand_ITaskListWndSite_vftable;
+void* CSecondaryTaskBand_ITaskListWndSite_vftable;
 
+using CTaskBand_GetTaskbarHost_t = void*(WINAPI*)(void* pThis, void** result);
 
-using CTaskBand_GetTaskbarHost_t =
-    void* (WINAPI*)(
-        void* pThis,
-        void** result);
+CTaskBand_GetTaskbarHost_t CTaskBand_GetTaskbarHost_Original;
 
-CTaskBand_GetTaskbarHost_t
-    CTaskBand_GetTaskbarHost_Original;
+using CSecondaryTaskBand_GetTaskbarHost_t = void*(WINAPI*)(void* pThis,
+                                                           void** result);
 
+CSecondaryTaskBand_GetTaskbarHost_t CSecondaryTaskBand_GetTaskbarHost_Original;
 
-using CSecondaryTaskBand_GetTaskbarHost_t =
-    void* (WINAPI*)(
-        void* pThis,
-        void** result);
+void* TaskbarHost_FrameHeight_Original;
 
-CSecondaryTaskBand_GetTaskbarHost_t
-    CSecondaryTaskBand_GetTaskbarHost_Original;
+using RefCountDecref_t = void(WINAPI*)(void* pThis);
 
-
-void*
-    TaskbarHost_FrameHeight_Original;
-
-
-using RefCountDecref_t =
-    void (WINAPI*)(
-        void* pThis);
-
-RefCountDecref_t
-    RefCountDecref_Original;
-
+RefCountDecref_t RefCountDecref_Original;
 
 // -----------------------------------------------------------------------------
 // Extract XamlRoot from TaskbarHost
 // -----------------------------------------------------------------------------
 
-wux::XamlRoot
-XamlRootFromTaskbarHostSharedPtr(
-    void* sharedPtr[2])
-{
-    if (!sharedPtr[0] &&
-        !sharedPtr[1])
-    {
+wux::XamlRoot XamlRootFromTaskbarHostSharedPtr(void* sharedPtr[2]) {
+    auto releaseSharedPtr = [sharedPtr]() {
+        if (sharedPtr[1] && RefCountDecref_Original) {
+            RefCountDecref_Original(sharedPtr[1]);
+
+            sharedPtr[1] = nullptr;
+        }
+    };
+
+    if (!sharedPtr[0]) {
+        releaseSharedPtr();
         return nullptr;
     }
 
-    size_t taskbarElementOffset =
-        0x48;
+    size_t taskbarElementOffset = 0x48;
 
 #if defined(_M_X64)
 
@@ -3228,24 +2641,19 @@ XamlRootFromTaskbarHostSharedPtr(
     // the function rather than hard-coding it
     // whenever possible.
     const BYTE* code =
-        reinterpret_cast<const BYTE*>(
-            TaskbarHost_FrameHeight_Original);
+        reinterpret_cast<const BYTE*>(TaskbarHost_FrameHeight_Original);
 
-    if (code &&
-        code[0] == 0x48 &&
-        code[1] == 0x83 &&
-        code[2] == 0xEC &&
-        code[4] == 0x48 &&
-        code[5] == 0x83 &&
-        code[6] == 0xC1 &&
-        code[7] <= 0x7F)
-    {
-        taskbarElementOffset =
-            code[7];
-    }
-    else {
+    if (code && code[0] == 0x48 && code[1] == 0x83 && code[2] == 0xEC &&
+        code[4] == 0x48 && code[5] == 0x83 && code[6] == 0xC1 &&
+        code[7] <= 0x7F) {
+        taskbarElementOffset = code[7];
+    } else {
         Wh_Log(
-            L"Unrecognized TaskbarHost::FrameHeight; using fallback offset 0x48");
+            L"Unrecognized TaskbarHost::FrameHeight; refusing an unsafe "
+            L"TaskbarHost layout fallback");
+
+        releaseSharedPtr();
+        return nullptr;
     }
 
 #elif defined(_M_ARM64)
@@ -3258,87 +2666,56 @@ XamlRootFromTaskbarHostSharedPtr(
 #error Unsupported architecture.
 #endif
 
-    auto* taskbarElementIUnknown =
-        *reinterpret_cast<IUnknown**>(
-            reinterpret_cast<BYTE*>(
-                sharedPtr[0]) +
-            taskbarElementOffset);
+    auto* taskbarElementIUnknown = *reinterpret_cast<IUnknown**>(
+        reinterpret_cast<BYTE*>(sharedPtr[0]) + taskbarElementOffset);
 
-    wux::FrameworkElement
-        taskbarElement{nullptr};
+    wux::FrameworkElement taskbarElement{nullptr};
 
     if (taskbarElementIUnknown) {
-        taskbarElementIUnknown
-            ->QueryInterface(
-                winrt::guid_of<
-                    wux::FrameworkElement>(),
-                winrt::put_abi(
-                    taskbarElement));
+        taskbarElementIUnknown->QueryInterface(
+            winrt::guid_of<wux::FrameworkElement>(),
+            winrt::put_abi(taskbarElement));
     }
 
     wux::XamlRoot result{nullptr};
 
     if (taskbarElement) {
-        result =
-            taskbarElement.XamlRoot();
+        result = taskbarElement.XamlRoot();
     }
 
-    if (sharedPtr[1] &&
-        RefCountDecref_Original)
-    {
-        RefCountDecref_Original(
-            sharedPtr[1]);
-    }
+    releaseSharedPtr();
 
     return result;
 }
-
 
 // -----------------------------------------------------------------------------
 // Primary taskbar XamlRoot
 // -----------------------------------------------------------------------------
 
-wux::XamlRoot GetTaskbarXamlRoot(
-    HWND taskbarWnd)
-{
+wux::XamlRoot GetTaskbarXamlRoot(HWND taskbarWnd) {
     HWND taskSwitchWnd =
-        reinterpret_cast<HWND>(
-            GetProp(
-                taskbarWnd,
-                L"TaskbandHWND"));
+        reinterpret_cast<HWND>(GetProp(taskbarWnd, L"TaskbandHWND"));
 
     if (!taskSwitchWnd) {
         return nullptr;
     }
 
     void* taskBand =
-        reinterpret_cast<void*>(
-            GetWindowLongPtr(
-                taskSwitchWnd,
-                0));
+        reinterpret_cast<void*>(GetWindowLongPtr(taskSwitchWnd, 0));
 
     if (!taskBand) {
         return nullptr;
     }
 
-    void* interfacePointer =
-        taskBand;
+    void* interfacePointer = taskBand;
 
-    for (int i = 0;
-         i < 20;
-         i++)
-    {
-        if (*reinterpret_cast<void**>(
-                interfacePointer) ==
-            CTaskBand_ITaskListWndSite_vftable)
-        {
+    for (int i = 0; i < 20; i++) {
+        if (*reinterpret_cast<void**>(interfacePointer) ==
+            CTaskBand_ITaskListWndSite_vftable) {
             break;
         }
 
-        interfacePointer =
-            reinterpret_cast<void**>(
-                interfacePointer) +
-            1;
+        interfacePointer = reinterpret_cast<void**>(interfacePointer) + 1;
 
         if (i == 19) {
             return nullptr;
@@ -3347,63 +2724,39 @@ wux::XamlRoot GetTaskbarXamlRoot(
 
     void* sharedPtr[2]{};
 
-    CTaskBand_GetTaskbarHost_Original(
-        interfacePointer,
-        sharedPtr);
+    CTaskBand_GetTaskbarHost_Original(interfacePointer, sharedPtr);
 
-    return
-        XamlRootFromTaskbarHostSharedPtr(
-            sharedPtr);
+    return XamlRootFromTaskbarHostSharedPtr(sharedPtr);
 }
-
 
 // -----------------------------------------------------------------------------
 // Secondary taskbar XamlRoot
 // -----------------------------------------------------------------------------
 
-wux::XamlRoot
-GetSecondaryTaskbarXamlRoot(
-    HWND secondaryTaskbarWnd)
-{
+wux::XamlRoot GetSecondaryTaskbarXamlRoot(HWND secondaryTaskbarWnd) {
     HWND taskSwitchWnd =
-        FindWindowEx(
-            secondaryTaskbarWnd,
-            nullptr,
-            L"WorkerW",
-            nullptr);
+        FindWindowEx(secondaryTaskbarWnd, nullptr, L"WorkerW", nullptr);
 
     if (!taskSwitchWnd) {
         return nullptr;
     }
 
     void* taskBand =
-        reinterpret_cast<void*>(
-            GetWindowLongPtr(
-                taskSwitchWnd,
-                0));
+        reinterpret_cast<void*>(GetWindowLongPtr(taskSwitchWnd, 0));
 
     if (!taskBand) {
         return nullptr;
     }
 
-    void* interfacePointer =
-        taskBand;
+    void* interfacePointer = taskBand;
 
-    for (int i = 0;
-         i < 20;
-         i++)
-    {
-        if (*reinterpret_cast<void**>(
-                interfacePointer) ==
-            CSecondaryTaskBand_ITaskListWndSite_vftable)
-        {
+    for (int i = 0; i < 20; i++) {
+        if (*reinterpret_cast<void**>(interfacePointer) ==
+            CSecondaryTaskBand_ITaskListWndSite_vftable) {
             break;
         }
 
-        interfacePointer =
-            reinterpret_cast<void**>(
-                interfacePointer) +
-            1;
+        interfacePointer = reinterpret_cast<void**>(interfacePointer) + 1;
 
         if (i == 19) {
             return nullptr;
@@ -3412,239 +2765,175 @@ GetSecondaryTaskbarXamlRoot(
 
     void* sharedPtr[2]{};
 
-    CSecondaryTaskBand_GetTaskbarHost_Original(
-        interfacePointer,
-        sharedPtr);
+    CSecondaryTaskBand_GetTaskbarHost_Original(interfacePointer, sharedPtr);
 
-    return
-        XamlRootFromTaskbarHostSharedPtr(
-            sharedPtr);
+    return XamlRootFromTaskbarHostSharedPtr(sharedPtr);
 }
-
 
 // -----------------------------------------------------------------------------
 // Run code on taskbar UI thread
 // -----------------------------------------------------------------------------
 
-using RunFromWindowThreadProc_t =
-    void (WINAPI*)(void* parameter);
+using RunFromWindowThreadProc_t = void(WINAPI*)(void* parameter);
 
-bool RunFromWindowThread(
-    HWND window,
-    RunFromWindowThreadProc_t proc,
-    void* procParam)
-{
-    static const UINT
-        registeredMessage =
-            RegisterWindowMessage(
-                L"Windhawk_RunFromWindowThread_"
-                WH_MOD_ID);
+bool RunFromWindowThread(HWND window,
+                         RunFromWindowThreadProc_t proc,
+                         void* procParam) {
+    static const UINT registeredMessage =
+        RegisterWindowMessage(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
 
     struct RunParam {
         RunFromWindowThreadProc_t proc;
         void* param;
     };
 
-    DWORD threadId =
-        GetWindowThreadProcessId(
-            window,
-            nullptr);
+    DWORD threadId = GetWindowThreadProcessId(window, nullptr);
 
     if (!threadId) {
         return false;
     }
 
-    if (threadId ==
-        GetCurrentThreadId())
-    {
+    if (threadId == GetCurrentThreadId()) {
         proc(procParam);
         return true;
     }
 
-    HHOOK hook =
-        SetWindowsHookEx(
-            WH_CALLWNDPROC,
-            [](int code,
-               WPARAM wParam,
-               LPARAM lParam)
-                -> LRESULT
-            {
-                if (code ==
-                    HC_ACTION)
-                {
-                    const CWPSTRUCT* cwp =
-                        reinterpret_cast<
-                            const CWPSTRUCT*>(
-                            lParam);
+    HHOOK hook = SetWindowsHookEx(
+        WH_CALLWNDPROC,
+        [](int code, WPARAM wParam, LPARAM lParam) -> LRESULT {
+            if (code == HC_ACTION) {
+                const CWPSTRUCT* cwp =
+                    reinterpret_cast<const CWPSTRUCT*>(lParam);
 
-                    if (cwp->message ==
-                        registeredMessage)
-                    {
-                        auto* parameter =
-                            reinterpret_cast<
-                                RunParam*>(
-                                cwp->lParam);
+                if (cwp->message == registeredMessage) {
+                    auto* parameter = reinterpret_cast<RunParam*>(cwp->lParam);
 
-                        parameter->proc(
-                            parameter
-                                ->param);
-                    }
+                    parameter->proc(parameter->param);
                 }
+            }
 
-                return CallNextHookEx(
-                    nullptr,
-                    code,
-                    wParam,
-                    lParam);
-            },
-            nullptr,
-            threadId);
+            return CallNextHookEx(nullptr, code, wParam, lParam);
+        },
+        nullptr, threadId);
 
     if (!hook) {
         return false;
     }
 
-    RunParam parameter{
-        proc,
-        procParam
-    };
+    RunParam parameter{proc, procParam};
 
-    SendMessage(
-        window,
-        registeredMessage,
-        0,
-        reinterpret_cast<LPARAM>(
-            &parameter));
+    SendMessage(window, registeredMessage, 0,
+                reinterpret_cast<LPARAM>(&parameter));
 
     UnhookWindowsHookEx(hook);
 
     return true;
 }
 
-
 // -----------------------------------------------------------------------------
 // Taskbar discovery
 // -----------------------------------------------------------------------------
 
-HWND FindCurrentProcessTaskbarWnd() {
-    HWND result = nullptr;
+std::vector<HWND> FindCurrentProcessTaskbarWindows() {
+    std::vector<HWND> result;
 
     EnumWindows(
-        [](HWND window,
-           LPARAM param)
-            -> BOOL
-        {
+        [](HWND window, LPARAM param) -> BOOL {
             DWORD processId = 0;
 
-            GetWindowThreadProcessId(
-                window,
-                &processId);
+            GetWindowThreadProcessId(window, &processId);
 
-            if (processId !=
-                GetCurrentProcessId())
-            {
+            if (processId != GetCurrentProcessId()) {
                 return TRUE;
             }
 
             wchar_t className[64]{};
 
-            if (!GetClassNameW(
-                    window,
-                    className,
-                    ARRAYSIZE(className)))
-            {
+            if (!GetClassNameW(window, className, ARRAYSIZE(className))) {
                 return TRUE;
             }
 
-            if (_wcsicmp(
-                    className,
-                    L"Shell_TrayWnd") ==
-                0)
-            {
-                *reinterpret_cast<HWND*>(
-                    param) =
-                    window;
-
-                return FALSE;
+            if (_wcsicmp(className, L"Shell_TrayWnd") == 0 ||
+                _wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0) {
+                reinterpret_cast<std::vector<HWND>*>(param)->push_back(window);
             }
 
             return TRUE;
         },
-        reinterpret_cast<LPARAM>(
-            &result));
+        reinterpret_cast<LPARAM>(&result));
 
     return result;
 }
 
+bool RunOnAllTaskbarThreads(RunFromWindowThreadProc_t proc, void* procParam) {
+    auto taskbarWindows = FindCurrentProcessTaskbarWindows();
+
+    std::vector<DWORD> processedThreadIds;
+    bool allSucceeded = true;
+
+    for (HWND taskbarWindow : taskbarWindows) {
+        DWORD threadId = GetWindowThreadProcessId(taskbarWindow, nullptr);
+
+        if (!threadId ||
+            std::find(processedThreadIds.begin(), processedThreadIds.end(),
+                      threadId) != processedThreadIds.end()) {
+            continue;
+        }
+
+        processedThreadIds.push_back(threadId);
+
+        if (!RunFromWindowThread(taskbarWindow, proc, procParam)) {
+            Wh_Log(L"Running code on taskbar thread %lu failed", threadId);
+            allSucceeded = false;
+        }
+    }
+
+    if (processedThreadIds.empty()) {
+        Wh_Log(L"No taskbar windows were found in explorer.exe");
+        return false;
+    }
+
+    return allSucceeded;
+}
 
 // -----------------------------------------------------------------------------
 // Apply/remove on taskbar thread
 // -----------------------------------------------------------------------------
 
-void ApplyFromTaskbarThread(
-    bool mainTaskbarOnly = false)
-{
+void ApplyFromTaskbarThread(bool mainTaskbarOnly = false) {
     EnumThreadWindows(
         GetCurrentThreadId(),
-        [](HWND window,
-           LPARAM param)
-            -> BOOL
-        {
-            bool mainOnly =
-                param != 0;
+        [](HWND window, LPARAM param) -> BOOL {
+            bool mainOnly = param != 0;
 
             wchar_t className[64]{};
 
-            if (!GetClassNameW(
-                    window,
-                    className,
-                    ARRAYSIZE(className)))
-            {
+            if (!GetClassNameW(window, className, ARRAYSIZE(className))) {
                 return TRUE;
             }
 
-            wux::XamlRoot xamlRoot{
-                nullptr
-            };
+            wux::XamlRoot xamlRoot{nullptr};
 
-            if (_wcsicmp(
-                    className,
-                    L"Shell_TrayWnd") ==
-                0)
-            {
-                xamlRoot =
-                    GetTaskbarXamlRoot(
-                        window);
-            }
-            else if (
-                !mainOnly &&
-                _wcsicmp(
-                    className,
-                    L"Shell_SecondaryTrayWnd") ==
-                    0)
-            {
-                xamlRoot =
-                    GetSecondaryTaskbarXamlRoot(
-                        window);
-            }
-            else {
+            if (_wcsicmp(className, L"Shell_TrayWnd") == 0) {
+                xamlRoot = GetTaskbarXamlRoot(window);
+            } else if (!mainOnly &&
+                       _wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0) {
+                xamlRoot = GetSecondaryTaskbarXamlRoot(window);
+            } else {
                 return TRUE;
             }
 
             if (!xamlRoot) {
-                Wh_Log(
-                    L"Couldn't obtain taskbar XamlRoot");
+                Wh_Log(L"Couldn't obtain taskbar XamlRoot");
 
                 return TRUE;
             }
 
-            ApplyToXamlRoot(
-                xamlRoot);
+            ApplyToXamlRoot(xamlRoot);
 
             return TRUE;
         },
-        static_cast<LPARAM>(
-            mainTaskbarOnly));
+        static_cast<LPARAM>(mainTaskbarOnly));
 }
 
 void RebuildFromTaskbarThread() {
@@ -3655,100 +2944,167 @@ void RebuildFromTaskbarThread() {
     }
 }
 
-void ApplyFromAnyThread(
-    HWND taskbarWnd)
-{
-    RunFromWindowThread(
-        taskbarWnd,
-        [](void*)
-        {
-            ApplyFromTaskbarThread();
-        },
-        nullptr);
+void WINAPI ApplyAllTaskbarsProc(void*) {
+    ApplyFromTaskbarThread();
 }
 
-void RebuildFromAnyThread(
-    HWND taskbarWnd)
-{
-    RunFromWindowThread(
-        taskbarWnd,
-        [](void*)
-        {
-            RebuildFromTaskbarThread();
-        },
-        nullptr);
+void WINAPI RebuildAllTaskbarsProc(void*) {
+    RebuildFromTaskbarThread();
 }
-
 
 // -----------------------------------------------------------------------------
 // Taskbar creation hooks
 // -----------------------------------------------------------------------------
 
-using TrayUI_StartTaskbar_t =
-    void (WINAPI*)(void* pThis);
+using TrayUI_StartTaskbar_t = void(WINAPI*)(void* pThis);
 
-TrayUI_StartTaskbar_t
-    TrayUI_StartTaskbar_Original;
+TrayUI_StartTaskbar_t TrayUI_StartTaskbar_Original;
 
-void WINAPI TrayUI_StartTaskbar_Hook(
-    void* pThis)
-{
-    TrayUI_StartTaskbar_Original(
-        pThis);
+void WINAPI TrayUI_StartTaskbar_Hook(void* pThis) {
+    TrayUI_StartTaskbar_Original(pThis);
 
     if (!g_unloading) {
-        ApplyFromTaskbarThread(
-            true);
+        ApplyFromTaskbarThread(true);
     }
 }
 
+using CSecondaryTray_GetTrayWindow_t = HWND(WINAPI*)(void* pThis);
 
-using CSecondaryTray_GetTrayWindow_t =
-    HWND (WINAPI*)(void* pThis);
+CSecondaryTray_GetTrayWindow_t CSecondaryTray_GetTrayWindow_Original;
 
-CSecondaryTray_GetTrayWindow_t
-    CSecondaryTray_GetTrayWindow_Original;
+using CSecondaryTray_InitModelAndHost_t = void(WINAPI*)(void* pThis,
+                                                        void* taskbarModel);
 
+CSecondaryTray_InitModelAndHost_t CSecondaryTray_InitModelAndHost_Original;
 
-using CSecondaryTray_InitModelAndHost_t =
-    void (WINAPI*)(
-        void* pThis,
-        void* taskbarModel);
-
-CSecondaryTray_InitModelAndHost_t
-    CSecondaryTray_InitModelAndHost_Original;
-
-void WINAPI
-CSecondaryTray_InitModelAndHost_Hook(
-    void* pThis,
-    void* taskbarModel)
-{
-    CSecondaryTray_InitModelAndHost_Original(
-        pThis,
-        taskbarModel);
+void WINAPI CSecondaryTray_InitModelAndHost_Hook(void* pThis,
+                                                 void* taskbarModel) {
+    CSecondaryTray_InitModelAndHost_Original(pThis, taskbarModel);
 
     if (g_unloading) {
         return;
     }
 
-    HWND taskbarWnd =
-        CSecondaryTray_GetTrayWindow_Original(
-            pThis);
+    HWND taskbarWnd = CSecondaryTray_GetTrayWindow_Original(pThis);
 
     if (!taskbarWnd) {
         return;
     }
 
-    auto xamlRoot =
-        GetSecondaryTaskbarXamlRoot(
-            taskbarWnd);
+    auto xamlRoot = GetSecondaryTaskbarXamlRoot(taskbarWnd);
 
     if (xamlRoot) {
-        ApplyToXamlRoot(
-            xamlRoot);
+        ApplyToXamlRoot(xamlRoot);
     }
 }
 
+// -----------------------------------------------------------------------------
+// Start button recreation hook
+// -----------------------------------------------------------------------------
+
+using ExperienceToggleButton_UpdateButtonPadding_t = void(WINAPI*)(void* pThis);
+
+ExperienceToggleButton_UpdateButtonPadding_t
+    ExperienceToggleButton_UpdateButtonPadding_Original;
+
+void WINAPI ExperienceToggleButton_UpdateButtonPadding_Hook(void* pThis) {
+    ExperienceToggleButton_UpdateButtonPadding_Original(pThis);
+
+    if (g_unloading || !pThis) {
+        return;
+    }
+
+    try {
+        IUnknown* inspectable = reinterpret_cast<IUnknown**>(pThis)[1];
+
+        if (!inspectable) {
+            return;
+        }
+
+        wux::FrameworkElement element{nullptr};
+
+        inspectable->QueryInterface(winrt::guid_of<wux::FrameworkElement>(),
+                                    winrt::put_abi(element));
+
+        if (!element ||
+            winrt::get_class_name(element) !=
+                L"Taskbar.ExperienceToggleButton" ||
+            wuxa::AutomationProperties::GetAutomationId(element) !=
+                L"StartButton") {
+            return;
+        }
+
+        AttachToStartButton(element);
+    } catch (const winrt::hresult_error& e) {
+        Wh_Log(L"Handling a recreated Start button failed: 0x%08X %s",
+               e.code().value, e.message().c_str());
+    } catch (...) {
+        Wh_Log(L"Handling a recreated Start button failed");
+    }
+}
+
+std::atomic<bool> g_taskbarViewDllLoaded = false;
+
+bool HookTaskbarViewDllSymbols(HMODULE module) {
+    // Taskbar.View.dll
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {
+        {
+            {LR"(protected: virtual void __cdecl winrt::Taskbar::implementation::ExperienceToggleButton::UpdateButtonPadding(void))"},
+            &ExperienceToggleButton_UpdateButtonPadding_Original,
+            ExperienceToggleButton_UpdateButtonPadding_Hook,
+        },
+    };
+
+    if (!WindhawkUtils::HookSymbols(module, hooks, ARRAYSIZE(hooks))) {
+        Wh_Log(L"Failed to resolve Taskbar.View.dll symbols");
+        return false;
+    }
+
+    return true;
+}
+
+HMODULE GetTaskbarViewModuleHandle() {
+    HMODULE module = GetModuleHandleW(L"Taskbar.View.dll");
+
+    if (!module) {
+        module = GetModuleHandleW(L"ExplorerExtensions.dll");
+    }
+
+    return module;
+}
+
+void HandleLoadedTaskbarViewModule(HMODULE module) {
+    if (g_unloading || !module || GetTaskbarViewModuleHandle() != module) {
+        return;
+    }
+
+    bool expected = false;
+
+    if (!g_taskbarViewDllLoaded.compare_exchange_strong(expected, true)) {
+        return;
+    }
+
+    Wh_Log(L"Taskbar view module loaded");
+
+    if (!HookTaskbarViewDllSymbols(module)) {
+        g_taskbarViewDllLoaded = false;
+        return;
+    }
+
+    Wh_ApplyHookOperations();
+}
+
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+
+LoadLibraryExW_t LoadLibraryExW_Original;
+
+HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName, HANDLE file, DWORD flags) {
+    HMODULE module = LoadLibraryExW_Original(fileName, file, flags);
+
+    HandleLoadedTaskbarViewModule(module);
+
+    return module;
+}
 
 // -----------------------------------------------------------------------------
 // Symbol hooks
@@ -3756,94 +3112,67 @@ CSecondaryTray_InitModelAndHost_Hook(
 
 bool HookTaskbarDllSymbols() {
     HMODULE taskbarDll =
-        LoadLibraryExW(
-            L"taskbar.dll",
-            nullptr,
-            LOAD_LIBRARY_SEARCH_SYSTEM32);
+        LoadLibraryExW(L"taskbar.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
 
     if (!taskbarDll) {
-        Wh_Log(
-            L"Failed to load taskbar.dll");
+        Wh_Log(L"Failed to load taskbar.dll");
 
         return false;
     }
 
-    WindhawkUtils::SYMBOL_HOOK
-        hooks[] = {
+    WindhawkUtils::SYMBOL_HOOK taskbarDllHooks[] = {
 
         {
-            {
-                LR"(const CTaskBand::`vftable'{for `ITaskListWndSite'})"
-            },
+            {LR"(const CTaskBand::`vftable'{for `ITaskListWndSite'})"},
             &CTaskBand_ITaskListWndSite_vftable,
         },
 
         {
-            {
-                LR"(const CSecondaryTaskBand::`vftable'{for `ITaskListWndSite'})"
-            },
+            {LR"(const CSecondaryTaskBand::`vftable'{for `ITaskListWndSite'})"},
             &CSecondaryTaskBand_ITaskListWndSite_vftable,
         },
 
         {
-            {
-                LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CTaskBand::GetTaskbarHost(void)const )"
-            },
+            {LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CTaskBand::GetTaskbarHost(void)const )"},
             &CTaskBand_GetTaskbarHost_Original,
         },
 
         {
-            {
-                LR"(public: int __cdecl TaskbarHost::FrameHeight(void)const )"
-            },
+            {LR"(public: int __cdecl TaskbarHost::FrameHeight(void)const )"},
             &TaskbarHost_FrameHeight_Original,
         },
 
         {
-            {
-                LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CSecondaryTaskBand::GetTaskbarHost(void)const )"
-            },
+            {LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CSecondaryTaskBand::GetTaskbarHost(void)const )"},
             &CSecondaryTaskBand_GetTaskbarHost_Original,
         },
 
         {
-            {
-                LR"(public: void __cdecl std::_Ref_count_base::_Decref(void))"
-            },
+            {LR"(public: void __cdecl std::_Ref_count_base::_Decref(void))"},
             &RefCountDecref_Original,
         },
 
         {
-            {
-                LR"(public: virtual void __cdecl TrayUI::StartTaskbar(void))"
-            },
+            {LR"(public: virtual void __cdecl TrayUI::StartTaskbar(void))"},
             &TrayUI_StartTaskbar_Original,
             TrayUI_StartTaskbar_Hook,
         },
 
         {
-            {
-                LR"(public: virtual struct HWND__ * __cdecl CSecondaryTray::GetTrayWindow(void))"
-            },
+            {LR"(public: virtual struct HWND__ * __cdecl CSecondaryTray::GetTrayWindow(void))"},
             &CSecondaryTray_GetTrayWindow_Original,
         },
 
         {
-            {
-                LR"(public: virtual void __cdecl CSecondaryTray::InitModelAndHost(struct winrt::WindowsUdk::UI::Shell::TaskbarModel))"
-            },
+            {LR"(public: virtual void __cdecl CSecondaryTray::InitModelAndHost(struct winrt::WindowsUdk::UI::Shell::TaskbarModel))"},
             &CSecondaryTray_InitModelAndHost_Original,
             CSecondaryTray_InitModelAndHost_Hook,
         },
     };
 
-    if (!WindhawkUtils::HookSymbols(
-            taskbarDll,
-            hooks,
-            ARRAYSIZE(hooks)))
-    {
-        Wh_Log(
-            L"Failed to resolve taskbar.dll symbols");
+    if (!WindhawkUtils::HookSymbols(taskbarDll, taskbarDllHooks,
+                                    ARRAYSIZE(taskbarDllHooks))) {
+        Wh_Log(L"Failed to resolve taskbar.dll symbols");
 
         return false;
     }
@@ -3851,70 +3180,79 @@ bool HookTaskbarDllSymbols() {
     return true;
 }
 
-
 // -----------------------------------------------------------------------------
 // Windhawk lifecycle
 // -----------------------------------------------------------------------------
 
 BOOL Wh_ModInit() {
-    Wh_Log(
-        L"Start Button Replacer initializing");
+    Wh_Log(L"Start Button Replacer initializing");
 
     g_unloading = false;
 
-    LoadSettings();
+    StoreSettings(LoadSettings());
 
     if (!HookTaskbarDllSymbols()) {
         return FALSE;
+    }
+
+    if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
+        g_taskbarViewDllLoaded = true;
+
+        if (!HookTaskbarViewDllSymbols(taskbarViewModule)) {
+            return FALSE;
+        }
+    } else {
+        HMODULE kernelBaseModule = GetModuleHandleW(L"kernelbase.dll");
+
+        if (!kernelBaseModule) {
+            Wh_Log(L"Failed to get kernelbase.dll");
+            return FALSE;
+        }
+
+        auto loadLibraryExW = reinterpret_cast<LoadLibraryExW_t>(
+            GetProcAddress(kernelBaseModule, "LoadLibraryExW"));
+
+        if (!loadLibraryExW) {
+            Wh_Log(L"Failed to find LoadLibraryExW");
+            return FALSE;
+        }
+
+        if (!WindhawkUtils::SetFunctionHook(loadLibraryExW, LoadLibraryExW_Hook,
+                                            &LoadLibraryExW_Original)) {
+            Wh_Log(L"Hooking LoadLibraryExW failed");
+            return FALSE;
+        }
     }
 
     return TRUE;
 }
 
 void Wh_ModAfterInit() {
-    Wh_Log(
-        L"Start Button Replacer applying");
+    Wh_Log(L"Start Button Replacer applying");
 
-    HWND taskbarWnd =
-        FindCurrentProcessTaskbarWnd();
-
-    if (taskbarWnd) {
-        ApplyFromAnyThread(
-            taskbarWnd);
+    if (!g_taskbarViewDllLoaded) {
+        HandleLoadedTaskbarViewModule(GetTaskbarViewModuleHandle());
     }
+
+    RunOnAllTaskbarThreads(ApplyAllTaskbarsProc, nullptr);
 }
 
 void Wh_ModBeforeUninit() {
-    Wh_Log(
-        L"Start Button Replacer restoring stock icon");
+    Wh_Log(L"Start Button Replacer restoring stock icon");
 
-    g_unloading = true;
+    auto instances = TakeAllInstancesForShutdown();
 
-    HWND taskbarWnd =
-        FindCurrentProcessTaskbarWnd();
-
-    if (taskbarWnd) {
-        RebuildFromAnyThread(
-            taskbarWnd);
-    }
+    DetachInstancesOnOwningThreads(instances);
 }
 
 void Wh_ModUninit() {
-    Wh_Log(
-        L"Start Button Replacer unloaded");
+    Wh_Log(L"Start Button Replacer unloaded");
 }
 
 void Wh_ModSettingsChanged() {
-    Wh_Log(
-        L"Start Button Replacer settings changed");
+    Wh_Log(L"Start Button Replacer settings changed");
 
-    LoadSettings();
+    StoreSettings(LoadSettings());
 
-    HWND taskbarWnd =
-        FindCurrentProcessTaskbarWnd();
-
-    if (taskbarWnd) {
-        RebuildFromAnyThread(
-            taskbarWnd);
-    }
+    RunOnAllTaskbarThreads(RebuildAllTaskbarsProc, nullptr);
 }

--- a/mods/start-button-replacer.wh.cpp
+++ b/mods/start-button-replacer.wh.cpp
@@ -300,17 +300,17 @@ struct ModSettings {
     int hoverFadeDuration = 120;
     int pressedFadeDuration = 80;
 
-    int iconSize = 24;
+    int iconSize = 34;
 
-    GifPlaybackMode gifPlayback = GifPlaybackMode::Always;
+    GifPlaybackMode gifPlayback = GifPlaybackMode::Hover;
 
-    double hoverScale = 1.0;
-    double hoverRotation = 0.0;
+    double hoverScale = 1.15;
+    double hoverRotation = 4.0;
     double hoverOpacity = 1.0;
     int hoverDuration = 120;
 
-    double pressedScale = 1.0;
-    double pressedRotation = 0.0;
+    double pressedScale = 0.95;
+    double pressedRotation = -4.0;
     double pressedOpacity = 1.0;
     int pressedDuration = 80;
 
@@ -445,9 +445,7 @@ std::wstring ExpandPath(const std::wstring& source) {
         return source;
     }
 
-    if (!result.empty() && result.back() == L'\0') {
-        result.pop_back();
-    }
+    result.resize(written - 1);
 
     return result;
 }
@@ -1793,6 +1791,27 @@ size_t GetTrackedInstanceCount() {
     return g_instances ? g_instances->size() : 0;
 }
 
+std::vector<DWORD> GetTrackedInstanceThreadIds() {
+    std::lock_guard<std::mutex> lock(g_instancesMutex);
+    std::vector<DWORD> threadIds;
+
+    if (!g_instances) {
+        return threadIds;
+    }
+
+    for (const auto& instance : *g_instances) {
+        if (!instance || !instance->threadId ||
+            std::find(threadIds.begin(), threadIds.end(),
+                      instance->threadId) != threadIds.end()) {
+            continue;
+        }
+
+        threadIds.push_back(instance->threadId);
+    }
+
+    return threadIds;
+}
+
 // -----------------------------------------------------------------------------
 // Bitmap/image loading
 // -----------------------------------------------------------------------------
@@ -1960,8 +1979,9 @@ bool LoadImageResource(const std::shared_ptr<StartIconInstance>& instance,
 
                 Wh_Log(L"Custom Start %s image loaded", IconStateName(state));
 
-                UpdateDisplayedImage(instance);
-                UpdateGifPlayback(instance);
+                // Apply both the image and the current transform. The pointer
+                // might already be hovering or pressed when decoding finishes.
+                ApplyCurrentState(instance, 0);
             });
 
         resource.imageOpenedAttached = true;
@@ -2558,6 +2578,10 @@ bool ApplyToXamlRoot(const wux::XamlRoot& xamlRoot) {
                e.message().c_str());
 
         return false;
+    } catch (...) {
+        Wh_Log(L"ApplyToXamlRoot failed with an unknown exception");
+
+        return false;
     }
 }
 
@@ -2592,16 +2616,18 @@ RefCountDecref_t RefCountDecref_Original;
 // -----------------------------------------------------------------------------
 
 wux::XamlRoot XamlRootFromTaskbarHostSharedPtr(void* sharedPtr[2]) {
-    auto releaseSharedPtr = [sharedPtr]() {
-        if (sharedPtr[1] && RefCountDecref_Original) {
-            RefCountDecref_Original(sharedPtr[1]);
+    struct SharedPtrReleaseGuard {
+        void** sharedPtr;
 
-            sharedPtr[1] = nullptr;
+        ~SharedPtrReleaseGuard() noexcept {
+            if (sharedPtr[1] && RefCountDecref_Original) {
+                RefCountDecref_Original(sharedPtr[1]);
+                sharedPtr[1] = nullptr;
+            }
         }
-    };
+    } releaseGuard{sharedPtr};
 
     if (!sharedPtr[0]) {
-        releaseSharedPtr();
         return nullptr;
     }
 
@@ -2627,7 +2653,6 @@ wux::XamlRoot XamlRootFromTaskbarHostSharedPtr(void* sharedPtr[2]) {
             L"Unrecognized TaskbarHost::FrameHeight; refusing an unsafe "
             L"TaskbarHost layout fallback");
 
-        releaseSharedPtr();
         return nullptr;
     }
 
@@ -2650,7 +2675,6 @@ wux::XamlRoot XamlRootFromTaskbarHostSharedPtr(void* sharedPtr[2]) {
             L"Unrecognized TaskbarHost::FrameHeight; refusing an unsafe "
             L"TaskbarHost layout fallback");
 
-        releaseSharedPtr();
         return nullptr;
     }
 
@@ -2674,8 +2698,6 @@ wux::XamlRoot XamlRootFromTaskbarHostSharedPtr(void* sharedPtr[2]) {
     if (taskbarElement) {
         result = taskbarElement.XamlRoot();
     }
-
-    releaseSharedPtr();
 
     return result;
 }
@@ -2778,6 +2800,7 @@ bool RunFromWindowThread(HWND window,
         RunFromWindowThreadProc_t proc;
         void* param;
         std::atomic<bool> invoked{false};
+        std::atomic<bool> succeeded{false};
     };
 
     DWORD threadId = GetWindowThreadProcessId(window, nullptr);
@@ -2787,8 +2810,17 @@ bool RunFromWindowThread(HWND window,
     }
 
     if (threadId == GetCurrentThreadId()) {
-        proc(procParam);
-        return true;
+        try {
+            proc(procParam);
+            return true;
+        } catch (const winrt::hresult_error& e) {
+            Wh_Log(L"Taskbar-thread callback failed: 0x%08X %s",
+                   e.code().value, e.message().c_str());
+        } catch (...) {
+            Wh_Log(L"Taskbar-thread callback failed with an unknown exception");
+        }
+
+        return false;
     }
 
     HHOOK hook = SetWindowsHookEx(
@@ -2801,7 +2833,17 @@ bool RunFromWindowThread(HWND window,
                 if (cwp->message == registeredMessage) {
                     auto* parameter = reinterpret_cast<RunParam*>(cwp->lParam);
 
-                    parameter->proc(parameter->param);
+                    try {
+                        parameter->proc(parameter->param);
+                        parameter->succeeded.store(true);
+                    } catch (const winrt::hresult_error& e) {
+                        Wh_Log(L"Taskbar-thread callback failed: 0x%08X %s",
+                               e.code().value, e.message().c_str());
+                    } catch (...) {
+                        Wh_Log(L"Taskbar-thread callback failed with an "
+                               L"unknown exception");
+                    }
+
                     parameter->invoked.store(true);
                 }
             }
@@ -2821,7 +2863,7 @@ bool RunFromWindowThread(HWND window,
 
     UnhookWindowsHookEx(hook);
 
-    return parameter.invoked.load();
+    return parameter.invoked.load() && parameter.succeeded.load();
 }
 
 // -----------------------------------------------------------------------------
@@ -2890,6 +2932,45 @@ bool RunOnAllTaskbarThreads(RunFromWindowThreadProc_t proc, void* procParam) {
     return allSucceeded;
 }
 
+HWND FindAnyWindowOnThread(DWORD threadId) {
+    HWND result = nullptr;
+
+    EnumThreadWindows(
+        threadId,
+        [](HWND window, LPARAM param) -> BOOL {
+            *reinterpret_cast<HWND*>(param) = window;
+            return FALSE;
+        },
+        reinterpret_cast<LPARAM>(&result));
+
+    return result;
+}
+
+bool RunOnTrackedInstanceThreads(RunFromWindowThreadProc_t proc,
+                                 void* procParam) {
+    auto threadIds = GetTrackedInstanceThreadIds();
+    bool allSucceeded = true;
+
+    for (DWORD threadId : threadIds) {
+        HWND window = FindAnyWindowOnThread(threadId);
+
+        if (!window) {
+            Wh_Log(L"No window was found on tracked taskbar thread %lu",
+                   threadId);
+            allSucceeded = false;
+            continue;
+        }
+
+        if (!RunFromWindowThread(window, proc, procParam)) {
+            Wh_Log(L"Running code on tracked taskbar thread %lu failed",
+                   threadId);
+            allSucceeded = false;
+        }
+    }
+
+    return allSucceeded;
+}
+
 // -----------------------------------------------------------------------------
 // Apply/remove on taskbar thread
 // -----------------------------------------------------------------------------
@@ -2898,32 +2979,41 @@ void ApplyFromTaskbarThread(bool mainTaskbarOnly = false) {
     EnumThreadWindows(
         GetCurrentThreadId(),
         [](HWND window, LPARAM param) -> BOOL {
-            bool mainOnly = param != 0;
+            try {
+                bool mainOnly = param != 0;
 
-            wchar_t className[64]{};
+                wchar_t className[64]{};
 
-            if (!GetClassNameW(window, className, ARRAYSIZE(className))) {
-                return TRUE;
+                if (!GetClassNameW(window, className, ARRAYSIZE(className))) {
+                    return TRUE;
+                }
+
+                wux::XamlRoot xamlRoot{nullptr};
+
+                if (_wcsicmp(className, L"Shell_TrayWnd") == 0) {
+                    xamlRoot = GetTaskbarXamlRoot(window);
+                } else if (!mainOnly &&
+                           _wcsicmp(className,
+                                    L"Shell_SecondaryTrayWnd") == 0) {
+                    xamlRoot = GetSecondaryTaskbarXamlRoot(window);
+                } else {
+                    return TRUE;
+                }
+
+                if (!xamlRoot) {
+                    Wh_Log(L"Couldn't obtain taskbar XamlRoot");
+
+                    return TRUE;
+                }
+
+                ApplyToXamlRoot(xamlRoot);
+            } catch (const winrt::hresult_error& e) {
+                Wh_Log(L"Applying a taskbar window failed: 0x%08X %s",
+                       e.code().value, e.message().c_str());
+            } catch (...) {
+                Wh_Log(L"Applying a taskbar window failed with an unknown "
+                       L"exception");
             }
-
-            wux::XamlRoot xamlRoot{nullptr};
-
-            if (_wcsicmp(className, L"Shell_TrayWnd") == 0) {
-                xamlRoot = GetTaskbarXamlRoot(window);
-            } else if (!mainOnly &&
-                       _wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0) {
-                xamlRoot = GetSecondaryTaskbarXamlRoot(window);
-            } else {
-                return TRUE;
-            }
-
-            if (!xamlRoot) {
-                Wh_Log(L"Couldn't obtain taskbar XamlRoot");
-
-                return TRUE;
-            }
-
-            ApplyToXamlRoot(xamlRoot);
 
             return TRUE;
         },
@@ -2983,16 +3073,24 @@ void WINAPI CSecondaryTray_InitModelAndHost_Hook(void* pThis,
         return;
     }
 
-    HWND taskbarWnd = CSecondaryTray_GetTrayWindow_Original(pThis);
+    try {
+        HWND taskbarWnd = CSecondaryTray_GetTrayWindow_Original(pThis);
 
-    if (!taskbarWnd) {
-        return;
-    }
+        if (!taskbarWnd) {
+            return;
+        }
 
-    auto xamlRoot = GetSecondaryTaskbarXamlRoot(taskbarWnd);
+        auto xamlRoot = GetSecondaryTaskbarXamlRoot(taskbarWnd);
 
-    if (xamlRoot) {
-        ApplyToXamlRoot(xamlRoot);
+        if (xamlRoot) {
+            ApplyToXamlRoot(xamlRoot);
+        }
+    } catch (const winrt::hresult_error& e) {
+        Wh_Log(L"Handling a secondary taskbar failed: 0x%08X %s",
+               e.code().value, e.message().c_str());
+    } catch (...) {
+        Wh_Log(L"Handling a secondary taskbar failed with an unknown "
+               L"exception");
     }
 }
 
@@ -3044,7 +3142,7 @@ void WINAPI ExperienceToggleButton_UpdateButtonPadding_Hook(void* pThis) {
 std::atomic<bool> g_taskbarViewDllLoaded = false;
 
 bool HookTaskbarViewDllSymbols(HMODULE module) {
-    // Taskbar.View.dll
+    // Taskbar.View.dll, ExplorerExtensions.dll
     WindhawkUtils::SYMBOL_HOOK hooks[] = {
         {
             {LR"(protected: virtual void __cdecl winrt::Taskbar::implementation::ExperienceToggleButton::UpdateButtonPadding(void))"},
@@ -3054,7 +3152,7 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
     };
 
     if (!WindhawkUtils::HookSymbols(module, hooks, ARRAYSIZE(hooks))) {
-        Wh_Log(L"Failed to resolve Taskbar.View.dll symbols");
+        Wh_Log(L"Failed to resolve taskbar view module symbols");
         return false;
     }
 
@@ -3072,7 +3170,8 @@ HMODULE GetTaskbarViewModuleHandle() {
 }
 
 void HandleLoadedTaskbarViewModule(HMODULE module) {
-    if (g_unloading || !module || GetTaskbarViewModuleHandle() != module) {
+    if (g_unloading || g_taskbarViewDllLoaded.load() || !module ||
+        GetTaskbarViewModuleHandle() != module) {
         return;
     }
 
@@ -3247,21 +3346,20 @@ void Wh_ModBeforeUninit() {
 
     BeginInstanceShutdown();
 
-    // Run synchronously on each owning taskbar UI thread. Unlike a queued
-    // CoreDispatcher callback, this has completed before RunFromWindowThread
-    // returns, so no handler implemented by this DLL remains queued or
-    // registered when controlled unload continues.
-    RunOnAllTaskbarThreads(DetachAllTaskbarsProc, nullptr);
+    // Drive cleanup from the instances themselves instead of rediscovering
+    // taskbar window classes. RunFromWindowThread is synchronous, so every
+    // callback and XAML reference is gone before controlled unload continues.
+    RunOnTrackedInstanceThreads(DetachAllTaskbarsProc, nullptr);
 
-    // A taskbar window can be recreated while windows are being enumerated.
-    // Retry once if the first pass didn't visit every tracked UI thread.
+    // A thread window can be recreated while it's being enumerated. Retry once
+    // if the first pass didn't visit every tracked owner thread.
     size_t remainingInstances = GetTrackedInstanceCount();
 
     if (remainingInstances != 0) {
         Wh_Log(L"%zu Start icon instance(s) remained after cleanup; retrying",
                remainingInstances);
 
-        RunOnAllTaskbarThreads(DetachAllTaskbarsProc, nullptr);
+        RunOnTrackedInstanceThreads(DetachAllTaskbarsProc, nullptr);
         remainingInstances = GetTrackedInstanceCount();
     }
 

--- a/mods/start-button-replacer.wh.cpp
+++ b/mods/start-button-replacer.wh.cpp
@@ -8,7 +8,7 @@
 // @twitter         https://twitter.com/NoobieNoodle89
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lshcore
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject
 // @license         GPL-3.0-only
 // ==/WindhawkMod==
 
@@ -83,9 +83,9 @@ the pressed duration. Set a duration to `0` to switch instantly.
 
 For crisp results, use a square image with transparency. Keep animated GIFs
 reasonably small, such as 64x64 or 128x128. The displayed size is independent
-from the source image resolution. Image files must be no larger than 8 MiB and
-must be stored on a fixed local drive. Network, mapped, removable and optical
-drives aren't read from Explorer's taskbar UI thread.
+from the source image resolution. XAML loads and decodes image sources
+asynchronously. XAML also caches images by source URI, so after replacing a file
+at the same path, reload the mod if the previous image remains visible.
 */
 // ==/WindhawkModReadme==
 
@@ -95,9 +95,9 @@ drives aren't read from Explorer's taskbar UI thread.
   - imageSource: ""
     $name: Image source (necessary)
     $description: >-
-      Absolute path on a fixed local drive, or a path containing environment
-      variables. Supports PNG, JPG and animated GIF files up to 8 MiB. This is
-      the normal image and the final fallback for every other state.
+      Absolute file path, or a path containing environment variables. Supports
+      PNG, JPG and animated GIF. This is the normal image and the final fallback
+      for every other state.
   - hoverImageSource: ""
     $name: Hover image source
     $description: >-
@@ -119,9 +119,7 @@ drives aren't read from Explorer's taskbar UI thread.
       Displayed size in device-independent pixels, from 8 to 128. The default is
       34.
   $name: Images
-  $description: >-
-    Configure the replacement images and their displayed size. Image files on
-    network, mapped, removable and optical drives aren't supported.
+  $description: Configure the replacement images and their displayed size.
 
 - imageAnimation:
   - gifPlayback: hover
@@ -218,13 +216,10 @@ drives aren't read from Explorer's taskbar UI thread.
 #include <string>
 #include <vector>
 
-#include <shcore.h>
-
 #undef GetCurrentTime
 
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.UI.Composition.h>
 #include <winrt/Windows.UI.Xaml.Automation.Peers.h>
 #include <winrt/Windows.UI.Xaml.Automation.h>
@@ -237,8 +232,6 @@ drives aren't read from Explorer's taskbar UI thread.
 #include <winrt/Windows.UI.Xaml.h>
 
 namespace wf = winrt::Windows::Foundation;
-
-namespace wss = winrt::Windows::Storage::Streams;
 
 namespace wuc = winrt::Windows::UI::Composition;
 
@@ -288,7 +281,6 @@ enum class IconState : size_t {
 };
 
 constexpr size_t kIconStateCount = static_cast<size_t>(IconState::Count);
-constexpr uint64_t kMaximumImageFileSize = 8ULL * 1024 * 1024;
 
 struct ModSettings {
     std::wstring imageSource;
@@ -331,9 +323,10 @@ std::atomic<bool> g_unloading = false;
 struct ImageResource {
     wuxmi::BitmapImage bitmap{nullptr};
 
-    // The source file is copied to memory so the file itself isn't kept open.
-    wss::IRandomAccessStream memoryStream{nullptr};
-    wf::IAsyncAction loadAction{nullptr};
+    // Assigning the bitmap to an Image connected to the XAML tree starts URI
+    // retrieval. The visible layers aren't assigned until ImageOpened so the
+    // stock icon remains visible while loading.
+    wuxc::Image loadTarget{nullptr};
 
     winrt::event_token imageOpenedToken{};
     winrt::event_token imageFailedToken{};
@@ -1666,8 +1659,14 @@ void DetachInstance(const std::shared_ptr<StartIconInstance>& instance) {
         } catch (...) {
         }
 
-        resource.loadAction = nullptr;
-        resource.memoryStream = nullptr;
+        try {
+            if (resource.loadTarget) {
+                resource.loadTarget.Source(wuxm::ImageSource{nullptr});
+            }
+        } catch (...) {
+        }
+
+        resource.loadTarget = nullptr;
         resource.bitmap = nullptr;
         resource.opened = false;
         resource.failed = false;
@@ -1816,125 +1815,6 @@ std::vector<DWORD> GetTrackedInstanceThreadIds() {
 // Bitmap/image loading
 // -----------------------------------------------------------------------------
 
-bool IsFixedLocalImagePath(const std::wstring& path) {
-    // Accept ordinary drive-letter paths and their extended-length form. UNC,
-    // device, relative and volume-GUID paths are intentionally rejected before
-    // CreateFileW can block Explorer's taskbar UI thread on external storage.
-    size_t driveOffset = 0;
-
-    if (path.compare(0, 4, L"\\\\?\\") == 0) {
-        driveOffset = 4;
-    }
-
-    if (path.size() < driveOffset + 3) {
-        return false;
-    }
-
-    wchar_t driveLetter = path[driveOffset];
-    bool isDriveLetter =
-        (driveLetter >= L'A' && driveLetter <= L'Z') ||
-        (driveLetter >= L'a' && driveLetter <= L'z');
-
-    if (!isDriveLetter || path[driveOffset + 1] != L':' ||
-        (path[driveOffset + 2] != L'\\' &&
-         path[driveOffset + 2] != L'/')) {
-        return false;
-    }
-
-    wchar_t driveRoot[] = {driveLetter, L':', L'\\', L'\0'};
-
-    return GetDriveTypeW(driveRoot) == DRIVE_FIXED;
-}
-
-HRESULT CreateMemoryBackedStreamFromFile(
-    const std::wstring& path,
-    wss::IRandomAccessStream& randomAccessStream) {
-    if (!IsFixedLocalImagePath(path)) {
-        return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
-    }
-
-    HANDLE file =
-        CreateFileW(path.c_str(), GENERIC_READ,
-                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                    nullptr, OPEN_EXISTING,
-                    FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, nullptr);
-
-    if (file == INVALID_HANDLE_VALUE) {
-        return HRESULT_FROM_WIN32(GetLastError());
-    }
-
-    std::unique_ptr<void, decltype(&CloseHandle)> fileOwner(file, CloseHandle);
-
-    LARGE_INTEGER fileSize{};
-
-    if (!GetFileSizeEx(file, &fileSize)) {
-        return HRESULT_FROM_WIN32(GetLastError());
-    }
-
-    if (fileSize.QuadPart < 0 ||
-        static_cast<uint64_t>(fileSize.QuadPart) > kMaximumImageFileSize) {
-        return HRESULT_FROM_WIN32(ERROR_FILE_TOO_LARGE);
-    }
-
-    winrt::com_ptr<IStream> memoryStream;
-    HRESULT hr = CreateStreamOnHGlobal(nullptr, TRUE, memoryStream.put());
-
-    if (FAILED(hr)) {
-        return hr;
-    }
-
-    std::array<BYTE, 64 * 1024> buffer;
-    uint64_t totalBytesRead = 0;
-
-    while (true) {
-        DWORD bytesRead = 0;
-
-        if (!ReadFile(file, buffer.data(), static_cast<DWORD>(buffer.size()),
-                      &bytesRead, nullptr)) {
-            return HRESULT_FROM_WIN32(GetLastError());
-        }
-
-        if (bytesRead == 0) {
-            break;
-        }
-
-        if (totalBytesRead > kMaximumImageFileSize - bytesRead) {
-            return HRESULT_FROM_WIN32(ERROR_FILE_TOO_LARGE);
-        }
-
-        totalBytesRead += bytesRead;
-
-        ULONG bytesWritten = 0;
-        hr = memoryStream->Write(buffer.data(), bytesRead, &bytesWritten);
-
-        if (FAILED(hr)) {
-            return hr;
-        }
-
-        if (bytesWritten != bytesRead) {
-            return STG_E_MEDIUMFULL;
-        }
-    }
-
-    // Close the source file before XAML starts decoding. The user can replace
-    // or delete it while the mod remains enabled.
-    fileOwner.reset();
-
-    LARGE_INTEGER beginning{};
-    hr = memoryStream->Seek(beginning, STREAM_SEEK_SET, nullptr);
-
-    if (FAILED(hr)) {
-        return hr;
-    }
-
-    winrt::guid streamGuid = winrt::guid_of<wss::IRandomAccessStream>();
-
-    return CreateRandomAccessStreamOverStream(
-        memoryStream.get(), BSOS_DEFAULT,
-        reinterpret_cast<const IID&>(streamGuid),
-        reinterpret_cast<void**>(winrt::put_abi(randomAccessStream)));
-}
-
 bool LoadImageResource(const std::shared_ptr<StartIconInstance>& instance,
                        IconState state,
                        const std::wstring& source) {
@@ -1972,8 +1852,6 @@ bool LoadImageResource(const std::shared_ptr<StartIconInstance>& instance,
 
                 resource.opened = true;
                 resource.failed = false;
-                resource.loadAction = nullptr;
-                resource.memoryStream = nullptr;
 
                 auto state = static_cast<IconState>(stateIndex);
 
@@ -2000,8 +1878,6 @@ bool LoadImageResource(const std::shared_ptr<StartIconInstance>& instance,
 
                 resource.opened = false;
                 resource.failed = true;
-                resource.loadAction = nullptr;
-                resource.memoryStream = nullptr;
 
                 auto state = static_cast<IconState>(stateIndex);
 
@@ -2021,40 +1897,32 @@ bool LoadImageResource(const std::shared_ptr<StartIconInstance>& instance,
             return false;
         }
 
-        if (!IsFixedLocalImagePath(path)) {
+        // UriSource lets XAML retrieve and decode the image asynchronously.
+        // ImageOpened and ImageFailed above report completion.
+        bitmap.UriSource(wf::Uri(path));
+
+        auto imageHost = instance->customImageHost.get();
+
+        if (!imageHost) {
             resource.failed = true;
-
-            Wh_Log(L"Reading %s image \"%s\" was refused: the source must "
-                   L"be on a fixed local drive",
-                   IconStateName(state), path.c_str());
-
             return false;
         }
 
-        wss::IRandomAccessStream stream{nullptr};
+        wuxc::Image loadTarget;
 
-        HRESULT hr = CreateMemoryBackedStreamFromFile(path, stream);
+        loadTarget.Opacity(0.0);
+        loadTarget.IsHitTestVisible(false);
 
-        if (FAILED(hr) || !stream) {
-            resource.failed = true;
+        wuxa::AutomationProperties::SetAccessibilityView(
+            loadTarget, wuxap::AccessibilityView::Raw);
 
-            if (hr == HRESULT_FROM_WIN32(ERROR_FILE_TOO_LARGE)) {
-                Wh_Log(L"Reading %s image \"%s\" was refused: the file "
-                       L"exceeds the 8 MiB limit",
-                       IconStateName(state), path.c_str());
-            } else {
-                Wh_Log(L"Reading %s image \"%s\" failed: 0x%08X",
-                       IconStateName(state), path.c_str(), hr);
-            }
+        resource.loadTarget = loadTarget;
 
-            return false;
-        }
-
-        resource.memoryStream = stream;
-
-        // SetSourceAsync decodes the bounded in-memory copy asynchronously. The
-        // source file itself was read synchronously above.
-        resource.loadAction = bitmap.SetSourceAsync(stream);
+        // Keep the target in the live tree for the lifetime of the resource.
+        // It stays fully transparent; only customImage and transitionImage are
+        // used to render the selected state.
+        imageHost.Children().Append(loadTarget);
+        loadTarget.Source(bitmap);
 
         return true;
     } catch (const winrt::hresult_error& e) {

--- a/mods/start-button-replacer.wh.cpp
+++ b/mods/start-button-replacer.wh.cpp
@@ -36,6 +36,8 @@ Replaces the icon inside the Windows 11 Start button with a custom PNG, JPG or
 GIF image. Animated GIF playback and hover/pressed effects are optional
 features.
 
+![preview](https://raw.githubusercontent.com/EnderDragonEP/asset/main/windhawk-mods/start-button-replacer/preview-1.gif)
+
 Only the icon is replaced. Windows continues to handle clicking, keyboard
 navigation, accessibility and Start menu activation.
 

--- a/mods/start-button-replacer.wh.cpp
+++ b/mods/start-button-replacer.wh.cpp
@@ -36,7 +36,7 @@ Replaces the icon inside the Windows 11 Start button with a custom PNG, JPG or
 GIF image. Animated GIF playback and hover/pressed effects are optional
 features.
 
-![preview](https://raw.githubusercontent.com/EnderDragonEP/asset/main/windhawk-mods/start-button-replacer/preview-1.gif)
+![preview-gifs](https://raw.githubusercontent.com/EnderDragonEP/asset/main/windhawk-mods/start-button-replacer/preview-1.gif)
 
 Only the icon is replaced. Windows continues to handle clicking, keyboard
 navigation, accessibility and Start menu activation.

--- a/mods/start-button-replacer.wh.cpp
+++ b/mods/start-button-replacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              start-button-replacer
 // @name            Start Button Replacer
 // @description     Replace the Windows 11 Start button icon with a custom PNG, JPG or GIF image
-// @version         0.12.3
+// @version         0.12.4
 // @author          Ender
 // @github          https://github.com/EnderDragonEP
 // @twitter         https://twitter.com/NoobieNoodle89
@@ -3345,14 +3345,18 @@ bool RunOnAllTaskbarThreads(RunFromWindowThreadProc_t proc, void* procParam) {
     return allSucceeded;
 }
 
-HWND FindAnyWindowOnThread(DWORD threadId) {
-    HWND result = nullptr;
+std::vector<HWND> FindWindowsOnThread(DWORD threadId) {
+    std::vector<HWND> result;
 
     EnumThreadWindows(
         threadId,
         [](HWND window, LPARAM param) -> BOOL {
-            *reinterpret_cast<HWND*>(param) = window;
-            return FALSE;
+            try {
+                reinterpret_cast<std::vector<HWND>*>(param)->push_back(window);
+                return TRUE;
+            } catch (...) {
+                return FALSE;
+            }
         },
         reinterpret_cast<LPARAM>(&result));
 
@@ -3365,16 +3369,25 @@ bool RunOnTrackedInstanceThreads(RunFromWindowThreadProc_t proc,
     bool allSucceeded = true;
 
     for (DWORD threadId : threadIds) {
-        HWND window = FindAnyWindowOnThread(threadId);
+        auto windows = FindWindowsOnThread(threadId);
 
-        if (!window) {
-            Wh_Log(L"No window was found on tracked taskbar thread %lu",
+        if (windows.empty()) {
+            Wh_Log(L"No windows were found on tracked taskbar thread %lu",
                    threadId);
             allSucceeded = false;
             continue;
         }
 
-        if (!RunFromWindowThread(window, proc, procParam)) {
+        bool succeeded = false;
+
+        for (HWND window : windows) {
+            if (RunFromWindowThread(window, proc, procParam)) {
+                succeeded = true;
+                break;
+            }
+        }
+
+        if (!succeeded) {
             Wh_Log(L"Running code on tracked taskbar thread %lu failed",
                    threadId);
             allSucceeded = false;
@@ -3597,7 +3610,6 @@ void HandleLoadedTaskbarViewModule(HMODULE module) {
     Wh_Log(L"Taskbar view module loaded");
 
     if (!HookTaskbarViewDllSymbols(module)) {
-        g_taskbarViewDllLoaded = false;
         return;
     }
 
@@ -3769,12 +3781,22 @@ void Wh_ModBeforeUninit() {
     // callback and XAML reference is gone before controlled unload continues.
     RunOnTrackedInstanceThreads(DetachAllTaskbarsProc, nullptr);
 
-    // A thread window can be recreated while it's being enumerated. Retry once
-    // if the first pass didn't visit every tracked owner thread.
     size_t remainingInstances = GetTrackedInstanceCount();
 
     if (remainingInstances != 0) {
-        Wh_Log(L"%zu Start icon instance(s) remained after cleanup; retrying",
+        Wh_Log(L"%zu Start icon instance(s) remained after owner-thread "
+               L"cleanup; trying current taskbar windows",
+               remainingInstances);
+
+        RunOnAllTaskbarThreads(DetachAllTaskbarsProc, nullptr);
+        remainingInstances = GetTrackedInstanceCount();
+    }
+
+    // A taskbar window can be recreated while either pass is enumerating.
+    // Retry the recorded owner threads once before allowing unload to continue.
+    if (remainingInstances != 0) {
+        Wh_Log(L"%zu Start icon instance(s) remained after taskbar-window "
+               L"cleanup; retrying owner threads",
                remainingInstances);
 
         RunOnTrackedInstanceThreads(DetachAllTaskbarsProc, nullptr);

--- a/mods/start-button-replacer.wh.cpp
+++ b/mods/start-button-replacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              start-button-replacer
 // @name            Start Button Replacer
 // @description     Replace the Windows 11 Start button icon with a custom PNG, JPG or GIF image
-// @version         0.12.2
+// @version         0.12.3
 // @author          Ender
 // @github          https://github.com/EnderDragonEP
 // @twitter         https://twitter.com/NoobieNoodle89
@@ -184,6 +184,8 @@ For crisp results, use a square image with transparency. Keep animated GIFs reas
 
 #include <windhawk_utils.h>
 
+#include <commctrl.h>
+
 #include <algorithm>
 #include <array>
 #include <atomic>
@@ -301,6 +303,9 @@ std::atomic<bool> g_unloading = false;
 std::mutex g_imageFailureMessagesMutex;
 uint64_t g_imageFailureMessageGeneration = 0;
 bool g_imageFailureMessageQueued = false;
+HANDLE g_imageFailureMessageThread = nullptr;
+std::atomic<HWND> g_imageFailureMessageWindow = nullptr;
+std::atomic<bool> g_imageFailureMessageCancelRequested = false;
 
 // -----------------------------------------------------------------------------
 // Start icon instance
@@ -791,37 +796,123 @@ std::wstring BuildImageFailureMessage(
 struct ImageFailureMessageParams {
     std::wstring message;
     uint64_t settingsGeneration = 0;
-    HMODULE pinnedModule = nullptr;
 };
 
 DWORD WINAPI ImageFailureMessageThreadProc(void* parameter) {
     std::unique_ptr<ImageFailureMessageParams> params(
         static_cast<ImageFailureMessageParams*>(parameter));
 
-    HMODULE pinnedModule = params->pinnedModule;
-
-    // Suppress a warning queued by old settings or just as controlled unload
-    // began. The module reference below still protects this worker if unload
-    // starts while an already visible message box is open.
-    if (!g_unloading &&
-        params->settingsGeneration ==
+    if (g_unloading || g_imageFailureMessageCancelRequested ||
+        params->settingsGeneration !=
             g_settingsGeneration.load(std::memory_order_relaxed)) {
-        MessageBoxW(nullptr, params->message.c_str(),
-                    kImageFailureMessageTitle,
-                    MB_OK | MB_ICONWARNING | MB_TOPMOST);
+        return 0;
     }
 
-    // Destroy all C++ objects while the mod is still mapped, then release the
-    // reference which keeps this worker's code valid during controlled unload.
-    params.reset();
-    FreeLibraryAndExitThread(pinnedModule, 0);
+    HMODULE comctl32 = GetModuleHandleW(L"comctl32.dll");
+    auto taskDialogIndirect = comctl32
+                                  ? reinterpret_cast<decltype(
+                                        &TaskDialogIndirect)>(GetProcAddress(
+                                        comctl32, "TaskDialogIndirect"))
+                                  : nullptr;
+
+    if (!taskDialogIndirect) {
+        Wh_Log(L"TaskDialogIndirect is unavailable; image failures are in the "
+               L"Windhawk log");
+        return 0;
+    }
+
+    TASKDIALOGCONFIG config{
+        .cbSize = sizeof(config),
+        .dwFlags = TDF_ALLOW_DIALOG_CANCELLATION,
+        .dwCommonButtons = TDCBF_OK_BUTTON,
+        .pszWindowTitle = kImageFailureMessageTitle,
+        .pszMainIcon = TD_WARNING_ICON,
+        .pszContent = params->message.c_str(),
+        .pfCallback = [](HWND hwnd, UINT notification, WPARAM, LPARAM,
+                         LONG_PTR callbackData) WINAPI -> HRESULT {
+            auto params = reinterpret_cast<ImageFailureMessageParams*>(
+                callbackData);
+
+            switch (notification) {
+                case TDN_CREATED:
+                    g_imageFailureMessageWindow = hwnd;
+                    SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0,
+                                 SWP_NOMOVE | SWP_NOSIZE);
+
+                    if (g_unloading ||
+                        g_imageFailureMessageCancelRequested || !params ||
+                        params->settingsGeneration != g_settingsGeneration.load(
+                                                          std::memory_order_relaxed)) {
+                        PostMessageW(hwnd, WM_CLOSE, 0, 0);
+                    }
+                    break;
+
+                case TDN_DESTROYED: {
+                    HWND expected = hwnd;
+                    g_imageFailureMessageWindow.compare_exchange_strong(
+                        expected, nullptr);
+                    break;
+                }
+            }
+
+            return S_OK;
+        },
+        .lpCallbackData = reinterpret_cast<LONG_PTR>(params.get()),
+    };
+
+    int button = 0;
+    HRESULT result = taskDialogIndirect(&config, &button, nullptr, nullptr);
+
+    if (FAILED(result)) {
+        Wh_Log(L"Showing the image failure dialog failed: 0x%08X",
+               result);
+    }
+
+    return 0;
+}
+
+void StopImageFailureMessageThread() {
+    HANDLE thread = nullptr;
+
+    {
+        std::lock_guard<std::mutex> lock(g_imageFailureMessagesMutex);
+        g_imageFailureMessageCancelRequested = true;
+        thread = g_imageFailureMessageThread;
+    }
+
+    if (HWND window = g_imageFailureMessageWindow.load()) {
+        PostMessageW(window, WM_CLOSE, 0, 0);
+    }
+
+    if (!thread) {
+        return;
+    }
+
+    DWORD waitResult = WaitForSingleObject(thread, INFINITE);
+
+    if (waitResult == WAIT_FAILED) {
+        Wh_Log(L"Waiting for the image failure dialog thread failed: %u",
+               GetLastError());
+    }
+
+    g_imageFailureMessageWindow = nullptr;
+    CloseHandle(thread);
+
+    std::lock_guard<std::mutex> lock(g_imageFailureMessagesMutex);
+
+    if (g_imageFailureMessageThread == thread) {
+        g_imageFailureMessageThread = nullptr;
+    }
 }
 
 void ResetReportedImageFailures(uint64_t settingsGeneration) {
+    StopImageFailureMessageThread();
+
     std::lock_guard<std::mutex> lock(g_imageFailureMessagesMutex);
 
     g_imageFailureMessageGeneration = settingsGeneration;
     g_imageFailureMessageQueued = false;
+    g_imageFailureMessageCancelRequested = false;
 }
 
 void ForgetReportedImageFailure(uint64_t settingsGeneration) {
@@ -870,33 +961,37 @@ void ShowImageFailureMessage(uint64_t settingsGeneration,
             return;
         }
 
-        if (!GetModuleHandleExW(
-                GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
-                reinterpret_cast<LPCWSTR>(&ImageFailureMessageThreadProc),
-                &params->pinnedModule)) {
-            Wh_Log(L"Pinning the mod for the image failure message failed: %u",
-                   GetLastError());
-            ForgetReportedImageFailure(settingsGeneration);
-            return;
+        {
+            std::lock_guard<std::mutex> lock(g_imageFailureMessagesMutex);
+
+            if (g_unloading || g_imageFailureMessageCancelRequested ||
+                settingsGeneration !=
+                    g_settingsGeneration.load(std::memory_order_relaxed) ||
+                g_imageFailureMessageGeneration != settingsGeneration ||
+                g_imageFailureMessageThread) {
+                if (g_imageFailureMessageGeneration == settingsGeneration) {
+                    g_imageFailureMessageQueued = false;
+                }
+
+                return;
+            }
+
+            auto rawParams = params.release();
+            HANDLE thread =
+                CreateThread(nullptr, 0, ImageFailureMessageThreadProc,
+                             rawParams, 0, nullptr);
+
+            if (!thread) {
+                DWORD error = GetLastError();
+                params.reset(rawParams);
+                g_imageFailureMessageQueued = false;
+                Wh_Log(L"Creating the image failure message thread failed: %u",
+                       error);
+                return;
+            }
+
+            g_imageFailureMessageThread = thread;
         }
-
-        auto rawParams = params.release();
-        HANDLE thread = CreateThread(nullptr, 0, ImageFailureMessageThreadProc,
-                                     rawParams, 0, nullptr);
-
-        if (!thread) {
-            DWORD error = GetLastError();
-            HMODULE pinnedModule = rawParams->pinnedModule;
-            params.reset(rawParams);
-            params.reset();
-            FreeLibrary(pinnedModule);
-            ForgetReportedImageFailure(settingsGeneration);
-            Wh_Log(L"Creating the image failure message thread failed: %u",
-                   error);
-            return;
-        }
-
-        CloseHandle(thread);
     } catch (...) {
         if (messageMarkedAsQueued) {
             try {
@@ -3664,6 +3759,10 @@ void Wh_ModBeforeUninit() {
     Wh_Log(L"Start Button Replacer restoring stock icon");
 
     BeginInstanceShutdown();
+
+    // The dialog owns a return address in this module. Close it and join its
+    // worker before Windhawk can unload the module.
+    StopImageFailureMessageThread();
 
     // Drive cleanup from the instances themselves instead of rediscovering
     // taskbar window classes. RunFromWindowThread is synchronous, so every

--- a/mods/start-button-replacer.wh.cpp
+++ b/mods/start-button-replacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              start-button-replacer
 // @name            Start Button Replacer
 // @description     Replace the Windows 11 Start button icon with a custom PNG, JPG or GIF image
-// @version         0.12.1
+// @version         0.12.2
 // @author          Ender
 // @github          https://github.com/EnderDragonEP
 // @twitter         https://twitter.com/NoobieNoodle89
@@ -32,14 +32,11 @@
 /*
 # Start Button Replacer
 
-Replaces the icon inside the Windows 11 Start button with a custom PNG, JPG or
-GIF image. Animated GIF playback and hover/pressed effects are optional
-features.
+Replaces the icon inside the Windows 11 Start button with a custom PNG, JPG or GIF image. Animated GIF playback and hover/pressed effects are optional features.
 
-![preview](https://raw.githubusercontent.com/EnderDragonEP/asset/main/windhawk-mods/start-button-replacer/preview-1.gif)
+![preview](https://raw.githubusercontent.com/EnderDragonEP/asset/7ae3c6659e0237bf98cc67f52576ebaff8d9fd44/windhawk-mods/start-button-replacer/preview-1.gif)
 
-Only the icon is replaced. Windows continues to handle clicking, keyboard
-navigation, accessibility and Start menu activation.
+Only the icon is replaced. Windows continues to handle clicking, keyboard navigation, accessibility and Start menu activation.
 
 ## Image sources
 
@@ -64,32 +61,19 @@ HTTP/HTTPS URLs are also supported:
 
 ## Effects
 
-Separate scale, rotation and opacity settings are available for hover and
-pressed states.
+Separate scale, rotation and opacity settings are available for hover and pressed states.
 
 ## Separate state images
 
-The main **Image source** is always the normal image. Add a hover, pressed or
-activated image source to enable that state automatically. The activated image
-is shown while the Start menu is open. If it is blank or unavailable, activated
-falls back to the pressed image, then the hover image, then the main image.
-Other blank or unavailable state images fall back to the main image.
+The main **Image source** is always the normal image. Add a hover, pressed or activated image source to enable that state automatically. The activated image is shown while the Start menu is open. If it is blank or unavailable, activated falls back to the pressed image, then the hover image, then the main image. Other blank or unavailable state images fall back to the main image.
 
-While the Start menu is shown, pressing the button temporarily uses the pressed
-state. The activated state resumes on release and otherwise takes priority over
-the hover state.
+While the Start menu is shown, pressing the button temporarily uses the pressed state. The activated state resumes on release and otherwise takes priority over the hover state.
 
-State images crossfade whenever their applicable duration is greater than zero.
-Hover transitions use the hover duration; pressed and activated transitions use
-the pressed duration. Set a duration to `0` to switch instantly.
+State images crossfade whenever their applicable duration is greater than zero. Hover transitions use the hover duration; pressed and activated transitions use the pressed duration. Set a duration to `0` to switch instantly.
 
 ## Notes
 
-For crisp results, use a square image with transparency. Keep animated GIFs
-reasonably small, such as 64x64 or 128x128. The displayed size is independent
-from the source image resolution. XAML loads and decodes image sources
-asynchronously. XAML also caches images by source URI, so after replacing a file
-at the same path, reload the mod if the previous image remains visible.
+For crisp results, use a square image with transparency. Keep animated GIFs reasonably small, such as 64x64 or 128x128. The displayed size is independent from the source image resolution. XAML loads and decodes image sources asynchronously. XAML also caches images by source URI, so after replacing a file at the same path, reload the mod if the previous image remains visible.
 */
 // ==/WindhawkModReadme==
 
@@ -97,31 +81,25 @@ at the same path, reload the mod if the previous image remains visible.
 /*
 - images:
   - imageSource: "https://raw.githubusercontent.com/EnderDragonEP/asset/be76faf00be2a45cb166a4971e67eb32afd4b1fb/windhawk-mods/start-button-replacer/gecko/normal-hover.gif"
-    $name: Image source (necessary)
+    $name: Image source (required)
     $description: >-
-      Absolute file path, path containing environment variables, or HTTP/HTTPS
-      URL. Supports PNG, JPG and animated GIF. This is the normal image and the
-      final fallback for every other state.
+      Absolute file path, path containing environment variables, or HTTP/HTTPS URL. Supports PNG, JPG and animated GIF. This is the normal image and the final fallback for every other state.
   - hoverImageSource: ""
     $name: Hover image source
     $description: >-
-      Image shown while the pointer is over the Start button. Leave blank to use
-      the normal image.
+      Image shown while the pointer is over the Start button. Leave blank to use the normal image.
   - pressedImageSource: "https://raw.githubusercontent.com/EnderDragonEP/asset/be76faf00be2a45cb166a4971e67eb32afd4b1fb/windhawk-mods/start-button-replacer/gecko/pressed.png"
     $name: Pressed image source
     $description: >-
-      Image shown while the Start button is pressed. Leave blank to use the
-      normal image.
+      Image shown while the Start button is pressed. Leave blank to use the normal image.
   - activatedImageSource: "https://raw.githubusercontent.com/EnderDragonEP/asset/be76faf00be2a45cb166a4971e67eb32afd4b1fb/windhawk-mods/start-button-replacer/gecko/activated.png"
     $name: Activated image source
     $description: >-
-      Image shown while the Start menu is open. If blank or unavailable, the
-      pressed image is used, followed by the hover image and normal image.
+      Image shown while the Start menu is open. If blank or unavailable, the pressed image is used, followed by the hover image and normal image.
   - iconSize: 34
     $name: Icon size
     $description: >-
-      Displayed size in device-independent pixels, from 8 to 128. The default is
-      34.
+      Displayed size in device-independent pixels, from 8 to 128. The default is 34.
   $name: Images
   $description: Configure the replacement images and their displayed size.
 
@@ -137,14 +115,11 @@ at the same path, reload the mod if the previous image remains visible.
   - hoverFadeDuration: 120
     $name: Hover crossfade duration
     $description: >-
-      Crossfade duration in milliseconds when entering or leaving the hover
-      state. Set to 0 to switch images instantly. The default is 120.
+      Crossfade duration in milliseconds when entering or leaving the hover state. Set to 0 to switch images instantly. The default is 120.
   - pressedFadeDuration: 80
     $name: Pressed and activated crossfade duration
     $description: >-
-      Crossfade duration in milliseconds when entering or leaving the pressed
-      or activated state. Set to 0 to switch images instantly. The default is
-      80.
+      Crossfade duration in milliseconds when entering or leaving the pressed or activated state. Set to 0 to switch images instantly. The default is 80.
   $name: Image animation
   $description: Configure animated GIF playback and crossfades between images.
 
@@ -152,8 +127,7 @@ at the same path, reload the mod if the previous image remains visible.
   - hoverScale: 115
     $name: Scale
     $description: >-
-      Icon scale as a percentage while hovering. 100 keeps its size. The default
-      is 115.
+      Icon scale as a percentage while hovering. 100 keeps its size. The default is 115.
   - hoverRotation: 4
     $name: Rotation
     $description: >-
@@ -173,8 +147,7 @@ at the same path, reload the mod if the previous image remains visible.
   - pressedScale: 95
     $name: Scale
     $description: >-
-      Icon scale as a percentage while pressed. 100 keeps its size. The default
-      is 95.
+      Icon scale as a percentage while pressed. 100 keeps its size. The default is 95.
   - pressedRotation: -4
     $name: Rotation
     $description: >-
@@ -194,15 +167,18 @@ at the same path, reload the mod if the previous image remains visible.
   - releaseDuration: 140
     $name: Release duration
     $description: >-
-      Effect transition duration in milliseconds when the pointer leaves or the
-      button is released. The default is 140.
+      Effect transition duration in milliseconds when the pointer leaves or the button is released. The default is 140.
   - respectSystemAnimations: true
     $name: Respect Windows animation setting
     $description: >-
-      Stop GIF playback and make all transitions instant when animation effects
-      are disabled in Windows.
+      Stop GIF playback and make all transitions instant when animation effects are disabled in Windows.
   $name: Animation behavior
   $description: Configure shared animation and accessibility behavior.
+
+- showImageLoadFailureWarnings: true
+  $name: Show image load failure warnings
+  $description: >-
+    Show a popup when one or more configured images cannot be loaded. Image-loading errors are always recorded in the Windhawk log.
 */
 // ==/WindhawkModSettings==
 
@@ -313,12 +289,18 @@ struct ModSettings {
     int releaseDuration = 140;
 
     bool respectSystemAnimations = true;
+    bool showImageLoadFailureWarnings = true;
 };
 
 ModSettings g_settings;
 std::mutex g_settingsMutex;
+std::atomic<uint64_t> g_settingsGeneration{0};
 
 std::atomic<bool> g_unloading = false;
+
+std::mutex g_imageFailureMessagesMutex;
+uint64_t g_imageFailureMessageGeneration = 0;
+bool g_imageFailureMessageQueued = false;
 
 // -----------------------------------------------------------------------------
 // Start icon instance
@@ -339,11 +321,13 @@ struct ImageResource {
     bool imageFailedAttached = false;
     bool opened = false;
     bool failed = false;
+    bool reportableFailure = false;
 };
 
 struct StartIconInstance {
     DWORD threadId = 0;
     ModSettings settings;
+    uint64_t settingsGeneration = 0;
 
     winrt::weak_ref<wux::FrameworkElement> startButton;
     winrt::weak_ref<wux::FrameworkElement> stockIcon;
@@ -359,6 +343,7 @@ struct StartIconInstance {
     // Multiple logical states can share one decoded image resource when their
     // configured sources are identical.
     std::array<size_t, kIconStateCount> imageResourceIndexByState{0, 1, 2, 3};
+    bool imageLoadingSetupComplete = false;
 
     size_t activeImageIndex = 0;
     bool activeImageSet = false;
@@ -459,6 +444,38 @@ std::wstring ExpandPath(const std::wstring& source) {
     return result;
 }
 
+std::wstring MakeFileUri(const std::wstring& path) {
+    std::wstring result;
+    result.reserve(path.size() + 8);
+    result = L"file:///";
+
+    for (wchar_t c : path) {
+        switch (c) {
+            case L'\\':
+                result += L'/';
+                break;
+
+            case L' ':
+                result += L"%20";
+                break;
+
+            case L'#':
+                result += L"%23";
+                break;
+
+            case L'%':
+                result += L"%25";
+                break;
+
+            default:
+                result += c;
+                break;
+        }
+    }
+
+    return result;
+}
+
 ModSettings LoadSettings() {
     ModSettings settings;
 
@@ -536,17 +553,27 @@ ModSettings LoadSettings() {
     settings.respectSystemAnimations =
         Wh_GetIntSetting(L"animationBehavior.respectSystemAnimations") != 0;
 
+    settings.showImageLoadFailureWarnings =
+        Wh_GetIntSetting(L"showImageLoadFailureWarnings") != 0;
+
     return settings;
 }
 
-void StoreSettings(ModSettings settings) {
+uint64_t StoreSettings(ModSettings settings) {
     std::lock_guard<std::mutex> lock(g_settingsMutex);
 
     g_settings = std::move(settings);
+
+    return g_settingsGeneration.fetch_add(1, std::memory_order_relaxed) + 1;
 }
 
-ModSettings GetSettingsSnapshot() {
+ModSettings GetSettingsSnapshot(uint64_t* generation = nullptr) {
     std::lock_guard<std::mutex> lock(g_settingsMutex);
+
+    if (generation) {
+        *generation =
+            g_settingsGeneration.load(std::memory_order_relaxed);
+    }
 
     return g_settings;
 }
@@ -694,6 +721,191 @@ const wchar_t* IconStateName(IconState state) {
 
         default:
             return L"unknown";
+    }
+}
+
+constexpr wchar_t kImageFailureMessageTitle[] =
+    L"Start Button Replacer - Windhawk";
+
+const wchar_t* IconStateSettingName(IconState state) {
+    switch (state) {
+        case IconState::Normal:
+            return L"Image source";
+
+        case IconState::Hover:
+            return L"Hover image source";
+
+        case IconState::Pressed:
+            return L"Pressed image source";
+
+        case IconState::Activated:
+            return L"Activated image source";
+
+        default:
+            return L"Image source";
+    }
+}
+
+struct ImageFailureDetail {
+    IconState state = IconState::Normal;
+};
+
+std::wstring BuildImageFailureMessage(
+    const std::vector<ImageFailureDetail>& failures) {
+    if (failures.empty()) {
+        return L"";
+    }
+
+    bool mainImageFailed = failures.front().state == IconState::Normal;
+    bool multipleFailures = failures.size() > 1;
+
+    std::wstring message = multipleFailures
+                               ? L"The following images could not be loaded:\n\n"
+                               : L"The following image could not be loaded:\n\n";
+
+    for (size_t i = 0; i < failures.size(); i++) {
+        message += L"- ";
+        message += IconStateSettingName(failures[i].state);
+        message += L"\n";
+    }
+
+    if (mainImageFailed) {
+        message +=
+            L"\nNo custom Start icon is applied because Image source is "
+            L"required.";
+    } else if (multipleFailures) {
+        message +=
+            L"\nThe custom Start icon remains active, using available "
+            L"fallback images for the affected states.";
+    } else {
+        message +=
+            L"\nThe custom Start icon remains active, using an available "
+            L"fallback image for the affected state.";
+    }
+
+    message += L"\n\nCheck the image settings and Windhawk log for details.";
+
+    return message;
+}
+
+struct ImageFailureMessageParams {
+    std::wstring message;
+    uint64_t settingsGeneration = 0;
+    HMODULE pinnedModule = nullptr;
+};
+
+DWORD WINAPI ImageFailureMessageThreadProc(void* parameter) {
+    std::unique_ptr<ImageFailureMessageParams> params(
+        static_cast<ImageFailureMessageParams*>(parameter));
+
+    HMODULE pinnedModule = params->pinnedModule;
+
+    // Suppress a warning queued by old settings or just as controlled unload
+    // began. The module reference below still protects this worker if unload
+    // starts while an already visible message box is open.
+    if (!g_unloading &&
+        params->settingsGeneration ==
+            g_settingsGeneration.load(std::memory_order_relaxed)) {
+        MessageBoxW(nullptr, params->message.c_str(),
+                    kImageFailureMessageTitle,
+                    MB_OK | MB_ICONWARNING | MB_TOPMOST);
+    }
+
+    // Destroy all C++ objects while the mod is still mapped, then release the
+    // reference which keeps this worker's code valid during controlled unload.
+    params.reset();
+    FreeLibraryAndExitThread(pinnedModule, 0);
+}
+
+void ResetReportedImageFailures(uint64_t settingsGeneration) {
+    std::lock_guard<std::mutex> lock(g_imageFailureMessagesMutex);
+
+    g_imageFailureMessageGeneration = settingsGeneration;
+    g_imageFailureMessageQueued = false;
+}
+
+void ForgetReportedImageFailure(uint64_t settingsGeneration) {
+    std::lock_guard<std::mutex> lock(g_imageFailureMessagesMutex);
+
+    if (g_imageFailureMessageGeneration == settingsGeneration) {
+        g_imageFailureMessageQueued = false;
+    }
+}
+
+void ShowImageFailureMessage(uint64_t settingsGeneration,
+                             const std::vector<ImageFailureDetail>& failures)
+    noexcept {
+    if (!settingsGeneration || failures.empty() || g_unloading ||
+        settingsGeneration !=
+            g_settingsGeneration.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    bool messageMarkedAsQueued = false;
+
+    try {
+        {
+            std::lock_guard<std::mutex> lock(g_imageFailureMessagesMutex);
+
+            if (g_unloading ||
+                settingsGeneration !=
+                    g_settingsGeneration.load(std::memory_order_relaxed) ||
+                g_imageFailureMessageGeneration != settingsGeneration ||
+                g_imageFailureMessageQueued) {
+                return;
+            }
+
+            g_imageFailureMessageQueued = true;
+            messageMarkedAsQueued = true;
+        }
+
+        auto params = std::make_unique<ImageFailureMessageParams>();
+        params->message = BuildImageFailureMessage(failures);
+        params->settingsGeneration = settingsGeneration;
+
+        if (g_unloading ||
+            settingsGeneration !=
+                g_settingsGeneration.load(std::memory_order_relaxed)) {
+            ForgetReportedImageFailure(settingsGeneration);
+            return;
+        }
+
+        if (!GetModuleHandleExW(
+                GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+                reinterpret_cast<LPCWSTR>(&ImageFailureMessageThreadProc),
+                &params->pinnedModule)) {
+            Wh_Log(L"Pinning the mod for the image failure message failed: %u",
+                   GetLastError());
+            ForgetReportedImageFailure(settingsGeneration);
+            return;
+        }
+
+        auto rawParams = params.release();
+        HANDLE thread = CreateThread(nullptr, 0, ImageFailureMessageThreadProc,
+                                     rawParams, 0, nullptr);
+
+        if (!thread) {
+            DWORD error = GetLastError();
+            HMODULE pinnedModule = rawParams->pinnedModule;
+            params.reset(rawParams);
+            params.reset();
+            FreeLibrary(pinnedModule);
+            ForgetReportedImageFailure(settingsGeneration);
+            Wh_Log(L"Creating the image failure message thread failed: %u",
+                   error);
+            return;
+        }
+
+        CloseHandle(thread);
+    } catch (...) {
+        if (messageMarkedAsQueued) {
+            try {
+                ForgetReportedImageFailure(settingsGeneration);
+            } catch (...) {
+            }
+        }
+
+        Wh_Log(L"Preparing the image failure message failed");
     }
 }
 
@@ -909,11 +1121,42 @@ bool UpdateDisplayedImage(const std::shared_ptr<StartIconInstance>& instance) {
         }
     };
 
+    auto useStockIcon = [&]() {
+        for (size_t layerIndex = 0; layerIndex < 2; layerIndex++) {
+            auto layer = GetImageLayer(instance, layerIndex);
+
+            try {
+                layer.Source(wuxm::ImageSource{nullptr});
+            } catch (...) {
+            }
+
+            SetImageLayerOpacity(layer, 0.0f);
+        }
+
+        instance->activeImageSet = false;
+        instance->displayedState = IconState::Normal;
+        instance->displayedStateSet = true;
+
+        setStockOpacity(instance->originalStockOpacity);
+
+        return false;
+    };
+
     IconState desiredState = GetCurrentIconState(instance);
 
     size_t normalIndex = IconStateIndex(IconState::Normal);
 
-    size_t selectedIndex = normalIndex;
+    size_t normalResourceIndex =
+        instance->imageResourceIndexByState[normalIndex];
+
+    // The main image is required. Keep the stock icon visible until it has
+    // opened successfully, and never display optional state images if it fails.
+    if (!ImageResourceAvailable(
+            instance->imageResources[normalResourceIndex])) {
+        return useStockIcon();
+    }
+
+    size_t selectedIndex = normalResourceIndex;
     IconState selectedState = IconState::Normal;
 
     auto selectIfAvailable = [&](IconState state) {
@@ -955,24 +1198,7 @@ bool UpdateDisplayedImage(const std::shared_ptr<StartIconInstance>& instance) {
     }
 
     if (!ImageResourceAvailable(selectedResource)) {
-        for (size_t layerIndex = 0; layerIndex < 2; layerIndex++) {
-            auto layer = GetImageLayer(instance, layerIndex);
-
-            try {
-                layer.Source(wuxm::ImageSource{nullptr});
-            } catch (...) {
-            }
-
-            SetImageLayerOpacity(layer, 0.0f);
-        }
-
-        instance->activeImageSet = false;
-        instance->displayedState = IconState::Normal;
-        instance->displayedStateSet = true;
-
-        setStockOpacity(instance->originalStockOpacity);
-
-        return false;
+        return useStockIcon();
     }
 
     if (instance->activeImageSet &&
@@ -1396,8 +1622,76 @@ wuxc::Panel FindHostPanel(const wux::FrameworkElement& stockIcon,
 
 void DetachInstance(const std::shared_ptr<StartIconInstance>& instance);
 
+bool IsInstanceAttachedToCurrentVisualTree(
+    const std::shared_ptr<StartIconInstance>& instance) {
+    if (!instance || instance->detached) {
+        return false;
+    }
+
+    auto startButton = instance->startButton.get();
+    auto stockIcon = instance->stockIcon.get();
+    auto hostPanel = instance->hostPanel.get();
+    auto imageHost = instance->customImageHost.get();
+
+    if (!startButton || !stockIcon || !hostPanel || !imageHost) {
+        return false;
+    }
+
+    try {
+        // A control can keep the same object while ApplyTemplate replaces its
+        // template-generated visual subtree. Verify both our injected host and
+        // the stock icon still belong to this Start button before treating the
+        // instance as attached.
+        auto imageHostParent = wuxm::VisualTreeHelper::GetParent(imageHost);
+
+        if (!imageHostParent || imageHostParent != hostPanel) {
+            return false;
+        }
+
+        bool foundStartButton = false;
+        wux::DependencyObject current = hostPanel;
+
+        while (current) {
+            if (current == startButton) {
+                foundStartButton = true;
+                break;
+            }
+
+            current = wuxm::VisualTreeHelper::GetParent(current);
+        }
+
+        if (!foundStartButton) {
+            return false;
+        }
+
+        // The stock icon is normally below the host panel, not above it. Check
+        // its ancestry separately to ensure it belongs to the same live
+        // template subtree.
+        bool foundHostPanel = false;
+        current = stockIcon;
+
+        while (current) {
+            if (current == hostPanel) {
+                foundHostPanel = true;
+            }
+
+            if (current == startButton) {
+                return foundHostPanel;
+            }
+
+            current = wuxm::VisualTreeHelper::GetParent(current);
+        }
+    } catch (...) {
+        // XAML access can fail while a template is being torn down. In that
+        // case, retire the old instance and let the caller attach a fresh one.
+    }
+
+    return false;
+}
+
 void PruneDeadInstancesForCurrentThread() {
     DWORD threadId = GetCurrentThreadId();
+    std::vector<std::shared_ptr<StartIconInstance>> threadInstances;
     std::vector<std::shared_ptr<StartIconInstance>> deadInstances;
 
     {
@@ -1407,26 +1701,37 @@ void PruneDeadInstancesForCurrentThread() {
             return;
         }
 
-        for (auto it = g_instances->begin(); it != g_instances->end();) {
-            auto instance = *it;
+        std::erase(*g_instances, nullptr);
 
-            if (!instance) {
-                it = g_instances->erase(it);
-                continue;
+        for (const auto& instance : *g_instances) {
+            if (instance->threadId == threadId) {
+                threadInstances.push_back(instance);
             }
+        }
+    }
 
-            if (instance->threadId == threadId &&
-                !instance->startButton.get()) {
-                deadInstances.push_back(instance);
-                it = g_instances->erase(it);
-                continue;
-            }
+    // Inspect XAML only on the instance's owning UI thread and without holding
+    // the global instance mutex.
+    for (const auto& instance : threadInstances) {
+        if (!IsInstanceAttachedToCurrentVisualTree(instance)) {
+            deadInstances.push_back(instance);
+        }
+    }
 
-            ++it;
+    if (!deadInstances.empty()) {
+        std::lock_guard<std::mutex> lock(g_instancesMutex);
+
+        if (g_instances) {
+            std::erase_if(*g_instances, [&](const auto& instance) {
+                return std::find(deadInstances.begin(), deadInstances.end(),
+                                 instance) != deadInstances.end();
+            });
         }
     }
 
     for (const auto& instance : deadInstances) {
+        Wh_Log(L"Start button template changed; replacing the stale custom "
+               L"image host");
         DetachInstance(instance);
     }
 }
@@ -1837,6 +2142,74 @@ std::vector<DWORD> GetTrackedInstanceThreadIds() {
 // Bitmap/image loading
 // -----------------------------------------------------------------------------
 
+void MaybeShowImageFailureMessageImpl(
+    const std::shared_ptr<StartIconInstance>& instance) {
+    if (!instance || instance->detached || g_unloading ||
+        !instance->imageLoadingSetupComplete ||
+        !instance->settings.showImageLoadFailureWarnings) {
+        return;
+    }
+
+    size_t normalIndex = IconStateIndex(IconState::Normal);
+    size_t normalResourceIndex =
+        instance->imageResourceIndexByState[normalIndex];
+    const auto& normalResource =
+        instance->imageResources[normalResourceIndex];
+
+    // A failed main image decides the result for every state, so report only
+    // that required setting without waiting for optional images.
+    if (normalResource.reportableFailure) {
+        ShowImageFailureMessage(instance->settingsGeneration,
+                                {{IconState::Normal}});
+        return;
+    }
+
+    // Optional failures only matter after the required main image succeeds.
+    if (!ImageResourceAvailable(normalResource)) {
+        return;
+    }
+
+    std::vector<ImageFailureDetail> failures;
+
+    for (size_t stateIndex = 1; stateIndex < kIconStateCount; stateIndex++) {
+        IconState state = static_cast<IconState>(stateIndex);
+        std::wstring source = GetImageSourceForState(instance->settings, state);
+
+        if (source.empty()) {
+            continue;
+        }
+
+        size_t resourceIndex =
+            instance->imageResourceIndexByState[stateIndex];
+        const auto& resource = instance->imageResources[resourceIndex];
+
+        // Wait for every configured optional resource to reach a terminal
+        // state so one dialog can list all unavailable settings.
+        if (!resource.opened && !resource.failed) {
+            return;
+        }
+
+        if (resource.reportableFailure) {
+            failures.push_back({state});
+        }
+    }
+
+    if (!failures.empty()) {
+        ShowImageFailureMessage(instance->settingsGeneration, failures);
+    }
+}
+
+void MaybeShowImageFailureMessage(
+    const std::shared_ptr<StartIconInstance>& instance) noexcept {
+    try {
+        MaybeShowImageFailureMessageImpl(instance);
+    } catch (...) {
+        // Never allow allocation or string-formatting failures to escape a
+        // XAML ImageOpened/ImageFailed callback into Explorer.
+        Wh_Log(L"Preparing the image failure summary failed");
+    }
+}
+
 bool LoadImageResource(const std::shared_ptr<StartIconInstance>& instance,
                        IconState state,
                        const std::wstring& source) {
@@ -1847,6 +2220,7 @@ bool LoadImageResource(const std::shared_ptr<StartIconInstance>& instance,
     size_t stateIndex = IconStateIndex(state);
 
     auto& resource = instance->imageResources[stateIndex];
+    bool sourceUriConstructionInProgress = false;
 
     try {
         wuxmi::BitmapImage bitmap;
@@ -1858,6 +2232,7 @@ bool LoadImageResource(const std::shared_ptr<StartIconInstance>& instance,
         resource.bitmap = bitmap;
         resource.opened = false;
         resource.failed = false;
+        resource.reportableFailure = false;
 
         std::weak_ptr<StartIconInstance> weakInstance = instance;
 
@@ -1866,7 +2241,7 @@ bool LoadImageResource(const std::shared_ptr<StartIconInstance>& instance,
                                        const wux::RoutedEventArgs&) {
                 auto instance = weakInstance.lock();
 
-                if (!instance) {
+                if (!instance || instance->detached || g_unloading) {
                     return;
                 }
 
@@ -1874,6 +2249,7 @@ bool LoadImageResource(const std::shared_ptr<StartIconInstance>& instance,
 
                 resource.opened = true;
                 resource.failed = false;
+                resource.reportableFailure = false;
 
                 auto state = static_cast<IconState>(stateIndex);
 
@@ -1882,17 +2258,19 @@ bool LoadImageResource(const std::shared_ptr<StartIconInstance>& instance,
                 // Apply both the image and the current transform. The pointer
                 // might already be hovering or pressed when decoding finishes.
                 ApplyCurrentState(instance, 0);
+                MaybeShowImageFailureMessage(instance);
             });
 
         resource.imageOpenedAttached = true;
 
-        resource.imageFailedToken =
-            bitmap.ImageFailed([weakInstance, stateIndex](
+        resource.imageFailedToken = bitmap.ImageFailed(
+            [weakInstance, stateIndex,
+             configuredSource = std::wstring(source)](
                                    const wf::IInspectable&,
                                    const wux::ExceptionRoutedEventArgs& args) {
                 auto instance = weakInstance.lock();
 
-                if (!instance) {
+                if (!instance || instance->detached || g_unloading) {
                     return;
                 }
 
@@ -1900,31 +2278,60 @@ bool LoadImageResource(const std::shared_ptr<StartIconInstance>& instance,
 
                 resource.opened = false;
                 resource.failed = true;
+                resource.reportableFailure = true;
 
                 auto state = static_cast<IconState>(stateIndex);
 
-                Wh_Log(L"Custom Start %s image failed: %s",
-                       IconStateName(state), args.ErrorMessage().c_str());
+                Wh_Log(L"Custom Start %s image failed: %s; source: %s",
+                       IconStateName(state), args.ErrorMessage().c_str(),
+                       configuredSource.c_str());
+
+                if (state == IconState::Normal) {
+                    Wh_Log(L"The main image is unavailable; keeping the stock "
+                           L"Start icon and ignoring optional state images");
+                }
 
                 UpdateDisplayedImage(instance);
                 UpdateGifPlayback(instance);
+                MaybeShowImageFailureMessage(instance);
             });
 
         resource.imageFailedAttached = true;
 
-        // Preserve URLs exactly, including percent-encoded content. Environment
-        // variable expansion applies only to local file paths.
-        std::wstring resolvedSource =
-            IsHttpUrl(source) ? source : ExpandPath(source);
+        // Preserve URLs exactly, including percent-encoded content. Local paths
+        // need environment expansion followed by conversion to an escaped file
+        // URI so characters such as '#' and '%' remain part of the filename.
+        std::wstring resolvedSource;
+
+        if (IsHttpUrl(source)) {
+            resolvedSource = source;
+        } else {
+            std::wstring expandedPath = ExpandPath(source);
+
+            if (expandedPath.empty()) {
+                resource.failed = true;
+                resource.reportableFailure = true;
+                Wh_Log(L"Custom Start %s image path couldn't be expanded: %s",
+                       IconStateName(state), source.c_str());
+                return false;
+            }
+
+            resolvedSource = MakeFileUri(expandedPath);
+        }
 
         if (resolvedSource.empty()) {
             resource.failed = true;
+            resource.reportableFailure = true;
+            Wh_Log(L"Custom Start %s image URI couldn't be created: %s",
+                   IconStateName(state), source.c_str());
             return false;
         }
 
         // UriSource lets XAML retrieve and decode the image asynchronously.
         // ImageOpened and ImageFailed above report completion.
+        sourceUriConstructionInProgress = true;
         bitmap.UriSource(wf::Uri(resolvedSource));
+        sourceUriConstructionInProgress = false;
 
         auto imageHost = instance->customImageHost.get();
 
@@ -1953,13 +2360,22 @@ bool LoadImageResource(const std::shared_ptr<StartIconInstance>& instance,
     } catch (const winrt::hresult_error& e) {
         resource.failed = true;
 
-        Wh_Log(L"Loading %s image failed: 0x%08X %s", IconStateName(state),
-               e.code().value, e.message().c_str());
+        Wh_Log(L"Loading %s image failed: 0x%08X %s; source: %s",
+               IconStateName(state), e.code().value, e.message().c_str(),
+               source.c_str());
+
+        if (sourceUriConstructionInProgress) {
+            resource.reportableFailure = true;
+        }
     } catch (...) {
         resource.failed = true;
 
-        Wh_Log(L"Loading %s image failed with unknown exception",
-               IconStateName(state));
+        Wh_Log(L"Loading %s image failed with unknown exception; source: %s",
+               IconStateName(state), source.c_str());
+
+        if (sourceUriConstructionInProgress) {
+            resource.reportableFailure = true;
+        }
     }
 
     return false;
@@ -1969,6 +2385,8 @@ bool LoadImages(const std::shared_ptr<StartIconInstance>& instance) {
     if (!instance) {
         return false;
     }
+
+    instance->imageLoadingSetupComplete = false;
 
     std::array<std::wstring, kIconStateCount> sources;
 
@@ -1981,6 +2399,8 @@ bool LoadImages(const std::shared_ptr<StartIconInstance>& instance) {
 
     if (!LoadImageResource(instance, IconState::Normal,
                            sources[IconStateIndex(IconState::Normal)])) {
+        instance->imageLoadingSetupComplete = true;
+        MaybeShowImageFailureMessage(instance);
         return false;
     }
 
@@ -2020,6 +2440,9 @@ bool LoadImages(const std::shared_ptr<StartIconInstance>& instance) {
                    IconStateName(state));
         }
     }
+
+    instance->imageLoadingSetupComplete = true;
+    MaybeShowImageFailureMessage(instance);
 
     return true;
 }
@@ -2278,7 +2701,8 @@ bool AttachToStartButton(const wux::FrameworkElement& startButton) {
         return false;
     }
 
-    ModSettings settings = GetSettingsSnapshot();
+    uint64_t settingsGeneration = 0;
+    ModSettings settings = GetSettingsSnapshot(&settingsGeneration);
 
     if (IsBlank(GetImageSourceForState(settings, IconState::Normal))) {
         // An earlier build or an interrupted hot reload might have left the
@@ -2337,6 +2761,7 @@ bool AttachToStartButton(const wux::FrameworkElement& startButton) {
         instance->threadId = GetCurrentThreadId();
 
         instance->settings = std::move(settings);
+        instance->settingsGeneration = settingsGeneration;
 
         instance->startButton = winrt::make_weak(startButton);
 
@@ -3179,7 +3604,8 @@ BOOL Wh_ModInit() {
 
     g_unloading = false;
 
-    StoreSettings(LoadSettings());
+    uint64_t settingsGeneration = StoreSettings(LoadSettings());
+    ResetReportedImageFailures(settingsGeneration);
 
     if (IsBlank(GetSettingsSnapshot().imageSource)) {
         Wh_Log(L"No image source is configured; leaving the stock Start icon "
@@ -3269,7 +3695,8 @@ void Wh_ModUninit() {
 void Wh_ModSettingsChanged() {
     Wh_Log(L"Start Button Replacer settings changed");
 
-    StoreSettings(LoadSettings());
+    uint64_t settingsGeneration = StoreSettings(LoadSettings());
+    ResetReportedImageFailures(settingsGeneration);
 
     RunOnAllTaskbarThreads(RebuildAllTaskbarsProc, nullptr);
 }

--- a/mods/start-button-replacer.wh.cpp
+++ b/mods/start-button-replacer.wh.cpp
@@ -96,7 +96,7 @@ at the same path, reload the mod if the previous image remains visible.
 // ==WindhawkModSettings==
 /*
 - images:
-  - imageSource: "https://raw.githubusercontent.com/EnderDragonEP/asset/main/windhawk-mods/start-button-replacer/gecko/normal-hover.gif"
+  - imageSource: "https://raw.githubusercontent.com/EnderDragonEP/asset/be76faf00be2a45cb166a4971e67eb32afd4b1fb/windhawk-mods/start-button-replacer/gecko/normal-hover.gif"
     $name: Image source (necessary)
     $description: >-
       Absolute file path, path containing environment variables, or HTTP/HTTPS
@@ -107,12 +107,12 @@ at the same path, reload the mod if the previous image remains visible.
     $description: >-
       Image shown while the pointer is over the Start button. Leave blank to use
       the normal image.
-  - pressedImageSource: "https://raw.githubusercontent.com/EnderDragonEP/asset/main/windhawk-mods/start-button-replacer/gecko/pressed.png"
+  - pressedImageSource: "https://raw.githubusercontent.com/EnderDragonEP/asset/be76faf00be2a45cb166a4971e67eb32afd4b1fb/windhawk-mods/start-button-replacer/gecko/pressed.png"
     $name: Pressed image source
     $description: >-
       Image shown while the Start button is pressed. Leave blank to use the
       normal image.
-  - activatedImageSource: "https://raw.githubusercontent.com/EnderDragonEP/asset/main/windhawk-mods/start-button-replacer/gecko/activated.png"
+  - activatedImageSource: "https://raw.githubusercontent.com/EnderDragonEP/asset/be76faf00be2a45cb166a4971e67eb32afd4b1fb/windhawk-mods/start-button-replacer/gecko/activated.png"
     $name: Activated image source
     $description: >-
       Image shown while the Start menu is open. If blank or unavailable, the


### PR DESCRIPTION
# Start Button Replacer

Replaces the icon inside the Windows 11 Start button with a custom PNG, JPG or
GIF image. Animated GIF playback and hover/pressed effects are optional
features.

![preview](https://raw.githubusercontent.com/EnderDragonEP/asset/main/windhawk-mods/start-button-replacer/preview-1.gif)

Only the icon is replaced. Windows continues to handle clicking, keyboard
navigation, accessibility and Start menu activation.

## Image sources

Local files:

    C:\Users\YourName\Pictures\start.png

Environment variables are supported:

    %USERPROFILE%\Pictures\start.jpg

HTTP/HTTPS URLs are also supported:

    https://example.com/start.gif

## Animated GIF playback

- Always
- Hover
- Pressed
- Stopped

## Effects

Separate scale, rotation and opacity settings are available for hover and
pressed states.

## Separate state images

The main **Image source** is always the normal image. Add a hover, pressed or
activated image source to enable that state automatically. The activated image
is shown while the Start menu is open. If it is blank or unavailable, activated
falls back to the pressed image, then the hover image, then the main image.
Other blank or unavailable state images fall back to the main image.

While the Start menu is shown, pressing the button temporarily uses the pressed
state. The activated state resumes on release and otherwise takes priority over
the hover state.

State images crossfade whenever their applicable duration is greater than zero.
Hover transitions use the hover duration; pressed and activated transitions use
the pressed duration. Set a duration to `0` to switch instantly.

## Notes

For crisp results, use a square image with transparency. Keep animated GIFs
reasonably small, such as 64x64 or 128x128. The displayed size is independent
from the source image resolution. XAML loads and decodes image sources
asynchronously. XAML also caches images by source URI, so after replacing a file
at the same path, reload the mod if the previous image remains visible.

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Not applicable. This pull request introduces a new mod.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [x] Another AI (please specify): OpenAI Codex
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.