### PR TITLE
add prevent-virtual-desktop-stealing.wh.cpp

### DIFF
--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -1,0 +1,1887 @@
+// ==WindhawkMod==
+// @id              prevent-virtual-desktop-stealing
+// @name            Prevent Window Activation from Stealing Virtual Desktop
+// @description     Redirect cross-desktop window activation to the current desktop.
+// @version         0.3.3
+// @author          meteoni
+// @include         explorer.exe
+// @compilerOptions -lole32
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Prevent Window Activation from Stealing Virtual Desktop
+
+Take back control over your virtual desktops!
+
+![Screenshot](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/prevent-virtual-desktop-stealing/prevent-virtual-desktop-stealing.gif)
+_Effect of redirecting window activation_
+
+Windows can switch you to another virtual desktop just because a window that was left open on that
+desktop is activated. 
+
+Clicking a flashing taskbar button, following a notification, opening an app through its tray icon, 
+or launching something that insists on reusing an existing window can all unexpectedly pull you away 
+from your current desktop. This mod keeps you where you are and brings the activated window to you instead.
+
+If you don't know what "virtual desktop stealing" is, try this small experiment:
+
+- Open Windhawk on your first virtual desktop.
+- Switch to another virtual desktop.
+- Click the Windhawk tray icon.
+
+Normally, Windows jumps back to the first desktop - not anymore with this mod.
+
+Intentional desktop navigation is left alone, including Win+Ctrl+Left/Right and
+Task View. The mod also remains compatible with **Disable Virtual Desktop
+Transition Animation**.
+
+### Notes
+
+Designed for Windows 11 24H2 and newer. This mod relies on undocumented Windows
+shell interfaces, so future Windows updates may require adjustments.
+*/
+// ==/WindhawkModReadme==
+
+#include <windows.h>
+#include <objbase.h>
+#include <servprov.h>
+#include <windhawk_api.h>
+#include <windhawk_utils.h>
+
+#include <atomic>
+#include <cstdint>
+
+// -----------------------------------------------------------------------------
+// Explicit COM IDs.
+// Keep these literal so the Windhawk Clang/MinGW toolchain doesn't need
+// __declspec(uuid), __uuidof, IID_PPV_ARGS, or uuid.lib.
+// -----------------------------------------------------------------------------
+
+static const CLSID kClsidImmersiveShell = {
+    0xC2F03A33, 0x21F5, 0x47FA,
+    {0xB4, 0xBB, 0x15, 0x63, 0x62, 0xA2, 0xF2, 0x39}
+};
+
+static const CLSID kClsidVirtualDesktopManagerInternal = {
+    0xC5E0CDCA, 0x7B6E, 0x41B2,
+    {0x9F, 0xC4, 0xD9, 0x39, 0x75, 0xCC, 0x46, 0x7B}
+};
+
+static const CLSID kClsidVirtualDesktopManager = {
+    0xAA509086, 0x5CA9, 0x4C25,
+    {0x8F, 0x95, 0x58, 0x9D, 0x3C, 0x07, 0xB4, 0x8A}
+};
+
+static const IID kIidIServiceProvider = {
+    0x6D5140C1, 0x7436, 0x11CE,
+    {0x80, 0x34, 0x00, 0xAA, 0x00, 0x60, 0x09, 0xFA}
+};
+
+static const IID kIidIUnknown = {
+    0x00000000, 0x0000, 0x0000,
+    {0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46}
+};
+
+static const GUID kServiceVirtualDesktopNotification = {
+    0xA501FDEC, 0x4A09, 0x464C,
+    {0xAE, 0x4E, 0x1B, 0x9C, 0x21, 0xB8, 0x49, 0x18}
+};
+
+static const IID kIidVirtualDesktopNotification = {
+    0xB9E5E94D, 0x233E, 0x49AB,
+    {0xAF, 0x5C, 0x2B, 0x45, 0x41, 0xC3, 0xAA, 0xDE}
+};
+
+static const IID kIidVirtualDesktopNotificationService = {
+    0x0CD45E71, 0xD927, 0x4F15,
+    {0x8B, 0x0A, 0x8F, 0xEF, 0x52, 0x53, 0x37, 0xBF}
+};
+
+// Windows 11 24H2+ IVirtualDesktopManagerInternal / Internal2 IID.
+static const IID kIidVirtualDesktopManagerInternal = {
+    0x53F5CA0B, 0x158F, 0x4124,
+    {0x90, 0x0C, 0x05, 0x71, 0x58, 0x06, 0x0B, 0x27}
+};
+
+static const IID kIidApplicationViewCollection = {
+    0x1841C6D7, 0x4F9D, 0x42C0,
+    {0xAF, 0x41, 0x87, 0x47, 0x53, 0x8F, 0x10, 0xE5}
+};
+
+static const IID kIidVirtualDesktopManager = {
+    0xA5CD92FF, 0x29BE, 0x454C,
+    {0x8D, 0x04, 0xD8, 0x28, 0x79, 0xFB, 0x3F, 0x1B}
+};
+
+// -----------------------------------------------------------------------------
+// Minimal undocumented/public interface declarations.
+// -----------------------------------------------------------------------------
+
+struct IVirtualDesktop : IUnknown {
+    virtual HRESULT STDMETHODCALLTYPE IsViewVisible(
+        IUnknown* view,
+        BOOL* visible) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE GetId(
+        GUID* desktopId) = 0;
+};
+
+struct IApplicationView : IUnknown {};
+
+struct IApplicationViewCollection : IUnknown {
+    virtual HRESULT STDMETHODCALLTYPE GetViews(
+        IUnknown** objectArray) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE GetViewsByZOrder(
+        IUnknown** objectArray) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE GetViewsByAppUserModelId(
+        LPCWSTR appUserModelId,
+        IUnknown** objectArray) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE GetViewForHwnd(
+        HWND hwnd,
+        IApplicationView** view) = 0;
+};
+
+struct IVirtualDesktopManagerInternal : IUnknown {};
+
+struct IVirtualDesktopManagerPublic : IUnknown {
+    virtual HRESULT STDMETHODCALLTYPE IsWindowOnCurrentVirtualDesktop(
+        HWND topLevelWindow,
+        BOOL* onCurrentDesktop) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE GetWindowDesktopId(
+        HWND topLevelWindow,
+        GUID* desktopId) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE MoveWindowToDesktop(
+        HWND topLevelWindow,
+        REFGUID desktopId) = 0;
+};
+
+struct IVirtualDesktopNotification : IUnknown {
+    virtual HRESULT STDMETHODCALLTYPE VirtualDesktopCreated(
+        IVirtualDesktop* desktop) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE VirtualDesktopDestroyBegin(
+        IVirtualDesktop* desktopDestroyed,
+        IVirtualDesktop* desktopFallback) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE VirtualDesktopDestroyFailed(
+        IVirtualDesktop* desktopDestroyed,
+        IVirtualDesktop* desktopFallback) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE VirtualDesktopDestroyed(
+        IVirtualDesktop* desktopDestroyed,
+        IVirtualDesktop* desktopFallback) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE VirtualDesktopMoved(
+        IVirtualDesktop* desktop,
+        INT64 oldIndex,
+        INT64 newIndex) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE VirtualDesktopNameChanged(
+        IVirtualDesktop* desktop,
+        void* name) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE ViewVirtualDesktopChanged(
+        IUnknown* view) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE CurrentVirtualDesktopChanged(
+        IVirtualDesktop* desktopOld,
+        IVirtualDesktop* desktopNew) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE VirtualDesktopWallpaperChanged(
+        IVirtualDesktop* desktop,
+        void* wallpaper) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE VirtualDesktopSwitched(
+        IVirtualDesktop* desktop) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE RemoteVirtualDesktopConnected(
+        IVirtualDesktop* desktop) = 0;
+};
+
+struct IVirtualDesktopNotificationService : IUnknown {
+    virtual HRESULT STDMETHODCALLTYPE Register(
+        IVirtualDesktopNotification* notification,
+        DWORD* cookie) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE Unregister(
+        DWORD cookie) = 0;
+};
+
+// -----------------------------------------------------------------------------
+// Helpers.
+// -----------------------------------------------------------------------------
+
+template <typename T>
+static T GetVTableFunction(void* object, int index) {
+    return reinterpret_cast<T>(
+        (*reinterpret_cast<void***>(object))[index]);
+}
+
+static bool GuidEqual(const GUID& a, const GUID& b) {
+    return IsEqualGUID(a, b) != FALSE;
+}
+
+static void GuidToString(const GUID& guid, wchar_t* buffer, int bufferCount) {
+    if (!buffer || bufferCount <= 0) {
+        return;
+    }
+
+    if (!StringFromGUID2(guid, buffer, bufferCount)) {
+        buffer[0] = L'\0';
+    }
+}
+
+static SRWLOCK g_currentDesktopLock = SRWLOCK_INIT;
+static GUID g_currentDesktopId = {};
+static bool g_currentDesktopValid = false;
+
+static void StoreCurrentDesktopId(const GUID& id) {
+    AcquireSRWLockExclusive(&g_currentDesktopLock);
+    g_currentDesktopId = id;
+    g_currentDesktopValid = true;
+    ReleaseSRWLockExclusive(&g_currentDesktopLock);
+}
+
+static void ClearCurrentDesktopId() {
+    AcquireSRWLockExclusive(&g_currentDesktopLock);
+    g_currentDesktopId = {};
+    g_currentDesktopValid = false;
+    ReleaseSRWLockExclusive(&g_currentDesktopLock);
+}
+
+static bool LoadCurrentDesktopId(GUID* id) {
+    if (!id) {
+        return false;
+    }
+
+    AcquireSRWLockShared(&g_currentDesktopLock);
+    bool valid = g_currentDesktopValid;
+    if (valid) {
+        *id = g_currentDesktopId;
+    }
+    ReleaseSRWLockShared(&g_currentDesktopLock);
+
+    return valid;
+}
+
+static bool IsRescueCandidate(HWND hwnd) {
+    if (!hwnd || !IsWindow(hwnd)) {
+        return false;
+    }
+
+    LONG_PTR style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+    LONG_PTR exStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+
+    if (!(style & WS_VISIBLE) || (style & WS_CHILD)) {
+        return false;
+    }
+
+    if (exStyle & WS_EX_TOOLWINDOW) {
+        return false;
+    }
+
+    // Same basic top-level-window filter used by Virtual Desktop Helper.
+    if (GetAncestor(hwnd, GA_ROOTOWNER) != hwnd) {
+        return false;
+    }
+
+    return true;
+}
+
+static void LogWindow(const wchar_t* label, HWND hwnd) {
+    if (!hwnd) {
+        Wh_Log(L"[VDREDIRECT] %s hwnd=null", label);
+        return;
+    }
+
+    DWORD pid = 0;
+    DWORD tid = GetWindowThreadProcessId(hwnd, &pid);
+
+    wchar_t cls[256] = {};
+    wchar_t title[512] = {};
+    GetClassNameW(hwnd, cls, ARRAYSIZE(cls));
+    GetWindowTextW(hwnd, title, ARRAYSIZE(title));
+
+    Wh_Log(
+        L"[VDREDIRECT] %s hwnd=%p pid=%lu tid=%lu class=%s "
+        L"zoomed=%d iconic=%d title=\"%s\"",
+        label,
+        hwnd,
+        pid,
+        tid,
+        cls[0] ? cls : L"?",
+        IsZoomed(hwnd),
+        IsIconic(hwnd),
+        title);
+}
+
+// -----------------------------------------------------------------------------
+// Explicit user-switch attribution.
+// -----------------------------------------------------------------------------
+
+// Disable Virtual Desktop Transition Animation causes the native
+// Win+Ctrl+Left/Right path to call SwitchDesktopInternal synchronously.
+// The probe confirmed that the call occurs while _CycleInDirection is still
+// active, so a thread-local nesting depth is sufficient; no timing grace
+// period or physical-key heuristic is used.
+static thread_local int g_hotkeyCycleDepth = 0;
+
+static bool IsExplicitHotkeySwitchContext() {
+    return g_hotkeyCycleDepth > 0;
+}
+
+// -----------------------------------------------------------------------------
+// Symbol-resolved shell functions.
+// -----------------------------------------------------------------------------
+
+using SwitchDesktopInternal_t =
+    HRESULT (*)(void* pThis, IVirtualDesktop* desktop);
+
+static SwitchDesktopInternal_t g_switchDesktopInternalOriginal = nullptr;
+
+using CycleInDirection_t =
+    HRESULT (*)(void* pThis, int direction);
+
+static CycleInDirection_t g_cycleInDirectionOriginal = nullptr;
+
+static HRESULT CycleInDirection_Hook(
+    void* pThis,
+    int direction) {
+
+    ++g_hotkeyCycleDepth;
+
+    Wh_Log(
+        L"[VDREDIRECT] HOTKEY-CYCLE begin direction=%d depth=%d",
+        direction,
+        g_hotkeyCycleDepth);
+
+    HRESULT hr =
+        g_cycleInDirectionOriginal(pThis, direction);
+
+    Wh_Log(
+        L"[VDREDIRECT] HOTKEY-CYCLE end direction=%d hr=0x%08X depth=%d",
+        direction,
+        static_cast<unsigned int>(hr),
+        g_hotkeyCycleDepth);
+
+    --g_hotkeyCycleDepth;
+    return hr;
+}
+
+// -----------------------------------------------------------------------------
+// Current-desktop cache via the private VD notification service.
+// -----------------------------------------------------------------------------
+
+static HANDLE g_notificationThread = nullptr;
+static DWORD g_notificationThreadId = 0;
+static HANDLE g_notificationReadyEvent = nullptr;
+static std::atomic<bool> g_notificationReady = false;
+
+class VirtualDesktopNotificationListener final
+    : public IVirtualDesktopNotification {
+public:
+    HRESULT STDMETHODCALLTYPE QueryInterface(
+        REFIID riid,
+        void** object) override {
+
+        if (!object) {
+            return E_POINTER;
+        }
+
+        *object = nullptr;
+
+        if (IsEqualIID(riid, kIidIUnknown) ||
+            IsEqualIID(riid, kIidVirtualDesktopNotification)) {
+            *object = static_cast<IVirtualDesktopNotification*>(this);
+            AddRef();
+            return S_OK;
+        }
+
+        return E_NOINTERFACE;
+    }
+
+    ULONG STDMETHODCALLTYPE AddRef() override {
+        return ++m_refCount;
+    }
+
+    ULONG STDMETHODCALLTYPE Release() override {
+        ULONG value = --m_refCount;
+        if (!value) {
+            delete this;
+        }
+        return value;
+    }
+
+    HRESULT STDMETHODCALLTYPE VirtualDesktopCreated(
+        IVirtualDesktop*) override {
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE VirtualDesktopDestroyBegin(
+        IVirtualDesktop*,
+        IVirtualDesktop*) override {
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE VirtualDesktopDestroyFailed(
+        IVirtualDesktop*,
+        IVirtualDesktop*) override {
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE VirtualDesktopDestroyed(
+        IVirtualDesktop*,
+        IVirtualDesktop*) override {
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE VirtualDesktopMoved(
+        IVirtualDesktop*,
+        INT64,
+        INT64) override {
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE VirtualDesktopNameChanged(
+        IVirtualDesktop*,
+        void*) override {
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE ViewVirtualDesktopChanged(
+        IUnknown*) override {
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE CurrentVirtualDesktopChanged(
+        IVirtualDesktop* desktopOld,
+        IVirtualDesktop* desktopNew) override {
+
+        GUID oldId = {};
+        GUID newId = {};
+
+        HRESULT oldHr = desktopOld ? desktopOld->GetId(&oldId) : E_POINTER;
+        HRESULT newHr = desktopNew ? desktopNew->GetId(&newId) : E_POINTER;
+
+        if (SUCCEEDED(newHr)) {
+            StoreCurrentDesktopId(newId);
+
+            wchar_t oldText[64] = {};
+            wchar_t newText[64] = {};
+            if (SUCCEEDED(oldHr)) {
+                GuidToString(oldId, oldText, ARRAYSIZE(oldText));
+            }
+            GuidToString(newId, newText, ARRAYSIZE(newText));
+
+            Wh_Log(
+                L"[VDREDIRECT] Current desktop cache updated old=%s new=%s",
+                SUCCEEDED(oldHr) ? oldText : L"<unknown>",
+                newText);
+        } else {
+            ClearCurrentDesktopId();
+            Wh_Log(
+                L"[VDREDIRECT] Current desktop cache invalidated: "
+                L"desktopNew->GetId failed hr=0x%08X",
+                static_cast<unsigned int>(newHr));
+        }
+
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE VirtualDesktopWallpaperChanged(
+        IVirtualDesktop*,
+        void*) override {
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE VirtualDesktopSwitched(
+        IVirtualDesktop*) override {
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE RemoteVirtualDesktopConnected(
+        IVirtualDesktop*) override {
+        return S_OK;
+    }
+
+private:
+    std::atomic<ULONG> m_refCount{1};
+};
+
+static DWORD WINAPI NotificationThreadProc(void*) {
+    HRESULT coHr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+    const bool shouldUninitialize = SUCCEEDED(coHr);
+
+    if (FAILED(coHr) && coHr != RPC_E_CHANGED_MODE) {
+        Wh_Log(
+            L"[VDREDIRECT] Notification CoInitializeEx failed hr=0x%08X",
+            static_cast<unsigned int>(coHr));
+        SetEvent(g_notificationReadyEvent);
+        return 0;
+    }
+
+    // Ensure this STA owns a message queue before registration.
+    MSG msg = {};
+    PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+
+    IServiceProvider* serviceProvider = nullptr;
+    IVirtualDesktopManagerInternal* managerInternal = nullptr;
+    IVirtualDesktopNotificationService* notificationService = nullptr;
+    VirtualDesktopNotificationListener* listener = nullptr;
+    DWORD cookie = 0;
+
+    HRESULT hr = CoCreateInstance(
+        kClsidImmersiveShell,
+        nullptr,
+        CLSCTX_LOCAL_SERVER,
+        kIidIServiceProvider,
+        reinterpret_cast<void**>(&serviceProvider));
+
+    if (SUCCEEDED(hr) && serviceProvider) {
+        hr = serviceProvider->QueryService(
+            kClsidVirtualDesktopManagerInternal,
+            kIidVirtualDesktopManagerInternal,
+            reinterpret_cast<void**>(&managerInternal));
+    }
+
+    if (SUCCEEDED(hr) && managerInternal) {
+        auto getCurrentDesktop = GetVTableFunction<
+            HRESULT(STDMETHODCALLTYPE*)(
+                void*,
+                IVirtualDesktop**)>(
+            managerInternal,
+            6);
+
+        IVirtualDesktop* currentDesktop = nullptr;
+        HRESULT currentHr =
+            getCurrentDesktop(managerInternal, &currentDesktop);
+
+        if (SUCCEEDED(currentHr) && currentDesktop) {
+            GUID id = {};
+            if (SUCCEEDED(currentDesktop->GetId(&id))) {
+                StoreCurrentDesktopId(id);
+            }
+            currentDesktop->Release();
+        }
+    }
+
+    if (SUCCEEDED(hr) && serviceProvider) {
+        hr = serviceProvider->QueryService(
+            kServiceVirtualDesktopNotification,
+            kIidVirtualDesktopNotificationService,
+            reinterpret_cast<void**>(&notificationService));
+    }
+
+    if (SUCCEEDED(hr) && notificationService) {
+        listener = new VirtualDesktopNotificationListener();
+        hr = notificationService->Register(listener, &cookie);
+    }
+
+    if (SUCCEEDED(hr) && cookie) {
+        GUID currentId = {};
+        if (LoadCurrentDesktopId(&currentId)) {
+            g_notificationReady.store(true);
+        } else {
+            hr = E_FAIL;
+        }
+    }
+
+    Wh_Log(
+        L"[VDREDIRECT] Notification/cache init hr=0x%08X cookie=%lu ready=%d",
+        static_cast<unsigned int>(hr),
+        cookie,
+        g_notificationReady.load());
+
+    SetEvent(g_notificationReadyEvent);
+
+    if (g_notificationReady.load()) {
+        while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+            TranslateMessage(&msg);
+            DispatchMessageW(&msg);
+        }
+    }
+
+    g_notificationReady.store(false);
+    ClearCurrentDesktopId();
+
+    if (notificationService && cookie) {
+        notificationService->Unregister(cookie);
+    }
+
+    if (listener) {
+        listener->Release();
+    }
+
+    if (notificationService) {
+        notificationService->Release();
+    }
+
+    if (managerInternal) {
+        managerInternal->Release();
+    }
+
+    if (serviceProvider) {
+        serviceProvider->Release();
+    }
+
+    if (shouldUninitialize) {
+        CoUninitialize();
+    }
+
+    Wh_Log(L"[VDREDIRECT] Notification thread exiting");
+    return 0;
+}
+
+static bool StartNotificationCache() {
+    g_notificationReadyEvent =
+        CreateEventW(nullptr, TRUE, FALSE, nullptr);
+
+    if (!g_notificationReadyEvent) {
+        Wh_Log(
+            L"[VDREDIRECT] Create notification-ready event failed error=%lu",
+            GetLastError());
+        return false;
+    }
+
+    g_notificationThread =
+        CreateThread(
+            nullptr,
+            0,
+            NotificationThreadProc,
+            nullptr,
+            0,
+            &g_notificationThreadId);
+
+    if (!g_notificationThread) {
+        Wh_Log(
+            L"[VDREDIRECT] Notification CreateThread failed error=%lu",
+            GetLastError());
+        return false;
+    }
+
+    DWORD waitResult =
+        WaitForSingleObject(g_notificationReadyEvent, 5000);
+
+    if (waitResult != WAIT_OBJECT_0 ||
+        !g_notificationReady.load()) {
+        Wh_Log(
+            L"[VDREDIRECT] Notification/current-desktop cache unavailable "
+            L"(waitResult=%lu)",
+            waitResult);
+        return false;
+    }
+
+    return true;
+}
+
+static void StopNotificationCache() {
+    if (g_notificationThread) {
+        if (g_notificationThreadId) {
+            PostThreadMessageW(
+                g_notificationThreadId,
+                WM_QUIT,
+                0,
+                0);
+        }
+
+        WaitForSingleObject(g_notificationThread, INFINITE);
+        CloseHandle(g_notificationThread);
+        g_notificationThread = nullptr;
+        g_notificationThreadId = 0;
+    }
+
+    if (g_notificationReadyEvent) {
+        CloseHandle(g_notificationReadyEvent);
+        g_notificationReadyEvent = nullptr;
+    }
+
+    g_notificationReady.store(false);
+    ClearCurrentDesktopId();
+}
+
+// -----------------------------------------------------------------------------
+// Rescue worker.
+// -----------------------------------------------------------------------------
+
+struct RescueRequest {
+    uint64_t sequence = 0;
+    HWND hwnd = nullptr;
+    DWORD pid = 0;
+    DWORD tid = 0;
+    GUID sourceDesktopId = {};
+    GUID requestedDesktopId = {};
+};
+
+static constexpr size_t kRescueQueueCapacity = 16;
+static SRWLOCK g_requestLock = SRWLOCK_INIT;
+static RescueRequest g_rescueQueue[kRescueQueueCapacity] = {};
+static size_t g_rescueQueueHead = 0;
+static size_t g_rescueQueueCount = 0;
+static std::atomic<uint64_t> g_nextSequence = 1;
+
+static HANDLE g_requestEvent = nullptr;  // auto-reset
+static HANDLE g_stopEvent = nullptr;     // manual-reset
+static HANDLE g_workerThread = nullptr;
+static HANDLE g_workerReadyEvent = nullptr;
+static std::atomic<bool> g_workerReady = false;
+
+struct WorkerComState {
+    IServiceProvider* serviceProvider = nullptr;
+    IVirtualDesktopManagerInternal* managerInternal = nullptr;
+    IApplicationViewCollection* viewCollection = nullptr;
+    IVirtualDesktopManagerPublic* publicManager = nullptr;
+};
+
+static void ReleaseWorkerComState(WorkerComState* state) {
+    if (!state) {
+        return;
+    }
+
+    if (state->publicManager) {
+        state->publicManager->Release();
+        state->publicManager = nullptr;
+    }
+
+    if (state->viewCollection) {
+        state->viewCollection->Release();
+        state->viewCollection = nullptr;
+    }
+
+    if (state->managerInternal) {
+        state->managerInternal->Release();
+        state->managerInternal = nullptr;
+    }
+
+    if (state->serviceProvider) {
+        state->serviceProvider->Release();
+        state->serviceProvider = nullptr;
+    }
+}
+
+static bool InitializeWorkerComState(WorkerComState* state) {
+    HRESULT hr = CoCreateInstance(
+        kClsidImmersiveShell,
+        nullptr,
+        CLSCTX_LOCAL_SERVER,
+        kIidIServiceProvider,
+        reinterpret_cast<void**>(&state->serviceProvider));
+
+    if (FAILED(hr) || !state->serviceProvider) {
+        Wh_Log(
+            L"[VDREDIRECT] Worker: CoCreateInstance(ImmersiveShell) failed "
+            L"hr=0x%08X",
+            static_cast<unsigned int>(hr));
+        return false;
+    }
+
+    hr = state->serviceProvider->QueryService(
+        kClsidVirtualDesktopManagerInternal,
+        kIidVirtualDesktopManagerInternal,
+        reinterpret_cast<void**>(&state->managerInternal));
+
+    if (FAILED(hr) || !state->managerInternal) {
+        Wh_Log(
+            L"[VDREDIRECT] Worker: QueryService(managerInternal) failed "
+            L"hr=0x%08X",
+            static_cast<unsigned int>(hr));
+        return false;
+    }
+
+    hr = state->serviceProvider->QueryService(
+        kIidApplicationViewCollection,
+        kIidApplicationViewCollection,
+        reinterpret_cast<void**>(&state->viewCollection));
+
+    if (FAILED(hr) || !state->viewCollection) {
+        Wh_Log(
+            L"[VDREDIRECT] Worker: QueryService(viewCollection) failed "
+            L"hr=0x%08X",
+            static_cast<unsigned int>(hr));
+        return false;
+    }
+
+    hr = CoCreateInstance(
+        kClsidVirtualDesktopManager,
+        nullptr,
+        CLSCTX_INPROC_SERVER,
+        kIidVirtualDesktopManager,
+        reinterpret_cast<void**>(&state->publicManager));
+
+    if (FAILED(hr) || !state->publicManager) {
+        Wh_Log(
+            L"[VDREDIRECT] Worker: CoCreateInstance(public manager) failed "
+            L"hr=0x%08X",
+            static_cast<unsigned int>(hr));
+        return false;
+    }
+
+    return true;
+}
+
+// 24H2+ vtable slots, matching Virtual Desktop Helper.
+static constexpr int kVtableMoveViewToDesktop = 4;
+static constexpr int kVtableGetCurrentDesktop = 6;
+
+static HRESULT WorkerGetCurrentDesktop(
+    WorkerComState* state,
+    IVirtualDesktop** desktop) {
+
+    auto fn = GetVTableFunction<
+        HRESULT(STDMETHODCALLTYPE*)(
+            void*,
+            IVirtualDesktop**)>(
+        state->managerInternal,
+        kVtableGetCurrentDesktop);
+
+    return fn(state->managerInternal, desktop);
+}
+
+static HRESULT WorkerMoveViewToDesktop(
+    WorkerComState* state,
+    IApplicationView* view,
+    IVirtualDesktop* desktop) {
+
+    auto fn = GetVTableFunction<
+        HRESULT(STDMETHODCALLTYPE*)(
+            void*,
+            IApplicationView*,
+            IVirtualDesktop*)>(
+        state->managerInternal,
+        kVtableMoveViewToDesktop);
+
+    return fn(state->managerInternal, view, desktop);
+}
+
+static bool TakePendingRequest(RescueRequest* request) {
+    if (!request) {
+        return false;
+    }
+
+    AcquireSRWLockExclusive(&g_requestLock);
+
+    if (!g_rescueQueueCount) {
+        ReleaseSRWLockExclusive(&g_requestLock);
+        return false;
+    }
+
+    *request = g_rescueQueue[g_rescueQueueHead];
+    g_rescueQueue[g_rescueQueueHead] = {};
+    g_rescueQueueHead =
+        (g_rescueQueueHead + 1) % kRescueQueueCapacity;
+    --g_rescueQueueCount;
+
+    ReleaseSRWLockExclusive(&g_requestLock);
+    return true;
+}
+
+static void ProcessRescueRequest(
+    WorkerComState* state,
+    const RescueRequest& request) {
+
+    wchar_t requestedText[64] = {};
+    GuidToString(
+        request.requestedDesktopId,
+        requestedText,
+        ARRAYSIZE(requestedText));
+
+    Wh_Log(
+        L"[VDREDIRECT #%llu] Rescue begin hwnd=%p requested=%s",
+        static_cast<unsigned long long>(request.sequence),
+        request.hwnd,
+        requestedText);
+
+    if (!IsRescueCandidate(request.hwnd)) {
+        Wh_Log(
+            L"[VDREDIRECT #%llu] Abort: HWND no longer eligible",
+            static_cast<unsigned long long>(request.sequence));
+        return;
+    }
+
+    DWORD currentPid = 0;
+    DWORD currentTid =
+        GetWindowThreadProcessId(request.hwnd, &currentPid);
+
+    if (currentPid != request.pid ||
+        currentTid != request.tid) {
+        Wh_Log(
+            L"[VDREDIRECT #%llu] Abort: HWND identity changed "
+            L"(expected pid=%lu tid=%lu, got pid=%lu tid=%lu)",
+            static_cast<unsigned long long>(request.sequence),
+            request.pid,
+            request.tid,
+            currentPid,
+            currentTid);
+        return;
+    }
+
+    // Read the real current desktop after the intercepted switch returned.
+    // Since SwitchDesktopInternal was suppressed, this is the desktop we stayed on.
+    IVirtualDesktop* currentDesktop = nullptr;
+    HRESULT hr =
+        WorkerGetCurrentDesktop(state, &currentDesktop);
+
+    if (FAILED(hr) || !currentDesktop) {
+        Wh_Log(
+            L"[VDREDIRECT #%llu] Abort: GetCurrentDesktop failed "
+            L"hr=0x%08X",
+            static_cast<unsigned long long>(request.sequence),
+            static_cast<unsigned int>(hr));
+        return;
+    }
+
+    GUID actualCurrentId = {};
+    hr = currentDesktop->GetId(&actualCurrentId);
+
+    if (FAILED(hr)) {
+        Wh_Log(
+            L"[VDREDIRECT #%llu] Abort: currentDesktop->GetId failed "
+            L"hr=0x%08X",
+            static_cast<unsigned long long>(request.sequence),
+            static_cast<unsigned int>(hr));
+        currentDesktop->Release();
+        return;
+    }
+
+    if (!GuidEqual(actualCurrentId, request.sourceDesktopId)) {
+        wchar_t expectedSourceText[64] = {};
+        wchar_t actualSourceText[64] = {};
+        GuidToString(
+            request.sourceDesktopId,
+            expectedSourceText,
+            ARRAYSIZE(expectedSourceText));
+        GuidToString(
+            actualCurrentId,
+            actualSourceText,
+            ARRAYSIZE(actualSourceText));
+
+        Wh_Log(
+            L"[VDREDIRECT #%llu] Abort: current desktop changed before rescue "
+            L"(source=%s now=%s)",
+            static_cast<unsigned long long>(request.sequence),
+            expectedSourceText,
+            actualSourceText);
+
+        currentDesktop->Release();
+        return;
+    }
+
+    BOOL onCurrentDesktop = FALSE;
+    HRESULT onCurrentHr =
+        state->publicManager->IsWindowOnCurrentVirtualDesktop(
+            request.hwnd,
+            &onCurrentDesktop);
+
+    if (SUCCEEDED(onCurrentHr) && onCurrentDesktop) {
+        Wh_Log(
+            L"[VDREDIRECT #%llu] Nothing to do: window is already visible "
+            L"on the current desktop (moved/pinned meanwhile)",
+            static_cast<unsigned long long>(request.sequence));
+        currentDesktop->Release();
+        SetForegroundWindow(request.hwnd);
+        return;
+    }
+
+    // Verify that the foreground window really belongs to the desktop Windows
+    // wanted to switch to. This makes the teleport much less likely to grab an
+    // unrelated foreground window.
+    GUID windowDesktopId = {};
+    hr = state->publicManager->GetWindowDesktopId(
+        request.hwnd,
+        &windowDesktopId);
+
+    if (FAILED(hr)) {
+        Wh_Log(
+            L"[VDREDIRECT #%llu] Abort: GetWindowDesktopId failed "
+            L"hr=0x%08X",
+            static_cast<unsigned long long>(request.sequence),
+            static_cast<unsigned int>(hr));
+        currentDesktop->Release();
+        return;
+    }
+
+    if (GuidEqual(windowDesktopId, actualCurrentId)) {
+        Wh_Log(
+            L"[VDREDIRECT #%llu] Nothing to do: window is already on "
+            L"current desktop",
+            static_cast<unsigned long long>(request.sequence));
+        currentDesktop->Release();
+        SetForegroundWindow(request.hwnd);
+        return;
+    }
+
+    if (!GuidEqual(
+            windowDesktopId,
+            request.requestedDesktopId)) {
+        wchar_t windowText[64] = {};
+        GuidToString(
+            windowDesktopId,
+            windowText,
+            ARRAYSIZE(windowText));
+
+        Wh_Log(
+            L"[VDREDIRECT #%llu] Abort: foreground window desktop "
+            L"doesn't match requested switch target "
+            L"(window=%s requested=%s)",
+            static_cast<unsigned long long>(request.sequence),
+            windowText,
+            requestedText);
+
+        currentDesktop->Release();
+        return;
+    }
+
+    IApplicationView* view = nullptr;
+    hr = state->viewCollection->GetViewForHwnd(
+        request.hwnd,
+        &view);
+
+    if (FAILED(hr) || !view) {
+        Wh_Log(
+            L"[VDREDIRECT #%llu] Abort: GetViewForHwnd failed "
+            L"hr=0x%08X",
+            static_cast<unsigned long long>(request.sequence),
+            static_cast<unsigned int>(hr));
+        currentDesktop->Release();
+        return;
+    }
+
+    // Re-check the source desktop immediately before committing the move.
+    // This prevents a legitimate desktop switch that happened while resolving
+    // the IApplicationView from dragging the rescued window along with it.
+    IVirtualDesktop* commitDesktop = nullptr;
+    HRESULT commitHr =
+        WorkerGetCurrentDesktop(state, &commitDesktop);
+
+    GUID commitDesktopId = {};
+    if (FAILED(commitHr) ||
+        !commitDesktop ||
+        FAILED(commitDesktop->GetId(&commitDesktopId)) ||
+        !GuidEqual(commitDesktopId, request.sourceDesktopId)) {
+
+        Wh_Log(
+            L"[VDREDIRECT #%llu] Abort: current desktop changed during rescue",
+            static_cast<unsigned long long>(request.sequence));
+
+        if (commitDesktop) {
+            commitDesktop->Release();
+        }
+        view->Release();
+        currentDesktop->Release();
+        return;
+    }
+
+    currentDesktop->Release();
+    currentDesktop = commitDesktop;
+
+    hr = WorkerMoveViewToDesktop(
+        state,
+        view,
+        currentDesktop);
+
+    view->Release();
+    currentDesktop->Release();
+
+    if (FAILED(hr)) {
+        Wh_Log(
+            L"[VDREDIRECT #%llu] MoveViewToDesktop failed "
+            L"hr=0x%08X",
+            static_cast<unsigned long long>(request.sequence),
+            static_cast<unsigned int>(hr));
+        return;
+    }
+
+    Wh_Log(
+        L"[VDREDIRECT #%llu] Teleported hwnd=%p to current desktop",
+        static_cast<unsigned long long>(request.sequence),
+        request.hwnd);
+
+    // Virtual Desktop Helper similarly restores/focuses the moved window.
+    if (IsIconic(request.hwnd)) {
+        ShowWindow(request.hwnd, SW_RESTORE);
+    }
+
+    SetForegroundWindow(request.hwnd);
+}
+
+static DWORD WINAPI WorkerThreadProc(void*) {
+    HRESULT coHr =
+        CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+
+    const bool shouldUninitialize =
+        SUCCEEDED(coHr);
+
+    if (FAILED(coHr) &&
+        coHr != RPC_E_CHANGED_MODE) {
+        Wh_Log(
+            L"[VDREDIRECT] Worker: CoInitializeEx failed hr=0x%08X",
+            static_cast<unsigned int>(coHr));
+
+        SetEvent(g_workerReadyEvent);
+        return 0;
+    }
+
+    WorkerComState state;
+
+    if (!InitializeWorkerComState(&state)) {
+        ReleaseWorkerComState(&state);
+
+        if (shouldUninitialize) {
+            CoUninitialize();
+        }
+
+        SetEvent(g_workerReadyEvent);
+        return 0;
+    }
+
+    g_workerReady.store(true);
+    SetEvent(g_workerReadyEvent);
+
+    Wh_Log(L"[VDREDIRECT] Worker ready");
+
+    HANDLE waits[] = {
+        g_stopEvent,
+        g_requestEvent,
+    };
+
+    while (true) {
+        DWORD waitResult =
+            WaitForMultipleObjects(
+                ARRAYSIZE(waits),
+                waits,
+                FALSE,
+                INFINITE);
+
+        if (waitResult == WAIT_OBJECT_0) {
+            break;
+        }
+
+        if (waitResult == WAIT_OBJECT_0 + 1) {
+            RescueRequest request;
+            while (TakePendingRequest(&request)) {
+                ProcessRescueRequest(
+                    &state,
+                    request);
+
+                if (WaitForSingleObject(g_stopEvent, 0) ==
+                    WAIT_OBJECT_0) {
+                    break;
+                }
+            }
+        }
+    }
+
+    ReleaseWorkerComState(&state);
+
+    if (shouldUninitialize) {
+        CoUninitialize();
+    }
+
+    Wh_Log(L"[VDREDIRECT] Worker exiting");
+    return 0;
+}
+
+static bool QueueRescue(
+    HWND hwnd,
+    DWORD pid,
+    DWORD tid,
+    const GUID& sourceDesktopId,
+    const GUID& requestedDesktopId) {
+
+    RescueRequest request;
+    request.sequence = g_nextSequence.fetch_add(1);
+    request.hwnd = hwnd;
+    request.pid = pid;
+    request.tid = tid;
+    request.sourceDesktopId = sourceDesktopId;
+    request.requestedDesktopId = requestedDesktopId;
+
+    bool queued = false;
+
+    AcquireSRWLockExclusive(&g_requestLock);
+
+    if (g_rescueQueueCount < kRescueQueueCapacity) {
+        size_t index =
+            (g_rescueQueueHead + g_rescueQueueCount) %
+            kRescueQueueCapacity;
+        g_rescueQueue[index] = request;
+        ++g_rescueQueueCount;
+        queued = true;
+    }
+
+    ReleaseSRWLockExclusive(&g_requestLock);
+
+    if (queued) {
+        SetEvent(g_requestEvent);
+    } else {
+        Wh_Log(
+            L"[VDREDIRECT] Rescue queue full; failing open");
+    }
+
+    return queued;
+}
+
+// -----------------------------------------------------------------------------
+// SwitchDesktopInternal hook.
+// -----------------------------------------------------------------------------
+
+static HRESULT SwitchDesktopInternal_Hook(
+    void* pThis,
+    IVirtualDesktop* requestedDesktop) {
+
+    if (!g_workerReady.load() ||
+        !pThis ||
+        !requestedDesktop) {
+        return g_switchDesktopInternalOriginal(
+            pThis,
+            requestedDesktop);
+    }
+
+    // Critical compatibility path:
+    // When Disable Virtual Desktop Transition Animation is enabled, the native
+    // Win+Ctrl+Left/Right handler can select SwitchDesktopInternal as its
+    // no-animation path. Since we're inside (or immediately after) the actual
+    // _CycleInDirection user action, this is intentional and must not be
+    // converted into a teleport.
+    if (IsExplicitHotkeySwitchContext()) {
+        Wh_Log(
+            L"[VDREDIRECT] ALLOW SwitchDesktopInternal: "
+            L"explicit HOTKEY-CYCLE context depth=%d",
+            g_hotkeyCycleDepth);
+
+        return g_switchDesktopInternalOriginal(
+            pThis,
+            requestedDesktop);
+    }
+
+    GUID sourceDesktopId = {};
+    if (!g_notificationReady.load() ||
+        !LoadCurrentDesktopId(&sourceDesktopId)) {
+        Wh_Log(
+            L"[VDREDIRECT] SwitchDesktopInternal allowed: "
+            L"current-desktop cache unavailable");
+
+        return g_switchDesktopInternalOriginal(
+            pThis,
+            requestedDesktop);
+    }
+
+    HWND foreground = GetForegroundWindow();
+
+    // If there isn't a plausible app window to rescue, don't interfere with
+    // an unknown internal switch path.
+    if (!IsRescueCandidate(foreground)) {
+        Wh_Log(
+            L"[VDREDIRECT] SwitchDesktopInternal allowed: "
+            L"no eligible foreground rescue candidate");
+
+        return g_switchDesktopInternalOriginal(
+            pThis,
+            requestedDesktop);
+    }
+
+    GUID requestedId = {};
+    HRESULT requestedIdHr =
+        requestedDesktop->GetId(&requestedId);
+
+    if (FAILED(requestedIdHr)) {
+        Wh_Log(
+            L"[VDREDIRECT] SwitchDesktopInternal allowed: "
+            L"requestedDesktop->GetId failed hr=0x%08X",
+            static_cast<unsigned int>(requestedIdHr));
+
+        return g_switchDesktopInternalOriginal(
+            pThis,
+            requestedDesktop);
+    }
+
+    if (GuidEqual(sourceDesktopId, requestedId)) {
+        Wh_Log(
+            L"[VDREDIRECT] SwitchDesktopInternal allowed: "
+            L"requested desktop is already current");
+
+        return g_switchDesktopInternalOriginal(
+            pThis,
+            requestedDesktop);
+    }
+
+    DWORD candidatePid = 0;
+    DWORD candidateTid =
+        GetWindowThreadProcessId(foreground, &candidatePid);
+
+    if (!candidatePid || !candidateTid) {
+        Wh_Log(
+            L"[VDREDIRECT] SwitchDesktopInternal allowed: "
+            L"failed to capture candidate HWND identity");
+
+        return g_switchDesktopInternalOriginal(
+            pThis,
+            requestedDesktop);
+    }
+
+    wchar_t sourceText[64] = {};
+    wchar_t requestedText[64] = {};
+    GuidToString(
+        sourceDesktopId,
+        sourceText,
+        ARRAYSIZE(sourceText));
+    GuidToString(
+        requestedId,
+        requestedText,
+        ARRAYSIZE(requestedText));
+
+    Wh_Log(
+        L"[VDREDIRECT] Candidate SwitchDesktopInternal "
+        L"source=%s requested=%s foreground=%p",
+        sourceText,
+        requestedText,
+        foreground);
+
+    LogWindow(L"candidate", foreground);
+
+    if (!QueueRescue(
+            foreground,
+            candidatePid,
+            candidateTid,
+            sourceDesktopId,
+            requestedId)) {
+        return g_switchDesktopInternalOriginal(
+            pThis,
+            requestedDesktop);
+    }
+
+    Wh_Log(
+        L"[VDREDIRECT] BLOCK SwitchDesktopInternal: rescue queued");
+
+    // Pretend the internal switch succeeded only after the rescue has been
+    // safely queued. Every failure before this point fails open.
+    return S_OK;
+}
+
+// -----------------------------------------------------------------------------
+// Windhawk lifecycle.
+// -----------------------------------------------------------------------------
+
+static bool StartWorker() {
+    g_requestEvent =
+        CreateEventW(
+            nullptr,
+            FALSE,
+            FALSE,
+            nullptr);
+
+    g_stopEvent =
+        CreateEventW(
+            nullptr,
+            TRUE,
+            FALSE,
+            nullptr);
+
+    g_workerReadyEvent =
+        CreateEventW(
+            nullptr,
+            TRUE,
+            FALSE,
+            nullptr);
+
+    if (!g_requestEvent ||
+        !g_stopEvent ||
+        !g_workerReadyEvent) {
+        Wh_Log(
+            L"[VDREDIRECT] Failed to create worker events");
+        return false;
+    }
+
+    g_workerThread =
+        CreateThread(
+            nullptr,
+            0,
+            WorkerThreadProc,
+            nullptr,
+            0,
+            nullptr);
+
+    if (!g_workerThread) {
+        Wh_Log(
+            L"[VDREDIRECT] CreateThread failed error=%lu",
+            GetLastError());
+        return false;
+    }
+
+    DWORD waitResult =
+        WaitForSingleObject(
+            g_workerReadyEvent,
+            5000);
+
+    if (waitResult != WAIT_OBJECT_0 ||
+        !g_workerReady.load()) {
+        Wh_Log(
+            L"[VDREDIRECT] Worker initialization failed "
+            L"(waitResult=%lu)",
+            waitResult);
+        return false;
+    }
+
+    return true;
+}
+
+static void StopWorker() {
+    if (g_stopEvent) {
+        SetEvent(g_stopEvent);
+    }
+
+    if (g_workerThread) {
+        WaitForSingleObject(
+            g_workerThread,
+            INFINITE);
+
+        CloseHandle(g_workerThread);
+        g_workerThread = nullptr;
+    }
+
+    if (g_workerReadyEvent) {
+        CloseHandle(g_workerReadyEvent);
+        g_workerReadyEvent = nullptr;
+    }
+
+    if (g_stopEvent) {
+        CloseHandle(g_stopEvent);
+        g_stopEvent = nullptr;
+    }
+
+    if (g_requestEvent) {
+        CloseHandle(g_requestEvent);
+        g_requestEvent = nullptr;
+    }
+
+    g_workerReady.store(false);
+}
+
+// -----------------------------------------------------------------------------
+// Explorer / shell-host lifecycle.
+// -----------------------------------------------------------------------------
+//
+// Windhawk's @include explorer.exe can inject this mod into more than one
+// explorer.exe when folder windows are hosted in separate processes.
+//
+// Therefore Wh_ModInit deliberately installs only one lightweight process-local
+// observer: CreateWindowExW. The process is promoted to "shell Explorer" only
+// after it creates (or already owns) the PRIMARY taskbar window:
+//
+//     Shell_TrayWnd
+//
+// Shell_SecondaryTrayWnd is intentionally ignored. Once shell ownership has
+// been proven, the twinui virtual-desktop hooks and COM runtime are installed
+// exactly once. Non-shell explorer.exe processes never load twinui.pcshell.dll
+// for this mod and never start the virtual-desktop worker/cache.
+
+static std::atomic<int> g_runtimeState{0};
+// 0 = dormant/stopped, 1 = shell-host initialization in progress, 2 = ready
+
+static std::atomic<bool> g_unloading{false};
+static std::atomic<bool> g_shellHostConfirmed{false};
+static std::atomic<bool> g_virtualDesktopHooksInstalled{false};
+
+static SRWLOCK g_runtimeInitLock = SRWLOCK_INIT;
+static HANDLE g_runtimeInitThread = nullptr;
+
+static BOOL CALLBACK FindCurrentProcessPrimaryTaskbarEnumProc(
+    HWND hwnd,
+    LPARAM lParam) {
+
+    DWORD pid = 0;
+    if (!GetWindowThreadProcessId(hwnd, &pid) ||
+        pid != GetCurrentProcessId()) {
+        return TRUE;
+    }
+
+    wchar_t className[32] = {};
+    if (!GetClassNameW(
+            hwnd,
+            className,
+            ARRAYSIZE(className))) {
+        return TRUE;
+    }
+
+    // Deliberately accept only the primary taskbar. Secondary taskbars are
+    // Shell_SecondaryTrayWnd and are not shell-process identity markers.
+    if (_wcsicmp(className, L"Shell_TrayWnd") == 0) {
+        *reinterpret_cast<HWND*>(lParam) = hwnd;
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+static HWND FindCurrentProcessPrimaryTaskbar() {
+    HWND result = nullptr;
+
+    EnumWindows(
+        FindCurrentProcessPrimaryTaskbarEnumProc,
+        reinterpret_cast<LPARAM>(&result));
+
+    return result;
+}
+
+static bool InstallVirtualDesktopHooks() {
+    if (g_virtualDesktopHooksInstalled.load(
+            std::memory_order_acquire)) {
+        return true;
+    }
+
+    HMODULE twinui =
+        LoadLibraryW(L"twinui.pcshell.dll");
+
+    if (!twinui) {
+        Wh_Log(
+            L"[VDREDIRECT] Shell host: "
+            L"LoadLibrary(twinui.pcshell.dll) failed error=%lu",
+            GetLastError());
+        return false;
+    }
+
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {
+        {
+            {
+                L"public: virtual long __cdecl "
+                L"CVirtualDesktopManager::SwitchDesktopInternal("
+                L"struct IVirtualDesktop *)"
+            },
+            reinterpret_cast<void**>(
+                &g_switchDesktopInternalOriginal),
+            reinterpret_cast<void*>(
+                SwitchDesktopInternal_Hook)
+        },
+        {
+            {
+                L"private: long __cdecl "
+                L"CVirtualDesktopHotkeyHandler::_CycleInDirection("
+                L"enum VirtualDesktopSwitchDirection)"
+            },
+            reinterpret_cast<void**>(
+                &g_cycleInDirectionOriginal),
+            reinterpret_cast<void*>(
+                CycleInDirection_Hook)
+        },
+    };
+
+    if (!WindhawkUtils::HookSymbols(
+            twinui,
+            hooks,
+            ARRAYSIZE(hooks))) {
+        Wh_Log(
+            L"[VDREDIRECT] Shell host: failed to resolve/install "
+            L"virtual-desktop symbols");
+        return false;
+    }
+
+    // These hooks are installed after Wh_ModInit, so explicitly apply the
+    // pending hook operations now.
+    Wh_ApplyHookOperations();
+
+    g_virtualDesktopHooksInstalled.store(
+        true,
+        std::memory_order_release);
+
+    Wh_Log(
+        L"[VDREDIRECT] Shell host: virtual-desktop hooks installed");
+
+    return true;
+}
+
+static DWORD WINAPI ShellHostInitThreadProc(void*) {
+    Wh_Log(
+        L"[VDREDIRECT] Shell-host initialization begin");
+
+    if (!InstallVirtualDesktopHooks()) {
+        g_runtimeState.store(0, std::memory_order_release);
+
+        Wh_Log(
+            L"[VDREDIRECT] Shell-host initialization failed: "
+            L"VD hooks unavailable; remaining fail-open");
+        return 0;
+    }
+
+    if (g_unloading.load(std::memory_order_acquire)) {
+        g_runtimeState.store(0, std::memory_order_release);
+        return 0;
+    }
+
+    if (!StartWorker()) {
+        StopWorker();
+        g_runtimeState.store(0, std::memory_order_release);
+
+        Wh_Log(
+            L"[VDREDIRECT] Shell-host initialization failed: "
+            L"worker unavailable; remaining fail-open");
+        return 0;
+    }
+
+    if (g_unloading.load(std::memory_order_acquire)) {
+        StopWorker();
+        g_runtimeState.store(0, std::memory_order_release);
+        return 0;
+    }
+
+    if (!StartNotificationCache()) {
+        StopNotificationCache();
+        StopWorker();
+        g_runtimeState.store(0, std::memory_order_release);
+
+        Wh_Log(
+            L"[VDREDIRECT] Shell-host initialization failed: "
+            L"desktop cache unavailable; remaining fail-open");
+        return 0;
+    }
+
+    if (g_unloading.load(std::memory_order_acquire)) {
+        StopNotificationCache();
+        StopWorker();
+        g_runtimeState.store(0, std::memory_order_release);
+        return 0;
+    }
+
+    g_runtimeState.store(2, std::memory_order_release);
+
+    Wh_Log(
+        L"[VDREDIRECT] Runtime ready: primary shell Explorer confirmed, "
+        L"source-desktop cache active, bounded rescue queue active");
+
+    return 0;
+}
+
+static void PromoteCurrentProcessToShellHost(
+    const wchar_t* reason) {
+
+    if (g_unloading.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    g_shellHostConfirmed.store(
+        true,
+        std::memory_order_release);
+
+    if (g_runtimeState.load(std::memory_order_acquire) == 2) {
+        return;
+    }
+
+    AcquireSRWLockExclusive(&g_runtimeInitLock);
+
+    if (g_unloading.load(std::memory_order_relaxed) ||
+        g_runtimeState.load(std::memory_order_relaxed) != 0) {
+        ReleaseSRWLockExclusive(&g_runtimeInitLock);
+        return;
+    }
+
+    // A previous runtime attempt may have failed after the VD hooks were
+    // installed. If the primary taskbar is recreated in the same Explorer
+    // process, allow another runtime attempt without installing the hooks twice.
+    if (g_runtimeInitThread) {
+        if (WaitForSingleObject(
+                g_runtimeInitThread,
+                0) == WAIT_OBJECT_0) {
+            CloseHandle(g_runtimeInitThread);
+            g_runtimeInitThread = nullptr;
+        } else {
+            ReleaseSRWLockExclusive(&g_runtimeInitLock);
+            return;
+        }
+    }
+
+    g_runtimeState.store(1, std::memory_order_release);
+
+    Wh_Log(
+        L"[VDREDIRECT] Primary Shell_TrayWnd confirmed; "
+        L"promoting this Explorer process reason=%s",
+        reason ? reason : L"<unknown>");
+
+    g_runtimeInitThread =
+        CreateThread(
+            nullptr,
+            0,
+            ShellHostInitThreadProc,
+            nullptr,
+            0,
+            nullptr);
+
+    if (!g_runtimeInitThread) {
+        Wh_Log(
+            L"[VDREDIRECT] Shell-host init CreateThread failed error=%lu",
+            GetLastError());
+        g_runtimeState.store(0, std::memory_order_release);
+    }
+
+    ReleaseSRWLockExclusive(&g_runtimeInitLock);
+}
+
+using CreateWindowExW_t = decltype(&CreateWindowExW);
+static CreateWindowExW_t g_createWindowExWOriginal = nullptr;
+
+static HWND WINAPI CreateWindowExW_Hook(
+    DWORD dwExStyle,
+    LPCWSTR lpClassName,
+    LPCWSTR lpWindowName,
+    DWORD dwStyle,
+    int X,
+    int Y,
+    int nWidth,
+    int nHeight,
+    HWND hWndParent,
+    HMENU hMenu,
+    HINSTANCE hInstance,
+    LPVOID lpParam) {
+
+    HWND hwnd =
+        g_createWindowExWOriginal(
+            dwExStyle,
+            lpClassName,
+            lpWindowName,
+            dwStyle,
+            X,
+            Y,
+            nWidth,
+            nHeight,
+            hWndParent,
+            hMenu,
+            hInstance,
+            lpParam);
+
+    if (!hwnd ||
+        g_unloading.load(std::memory_order_acquire)) {
+        return hwnd;
+    }
+
+    // Once the runtime is healthy, the observer becomes effectively free.
+    // If initialization failed, keep watching for a recreated primary taskbar
+    // so the same Explorer process gets a natural retry opportunity.
+    if (g_shellHostConfirmed.load(std::memory_order_acquire) &&
+        g_runtimeState.load(std::memory_order_acquire) == 2) {
+        return hwnd;
+    }
+
+    bool isPrimaryTaskbar = false;
+
+    if (lpClassName &&
+        !IS_INTRESOURCE(lpClassName)) {
+        isPrimaryTaskbar =
+            _wcsicmp(
+                lpClassName,
+                L"Shell_TrayWnd") == 0;
+    } else {
+        // Registered classes may be passed to CreateWindowExW by atom. Resolve
+        // the actual class from the resulting HWND in that case.
+        wchar_t className[32] = {};
+        if (GetClassNameW(
+                hwnd,
+                className,
+                ARRAYSIZE(className))) {
+            isPrimaryTaskbar =
+                _wcsicmp(
+                    className,
+                    L"Shell_TrayWnd") == 0;
+        }
+    }
+
+    if (!isPrimaryTaskbar) {
+        // Shell_SecondaryTrayWnd intentionally lands here and is ignored.
+        return hwnd;
+    }
+
+    DWORD ownerPid = 0;
+    GetWindowThreadProcessId(
+        hwnd,
+        &ownerPid);
+
+    if (ownerPid != GetCurrentProcessId()) {
+        return hwnd;
+    }
+
+    // Never do symbol resolution / COM initialization while still inside
+    // CreateWindowExW. Only schedule the process promotion here.
+    PromoteCurrentProcessToShellHost(
+        L"primary Shell_TrayWnd created");
+
+    return hwnd;
+}
+
+static void StopRuntime() {
+    g_unloading.store(true, std::memory_order_release);
+
+    HANDLE initThread = nullptr;
+
+    AcquireSRWLockShared(&g_runtimeInitLock);
+    initThread = g_runtimeInitThread;
+    ReleaseSRWLockShared(&g_runtimeInitLock);
+
+    if (initThread) {
+        WaitForSingleObject(
+            initThread,
+            INFINITE);
+    }
+
+    StopNotificationCache();
+    StopWorker();
+
+    AcquireSRWLockExclusive(&g_runtimeInitLock);
+
+    if (g_runtimeInitThread) {
+        CloseHandle(g_runtimeInitThread);
+        g_runtimeInitThread = nullptr;
+    }
+
+    g_runtimeState.store(0, std::memory_order_release);
+
+    ReleaseSRWLockExclusive(&g_runtimeInitLock);
+}
+
+BOOL Wh_ModInit() {
+    Wh_Log(
+        L"[VDREDIRECT] Init: installing lightweight "
+        L"primary-taskbar observer");
+
+    // Deliberately don't load twinui.pcshell.dll or taskbar.dll here. This code
+    // executes in every explorer.exe matched by @include. Non-shell Explorer
+    // processes should remain as inert as possible.
+    if (!Wh_SetFunctionHook(
+            reinterpret_cast<void*>(CreateWindowExW),
+            reinterpret_cast<void*>(CreateWindowExW_Hook),
+            reinterpret_cast<void**>(
+                &g_createWindowExWOriginal))) {
+        Wh_Log(
+            L"[VDREDIRECT] Failed to hook CreateWindowExW");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    // Manual enable/reload: the shell Explorer may already have created its
+    // primary taskbar before our CreateWindowExW observer was installed.
+    HWND primaryTaskbar =
+        FindCurrentProcessPrimaryTaskbar();
+
+    if (primaryTaskbar) {
+        Wh_Log(
+            L"[VDREDIRECT] Existing primary Shell_TrayWnd=%p "
+            L"belongs to this Explorer process",
+            primaryTaskbar);
+
+        PromoteCurrentProcessToShellHost(
+            L"existing primary Shell_TrayWnd");
+    } else {
+        Wh_Log(
+            L"[VDREDIRECT] No primary Shell_TrayWnd owned by this PID; "
+            L"remaining inert unless one is created");
+    }
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L"[VDREDIRECT] Uninit");
+    StopRuntime();
+}

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -2,7 +2,7 @@
 // @id              prevent-virtual-desktop-stealing
 // @name            Prevent Window Activation from Stealing Virtual Desktop
 // @description     Redirect cross-desktop window activation to the current desktop.
-// @version         0.3.10
+// @version         0.3.11
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @include         explorer.exe
@@ -48,6 +48,7 @@ shell interfaces, so future Windows updates may require adjustments.
 #include <windows.h>
 #include <objbase.h>
 #include <servprov.h>
+#include <shobjidl.h>
 #include <windhawk_api.h>
 #include <windhawk_utils.h>
 
@@ -66,21 +67,6 @@ static const CLSID kClsidImmersiveShell = {
 static const CLSID kClsidVirtualDesktopManagerInternal = {
     0xC5E0CDCA, 0x7B6E, 0x41B2,
     {0x9F, 0xC4, 0xD9, 0x39, 0x75, 0xCC, 0x46, 0x7B}
-};
-
-static const CLSID kClsidVirtualDesktopManager = {
-    0xAA509086, 0x5CA9, 0x4C25,
-    {0x8F, 0x95, 0x58, 0x9D, 0x3C, 0x07, 0xB4, 0x8A}
-};
-
-static const IID kIidIServiceProvider = {
-    0x6D5140C1, 0x7436, 0x11CE,
-    {0x80, 0x34, 0x00, 0xAA, 0x00, 0x60, 0x09, 0xFA}
-};
-
-static const IID kIidIUnknown = {
-    0x00000000, 0x0000, 0x0000,
-    {0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46}
 };
 
 static const GUID kServiceVirtualDesktopNotification = {
@@ -115,11 +101,6 @@ static const IID kIidApplicationViewCollection = {
     {0xAF, 0x41, 0x87, 0x47, 0x53, 0x8F, 0x10, 0xE5}
 };
 
-static const IID kIidVirtualDesktopManager = {
-    0xA5CD92FF, 0x29BE, 0x454C,
-    {0x8D, 0x04, 0xD8, 0x28, 0x79, 0xFB, 0x3F, 0x1B}
-};
-
 // -----------------------------------------------------------------------------
 // Minimal undocumented/public interface declarations.
 // -----------------------------------------------------------------------------
@@ -152,20 +133,6 @@ struct IApplicationViewCollection : IUnknown {
 };
 
 struct IVirtualDesktopManagerInternal : IUnknown {};
-
-struct IVirtualDesktopManagerPublic : IUnknown {
-    virtual HRESULT STDMETHODCALLTYPE IsWindowOnCurrentVirtualDesktop(
-        HWND topLevelWindow,
-        BOOL* onCurrentDesktop) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE GetWindowDesktopId(
-        HWND topLevelWindow,
-        GUID* desktopId) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE MoveWindowToDesktop(
-        HWND topLevelWindow,
-        REFGUID desktopId) = 0;
-};
 
 struct IVirtualDesktopNotification : IUnknown {
     virtual HRESULT STDMETHODCALLTYPE VirtualDesktopCreated(
@@ -387,6 +354,18 @@ static bool IsExplicitHotkeySwitchContext() {
     return g_hotkeyCycleDepth > 0;
 }
 
+static const wchar_t* GuidToStringForLog(const GUID& guid) {
+    // A ring keeps multiple GUID arguments in one Wh_Log call distinct. Since
+    // this helper is called only from Wh_Log arguments, formatting is skipped
+    // entirely when logging is disabled.
+    static thread_local wchar_t buffers[8][64];
+    static thread_local size_t nextBuffer = 0;
+
+    wchar_t* buffer = buffers[nextBuffer++ % ARRAYSIZE(buffers)];
+    GuidToString(guid, buffer, ARRAYSIZE(buffers[0]));
+    return buffer[0] ? buffer : L"<invalid>";
+}
+
 static bool ExplicitSwitchExpired(
     const ExplicitSwitchTransaction& transaction,
     ULONGLONG now) {
@@ -449,18 +428,13 @@ static uint64_t BeginExplicitSwitchTransaction(
     g_explicitSwitch.startedAt = GetTickCount64();
     ReleaseSRWLockExclusive(&g_explicitSwitchLock);
 
-    wchar_t sourceText[64] = {};
-    wchar_t targetText[64] = {};
-    GuidToString(sourceId, sourceText, ARRAYSIZE(sourceText));
-    GuidToString(targetId, targetText, ARRAYSIZE(targetText));
-
     Wh_Log(
         L"Explicit switch transaction #%llu begin route=%s "
         L"source=%s target=%s",
         static_cast<unsigned long long>(sequence),
         route ? route : L"<unknown>",
-        sourceText,
-        targetText);
+        GuidToStringForLog(sourceId),
+        GuidToStringForLog(targetId));
 
     return sequence;
 }
@@ -622,14 +596,6 @@ static void FinishExplicitSwitchTransaction(
         return;
     }
 
-    wchar_t switchedText[64] = {};
-    wchar_t targetText[64] = {};
-    GuidToString(switchedId, switchedText, ARRAYSIZE(switchedText));
-    GuidToString(
-        transaction.targetDesktopId,
-        targetText,
-        ARRAYSIZE(targetText));
-
     if (expired) {
         Wh_Log(
             L"Explicit switch transaction #%llu expired on completion",
@@ -638,14 +604,14 @@ static void FinishExplicitSwitchTransaction(
         Wh_Log(
             L"Explicit switch transaction #%llu complete switched=%s",
             static_cast<unsigned long long>(transaction.sequence),
-            switchedText);
+            GuidToStringForLog(switchedId));
     } else if (ignored) {
         Wh_Log(
             L"Explicit switch transaction #%llu ignored stale completion "
             L"switched=%s target=%s targetChangeObserved=%d",
             static_cast<unsigned long long>(transaction.sequence),
-            switchedText,
-            targetText,
+            GuidToStringForLog(switchedId),
+            GuidToStringForLog(transaction.targetDesktopId),
             transaction.targetChangeObserved);
     }
 }
@@ -779,7 +745,7 @@ public:
 
         *object = nullptr;
 
-        if (IsEqualIID(riid, kIidIUnknown) ||
+        if (IsEqualIID(riid, __uuidof(IUnknown)) ||
             IsEqualIID(riid, kIidVirtualDesktopNotification)) {
             *object = static_cast<IVirtualDesktopNotification*>(this);
             AddRef();
@@ -856,17 +822,12 @@ public:
             StoreCurrentDesktopId(newId);
             ObserveExplicitSwitchDesktopChange(newId);
 
-            wchar_t oldText[64] = {};
-            wchar_t newText[64] = {};
-            if (SUCCEEDED(oldHr)) {
-                GuidToString(oldId, oldText, ARRAYSIZE(oldText));
-            }
-            GuidToString(newId, newText, ARRAYSIZE(newText));
-
             Wh_Log(
                 L"Current desktop cache updated old=%s new=%s",
-                SUCCEEDED(oldHr) ? oldText : L"<unknown>",
-                newText);
+                SUCCEEDED(oldHr)
+                    ? GuidToStringForLog(oldId)
+                    : L"<unknown>",
+                GuidToStringForLog(newId));
         } else {
             ClearCurrentDesktopId();
             Wh_Log(
@@ -926,7 +887,7 @@ static DWORD WINAPI NotificationThreadProc(void*) {
         kClsidImmersiveShell,
         nullptr,
         CLSCTX_LOCAL_SERVER,
-        kIidIServiceProvider,
+        __uuidof(IServiceProvider),
         reinterpret_cast<void**>(&serviceProvider));
 
     if (SUCCEEDED(hr) && serviceProvider) {
@@ -1135,7 +1096,7 @@ struct WorkerComState {
     IServiceProvider* serviceProvider = nullptr;
     IVirtualDesktopManagerInternal* managerInternal = nullptr;
     IApplicationViewCollection* viewCollection = nullptr;
-    IVirtualDesktopManagerPublic* publicManager = nullptr;
+    IVirtualDesktopManager* publicManager = nullptr;
 };
 
 static void ReleaseWorkerComState(WorkerComState* state) {
@@ -1169,7 +1130,7 @@ static bool InitializeWorkerComState(WorkerComState* state) {
         kClsidImmersiveShell,
         nullptr,
         CLSCTX_LOCAL_SERVER,
-        kIidIServiceProvider,
+        __uuidof(IServiceProvider),
         reinterpret_cast<void**>(&state->serviceProvider));
 
     if (FAILED(hr) || !state->serviceProvider) {
@@ -1215,11 +1176,10 @@ static bool InitializeWorkerComState(WorkerComState* state) {
     }
 
     hr = CoCreateInstance(
-        kClsidVirtualDesktopManager,
+        __uuidof(VirtualDesktopManager),
         nullptr,
         CLSCTX_INPROC_SERVER,
-        kIidVirtualDesktopManager,
-        reinterpret_cast<void**>(&state->publicManager));
+        IID_PPV_ARGS(&state->publicManager));
 
     if (FAILED(hr) || !state->publicManager) {
         Wh_Log(
@@ -1300,17 +1260,11 @@ static void ProcessRescueRequest(
     // shell hooks from this worker apartment. Keep every abort fail-stationary
     // and logged rather than manufacturing a stale cross-thread switch.
 
-    wchar_t requestedText[64] = {};
-    GuidToString(
-        request.requestedDesktopId,
-        requestedText,
-        ARRAYSIZE(requestedText));
-
     Wh_Log(
         L"[#%llu] Rescue begin hwnd=%p requested=%s",
         static_cast<unsigned long long>(request.sequence),
         request.hwnd,
-        requestedText);
+        GuidToStringForLog(request.requestedDesktopId));
 
     if (!IsRescueCandidate(request.hwnd)) {
         Wh_Log(
@@ -1365,23 +1319,12 @@ static void ProcessRescueRequest(
     }
 
     if (!GuidEqual(actualCurrentId, request.sourceDesktopId)) {
-        wchar_t expectedSourceText[64] = {};
-        wchar_t actualSourceText[64] = {};
-        GuidToString(
-            request.sourceDesktopId,
-            expectedSourceText,
-            ARRAYSIZE(expectedSourceText));
-        GuidToString(
-            actualCurrentId,
-            actualSourceText,
-            ARRAYSIZE(actualSourceText));
-
         Wh_Log(
             L"[#%llu] Abort: current desktop changed before rescue "
             L"(source=%s now=%s)",
             static_cast<unsigned long long>(request.sequence),
-            expectedSourceText,
-            actualSourceText);
+            GuidToStringForLog(request.sourceDesktopId),
+            GuidToStringForLog(actualCurrentId));
 
         currentDesktop->Release();
         return;
@@ -1399,7 +1342,6 @@ static void ProcessRescueRequest(
             L"on the current desktop (moved/pinned meanwhile)",
             static_cast<unsigned long long>(request.sequence));
         currentDesktop->Release();
-        SetForegroundWindow(request.hwnd);
         return;
     }
 
@@ -1427,26 +1369,19 @@ static void ProcessRescueRequest(
             L"current desktop",
             static_cast<unsigned long long>(request.sequence));
         currentDesktop->Release();
-        SetForegroundWindow(request.hwnd);
         return;
     }
 
     if (!GuidEqual(
             windowDesktopId,
             request.requestedDesktopId)) {
-        wchar_t windowText[64] = {};
-        GuidToString(
-            windowDesktopId,
-            windowText,
-            ARRAYSIZE(windowText));
-
         Wh_Log(
             L"[#%llu] Abort: foreground window desktop "
             L"doesn't match requested switch target "
             L"(window=%s requested=%s)",
             static_cast<unsigned long long>(request.sequence),
-            windowText,
-            requestedText);
+            GuidToStringForLog(windowDesktopId),
+            GuidToStringForLog(request.requestedDesktopId));
 
         currentDesktop->Release();
         return;
@@ -1726,18 +1661,12 @@ static HRESULT SwitchDesktopInternal_Hook(
     if (explicitDisposition ==
         ExplicitInternalSwitchDisposition::SuppressStaleSource) {
 
-        wchar_t targetText[64] = {};
-        GuidToString(
-            explicitSnapshot.targetDesktopId,
-            targetText,
-            ARRAYSIZE(targetText));
-
         Wh_Log(
             L"SUPPRESS SwitchDesktopInternal: stale source rebound "
             L"during explicit transaction #%llu target=%s",
             static_cast<unsigned long long>(
                 explicitSnapshot.sequence),
-            targetText);
+            GuidToStringForLog(explicitSnapshot.targetDesktopId));
 
         return S_OK;
     }
@@ -1792,22 +1721,11 @@ static HRESULT SwitchDesktopInternal_Hook(
             requestedDesktop);
     }
 
-    wchar_t sourceText[64] = {};
-    wchar_t requestedText[64] = {};
-    GuidToString(
-        sourceDesktopId,
-        sourceText,
-        ARRAYSIZE(sourceText));
-    GuidToString(
-        requestedId,
-        requestedText,
-        ARRAYSIZE(requestedText));
-
     Wh_Log(
         L"Candidate SwitchDesktopInternal "
         L"source=%s requested=%s foreground=%p",
-        sourceText,
-        requestedText,
+        GuidToStringForLog(sourceDesktopId),
+        GuidToStringForLog(requestedId),
         foreground);
 
     LogWindow(L"candidate", foreground);

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -1600,6 +1600,11 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
     Wh_Log(
         L"[VDREDIRECT] Shell-host initialization begin");
 
+    if (g_unloading.load(std::memory_order_acquire)) {
+        g_runtimeState.store(0, std::memory_order_release);
+        return 0;
+    }
+
     if (!InstallVirtualDesktopHooks()) {
         g_runtimeState.store(0, std::memory_order_release);
 
@@ -1811,34 +1816,28 @@ static HWND WINAPI CreateWindowExW_Hook(
     return hwnd;
 }
 
-static void StopRuntime() {
+static void StopRuntimeBeforeUninit() {
     g_unloading.store(true, std::memory_order_release);
 
     HANDLE initThread = nullptr;
 
-    AcquireSRWLockShared(&g_runtimeInitLock);
+    AcquireSRWLockExclusive(&g_runtimeInitLock);
     initThread = g_runtimeInitThread;
-    ReleaseSRWLockShared(&g_runtimeInitLock);
+    g_runtimeInitThread = nullptr;
+    ReleaseSRWLockExclusive(&g_runtimeInitLock);
 
     if (initThread) {
         WaitForSingleObject(
             initThread,
             INFINITE);
+        CloseHandle(initThread);
     }
+}
 
+static void StopRuntime() {
     StopNotificationCache();
     StopWorker();
-
-    AcquireSRWLockExclusive(&g_runtimeInitLock);
-
-    if (g_runtimeInitThread) {
-        CloseHandle(g_runtimeInitThread);
-        g_runtimeInitThread = nullptr;
-    }
-
     g_runtimeState.store(0, std::memory_order_release);
-
-    ReleaseSRWLockExclusive(&g_runtimeInitLock);
 }
 
 BOOL Wh_ModInit() {
@@ -1881,6 +1880,10 @@ void Wh_ModAfterInit() {
             L"[VDREDIRECT] No primary Shell_TrayWnd owned by this PID; "
             L"remaining inert unless one is created");
     }
+}
+
+void Wh_ModBeforeUninit() {
+    StopRuntimeBeforeUninit();
 }
 
 void Wh_ModUninit() {

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -2,7 +2,7 @@
 // @id              prevent-virtual-desktop-stealing
 // @name            Prevent Window Activation from Stealing Virtual Desktop
 // @description     Redirect cross-desktop window activation to the current desktop.
-// @version         0.3.5
+// @version         0.3.7
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @include         explorer.exe
@@ -357,8 +357,194 @@ static void LogWindow(const wchar_t* label, HWND hwnd) {
 // period or physical-key heuristic is used.
 static thread_local int g_hotkeyCycleDepth = 0;
 
+// Task View and direct shell/API desktop switches are asynchronous: their public
+// SwitchDesktop* entry point can return before CurrentVirtualDesktopChanged is
+// delivered. Keep an event-driven transaction alive until the notification
+// service reports that the explicitly requested desktop finished switching.
+//
+// This state is process-global rather than thread_local because the public
+// switch call, SwitchDesktopInternal, and virtual-desktop notifications can run
+// on different Explorer threads.
+struct ExplicitSwitchTransaction {
+    bool active = false;
+    GUID sourceDesktopId = {};
+    GUID targetDesktopId = {};
+    uint64_t sequence = 0;
+};
+
+static SRWLOCK g_explicitSwitchLock = SRWLOCK_INIT;
+static ExplicitSwitchTransaction g_explicitSwitch = {};
+static std::atomic<uint64_t> g_nextExplicitSwitchSequence{1};
+
+// SwitchDesktopWithAnimation synchronously calls SwitchDesktop on current
+// builds. Only the outermost public switch entry should create a transaction.
+static thread_local int g_explicitSwitchEntryDepth = 0;
+
 static bool IsExplicitHotkeySwitchContext() {
     return g_hotkeyCycleDepth > 0;
+}
+
+static uint64_t BeginExplicitSwitchTransaction(
+    IVirtualDesktop* targetDesktop,
+    const wchar_t* route) {
+
+    if (!targetDesktop) {
+        return 0;
+    }
+
+    GUID targetId = {};
+    if (FAILED(targetDesktop->GetId(&targetId))) {
+        return 0;
+    }
+
+    GUID sourceId = {};
+    if (!LoadCurrentDesktopId(&sourceId)) {
+        return 0;
+    }
+
+    const uint64_t sequence =
+        g_nextExplicitSwitchSequence.fetch_add(
+            1,
+            std::memory_order_relaxed);
+
+    AcquireSRWLockExclusive(&g_explicitSwitchLock);
+    g_explicitSwitch.active = true;
+    g_explicitSwitch.sourceDesktopId = sourceId;
+    g_explicitSwitch.targetDesktopId = targetId;
+    g_explicitSwitch.sequence = sequence;
+    ReleaseSRWLockExclusive(&g_explicitSwitchLock);
+
+    wchar_t sourceText[64] = {};
+    wchar_t targetText[64] = {};
+    GuidToString(sourceId, sourceText, ARRAYSIZE(sourceText));
+    GuidToString(targetId, targetText, ARRAYSIZE(targetText));
+
+    Wh_Log(
+        L"Explicit switch transaction #%llu begin route=%s "
+        L"source=%s target=%s",
+        static_cast<unsigned long long>(sequence),
+        route ? route : L"<unknown>",
+        sourceText,
+        targetText);
+
+    return sequence;
+}
+
+static void CancelExplicitSwitchTransaction(
+    uint64_t sequence,
+    const wchar_t* reason) {
+
+    if (!sequence) {
+        return;
+    }
+
+    bool cancelled = false;
+
+    AcquireSRWLockExclusive(&g_explicitSwitchLock);
+    if (g_explicitSwitch.active &&
+        g_explicitSwitch.sequence == sequence) {
+        g_explicitSwitch = {};
+        cancelled = true;
+    }
+    ReleaseSRWLockExclusive(&g_explicitSwitchLock);
+
+    if (cancelled) {
+        Wh_Log(
+            L"Explicit switch transaction #%llu cancelled: %s",
+            static_cast<unsigned long long>(sequence),
+            reason ? reason : L"<unknown>");
+    }
+}
+
+enum class ExplicitInternalSwitchDisposition {
+    None,
+    AllowTarget,
+    SuppressStaleSource,
+};
+
+static ExplicitInternalSwitchDisposition
+ClassifyInternalSwitchAgainstExplicitTransaction(
+    const GUID& requestedId,
+    ExplicitSwitchTransaction* snapshot) {
+
+    ExplicitSwitchTransaction current = {};
+
+    AcquireSRWLockShared(&g_explicitSwitchLock);
+    current = g_explicitSwitch;
+    ReleaseSRWLockShared(&g_explicitSwitchLock);
+
+    if (snapshot) {
+        *snapshot = current;
+    }
+
+    if (!current.active) {
+        return ExplicitInternalSwitchDisposition::None;
+    }
+
+    if (GuidEqual(requestedId, current.targetDesktopId)) {
+        return ExplicitInternalSwitchDisposition::AllowTarget;
+    }
+
+    if (!GuidEqual(
+            current.sourceDesktopId,
+            current.targetDesktopId) &&
+        GuidEqual(requestedId, current.sourceDesktopId)) {
+        return ExplicitInternalSwitchDisposition::SuppressStaleSource;
+    }
+
+    return ExplicitInternalSwitchDisposition::None;
+}
+
+static void FinishExplicitSwitchTransaction(
+    IVirtualDesktop* switchedDesktop) {
+
+    if (!switchedDesktop) {
+        return;
+    }
+
+    GUID switchedId = {};
+    if (FAILED(switchedDesktop->GetId(&switchedId))) {
+        return;
+    }
+
+    ExplicitSwitchTransaction finished = {};
+    bool hadTransaction = false;
+    bool reachedTarget = false;
+
+    AcquireSRWLockExclusive(&g_explicitSwitchLock);
+    if (g_explicitSwitch.active) {
+        finished = g_explicitSwitch;
+        hadTransaction = true;
+        reachedTarget =
+            GuidEqual(
+                switchedId,
+                g_explicitSwitch.targetDesktopId);
+        // Any completed desktop-switch notification ends the current
+        // transaction. A non-target completion means it was superseded or the
+        // shell chose another route; don't leave stale suppression armed.
+        g_explicitSwitch = {};
+    }
+    ReleaseSRWLockExclusive(&g_explicitSwitchLock);
+
+    if (!hadTransaction) {
+        return;
+    }
+
+    wchar_t switchedText[64] = {};
+    wchar_t targetText[64] = {};
+    GuidToString(switchedId, switchedText, ARRAYSIZE(switchedText));
+    GuidToString(
+        finished.targetDesktopId,
+        targetText,
+        ARRAYSIZE(targetText));
+
+    Wh_Log(
+        L"Explicit switch transaction #%llu %s "
+        L"switched=%s target=%s",
+        static_cast<unsigned long long>(finished.sequence),
+        reachedTarget ? L"complete" : L"ended on unexpected desktop",
+        switchedText,
+        targetText);
 }
 
 // -----------------------------------------------------------------------------
@@ -370,10 +556,79 @@ using SwitchDesktopInternal_t =
 
 static SwitchDesktopInternal_t g_switchDesktopInternalOriginal = nullptr;
 
+using SwitchDesktop_t =
+    HRESULT (*)(void* pThis, IVirtualDesktop* desktop);
+
+static SwitchDesktop_t g_switchDesktopOriginal = nullptr;
+
+using SwitchDesktopWithAnimation_t =
+    HRESULT (*)(void* pThis, IVirtualDesktop* desktop);
+
+static SwitchDesktopWithAnimation_t
+    g_switchDesktopWithAnimationOriginal = nullptr;
+
 using CycleInDirection_t =
     HRESULT (*)(void* pThis, int direction);
 
 static CycleInDirection_t g_cycleInDirectionOriginal = nullptr;
+
+static HRESULT SwitchDesktop_Hook(
+    void* pThis,
+    IVirtualDesktop* desktop) {
+
+    ++g_explicitSwitchEntryDepth;
+
+    uint64_t sequence = 0;
+    if (g_explicitSwitchEntryDepth == 1) {
+        sequence =
+            BeginExplicitSwitchTransaction(
+                desktop,
+                L"SwitchDesktop");
+    }
+
+    HRESULT hr =
+        g_switchDesktopOriginal(
+            pThis,
+            desktop);
+
+    if (FAILED(hr) && sequence) {
+        CancelExplicitSwitchTransaction(
+            sequence,
+            L"SwitchDesktop failed");
+    }
+
+    --g_explicitSwitchEntryDepth;
+    return hr;
+}
+
+static HRESULT SwitchDesktopWithAnimation_Hook(
+    void* pThis,
+    IVirtualDesktop* desktop) {
+
+    ++g_explicitSwitchEntryDepth;
+
+    uint64_t sequence = 0;
+    if (g_explicitSwitchEntryDepth == 1) {
+        sequence =
+            BeginExplicitSwitchTransaction(
+                desktop,
+                L"SwitchDesktopWithAnimation");
+    }
+
+    HRESULT hr =
+        g_switchDesktopWithAnimationOriginal(
+            pThis,
+            desktop);
+
+    if (FAILED(hr) && sequence) {
+        CancelExplicitSwitchTransaction(
+            sequence,
+            L"SwitchDesktopWithAnimation failed");
+    }
+
+    --g_explicitSwitchEntryDepth;
+    return hr;
+}
 
 static HRESULT CycleInDirection_Hook(
     void* pThis,
@@ -526,7 +781,9 @@ public:
     }
 
     HRESULT STDMETHODCALLTYPE VirtualDesktopSwitched(
-        IVirtualDesktop*) override {
+        IVirtualDesktop* desktop) override {
+
+        FinishExplicitSwitchTransaction(desktop);
         return S_OK;
     }
 
@@ -1307,6 +1564,65 @@ static HRESULT SwitchDesktopInternal_Hook(
             requestedDesktop);
     }
 
+    GUID requestedId = {};
+    HRESULT requestedIdHr =
+        requestedDesktop->GetId(&requestedId);
+
+    if (FAILED(requestedIdHr)) {
+        Wh_Log(
+            L"SwitchDesktopInternal allowed: "
+            L"requestedDesktop->GetId failed hr=0x%08X",
+            static_cast<unsigned int>(requestedIdHr));
+
+        return g_switchDesktopInternalOriginal(
+            pThis,
+            requestedDesktop);
+    }
+
+    // Task View can briefly try to restore/reactivate the foreground window
+    // from the desktop we just left (especially a fullscreen app) after the
+    // explicit SwitchDesktop* entry point has already returned. During the
+    // event-bounded explicit transaction, suppress exactly that request back
+    // to the captured source desktop. This is shell transition cleanup, so do
+    // NOT queue a teleport.
+    ExplicitSwitchTransaction explicitSnapshot = {};
+    ExplicitInternalSwitchDisposition explicitDisposition =
+        ClassifyInternalSwitchAgainstExplicitTransaction(
+            requestedId,
+            &explicitSnapshot);
+
+    if (explicitDisposition ==
+        ExplicitInternalSwitchDisposition::AllowTarget) {
+        Wh_Log(
+            L"ALLOW SwitchDesktopInternal: "
+            L"explicit transaction #%llu target",
+            static_cast<unsigned long long>(
+                explicitSnapshot.sequence));
+
+        return g_switchDesktopInternalOriginal(
+            pThis,
+            requestedDesktop);
+    }
+
+    if (explicitDisposition ==
+        ExplicitInternalSwitchDisposition::SuppressStaleSource) {
+
+        wchar_t targetText[64] = {};
+        GuidToString(
+            explicitSnapshot.targetDesktopId,
+            targetText,
+            ARRAYSIZE(targetText));
+
+        Wh_Log(
+            L"SUPPRESS SwitchDesktopInternal: stale source rebound "
+            L"during explicit transaction #%llu target=%s",
+            static_cast<unsigned long long>(
+                explicitSnapshot.sequence),
+            targetText);
+
+        return S_OK;
+    }
+
     GUID sourceDesktopId = {};
     if (!g_notificationReady.load() ||
         !LoadCurrentDesktopId(&sourceDesktopId)) {
@@ -1327,21 +1643,6 @@ static HRESULT SwitchDesktopInternal_Hook(
         Wh_Log(
             L"SwitchDesktopInternal allowed: "
             L"no eligible foreground rescue candidate");
-
-        return g_switchDesktopInternalOriginal(
-            pThis,
-            requestedDesktop);
-    }
-
-    GUID requestedId = {};
-    HRESULT requestedIdHr =
-        requestedDesktop->GetId(&requestedId);
-
-    if (FAILED(requestedIdHr)) {
-        Wh_Log(
-            L"SwitchDesktopInternal allowed: "
-            L"requestedDesktop->GetId failed hr=0x%08X",
-            static_cast<unsigned int>(requestedIdHr));
 
         return g_switchDesktopInternalOriginal(
             pThis,
@@ -1614,6 +1915,28 @@ static bool InstallVirtualDesktopHooks() {
                 &g_switchDesktopInternalOriginal),
             reinterpret_cast<void*>(
                 SwitchDesktopInternal_Hook)
+        },
+        {
+            {
+                L"public: virtual long __cdecl "
+                L"CVirtualDesktopManager::SwitchDesktop("
+                L"struct IVirtualDesktop *)"
+            },
+            reinterpret_cast<void**>(
+                &g_switchDesktopOriginal),
+            reinterpret_cast<void*>(
+                SwitchDesktop_Hook)
+        },
+        {
+            {
+                L"public: virtual long __cdecl "
+                L"CVirtualDesktopManager::SwitchDesktopWithAnimation("
+                L"struct IVirtualDesktop *)"
+            },
+            reinterpret_cast<void**>(
+                &g_switchDesktopWithAnimationOriginal),
+            reinterpret_cast<void*>(
+                SwitchDesktopWithAnimation_Hook)
         },
         {
             {

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -2,7 +2,7 @@
 // @id              prevent-virtual-desktop-stealing
 // @name            Prevent Window Activation from Stealing Virtual Desktop
 // @description     Redirect cross-desktop window activation to the current desktop.
-// @version         0.3.7
+// @version         0.3.8
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @include         explorer.exe
@@ -370,8 +370,11 @@ struct ExplicitSwitchTransaction {
     GUID sourceDesktopId = {};
     GUID targetDesktopId = {};
     uint64_t sequence = 0;
+    bool targetChangeObserved = false;
+    ULONGLONG startedAt = 0;
 };
 
+static constexpr ULONGLONG kExplicitSwitchExpiryMs = 2000;
 static SRWLOCK g_explicitSwitchLock = SRWLOCK_INIT;
 static ExplicitSwitchTransaction g_explicitSwitch = {};
 static std::atomic<uint64_t> g_nextExplicitSwitchSequence{1};
@@ -382,6 +385,32 @@ static thread_local int g_explicitSwitchEntryDepth = 0;
 
 static bool IsExplicitHotkeySwitchContext() {
     return g_hotkeyCycleDepth > 0;
+}
+
+static bool ExplicitSwitchExpired(
+    const ExplicitSwitchTransaction& transaction,
+    ULONGLONG now) {
+
+    return transaction.active &&
+        now - transaction.startedAt > kExplicitSwitchExpiryMs;
+}
+
+static void ClearExplicitSwitchTransaction(const wchar_t* reason) {
+    ExplicitSwitchTransaction cleared = {};
+
+    AcquireSRWLockExclusive(&g_explicitSwitchLock);
+    if (g_explicitSwitch.active) {
+        cleared = g_explicitSwitch;
+        g_explicitSwitch = {};
+    }
+    ReleaseSRWLockExclusive(&g_explicitSwitchLock);
+
+    if (cleared.active) {
+        Wh_Log(
+            L"Explicit switch transaction #%llu cleared: %s",
+            static_cast<unsigned long long>(cleared.sequence),
+            reason ? reason : L"<unknown>");
+    }
 }
 
 static uint64_t BeginExplicitSwitchTransaction(
@@ -402,6 +431,10 @@ static uint64_t BeginExplicitSwitchTransaction(
         return 0;
     }
 
+    if (GuidEqual(sourceId, targetId)) {
+        return 0;
+    }
+
     const uint64_t sequence =
         g_nextExplicitSwitchSequence.fetch_add(
             1,
@@ -412,6 +445,8 @@ static uint64_t BeginExplicitSwitchTransaction(
     g_explicitSwitch.sourceDesktopId = sourceId;
     g_explicitSwitch.targetDesktopId = targetId;
     g_explicitSwitch.sequence = sequence;
+    g_explicitSwitch.targetChangeObserved = false;
+    g_explicitSwitch.startedAt = GetTickCount64();
     ReleaseSRWLockExclusive(&g_explicitSwitchLock);
 
     wchar_t sourceText[64] = {};
@@ -469,9 +504,22 @@ ClassifyInternalSwitchAgainstExplicitTransaction(
 
     ExplicitSwitchTransaction current = {};
 
-    AcquireSRWLockShared(&g_explicitSwitchLock);
+    bool expired = false;
+
+    AcquireSRWLockExclusive(&g_explicitSwitchLock);
     current = g_explicitSwitch;
-    ReleaseSRWLockShared(&g_explicitSwitchLock);
+    if (ExplicitSwitchExpired(current, GetTickCount64())) {
+        g_explicitSwitch = {};
+        expired = true;
+    }
+    ReleaseSRWLockExclusive(&g_explicitSwitchLock);
+
+    if (expired) {
+        Wh_Log(
+            L"Explicit switch transaction #%llu expired",
+            static_cast<unsigned long long>(current.sequence));
+        current = {};
+    }
 
     if (snapshot) {
         *snapshot = current;
@@ -495,6 +543,48 @@ ClassifyInternalSwitchAgainstExplicitTransaction(
     return ExplicitInternalSwitchDisposition::None;
 }
 
+static void ObserveExplicitSwitchDesktopChange(const GUID& newDesktopId) {
+    ExplicitSwitchTransaction transaction = {};
+    bool expired = false;
+    bool targetObserved = false;
+    bool unexpected = false;
+
+    AcquireSRWLockExclusive(&g_explicitSwitchLock);
+    transaction = g_explicitSwitch;
+
+    if (ExplicitSwitchExpired(transaction, GetTickCount64())) {
+        g_explicitSwitch = {};
+        expired = true;
+    } else if (transaction.active &&
+               GuidEqual(newDesktopId, transaction.targetDesktopId)) {
+        g_explicitSwitch.targetChangeObserved = true;
+        targetObserved = true;
+    } else if (transaction.active &&
+               !GuidEqual(newDesktopId, transaction.sourceDesktopId)) {
+        // A change to neither endpoint can't be attributed to this
+        // transaction. Disarm it rather than retaining ambiguous suppression.
+        g_explicitSwitch = {};
+        unexpected = true;
+    }
+
+    ReleaseSRWLockExclusive(&g_explicitSwitchLock);
+
+    if (expired) {
+        Wh_Log(
+            L"Explicit switch transaction #%llu expired on desktop change",
+            static_cast<unsigned long long>(transaction.sequence));
+    } else if (targetObserved) {
+        Wh_Log(
+            L"Explicit switch transaction #%llu observed target change",
+            static_cast<unsigned long long>(transaction.sequence));
+    } else if (unexpected) {
+        Wh_Log(
+            L"Explicit switch transaction #%llu cleared by unexpected "
+            L"desktop change",
+            static_cast<unsigned long long>(transaction.sequence));
+    }
+}
+
 static void FinishExplicitSwitchTransaction(
     IVirtualDesktop* switchedDesktop) {
 
@@ -507,26 +597,28 @@ static void FinishExplicitSwitchTransaction(
         return;
     }
 
-    ExplicitSwitchTransaction finished = {};
-    bool hadTransaction = false;
-    bool reachedTarget = false;
+    ExplicitSwitchTransaction transaction = {};
+    bool expired = false;
+    bool completed = false;
+    bool ignored = false;
 
     AcquireSRWLockExclusive(&g_explicitSwitchLock);
-    if (g_explicitSwitch.active) {
-        finished = g_explicitSwitch;
-        hadTransaction = true;
-        reachedTarget =
-            GuidEqual(
-                switchedId,
-                g_explicitSwitch.targetDesktopId);
-        // Any completed desktop-switch notification ends the current
-        // transaction. A non-target completion means it was superseded or the
-        // shell chose another route; don't leave stale suppression armed.
+    transaction = g_explicitSwitch;
+
+    if (ExplicitSwitchExpired(transaction, GetTickCount64())) {
         g_explicitSwitch = {};
+        expired = true;
+    } else if (transaction.active &&
+               transaction.targetChangeObserved &&
+               GuidEqual(switchedId, transaction.targetDesktopId)) {
+        g_explicitSwitch = {};
+        completed = true;
+    } else if (transaction.active) {
+        ignored = true;
     }
     ReleaseSRWLockExclusive(&g_explicitSwitchLock);
 
-    if (!hadTransaction) {
+    if (!transaction.active) {
         return;
     }
 
@@ -534,17 +626,28 @@ static void FinishExplicitSwitchTransaction(
     wchar_t targetText[64] = {};
     GuidToString(switchedId, switchedText, ARRAYSIZE(switchedText));
     GuidToString(
-        finished.targetDesktopId,
+        transaction.targetDesktopId,
         targetText,
         ARRAYSIZE(targetText));
 
-    Wh_Log(
-        L"Explicit switch transaction #%llu %s "
-        L"switched=%s target=%s",
-        static_cast<unsigned long long>(finished.sequence),
-        reachedTarget ? L"complete" : L"ended on unexpected desktop",
-        switchedText,
-        targetText);
+    if (expired) {
+        Wh_Log(
+            L"Explicit switch transaction #%llu expired on completion",
+            static_cast<unsigned long long>(transaction.sequence));
+    } else if (completed) {
+        Wh_Log(
+            L"Explicit switch transaction #%llu complete switched=%s",
+            static_cast<unsigned long long>(transaction.sequence),
+            switchedText);
+    } else if (ignored) {
+        Wh_Log(
+            L"Explicit switch transaction #%llu ignored stale completion "
+            L"switched=%s target=%s targetChangeObserved=%d",
+            static_cast<unsigned long long>(transaction.sequence),
+            switchedText,
+            targetText,
+            transaction.targetChangeObserved);
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -751,6 +854,7 @@ public:
 
         if (SUCCEEDED(newHr)) {
             StoreCurrentDesktopId(newId);
+            ObserveExplicitSwitchDesktopChange(newId);
 
             wchar_t oldText[64] = {};
             wchar_t newText[64] = {};
@@ -972,6 +1076,7 @@ static bool StartNotificationCache() {
 
 static void StopNotificationCache() {
     g_notificationReady.store(false, std::memory_order_release);
+    ClearExplicitSwitchTransaction(L"notification cache stopping");
 
     if (g_notificationThread) {
         if (g_notificationThreadId) {

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -2,7 +2,7 @@
 // @id              prevent-virtual-desktop-stealing
 // @name            Prevent Window Activation from Stealing Virtual Desktop
 // @description     Redirect cross-desktop window activation to the current desktop.
-// @version         0.3.11
+// @version         0.3.12
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @include         explorer.exe
@@ -40,7 +40,7 @@ Transition Animation**.
 
 ### Notes
 
-Designed for Windows 11 22H2 and newer. This mod relies on undocumented Windows
+Designed for Windows 11 24H2 and newer. This mod relies on undocumented Windows
 shell interfaces, so future Windows updates may require adjustments.
 */
 // ==/WindhawkModReadme==
@@ -115,6 +115,9 @@ struct IVirtualDesktop : IUnknown {
 };
 
 struct IApplicationView : IUnknown {};
+
+struct IVirtualDesktopManagerPrivate;
+struct IVirtualDesktopSwitchAnimator;
 
 struct IApplicationViewCollection : IUnknown {
     virtual HRESULT STDMETHODCALLTYPE GetViews(
@@ -317,12 +320,16 @@ static void LogWindow(const wchar_t* label, HWND hwnd) {
 // Explicit user-switch attribution.
 // -----------------------------------------------------------------------------
 
-// Disable Virtual Desktop Transition Animation causes the native
-// Win+Ctrl+Left/Right path to call SwitchDesktopInternal synchronously.
-// The probe confirmed that the call occurs while _CycleInDirection is still
-// active, so a thread-local nesting depth is sufficient; no timing grace
-// period or physical-key heuristic is used.
-static thread_local int g_hotkeyCycleDepth = 0;
+// Cross-desktop activation switches were probed to originate synchronously
+// inside CVirtualDesktopForegroundPolicy::ForegroundViewChanged. Deliberate
+// low-level switches (including Win+Ctrl+Left/Right when Disable Virtual
+// Desktop Transition Animation is installed) enter SwitchDesktopInternal with
+// this depth at zero.
+//
+// This is the primary blast-radius guard: unknown SwitchDesktopInternal callers
+// are always allowed. Only a positively attributed foreground-policy switch is
+// eligible for redirect.
+static thread_local int g_foregroundPolicyDepth = 0;
 
 // Task View and direct shell/API desktop switches are asynchronous: their public
 // SwitchDesktop* entry point can return before CurrentVirtualDesktopChanged is
@@ -349,10 +356,6 @@ static std::atomic<uint64_t> g_nextExplicitSwitchSequence{1};
 // SwitchDesktopWithAnimation synchronously calls SwitchDesktop on current
 // builds. Only the outermost public switch entry should create a transaction.
 static thread_local int g_explicitSwitchEntryDepth = 0;
-
-static bool IsExplicitHotkeySwitchContext() {
-    return g_hotkeyCycleDepth > 0;
-}
 
 static const wchar_t* GuidToStringForLog(const GUID& guid) {
     // A ring keeps multiple GUID arguments in one Wh_Log call distinct. Since
@@ -636,10 +639,15 @@ using SwitchDesktopWithAnimation_t =
 static SwitchDesktopWithAnimation_t
     g_switchDesktopWithAnimationOriginal = nullptr;
 
-using CycleInDirection_t =
-    HRESULT (*)(void* pThis, int direction);
+using ForegroundViewChanged_t =
+    HRESULT (*)(
+        void* pThis,
+        IVirtualDesktopManagerPrivate* manager,
+        IVirtualDesktopSwitchAnimator* animator,
+        IApplicationView* view);
 
-static CycleInDirection_t g_cycleInDirectionOriginal = nullptr;
+static ForegroundViewChanged_t
+    g_foregroundViewChangedOriginal = nullptr;
 
 static HRESULT SwitchDesktop_Hook(
     void* pThis,
@@ -699,27 +707,22 @@ static HRESULT SwitchDesktopWithAnimation_Hook(
     return hr;
 }
 
-static HRESULT CycleInDirection_Hook(
+static HRESULT ForegroundViewChanged_Hook(
     void* pThis,
-    int direction) {
+    IVirtualDesktopManagerPrivate* manager,
+    IVirtualDesktopSwitchAnimator* animator,
+    IApplicationView* view) {
 
-    ++g_hotkeyCycleDepth;
-
-    Wh_Log(
-        L"HOTKEY-CYCLE begin direction=%d depth=%d",
-        direction,
-        g_hotkeyCycleDepth);
+    ++g_foregroundPolicyDepth;
 
     HRESULT hr =
-        g_cycleInDirectionOriginal(pThis, direction);
+        g_foregroundViewChangedOriginal(
+            pThis,
+            manager,
+            animator,
+            view);
 
-    Wh_Log(
-        L"HOTKEY-CYCLE end direction=%d hr=0x%08X depth=%d",
-        direction,
-        static_cast<unsigned int>(hr),
-        g_hotkeyCycleDepth);
-
-    --g_hotkeyCycleDepth;
+    --g_foregroundPolicyDepth;
     return hr;
 }
 
@@ -1593,26 +1596,23 @@ static HRESULT SwitchDesktopInternal_Hook(
     void* pThis,
     IVirtualDesktop* requestedDesktop) {
 
-    if (!g_workerReady.load() ||
-        !pThis ||
-        !requestedDesktop) {
+    if (!pThis || !requestedDesktop) {
         return g_switchDesktopInternalOriginal(
             pThis,
             requestedDesktop);
     }
 
-    // Critical compatibility path:
-    // When Disable Virtual Desktop Transition Animation is enabled, the native
-    // Win+Ctrl+Left/Right handler can select SwitchDesktopInternal as its
-    // no-animation path. Since we're inside (or immediately after) the actual
-    // _CycleInDirection user action, this is intentional and must not be
-    // converted into a teleport.
-    if (IsExplicitHotkeySwitchContext()) {
-        Wh_Log(
-            L"ALLOW SwitchDesktopInternal: "
-            L"explicit HOTKEY-CYCLE context depth=%d",
-            g_hotkeyCycleDepth);
+    // Hard blast-radius boundary: if the foreground policy didn't synchronously
+    // cause this switch, don't inspect or classify it at all.
+    if (g_foregroundPolicyDepth <= 0) {
+        return g_switchDesktopInternalOriginal(
+            pThis,
+            requestedDesktop);
+    }
 
+    // From here down, the switch is positively attributed to
+    // CVirtualDesktopForegroundPolicy::ForegroundViewChanged.
+    if (!g_workerReady.load()) {
         return g_switchDesktopInternalOriginal(
             pThis,
             requestedDesktop);
@@ -1661,12 +1661,17 @@ static HRESULT SwitchDesktopInternal_Hook(
     if (explicitDisposition ==
         ExplicitInternalSwitchDisposition::SuppressStaleSource) {
 
+        // Rapid Task View switching can make foreground policy try to restore
+        // the view from the desktop we just left. Suppress that exact rebound,
+        // but don't queue a rescue/teleport.
         Wh_Log(
             L"SUPPRESS SwitchDesktopInternal: stale source rebound "
-            L"during explicit transaction #%llu target=%s",
+            L"during explicit transaction #%llu target=%s "
+            L"foregroundPolicyDepth=%d",
             static_cast<unsigned long long>(
                 explicitSnapshot.sequence),
-            GuidToStringForLog(explicitSnapshot.targetDesktopId));
+            GuidToStringForLog(explicitSnapshot.targetDesktopId),
+            g_foregroundPolicyDepth);
 
         return S_OK;
     }
@@ -1685,8 +1690,8 @@ static HRESULT SwitchDesktopInternal_Hook(
 
     HWND foreground = GetForegroundWindow();
 
-    // If there isn't a plausible app window to rescue, don't interfere with
-    // an unknown internal switch path.
+    // Even inside the positively attributed activation path, fail open unless
+    // there is a plausible top-level app window to rescue.
     if (!IsRescueCandidate(foreground)) {
         Wh_Log(
             L"SwitchDesktopInternal allowed: "
@@ -1722,11 +1727,13 @@ static HRESULT SwitchDesktopInternal_Hook(
     }
 
     Wh_Log(
-        L"Candidate SwitchDesktopInternal "
-        L"source=%s requested=%s foreground=%p",
+        L"Candidate activation-driven SwitchDesktopInternal "
+        L"source=%s requested=%s foreground=%p "
+        L"foregroundPolicyDepth=%d",
         GuidToStringForLog(sourceDesktopId),
         GuidToStringForLog(requestedId),
-        foreground);
+        foreground,
+        g_foregroundPolicyDepth);
 
     LogWindow(L"candidate", foreground);
 
@@ -1962,14 +1969,16 @@ static bool InstallVirtualDesktopHooks() {
         },
         {
             {
-                L"private: long __cdecl "
-                L"CVirtualDesktopHotkeyHandler::_CycleInDirection("
-                L"enum VirtualDesktopSwitchDirection)"
+                L"public: virtual long __cdecl "
+                L"CVirtualDesktopForegroundPolicy::ForegroundViewChanged("
+                L"struct IVirtualDesktopManagerPrivate *,"
+                L"struct IVirtualDesktopSwitchAnimator *,"
+                L"struct IApplicationView *)"
             },
             reinterpret_cast<void**>(
-                &g_cycleInDirectionOriginal),
+                &g_foregroundViewChangedOriginal),
             reinterpret_cast<void*>(
-                CycleInDirection_Hook)
+                ForegroundViewChanged_Hook)
         },
     };
 

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -361,11 +361,6 @@ static ExplicitSwitchTransaction g_explicitSwitch = {};
 static std::atomic<uint64_t> g_nextExplicitSwitchSequence{1};
 
 // IVirtualDesktopManagerInternal slots for the 24H2 IID above.
-// Keep the two calls as named, version-gated vtable accesses rather than
-// declaring a full C++ interface: the undocumented methods between IUnknown
-// and these slots have signatures that vary across shell versions. Placeholder
-// declarations would suggest ABI guarantees that the mod neither needs nor
-// has verified. The 24H2 IID is the layout gate for both indices.
 static constexpr int kVtableMoveViewToDesktop = 4;
 static constexpr int kVtableGetCurrentDesktop = 6;
 
@@ -798,9 +793,8 @@ static HRESULT ForegroundViewChanged_Hook(
 // -----------------------------------------------------------------------------
 
 static HANDLE g_notificationThread = nullptr;
+static DWORD g_notificationThreadId = 0;
 static HANDLE g_notificationReadyEvent = nullptr;
-static HANDLE g_notificationStopEvent = nullptr;
-static HANDLE g_unloadEvent = nullptr;
 static std::atomic<bool> g_notificationReady = false;
 
 class VirtualDesktopNotificationListener final
@@ -1020,37 +1014,9 @@ static DWORD WINAPI NotificationThreadProc(void*) {
     SetEvent(g_notificationReadyEvent);
 
     if (g_notificationReady.load()) {
-        while (true) {
-            DWORD waitResult =
-                MsgWaitForMultipleObjects(
-                    1,
-                    &g_notificationStopEvent,
-                    FALSE,
-                    INFINITE,
-                    QS_ALLINPUT);
-
-            if (waitResult == WAIT_OBJECT_0) {
-                break;
-            }
-
-            if (waitResult != WAIT_OBJECT_0 + 1) {
-                Wh_Log(
-                    L"Notification message wait failed result=%lu "
-                    L"error=%lu",
-                    waitResult,
-                    GetLastError());
-                break;
-            }
-
-            while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
-                if (msg.message == WM_QUIT) {
-                    SetEvent(g_notificationStopEvent);
-                    break;
-                }
-
-                TranslateMessage(&msg);
-                DispatchMessageW(&msg);
-            }
+        while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+            TranslateMessage(&msg);
+            DispatchMessageW(&msg);
         }
     }
 
@@ -1093,13 +1059,9 @@ static bool StartNotificationCache() {
     g_notificationReadyEvent =
         CreateEventW(nullptr, TRUE, FALSE, nullptr);
 
-    g_notificationStopEvent =
-        CreateEventW(nullptr, TRUE, FALSE, nullptr);
-
-    if (!g_notificationReadyEvent ||
-        !g_notificationStopEvent) {
+    if (!g_notificationReadyEvent) {
         Wh_Log(
-            L"Create notification events failed error=%lu",
+            L"Create notification-ready event failed error=%lu",
             GetLastError());
         return false;
     }
@@ -1111,7 +1073,7 @@ static bool StartNotificationCache() {
             NotificationThreadProc,
             nullptr,
             0,
-            nullptr);
+            &g_notificationThreadId);
 
     if (!g_notificationThread) {
         Wh_Log(
@@ -1120,17 +1082,8 @@ static bool StartNotificationCache() {
         return false;
     }
 
-    HANDLE waits[] = {
-        g_notificationReadyEvent,
-        g_unloadEvent,
-    };
-
     DWORD waitResult =
-        WaitForMultipleObjects(
-            ARRAYSIZE(waits),
-            waits,
-            FALSE,
-            5000);
+        WaitForSingleObject(g_notificationReadyEvent, 5000);
 
     if (waitResult != WAIT_OBJECT_0 ||
         !g_notificationReady.load()) {
@@ -1148,24 +1101,24 @@ static void StopNotificationCache() {
     g_notificationReady.store(false, std::memory_order_release);
     ClearExplicitSwitchTransaction(L"notification cache stopping");
 
-    if (g_notificationStopEvent) {
-        SetEvent(g_notificationStopEvent);
-    }
-
     if (g_notificationThread) {
+        if (g_notificationThreadId) {
+            PostThreadMessageW(
+                g_notificationThreadId,
+                WM_QUIT,
+                0,
+                0);
+        }
+
         WaitForSingleObject(g_notificationThread, INFINITE);
         CloseHandle(g_notificationThread);
         g_notificationThread = nullptr;
+        g_notificationThreadId = 0;
     }
 
     if (g_notificationReadyEvent) {
         CloseHandle(g_notificationReadyEvent);
         g_notificationReadyEvent = nullptr;
-    }
-
-    if (g_notificationStopEvent) {
-        CloseHandle(g_notificationStopEvent);
-        g_notificationStopEvent = nullptr;
     }
 
     ClearCurrentDesktopId();
@@ -1906,16 +1859,9 @@ static bool StartWorker() {
         return false;
     }
 
-    HANDLE waits[] = {
-        g_workerReadyEvent,
-        g_unloadEvent,
-    };
-
     DWORD waitResult =
-        WaitForMultipleObjects(
-            ARRAYSIZE(waits),
-            waits,
-            FALSE,
+        WaitForSingleObject(
+            g_workerReadyEvent,
             5000);
 
     if (waitResult != WAIT_OBJECT_0 ||
@@ -2001,6 +1947,24 @@ static std::atomic<bool> g_virtualDesktopHooksInstalled{false};
 
 static SRWLOCK g_runtimeInitLock = SRWLOCK_INIT;
 static HANDLE g_runtimeInitThread = nullptr;
+
+static HWND FindCurrentProcessPrimaryTaskbar() {
+    HWND taskbar = FindWindowW(
+        L"Shell_TrayWnd",
+        nullptr);
+
+    if (!taskbar) {
+        return nullptr;
+    }
+
+    DWORD pid = 0;
+    if (!GetWindowThreadProcessId(taskbar, &pid) ||
+        pid != GetCurrentProcessId()) {
+        return nullptr;
+    }
+
+    return taskbar;
+}
 
 static HWND FindCurrentProcessShellWindow() {
     HWND shellWindow = GetShellWindow();
@@ -2111,8 +2075,9 @@ static bool InstallVirtualDesktopHooks() {
 }
 
 static bool WaitForShellHostRetryDelay() {
-    // Keep unload latency short while allowing the shell's COM services time
-    // to register after a fresh Explorer start.
+    // Fresh Explorer startup can expose Shell_TrayWnd before the immersive-shell
+    // virtual-desktop COM services are fully ready. Keep the retry interval
+    // fixed and bounded, but give those services a generous startup window.
     for (int i = 0; i < 10; ++i) {
         if (g_unloading.load(std::memory_order_acquire)) {
             return false;
@@ -2142,10 +2107,6 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
         return 0;
     }
 
-    // Explorer's virtual-desktop COM services can become available well after
-    // the primary taskbar appears during a shell restart. Preserve the broad
-    // retry window; the ready waits and this delay all observe unloading, so
-    // the larger budget doesn't increase mod-disable latency.
     constexpr int kMaxRuntimeStartAttempts = 30;
 
     for (int attempt = 1; attempt <= kMaxRuntimeStartAttempts; ++attempt) {
@@ -2362,10 +2323,6 @@ static HWND WINAPI CreateWindowExW_Hook(
 static void StopRuntimeBeforeUninit() {
     g_unloading.store(true, std::memory_order_release);
 
-    if (g_unloadEvent) {
-        SetEvent(g_unloadEvent);
-    }
-
     HANDLE initThread = nullptr;
 
     AcquireSRWLockExclusive(&g_runtimeInitLock);
@@ -2392,16 +2349,6 @@ BOOL Wh_ModInit() {
         L"Init: installing lightweight "
         L"primary-taskbar observer");
 
-    g_unloadEvent =
-        CreateEventW(nullptr, TRUE, FALSE, nullptr);
-
-    if (!g_unloadEvent) {
-        Wh_Log(
-            L"Failed to create unload event error=%lu",
-            GetLastError());
-        return FALSE;
-    }
-
     // Deliberately don't load twinui.pcshell.dll or taskbar.dll here. This code
     // executes in every explorer.exe matched by @include. Non-shell Explorer
     // processes should remain as inert as possible.
@@ -2411,8 +2358,6 @@ BOOL Wh_ModInit() {
             &g_createWindowExWOriginal)) {
         Wh_Log(
             L"Failed to hook CreateWindowExW");
-        CloseHandle(g_unloadEvent);
-        g_unloadEvent = nullptr;
         return FALSE;
     }
 
@@ -2420,9 +2365,25 @@ BOOL Wh_ModInit() {
 }
 
 void Wh_ModAfterInit() {
-    // Manual enable/reload: the shell window may already identify this process
-    // before our CreateWindowExW observer sees the primary taskbar creation.
-    HWND shellWindow = FindCurrentProcessShellWindow();
+    // Injection/reload can happen after the primary taskbar was already created,
+    // so don't rely solely on observing CreateWindowExW. Detect Shell_TrayWnd
+    // directly first; GetShellWindow is retained as an additional shell-host
+    // signal for manual reloads and unusual startup ordering.
+    HWND primaryTaskbar =
+        FindCurrentProcessPrimaryTaskbar();
+
+    if (primaryTaskbar) {
+        Wh_Log(
+            L"Existing primary taskbar=%p belongs to this Explorer process",
+            primaryTaskbar);
+
+        PromoteCurrentProcessToShellHost(
+            L"existing primary Shell_TrayWnd");
+        return;
+    }
+
+    HWND shellWindow =
+        FindCurrentProcessShellWindow();
 
     if (shellWindow) {
         Wh_Log(
@@ -2433,8 +2394,8 @@ void Wh_ModAfterInit() {
             L"existing shell window");
     } else {
         Wh_Log(
-            L"No shell window owned by this PID; "
-            L"remaining inert unless one is created");
+            L"No primary taskbar or shell window owned by this PID; "
+            L"remaining inert unless Shell_TrayWnd is created");
     }
 }
 
@@ -2445,9 +2406,4 @@ void Wh_ModBeforeUninit() {
 void Wh_ModUninit() {
     Wh_Log(L"Uninit");
     StopRuntime();
-
-    if (g_unloadEvent) {
-        CloseHandle(g_unloadEvent);
-        g_unloadEvent = nullptr;
-    }
 }

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -1249,22 +1249,26 @@ static bool QueueRescue(
 
     AcquireSRWLockExclusive(&g_requestLock);
 
-    if (g_rescueQueueCount < kRescueQueueCapacity) {
+    if (g_workerReady.load(std::memory_order_acquire) &&
+        g_requestEvent &&
+        g_rescueQueueCount < kRescueQueueCapacity) {
         size_t index =
             (g_rescueQueueHead + g_rescueQueueCount) %
             kRescueQueueCapacity;
         g_rescueQueue[index] = request;
         ++g_rescueQueueCount;
-        queued = true;
+        if (SetEvent(g_requestEvent)) {
+            queued = true;
+        } else {
+            --g_rescueQueueCount;
+        }
     }
 
     ReleaseSRWLockExclusive(&g_requestLock);
 
-    if (queued) {
-        SetEvent(g_requestEvent);
-    } else {
+    if (!queued) {
         Wh_Log(
-            L"Rescue queue full; failing open");
+            L"Rescue queue unavailable or full; failing open");
     }
 
     return queued;
@@ -1475,7 +1479,11 @@ static bool StartWorker() {
 }
 
 static void StopWorker() {
+    AcquireSRWLockExclusive(&g_requestLock);
     g_workerReady.store(false, std::memory_order_release);
+    g_rescueQueueHead = 0;
+    g_rescueQueueCount = 0;
+    ReleaseSRWLockExclusive(&g_requestLock);
 
     if (g_stopEvent) {
         SetEvent(g_stopEvent);
@@ -1500,10 +1508,12 @@ static void StopWorker() {
         g_stopEvent = nullptr;
     }
 
+    AcquireSRWLockExclusive(&g_requestLock);
     if (g_requestEvent) {
         CloseHandle(g_requestEvent);
         g_requestEvent = nullptr;
     }
+    ReleaseSRWLockExclusive(&g_requestLock);
 
 }
 

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -2110,11 +2110,10 @@ static bool InstallVirtualDesktopHooks() {
     return true;
 }
 
-static bool WaitForShellHostRetryDelay(int attempt) {
+static bool WaitForShellHostRetryDelay() {
     // Keep unload latency short while allowing the shell's COM services time
     // to register after a fresh Explorer start.
-    // Back off from 500 ms to 2 seconds across the bounded retry budget.
-    for (int i = 0; i < attempt * 10; ++i) {
+    for (int i = 0; i < 10; ++i) {
         if (g_unloading.load(std::memory_order_acquire)) {
             return false;
         }
@@ -2143,7 +2142,11 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
         return 0;
     }
 
-    constexpr int kMaxRuntimeStartAttempts = 4;
+    // Explorer's virtual-desktop COM services can become available well after
+    // the primary taskbar appears during a shell restart. Preserve the broad
+    // retry window; the ready waits and this delay all observe unloading, so
+    // the larger budget doesn't increase mod-disable latency.
+    constexpr int kMaxRuntimeStartAttempts = 30;
 
     for (int attempt = 1; attempt <= kMaxRuntimeStartAttempts; ++attempt) {
         bool workerStarted = StartWorker();
@@ -2182,7 +2185,7 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
                 L"Shell-host runtime unavailable on attempt %d; retrying",
                 attempt);
 
-            if (!WaitForShellHostRetryDelay(attempt)) {
+            if (!WaitForShellHostRetryDelay()) {
                 g_runtimeState.store(
                     RuntimeState::Stopped,
                     std::memory_order_release);

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -2,7 +2,7 @@
 // @id              prevent-virtual-desktop-stealing
 // @name            Prevent Window Activation from Stealing Virtual Desktop
 // @description     Redirect cross-desktop window activation to the current desktop.
-// @version         0.3.13
+// @version         0.3.14
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @include         explorer.exe
@@ -20,10 +20,10 @@ Take back control over your virtual desktops!
 _Effect of redirecting window activation_
 
 Windows can switch you to another virtual desktop just because a window that was left open on that
-desktop is activated. 
+desktop is activated.
 
-Clicking a flashing taskbar button, following a notification, opening an app through its tray icon, 
-or launching something that insists on reusing an existing window can all unexpectedly pull you away 
+Clicking a flashing taskbar button, following a notification, opening an app through its tray icon,
+or launching something that insists on reusing an existing window can all unexpectedly pull you away
 from your current desktop. This mod keeps you where you are and brings the activated window to you instead.
 
 If you don't know what "virtual desktop stealing" is, try this small experiment:
@@ -133,6 +133,12 @@ struct IApplicationViewCollection : IUnknown {
 
 struct IVirtualDesktopManagerInternal : IUnknown {};
 
+// Windows 11 24H2 (build 26100) uses 14 total vtable slots for IID
+// B9E5E94D-233E-49AB-AF5C-2B4541C3AADE: IUnknown at slots 0-2, the
+// callbacks below at slots 3-13, CurrentVirtualDesktopChanged at slot 10,
+// VirtualDesktopSwitched at slot 12, and RemoteVirtualDesktopConnected at
+// slot 13. The older CD403E52-... monitor-aware interface has a different
+// layout, including VirtualDesktopIsPerMonitorChanged, and is not used here.
 struct IVirtualDesktopNotification : IUnknown {
     virtual HRESULT STDMETHODCALLTYPE VirtualDesktopCreated(
         IVirtualDesktop* desktop) = 0;
@@ -193,6 +199,108 @@ template <typename T>
 static T GetVTableFunction(void* object, int index) {
     return reinterpret_cast<T>(
         (*reinterpret_cast<void***>(object))[index]);
+}
+
+enum class RuntimeStartOutcome {
+    Ready,
+    RetryableFailure,
+    Unsupported,
+    Cancelled,
+};
+
+struct RuntimeStartResult {
+    RuntimeStartOutcome outcome;
+    HRESULT hr;
+};
+
+struct RuntimeStartResultSlot {
+    std::atomic<RuntimeStartOutcome> outcome{
+        RuntimeStartOutcome::RetryableFailure};
+    std::atomic<HRESULT> hr{E_PENDING};
+};
+
+static HANDLE g_runtimeCancelEvent = nullptr;  // manual-reset, process lifetime
+
+static void ResetStartResult(RuntimeStartResultSlot* slot) {
+    slot->hr.store(E_PENDING, std::memory_order_relaxed);
+    slot->outcome.store(
+        RuntimeStartOutcome::RetryableFailure,
+        std::memory_order_release);
+}
+
+static void PublishStartResult(
+    RuntimeStartResultSlot* slot,
+    HANDLE readyEvent,
+    RuntimeStartResult result) {
+
+    slot->hr.store(result.hr, std::memory_order_relaxed);
+    slot->outcome.store(result.outcome, std::memory_order_release);
+    SetEvent(readyEvent);
+}
+
+static RuntimeStartResult LoadStartResult(
+    RuntimeStartResultSlot* slot) {
+
+    RuntimeStartOutcome outcome =
+        slot->outcome.load(std::memory_order_acquire);
+
+    return {
+        outcome,
+        slot->hr.load(std::memory_order_relaxed),
+    };
+}
+
+static bool RuntimeCancellationRequested() {
+    return g_runtimeCancelEvent &&
+        WaitForSingleObject(g_runtimeCancelEvent, 0) == WAIT_OBJECT_0;
+}
+
+static RuntimeStartResult RuntimeStartFailure(HRESULT hr) {
+    // ImmersiveShell activation can temporarily return REGDB_E_CLASSNOTREG
+    // during early Explorer startup. Only a caller that positively identified
+    // a missing required private interface may use RuntimeStartUnsupported.
+    return {
+        RuntimeStartOutcome::RetryableFailure,
+        hr,
+    };
+}
+
+static RuntimeStartResult RuntimeStartUnsupported(HRESULT hr) {
+    return {
+        RuntimeStartOutcome::Unsupported,
+        hr,
+    };
+}
+
+static RuntimeStartResult RuntimeStartCancelled() {
+    return {
+        RuntimeStartOutcome::Cancelled,
+        HRESULT_FROM_WIN32(ERROR_CANCELLED),
+    };
+}
+
+static DWORD GetWindowsBuildNumber() {
+    using RtlGetVersion_t = LONG (WINAPI*)(OSVERSIONINFOW* versionInfo);
+
+    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+    if (!ntdll) {
+        return 0;
+    }
+
+    auto rtlGetVersion = reinterpret_cast<RtlGetVersion_t>(
+        GetProcAddress(ntdll, "RtlGetVersion"));
+    if (!rtlGetVersion) {
+        return 0;
+    }
+
+    OSVERSIONINFOW versionInfo = {};
+    versionInfo.dwOSVersionInfoSize = sizeof(versionInfo);
+
+    if (rtlGetVersion(&versionInfo) != 0) {
+        return 0;
+    }
+
+    return versionInfo.dwBuildNumber;
 }
 
 static bool GuidEqual(const GUID& a, const GUID& b) {
@@ -329,10 +437,9 @@ static thread_local int g_foregroundPolicyDepth = 0;
 
 // Exact window identity supplied by the active foreground-policy view.
 //
-// IApplicationView::GetThumbnailWindow is vtable slot 9 on the Windows 11
-// 24H2+ shell ABI used by this mod. Probing confirmed that calling this slot
-// synchronously from ForegroundViewChanged returns the HWND of the exact view
-// which is driving a cross-desktop activation.
+// The active IApplicationView is mapped to an HWND only through symbol-resolved
+// concrete implementations whose vtable identity is known. Probing confirmed
+// that this returns the HWND of the exact view driving cross-desktop activation.
 //
 // Keep only the plain HWND in TLS. Never carry the raw IApplicationView pointer
 // into the rescue worker apartment.
@@ -660,9 +767,29 @@ using ForegroundViewChanged_t =
 static ForegroundViewChanged_t
     g_foregroundViewChangedOriginal = nullptr;
 
+static void* g_win32ApplicationViewVtable = nullptr;
+static void* g_winRtApplicationViewVtable = nullptr;
+
+using ApplicationViewGetNativeWindow_t =
+    HRESULT (WINAPI*)(void* pThis, HWND* windowHandle);
+
+static ApplicationViewGetNativeWindow_t
+    g_win32ApplicationViewGetNativeWindow = nullptr;
+static ApplicationViewGetNativeWindow_t
+    g_winRtApplicationViewGetNativeWindow = nullptr;
+
+// Hook operations can be applied only after Wh_ModInit has returned. Keep the
+// detours inert until both COM runtimes are ready, and disable them before
+// teardown begins.
+static std::atomic<bool> g_interceptionEnabled{false};
+
 static HRESULT SwitchDesktop_Hook(
     void* pThis,
     IVirtualDesktop* desktop) {
+
+    if (!g_interceptionEnabled.load(std::memory_order_acquire)) {
+        return g_switchDesktopOriginal(pThis, desktop);
+    }
 
     ++g_explicitSwitchEntryDepth;
 
@@ -692,6 +819,10 @@ static HRESULT SwitchDesktop_Hook(
 static HRESULT SwitchDesktopWithAnimation_Hook(
     void* pThis,
     IVirtualDesktop* desktop) {
+
+    if (!g_interceptionEnabled.load(std::memory_order_acquire)) {
+        return g_switchDesktopWithAnimationOriginal(pThis, desktop);
+    }
 
     ++g_explicitSwitchEntryDepth;
 
@@ -725,31 +856,33 @@ static HWND GetForegroundPolicyViewHwnd(
         return nullptr;
     }
 
-    // IApplicationView::GetThumbnailWindow(HWND*) is slot 9 including the
-    // three IUnknown entries. Use the interface vtable so Win32/WinRT views
-    // dispatch to their own implementation.
-    using GetThumbnailWindow_t =
-        HRESULT (*)(IApplicationView*, HWND*);
+    void* vtable = *reinterpret_cast<void**>(view);
+    ApplicationViewGetNativeWindow_t getNativeWindow = nullptr;
 
-    auto getThumbnailWindow =
-        GetVTableFunction<GetThumbnailWindow_t>(
-            view,
-            9);
-
-    if (!getThumbnailWindow) {
+    if (vtable == g_win32ApplicationViewVtable &&
+        g_win32ApplicationViewGetNativeWindow) {
+        getNativeWindow = g_win32ApplicationViewGetNativeWindow;
+    } else if (vtable == g_winRtApplicationViewVtable &&
+               g_winRtApplicationViewGetNativeWindow) {
+        getNativeWindow = g_winRtApplicationViewGetNativeWindow;
+    } else {
+        Wh_Log(
+            L"ForegroundViewChanged: unknown IApplicationView vtable=%p; "
+            L"failing open",
+            vtable);
         return nullptr;
     }
 
     HWND hwnd = nullptr;
     HRESULT hr =
-        getThumbnailWindow(
+        getNativeWindow(
             view,
             &hwnd);
 
     if (FAILED(hr)) {
         Wh_Log(
             L"ForegroundViewChanged: "
-            L"GetThumbnailWindow failed hr=0x%08X",
+            L"v_GetNativeWindow failed hr=0x%08X",
             static_cast<unsigned int>(hr));
         return nullptr;
     }
@@ -762,6 +895,14 @@ static HRESULT ForegroundViewChanged_Hook(
     IVirtualDesktopManagerPrivate* manager,
     IVirtualDesktopSwitchAnimator* animator,
     IApplicationView* view) {
+
+    if (!g_interceptionEnabled.load(std::memory_order_acquire)) {
+        return g_foregroundViewChangedOriginal(
+            pThis,
+            manager,
+            animator,
+            view);
+    }
 
     HWND previousHwnd =
         g_foregroundPolicyHwnd;
@@ -795,7 +936,15 @@ static HRESULT ForegroundViewChanged_Hook(
 static HANDLE g_notificationThread = nullptr;
 static DWORD g_notificationThreadId = 0;
 static HANDLE g_notificationReadyEvent = nullptr;
+static HANDLE g_notificationStopEvent = nullptr;
 static std::atomic<bool> g_notificationReady = false;
+static RuntimeStartResultSlot g_notificationStartResult;
+
+static bool NotificationStopRequested() {
+    return RuntimeCancellationRequested() ||
+        (g_notificationStopEvent &&
+         WaitForSingleObject(g_notificationStopEvent, 0) == WAIT_OBJECT_0);
+}
 
 class VirtualDesktopNotificationListener final
     : public IVirtualDesktopNotification {
@@ -927,6 +1076,20 @@ private:
 };
 
 static DWORD WINAPI NotificationThreadProc(void*) {
+    // Create the thread message queue before doing anything that can block. If
+    // StopNotificationCache posted too early for PostThreadMessage to succeed,
+    // the durable stop event below still prevents entry into GetMessage.
+    MSG msg = {};
+    PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+
+    if (NotificationStopRequested()) {
+        PublishStartResult(
+            &g_notificationStartResult,
+            g_notificationReadyEvent,
+            RuntimeStartCancelled());
+        return 0;
+    }
+
     HRESULT coHr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
     const bool shouldUninitialize = SUCCEEDED(coHr);
 
@@ -934,19 +1097,35 @@ static DWORD WINAPI NotificationThreadProc(void*) {
         Wh_Log(
             L"Notification CoInitializeEx failed hr=0x%08X",
             static_cast<unsigned int>(coHr));
-        SetEvent(g_notificationReadyEvent);
+
+        PublishStartResult(
+            &g_notificationStartResult,
+            g_notificationReadyEvent,
+            NotificationStopRequested()
+                ? RuntimeStartCancelled()
+                : RuntimeStartFailure(coHr));
         return 0;
     }
 
-    // Ensure this STA owns a message queue before registration.
-    MSG msg = {};
-    PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+    if (NotificationStopRequested()) {
+        PublishStartResult(
+            &g_notificationStartResult,
+            g_notificationReadyEvent,
+            RuntimeStartCancelled());
+
+        if (shouldUninitialize) {
+            CoUninitialize();
+        }
+
+        return 0;
+    }
 
     IServiceProvider* serviceProvider = nullptr;
     IVirtualDesktopManagerInternal* managerInternal = nullptr;
     IVirtualDesktopNotificationService* notificationService = nullptr;
     VirtualDesktopNotificationListener* listener = nullptr;
     DWORD cookie = 0;
+    bool unsupported = false;
 
     HRESULT hr = CoCreateInstance(
         kClsidImmersiveShell,
@@ -955,15 +1134,25 @@ static DWORD WINAPI NotificationThreadProc(void*) {
         __uuidof(IServiceProvider),
         reinterpret_cast<void**>(&serviceProvider));
 
-    if (SUCCEEDED(hr) && serviceProvider) {
+    if (SUCCEEDED(hr) && !serviceProvider) {
+        hr = E_FAIL;
+    }
+
+    if (SUCCEEDED(hr) && !NotificationStopRequested()) {
         hr = serviceProvider->QueryService(
             kClsidVirtualDesktopManagerInternal,
             kIidVirtualDesktopManagerInternal24H2,
             reinterpret_cast<void**>(&managerInternal));
 
+        if (hr == E_NOINTERFACE) {
+            unsupported = true;
+        } else if (SUCCEEDED(hr) && !managerInternal) {
+            hr = E_NOINTERFACE;
+            unsupported = true;
+        }
     }
 
-    if (SUCCEEDED(hr) && managerInternal) {
+    if (SUCCEEDED(hr) && !NotificationStopRequested()) {
         auto getCurrentDesktop = GetVTableFunction<
             HRESULT(STDMETHODCALLTYPE*)(
                 void*,
@@ -977,23 +1166,39 @@ static DWORD WINAPI NotificationThreadProc(void*) {
 
         if (SUCCEEDED(currentHr) && currentDesktop) {
             GUID id = {};
-            if (SUCCEEDED(currentDesktop->GetId(&id))) {
+            HRESULT idHr = currentDesktop->GetId(&id);
+            if (SUCCEEDED(idHr)) {
                 StoreCurrentDesktopId(id);
+            } else {
+                hr = idHr;
             }
             currentDesktop->Release();
+        } else {
+            hr = FAILED(currentHr) ? currentHr : E_FAIL;
         }
     }
 
-    if (SUCCEEDED(hr) && serviceProvider) {
+    if (SUCCEEDED(hr) && !NotificationStopRequested()) {
         hr = serviceProvider->QueryService(
             kServiceVirtualDesktopNotification,
             kIidVirtualDesktopNotificationService,
             reinterpret_cast<void**>(&notificationService));
+
+        if (hr == E_NOINTERFACE) {
+            unsupported = true;
+        } else if (SUCCEEDED(hr) && !notificationService) {
+            hr = E_NOINTERFACE;
+            unsupported = true;
+        }
     }
 
-    if (SUCCEEDED(hr) && notificationService) {
+    if (SUCCEEDED(hr) && !NotificationStopRequested()) {
         listener = new VirtualDesktopNotificationListener();
         hr = notificationService->Register(listener, &cookie);
+    }
+
+    if (SUCCEEDED(hr) && !cookie) {
+        hr = E_FAIL;
     }
 
     if (SUCCEEDED(hr) && cookie) {
@@ -1005,15 +1210,33 @@ static DWORD WINAPI NotificationThreadProc(void*) {
         }
     }
 
+    RuntimeStartResult startResult;
+    if (NotificationStopRequested()) {
+        g_notificationReady.store(false, std::memory_order_release);
+        hr = HRESULT_FROM_WIN32(ERROR_CANCELLED);
+        startResult = RuntimeStartCancelled();
+    } else if (g_notificationReady.load(std::memory_order_acquire)) {
+        startResult = {RuntimeStartOutcome::Ready, S_OK};
+    } else {
+        startResult = unsupported
+            ? RuntimeStartUnsupported(hr)
+            : RuntimeStartFailure(hr);
+    }
+
     Wh_Log(
-        L"Notification/cache init hr=0x%08X cookie=%lu ready=%d",
+        L"Notification/cache init hr=0x%08X cookie=%lu ready=%d outcome=%d",
         static_cast<unsigned int>(hr),
         cookie,
-        g_notificationReady.load());
+        g_notificationReady.load(),
+        static_cast<int>(startResult.outcome));
 
-    SetEvent(g_notificationReadyEvent);
+    PublishStartResult(
+        &g_notificationStartResult,
+        g_notificationReadyEvent,
+        startResult);
 
-    if (g_notificationReady.load()) {
+    if (g_notificationReady.load(std::memory_order_acquire) &&
+        !NotificationStopRequested()) {
         while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
             TranslateMessage(&msg);
             DispatchMessageW(&msg);
@@ -1051,19 +1274,36 @@ static DWORD WINAPI NotificationThreadProc(void*) {
     return 0;
 }
 
-static bool StartNotificationCache() {
+static RuntimeStartResult StartNotificationCache() {
     // Each start attempt owns its readiness result. Don't inherit a true value
     // from a previous notification thread that exited during startup retry.
     g_notificationReady.store(false, std::memory_order_release);
+    ResetStartResult(&g_notificationStartResult);
+
+    if (RuntimeCancellationRequested()) {
+        return RuntimeStartCancelled();
+    }
 
     g_notificationReadyEvent =
         CreateEventW(nullptr, TRUE, FALSE, nullptr);
 
     if (!g_notificationReadyEvent) {
+        DWORD error = GetLastError();
         Wh_Log(
             L"Create notification-ready event failed error=%lu",
-            GetLastError());
-        return false;
+            error);
+        return RuntimeStartFailure(HRESULT_FROM_WIN32(error));
+    }
+
+    g_notificationStopEvent =
+        CreateEventW(nullptr, TRUE, FALSE, nullptr);
+
+    if (!g_notificationStopEvent) {
+        DWORD error = GetLastError();
+        Wh_Log(
+            L"Create notification-stop event failed error=%lu",
+            error);
+        return RuntimeStartFailure(HRESULT_FROM_WIN32(error));
     }
 
     g_notificationThread =
@@ -1076,38 +1316,77 @@ static bool StartNotificationCache() {
             &g_notificationThreadId);
 
     if (!g_notificationThread) {
+        DWORD error = GetLastError();
         Wh_Log(
             L"Notification CreateThread failed error=%lu",
-            GetLastError());
-        return false;
+            error);
+        return RuntimeStartFailure(HRESULT_FROM_WIN32(error));
     }
 
-    DWORD waitResult =
-        WaitForSingleObject(g_notificationReadyEvent, 5000);
+    HANDLE waits[] = {
+        g_runtimeCancelEvent,
+        g_notificationReadyEvent,
+    };
 
-    if (waitResult != WAIT_OBJECT_0 ||
-        !g_notificationReady.load()) {
-        Wh_Log(
-            L"Notification/current-desktop cache unavailable "
-            L"(waitResult=%lu)",
-            waitResult);
-        return false;
+    DWORD waitResult = WaitForMultipleObjects(
+        ARRAYSIZE(waits),
+        waits,
+        FALSE,
+        5000);
+
+    if (waitResult == WAIT_OBJECT_0) {
+        return RuntimeStartCancelled();
     }
 
-    return true;
+    if (waitResult == WAIT_OBJECT_0 + 1) {
+        RuntimeStartResult result =
+            LoadStartResult(&g_notificationStartResult);
+
+        if (result.outcome == RuntimeStartOutcome::Ready &&
+            !g_notificationReady.load(std::memory_order_acquire)) {
+            return RuntimeStartFailure(E_FAIL);
+        }
+
+        return result;
+    }
+
+    HRESULT waitHr = waitResult == WAIT_TIMEOUT
+        ? HRESULT_FROM_WIN32(ERROR_TIMEOUT)
+        : HRESULT_FROM_WIN32(GetLastError());
+
+    Wh_Log(
+        L"Notification/current-desktop cache unavailable "
+        L"(waitResult=%lu hr=0x%08X)",
+        waitResult,
+        static_cast<unsigned int>(waitHr));
+
+    return RuntimeStartFailure(waitHr);
 }
 
 static void StopNotificationCache() {
     g_notificationReady.store(false, std::memory_order_release);
     ClearExplicitSwitchTransaction(L"notification cache stopping");
 
+    if (g_notificationStopEvent) {
+        SetEvent(g_notificationStopEvent);
+    }
+
     if (g_notificationThread) {
         if (g_notificationThreadId) {
-            PostThreadMessageW(
-                g_notificationThreadId,
-                WM_QUIT,
-                0,
-                0);
+            if (!PostThreadMessageW(
+                    g_notificationThreadId,
+                    WM_QUIT,
+                    0,
+                    0)) {
+                DWORD error = GetLastError();
+                // ERROR_INVALID_THREAD_ID is expected if the stop event won
+                // the race before the thread created its message queue.
+                if (error != ERROR_INVALID_THREAD_ID) {
+                    Wh_Log(
+                        L"Notification WM_QUIT post failed error=%lu",
+                        error);
+                }
+            }
         }
 
         WaitForSingleObject(g_notificationThread, INFINITE);
@@ -1119,6 +1398,11 @@ static void StopNotificationCache() {
     if (g_notificationReadyEvent) {
         CloseHandle(g_notificationReadyEvent);
         g_notificationReadyEvent = nullptr;
+    }
+
+    if (g_notificationStopEvent) {
+        CloseHandle(g_notificationStopEvent);
+        g_notificationStopEvent = nullptr;
     }
 
     ClearCurrentDesktopId();
@@ -1149,6 +1433,13 @@ static HANDLE g_stopEvent = nullptr;     // manual-reset
 static HANDLE g_workerThread = nullptr;
 static HANDLE g_workerReadyEvent = nullptr;
 static std::atomic<bool> g_workerReady = false;
+static RuntimeStartResultSlot g_workerStartResult;
+
+static bool WorkerStopRequested() {
+    return RuntimeCancellationRequested() ||
+        (g_stopEvent &&
+         WaitForSingleObject(g_stopEvent, 0) == WAIT_OBJECT_0);
+}
 
 struct WorkerComState {
     IServiceProvider* serviceProvider = nullptr;
@@ -1183,7 +1474,12 @@ static void ReleaseWorkerComState(WorkerComState* state) {
     }
 }
 
-static bool InitializeWorkerComState(WorkerComState* state) {
+static HRESULT InitializeWorkerComState(
+    WorkerComState* state,
+    bool* unsupported) {
+
+    *unsupported = false;
+
     HRESULT hr = CoCreateInstance(
         kClsidImmersiveShell,
         nullptr,
@@ -1192,11 +1488,19 @@ static bool InitializeWorkerComState(WorkerComState* state) {
         reinterpret_cast<void**>(&state->serviceProvider));
 
     if (FAILED(hr) || !state->serviceProvider) {
+        if (SUCCEEDED(hr)) {
+            hr = E_FAIL;
+        }
+
         Wh_Log(
             L"Worker: CoCreateInstance(ImmersiveShell) failed "
             L"hr=0x%08X",
             static_cast<unsigned int>(hr));
-        return false;
+        return hr;
+    }
+
+    if (WorkerStopRequested()) {
+        return HRESULT_FROM_WIN32(ERROR_CANCELLED);
     }
 
     hr = state->serviceProvider->QueryService(
@@ -1205,11 +1509,21 @@ static bool InitializeWorkerComState(WorkerComState* state) {
         reinterpret_cast<void**>(&state->managerInternal));
 
     if (FAILED(hr) || !state->managerInternal) {
+        if (SUCCEEDED(hr)) {
+            hr = E_NOINTERFACE;
+        }
+
+        *unsupported = hr == E_NOINTERFACE;
+
         Wh_Log(
             L"Worker: QueryService(managerInternal) failed "
             L"hr=0x%08X",
             static_cast<unsigned int>(hr));
-        return false;
+        return hr;
+    }
+
+    if (WorkerStopRequested()) {
+        return HRESULT_FROM_WIN32(ERROR_CANCELLED);
     }
 
     hr = state->serviceProvider->QueryService(
@@ -1218,11 +1532,21 @@ static bool InitializeWorkerComState(WorkerComState* state) {
         reinterpret_cast<void**>(&state->viewCollection));
 
     if (FAILED(hr) || !state->viewCollection) {
+        if (SUCCEEDED(hr)) {
+            hr = E_NOINTERFACE;
+        }
+
+        *unsupported = hr == E_NOINTERFACE;
+
         Wh_Log(
             L"Worker: QueryService(viewCollection) failed "
             L"hr=0x%08X",
             static_cast<unsigned int>(hr));
-        return false;
+        return hr;
+    }
+
+    if (WorkerStopRequested()) {
+        return HRESULT_FROM_WIN32(ERROR_CANCELLED);
     }
 
     hr = CoCreateInstance(
@@ -1232,14 +1556,20 @@ static bool InitializeWorkerComState(WorkerComState* state) {
         IID_PPV_ARGS(&state->publicManager));
 
     if (FAILED(hr) || !state->publicManager) {
+        if (SUCCEEDED(hr)) {
+            hr = E_FAIL;
+        }
+
         Wh_Log(
             L"Worker: CoCreateInstance(public manager) failed "
             L"hr=0x%08X",
             static_cast<unsigned int>(hr));
-        return false;
+        return hr;
     }
 
-    return true;
+    return WorkerStopRequested()
+        ? HRESULT_FROM_WIN32(ERROR_CANCELLED)
+        : S_OK;
 }
 
 // Older monitor-aware interface versions aren't queried because their method
@@ -1520,27 +1850,58 @@ static DWORD WINAPI WorkerThreadProc(void*) {
             L"Worker: CoInitializeEx failed hr=0x%08X",
             static_cast<unsigned int>(coHr));
 
-        g_workerReady.store(false, std::memory_order_release);
-        SetEvent(g_workerReadyEvent);
+        PublishStartResult(
+            &g_workerStartResult,
+            g_workerReadyEvent,
+            WorkerStopRequested()
+                ? RuntimeStartCancelled()
+                : RuntimeStartFailure(coHr));
+        return 0;
+    }
+
+    if (WorkerStopRequested()) {
+        PublishStartResult(
+            &g_workerStartResult,
+            g_workerReadyEvent,
+            RuntimeStartCancelled());
+
+        if (shouldUninitialize) {
+            CoUninitialize();
+        }
+
         return 0;
     }
 
     WorkerComState state;
+    bool initUnsupported = false;
+    HRESULT initHr =
+        InitializeWorkerComState(
+            &state,
+            &initUnsupported);
 
-    if (!InitializeWorkerComState(&state)) {
+    if (FAILED(initHr)) {
         ReleaseWorkerComState(&state);
 
         if (shouldUninitialize) {
             CoUninitialize();
         }
 
-        g_workerReady.store(false, std::memory_order_release);
-        SetEvent(g_workerReadyEvent);
+        PublishStartResult(
+            &g_workerStartResult,
+            g_workerReadyEvent,
+            WorkerStopRequested()
+                ? RuntimeStartCancelled()
+                : initUnsupported
+                    ? RuntimeStartUnsupported(initHr)
+                    : RuntimeStartFailure(initHr));
         return 0;
     }
 
-    g_workerReady.store(true);
-    SetEvent(g_workerReadyEvent);
+    g_workerReady.store(true, std::memory_order_release);
+    PublishStartResult(
+        &g_workerStartResult,
+        g_workerReadyEvent,
+        {RuntimeStartOutcome::Ready, S_OK});
 
     Wh_Log(L"Worker ready");
 
@@ -1638,6 +1999,12 @@ static bool QueueRescue(
 static HRESULT SwitchDesktopInternal_Hook(
     void* pThis,
     IVirtualDesktop* requestedDesktop) {
+
+    if (!g_interceptionEnabled.load(std::memory_order_acquire)) {
+        return g_switchDesktopInternalOriginal(
+            pThis,
+            requestedDesktop);
+    }
 
     if (!pThis || !requestedDesktop) {
         return g_switchDesktopInternalOriginal(
@@ -1809,10 +2176,15 @@ static HRESULT SwitchDesktopInternal_Hook(
 // Windhawk lifecycle.
 // -----------------------------------------------------------------------------
 
-static bool StartWorker() {
+static RuntimeStartResult StartWorker() {
     // Each start attempt owns its readiness result. A slow previous worker can
     // otherwise publish true after StopWorker already cleared the flag.
     g_workerReady.store(false, std::memory_order_release);
+    ResetStartResult(&g_workerStartResult);
+
+    if (RuntimeCancellationRequested()) {
+        return RuntimeStartCancelled();
+    }
 
     g_requestEvent =
         CreateEventW(
@@ -1821,12 +2193,28 @@ static bool StartWorker() {
             FALSE,
             nullptr);
 
+    if (!g_requestEvent) {
+        DWORD error = GetLastError();
+        Wh_Log(
+            L"Create worker-request event failed error=%lu",
+            error);
+        return RuntimeStartFailure(HRESULT_FROM_WIN32(error));
+    }
+
     g_stopEvent =
         CreateEventW(
             nullptr,
             TRUE,
             FALSE,
             nullptr);
+
+    if (!g_stopEvent) {
+        DWORD error = GetLastError();
+        Wh_Log(
+            L"Create worker-stop event failed error=%lu",
+            error);
+        return RuntimeStartFailure(HRESULT_FROM_WIN32(error));
+    }
 
     g_workerReadyEvent =
         CreateEventW(
@@ -1835,12 +2223,12 @@ static bool StartWorker() {
             FALSE,
             nullptr);
 
-    if (!g_requestEvent ||
-        !g_stopEvent ||
-        !g_workerReadyEvent) {
+    if (!g_workerReadyEvent) {
+        DWORD error = GetLastError();
         Wh_Log(
-            L"Failed to create worker events");
-        return false;
+            L"Create worker-ready event failed error=%lu",
+            error);
+        return RuntimeStartFailure(HRESULT_FROM_WIN32(error));
     }
 
     g_workerThread =
@@ -1853,27 +2241,51 @@ static bool StartWorker() {
             nullptr);
 
     if (!g_workerThread) {
+        DWORD error = GetLastError();
         Wh_Log(
             L"CreateThread failed error=%lu",
-            GetLastError());
-        return false;
+            error);
+        return RuntimeStartFailure(HRESULT_FROM_WIN32(error));
     }
 
-    DWORD waitResult =
-        WaitForSingleObject(
-            g_workerReadyEvent,
-            5000);
+    HANDLE waits[] = {
+        g_runtimeCancelEvent,
+        g_workerReadyEvent,
+    };
 
-    if (waitResult != WAIT_OBJECT_0 ||
-        !g_workerReady.load()) {
-        Wh_Log(
-            L"Worker initialization failed "
-            L"(waitResult=%lu)",
-            waitResult);
-        return false;
+    DWORD waitResult = WaitForMultipleObjects(
+        ARRAYSIZE(waits),
+        waits,
+        FALSE,
+        5000);
+
+    if (waitResult == WAIT_OBJECT_0) {
+        return RuntimeStartCancelled();
     }
 
-    return true;
+    if (waitResult == WAIT_OBJECT_0 + 1) {
+        RuntimeStartResult result =
+            LoadStartResult(&g_workerStartResult);
+
+        if (result.outcome == RuntimeStartOutcome::Ready &&
+            !g_workerReady.load(std::memory_order_acquire)) {
+            return RuntimeStartFailure(E_FAIL);
+        }
+
+        return result;
+    }
+
+    HRESULT waitHr = waitResult == WAIT_TIMEOUT
+        ? HRESULT_FROM_WIN32(ERROR_TIMEOUT)
+        : HRESULT_FROM_WIN32(GetLastError());
+
+    Wh_Log(
+        L"Worker initialization failed "
+        L"(waitResult=%lu hr=0x%08X)",
+        waitResult,
+        static_cast<unsigned int>(waitHr));
+
+    return RuntimeStartFailure(waitHr);
 }
 
 static void StopWorker() {
@@ -1937,6 +2349,7 @@ enum class RuntimeState {
     Stopped,
     Initializing,
     Ready,
+    Unsupported,
 };
 
 static std::atomic<RuntimeState> g_runtimeState{RuntimeState::Stopped};
@@ -1987,6 +2400,10 @@ static bool InstallVirtualDesktopHooks() {
         return true;
     }
 
+    if (RuntimeCancellationRequested()) {
+        return false;
+    }
+
     HMODULE twinui = LoadLibraryExW(
         L"twinui.pcshell.dll",
         nullptr,
@@ -2000,8 +2417,40 @@ static bool InstallVirtualDesktopHooks() {
         return false;
     }
 
+    if (RuntimeCancellationRequested()) {
+        return false;
+    }
+
     // twinui.pcshell.dll
     WindhawkUtils::SYMBOL_HOOK twinuiPcshellHooks[] = {
+        {
+            {
+                LR"(const CWin32ApplicationView::`vftable'{for `IApplicationView'})"
+            },
+            reinterpret_cast<void**>(
+                &g_win32ApplicationViewVtable)
+        },
+        {
+            {
+                LR"(private: virtual long __cdecl CWin32ApplicationView::v_GetNativeWindow(struct HWND__ * *))"
+            },
+            reinterpret_cast<void**>(
+                &g_win32ApplicationViewGetNativeWindow)
+        },
+        {
+            {
+                LR"(const CWinRTApplicationView::`vftable'{for `IApplicationView'})"
+            },
+            reinterpret_cast<void**>(
+                &g_winRtApplicationViewVtable)
+        },
+        {
+            {
+                LR"(private: virtual long __cdecl CWinRTApplicationView::v_GetNativeWindow(struct HWND__ * *))"
+            },
+            reinterpret_cast<void**>(
+                &g_winRtApplicationViewGetNativeWindow)
+        },
         {
             {
                 L"public: virtual long __cdecl "
@@ -2062,7 +2511,14 @@ static bool InstallVirtualDesktopHooks() {
 
     // These hooks are installed after Wh_ModInit, so explicitly apply the
     // pending hook operations now.
-    Wh_ApplyHookOperations();
+    SetLastError(ERROR_SUCCESS);
+    if (!Wh_ApplyHookOperations()) {
+        DWORD error = GetLastError();
+        Wh_Log(
+            L"Shell host: Wh_ApplyHookOperations failed error=%lu",
+            error);
+        return false;
+    }
 
     g_virtualDesktopHooksInstalled.store(
         true,
@@ -2071,55 +2527,84 @@ static bool InstallVirtualDesktopHooks() {
     Wh_Log(
         L"Shell host: virtual-desktop hooks installed");
 
-    return true;
+    return !RuntimeCancellationRequested();
 }
 
 static bool WaitForShellHostRetryDelay() {
     // Fresh Explorer startup can expose Shell_TrayWnd before the immersive-shell
     // virtual-desktop COM services are fully ready. Keep the retry interval
     // fixed and bounded, but give those services a generous startup window.
-    for (int i = 0; i < 10; ++i) {
-        if (g_unloading.load(std::memory_order_acquire)) {
-            return false;
-        }
+    DWORD waitResult =
+        WaitForSingleObject(g_runtimeCancelEvent, 500);
 
-        Sleep(50);
+    if (waitResult == WAIT_TIMEOUT) {
+        return !g_unloading.load(std::memory_order_acquire);
     }
 
-    return !g_unloading.load(std::memory_order_acquire);
+    if (waitResult == WAIT_FAILED) {
+        Wh_Log(
+            L"Shell-host retry wait failed error=%lu",
+            GetLastError());
+    }
+
+    return false;
 }
 
 static DWORD WINAPI ShellHostInitThreadProc(void*) {
     Wh_Log(
         L"Shell-host initialization begin");
 
-    if (g_unloading.load(std::memory_order_acquire)) {
+    if (g_unloading.load(std::memory_order_acquire) ||
+        RuntimeCancellationRequested()) {
         g_runtimeState.store(RuntimeState::Stopped, std::memory_order_release);
-        return 0;
-    }
-
-    if (!InstallVirtualDesktopHooks()) {
-        g_runtimeState.store(RuntimeState::Stopped, std::memory_order_release);
-
-        Wh_Log(
-            L"Shell-host initialization failed: "
-            L"VD hooks unavailable; remaining fail-open");
         return 0;
     }
 
     constexpr int kMaxRuntimeStartAttempts = 30;
 
     for (int attempt = 1; attempt <= kMaxRuntimeStartAttempts; ++attempt) {
-        bool workerStarted = StartWorker();
-        bool cacheStarted = false;
+        RuntimeStartResult workerResult = StartWorker();
+        RuntimeStartResult cacheResult = {
+            RuntimeStartOutcome::RetryableFailure,
+            E_PENDING,
+        };
 
-        if (workerStarted &&
-            !g_unloading.load(std::memory_order_acquire)) {
-            cacheStarted = StartNotificationCache();
+        if (workerResult.outcome == RuntimeStartOutcome::Ready &&
+            !RuntimeCancellationRequested()) {
+            cacheResult = StartNotificationCache();
+        } else if (RuntimeCancellationRequested()) {
+            cacheResult = RuntimeStartCancelled();
         }
 
-        if (workerStarted && cacheStarted &&
-            !g_unloading.load(std::memory_order_acquire)) {
+        if (workerResult.outcome == RuntimeStartOutcome::Ready &&
+            cacheResult.outcome == RuntimeStartOutcome::Ready &&
+            !RuntimeCancellationRequested()) {
+
+            if (!InstallVirtualDesktopHooks()) {
+                StopNotificationCache();
+                StopWorker();
+
+                RuntimeState state = RuntimeCancellationRequested()
+                    ? RuntimeState::Stopped
+                    : RuntimeState::Unsupported;
+                g_runtimeState.store(state, std::memory_order_release);
+
+                Wh_Log(
+                    L"Shell-host initialization failed: "
+                    L"VD hooks unavailable; remaining fail-open");
+                return 0;
+            }
+
+            if (RuntimeCancellationRequested()) {
+                StopNotificationCache();
+                StopWorker();
+                g_runtimeState.store(
+                    RuntimeState::Stopped,
+                    std::memory_order_release);
+                return 0;
+            }
+
+            g_interceptionEnabled.store(true, std::memory_order_release);
             g_runtimeState.store(RuntimeState::Ready, std::memory_order_release);
 
             Wh_Log(
@@ -2134,17 +2619,38 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
         StopNotificationCache();
         StopWorker();
 
-        if (g_unloading.load(std::memory_order_acquire)) {
+        RuntimeStartResult failureResult =
+            workerResult.outcome != RuntimeStartOutcome::Ready
+                ? workerResult
+                : cacheResult;
+
+        if (g_unloading.load(std::memory_order_acquire) ||
+            RuntimeCancellationRequested() ||
+            failureResult.outcome == RuntimeStartOutcome::Cancelled) {
             g_runtimeState.store(
                 RuntimeState::Stopped,
                 std::memory_order_release);
             return 0;
         }
 
+        if (failureResult.outcome == RuntimeStartOutcome::Unsupported) {
+            g_runtimeState.store(
+                RuntimeState::Unsupported,
+                std::memory_order_release);
+
+            Wh_Log(
+                L"Shell-host runtime unsupported hr=0x%08X; "
+                L"remaining fail-open",
+                static_cast<unsigned int>(failureResult.hr));
+            return 0;
+        }
+
         if (attempt < kMaxRuntimeStartAttempts) {
             Wh_Log(
-                L"Shell-host runtime unavailable on attempt %d; retrying",
-                attempt);
+                L"Shell-host runtime unavailable on attempt %d "
+                L"hr=0x%08X; retrying",
+                attempt,
+                static_cast<unsigned int>(failureResult.hr));
 
             if (!WaitForShellHostRetryDelay()) {
                 g_runtimeState.store(
@@ -2174,8 +2680,10 @@ static void PromoteCurrentProcessToShellHost(
         true,
         std::memory_order_release);
 
-    if (g_runtimeState.load(std::memory_order_acquire) ==
-        RuntimeState::Ready) {
+    RuntimeState state =
+        g_runtimeState.load(std::memory_order_acquire);
+    if (state == RuntimeState::Ready ||
+        state == RuntimeState::Unsupported) {
         return;
     }
 
@@ -2269,10 +2777,13 @@ static HWND WINAPI CreateWindowExW_Hook(
     // Once the runtime is healthy, the observer becomes effectively free.
     // If initialization failed, keep watching for a recreated primary taskbar
     // so the same Explorer process gets a natural retry opportunity.
-    if (g_shellHostConfirmed.load(std::memory_order_acquire) &&
-        g_runtimeState.load(std::memory_order_acquire) ==
-            RuntimeState::Ready) {
-        return hwnd;
+    if (g_shellHostConfirmed.load(std::memory_order_acquire)) {
+        RuntimeState state =
+            g_runtimeState.load(std::memory_order_acquire);
+        if (state == RuntimeState::Ready ||
+            state == RuntimeState::Unsupported) {
+            return hwnd;
+        }
     }
 
     bool isPrimaryTaskbar = false;
@@ -2321,7 +2832,12 @@ static HWND WINAPI CreateWindowExW_Hook(
 }
 
 static void StopRuntimeBeforeUninit() {
+    g_interceptionEnabled.store(false, std::memory_order_release);
     g_unloading.store(true, std::memory_order_release);
+
+    if (g_runtimeCancelEvent) {
+        SetEvent(g_runtimeCancelEvent);
+    }
 
     HANDLE initThread = nullptr;
 
@@ -2339,12 +2855,39 @@ static void StopRuntimeBeforeUninit() {
 }
 
 static void StopRuntime() {
+    g_interceptionEnabled.store(false, std::memory_order_release);
     StopNotificationCache();
     StopWorker();
     g_runtimeState.store(RuntimeState::Stopped, std::memory_order_release);
 }
 
 BOOL Wh_ModInit() {
+    constexpr DWORD kMinimumSupportedBuild = 26100;
+
+    DWORD buildNumber = GetWindowsBuildNumber();
+    if (buildNumber && buildNumber < kMinimumSupportedBuild) {
+        Wh_Log(
+            L"Unsupported Windows build %lu; build %lu or newer is required",
+            buildNumber,
+            kMinimumSupportedBuild);
+        return FALSE;
+    }
+
+    if (!buildNumber) {
+        Wh_Log(
+            L"Couldn't determine the Windows build; continuing with the "
+            L"runtime compatibility probe");
+    }
+
+    g_runtimeCancelEvent =
+        CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    if (!g_runtimeCancelEvent) {
+        Wh_Log(
+            L"Failed to create runtime cancellation event error=%lu",
+            GetLastError());
+        return FALSE;
+    }
+
     Wh_Log(
         L"Init: installing lightweight "
         L"primary-taskbar observer");
@@ -2358,6 +2901,9 @@ BOOL Wh_ModInit() {
             &g_createWindowExWOriginal)) {
         Wh_Log(
             L"Failed to hook CreateWindowExW");
+
+        CloseHandle(g_runtimeCancelEvent);
+        g_runtimeCancelEvent = nullptr;
         return FALSE;
     }
 
@@ -2406,4 +2952,9 @@ void Wh_ModBeforeUninit() {
 void Wh_ModUninit() {
     Wh_Log(L"Uninit");
     StopRuntime();
+
+    if (g_runtimeCancelEvent) {
+        CloseHandle(g_runtimeCancelEvent);
+        g_runtimeCancelEvent = nullptr;
+    }
 }

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -2,10 +2,11 @@
 // @id              prevent-virtual-desktop-stealing
 // @name            Prevent Window Activation from Stealing Virtual Desktop
 // @description     Redirect cross-desktop window activation to the current desktop.
-// @version         0.3.3
+// @version         0.3.4
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @include         explorer.exe
+// @architecture    x86-64
 // @compilerOptions -lole32
 // ==/WindhawkMod==
 
@@ -39,7 +40,7 @@ Transition Animation**.
 
 ### Notes
 
-Designed for Windows 11 24H2 and newer. This mod relies on undocumented Windows
+Designed for Windows 11 22H2 and newer. This mod relies on undocumented Windows
 shell interfaces, so future Windows updates may require adjustments.
 */
 // ==/WindhawkModReadme==
@@ -54,9 +55,7 @@ shell interfaces, so future Windows updates may require adjustments.
 #include <cstdint>
 
 // -----------------------------------------------------------------------------
-// Explicit COM IDs.
-// Keep these literal so the Windhawk Clang/MinGW toolchain doesn't need
-// __declspec(uuid), __uuidof, IID_PPV_ARGS, or uuid.lib.
+// Explicit COM IDs used by the minimal interface declarations below.
 // -----------------------------------------------------------------------------
 
 static const CLSID kClsidImmersiveShell = {
@@ -100,9 +99,15 @@ static const IID kIidVirtualDesktopNotificationService = {
 };
 
 // Windows 11 24H2+ IVirtualDesktopManagerInternal / Internal2 IID.
-static const IID kIidVirtualDesktopManagerInternal = {
+static const IID kIidVirtualDesktopManagerInternal24H2 = {
     0x53F5CA0B, 0x158F, 0x4124,
     {0x90, 0x0C, 0x05, 0x71, 0x58, 0x06, 0x0B, 0x27}
+};
+
+// Windows 11 22H2/23H2 IVirtualDesktopManagerInternal IID.
+static const IID kIidVirtualDesktopManagerInternal22H2 = {
+    0xA3175F2D, 0x239C, 0x4BD2,
+    {0x8A, 0xA0, 0xEE, 0xBA, 0x8B, 0x0B, 0x13, 0x8E}
 };
 
 static const IID kIidApplicationViewCollection = {
@@ -295,31 +300,50 @@ static bool IsRescueCandidate(HWND hwnd) {
     return true;
 }
 
+static DWORD GetWindowProcessIdForLog(HWND hwnd) {
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hwnd, &pid);
+    return pid;
+}
+
+static DWORD GetWindowThreadIdForLog(HWND hwnd) {
+    DWORD pid = 0;
+    return GetWindowThreadProcessId(hwnd, &pid);
+}
+
+static const wchar_t* GetWindowClassForLog(HWND hwnd) {
+    static thread_local wchar_t className[256];
+    className[0] = L'\0';
+    GetClassNameW(hwnd, className, ARRAYSIZE(className));
+    return className[0] ? className : L"?";
+}
+
+static const wchar_t* GetWindowTitleForLog(HWND hwnd) {
+    static thread_local wchar_t title[512];
+    title[0] = L'\0';
+    GetWindowTextW(hwnd, title, ARRAYSIZE(title));
+    return title;
+}
+
 static void LogWindow(const wchar_t* label, HWND hwnd) {
     if (!hwnd) {
-        Wh_Log(L"[VDREDIRECT] %s hwnd=null", label);
+        Wh_Log(L"%s hwnd=null", label);
         return;
     }
 
-    DWORD pid = 0;
-    DWORD tid = GetWindowThreadProcessId(hwnd, &pid);
-
-    wchar_t cls[256] = {};
-    wchar_t title[512] = {};
-    GetClassNameW(hwnd, cls, ARRAYSIZE(cls));
-    GetWindowTextW(hwnd, title, ARRAYSIZE(title));
-
+    // Wh_Log evaluates its arguments only when logging is enabled, so all
+    // window inspection stays behind the logging gate.
     Wh_Log(
-        L"[VDREDIRECT] %s hwnd=%p pid=%lu tid=%lu class=%s "
+        L"%s hwnd=%p pid=%lu tid=%lu class=%s "
         L"zoomed=%d iconic=%d title=\"%s\"",
         label,
         hwnd,
-        pid,
-        tid,
-        cls[0] ? cls : L"?",
+        GetWindowProcessIdForLog(hwnd),
+        GetWindowThreadIdForLog(hwnd),
+        GetWindowClassForLog(hwnd),
         IsZoomed(hwnd),
         IsIconic(hwnd),
-        title);
+        GetWindowTitleForLog(hwnd));
 }
 
 // -----------------------------------------------------------------------------
@@ -358,7 +382,7 @@ static HRESULT CycleInDirection_Hook(
     ++g_hotkeyCycleDepth;
 
     Wh_Log(
-        L"[VDREDIRECT] HOTKEY-CYCLE begin direction=%d depth=%d",
+        L"HOTKEY-CYCLE begin direction=%d depth=%d",
         direction,
         g_hotkeyCycleDepth);
 
@@ -366,7 +390,7 @@ static HRESULT CycleInDirection_Hook(
         g_cycleInDirectionOriginal(pThis, direction);
 
     Wh_Log(
-        L"[VDREDIRECT] HOTKEY-CYCLE end direction=%d hr=0x%08X depth=%d",
+        L"HOTKEY-CYCLE end direction=%d hr=0x%08X depth=%d",
         direction,
         static_cast<unsigned int>(hr),
         g_hotkeyCycleDepth);
@@ -481,13 +505,13 @@ public:
             GuidToString(newId, newText, ARRAYSIZE(newText));
 
             Wh_Log(
-                L"[VDREDIRECT] Current desktop cache updated old=%s new=%s",
+                L"Current desktop cache updated old=%s new=%s",
                 SUCCEEDED(oldHr) ? oldText : L"<unknown>",
                 newText);
         } else {
             ClearCurrentDesktopId();
             Wh_Log(
-                L"[VDREDIRECT] Current desktop cache invalidated: "
+                L"Current desktop cache invalidated: "
                 L"desktopNew->GetId failed hr=0x%08X",
                 static_cast<unsigned int>(newHr));
         }
@@ -521,7 +545,7 @@ static DWORD WINAPI NotificationThreadProc(void*) {
 
     if (FAILED(coHr) && coHr != RPC_E_CHANGED_MODE) {
         Wh_Log(
-            L"[VDREDIRECT] Notification CoInitializeEx failed hr=0x%08X",
+            L"Notification CoInitializeEx failed hr=0x%08X",
             static_cast<unsigned int>(coHr));
         SetEvent(g_notificationReadyEvent);
         return 0;
@@ -547,8 +571,16 @@ static DWORD WINAPI NotificationThreadProc(void*) {
     if (SUCCEEDED(hr) && serviceProvider) {
         hr = serviceProvider->QueryService(
             kClsidVirtualDesktopManagerInternal,
-            kIidVirtualDesktopManagerInternal,
+            kIidVirtualDesktopManagerInternal24H2,
             reinterpret_cast<void**>(&managerInternal));
+
+        if (FAILED(hr) || !managerInternal) {
+            managerInternal = nullptr;
+            hr = serviceProvider->QueryService(
+                kClsidVirtualDesktopManagerInternal,
+                kIidVirtualDesktopManagerInternal22H2,
+                reinterpret_cast<void**>(&managerInternal));
+        }
     }
 
     if (SUCCEEDED(hr) && managerInternal) {
@@ -594,7 +626,7 @@ static DWORD WINAPI NotificationThreadProc(void*) {
     }
 
     Wh_Log(
-        L"[VDREDIRECT] Notification/cache init hr=0x%08X cookie=%lu ready=%d",
+        L"Notification/cache init hr=0x%08X cookie=%lu ready=%d",
         static_cast<unsigned int>(hr),
         cookie,
         g_notificationReady.load());
@@ -635,7 +667,7 @@ static DWORD WINAPI NotificationThreadProc(void*) {
         CoUninitialize();
     }
 
-    Wh_Log(L"[VDREDIRECT] Notification thread exiting");
+    Wh_Log(L"Notification thread exiting");
     return 0;
 }
 
@@ -645,7 +677,7 @@ static bool StartNotificationCache() {
 
     if (!g_notificationReadyEvent) {
         Wh_Log(
-            L"[VDREDIRECT] Create notification-ready event failed error=%lu",
+            L"Create notification-ready event failed error=%lu",
             GetLastError());
         return false;
     }
@@ -661,7 +693,7 @@ static bool StartNotificationCache() {
 
     if (!g_notificationThread) {
         Wh_Log(
-            L"[VDREDIRECT] Notification CreateThread failed error=%lu",
+            L"Notification CreateThread failed error=%lu",
             GetLastError());
         return false;
     }
@@ -672,7 +704,7 @@ static bool StartNotificationCache() {
     if (waitResult != WAIT_OBJECT_0 ||
         !g_notificationReady.load()) {
         Wh_Log(
-            L"[VDREDIRECT] Notification/current-desktop cache unavailable "
+            L"Notification/current-desktop cache unavailable "
             L"(waitResult=%lu)",
             waitResult);
         return false;
@@ -776,7 +808,7 @@ static bool InitializeWorkerComState(WorkerComState* state) {
 
     if (FAILED(hr) || !state->serviceProvider) {
         Wh_Log(
-            L"[VDREDIRECT] Worker: CoCreateInstance(ImmersiveShell) failed "
+            L"Worker: CoCreateInstance(ImmersiveShell) failed "
             L"hr=0x%08X",
             static_cast<unsigned int>(hr));
         return false;
@@ -784,12 +816,20 @@ static bool InitializeWorkerComState(WorkerComState* state) {
 
     hr = state->serviceProvider->QueryService(
         kClsidVirtualDesktopManagerInternal,
-        kIidVirtualDesktopManagerInternal,
+        kIidVirtualDesktopManagerInternal24H2,
         reinterpret_cast<void**>(&state->managerInternal));
 
     if (FAILED(hr) || !state->managerInternal) {
+        state->managerInternal = nullptr;
+        hr = state->serviceProvider->QueryService(
+            kClsidVirtualDesktopManagerInternal,
+            kIidVirtualDesktopManagerInternal22H2,
+            reinterpret_cast<void**>(&state->managerInternal));
+    }
+
+    if (FAILED(hr) || !state->managerInternal) {
         Wh_Log(
-            L"[VDREDIRECT] Worker: QueryService(managerInternal) failed "
+            L"Worker: QueryService(managerInternal) failed "
             L"hr=0x%08X",
             static_cast<unsigned int>(hr));
         return false;
@@ -802,7 +842,7 @@ static bool InitializeWorkerComState(WorkerComState* state) {
 
     if (FAILED(hr) || !state->viewCollection) {
         Wh_Log(
-            L"[VDREDIRECT] Worker: QueryService(viewCollection) failed "
+            L"Worker: QueryService(viewCollection) failed "
             L"hr=0x%08X",
             static_cast<unsigned int>(hr));
         return false;
@@ -817,7 +857,7 @@ static bool InitializeWorkerComState(WorkerComState* state) {
 
     if (FAILED(hr) || !state->publicManager) {
         Wh_Log(
-            L"[VDREDIRECT] Worker: CoCreateInstance(public manager) failed "
+            L"Worker: CoCreateInstance(public manager) failed "
             L"hr=0x%08X",
             static_cast<unsigned int>(hr));
         return false;
@@ -826,7 +866,9 @@ static bool InitializeWorkerComState(WorkerComState* state) {
     return true;
 }
 
-// 24H2+ vtable slots, matching Virtual Desktop Helper.
+// These slots and signatures are shared by the version-gating IIDs above.
+// Older monitor-aware interface versions aren't queried because their method
+// signatures differ.
 static constexpr int kVtableMoveViewToDesktop = 4;
 static constexpr int kVtableGetCurrentDesktop = 6;
 
@@ -893,14 +935,14 @@ static void ProcessRescueRequest(
         ARRAYSIZE(requestedText));
 
     Wh_Log(
-        L"[VDREDIRECT #%llu] Rescue begin hwnd=%p requested=%s",
+        L"[#%llu] Rescue begin hwnd=%p requested=%s",
         static_cast<unsigned long long>(request.sequence),
         request.hwnd,
         requestedText);
 
     if (!IsRescueCandidate(request.hwnd)) {
         Wh_Log(
-            L"[VDREDIRECT #%llu] Abort: HWND no longer eligible",
+            L"[#%llu] Abort: HWND no longer eligible",
             static_cast<unsigned long long>(request.sequence));
         return;
     }
@@ -912,7 +954,7 @@ static void ProcessRescueRequest(
     if (currentPid != request.pid ||
         currentTid != request.tid) {
         Wh_Log(
-            L"[VDREDIRECT #%llu] Abort: HWND identity changed "
+            L"[#%llu] Abort: HWND identity changed "
             L"(expected pid=%lu tid=%lu, got pid=%lu tid=%lu)",
             static_cast<unsigned long long>(request.sequence),
             request.pid,
@@ -930,7 +972,7 @@ static void ProcessRescueRequest(
 
     if (FAILED(hr) || !currentDesktop) {
         Wh_Log(
-            L"[VDREDIRECT #%llu] Abort: GetCurrentDesktop failed "
+            L"[#%llu] Abort: GetCurrentDesktop failed "
             L"hr=0x%08X",
             static_cast<unsigned long long>(request.sequence),
             static_cast<unsigned int>(hr));
@@ -942,7 +984,7 @@ static void ProcessRescueRequest(
 
     if (FAILED(hr)) {
         Wh_Log(
-            L"[VDREDIRECT #%llu] Abort: currentDesktop->GetId failed "
+            L"[#%llu] Abort: currentDesktop->GetId failed "
             L"hr=0x%08X",
             static_cast<unsigned long long>(request.sequence),
             static_cast<unsigned int>(hr));
@@ -963,7 +1005,7 @@ static void ProcessRescueRequest(
             ARRAYSIZE(actualSourceText));
 
         Wh_Log(
-            L"[VDREDIRECT #%llu] Abort: current desktop changed before rescue "
+            L"[#%llu] Abort: current desktop changed before rescue "
             L"(source=%s now=%s)",
             static_cast<unsigned long long>(request.sequence),
             expectedSourceText,
@@ -981,7 +1023,7 @@ static void ProcessRescueRequest(
 
     if (SUCCEEDED(onCurrentHr) && onCurrentDesktop) {
         Wh_Log(
-            L"[VDREDIRECT #%llu] Nothing to do: window is already visible "
+            L"[#%llu] Nothing to do: window is already visible "
             L"on the current desktop (moved/pinned meanwhile)",
             static_cast<unsigned long long>(request.sequence));
         currentDesktop->Release();
@@ -999,7 +1041,7 @@ static void ProcessRescueRequest(
 
     if (FAILED(hr)) {
         Wh_Log(
-            L"[VDREDIRECT #%llu] Abort: GetWindowDesktopId failed "
+            L"[#%llu] Abort: GetWindowDesktopId failed "
             L"hr=0x%08X",
             static_cast<unsigned long long>(request.sequence),
             static_cast<unsigned int>(hr));
@@ -1009,7 +1051,7 @@ static void ProcessRescueRequest(
 
     if (GuidEqual(windowDesktopId, actualCurrentId)) {
         Wh_Log(
-            L"[VDREDIRECT #%llu] Nothing to do: window is already on "
+            L"[#%llu] Nothing to do: window is already on "
             L"current desktop",
             static_cast<unsigned long long>(request.sequence));
         currentDesktop->Release();
@@ -1027,7 +1069,7 @@ static void ProcessRescueRequest(
             ARRAYSIZE(windowText));
 
         Wh_Log(
-            L"[VDREDIRECT #%llu] Abort: foreground window desktop "
+            L"[#%llu] Abort: foreground window desktop "
             L"doesn't match requested switch target "
             L"(window=%s requested=%s)",
             static_cast<unsigned long long>(request.sequence),
@@ -1045,7 +1087,7 @@ static void ProcessRescueRequest(
 
     if (FAILED(hr) || !view) {
         Wh_Log(
-            L"[VDREDIRECT #%llu] Abort: GetViewForHwnd failed "
+            L"[#%llu] Abort: GetViewForHwnd failed "
             L"hr=0x%08X",
             static_cast<unsigned long long>(request.sequence),
             static_cast<unsigned int>(hr));
@@ -1067,7 +1109,7 @@ static void ProcessRescueRequest(
         !GuidEqual(commitDesktopId, request.sourceDesktopId)) {
 
         Wh_Log(
-            L"[VDREDIRECT #%llu] Abort: current desktop changed during rescue",
+            L"[#%llu] Abort: current desktop changed during rescue",
             static_cast<unsigned long long>(request.sequence));
 
         if (commitDesktop) {
@@ -1091,7 +1133,7 @@ static void ProcessRescueRequest(
 
     if (FAILED(hr)) {
         Wh_Log(
-            L"[VDREDIRECT #%llu] MoveViewToDesktop failed "
+            L"[#%llu] MoveViewToDesktop failed "
             L"hr=0x%08X",
             static_cast<unsigned long long>(request.sequence),
             static_cast<unsigned int>(hr));
@@ -1099,7 +1141,7 @@ static void ProcessRescueRequest(
     }
 
     Wh_Log(
-        L"[VDREDIRECT #%llu] Teleported hwnd=%p to current desktop",
+        L"[#%llu] Teleported hwnd=%p to current desktop",
         static_cast<unsigned long long>(request.sequence),
         request.hwnd);
 
@@ -1121,7 +1163,7 @@ static DWORD WINAPI WorkerThreadProc(void*) {
     if (FAILED(coHr) &&
         coHr != RPC_E_CHANGED_MODE) {
         Wh_Log(
-            L"[VDREDIRECT] Worker: CoInitializeEx failed hr=0x%08X",
+            L"Worker: CoInitializeEx failed hr=0x%08X",
             static_cast<unsigned int>(coHr));
 
         SetEvent(g_workerReadyEvent);
@@ -1144,7 +1186,7 @@ static DWORD WINAPI WorkerThreadProc(void*) {
     g_workerReady.store(true);
     SetEvent(g_workerReadyEvent);
 
-    Wh_Log(L"[VDREDIRECT] Worker ready");
+    Wh_Log(L"Worker ready");
 
     HANDLE waits[] = {
         g_stopEvent,
@@ -1184,7 +1226,7 @@ static DWORD WINAPI WorkerThreadProc(void*) {
         CoUninitialize();
     }
 
-    Wh_Log(L"[VDREDIRECT] Worker exiting");
+    Wh_Log(L"Worker exiting");
     return 0;
 }
 
@@ -1222,7 +1264,7 @@ static bool QueueRescue(
         SetEvent(g_requestEvent);
     } else {
         Wh_Log(
-            L"[VDREDIRECT] Rescue queue full; failing open");
+            L"Rescue queue full; failing open");
     }
 
     return queued;
@@ -1252,7 +1294,7 @@ static HRESULT SwitchDesktopInternal_Hook(
     // converted into a teleport.
     if (IsExplicitHotkeySwitchContext()) {
         Wh_Log(
-            L"[VDREDIRECT] ALLOW SwitchDesktopInternal: "
+            L"ALLOW SwitchDesktopInternal: "
             L"explicit HOTKEY-CYCLE context depth=%d",
             g_hotkeyCycleDepth);
 
@@ -1265,7 +1307,7 @@ static HRESULT SwitchDesktopInternal_Hook(
     if (!g_notificationReady.load() ||
         !LoadCurrentDesktopId(&sourceDesktopId)) {
         Wh_Log(
-            L"[VDREDIRECT] SwitchDesktopInternal allowed: "
+            L"SwitchDesktopInternal allowed: "
             L"current-desktop cache unavailable");
 
         return g_switchDesktopInternalOriginal(
@@ -1279,7 +1321,7 @@ static HRESULT SwitchDesktopInternal_Hook(
     // an unknown internal switch path.
     if (!IsRescueCandidate(foreground)) {
         Wh_Log(
-            L"[VDREDIRECT] SwitchDesktopInternal allowed: "
+            L"SwitchDesktopInternal allowed: "
             L"no eligible foreground rescue candidate");
 
         return g_switchDesktopInternalOriginal(
@@ -1293,7 +1335,7 @@ static HRESULT SwitchDesktopInternal_Hook(
 
     if (FAILED(requestedIdHr)) {
         Wh_Log(
-            L"[VDREDIRECT] SwitchDesktopInternal allowed: "
+            L"SwitchDesktopInternal allowed: "
             L"requestedDesktop->GetId failed hr=0x%08X",
             static_cast<unsigned int>(requestedIdHr));
 
@@ -1304,7 +1346,7 @@ static HRESULT SwitchDesktopInternal_Hook(
 
     if (GuidEqual(sourceDesktopId, requestedId)) {
         Wh_Log(
-            L"[VDREDIRECT] SwitchDesktopInternal allowed: "
+            L"SwitchDesktopInternal allowed: "
             L"requested desktop is already current");
 
         return g_switchDesktopInternalOriginal(
@@ -1318,7 +1360,7 @@ static HRESULT SwitchDesktopInternal_Hook(
 
     if (!candidatePid || !candidateTid) {
         Wh_Log(
-            L"[VDREDIRECT] SwitchDesktopInternal allowed: "
+            L"SwitchDesktopInternal allowed: "
             L"failed to capture candidate HWND identity");
 
         return g_switchDesktopInternalOriginal(
@@ -1338,7 +1380,7 @@ static HRESULT SwitchDesktopInternal_Hook(
         ARRAYSIZE(requestedText));
 
     Wh_Log(
-        L"[VDREDIRECT] Candidate SwitchDesktopInternal "
+        L"Candidate SwitchDesktopInternal "
         L"source=%s requested=%s foreground=%p",
         sourceText,
         requestedText,
@@ -1358,7 +1400,7 @@ static HRESULT SwitchDesktopInternal_Hook(
     }
 
     Wh_Log(
-        L"[VDREDIRECT] BLOCK SwitchDesktopInternal: rescue queued");
+        L"BLOCK SwitchDesktopInternal: rescue queued");
 
     // Pretend the internal switch succeeded only after the rescue has been
     // safely queued. Every failure before this point fails open.
@@ -1395,7 +1437,7 @@ static bool StartWorker() {
         !g_stopEvent ||
         !g_workerReadyEvent) {
         Wh_Log(
-            L"[VDREDIRECT] Failed to create worker events");
+            L"Failed to create worker events");
         return false;
     }
 
@@ -1410,7 +1452,7 @@ static bool StartWorker() {
 
     if (!g_workerThread) {
         Wh_Log(
-            L"[VDREDIRECT] CreateThread failed error=%lu",
+            L"CreateThread failed error=%lu",
             GetLastError());
         return false;
     }
@@ -1423,7 +1465,7 @@ static bool StartWorker() {
     if (waitResult != WAIT_OBJECT_0 ||
         !g_workerReady.load()) {
         Wh_Log(
-            L"[VDREDIRECT] Worker initialization failed "
+            L"Worker initialization failed "
             L"(waitResult=%lu)",
             waitResult);
         return false;
@@ -1537,12 +1579,14 @@ static bool InstallVirtualDesktopHooks() {
         return true;
     }
 
-    HMODULE twinui =
-        LoadLibraryW(L"twinui.pcshell.dll");
+    HMODULE twinui = LoadLibraryExW(
+        L"twinui.pcshell.dll",
+        nullptr,
+        LOAD_LIBRARY_SEARCH_SYSTEM32);
 
     if (!twinui) {
         Wh_Log(
-            L"[VDREDIRECT] Shell host: "
+            L"Shell host: "
             L"LoadLibrary(twinui.pcshell.dll) failed error=%lu",
             GetLastError());
         return false;
@@ -1578,8 +1622,8 @@ static bool InstallVirtualDesktopHooks() {
             twinui,
             twinuiPcshellHooks,
             ARRAYSIZE(twinuiPcshellHooks))) {
-                  Wh_Log(
-            L"[VDREDIRECT] Shell host: failed to resolve/install "
+        Wh_Log(
+            L"Shell host: failed to resolve/install "
             L"virtual-desktop symbols");
         return false;
     }
@@ -1593,14 +1637,14 @@ static bool InstallVirtualDesktopHooks() {
         std::memory_order_release);
 
     Wh_Log(
-        L"[VDREDIRECT] Shell host: virtual-desktop hooks installed");
+        L"Shell host: virtual-desktop hooks installed");
 
     return true;
 }
 
 static DWORD WINAPI ShellHostInitThreadProc(void*) {
     Wh_Log(
-        L"[VDREDIRECT] Shell-host initialization begin");
+        L"Shell-host initialization begin");
 
     if (g_unloading.load(std::memory_order_acquire)) {
         g_runtimeState.store(0, std::memory_order_release);
@@ -1611,7 +1655,7 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
         g_runtimeState.store(0, std::memory_order_release);
 
         Wh_Log(
-            L"[VDREDIRECT] Shell-host initialization failed: "
+            L"Shell-host initialization failed: "
             L"VD hooks unavailable; remaining fail-open");
         return 0;
     }
@@ -1626,7 +1670,7 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
         g_runtimeState.store(0, std::memory_order_release);
 
         Wh_Log(
-            L"[VDREDIRECT] Shell-host initialization failed: "
+            L"Shell-host initialization failed: "
             L"worker unavailable; remaining fail-open");
         return 0;
     }
@@ -1643,7 +1687,7 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
         g_runtimeState.store(0, std::memory_order_release);
 
         Wh_Log(
-            L"[VDREDIRECT] Shell-host initialization failed: "
+            L"Shell-host initialization failed: "
             L"desktop cache unavailable; remaining fail-open");
         return 0;
     }
@@ -1658,7 +1702,7 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
     g_runtimeState.store(2, std::memory_order_release);
 
     Wh_Log(
-        L"[VDREDIRECT] Runtime ready: primary shell Explorer confirmed, "
+        L"Runtime ready: primary shell Explorer confirmed, "
         L"source-desktop cache active, bounded rescue queue active");
 
     return 0;
@@ -1705,7 +1749,7 @@ static void PromoteCurrentProcessToShellHost(
     g_runtimeState.store(1, std::memory_order_release);
 
     Wh_Log(
-        L"[VDREDIRECT] Primary Shell_TrayWnd confirmed; "
+        L"Primary Shell_TrayWnd confirmed; "
         L"promoting this Explorer process reason=%s",
         reason ? reason : L"<unknown>");
 
@@ -1720,7 +1764,7 @@ static void PromoteCurrentProcessToShellHost(
 
     if (!g_runtimeInitThread) {
         Wh_Log(
-            L"[VDREDIRECT] Shell-host init CreateThread failed error=%lu",
+            L"Shell-host init CreateThread failed error=%lu",
             GetLastError());
         g_runtimeState.store(0, std::memory_order_release);
     }
@@ -1844,19 +1888,18 @@ static void StopRuntime() {
 
 BOOL Wh_ModInit() {
     Wh_Log(
-        L"[VDREDIRECT] Init: installing lightweight "
+        L"Init: installing lightweight "
         L"primary-taskbar observer");
 
     // Deliberately don't load twinui.pcshell.dll or taskbar.dll here. This code
     // executes in every explorer.exe matched by @include. Non-shell Explorer
     // processes should remain as inert as possible.
-    if (!Wh_SetFunctionHook(
-            reinterpret_cast<void*>(CreateWindowExW),
-            reinterpret_cast<void*>(CreateWindowExW_Hook),
-            reinterpret_cast<void**>(
-                &g_createWindowExWOriginal))) {
+    if (!WindhawkUtils::SetFunctionHook(
+            CreateWindowExW,
+            CreateWindowExW_Hook,
+            &g_createWindowExWOriginal)) {
         Wh_Log(
-            L"[VDREDIRECT] Failed to hook CreateWindowExW");
+            L"Failed to hook CreateWindowExW");
         return FALSE;
     }
 
@@ -1871,7 +1914,7 @@ void Wh_ModAfterInit() {
 
     if (primaryTaskbar) {
         Wh_Log(
-            L"[VDREDIRECT] Existing primary Shell_TrayWnd=%p "
+            L"Existing primary Shell_TrayWnd=%p "
             L"belongs to this Explorer process",
             primaryTaskbar);
 
@@ -1879,7 +1922,7 @@ void Wh_ModAfterInit() {
             L"existing primary Shell_TrayWnd");
     } else {
         Wh_Log(
-            L"[VDREDIRECT] No primary Shell_TrayWnd owned by this PID; "
+            L"No primary Shell_TrayWnd owned by this PID; "
             L"remaining inert unless one is created");
     }
 }
@@ -1889,6 +1932,6 @@ void Wh_ModBeforeUninit() {
 }
 
 void Wh_ModUninit() {
-    Wh_Log(L"[VDREDIRECT] Uninit");
+    Wh_Log(L"Uninit");
     StopRuntime();
 }

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -4,6 +4,7 @@
 // @description     Redirect cross-desktop window activation to the current desktop.
 // @version         0.3.3
 // @author          meteoni
+// @github          https://github.com/Meteony
 // @include         explorer.exe
 // @compilerOptions -lole32
 // ==/WindhawkMod==
@@ -1545,7 +1546,7 @@ static bool InstallVirtualDesktopHooks() {
         return false;
     }
 
-    WindhawkUtils::SYMBOL_HOOK hooks[] = {
+    WindhawkUtils::SYMBOL_HOOK twinuiPcshellDllHooks[] = {
         {
             {
                 L"public: virtual long __cdecl "
@@ -1572,8 +1573,8 @@ static bool InstallVirtualDesktopHooks() {
 
     if (!WindhawkUtils::HookSymbols(
             twinui,
-            hooks,
-            ARRAYSIZE(hooks))) {
+            twinuiPcshellDllHooks,
+            ARRAYSIZE(twinuiPcshellDllHooks))) {
         Wh_Log(
             L"[VDREDIRECT] Shell host: failed to resolve/install "
             L"virtual-desktop symbols");

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -682,6 +682,8 @@ static bool StartNotificationCache() {
 }
 
 static void StopNotificationCache() {
+    g_notificationReady.store(false, std::memory_order_release);
+
     if (g_notificationThread) {
         if (g_notificationThreadId) {
             PostThreadMessageW(
@@ -702,7 +704,6 @@ static void StopNotificationCache() {
         g_notificationReadyEvent = nullptr;
     }
 
-    g_notificationReady.store(false);
     ClearCurrentDesktopId();
 }
 
@@ -1432,6 +1433,8 @@ static bool StartWorker() {
 }
 
 static void StopWorker() {
+    g_workerReady.store(false, std::memory_order_release);
+
     if (g_stopEvent) {
         SetEvent(g_stopEvent);
     }
@@ -1460,7 +1463,6 @@ static void StopWorker() {
         g_requestEvent = nullptr;
     }
 
-    g_workerReady.store(false);
 }
 
 // -----------------------------------------------------------------------------

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -361,6 +361,11 @@ static ExplicitSwitchTransaction g_explicitSwitch = {};
 static std::atomic<uint64_t> g_nextExplicitSwitchSequence{1};
 
 // IVirtualDesktopManagerInternal slots for the 24H2 IID above.
+// Keep the two calls as named, version-gated vtable accesses rather than
+// declaring a full C++ interface: the undocumented methods between IUnknown
+// and these slots have signatures that vary across shell versions. Placeholder
+// declarations would suggest ABI guarantees that the mod neither needs nor
+// has verified. The 24H2 IID is the layout gate for both indices.
 static constexpr int kVtableMoveViewToDesktop = 4;
 static constexpr int kVtableGetCurrentDesktop = 6;
 

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -2182,6 +2182,8 @@ static HWND FindCurrentProcessShellWindow() {
     return shellWindow;
 }
 
+static bool WaitForShellHostRetryDelay();
+
 static bool InstallVirtualDesktopHooks() {
     if (g_virtualDesktopHooksInstalled.load(
             std::memory_order_acquire)) {
@@ -2287,13 +2289,41 @@ static bool InstallVirtualDesktopHooks() {
         },
     };
 
-    if (!WindhawkUtils::HookSymbols(
-            twinui,
-            twinuiPcshellHooks,
-            ARRAYSIZE(twinuiPcshellHooks))) {
+    constexpr int kMaxSymbolResolutionAttempts = 3;
+    bool symbolsResolved = false;
+
+    for (int attempt = 1;
+         attempt <= kMaxSymbolResolutionAttempts;
+         ++attempt) {
+        if (WindhawkUtils::HookSymbols(
+                twinui,
+                twinuiPcshellHooks,
+                ARRAYSIZE(twinuiPcshellHooks))) {
+            symbolsResolved = true;
+            break;
+        }
+
+        if (RuntimeCancellationRequested()) {
+            return false;
+        }
+
+        if (attempt < kMaxSymbolResolutionAttempts) {
+            Wh_Log(
+                L"Shell host: symbol resolution failed on attempt %d; "
+                L"retrying",
+                attempt);
+
+            if (!WaitForShellHostRetryDelay()) {
+                return false;
+            }
+        }
+    }
+
+    if (!symbolsResolved) {
         Wh_Log(
-            L"Shell host: failed to resolve/install "
-            L"virtual-desktop symbols");
+            L"Shell host: failed to resolve/install virtual-desktop "
+            L"symbols after %d attempts",
+            kMaxSymbolResolutionAttempts);
         return false;
     }
 
@@ -2319,9 +2349,7 @@ static bool InstallVirtualDesktopHooks() {
 }
 
 static bool WaitForShellHostRetryDelay() {
-    // Fresh Explorer startup can expose Shell_TrayWnd before the immersive-shell
-    // virtual-desktop COM services are fully ready. Keep the retry interval
-    // fixed and bounded, but give those services a generous startup window.
+    // Keep shell-host startup retries cancellable, fixed, and bounded.
     DWORD waitResult =
         WaitForSingleObject(g_runtimeCancelEvent, 500);
 
@@ -2351,6 +2379,7 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
     constexpr int kMaxRuntimeStartAttempts = 30;
 
     for (int attempt = 1; attempt <= kMaxRuntimeStartAttempts; ++attempt) {
+        bool hookInstallFailed = false;
         bool started = StartWorker();
 
         if (started && !RuntimeCancellationRequested()) {
@@ -2368,13 +2397,22 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
             }
 
             if (!RuntimeCancellationRequested()) {
-                g_startUnsupported.store(true, std::memory_order_release);
                 g_startHr.store(E_FAIL, std::memory_order_relaxed);
+                hookInstallFailed = true;
             }
         }
 
         StopNotificationCache();
         StopWorker();
+
+        if (hookInstallFailed) {
+            g_runtimeState.store(
+                RuntimeState::Stopped,
+                std::memory_order_release);
+            Wh_Log(
+                L"Shell-host hook installation failed; remaining fail-open");
+            return 0;
+        }
 
         bool unsupported =
             g_startUnsupported.load(std::memory_order_acquire);

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -798,8 +798,9 @@ static HRESULT ForegroundViewChanged_Hook(
 // -----------------------------------------------------------------------------
 
 static HANDLE g_notificationThread = nullptr;
-static DWORD g_notificationThreadId = 0;
 static HANDLE g_notificationReadyEvent = nullptr;
+static HANDLE g_notificationStopEvent = nullptr;
+static HANDLE g_unloadEvent = nullptr;
 static std::atomic<bool> g_notificationReady = false;
 
 class VirtualDesktopNotificationListener final
@@ -1019,9 +1020,37 @@ static DWORD WINAPI NotificationThreadProc(void*) {
     SetEvent(g_notificationReadyEvent);
 
     if (g_notificationReady.load()) {
-        while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
-            TranslateMessage(&msg);
-            DispatchMessageW(&msg);
+        while (true) {
+            DWORD waitResult =
+                MsgWaitForMultipleObjects(
+                    1,
+                    &g_notificationStopEvent,
+                    FALSE,
+                    INFINITE,
+                    QS_ALLINPUT);
+
+            if (waitResult == WAIT_OBJECT_0) {
+                break;
+            }
+
+            if (waitResult != WAIT_OBJECT_0 + 1) {
+                Wh_Log(
+                    L"Notification message wait failed result=%lu "
+                    L"error=%lu",
+                    waitResult,
+                    GetLastError());
+                break;
+            }
+
+            while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+                if (msg.message == WM_QUIT) {
+                    SetEvent(g_notificationStopEvent);
+                    break;
+                }
+
+                TranslateMessage(&msg);
+                DispatchMessageW(&msg);
+            }
         }
     }
 
@@ -1064,9 +1093,13 @@ static bool StartNotificationCache() {
     g_notificationReadyEvent =
         CreateEventW(nullptr, TRUE, FALSE, nullptr);
 
-    if (!g_notificationReadyEvent) {
+    g_notificationStopEvent =
+        CreateEventW(nullptr, TRUE, FALSE, nullptr);
+
+    if (!g_notificationReadyEvent ||
+        !g_notificationStopEvent) {
         Wh_Log(
-            L"Create notification-ready event failed error=%lu",
+            L"Create notification events failed error=%lu",
             GetLastError());
         return false;
     }
@@ -1078,7 +1111,7 @@ static bool StartNotificationCache() {
             NotificationThreadProc,
             nullptr,
             0,
-            &g_notificationThreadId);
+            nullptr);
 
     if (!g_notificationThread) {
         Wh_Log(
@@ -1087,8 +1120,17 @@ static bool StartNotificationCache() {
         return false;
     }
 
+    HANDLE waits[] = {
+        g_notificationReadyEvent,
+        g_unloadEvent,
+    };
+
     DWORD waitResult =
-        WaitForSingleObject(g_notificationReadyEvent, 5000);
+        WaitForMultipleObjects(
+            ARRAYSIZE(waits),
+            waits,
+            FALSE,
+            5000);
 
     if (waitResult != WAIT_OBJECT_0 ||
         !g_notificationReady.load()) {
@@ -1106,24 +1148,24 @@ static void StopNotificationCache() {
     g_notificationReady.store(false, std::memory_order_release);
     ClearExplicitSwitchTransaction(L"notification cache stopping");
 
-    if (g_notificationThread) {
-        if (g_notificationThreadId) {
-            PostThreadMessageW(
-                g_notificationThreadId,
-                WM_QUIT,
-                0,
-                0);
-        }
+    if (g_notificationStopEvent) {
+        SetEvent(g_notificationStopEvent);
+    }
 
+    if (g_notificationThread) {
         WaitForSingleObject(g_notificationThread, INFINITE);
         CloseHandle(g_notificationThread);
         g_notificationThread = nullptr;
-        g_notificationThreadId = 0;
     }
 
     if (g_notificationReadyEvent) {
         CloseHandle(g_notificationReadyEvent);
         g_notificationReadyEvent = nullptr;
+    }
+
+    if (g_notificationStopEvent) {
+        CloseHandle(g_notificationStopEvent);
+        g_notificationStopEvent = nullptr;
     }
 
     ClearCurrentDesktopId();
@@ -1864,9 +1906,16 @@ static bool StartWorker() {
         return false;
     }
 
+    HANDLE waits[] = {
+        g_workerReadyEvent,
+        g_unloadEvent,
+    };
+
     DWORD waitResult =
-        WaitForSingleObject(
-            g_workerReadyEvent,
+        WaitForMultipleObjects(
+            ARRAYSIZE(waits),
+            waits,
+            FALSE,
             5000);
 
     if (waitResult != WAIT_OBJECT_0 ||
@@ -2310,6 +2359,10 @@ static HWND WINAPI CreateWindowExW_Hook(
 static void StopRuntimeBeforeUninit() {
     g_unloading.store(true, std::memory_order_release);
 
+    if (g_unloadEvent) {
+        SetEvent(g_unloadEvent);
+    }
+
     HANDLE initThread = nullptr;
 
     AcquireSRWLockExclusive(&g_runtimeInitLock);
@@ -2336,6 +2389,16 @@ BOOL Wh_ModInit() {
         L"Init: installing lightweight "
         L"primary-taskbar observer");
 
+    g_unloadEvent =
+        CreateEventW(nullptr, TRUE, FALSE, nullptr);
+
+    if (!g_unloadEvent) {
+        Wh_Log(
+            L"Failed to create unload event error=%lu",
+            GetLastError());
+        return FALSE;
+    }
+
     // Deliberately don't load twinui.pcshell.dll or taskbar.dll here. This code
     // executes in every explorer.exe matched by @include. Non-shell Explorer
     // processes should remain as inert as possible.
@@ -2345,6 +2408,8 @@ BOOL Wh_ModInit() {
             &g_createWindowExWOriginal)) {
         Wh_Log(
             L"Failed to hook CreateWindowExW");
+        CloseHandle(g_unloadEvent);
+        g_unloadEvent = nullptr;
         return FALSE;
     }
 
@@ -2377,4 +2442,9 @@ void Wh_ModBeforeUninit() {
 void Wh_ModUninit() {
     Wh_Log(L"Uninit");
     StopRuntime();
+
+    if (g_unloadEvent) {
+        CloseHandle(g_unloadEvent);
+        g_unloadEvent = nullptr;
+    }
 }

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -2182,8 +2182,6 @@ static HWND FindCurrentProcessShellWindow() {
     return shellWindow;
 }
 
-static bool WaitForShellHostRetryDelay();
-
 static bool InstallVirtualDesktopHooks() {
     if (g_virtualDesktopHooksInstalled.load(
             std::memory_order_acquire)) {
@@ -2289,41 +2287,13 @@ static bool InstallVirtualDesktopHooks() {
         },
     };
 
-    constexpr int kMaxSymbolResolutionAttempts = 3;
-    bool symbolsResolved = false;
-
-    for (int attempt = 1;
-         attempt <= kMaxSymbolResolutionAttempts;
-         ++attempt) {
-        if (WindhawkUtils::HookSymbols(
-                twinui,
-                twinuiPcshellHooks,
-                ARRAYSIZE(twinuiPcshellHooks))) {
-            symbolsResolved = true;
-            break;
-        }
-
-        if (RuntimeCancellationRequested()) {
-            return false;
-        }
-
-        if (attempt < kMaxSymbolResolutionAttempts) {
-            Wh_Log(
-                L"Shell host: symbol resolution failed on attempt %d; "
-                L"retrying",
-                attempt);
-
-            if (!WaitForShellHostRetryDelay()) {
-                return false;
-            }
-        }
-    }
-
-    if (!symbolsResolved) {
+    if (!WindhawkUtils::HookSymbols(
+            twinui,
+            twinuiPcshellHooks,
+            ARRAYSIZE(twinuiPcshellHooks))) {
         Wh_Log(
-            L"Shell host: failed to resolve/install virtual-desktop "
-            L"symbols after %d attempts",
-            kMaxSymbolResolutionAttempts);
+            L"Shell host: failed to resolve/install "
+            L"virtual-desktop symbols");
         return false;
     }
 

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -201,53 +201,25 @@ static T GetVTableFunction(void* object, int index) {
         (*reinterpret_cast<void***>(object))[index]);
 }
 
-enum class RuntimeStartOutcome {
-    Ready,
-    RetryableFailure,
-    Unsupported,
-    Cancelled,
-};
-
-struct RuntimeStartResult {
-    RuntimeStartOutcome outcome;
-    HRESULT hr;
-};
-
-struct RuntimeStartResultSlot {
-    std::atomic<RuntimeStartOutcome> outcome{
-        RuntimeStartOutcome::RetryableFailure};
-    std::atomic<HRESULT> hr{E_PENDING};
-};
-
 static HANDLE g_runtimeCancelEvent = nullptr;  // manual-reset, process lifetime
+// Set only for a missing required QueryService interface. Early ImmersiveShell
+// activation failures, including REGDB_E_CLASSNOTREG, remain retryable.
+static std::atomic<bool> g_startUnsupported{false};
+static std::atomic<HRESULT> g_startHr{E_PENDING};
 
-static void ResetStartResult(RuntimeStartResultSlot* slot) {
-    slot->hr.store(E_PENDING, std::memory_order_relaxed);
-    slot->outcome.store(
-        RuntimeStartOutcome::RetryableFailure,
-        std::memory_order_release);
+static void ResetStartResult() {
+    g_startHr.store(E_PENDING, std::memory_order_relaxed);
+    g_startUnsupported.store(false, std::memory_order_release);
 }
 
 static void PublishStartResult(
-    RuntimeStartResultSlot* slot,
-    HANDLE readyEvent,
-    RuntimeStartResult result) {
+    bool unsupported,
+    HRESULT hr,
+    HANDLE readyEvent) {
 
-    slot->hr.store(result.hr, std::memory_order_relaxed);
-    slot->outcome.store(result.outcome, std::memory_order_release);
+    g_startHr.store(hr, std::memory_order_relaxed);
+    g_startUnsupported.store(unsupported, std::memory_order_release);
     SetEvent(readyEvent);
-}
-
-static RuntimeStartResult LoadStartResult(
-    RuntimeStartResultSlot* slot) {
-
-    RuntimeStartOutcome outcome =
-        slot->outcome.load(std::memory_order_acquire);
-
-    return {
-        outcome,
-        slot->hr.load(std::memory_order_relaxed),
-    };
 }
 
 static bool RuntimeCancellationRequested() {
@@ -255,53 +227,11 @@ static bool RuntimeCancellationRequested() {
         WaitForSingleObject(g_runtimeCancelEvent, 0) == WAIT_OBJECT_0;
 }
 
-static RuntimeStartResult RuntimeStartFailure(HRESULT hr) {
-    // ImmersiveShell activation can temporarily return REGDB_E_CLASSNOTREG
-    // during early Explorer startup. Only a caller that positively identified
-    // a missing required private interface may use RuntimeStartUnsupported.
-    return {
-        RuntimeStartOutcome::RetryableFailure,
-        hr,
-    };
+static bool RecordStartFailure(HRESULT hr) {
+    g_startHr.store(hr, std::memory_order_relaxed);
+    return false;
 }
 
-static RuntimeStartResult RuntimeStartUnsupported(HRESULT hr) {
-    return {
-        RuntimeStartOutcome::Unsupported,
-        hr,
-    };
-}
-
-static RuntimeStartResult RuntimeStartCancelled() {
-    return {
-        RuntimeStartOutcome::Cancelled,
-        HRESULT_FROM_WIN32(ERROR_CANCELLED),
-    };
-}
-
-static DWORD GetWindowsBuildNumber() {
-    using RtlGetVersion_t = LONG (WINAPI*)(OSVERSIONINFOW* versionInfo);
-
-    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-    if (!ntdll) {
-        return 0;
-    }
-
-    auto rtlGetVersion = reinterpret_cast<RtlGetVersion_t>(
-        GetProcAddress(ntdll, "RtlGetVersion"));
-    if (!rtlGetVersion) {
-        return 0;
-    }
-
-    OSVERSIONINFOW versionInfo = {};
-    versionInfo.dwOSVersionInfoSize = sizeof(versionInfo);
-
-    if (rtlGetVersion(&versionInfo) != 0) {
-        return 0;
-    }
-
-    return versionInfo.dwBuildNumber;
-}
 
 static bool GuidEqual(const GUID& a, const GUID& b) {
     return IsEqualGUID(a, b) != FALSE;
@@ -778,18 +708,9 @@ static ApplicationViewGetNativeWindow_t
 static ApplicationViewGetNativeWindow_t
     g_winRtApplicationViewGetNativeWindow = nullptr;
 
-// Hook operations can be applied only after Wh_ModInit has returned. Keep the
-// detours inert until both COM runtimes are ready, and disable them before
-// teardown begins.
-static std::atomic<bool> g_interceptionEnabled{false};
-
 static HRESULT SwitchDesktop_Hook(
     void* pThis,
     IVirtualDesktop* desktop) {
-
-    if (!g_interceptionEnabled.load(std::memory_order_acquire)) {
-        return g_switchDesktopOriginal(pThis, desktop);
-    }
 
     ++g_explicitSwitchEntryDepth;
 
@@ -819,10 +740,6 @@ static HRESULT SwitchDesktop_Hook(
 static HRESULT SwitchDesktopWithAnimation_Hook(
     void* pThis,
     IVirtualDesktop* desktop) {
-
-    if (!g_interceptionEnabled.load(std::memory_order_acquire)) {
-        return g_switchDesktopWithAnimationOriginal(pThis, desktop);
-    }
 
     ++g_explicitSwitchEntryDepth;
 
@@ -896,14 +813,6 @@ static HRESULT ForegroundViewChanged_Hook(
     IVirtualDesktopSwitchAnimator* animator,
     IApplicationView* view) {
 
-    if (!g_interceptionEnabled.load(std::memory_order_acquire)) {
-        return g_foregroundViewChangedOriginal(
-            pThis,
-            manager,
-            animator,
-            view);
-    }
-
     HWND previousHwnd =
         g_foregroundPolicyHwnd;
 
@@ -938,7 +847,6 @@ static DWORD g_notificationThreadId = 0;
 static HANDLE g_notificationReadyEvent = nullptr;
 static HANDLE g_notificationStopEvent = nullptr;
 static std::atomic<bool> g_notificationReady = false;
-static RuntimeStartResultSlot g_notificationStartResult;
 
 static bool NotificationStopRequested() {
     return RuntimeCancellationRequested() ||
@@ -1084,9 +992,9 @@ static DWORD WINAPI NotificationThreadProc(void*) {
 
     if (NotificationStopRequested()) {
         PublishStartResult(
-            &g_notificationStartResult,
-            g_notificationReadyEvent,
-            RuntimeStartCancelled());
+            false,
+            HRESULT_FROM_WIN32(ERROR_CANCELLED),
+            g_notificationReadyEvent);
         return 0;
     }
 
@@ -1099,19 +1007,17 @@ static DWORD WINAPI NotificationThreadProc(void*) {
             static_cast<unsigned int>(coHr));
 
         PublishStartResult(
-            &g_notificationStartResult,
-            g_notificationReadyEvent,
-            NotificationStopRequested()
-                ? RuntimeStartCancelled()
-                : RuntimeStartFailure(coHr));
+            false,
+            coHr,
+            g_notificationReadyEvent);
         return 0;
     }
 
     if (NotificationStopRequested()) {
         PublishStartResult(
-            &g_notificationStartResult,
-            g_notificationReadyEvent,
-            RuntimeStartCancelled());
+            false,
+            HRESULT_FROM_WIN32(ERROR_CANCELLED),
+            g_notificationReadyEvent);
 
         if (shouldUninitialize) {
             CoUninitialize();
@@ -1134,25 +1040,39 @@ static DWORD WINAPI NotificationThreadProc(void*) {
         __uuidof(IServiceProvider),
         reinterpret_cast<void**>(&serviceProvider));
 
-    if (SUCCEEDED(hr) && !serviceProvider) {
-        hr = E_FAIL;
-    }
-
-    if (SUCCEEDED(hr) && !NotificationStopRequested()) {
+    if (SUCCEEDED(hr) && serviceProvider) {
         hr = serviceProvider->QueryService(
             kClsidVirtualDesktopManagerInternal,
             kIidVirtualDesktopManagerInternal24H2,
             reinterpret_cast<void**>(&managerInternal));
 
-        if (hr == E_NOINTERFACE) {
-            unsupported = true;
-        } else if (SUCCEEDED(hr) && !managerInternal) {
+        if (SUCCEEDED(hr) && !managerInternal) {
             hr = E_NOINTERFACE;
-            unsupported = true;
         }
+
+        unsupported = hr == E_NOINTERFACE;
     }
 
-    if (SUCCEEDED(hr) && !NotificationStopRequested()) {
+    if (SUCCEEDED(hr) && serviceProvider) {
+        hr = serviceProvider->QueryService(
+            kServiceVirtualDesktopNotification,
+            kIidVirtualDesktopNotificationService,
+            reinterpret_cast<void**>(&notificationService));
+
+        if (SUCCEEDED(hr) && !notificationService) {
+            hr = E_NOINTERFACE;
+        }
+
+        unsupported = unsupported || hr == E_NOINTERFACE;
+    }
+
+    if (SUCCEEDED(hr) && notificationService) {
+        listener = new VirtualDesktopNotificationListener();
+        hr = notificationService->Register(listener, &cookie);
+    }
+
+    // Register before seeding so a desktop change during the seed isn't lost.
+    if (SUCCEEDED(hr) && managerInternal) {
         auto getCurrentDesktop = GetVTableFunction<
             HRESULT(STDMETHODCALLTYPE*)(
                 void*,
@@ -1166,39 +1086,11 @@ static DWORD WINAPI NotificationThreadProc(void*) {
 
         if (SUCCEEDED(currentHr) && currentDesktop) {
             GUID id = {};
-            HRESULT idHr = currentDesktop->GetId(&id);
-            if (SUCCEEDED(idHr)) {
+            if (SUCCEEDED(currentDesktop->GetId(&id))) {
                 StoreCurrentDesktopId(id);
-            } else {
-                hr = idHr;
             }
             currentDesktop->Release();
-        } else {
-            hr = FAILED(currentHr) ? currentHr : E_FAIL;
         }
-    }
-
-    if (SUCCEEDED(hr) && !NotificationStopRequested()) {
-        hr = serviceProvider->QueryService(
-            kServiceVirtualDesktopNotification,
-            kIidVirtualDesktopNotificationService,
-            reinterpret_cast<void**>(&notificationService));
-
-        if (hr == E_NOINTERFACE) {
-            unsupported = true;
-        } else if (SUCCEEDED(hr) && !notificationService) {
-            hr = E_NOINTERFACE;
-            unsupported = true;
-        }
-    }
-
-    if (SUCCEEDED(hr) && !NotificationStopRequested()) {
-        listener = new VirtualDesktopNotificationListener();
-        hr = notificationService->Register(listener, &cookie);
-    }
-
-    if (SUCCEEDED(hr) && !cookie) {
-        hr = E_FAIL;
     }
 
     if (SUCCEEDED(hr) && cookie) {
@@ -1210,30 +1102,25 @@ static DWORD WINAPI NotificationThreadProc(void*) {
         }
     }
 
-    RuntimeStartResult startResult;
     if (NotificationStopRequested()) {
         g_notificationReady.store(false, std::memory_order_release);
         hr = HRESULT_FROM_WIN32(ERROR_CANCELLED);
-        startResult = RuntimeStartCancelled();
     } else if (g_notificationReady.load(std::memory_order_acquire)) {
-        startResult = {RuntimeStartOutcome::Ready, S_OK};
-    } else {
-        startResult = unsupported
-            ? RuntimeStartUnsupported(hr)
-            : RuntimeStartFailure(hr);
+        hr = S_OK;
+    } else if (SUCCEEDED(hr)) {
+        hr = E_FAIL;
     }
 
     Wh_Log(
-        L"Notification/cache init hr=0x%08X cookie=%lu ready=%d outcome=%d",
+        L"Notification/cache init hr=0x%08X cookie=%lu ready=%d",
         static_cast<unsigned int>(hr),
         cookie,
-        g_notificationReady.load(),
-        static_cast<int>(startResult.outcome));
+        g_notificationReady.load());
 
     PublishStartResult(
-        &g_notificationStartResult,
-        g_notificationReadyEvent,
-        startResult);
+        unsupported,
+        hr,
+        g_notificationReadyEvent);
 
     if (g_notificationReady.load(std::memory_order_acquire) &&
         !NotificationStopRequested()) {
@@ -1274,36 +1161,25 @@ static DWORD WINAPI NotificationThreadProc(void*) {
     return 0;
 }
 
-static RuntimeStartResult StartNotificationCache() {
+static bool StartNotificationCache() {
     // Each start attempt owns its readiness result. Don't inherit a true value
     // from a previous notification thread that exited during startup retry.
     g_notificationReady.store(false, std::memory_order_release);
-    ResetStartResult(&g_notificationStartResult);
+    ResetStartResult();
 
     if (RuntimeCancellationRequested()) {
-        return RuntimeStartCancelled();
+        return RecordStartFailure(HRESULT_FROM_WIN32(ERROR_CANCELLED));
     }
 
     g_notificationReadyEvent =
         CreateEventW(nullptr, TRUE, FALSE, nullptr);
 
-    if (!g_notificationReadyEvent) {
-        DWORD error = GetLastError();
-        Wh_Log(
-            L"Create notification-ready event failed error=%lu",
-            error);
-        return RuntimeStartFailure(HRESULT_FROM_WIN32(error));
-    }
-
     g_notificationStopEvent =
         CreateEventW(nullptr, TRUE, FALSE, nullptr);
 
-    if (!g_notificationStopEvent) {
-        DWORD error = GetLastError();
-        Wh_Log(
-            L"Create notification-stop event failed error=%lu",
-            error);
-        return RuntimeStartFailure(HRESULT_FROM_WIN32(error));
+    if (!g_notificationReadyEvent || !g_notificationStopEvent) {
+        Wh_Log(L"Failed to create notification events");
+        return RecordStartFailure(E_FAIL);
     }
 
     g_notificationThread =
@@ -1320,7 +1196,7 @@ static RuntimeStartResult StartNotificationCache() {
         Wh_Log(
             L"Notification CreateThread failed error=%lu",
             error);
-        return RuntimeStartFailure(HRESULT_FROM_WIN32(error));
+        return RecordStartFailure(HRESULT_FROM_WIN32(error));
     }
 
     HANDLE waits[] = {
@@ -1335,19 +1211,11 @@ static RuntimeStartResult StartNotificationCache() {
         5000);
 
     if (waitResult == WAIT_OBJECT_0) {
-        return RuntimeStartCancelled();
+        return RecordStartFailure(HRESULT_FROM_WIN32(ERROR_CANCELLED));
     }
 
     if (waitResult == WAIT_OBJECT_0 + 1) {
-        RuntimeStartResult result =
-            LoadStartResult(&g_notificationStartResult);
-
-        if (result.outcome == RuntimeStartOutcome::Ready &&
-            !g_notificationReady.load(std::memory_order_acquire)) {
-            return RuntimeStartFailure(E_FAIL);
-        }
-
-        return result;
+        return g_notificationReady.load(std::memory_order_acquire);
     }
 
     HRESULT waitHr = waitResult == WAIT_TIMEOUT
@@ -1360,7 +1228,7 @@ static RuntimeStartResult StartNotificationCache() {
         waitResult,
         static_cast<unsigned int>(waitHr));
 
-    return RuntimeStartFailure(waitHr);
+    return RecordStartFailure(waitHr);
 }
 
 static void StopNotificationCache() {
@@ -1373,20 +1241,11 @@ static void StopNotificationCache() {
 
     if (g_notificationThread) {
         if (g_notificationThreadId) {
-            if (!PostThreadMessageW(
-                    g_notificationThreadId,
-                    WM_QUIT,
-                    0,
-                    0)) {
-                DWORD error = GetLastError();
-                // ERROR_INVALID_THREAD_ID is expected if the stop event won
-                // the race before the thread created its message queue.
-                if (error != ERROR_INVALID_THREAD_ID) {
-                    Wh_Log(
-                        L"Notification WM_QUIT post failed error=%lu",
-                        error);
-                }
-            }
+            PostThreadMessageW(
+                g_notificationThreadId,
+                WM_QUIT,
+                0,
+                0);
         }
 
         WaitForSingleObject(g_notificationThread, INFINITE);
@@ -1433,7 +1292,6 @@ static HANDLE g_stopEvent = nullptr;     // manual-reset
 static HANDLE g_workerThread = nullptr;
 static HANDLE g_workerReadyEvent = nullptr;
 static std::atomic<bool> g_workerReady = false;
-static RuntimeStartResultSlot g_workerStartResult;
 
 static bool WorkerStopRequested() {
     return RuntimeCancellationRequested() ||
@@ -1474,12 +1332,7 @@ static void ReleaseWorkerComState(WorkerComState* state) {
     }
 }
 
-static HRESULT InitializeWorkerComState(
-    WorkerComState* state,
-    bool* unsupported) {
-
-    *unsupported = false;
-
+static bool InitializeWorkerComState(WorkerComState* state) {
     HRESULT hr = CoCreateInstance(
         kClsidImmersiveShell,
         nullptr,
@@ -1496,11 +1349,8 @@ static HRESULT InitializeWorkerComState(
             L"Worker: CoCreateInstance(ImmersiveShell) failed "
             L"hr=0x%08X",
             static_cast<unsigned int>(hr));
-        return hr;
-    }
-
-    if (WorkerStopRequested()) {
-        return HRESULT_FROM_WIN32(ERROR_CANCELLED);
+        g_startHr.store(hr, std::memory_order_relaxed);
+        return false;
     }
 
     hr = state->serviceProvider->QueryService(
@@ -1513,17 +1363,15 @@ static HRESULT InitializeWorkerComState(
             hr = E_NOINTERFACE;
         }
 
-        *unsupported = hr == E_NOINTERFACE;
-
         Wh_Log(
             L"Worker: QueryService(managerInternal) failed "
             L"hr=0x%08X",
             static_cast<unsigned int>(hr));
-        return hr;
-    }
-
-    if (WorkerStopRequested()) {
-        return HRESULT_FROM_WIN32(ERROR_CANCELLED);
+        g_startHr.store(hr, std::memory_order_relaxed);
+        g_startUnsupported.store(
+            hr == E_NOINTERFACE,
+            std::memory_order_release);
+        return false;
     }
 
     hr = state->serviceProvider->QueryService(
@@ -1536,17 +1384,15 @@ static HRESULT InitializeWorkerComState(
             hr = E_NOINTERFACE;
         }
 
-        *unsupported = hr == E_NOINTERFACE;
-
         Wh_Log(
             L"Worker: QueryService(viewCollection) failed "
             L"hr=0x%08X",
             static_cast<unsigned int>(hr));
-        return hr;
-    }
-
-    if (WorkerStopRequested()) {
-        return HRESULT_FROM_WIN32(ERROR_CANCELLED);
+        g_startHr.store(hr, std::memory_order_relaxed);
+        g_startUnsupported.store(
+            hr == E_NOINTERFACE,
+            std::memory_order_release);
+        return false;
     }
 
     hr = CoCreateInstance(
@@ -1564,12 +1410,11 @@ static HRESULT InitializeWorkerComState(
             L"Worker: CoCreateInstance(public manager) failed "
             L"hr=0x%08X",
             static_cast<unsigned int>(hr));
-        return hr;
+        g_startHr.store(hr, std::memory_order_relaxed);
+        return false;
     }
 
-    return WorkerStopRequested()
-        ? HRESULT_FROM_WIN32(ERROR_CANCELLED)
-        : S_OK;
+    return true;
 }
 
 // Older monitor-aware interface versions aren't queried because their method
@@ -1830,7 +1675,7 @@ static void ProcessRescueRequest(
 
     // Virtual Desktop Helper similarly restores/focuses the moved window.
     if (IsIconic(request.hwnd)) {
-        ShowWindow(request.hwnd, SW_RESTORE);
+        ShowWindowAsync(request.hwnd, SW_RESTORE);
     }
 
     SetForegroundWindow(request.hwnd);
@@ -1851,19 +1696,17 @@ static DWORD WINAPI WorkerThreadProc(void*) {
             static_cast<unsigned int>(coHr));
 
         PublishStartResult(
-            &g_workerStartResult,
-            g_workerReadyEvent,
-            WorkerStopRequested()
-                ? RuntimeStartCancelled()
-                : RuntimeStartFailure(coHr));
+            false,
+            coHr,
+            g_workerReadyEvent);
         return 0;
     }
 
     if (WorkerStopRequested()) {
         PublishStartResult(
-            &g_workerStartResult,
-            g_workerReadyEvent,
-            RuntimeStartCancelled());
+            false,
+            HRESULT_FROM_WIN32(ERROR_CANCELLED),
+            g_workerReadyEvent);
 
         if (shouldUninitialize) {
             CoUninitialize();
@@ -1873,13 +1716,7 @@ static DWORD WINAPI WorkerThreadProc(void*) {
     }
 
     WorkerComState state;
-    bool initUnsupported = false;
-    HRESULT initHr =
-        InitializeWorkerComState(
-            &state,
-            &initUnsupported);
-
-    if (FAILED(initHr)) {
+    if (!InitializeWorkerComState(&state)) {
         ReleaseWorkerComState(&state);
 
         if (shouldUninitialize) {
@@ -1887,21 +1724,17 @@ static DWORD WINAPI WorkerThreadProc(void*) {
         }
 
         PublishStartResult(
-            &g_workerStartResult,
-            g_workerReadyEvent,
-            WorkerStopRequested()
-                ? RuntimeStartCancelled()
-                : initUnsupported
-                    ? RuntimeStartUnsupported(initHr)
-                    : RuntimeStartFailure(initHr));
+            g_startUnsupported.load(std::memory_order_acquire),
+            g_startHr.load(std::memory_order_relaxed),
+            g_workerReadyEvent);
         return 0;
     }
 
     g_workerReady.store(true, std::memory_order_release);
     PublishStartResult(
-        &g_workerStartResult,
-        g_workerReadyEvent,
-        {RuntimeStartOutcome::Ready, S_OK});
+        false,
+        S_OK,
+        g_workerReadyEvent);
 
     Wh_Log(L"Worker ready");
 
@@ -1999,12 +1832,6 @@ static bool QueueRescue(
 static HRESULT SwitchDesktopInternal_Hook(
     void* pThis,
     IVirtualDesktop* requestedDesktop) {
-
-    if (!g_interceptionEnabled.load(std::memory_order_acquire)) {
-        return g_switchDesktopInternalOriginal(
-            pThis,
-            requestedDesktop);
-    }
 
     if (!pThis || !requestedDesktop) {
         return g_switchDesktopInternalOriginal(
@@ -2176,59 +2003,28 @@ static HRESULT SwitchDesktopInternal_Hook(
 // Windhawk lifecycle.
 // -----------------------------------------------------------------------------
 
-static RuntimeStartResult StartWorker() {
+static bool StartWorker() {
     // Each start attempt owns its readiness result. A slow previous worker can
     // otherwise publish true after StopWorker already cleared the flag.
     g_workerReady.store(false, std::memory_order_release);
-    ResetStartResult(&g_workerStartResult);
+    ResetStartResult();
 
     if (RuntimeCancellationRequested()) {
-        return RuntimeStartCancelled();
+        return RecordStartFailure(HRESULT_FROM_WIN32(ERROR_CANCELLED));
     }
 
     g_requestEvent =
-        CreateEventW(
-            nullptr,
-            FALSE,
-            FALSE,
-            nullptr);
-
-    if (!g_requestEvent) {
-        DWORD error = GetLastError();
-        Wh_Log(
-            L"Create worker-request event failed error=%lu",
-            error);
-        return RuntimeStartFailure(HRESULT_FROM_WIN32(error));
-    }
+        CreateEventW(nullptr, FALSE, FALSE, nullptr);
 
     g_stopEvent =
-        CreateEventW(
-            nullptr,
-            TRUE,
-            FALSE,
-            nullptr);
-
-    if (!g_stopEvent) {
-        DWORD error = GetLastError();
-        Wh_Log(
-            L"Create worker-stop event failed error=%lu",
-            error);
-        return RuntimeStartFailure(HRESULT_FROM_WIN32(error));
-    }
+        CreateEventW(nullptr, TRUE, FALSE, nullptr);
 
     g_workerReadyEvent =
-        CreateEventW(
-            nullptr,
-            TRUE,
-            FALSE,
-            nullptr);
+        CreateEventW(nullptr, TRUE, FALSE, nullptr);
 
-    if (!g_workerReadyEvent) {
-        DWORD error = GetLastError();
-        Wh_Log(
-            L"Create worker-ready event failed error=%lu",
-            error);
-        return RuntimeStartFailure(HRESULT_FROM_WIN32(error));
+    if (!g_requestEvent || !g_stopEvent || !g_workerReadyEvent) {
+        Wh_Log(L"Failed to create worker events");
+        return RecordStartFailure(E_FAIL);
     }
 
     g_workerThread =
@@ -2245,7 +2041,7 @@ static RuntimeStartResult StartWorker() {
         Wh_Log(
             L"CreateThread failed error=%lu",
             error);
-        return RuntimeStartFailure(HRESULT_FROM_WIN32(error));
+        return RecordStartFailure(HRESULT_FROM_WIN32(error));
     }
 
     HANDLE waits[] = {
@@ -2260,19 +2056,11 @@ static RuntimeStartResult StartWorker() {
         5000);
 
     if (waitResult == WAIT_OBJECT_0) {
-        return RuntimeStartCancelled();
+        return RecordStartFailure(HRESULT_FROM_WIN32(ERROR_CANCELLED));
     }
 
     if (waitResult == WAIT_OBJECT_0 + 1) {
-        RuntimeStartResult result =
-            LoadStartResult(&g_workerStartResult);
-
-        if (result.outcome == RuntimeStartOutcome::Ready &&
-            !g_workerReady.load(std::memory_order_acquire)) {
-            return RuntimeStartFailure(E_FAIL);
-        }
-
-        return result;
+        return g_workerReady.load(std::memory_order_acquire);
     }
 
     HRESULT waitHr = waitResult == WAIT_TIMEOUT
@@ -2285,7 +2073,7 @@ static RuntimeStartResult StartWorker() {
         waitResult,
         static_cast<unsigned int>(waitHr));
 
-    return RuntimeStartFailure(waitHr);
+    return RecordStartFailure(waitHr);
 }
 
 static void StopWorker() {
@@ -2563,77 +2351,44 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
     constexpr int kMaxRuntimeStartAttempts = 30;
 
     for (int attempt = 1; attempt <= kMaxRuntimeStartAttempts; ++attempt) {
-        RuntimeStartResult workerResult = StartWorker();
-        RuntimeStartResult cacheResult = {
-            RuntimeStartOutcome::RetryableFailure,
-            E_PENDING,
-        };
+        bool started = StartWorker();
 
-        if (workerResult.outcome == RuntimeStartOutcome::Ready &&
-            !RuntimeCancellationRequested()) {
-            cacheResult = StartNotificationCache();
-        } else if (RuntimeCancellationRequested()) {
-            cacheResult = RuntimeStartCancelled();
+        if (started && !RuntimeCancellationRequested()) {
+            started = StartNotificationCache();
         }
 
-        if (workerResult.outcome == RuntimeStartOutcome::Ready &&
-            cacheResult.outcome == RuntimeStartOutcome::Ready &&
-            !RuntimeCancellationRequested()) {
-
-            if (!InstallVirtualDesktopHooks()) {
-                StopNotificationCache();
-                StopWorker();
-
-                RuntimeState state = RuntimeCancellationRequested()
-                    ? RuntimeState::Stopped
-                    : RuntimeState::Unsupported;
-                g_runtimeState.store(state, std::memory_order_release);
-
-                Wh_Log(
-                    L"Shell-host initialization failed: "
-                    L"VD hooks unavailable; remaining fail-open");
-                return 0;
-            }
-
-            if (RuntimeCancellationRequested()) {
-                StopNotificationCache();
-                StopWorker();
+        if (started && !RuntimeCancellationRequested()) {
+            if (InstallVirtualDesktopHooks() &&
+                !RuntimeCancellationRequested()) {
                 g_runtimeState.store(
-                    RuntimeState::Stopped,
+                    RuntimeState::Ready,
                     std::memory_order_release);
+                Wh_Log(L"Runtime ready after attempt %d", attempt);
                 return 0;
             }
 
-            g_interceptionEnabled.store(true, std::memory_order_release);
-            g_runtimeState.store(RuntimeState::Ready, std::memory_order_release);
-
-            Wh_Log(
-                L"Runtime ready after attempt %d: primary shell Explorer "
-                L"confirmed, source-desktop cache active, bounded rescue "
-                L"queue active",
-                attempt);
-
-            return 0;
+            if (!RuntimeCancellationRequested()) {
+                g_startUnsupported.store(true, std::memory_order_release);
+                g_startHr.store(E_FAIL, std::memory_order_relaxed);
+            }
         }
 
         StopNotificationCache();
         StopWorker();
 
-        RuntimeStartResult failureResult =
-            workerResult.outcome != RuntimeStartOutcome::Ready
-                ? workerResult
-                : cacheResult;
+        bool unsupported =
+            g_startUnsupported.load(std::memory_order_acquire);
+        HRESULT failureHr = g_startHr.load(std::memory_order_relaxed);
 
         if (g_unloading.load(std::memory_order_acquire) ||
-            RuntimeCancellationRequested() ||
-            failureResult.outcome == RuntimeStartOutcome::Cancelled) {
+            RuntimeCancellationRequested()) {
             g_runtimeState.store(
                 RuntimeState::Stopped,
                 std::memory_order_release);
             return 0;
         }
 
-        if (failureResult.outcome == RuntimeStartOutcome::Unsupported) {
+        if (unsupported) {
             g_runtimeState.store(
                 RuntimeState::Unsupported,
                 std::memory_order_release);
@@ -2641,7 +2396,7 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
             Wh_Log(
                 L"Shell-host runtime unsupported hr=0x%08X; "
                 L"remaining fail-open",
-                static_cast<unsigned int>(failureResult.hr));
+                static_cast<unsigned int>(failureHr));
             return 0;
         }
 
@@ -2650,7 +2405,7 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
                 L"Shell-host runtime unavailable on attempt %d "
                 L"hr=0x%08X; retrying",
                 attempt,
-                static_cast<unsigned int>(failureResult.hr));
+                static_cast<unsigned int>(failureHr));
 
             if (!WaitForShellHostRetryDelay()) {
                 g_runtimeState.store(
@@ -2832,7 +2587,6 @@ static HWND WINAPI CreateWindowExW_Hook(
 }
 
 static void StopRuntimeBeforeUninit() {
-    g_interceptionEnabled.store(false, std::memory_order_release);
     g_unloading.store(true, std::memory_order_release);
 
     if (g_runtimeCancelEvent) {
@@ -2855,30 +2609,12 @@ static void StopRuntimeBeforeUninit() {
 }
 
 static void StopRuntime() {
-    g_interceptionEnabled.store(false, std::memory_order_release);
     StopNotificationCache();
     StopWorker();
     g_runtimeState.store(RuntimeState::Stopped, std::memory_order_release);
 }
 
 BOOL Wh_ModInit() {
-    constexpr DWORD kMinimumSupportedBuild = 26100;
-
-    DWORD buildNumber = GetWindowsBuildNumber();
-    if (buildNumber && buildNumber < kMinimumSupportedBuild) {
-        Wh_Log(
-            L"Unsupported Windows build %lu; build %lu or newer is required",
-            buildNumber,
-            kMinimumSupportedBuild);
-        return FALSE;
-    }
-
-    if (!buildNumber) {
-        Wh_Log(
-            L"Couldn't determine the Windows build; continuing with the "
-            L"runtime compatibility probe");
-    }
-
     g_runtimeCancelEvent =
         CreateEventW(nullptr, TRUE, FALSE, nullptr);
     if (!g_runtimeCancelEvent) {

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -2,7 +2,7 @@
 // @id              prevent-virtual-desktop-stealing
 // @name            Prevent Window Activation from Stealing Virtual Desktop
 // @description     Redirect cross-desktop window activation to the current desktop.
-// @version         0.3.9
+// @version         0.3.10
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @include         explorer.exe
@@ -1968,46 +1968,24 @@ static std::atomic<int> g_runtimeState{0};
 static std::atomic<bool> g_unloading{false};
 static std::atomic<bool> g_shellHostConfirmed{false};
 static std::atomic<bool> g_virtualDesktopHooksInstalled{false};
+static std::atomic<bool> g_taskbarObserverInstalled{false};
 
 static SRWLOCK g_runtimeInitLock = SRWLOCK_INIT;
 static HANDLE g_runtimeInitThread = nullptr;
 
-static BOOL CALLBACK FindCurrentProcessPrimaryTaskbarEnumProc(
-    HWND hwnd,
-    LPARAM lParam) {
+static HWND FindCurrentProcessShellWindow() {
+    HWND shellWindow = GetShellWindow();
+    if (!shellWindow) {
+        return nullptr;
+    }
 
     DWORD pid = 0;
-    if (!GetWindowThreadProcessId(hwnd, &pid) ||
+    if (!GetWindowThreadProcessId(shellWindow, &pid) ||
         pid != GetCurrentProcessId()) {
-        return TRUE;
+        return nullptr;
     }
 
-    wchar_t className[32] = {};
-    if (!GetClassNameW(
-            hwnd,
-            className,
-            ARRAYSIZE(className))) {
-        return TRUE;
-    }
-
-    // Deliberately accept only the primary taskbar. Secondary taskbars are
-    // Shell_SecondaryTrayWnd and are not shell-process identity markers.
-    if (_wcsicmp(className, L"Shell_TrayWnd") == 0) {
-        *reinterpret_cast<HWND*>(lParam) = hwnd;
-        return FALSE;
-    }
-
-    return TRUE;
-}
-
-static HWND FindCurrentProcessPrimaryTaskbar() {
-    HWND result = nullptr;
-
-    EnumWindows(
-        FindCurrentProcessPrimaryTaskbarEnumProc,
-        reinterpret_cast<LPARAM>(&result));
-
-    return result;
+    return shellWindow;
 }
 
 static bool InstallVirtualDesktopHooks() {
@@ -2115,6 +2093,26 @@ static bool WaitForShellHostRetryDelay() {
     return !g_unloading.load(std::memory_order_acquire);
 }
 
+static void RemoveTaskbarObserver() {
+    if (!g_taskbarObserverInstalled.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    if (!Wh_RemoveFunctionHook(
+            reinterpret_cast<void*>(CreateWindowExW))) {
+        Wh_Log(L"Failed to register taskbar-observer hook removal");
+        return;
+    }
+
+    if (!Wh_ApplyHookOperations()) {
+        Wh_Log(L"Failed to apply taskbar-observer hook removal");
+        return;
+    }
+
+    g_taskbarObserverInstalled.store(false, std::memory_order_release);
+    Wh_Log(L"Taskbar observer removed after successful shell promotion");
+}
+
 static DWORD WINAPI ShellHostInitThreadProc(void*) {
     Wh_Log(
         L"Shell-host initialization begin");
@@ -2153,6 +2151,8 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
                 L"confirmed, source-desktop cache active, bounded rescue "
                 L"queue active",
                 attempt);
+
+            RemoveTaskbarObserver();
             return 0;
         }
 
@@ -2379,26 +2379,26 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
+    g_taskbarObserverInstalled.store(true, std::memory_order_release);
+
     return TRUE;
 }
 
 void Wh_ModAfterInit() {
-    // Manual enable/reload: the shell Explorer may already have created its
-    // primary taskbar before our CreateWindowExW observer was installed.
-    HWND primaryTaskbar =
-        FindCurrentProcessPrimaryTaskbar();
+    // Manual enable/reload: the shell window may already identify this process
+    // before our CreateWindowExW observer sees the primary taskbar creation.
+    HWND shellWindow = FindCurrentProcessShellWindow();
 
-    if (primaryTaskbar) {
+    if (shellWindow) {
         Wh_Log(
-            L"Existing primary Shell_TrayWnd=%p "
-            L"belongs to this Explorer process",
-            primaryTaskbar);
+            L"Existing shell window=%p belongs to this Explorer process",
+            shellWindow);
 
         PromoteCurrentProcessToShellHost(
-            L"existing primary Shell_TrayWnd");
+            L"existing shell window");
     } else {
         Wh_Log(
-            L"No primary Shell_TrayWnd owned by this PID; "
+            L"No shell window owned by this PID; "
             L"remaining inert unless one is created");
     }
 }

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -2,7 +2,7 @@
 // @id              prevent-virtual-desktop-stealing
 // @name            Prevent Window Activation from Stealing Virtual Desktop
 // @description     Redirect cross-desktop window activation to the current desktop.
-// @version         0.3.4
+// @version         0.3.5
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @include         explorer.exe
@@ -1642,6 +1642,20 @@ static bool InstallVirtualDesktopHooks() {
     return true;
 }
 
+static bool WaitForShellHostRetryDelay() {
+    // Keep unload latency short while allowing the shell's COM services time
+    // to register after a fresh Explorer start.
+    for (int i = 0; i < 10; ++i) {
+        if (g_unloading.load(std::memory_order_acquire)) {
+            return false;
+        }
+
+        Sleep(50);
+    }
+
+    return !g_unloading.load(std::memory_order_acquire);
+}
+
 static DWORD WINAPI ShellHostInitThreadProc(void*) {
     Wh_Log(
         L"Shell-host initialization begin");
@@ -1660,51 +1674,54 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
         return 0;
     }
 
-    if (g_unloading.load(std::memory_order_acquire)) {
-        g_runtimeState.store(0, std::memory_order_release);
-        return 0;
-    }
+    constexpr int kMaxRuntimeStartAttempts = 30;
 
-    if (!StartWorker()) {
-        StopWorker();
-        g_runtimeState.store(0, std::memory_order_release);
+    for (int attempt = 1; attempt <= kMaxRuntimeStartAttempts; ++attempt) {
+        bool workerStarted = StartWorker();
+        bool cacheStarted = false;
 
-        Wh_Log(
-            L"Shell-host initialization failed: "
-            L"worker unavailable; remaining fail-open");
-        return 0;
-    }
+        if (workerStarted &&
+            !g_unloading.load(std::memory_order_acquire)) {
+            cacheStarted = StartNotificationCache();
+        }
 
-    if (g_unloading.load(std::memory_order_acquire)) {
-        StopWorker();
-        g_runtimeState.store(0, std::memory_order_release);
-        return 0;
-    }
+        if (workerStarted && cacheStarted &&
+            !g_unloading.load(std::memory_order_acquire)) {
+            g_runtimeState.store(2, std::memory_order_release);
 
-    if (!StartNotificationCache()) {
+            Wh_Log(
+                L"Runtime ready after attempt %d: primary shell Explorer "
+                L"confirmed, source-desktop cache active, bounded rescue "
+                L"queue active",
+                attempt);
+            return 0;
+        }
+
         StopNotificationCache();
         StopWorker();
-        g_runtimeState.store(0, std::memory_order_release);
 
-        Wh_Log(
-            L"Shell-host initialization failed: "
-            L"desktop cache unavailable; remaining fail-open");
-        return 0;
+        if (g_unloading.load(std::memory_order_acquire)) {
+            g_runtimeState.store(0, std::memory_order_release);
+            return 0;
+        }
+
+        if (attempt < kMaxRuntimeStartAttempts) {
+            Wh_Log(
+                L"Shell-host runtime unavailable on attempt %d; retrying",
+                attempt);
+
+            if (!WaitForShellHostRetryDelay()) {
+                g_runtimeState.store(0, std::memory_order_release);
+                return 0;
+            }
+        }
     }
 
-    if (g_unloading.load(std::memory_order_acquire)) {
-        StopNotificationCache();
-        StopWorker();
-        g_runtimeState.store(0, std::memory_order_release);
-        return 0;
-    }
-
-    g_runtimeState.store(2, std::memory_order_release);
-
+    g_runtimeState.store(0, std::memory_order_release);
     Wh_Log(
-        L"Runtime ready: primary shell Explorer confirmed, "
-        L"source-desktop cache active, bounded rescue queue active");
-
+        L"Shell-host initialization failed after %d attempts; "
+        L"remaining fail-open",
+        kMaxRuntimeStartAttempts);
     return 0;
 }
 

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -55,6 +55,7 @@ Windows updates may require adjustments.
 
 #include <atomic>
 #include <cstdint>
+#include <wchar.h>
 
 // -----------------------------------------------------------------------------
 // Explicit COM IDs used by the minimal interface declarations below.
@@ -89,12 +90,6 @@ static const IID kIidVirtualDesktopNotificationService = {
 static const IID kIidVirtualDesktopManagerInternal24H2 = {
     0x53F5CA0B, 0x158F, 0x4124,
     {0x90, 0x0C, 0x05, 0x71, 0x58, 0x06, 0x0B, 0x27}
-};
-
-// Windows 11 22H2/23H2 IVirtualDesktopManagerInternal IID.
-static const IID kIidVirtualDesktopManagerInternal22H2 = {
-    0xA3175F2D, 0x239C, 0x4BD2,
-    {0x8A, 0xA0, 0xEE, 0xBA, 0x8B, 0x0B, 0x13, 0x8E}
 };
 
 static const IID kIidApplicationViewCollection = {
@@ -364,6 +359,10 @@ static constexpr ULONGLONG kExplicitSwitchExpiryMs = 2000;
 static SRWLOCK g_explicitSwitchLock = SRWLOCK_INIT;
 static ExplicitSwitchTransaction g_explicitSwitch = {};
 static std::atomic<uint64_t> g_nextExplicitSwitchSequence{1};
+
+// IVirtualDesktopManagerInternal slots for the 24H2 IID above.
+static constexpr int kVtableMoveViewToDesktop = 4;
+static constexpr int kVtableGetCurrentDesktop = 6;
 
 // SwitchDesktopWithAnimation synchronously calls SwitchDesktop on current
 // builds. Only the outermost public switch entry should create a transaction.
@@ -962,13 +961,6 @@ static DWORD WINAPI NotificationThreadProc(void*) {
             kIidVirtualDesktopManagerInternal24H2,
             reinterpret_cast<void**>(&managerInternal));
 
-        if (FAILED(hr) || !managerInternal) {
-            managerInternal = nullptr;
-            hr = serviceProvider->QueryService(
-                kClsidVirtualDesktopManagerInternal,
-                kIidVirtualDesktopManagerInternal22H2,
-                reinterpret_cast<void**>(&managerInternal));
-        }
     }
 
     if (SUCCEEDED(hr) && managerInternal) {
@@ -977,7 +969,7 @@ static DWORD WINAPI NotificationThreadProc(void*) {
                 void*,
                 IVirtualDesktop**)>(
             managerInternal,
-            6);
+            kVtableGetCurrentDesktop);
 
         IVirtualDesktop* currentDesktop = nullptr;
         HRESULT currentHr =
@@ -1213,14 +1205,6 @@ static bool InitializeWorkerComState(WorkerComState* state) {
         reinterpret_cast<void**>(&state->managerInternal));
 
     if (FAILED(hr) || !state->managerInternal) {
-        state->managerInternal = nullptr;
-        hr = state->serviceProvider->QueryService(
-            kClsidVirtualDesktopManagerInternal,
-            kIidVirtualDesktopManagerInternal22H2,
-            reinterpret_cast<void**>(&state->managerInternal));
-    }
-
-    if (FAILED(hr) || !state->managerInternal) {
         Wh_Log(
             L"Worker: QueryService(managerInternal) failed "
             L"hr=0x%08X",
@@ -1258,12 +1242,8 @@ static bool InitializeWorkerComState(WorkerComState* state) {
     return true;
 }
 
-// These slots and signatures are shared by the version-gating IIDs above.
 // Older monitor-aware interface versions aren't queried because their method
-// signatures differ.
-static constexpr int kVtableMoveViewToDesktop = 4;
-static constexpr int kVtableGetCurrentDesktop = 6;
-
+// signatures differ from the 24H2 interface used here.
 static HRESULT WorkerGetCurrentDesktop(
     WorkerComState* state,
     IVirtualDesktop** desktop) {
@@ -1953,13 +1933,17 @@ static void StopWorker() {
 // exactly once. Non-shell explorer.exe processes never load twinui.pcshell.dll
 // for this mod and never start the virtual-desktop worker/cache.
 
-static std::atomic<int> g_runtimeState{0};
-// 0 = dormant/stopped, 1 = shell-host initialization in progress, 2 = ready
+enum class RuntimeState {
+    Stopped,
+    Initializing,
+    Ready,
+};
+
+static std::atomic<RuntimeState> g_runtimeState{RuntimeState::Stopped};
 
 static std::atomic<bool> g_unloading{false};
 static std::atomic<bool> g_shellHostConfirmed{false};
 static std::atomic<bool> g_virtualDesktopHooksInstalled{false};
-static std::atomic<bool> g_taskbarObserverInstalled{false};
 
 static SRWLOCK g_runtimeInitLock = SRWLOCK_INIT;
 static HANDLE g_runtimeInitThread = nullptr;
@@ -2072,10 +2056,11 @@ static bool InstallVirtualDesktopHooks() {
     return true;
 }
 
-static bool WaitForShellHostRetryDelay() {
+static bool WaitForShellHostRetryDelay(int attempt) {
     // Keep unload latency short while allowing the shell's COM services time
     // to register after a fresh Explorer start.
-    for (int i = 0; i < 10; ++i) {
+    // Back off from 500 ms to 2 seconds across the bounded retry budget.
+    for (int i = 0; i < attempt * 10; ++i) {
         if (g_unloading.load(std::memory_order_acquire)) {
             return false;
         }
@@ -2086,37 +2071,17 @@ static bool WaitForShellHostRetryDelay() {
     return !g_unloading.load(std::memory_order_acquire);
 }
 
-static void RemoveTaskbarObserver() {
-    if (!g_taskbarObserverInstalled.load(std::memory_order_acquire)) {
-        return;
-    }
-
-    if (!Wh_RemoveFunctionHook(
-            reinterpret_cast<void*>(CreateWindowExW))) {
-        Wh_Log(L"Failed to register taskbar-observer hook removal");
-        return;
-    }
-
-    if (!Wh_ApplyHookOperations()) {
-        Wh_Log(L"Failed to apply taskbar-observer hook removal");
-        return;
-    }
-
-    g_taskbarObserverInstalled.store(false, std::memory_order_release);
-    Wh_Log(L"Taskbar observer removed after successful shell promotion");
-}
-
 static DWORD WINAPI ShellHostInitThreadProc(void*) {
     Wh_Log(
         L"Shell-host initialization begin");
 
     if (g_unloading.load(std::memory_order_acquire)) {
-        g_runtimeState.store(0, std::memory_order_release);
+        g_runtimeState.store(RuntimeState::Stopped, std::memory_order_release);
         return 0;
     }
 
     if (!InstallVirtualDesktopHooks()) {
-        g_runtimeState.store(0, std::memory_order_release);
+        g_runtimeState.store(RuntimeState::Stopped, std::memory_order_release);
 
         Wh_Log(
             L"Shell-host initialization failed: "
@@ -2124,7 +2089,7 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
         return 0;
     }
 
-    constexpr int kMaxRuntimeStartAttempts = 30;
+    constexpr int kMaxRuntimeStartAttempts = 4;
 
     for (int attempt = 1; attempt <= kMaxRuntimeStartAttempts; ++attempt) {
         bool workerStarted = StartWorker();
@@ -2137,7 +2102,7 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
 
         if (workerStarted && cacheStarted &&
             !g_unloading.load(std::memory_order_acquire)) {
-            g_runtimeState.store(2, std::memory_order_release);
+            g_runtimeState.store(RuntimeState::Ready, std::memory_order_release);
 
             Wh_Log(
                 L"Runtime ready after attempt %d: primary shell Explorer "
@@ -2145,7 +2110,6 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
                 L"queue active",
                 attempt);
 
-            RemoveTaskbarObserver();
             return 0;
         }
 
@@ -2153,7 +2117,9 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
         StopWorker();
 
         if (g_unloading.load(std::memory_order_acquire)) {
-            g_runtimeState.store(0, std::memory_order_release);
+            g_runtimeState.store(
+                RuntimeState::Stopped,
+                std::memory_order_release);
             return 0;
         }
 
@@ -2162,14 +2128,16 @@ static DWORD WINAPI ShellHostInitThreadProc(void*) {
                 L"Shell-host runtime unavailable on attempt %d; retrying",
                 attempt);
 
-            if (!WaitForShellHostRetryDelay()) {
-                g_runtimeState.store(0, std::memory_order_release);
+            if (!WaitForShellHostRetryDelay(attempt)) {
+                g_runtimeState.store(
+                    RuntimeState::Stopped,
+                    std::memory_order_release);
                 return 0;
             }
         }
     }
 
-    g_runtimeState.store(0, std::memory_order_release);
+    g_runtimeState.store(RuntimeState::Stopped, std::memory_order_release);
     Wh_Log(
         L"Shell-host initialization failed after %d attempts; "
         L"remaining fail-open",
@@ -2188,14 +2156,16 @@ static void PromoteCurrentProcessToShellHost(
         true,
         std::memory_order_release);
 
-    if (g_runtimeState.load(std::memory_order_acquire) == 2) {
+    if (g_runtimeState.load(std::memory_order_acquire) ==
+        RuntimeState::Ready) {
         return;
     }
 
     AcquireSRWLockExclusive(&g_runtimeInitLock);
 
     if (g_unloading.load(std::memory_order_relaxed) ||
-        g_runtimeState.load(std::memory_order_relaxed) != 0) {
+        g_runtimeState.load(std::memory_order_relaxed) !=
+            RuntimeState::Stopped) {
         ReleaseSRWLockExclusive(&g_runtimeInitLock);
         return;
     }
@@ -2215,7 +2185,7 @@ static void PromoteCurrentProcessToShellHost(
         }
     }
 
-    g_runtimeState.store(1, std::memory_order_release);
+    g_runtimeState.store(RuntimeState::Initializing, std::memory_order_release);
 
     Wh_Log(
         L"Primary Shell_TrayWnd confirmed; "
@@ -2235,7 +2205,7 @@ static void PromoteCurrentProcessToShellHost(
         Wh_Log(
             L"Shell-host init CreateThread failed error=%lu",
             GetLastError());
-        g_runtimeState.store(0, std::memory_order_release);
+        g_runtimeState.store(RuntimeState::Stopped, std::memory_order_release);
     }
 
     ReleaseSRWLockExclusive(&g_runtimeInitLock);
@@ -2282,7 +2252,8 @@ static HWND WINAPI CreateWindowExW_Hook(
     // If initialization failed, keep watching for a recreated primary taskbar
     // so the same Explorer process gets a natural retry opportunity.
     if (g_shellHostConfirmed.load(std::memory_order_acquire) &&
-        g_runtimeState.load(std::memory_order_acquire) == 2) {
+        g_runtimeState.load(std::memory_order_acquire) ==
+            RuntimeState::Ready) {
         return hwnd;
     }
 
@@ -2352,7 +2323,7 @@ static void StopRuntimeBeforeUninit() {
 static void StopRuntime() {
     StopNotificationCache();
     StopWorker();
-    g_runtimeState.store(0, std::memory_order_release);
+    g_runtimeState.store(RuntimeState::Stopped, std::memory_order_release);
 }
 
 BOOL Wh_ModInit() {
@@ -2371,8 +2342,6 @@ BOOL Wh_ModInit() {
             L"Failed to hook CreateWindowExW");
         return FALSE;
     }
-
-    g_taskbarObserverInstalled.store(true, std::memory_order_release);
 
     return TRUE;
 }

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -2,7 +2,7 @@
 // @id              prevent-virtual-desktop-stealing
 // @name            Prevent Window Activation from Stealing Virtual Desktop
 // @description     Redirect cross-desktop window activation to the current desktop.
-// @version         0.3.8
+// @version         0.3.9
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @include         explorer.exe
@@ -1033,6 +1033,10 @@ static DWORD WINAPI NotificationThreadProc(void*) {
 }
 
 static bool StartNotificationCache() {
+    // Each start attempt owns its readiness result. Don't inherit a true value
+    // from a previous notification thread that exited during startup retry.
+    g_notificationReady.store(false, std::memory_order_release);
+
     g_notificationReadyEvent =
         CreateEventW(nullptr, TRUE, FALSE, nullptr);
 
@@ -1290,6 +1294,12 @@ static void ProcessRescueRequest(
     WorkerComState* state,
     const RescueRequest& request) {
 
+    // Abort paths below intentionally don't replay the suppressed switch.
+    // By the time this worker runs, a newer user navigation may have superseded
+    // the request; switching here would override it and would re-enter the
+    // shell hooks from this worker apartment. Keep every abort fail-stationary
+    // and logged rather than manufacturing a stale cross-thread switch.
+
     wchar_t requestedText[64] = {};
     GuidToString(
         request.requestedDesktopId,
@@ -1516,18 +1526,20 @@ static void ProcessRescueRequest(
 }
 
 static DWORD WINAPI WorkerThreadProc(void*) {
+    g_workerReady.store(false, std::memory_order_release);
+
     HRESULT coHr =
-        CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+        CoInitializeEx(nullptr, COINIT_MULTITHREADED);
 
     const bool shouldUninitialize =
         SUCCEEDED(coHr);
 
-    if (FAILED(coHr) &&
-        coHr != RPC_E_CHANGED_MODE) {
+    if (FAILED(coHr)) {
         Wh_Log(
             L"Worker: CoInitializeEx failed hr=0x%08X",
             static_cast<unsigned int>(coHr));
 
+        g_workerReady.store(false, std::memory_order_release);
         SetEvent(g_workerReadyEvent);
         return 0;
     }
@@ -1541,6 +1553,7 @@ static DWORD WINAPI WorkerThreadProc(void*) {
             CoUninitialize();
         }
 
+        g_workerReady.store(false, std::memory_order_release);
         SetEvent(g_workerReadyEvent);
         return 0;
     }
@@ -1582,6 +1595,7 @@ static DWORD WINAPI WorkerThreadProc(void*) {
         }
     }
 
+    g_workerReady.store(false, std::memory_order_release);
     ReleaseWorkerComState(&state);
 
     if (shouldUninitialize) {
@@ -1813,7 +1827,10 @@ static HRESULT SwitchDesktopInternal_Hook(
         L"BLOCK SwitchDesktopInternal: rescue queued");
 
     // Pretend the internal switch succeeded only after the rescue has been
-    // safely queued. Every failure before this point fails open.
+    // safely queued. Every failure before this point fails open. If the worker
+    // later aborts, it deliberately doesn't replay this request: the desktop
+    // may have changed meanwhile, and replay from the worker apartment would
+    // risk overriding newer navigation and re-entering this hook.
     return S_OK;
 }
 
@@ -1822,6 +1839,10 @@ static HRESULT SwitchDesktopInternal_Hook(
 // -----------------------------------------------------------------------------
 
 static bool StartWorker() {
+    // Each start attempt owns its readiness result. A slow previous worker can
+    // otherwise publish true after StopWorker already cleared the flag.
+    g_workerReady.store(false, std::memory_order_release);
+
     g_requestEvent =
         CreateEventW(
             nullptr,

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -1546,7 +1546,8 @@ static bool InstallVirtualDesktopHooks() {
         return false;
     }
 
-    WindhawkUtils::SYMBOL_HOOK twinuiPcshellDllHooks[] = {
+    // twinui.pcshell.dll
+    WindhawkUtils::SYMBOL_HOOK twinuiPcshellHooks[] = {
         {
             {
                 L"public: virtual long __cdecl "
@@ -1573,9 +1574,9 @@ static bool InstallVirtualDesktopHooks() {
 
     if (!WindhawkUtils::HookSymbols(
             twinui,
-            twinuiPcshellDllHooks,
-            ARRAYSIZE(twinuiPcshellDllHooks))) {
-        Wh_Log(
+            twinuiPcshellHooks,
+            ARRAYSIZE(twinuiPcshellHooks))) {
+                  Wh_Log(
             L"[VDREDIRECT] Shell host: failed to resolve/install "
             L"virtual-desktop symbols");
         return false;

--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -2,7 +2,7 @@
 // @id              prevent-virtual-desktop-stealing
 // @name            Prevent Window Activation from Stealing Virtual Desktop
 // @description     Redirect cross-desktop window activation to the current desktop.
-// @version         0.3.12
+// @version         0.3.13
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @include         explorer.exe
@@ -41,7 +41,8 @@ Transition Animation**.
 ### Notes
 
 Designed for Windows 11 24H2 and newer. This mod relies on undocumented Windows
-shell interfaces, so future Windows updates may require adjustments.
+shell interfaces, including the private IApplicationView layout, so future
+Windows updates may require adjustments.
 */
 // ==/WindhawkModReadme==
 
@@ -330,6 +331,17 @@ static void LogWindow(const wchar_t* label, HWND hwnd) {
 // are always allowed. Only a positively attributed foreground-policy switch is
 // eligible for redirect.
 static thread_local int g_foregroundPolicyDepth = 0;
+
+// Exact window identity supplied by the active foreground-policy view.
+//
+// IApplicationView::GetThumbnailWindow is vtable slot 9 on the Windows 11
+// 24H2+ shell ABI used by this mod. Probing confirmed that calling this slot
+// synchronously from ForegroundViewChanged returns the HWND of the exact view
+// which is driving a cross-desktop activation.
+//
+// Keep only the plain HWND in TLS. Never carry the raw IApplicationView pointer
+// into the rescue worker apartment.
+static thread_local HWND g_foregroundPolicyHwnd = nullptr;
 
 // Task View and direct shell/API desktop switches are asynchronous: their public
 // SwitchDesktop* entry point can return before CurrentVirtualDesktopChanged is
@@ -707,13 +719,61 @@ static HRESULT SwitchDesktopWithAnimation_Hook(
     return hr;
 }
 
+static HWND GetForegroundPolicyViewHwnd(
+    IApplicationView* view) {
+
+    if (!view) {
+        return nullptr;
+    }
+
+    // IApplicationView::GetThumbnailWindow(HWND*) is slot 9 including the
+    // three IUnknown entries. Use the interface vtable so Win32/WinRT views
+    // dispatch to their own implementation.
+    using GetThumbnailWindow_t =
+        HRESULT (*)(IApplicationView*, HWND*);
+
+    auto getThumbnailWindow =
+        GetVTableFunction<GetThumbnailWindow_t>(
+            view,
+            9);
+
+    if (!getThumbnailWindow) {
+        return nullptr;
+    }
+
+    HWND hwnd = nullptr;
+    HRESULT hr =
+        getThumbnailWindow(
+            view,
+            &hwnd);
+
+    if (FAILED(hr)) {
+        Wh_Log(
+            L"ForegroundViewChanged: "
+            L"GetThumbnailWindow failed hr=0x%08X",
+            static_cast<unsigned int>(hr));
+        return nullptr;
+    }
+
+    return hwnd;
+}
+
 static HRESULT ForegroundViewChanged_Hook(
     void* pThis,
     IVirtualDesktopManagerPrivate* manager,
     IVirtualDesktopSwitchAnimator* animator,
     IApplicationView* view) {
 
+    HWND previousHwnd =
+        g_foregroundPolicyHwnd;
+
     ++g_foregroundPolicyDepth;
+
+    // Resolve the exact view synchronously, while the IApplicationView pointer
+    // is valid on this shell call stack. Only the HWND crosses into the nested
+    // SwitchDesktopInternal hook and, later, the worker queue.
+    g_foregroundPolicyHwnd =
+        GetForegroundPolicyViewHwnd(view);
 
     HRESULT hr =
         g_foregroundViewChangedOriginal(
@@ -721,6 +781,9 @@ static HRESULT ForegroundViewChanged_Hook(
             manager,
             animator,
             view);
+
+    g_foregroundPolicyHwnd =
+        previousHwnd;
 
     --g_foregroundPolicyDepth;
     return hr;
@@ -1688,14 +1751,17 @@ static HRESULT SwitchDesktopInternal_Hook(
             requestedDesktop);
     }
 
-    HWND foreground = GetForegroundWindow();
+    HWND candidate =
+        g_foregroundPolicyHwnd;
 
     // Even inside the positively attributed activation path, fail open unless
-    // there is a plausible top-level app window to rescue.
-    if (!IsRescueCandidate(foreground)) {
+    // the exact foreground-policy view resolved to a plausible top-level app
+    // window. Do not fall back to GetForegroundWindow(): doing so would throw
+    // away the precise view identity that ForegroundViewChanged supplied.
+    if (!IsRescueCandidate(candidate)) {
         Wh_Log(
             L"SwitchDesktopInternal allowed: "
-            L"no eligible foreground rescue candidate");
+            L"no eligible exact-view rescue candidate");
 
         return g_switchDesktopInternalOriginal(
             pThis,
@@ -1714,7 +1780,7 @@ static HRESULT SwitchDesktopInternal_Hook(
 
     DWORD candidatePid = 0;
     DWORD candidateTid =
-        GetWindowThreadProcessId(foreground, &candidatePid);
+        GetWindowThreadProcessId(candidate, &candidatePid);
 
     if (!candidatePid || !candidateTid) {
         Wh_Log(
@@ -1728,17 +1794,17 @@ static HRESULT SwitchDesktopInternal_Hook(
 
     Wh_Log(
         L"Candidate activation-driven SwitchDesktopInternal "
-        L"source=%s requested=%s foreground=%p "
+        L"source=%s requested=%s exactViewHwnd=%p "
         L"foregroundPolicyDepth=%d",
         GuidToStringForLog(sourceDesktopId),
         GuidToStringForLog(requestedId),
-        foreground,
+        candidate,
         g_foregroundPolicyDepth);
 
-    LogWindow(L"candidate", foreground);
+    LogWindow(L"candidate", candidate);
 
     if (!QueueRescue(
-            foreground,
+            candidate,
             candidatePid,
             candidateTid,
             sourceDesktopId,


### PR DESCRIPTION
## Changelog
# Prevent Window Activation from Stealing Virtual Desktop

Take back control over your virtual desktops!

![Screenshot](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/prevent-virtual-desktop-stealing/prevent-virtual-desktop-stealing.gif)
_Effect of redirecting window activation_

Windows can switch you to another virtual desktop just because a window that was left open on that
desktop is activated. 

Clicking a flashing taskbar button, following a notification, opening an app through its tray icon, 
or launching something that insists on reusing an existing window can all unexpectedly pull you away 
from your current desktop. This mod keeps you where you are and brings the activated window to you instead.

If you don't know what "virtual desktop stealing" is, try this small experiment:

- Open Windhawk on your first virtual desktop.
- Switch to another virtual desktop.
- Click the Windhawk tray icon.

Normally, Windows jumps back to the first desktop - not anymore with this mod.

Intentional desktop navigation is left alone, including Win+Ctrl+Left/Right and
Task View. The mod also remains compatible with **Disable Virtual Desktop
Transition Animation**.

### Notes

Designed for Windows 11 24H2 and newer. This mod relies on undocumented Windows
shell interfaces, so future Windows updates may require adjustments.

## Mod authorship

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 
