### PR TITLE
Add On-Screen Indicator Position mod

### DIFF
--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,12 +2,11 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Place the volume/brightness/camera on-screen indicator anywhere on the screen, not just the three positions Windows offers
-// @version         1.0.3
+// @version         1.1.0
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lshcore
 // ==/WindhawkMod==
 
 // Source code is published under The GNU General Public License v3.0.
@@ -25,9 +24,8 @@ changes. Under **Settings > System > Notifications > On-screen indicators**,
 Windows lets you put it in one of three places: top left, top center, or bottom
 center.
 
-This mod replaces that with a full nine-point grid — any corner, any edge
-center, or dead center of the screen — plus a pixel offset for fine-tuning and a
-choice of which monitor it appears on.
+This mod replaces that with a full nine-point grid, any corner, any edge center,
+or dead center, plus a pixel offset for fine-tuning.
 
 The brightness indicator moved to the middle of the right edge:
 
@@ -41,9 +39,17 @@ The brightness indicator moved to the middle of the right edge:
  Bottom left     Bottom center     Bottom right
 ```
 
-By default the indicator is placed inside the work area, so it won't sit
-underneath the taskbar. Turn off "Keep clear of the taskbar" to use the whole
-screen instead.
+The indicator is kept inside the area Windows lays it out in, so an offset that
+would push it past an edge stops at the edge instead of moving off screen. You
+can also leave the position on **Windows default** and use the offsets alone to
+nudge one of the built-in positions.
+
+## Choosing a monitor
+
+This mod only changes where the indicator sits on a screen, not which screen it
+appears on. For that, use [Volume control open
+location](https://windhawk.net/mods/volume-control-open-location), which selects
+a monitor by number or by interface name. The two work together.
 
 ## Notes
 
@@ -51,10 +57,7 @@ screen instead.
   setting, not by this mod. If the animation looks wrong for your new position,
   change the built-in setting to whichever of the three has the animation you
   like, then let this mod do the actual placement.
-* The indicator is drawn by Explorer, so the mod targets `explorer.exe`. If
-  Explorer restarts, the mod keeps working.
-* Tested on Windows 11 build 26200 (25H2) x64. Other builds are untested, and
-  older ones draw this indicator differently.
+* Tested on Windows 11 build 26200 (25H2) x64.
 */
 // ==/WindhawkModReadme==
 
@@ -64,7 +67,7 @@ screen instead.
   $name: Position
   $description: Where on the screen the indicator appears
   $options:
-  - windowsDefault: Windows default (don't move it)
+  - windowsDefault: Windows default (only apply the offsets)
   - topLeft: Top left
   - topCenter: Top center
   - topRight: Top right
@@ -78,36 +81,18 @@ screen instead.
   $name: Horizontal offset
   $description: >-
     Pixels to nudge the indicator by. Positive moves right, negative moves left.
-    Scaled with the monitor's DPI.
+    The indicator is kept on screen, so an offset that would push it past the
+    edge is ignored.
 - offsetY: 0
   $name: Vertical offset
   $description: >-
     Pixels to nudge the indicator by. Positive moves down, negative moves up.
-    Scaled with the monitor's DPI.
-- monitor: windowsDefault
-  $name: Monitor
-  $description: Which monitor the indicator appears on
-  $options:
-  - windowsDefault: Windows default (don't change it)
-  - primary: Primary monitor
-  - cursor: Monitor with the mouse cursor
-  - foreground: Monitor with the active window
-- useWorkArea: true
-  $name: Keep clear of the taskbar
-  $description: >-
-    Position within the work area rather than the full screen, so the indicator
-    isn't hidden behind the taskbar.
+    The indicator is kept on screen, so an offset that would push it past the
+    edge is ignored.
 */
 // ==/WindhawkModSettings==
 
 #include <windhawk_utils.h>
-
-#include <shellscalingapi.h>
-
-// The Explorer thread that owns the indicator window names itself. This is an
-// exact match, so the mod doesn't have to guess at window class names that
-// change between builds.
-constexpr PCWSTR kConfirmatorThreadName = L"HardwareConfirmator UI Thread";
 
 enum class Position {
     windowsDefault,
@@ -122,340 +107,115 @@ enum class Position {
     bottomRight,
 };
 
-enum class MonitorChoice {
-    windowsDefault,
-    primary,
-    cursor,
-    foreground,
-};
-
 struct {
     Position position;
     int offsetX;
     int offsetY;
-    MonitorChoice monitor;
-    bool useWorkArea;
 } g_settings;
 
-// Explorer moves windows constantly, so this has to be nearly free once the
-// answer is known. A thread that has already named itself something else will
-// never become the indicator's, so that answer is kept for good. Only a thread
-// with no name yet stays undecided, since it may still be on its way to naming
-// itself, and pinning that would send the first indicator to Windows' position.
-bool IsCurrentThreadConfirmatorThread() {
-    static thread_local int cached = -1;  // -1 unknown, 0 no, 1 yes.
+HMODULE g_hardwareConfirmatorModule;
 
-    if (cached >= 0) {
-        return cached == 1;
-    }
+// winrt::Windows::Foundation::Rect
+struct WinrtRect {
+    float X;
+    float Y;
+    float Width;
+    float Height;
+};
 
-    PWSTR threadDescription;
-    if (FAILED(GetThreadDescription(GetCurrentThread(), &threadDescription))) {
-        return false;
-    }
+// `area` is the region the indicator is laid out in, already shifted to 0,0.
+// `rect` comes back from the original function holding the size Windows chose
+// and the position it picked from the built-in setting; only the position is
+// replaced.
+void PlaceInArea(const WinrtRect& area, WinrtRect* rect) {
+    float left = 0;
+    float centerX = (area.Width - rect->Width) / 2;
+    float right = area.Width - rect->Width;
 
-    bool match = wcscmp(threadDescription, kConfirmatorThreadName) == 0;
-    bool named = *threadDescription != L'\0';
-    LocalFree(threadDescription);
-
-    if (match || named) {
-        cached = match ? 1 : 0;
-    }
-
-    return match;
-}
-
-bool IsIndicatorWindow(HWND hWnd) {
-    if (!hWnd) {
-        return false;
-    }
-
-    // The indicator is moved by the thread that owns it, so anything else is
-    // ruled out before the more expensive thread-name lookup runs.
-    DWORD processId = 0;
-    DWORD threadId = GetWindowThreadProcessId(hWnd, &processId);
-    if (threadId != GetCurrentThreadId() ||
-        processId != GetCurrentProcessId()) {
-        return false;
-    }
-
-    // Only top-level windows are placed on screen.
-    if (GetAncestor(hWnd, GA_PARENT) != GetDesktopWindow()) {
-        return false;
-    }
-
-    return IsCurrentThreadConfirmatorThread();
-}
-
-// `targetRect` is where the indicator is about to go, not where it is. The
-// window's current rect is the previous placement, and since the mod pins the
-// window, using it would feed each decision back into the next one and lock the
-// indicator onto whichever monitor it first landed on.
-HMONITOR PickMonitor(const RECT& targetRect) {
-    switch (g_settings.monitor) {
-        case MonitorChoice::primary:
-            return MonitorFromPoint(POINT{0, 0}, MONITOR_DEFAULTTOPRIMARY);
-
-        case MonitorChoice::cursor: {
-            POINT pt;
-            if (GetCursorPos(&pt)) {
-                return MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
-            }
-            break;
-        }
-
-        case MonitorChoice::foreground: {
-            HWND foregroundWnd = GetForegroundWindow();
-            if (foregroundWnd) {
-                return MonitorFromWindow(foregroundWnd,
-                                         MONITOR_DEFAULTTONEAREST);
-            }
-            break;
-        }
-
-        case MonitorChoice::windowsDefault:
-            break;
-    }
-
-    return MonitorFromRect(&targetRect, MONITOR_DEFAULTTONEAREST);
-}
-
-// Places a window of the given size within `area` according to the configured
-// position, applies the DPI-scaled offsets, and clamps the result so the window
-// stays inside the monitor.
-void CalculatePosition(HMONITOR monitor,
-                       const RECT& area,
-                       int width,
-                       int height,
-                       int* x,
-                       int* y) {
-    int left = area.left;
-    int centerX = area.left + (area.right - area.left - width) / 2;
-    int right = area.right - width;
-
-    int top = area.top;
-    int middleY = area.top + (area.bottom - area.top - height) / 2;
-    int bottom = area.bottom - height;
+    float top = 0;
+    float middleY = (area.Height - rect->Height) / 2;
+    float bottom = area.Height - rect->Height;
 
     switch (g_settings.position) {
         case Position::topLeft:
-            *x = left, *y = top;
+            rect->X = left, rect->Y = top;
             break;
         case Position::topCenter:
-            *x = centerX, *y = top;
+            rect->X = centerX, rect->Y = top;
             break;
         case Position::topRight:
-            *x = right, *y = top;
+            rect->X = right, rect->Y = top;
             break;
         case Position::middleLeft:
-            *x = left, *y = middleY;
+            rect->X = left, rect->Y = middleY;
             break;
         case Position::center:
-            *x = centerX, *y = middleY;
+            rect->X = centerX, rect->Y = middleY;
             break;
         case Position::middleRight:
-            *x = right, *y = middleY;
+            rect->X = right, rect->Y = middleY;
             break;
         case Position::bottomLeft:
-            *x = left, *y = bottom;
+            rect->X = left, rect->Y = bottom;
             break;
         case Position::bottomCenter:
-            *x = centerX, *y = bottom;
+            rect->X = centerX, rect->Y = bottom;
             break;
         case Position::bottomRight:
-            *x = right, *y = bottom;
+            rect->X = right, rect->Y = bottom;
             break;
         case Position::windowsDefault:
-            return;
+            // Keep the position Windows picked and only apply the offsets.
+            break;
     }
 
-    UINT dpiX = 96;
-    UINT dpiY = 96;
-    GetDpiForMonitor(monitor, MDT_DEFAULT, &dpiX, &dpiY);
-
-    *x += MulDiv(g_settings.offsetX, dpiX, 96);
-    *y += MulDiv(g_settings.offsetY, dpiY, 96);
+    rect->X += g_settings.offsetX;
+    rect->Y += g_settings.offsetY;
 
     // An offset large enough to push the indicator off screen would just make
-    // it invisible with no way to tell why, so keep it within the area above,
-    // which is the work area unless the taskbar setting says otherwise.
-    if (*x < area.left) {
-        *x = area.left;
-    } else if (*x > area.right - width) {
-        *x = area.right - width;
+    // it invisible with no way to tell why, so keep it within the area.
+    if (rect->X < 0) {
+        rect->X = 0;
+    } else if (rect->X > right) {
+        rect->X = right > 0 ? right : 0;
     }
 
-    if (*y < area.top) {
-        *y = area.top;
-    } else if (*y > area.bottom - height) {
-        *y = area.bottom - height;
+    if (rect->Y < 0) {
+        rect->Y = 0;
+    } else if (rect->Y > bottom) {
+        rect->Y = bottom > 0 ? bottom : 0;
     }
 }
 
-// `width` and `height` are in and out: sending the indicator to a monitor with
-// different scaling means it has to be resized to match, or it arrives at the
-// size the source monitor implied and every anchor except top left is off by
-// the difference once the window rescales itself. `canResize` is false when the
-// caller isn't setting a size, in which case the window is left to handle the
-// DPI change on its own.
-bool AdjustIndicatorPos(int* width, int* height, int* x, int* y, bool canResize) {
-    RECT targetRect{
-        .left = *x,
-        .top = *y,
-        .right = *x + *width,
-        .bottom = *y + *height,
-    };
+using HardwareConfirmatorHost_GetPositionRect_t =
+    WinrtRect*(WINAPI*)(void* pThis, WinrtRect* retval, const WinrtRect* rect);
+HardwareConfirmatorHost_GetPositionRect_t
+    HardwareConfirmatorHost_GetPositionRect_Original;
+WinrtRect* WINAPI
+HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
+                                             WinrtRect* retval,
+                                             const WinrtRect* rect) {
+    Wh_Log(L">");
 
-    HMONITOR monitor = PickMonitor(targetRect);
-    if (!monitor) {
-        return false;
+    // Shift the input rect to 0,0 since the original function assumes that.
+    WinrtRect shiftedRect = *rect;
+    float offsetX = shiftedRect.X;
+    float offsetY = shiftedRect.Y;
+    shiftedRect.X = 0;
+    shiftedRect.Y = 0;
+
+    WinrtRect* result = HardwareConfirmatorHost_GetPositionRect_Original(
+        pThis, retval, &shiftedRect);
+
+    if (result) {
+        PlaceInArea(shiftedRect, result);
+
+        // Shift the result back.
+        result->X += offsetX;
+        result->Y += offsetY;
     }
 
-    if (canResize) {
-        HMONITOR sourceMonitor =
-            MonitorFromRect(&targetRect, MONITOR_DEFAULTTONEAREST);
-        UINT sourceDpiX = 96, sourceDpiY = 96;
-        UINT targetDpiX = 96, targetDpiY = 96;
-        if (sourceMonitor && sourceMonitor != monitor &&
-            SUCCEEDED(GetDpiForMonitor(sourceMonitor, MDT_DEFAULT, &sourceDpiX,
-                                       &sourceDpiY)) &&
-            SUCCEEDED(GetDpiForMonitor(monitor, MDT_DEFAULT, &targetDpiX,
-                                       &targetDpiY)) &&
-            sourceDpiX && sourceDpiY) {
-            *width = MulDiv(*width, targetDpiX, sourceDpiX);
-            *height = MulDiv(*height, targetDpiY, sourceDpiY);
-        }
-    }
-
-    MONITORINFO monitorInfo{
-        .cbSize = sizeof(MONITORINFO),
-    };
-    if (!GetMonitorInfo(monitor, &monitorInfo)) {
-        return false;
-    }
-
-    const RECT& area =
-        g_settings.useWorkArea ? monitorInfo.rcWork : monitorInfo.rcMonitor;
-
-    if (area.right - area.left < *width || area.bottom - area.top < *height) {
-        return false;
-    }
-
-    CalculatePosition(monitor, area, *width, *height, x, y);
-    return true;
-}
-
-// The class name isn't used to identify the window, since it's undocumented and
-// free to change between builds. Logging it means that if the thread-name match
-// ever starts catching the wrong window, a user's log says which one.
-void LogMove(HWND hWnd, int x, int y, int width, int height) {
-    WCHAR className[64];
-    if (!GetClassName(hWnd, className, ARRAYSIZE(className))) {
-        className[0] = L'\0';
-    }
-
-    Wh_Log(L"Moving indicator (class %s) to %dx%d (%dx%d)", className, x, y,
-           width, height);
-}
-
-// On build 26200 the indicator is placed with MoveWindow and this hook never
-// fires. It's kept deliberately, as a fallback for builds that go through
-// SetWindowPos instead.
-using SetWindowPos_t = decltype(&SetWindowPos);
-SetWindowPos_t SetWindowPos_Original;
-
-BOOL WINAPI SetWindowPos_Hook(HWND hWnd,
-                              HWND hWndInsertAfter,
-                              int X,
-                              int Y,
-                              int cx,
-                              int cy,
-                              UINT uFlags) {
-    auto original = [=]() {
-        return SetWindowPos_Original(hWnd, hWndInsertAfter, X, Y, cx, cy,
-                                     uFlags);
-    };
-
-    if (g_settings.position == Position::windowsDefault) {
-        return original();
-    }
-
-    if ((uFlags & (SWP_NOSIZE | SWP_NOMOVE)) == (SWP_NOSIZE | SWP_NOMOVE)) {
-        return original();
-    }
-
-    // A real sizing call follows, so there's nothing to place yet.
-    if (!(uFlags & SWP_NOSIZE) && (cx <= 0 || cy <= 0)) {
-        return original();
-    }
-
-    if (!IsIndicatorWindow(hWnd)) {
-        return original();
-    }
-
-    RECT rc{};
-    if (!GetWindowRect(hWnd, &rc)) {
-        return original();
-    }
-
-    int width = (uFlags & SWP_NOSIZE) ? rc.right - rc.left : cx;
-    int height = (uFlags & SWP_NOSIZE) ? rc.bottom - rc.top : cy;
-
-    // The window is sized and moved in separate calls. Move it on the sizing
-    // call too, otherwise it lands in the right place only every other time.
-    int x = (uFlags & SWP_NOMOVE) ? rc.left : X;
-    int y = (uFlags & SWP_NOMOVE) ? rc.top : Y;
-
-    bool canResize = !(uFlags & SWP_NOSIZE);
-    if (!AdjustIndicatorPos(&width, &height, &x, &y, canResize)) {
-        return original();
-    }
-
-    LogMove(hWnd, x, y, width, height);
-
-    return SetWindowPos_Original(hWnd, hWndInsertAfter, x, y,
-                                 canResize ? width : cx,
-                                 canResize ? height : cy,
-                                 uFlags & ~SWP_NOMOVE);
-}
-
-using MoveWindow_t = decltype(&MoveWindow);
-MoveWindow_t MoveWindow_Original;
-
-BOOL WINAPI MoveWindow_Hook(HWND hWnd,
-                            int X,
-                            int Y,
-                            int nWidth,
-                            int nHeight,
-                            BOOL bRepaint) {
-    auto original = [=]() {
-        return MoveWindow_Original(hWnd, X, Y, nWidth, nHeight, bRepaint);
-    };
-
-    if (g_settings.position == Position::windowsDefault) {
-        return original();
-    }
-
-    // Same guard SetWindowPos_Hook has: a real sizing call follows.
-    if (nWidth <= 0 || nHeight <= 0) {
-        return original();
-    }
-
-    if (!IsIndicatorWindow(hWnd)) {
-        return original();
-    }
-
-    int x = X;
-    int y = Y;
-    int width = nWidth;
-    int height = nHeight;
-    if (!AdjustIndicatorPos(&width, &height, &x, &y, true)) {
-        return original();
-    }
-
-    LogMove(hWnd, x, y, width, height);
-
-    return MoveWindow_Original(hWnd, x, y, width, height, bRepaint);
+    return result;
 }
 
 Position PositionFromString(PCWSTR value) {
@@ -482,18 +242,6 @@ Position PositionFromString(PCWSTR value) {
     return Position::windowsDefault;
 }
 
-MonitorChoice MonitorChoiceFromString(PCWSTR value) {
-    if (wcscmp(value, L"primary") == 0) {
-        return MonitorChoice::primary;
-    } else if (wcscmp(value, L"cursor") == 0) {
-        return MonitorChoice::cursor;
-    } else if (wcscmp(value, L"foreground") == 0) {
-        return MonitorChoice::foreground;
-    }
-
-    return MonitorChoice::windowsDefault;
-}
-
 void LoadSettings() {
     WindhawkUtils::StringSetting position =
         WindhawkUtils::StringSetting::make(L"position");
@@ -501,12 +249,6 @@ void LoadSettings() {
 
     g_settings.offsetX = Wh_GetIntSetting(L"offsetX");
     g_settings.offsetY = Wh_GetIntSetting(L"offsetY");
-
-    WindhawkUtils::StringSetting monitor =
-        WindhawkUtils::StringSetting::make(L"monitor");
-    g_settings.monitor = MonitorChoiceFromString(monitor.get());
-
-    g_settings.useWorkArea = Wh_GetIntSetting(L"useWorkArea");
 }
 
 BOOL Wh_ModInit() {
@@ -514,17 +256,28 @@ BOOL Wh_ModInit() {
 
     LoadSettings();
 
-    // Nothing to do, so don't hook at all. Windhawk loads the mod again after a
-    // settings change, which is when a real position can arrive.
-    if (g_settings.position == Position::windowsDefault) {
-        Wh_Log(L"No position configured, not loading");
+    g_hardwareConfirmatorModule =
+        LoadLibraryEx(L"Windows.Internal.HardwareConfirmator.dll", nullptr,
+                      LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!g_hardwareConfirmatorModule) {
+        Wh_Log(L"Couldn't load Windows.Internal.HardwareConfirmator.dll");
         return FALSE;
     }
 
-    WindhawkUtils::SetFunctionHook(SetWindowPos, SetWindowPos_Hook,
-                                   &SetWindowPos_Original);
-    WindhawkUtils::SetFunctionHook(MoveWindow, MoveWindow_Hook,
-                                   &MoveWindow_Original);
+    // Windows.Internal.HardwareConfirmator.dll
+    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+        {
+            {LR"(private: struct winrt::Windows::Foundation::Rect __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::GetPositionRect(struct winrt::Windows::Foundation::Rect const &))"},
+            &HardwareConfirmatorHost_GetPositionRect_Original,
+            HardwareConfirmatorHost_GetPositionRect_Hook,
+        },
+    };
+
+    if (!HookSymbols(g_hardwareConfirmatorModule, symbolHooks,
+                     ARRAYSIZE(symbolHooks))) {
+        Wh_Log(L"HookSymbols failed");
+        return FALSE;
+    }
 
     return TRUE;
 }

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Place the volume/brightness/camera on-screen indicator anywhere on the screen, not just the three positions Windows offers
-// @version         1.0.2
+// @version         1.0.3
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -137,31 +137,32 @@ struct {
     bool useWorkArea;
 } g_settings;
 
-bool CurrentThreadHasConfirmatorName() {
-    bool match = false;
+// Explorer moves windows constantly, so this has to be nearly free once the
+// answer is known. A thread that has already named itself something else will
+// never become the indicator's, so that answer is kept for good. Only a thread
+// with no name yet stays undecided, since it may still be on its way to naming
+// itself, and pinning that would send the first indicator to Windows' position.
+bool IsCurrentThreadConfirmatorThread() {
+    static thread_local int cached = -1;  // -1 unknown, 0 no, 1 yes.
+
+    if (cached >= 0) {
+        return cached == 1;
+    }
 
     PWSTR threadDescription;
-    if (SUCCEEDED(GetThreadDescription(GetCurrentThread(),
-                                       &threadDescription))) {
-        match = wcscmp(threadDescription, kConfirmatorThreadName) == 0;
-        LocalFree(threadDescription);
+    if (FAILED(GetThreadDescription(GetCurrentThread(), &threadDescription))) {
+        return false;
+    }
+
+    bool match = wcscmp(threadDescription, kConfirmatorThreadName) == 0;
+    bool named = *threadDescription != L'\0';
+    LocalFree(threadDescription);
+
+    if (match || named) {
+        cached = match ? 1 : 0;
     }
 
     return match;
-}
-
-// Only a positive is cached. Caching a negative risks pinning the answer for a
-// thread that simply hadn't named itself yet, which would send the first
-// indicator to Windows' position instead of the configured one.
-bool IsCurrentThreadConfirmatorThread() {
-    static thread_local bool isConfirmator = false;
-
-    if (isConfirmator) {
-        return true;
-    }
-
-    isConfirmator = CurrentThreadHasConfirmatorName();
-    return isConfirmator;
 }
 
 bool IsIndicatorWindow(HWND hWnd) {
@@ -276,7 +277,8 @@ void CalculatePosition(HMONITOR monitor,
     *y += MulDiv(g_settings.offsetY, dpiY, 96);
 
     // An offset large enough to push the indicator off screen would just make
-    // it invisible with no way to tell why, so keep it within the monitor.
+    // it invisible with no way to tell why, so keep it within the area above,
+    // which is the work area unless the taskbar setting says otherwise.
     if (*x < area.left) {
         *x = area.left;
     } else if (*x > area.right - width) {
@@ -290,17 +292,39 @@ void CalculatePosition(HMONITOR monitor,
     }
 }
 
-bool AdjustIndicatorPos(int width, int height, int* x, int* y) {
+// `width` and `height` are in and out: sending the indicator to a monitor with
+// different scaling means it has to be resized to match, or it arrives at the
+// size the source monitor implied and every anchor except top left is off by
+// the difference once the window rescales itself. `canResize` is false when the
+// caller isn't setting a size, in which case the window is left to handle the
+// DPI change on its own.
+bool AdjustIndicatorPos(int* width, int* height, int* x, int* y, bool canResize) {
     RECT targetRect{
         .left = *x,
         .top = *y,
-        .right = *x + width,
-        .bottom = *y + height,
+        .right = *x + *width,
+        .bottom = *y + *height,
     };
 
     HMONITOR monitor = PickMonitor(targetRect);
     if (!monitor) {
         return false;
+    }
+
+    if (canResize) {
+        HMONITOR sourceMonitor =
+            MonitorFromRect(&targetRect, MONITOR_DEFAULTTONEAREST);
+        UINT sourceDpiX = 96, sourceDpiY = 96;
+        UINT targetDpiX = 96, targetDpiY = 96;
+        if (sourceMonitor && sourceMonitor != monitor &&
+            SUCCEEDED(GetDpiForMonitor(sourceMonitor, MDT_DEFAULT, &sourceDpiX,
+                                       &sourceDpiY)) &&
+            SUCCEEDED(GetDpiForMonitor(monitor, MDT_DEFAULT, &targetDpiX,
+                                       &targetDpiY)) &&
+            sourceDpiX && sourceDpiY) {
+            *width = MulDiv(*width, targetDpiX, sourceDpiX);
+            *height = MulDiv(*height, targetDpiY, sourceDpiY);
+        }
     }
 
     MONITORINFO monitorInfo{
@@ -313,11 +337,11 @@ bool AdjustIndicatorPos(int width, int height, int* x, int* y) {
     const RECT& area =
         g_settings.useWorkArea ? monitorInfo.rcWork : monitorInfo.rcMonitor;
 
-    if (area.right - area.left < width || area.bottom - area.top < height) {
+    if (area.right - area.left < *width || area.bottom - area.top < *height) {
         return false;
     }
 
-    CalculatePosition(monitor, area, width, height, x, y);
+    CalculatePosition(monitor, area, *width, *height, x, y);
     return true;
 }
 
@@ -382,13 +406,16 @@ BOOL WINAPI SetWindowPos_Hook(HWND hWnd,
     int x = (uFlags & SWP_NOMOVE) ? rc.left : X;
     int y = (uFlags & SWP_NOMOVE) ? rc.top : Y;
 
-    if (!AdjustIndicatorPos(width, height, &x, &y)) {
+    bool canResize = !(uFlags & SWP_NOSIZE);
+    if (!AdjustIndicatorPos(&width, &height, &x, &y, canResize)) {
         return original();
     }
 
     LogMove(hWnd, x, y, width, height);
 
-    return SetWindowPos_Original(hWnd, hWndInsertAfter, x, y, cx, cy,
+    return SetWindowPos_Original(hWnd, hWndInsertAfter, x, y,
+                                 canResize ? width : cx,
+                                 canResize ? height : cy,
                                  uFlags & ~SWP_NOMOVE);
 }
 
@@ -409,19 +436,26 @@ BOOL WINAPI MoveWindow_Hook(HWND hWnd,
         return original();
     }
 
+    // Same guard SetWindowPos_Hook has: a real sizing call follows.
+    if (nWidth <= 0 || nHeight <= 0) {
+        return original();
+    }
+
     if (!IsIndicatorWindow(hWnd)) {
         return original();
     }
 
     int x = X;
     int y = Y;
-    if (!AdjustIndicatorPos(nWidth, nHeight, &x, &y)) {
+    int width = nWidth;
+    int height = nHeight;
+    if (!AdjustIndicatorPos(&width, &height, &x, &y, true)) {
         return original();
     }
 
-    LogMove(hWnd, x, y, nWidth, nHeight);
+    LogMove(hWnd, x, y, width, height);
 
-    return MoveWindow_Original(hWnd, x, y, nWidth, nHeight, bRepaint);
+    return MoveWindow_Original(hWnd, x, y, width, height, bRepaint);
 }
 
 Position PositionFromString(PCWSTR value) {

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -1,0 +1,468 @@
+// ==WindhawkMod==
+// @id              on-screen-indicator-position
+// @name            On-Screen Indicator Position
+// @description     Place the volume/brightness/camera on-screen indicator anywhere on the screen, not just the three positions Windows offers
+// @version         1.0.0
+// @author          mario0318
+// @github          https://github.com/mario0318
+// @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -lshcore
+// ==/WindhawkMod==
+
+// Source code is published under The GNU General Public License v3.0.
+//
+// For bug reports and feature requests, please open an issue here:
+// https://github.com/ramensoftware/windhawk-mods/issues
+
+// ==WindhawkModReadme==
+/*
+# On-Screen Indicator Position
+
+Windows 11 shows an on-screen indicator when you change the volume or
+brightness, toggle airplane mode, or when the camera or microphone privacy state
+changes. Under **Settings > System > Notifications > On-screen indicators**,
+Windows lets you put it in one of three places: top left, top center, or bottom
+center.
+
+This mod replaces that with a full nine-point grid — any corner, any edge
+center, or dead center of the screen — plus a pixel offset for fine-tuning and a
+choice of which monitor it appears on.
+
+## Positions
+
+```
+ Top left        Top center        Top right
+ Middle left     Center            Middle right
+ Bottom left     Bottom center     Bottom right
+```
+
+By default the indicator is placed inside the work area, so it won't sit
+underneath the taskbar. Turn off "Keep clear of the taskbar" to use the whole
+screen instead.
+
+## Notes
+
+* The slide-in animation direction is chosen by Windows from the built-in
+  setting, not by this mod. If the animation looks wrong for your new position,
+  change the built-in setting to whichever of the three has the animation you
+  like, then let this mod do the actual placement.
+* The indicator is drawn by Explorer, so the mod targets `explorer.exe`. If
+  Explorer restarts, the mod keeps working.
+* Tested on Windows 11 24H2/25H2. Older builds draw this indicator differently
+  and are not supported.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- position: topRight
+  $name: Position
+  $description: Where on the screen the indicator appears
+  $options:
+  - windowsDefault: Windows default (don't move it)
+  - topLeft: Top left
+  - topCenter: Top center
+  - topRight: Top right
+  - middleLeft: Middle left
+  - center: Center
+  - middleRight: Middle right
+  - bottomLeft: Bottom left
+  - bottomCenter: Bottom center
+  - bottomRight: Bottom right
+- offsetX: 0
+  $name: Horizontal offset
+  $description: >-
+    Pixels to nudge the indicator by. Positive moves right, negative moves left.
+    Scaled with the monitor's DPI.
+- offsetY: 0
+  $name: Vertical offset
+  $description: >-
+    Pixels to nudge the indicator by. Positive moves down, negative moves up.
+    Scaled with the monitor's DPI.
+- monitor: windowsDefault
+  $name: Monitor
+  $description: Which monitor the indicator appears on
+  $options:
+  - windowsDefault: Windows default (don't change it)
+  - primary: Primary monitor
+  - cursor: Monitor with the mouse cursor
+  - foreground: Monitor with the active window
+- useWorkArea: true
+  $name: Keep clear of the taskbar
+  $description: >-
+    Position within the work area rather than the full screen, so the indicator
+    isn't hidden behind the taskbar.
+*/
+// ==/WindhawkModSettings==
+
+#include <windhawk_utils.h>
+
+#include <shellscalingapi.h>
+
+// The Explorer thread that owns the indicator window names itself. This is an
+// exact match, so the mod doesn't have to guess at window class names that
+// change between builds.
+constexpr PCWSTR kConfirmatorThreadName = L"HardwareConfirmator UI Thread";
+
+enum class Position {
+    windowsDefault,
+    topLeft,
+    topCenter,
+    topRight,
+    middleLeft,
+    center,
+    middleRight,
+    bottomLeft,
+    bottomCenter,
+    bottomRight,
+};
+
+enum class MonitorChoice {
+    windowsDefault,
+    primary,
+    cursor,
+    foreground,
+};
+
+struct {
+    Position position;
+    int offsetX;
+    int offsetY;
+    MonitorChoice monitor;
+    bool useWorkArea;
+} g_settings;
+
+bool CurrentThreadHasConfirmatorName() {
+    bool match = false;
+
+    PWSTR threadDescription;
+    if (SUCCEEDED(GetThreadDescription(GetCurrentThread(),
+                                       &threadDescription))) {
+        match = wcscmp(threadDescription, kConfirmatorThreadName) == 0;
+        LocalFree(threadDescription);
+    }
+
+    return match;
+}
+
+// Explorer calls SetWindowPos constantly, so the check has to be nearly free in
+// the common case. The indicator is always moved by the thread that owns it, so
+// it's enough to ask whether this thread is the indicator's, and that answer is
+// cached per thread. A negative is only cached briefly, because a thread names
+// itself shortly after it starts and may not have done so on the first call.
+bool IsCurrentThreadConfirmatorThread() {
+    static thread_local bool isConfirmator = false;
+    static thread_local ULONGLONG lastCheckTick = 0;
+
+    if (isConfirmator) {
+        return true;
+    }
+
+    ULONGLONG tick = GetTickCount64();
+    if (lastCheckTick && tick - lastCheckTick < 2000) {
+        return false;
+    }
+
+    lastCheckTick = tick;
+    isConfirmator = CurrentThreadHasConfirmatorName();
+    return isConfirmator;
+}
+
+bool IsIndicatorWindow(HWND hWnd) {
+    if (!hWnd || !IsCurrentThreadConfirmatorThread()) {
+        return false;
+    }
+
+    DWORD processId = 0;
+    DWORD threadId = GetWindowThreadProcessId(hWnd, &processId);
+    if (threadId != GetCurrentThreadId() ||
+        processId != GetCurrentProcessId()) {
+        return false;
+    }
+
+    // Only top-level windows are placed on screen.
+    return GetAncestor(hWnd, GA_PARENT) == GetDesktopWindow();
+}
+
+HMONITOR PickMonitor(HWND hWnd) {
+    switch (g_settings.monitor) {
+        case MonitorChoice::primary:
+            return MonitorFromPoint(POINT{0, 0}, MONITOR_DEFAULTTOPRIMARY);
+
+        case MonitorChoice::cursor: {
+            POINT pt;
+            if (GetCursorPos(&pt)) {
+                return MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+            }
+            break;
+        }
+
+        case MonitorChoice::foreground: {
+            HWND foregroundWnd = GetForegroundWindow();
+            if (foregroundWnd) {
+                return MonitorFromWindow(foregroundWnd,
+                                         MONITOR_DEFAULTTONEAREST);
+            }
+            break;
+        }
+
+        case MonitorChoice::windowsDefault:
+            break;
+    }
+
+    return MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+}
+
+// Places a window of the given size within `area` according to the configured
+// position, applies the DPI-scaled offsets, and clamps the result so the window
+// stays inside the monitor.
+void CalculatePosition(HMONITOR monitor,
+                       const RECT& area,
+                       int width,
+                       int height,
+                       int* x,
+                       int* y) {
+    int left = area.left;
+    int centerX = area.left + (area.right - area.left - width) / 2;
+    int right = area.right - width;
+
+    int top = area.top;
+    int middleY = area.top + (area.bottom - area.top - height) / 2;
+    int bottom = area.bottom - height;
+
+    switch (g_settings.position) {
+        case Position::topLeft:
+            *x = left, *y = top;
+            break;
+        case Position::topCenter:
+            *x = centerX, *y = top;
+            break;
+        case Position::topRight:
+            *x = right, *y = top;
+            break;
+        case Position::middleLeft:
+            *x = left, *y = middleY;
+            break;
+        case Position::center:
+            *x = centerX, *y = middleY;
+            break;
+        case Position::middleRight:
+            *x = right, *y = middleY;
+            break;
+        case Position::bottomLeft:
+            *x = left, *y = bottom;
+            break;
+        case Position::bottomCenter:
+            *x = centerX, *y = bottom;
+            break;
+        case Position::bottomRight:
+            *x = right, *y = bottom;
+            break;
+        case Position::windowsDefault:
+            return;
+    }
+
+    UINT dpiX = 96;
+    UINT dpiY = 96;
+    GetDpiForMonitor(monitor, MDT_DEFAULT, &dpiX, &dpiY);
+
+    *x += MulDiv(g_settings.offsetX, dpiX, 96);
+    *y += MulDiv(g_settings.offsetY, dpiY, 96);
+
+    // An offset large enough to push the indicator off screen would just make
+    // it invisible with no way to tell why, so keep it within the monitor.
+    if (*x < area.left) {
+        *x = area.left;
+    } else if (*x > area.right - width) {
+        *x = area.right - width;
+    }
+
+    if (*y < area.top) {
+        *y = area.top;
+    } else if (*y > area.bottom - height) {
+        *y = area.bottom - height;
+    }
+}
+
+bool AdjustIndicatorPos(HWND hWnd, int width, int height, int* x, int* y) {
+    HMONITOR monitor = PickMonitor(hWnd);
+    if (!monitor) {
+        return false;
+    }
+
+    MONITORINFO monitorInfo{
+        .cbSize = sizeof(MONITORINFO),
+    };
+    if (!GetMonitorInfo(monitor, &monitorInfo)) {
+        return false;
+    }
+
+    const RECT& area =
+        g_settings.useWorkArea ? monitorInfo.rcWork : monitorInfo.rcMonitor;
+
+    if (area.right - area.left < width || area.bottom - area.top < height) {
+        return false;
+    }
+
+    CalculatePosition(monitor, area, width, height, x, y);
+    return true;
+}
+
+using SetWindowPos_t = decltype(&SetWindowPos);
+SetWindowPos_t SetWindowPos_Original;
+
+BOOL WINAPI SetWindowPos_Hook(HWND hWnd,
+                              HWND hWndInsertAfter,
+                              int X,
+                              int Y,
+                              int cx,
+                              int cy,
+                              UINT uFlags) {
+    auto original = [=]() {
+        return SetWindowPos_Original(hWnd, hWndInsertAfter, X, Y, cx, cy,
+                                     uFlags);
+    };
+
+    if (g_settings.position == Position::windowsDefault) {
+        return original();
+    }
+
+    if ((uFlags & (SWP_NOSIZE | SWP_NOMOVE)) == (SWP_NOSIZE | SWP_NOMOVE)) {
+        return original();
+    }
+
+    if (!IsIndicatorWindow(hWnd)) {
+        return original();
+    }
+
+    RECT rc{};
+    if (!GetWindowRect(hWnd, &rc)) {
+        return original();
+    }
+
+    int width = (uFlags & SWP_NOSIZE) ? rc.right - rc.left : cx;
+    int height = (uFlags & SWP_NOSIZE) ? rc.bottom - rc.top : cy;
+
+    // The window is sized and moved in separate calls. Move it on the sizing
+    // call too, otherwise it lands in the right place only every other time.
+    int x = (uFlags & SWP_NOMOVE) ? rc.left : X;
+    int y = (uFlags & SWP_NOMOVE) ? rc.top : Y;
+
+    if (!AdjustIndicatorPos(hWnd, width, height, &x, &y)) {
+        return original();
+    }
+
+    Wh_Log(L"Moving indicator to %dx%d (%dx%d)", x, y, width, height);
+
+    return SetWindowPos_Original(hWnd, hWndInsertAfter, x, y, cx, cy,
+                                 uFlags & ~SWP_NOMOVE);
+}
+
+using MoveWindow_t = decltype(&MoveWindow);
+MoveWindow_t MoveWindow_Original;
+
+BOOL WINAPI MoveWindow_Hook(HWND hWnd,
+                            int X,
+                            int Y,
+                            int nWidth,
+                            int nHeight,
+                            BOOL bRepaint) {
+    auto original = [=]() {
+        return MoveWindow_Original(hWnd, X, Y, nWidth, nHeight, bRepaint);
+    };
+
+    if (g_settings.position == Position::windowsDefault) {
+        return original();
+    }
+
+    if (!IsIndicatorWindow(hWnd)) {
+        return original();
+    }
+
+    int x = X;
+    int y = Y;
+    if (!AdjustIndicatorPos(hWnd, nWidth, nHeight, &x, &y)) {
+        return original();
+    }
+
+    Wh_Log(L"Moving indicator to %dx%d (%dx%d)", x, y, nWidth, nHeight);
+
+    return MoveWindow_Original(hWnd, x, y, nWidth, nHeight, bRepaint);
+}
+
+Position PositionFromString(PCWSTR value) {
+    if (wcscmp(value, L"topLeft") == 0) {
+        return Position::topLeft;
+    } else if (wcscmp(value, L"topCenter") == 0) {
+        return Position::topCenter;
+    } else if (wcscmp(value, L"topRight") == 0) {
+        return Position::topRight;
+    } else if (wcscmp(value, L"middleLeft") == 0) {
+        return Position::middleLeft;
+    } else if (wcscmp(value, L"center") == 0) {
+        return Position::center;
+    } else if (wcscmp(value, L"middleRight") == 0) {
+        return Position::middleRight;
+    } else if (wcscmp(value, L"bottomLeft") == 0) {
+        return Position::bottomLeft;
+    } else if (wcscmp(value, L"bottomCenter") == 0) {
+        return Position::bottomCenter;
+    } else if (wcscmp(value, L"bottomRight") == 0) {
+        return Position::bottomRight;
+    }
+
+    return Position::windowsDefault;
+}
+
+MonitorChoice MonitorChoiceFromString(PCWSTR value) {
+    if (wcscmp(value, L"primary") == 0) {
+        return MonitorChoice::primary;
+    } else if (wcscmp(value, L"cursor") == 0) {
+        return MonitorChoice::cursor;
+    } else if (wcscmp(value, L"foreground") == 0) {
+        return MonitorChoice::foreground;
+    }
+
+    return MonitorChoice::windowsDefault;
+}
+
+void LoadSettings() {
+    WindhawkUtils::StringSetting position =
+        WindhawkUtils::StringSetting::make(L"position");
+    g_settings.position = PositionFromString(position.get());
+
+    g_settings.offsetX = Wh_GetIntSetting(L"offsetX");
+    g_settings.offsetY = Wh_GetIntSetting(L"offsetY");
+
+    WindhawkUtils::StringSetting monitor =
+        WindhawkUtils::StringSetting::make(L"monitor");
+    g_settings.monitor = MonitorChoiceFromString(monitor.get());
+
+    g_settings.useWorkArea = Wh_GetIntSetting(L"useWorkArea");
+}
+
+BOOL Wh_ModInit() {
+    Wh_Log(L">");
+
+    LoadSettings();
+
+    WindhawkUtils::SetFunctionHook(SetWindowPos, SetWindowPos_Hook,
+                                   &SetWindowPos_Original);
+    WindhawkUtils::SetFunctionHook(MoveWindow, MoveWindow_Hook,
+                                   &MoveWindow_Original);
+
+    return TRUE;
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L">");
+}
+
+BOOL Wh_ModSettingsChanged(BOOL* bReload) {
+    Wh_Log(L">");
+
+    LoadSettings();
+
+    return TRUE;
+}

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,11 +2,12 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Place the volume/brightness/camera on-screen indicator anywhere on the screen, not just the three positions Windows offers
-// @version         1.1.2
+// @version         1.1.3
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
 // @architecture    x86-64
+// @compilerOptions -lshcore
 // ==/WindhawkMod==
 
 // Source code is published under The GNU General Public License v3.0.
@@ -57,7 +58,10 @@ a monitor by number or by interface name. The two work together.
   setting, not by this mod. If the animation looks wrong for your new position,
   change the built-in setting to whichever of the three has the animation you
   like, then let this mod do the actual placement.
-* Tested on Windows 11 build 26200 (25H2) x64.
+* Offsets are given at 100% scaling and scaled to whichever monitor the
+  indicator appears on, so the same value moves the same distance on a display
+  running at 150%.
+* Tested on Windows 11 build 26200 (25H2) x64, on a 100% and a 150% display.
 
 ## Credits
 
@@ -88,19 +92,25 @@ both target the same function and work out the origin handling.
 - offsetX: 0
   $name: Horizontal offset
   $description: >-
-    Pixels to nudge the indicator by. Positive moves right, negative moves left.
-    The indicator is kept inside the area Windows lays it out in, so an offset
-    that would push it past an edge stops at the edge instead.
+    Pixels to nudge the indicator by, at 100% scaling. Positive moves right,
+    negative moves left. The value is scaled to match the monitor, so the same
+    setting moves the same distance on a scaled display. The indicator is kept
+    inside the area Windows lays it out in, so an offset that would push it past
+    an edge stops at the edge instead.
 - offsetY: 0
   $name: Vertical offset
   $description: >-
-    Pixels to nudge the indicator by. Positive moves down, negative moves up.
-    The indicator is kept inside the area Windows lays it out in, so an offset
-    that would push it past an edge stops at the edge instead.
+    Pixels to nudge the indicator by, at 100% scaling. Positive moves down,
+    negative moves up. The value is scaled to match the monitor, so the same
+    setting moves the same distance on a scaled display. The indicator is kept
+    inside the area Windows lays it out in, so an offset that would push it past
+    an edge stops at the edge instead.
 */
 // ==/WindhawkModSettings==
 
 #include <windhawk_utils.h>
+
+#include <shellscalingapi.h>
 
 #include <atomic>
 
@@ -141,7 +151,7 @@ struct WinrtRect {
 // `rect` comes back from the original function holding the size Windows chose
 // and the position it picked from the built-in setting; only the position is
 // replaced.
-void PlaceInArea(const WinrtRect& area, WinrtRect* rect) {
+void PlaceInArea(const WinrtRect& area, UINT dpiX, UINT dpiY, WinrtRect* rect) {
     float centerX = (area.Width - rect->Width) / 2;
     float right = area.Width - rect->Width;
 
@@ -190,8 +200,11 @@ void PlaceInArea(const WinrtRect& area, WinrtRect* rect) {
             break;
     }
 
-    rect->X += g_settings.offsetX.load();
-    rect->Y += g_settings.offsetY.load();
+    // The rect is in the target monitor's physical pixels, so a raw offset
+    // would cover less ground the more the monitor is scaled up. Scaling by the
+    // monitor's DPI keeps the setting meaning the same distance everywhere.
+    rect->X += MulDiv(g_settings.offsetX.load(), dpiX, 96);
+    rect->Y += MulDiv(g_settings.offsetY.load(), dpiY, 96);
 
     // An offset large enough to push the indicator out of the area would just
     // make it invisible with no way to tell why, so keep it inside.
@@ -218,6 +231,25 @@ HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
                                              const WinrtRect* rect) {
     Wh_Log(L">");
 
+    // Resolve the scaling of the monitor this rect belongs to, before the
+    // origin is shifted away.
+    UINT dpiX = 96;
+    UINT dpiY = 96;
+    RECT areaRect{
+        .left = (LONG)rect->X,
+        .top = (LONG)rect->Y,
+        .right = (LONG)(rect->X + rect->Width),
+        .bottom = (LONG)(rect->Y + rect->Height),
+    };
+    if (HMONITOR monitor = MonitorFromRect(&areaRect, MONITOR_DEFAULTTONEAREST)) {
+        UINT x = 96;
+        UINT y = 96;
+        if (SUCCEEDED(GetDpiForMonitor(monitor, MDT_DEFAULT, &x, &y)) && x && y) {
+            dpiX = x;
+            dpiY = y;
+        }
+    }
+
     // Shift the input rect to 0,0 since the original function assumes that.
     WinrtRect shiftedRect = *rect;
     float offsetX = shiftedRect.X;
@@ -229,7 +261,7 @@ HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
         pThis, retval, &shiftedRect);
 
     if (result) {
-        PlaceInArea(shiftedRect, result);
+        PlaceInArea(shiftedRect, dpiX, dpiY, result);
 
         // Shift the result back.
         result->X += offsetX;

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Place the volume/brightness/camera on-screen indicator anywhere on the screen, not just the three positions Windows offers
-// @version         1.1.0
+// @version         1.1.1
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -58,6 +58,14 @@ a monitor by number or by interface name. The two work together.
   change the built-in setting to whichever of the three has the animation you
   like, then let this mod do the actual placement.
 * Tested on Windows 11 build 26200 (25H2) x64.
+
+## Credits
+
+The hook onto the indicator's own placement function comes from [Volume control
+open location](https://windhawk.net/mods/volume-control-open-location) and
+[Taskbar primary on secondary
+monitor](https://windhawk.net/mods/taskbar-primary-on-secondary-monitor), which
+both target the same function and work out the origin handling.
 */
 // ==/WindhawkModReadme==
 
@@ -82,13 +90,13 @@ a monitor by number or by interface name. The two work together.
   $description: >-
     Pixels to nudge the indicator by. Positive moves right, negative moves left.
     The indicator is kept on screen, so an offset that would push it past the
-    edge is ignored.
+    edge stops at the edge instead.
 - offsetY: 0
   $name: Vertical offset
   $description: >-
     Pixels to nudge the indicator by. Positive moves down, negative moves up.
     The indicator is kept on screen, so an offset that would push it past the
-    edge is ignored.
+    edge stops at the edge instead.
 */
 // ==/WindhawkModSettings==
 
@@ -255,6 +263,15 @@ BOOL Wh_ModInit() {
     Wh_Log(L">");
 
     LoadSettings();
+
+    // Nothing to place and nothing to nudge, so don't load the DLL or install a
+    // hook that would only pass the rect straight through. Windhawk reloads the
+    // mod after a settings change, so it comes back as soon as there is work.
+    if (g_settings.position == Position::windowsDefault && !g_settings.offsetX &&
+        !g_settings.offsetY) {
+        Wh_Log(L"Nothing to do");
+        return FALSE;
+    }
 
     g_hardwareConfirmatorModule =
         LoadLibraryEx(L"Windows.Internal.HardwareConfirmator.dll", nullptr,

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Place the volume/brightness/camera on-screen indicator anywhere on the screen, not just the three positions Windows offers
-// @version         1.1.1
+// @version         1.1.2
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -89,18 +89,20 @@ both target the same function and work out the origin handling.
   $name: Horizontal offset
   $description: >-
     Pixels to nudge the indicator by. Positive moves right, negative moves left.
-    The indicator is kept on screen, so an offset that would push it past the
-    edge stops at the edge instead.
+    The indicator is kept inside the area Windows lays it out in, so an offset
+    that would push it past an edge stops at the edge instead.
 - offsetY: 0
   $name: Vertical offset
   $description: >-
     Pixels to nudge the indicator by. Positive moves down, negative moves up.
-    The indicator is kept on screen, so an offset that would push it past the
-    edge stops at the edge instead.
+    The indicator is kept inside the area Windows lays it out in, so an offset
+    that would push it past an edge stops at the edge instead.
 */
 // ==/WindhawkModSettings==
 
 #include <windhawk_utils.h>
+
+#include <atomic>
 
 enum class Position {
     windowsDefault,
@@ -115,10 +117,14 @@ enum class Position {
     bottomRight,
 };
 
+// Written from Wh_ModSettingsChanged on an arbitrary thread and read on the
+// confirmator's UI thread, so the members are atomic. There is nothing to tear
+// so it costs nothing here, and it keeps a settings change from being read
+// half-applied.
 struct {
-    Position position;
-    int offsetX;
-    int offsetY;
+    std::atomic<Position> position;
+    std::atomic<int> offsetX;
+    std::atomic<int> offsetY;
 } g_settings;
 
 HMODULE g_hardwareConfirmatorModule;
@@ -136,52 +142,59 @@ struct WinrtRect {
 // and the position it picked from the built-in setting; only the position is
 // replaced.
 void PlaceInArea(const WinrtRect& area, WinrtRect* rect) {
-    float left = 0;
     float centerX = (area.Width - rect->Width) / 2;
     float right = area.Width - rect->Width;
 
-    float top = 0;
     float middleY = (area.Height - rect->Height) / 2;
     float bottom = area.Height - rect->Height;
 
-    switch (g_settings.position) {
+    switch (g_settings.position.load()) {
         case Position::topLeft:
-            rect->X = left, rect->Y = top;
+            rect->X = 0;
+            rect->Y = 0;
             break;
         case Position::topCenter:
-            rect->X = centerX, rect->Y = top;
+            rect->X = centerX;
+            rect->Y = 0;
             break;
         case Position::topRight:
-            rect->X = right, rect->Y = top;
+            rect->X = right;
+            rect->Y = 0;
             break;
         case Position::middleLeft:
-            rect->X = left, rect->Y = middleY;
+            rect->X = 0;
+            rect->Y = middleY;
             break;
         case Position::center:
-            rect->X = centerX, rect->Y = middleY;
+            rect->X = centerX;
+            rect->Y = middleY;
             break;
         case Position::middleRight:
-            rect->X = right, rect->Y = middleY;
+            rect->X = right;
+            rect->Y = middleY;
             break;
         case Position::bottomLeft:
-            rect->X = left, rect->Y = bottom;
+            rect->X = 0;
+            rect->Y = bottom;
             break;
         case Position::bottomCenter:
-            rect->X = centerX, rect->Y = bottom;
+            rect->X = centerX;
+            rect->Y = bottom;
             break;
         case Position::bottomRight:
-            rect->X = right, rect->Y = bottom;
+            rect->X = right;
+            rect->Y = bottom;
             break;
         case Position::windowsDefault:
             // Keep the position Windows picked and only apply the offsets.
             break;
     }
 
-    rect->X += g_settings.offsetX;
-    rect->Y += g_settings.offsetY;
+    rect->X += g_settings.offsetX.load();
+    rect->Y += g_settings.offsetY.load();
 
-    // An offset large enough to push the indicator off screen would just make
-    // it invisible with no way to tell why, so keep it within the area.
+    // An offset large enough to push the indicator out of the area would just
+    // make it invisible with no way to tell why, so keep it inside.
     if (rect->X < 0) {
         rect->X = 0;
     } else if (rect->X > right) {
@@ -245,6 +258,12 @@ Position PositionFromString(PCWSTR value) {
         return Position::bottomCenter;
     } else if (wcscmp(value, L"bottomRight") == 0) {
         return Position::bottomRight;
+    }
+
+    // A stale or mistyped stored value would otherwise look like the mod simply
+    // isn't working.
+    if (wcscmp(value, L"windowsDefault") != 0) {
+        Wh_Log(L"Unknown position \"%s\", using the Windows default", value);
     }
 
     return Position::windowsDefault;

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Place the volume/brightness/camera on-screen indicator anywhere on the screen, not just the three positions Windows offers
-// @version         1.0.0
+// @version         1.0.1
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -49,8 +49,8 @@ screen instead.
   like, then let this mod do the actual placement.
 * The indicator is drawn by Explorer, so the mod targets `explorer.exe`. If
   Explorer restarts, the mod keeps working.
-* Tested on Windows 11 24H2/25H2. Older builds draw this indicator differently
-  and are not supported.
+* Tested on Windows 11 build 26200 (25H2) x64. Other builds are untested, and
+  older ones draw this indicator differently.
 */
 // ==/WindhawkModReadme==
 
@@ -146,34 +146,27 @@ bool CurrentThreadHasConfirmatorName() {
     return match;
 }
 
-// Explorer calls SetWindowPos constantly, so the check has to be nearly free in
-// the common case. The indicator is always moved by the thread that owns it, so
-// it's enough to ask whether this thread is the indicator's, and that answer is
-// cached per thread. A negative is only cached briefly, because a thread names
-// itself shortly after it starts and may not have done so on the first call.
+// Only a positive is cached. Caching a negative risks pinning the answer for a
+// thread that simply hadn't named itself yet, which would send the first
+// indicator to Windows' position instead of the configured one.
 bool IsCurrentThreadConfirmatorThread() {
     static thread_local bool isConfirmator = false;
-    static thread_local ULONGLONG lastCheckTick = 0;
 
     if (isConfirmator) {
         return true;
     }
 
-    ULONGLONG tick = GetTickCount64();
-    if (lastCheckTick && tick - lastCheckTick < 2000) {
-        return false;
-    }
-
-    lastCheckTick = tick;
     isConfirmator = CurrentThreadHasConfirmatorName();
     return isConfirmator;
 }
 
 bool IsIndicatorWindow(HWND hWnd) {
-    if (!hWnd || !IsCurrentThreadConfirmatorThread()) {
+    if (!hWnd) {
         return false;
     }
 
+    // The indicator is moved by the thread that owns it, so anything else is
+    // ruled out before the more expensive thread-name lookup runs.
     DWORD processId = 0;
     DWORD threadId = GetWindowThreadProcessId(hWnd, &processId);
     if (threadId != GetCurrentThreadId() ||
@@ -182,10 +175,18 @@ bool IsIndicatorWindow(HWND hWnd) {
     }
 
     // Only top-level windows are placed on screen.
-    return GetAncestor(hWnd, GA_PARENT) == GetDesktopWindow();
+    if (GetAncestor(hWnd, GA_PARENT) != GetDesktopWindow()) {
+        return false;
+    }
+
+    return IsCurrentThreadConfirmatorThread();
 }
 
-HMONITOR PickMonitor(HWND hWnd) {
+// `targetRect` is where the indicator is about to go, not where it is. The
+// window's current rect is the previous placement, and since the mod pins the
+// window, using it would feed each decision back into the next one and lock the
+// indicator onto whichever monitor it first landed on.
+HMONITOR PickMonitor(const RECT& targetRect) {
     switch (g_settings.monitor) {
         case MonitorChoice::primary:
             return MonitorFromPoint(POINT{0, 0}, MONITOR_DEFAULTTOPRIMARY);
@@ -211,7 +212,7 @@ HMONITOR PickMonitor(HWND hWnd) {
             break;
     }
 
-    return MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+    return MonitorFromRect(&targetRect, MONITOR_DEFAULTTONEAREST);
 }
 
 // Places a window of the given size within `area` according to the configured
@@ -285,8 +286,15 @@ void CalculatePosition(HMONITOR monitor,
     }
 }
 
-bool AdjustIndicatorPos(HWND hWnd, int width, int height, int* x, int* y) {
-    HMONITOR monitor = PickMonitor(hWnd);
+bool AdjustIndicatorPos(int width, int height, int* x, int* y) {
+    RECT targetRect{
+        .left = *x,
+        .top = *y,
+        .right = *x + width,
+        .bottom = *y + height,
+    };
+
+    HMONITOR monitor = PickMonitor(targetRect);
     if (!monitor) {
         return false;
     }
@@ -309,6 +317,22 @@ bool AdjustIndicatorPos(HWND hWnd, int width, int height, int* x, int* y) {
     return true;
 }
 
+// The class name isn't used to identify the window, since it's undocumented and
+// free to change between builds. Logging it means that if the thread-name match
+// ever starts catching the wrong window, a user's log says which one.
+void LogMove(HWND hWnd, int x, int y, int width, int height) {
+    WCHAR className[64];
+    if (!GetClassName(hWnd, className, ARRAYSIZE(className))) {
+        className[0] = L'\0';
+    }
+
+    Wh_Log(L"Moving indicator (class %s) to %dx%d (%dx%d)", className, x, y,
+           width, height);
+}
+
+// On build 26200 the indicator is placed with MoveWindow and this hook never
+// fires. It's kept deliberately, as a fallback for builds that go through
+// SetWindowPos instead.
 using SetWindowPos_t = decltype(&SetWindowPos);
 SetWindowPos_t SetWindowPos_Original;
 
@@ -332,6 +356,11 @@ BOOL WINAPI SetWindowPos_Hook(HWND hWnd,
         return original();
     }
 
+    // A real sizing call follows, so there's nothing to place yet.
+    if (!(uFlags & SWP_NOSIZE) && (cx <= 0 || cy <= 0)) {
+        return original();
+    }
+
     if (!IsIndicatorWindow(hWnd)) {
         return original();
     }
@@ -349,11 +378,11 @@ BOOL WINAPI SetWindowPos_Hook(HWND hWnd,
     int x = (uFlags & SWP_NOMOVE) ? rc.left : X;
     int y = (uFlags & SWP_NOMOVE) ? rc.top : Y;
 
-    if (!AdjustIndicatorPos(hWnd, width, height, &x, &y)) {
+    if (!AdjustIndicatorPos(width, height, &x, &y)) {
         return original();
     }
 
-    Wh_Log(L"Moving indicator to %dx%d (%dx%d)", x, y, width, height);
+    LogMove(hWnd, x, y, width, height);
 
     return SetWindowPos_Original(hWnd, hWndInsertAfter, x, y, cx, cy,
                                  uFlags & ~SWP_NOMOVE);
@@ -382,11 +411,11 @@ BOOL WINAPI MoveWindow_Hook(HWND hWnd,
 
     int x = X;
     int y = Y;
-    if (!AdjustIndicatorPos(hWnd, nWidth, nHeight, &x, &y)) {
+    if (!AdjustIndicatorPos(nWidth, nHeight, &x, &y)) {
         return original();
     }
 
-    Wh_Log(L"Moving indicator to %dx%d (%dx%d)", x, y, nWidth, nHeight);
+    LogMove(hWnd, x, y, nWidth, nHeight);
 
     return MoveWindow_Original(hWnd, x, y, nWidth, nHeight, bRepaint);
 }
@@ -447,6 +476,13 @@ BOOL Wh_ModInit() {
 
     LoadSettings();
 
+    // Nothing to do, so don't hook at all. Windhawk loads the mod again after a
+    // settings change, which is when a real position can arrive.
+    if (g_settings.position == Position::windowsDefault) {
+        Wh_Log(L"No position configured, not loading");
+        return FALSE;
+    }
+
     WindhawkUtils::SetFunctionHook(SetWindowPos, SetWindowPos_Hook,
                                    &SetWindowPos_Original);
     WindhawkUtils::SetFunctionHook(MoveWindow, MoveWindow_Hook,
@@ -459,10 +495,8 @@ void Wh_ModUninit() {
     Wh_Log(L">");
 }
 
-BOOL Wh_ModSettingsChanged(BOOL* bReload) {
+void Wh_ModSettingsChanged() {
     Wh_Log(L">");
 
     LoadSettings();
-
-    return TRUE;
 }

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Place the volume/brightness/camera on-screen indicator anywhere on the screen, not just the three positions Windows offers
-// @version         1.0.1
+// @version         1.0.2
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -28,6 +28,10 @@ center.
 This mod replaces that with a full nine-point grid — any corner, any edge
 center, or dead center of the screen — plus a pixel offset for fine-tuning and a
 choice of which monitor it appears on.
+
+The brightness indicator moved to the middle of the right edge:
+
+![Indicator at middle right](https://raw.githubusercontent.com/mario0318/windhawk-mods/3685cdf56c55ba8cb3398b1cf9e35b5e95e68eb1/on-screen-indicator-position/middle-right.jpg)
 
 ## Positions
 

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Place the volume/brightness/camera on-screen indicator anywhere on the screen, not just the three positions Windows offers
-// @version         1.1.3
+// @version         1.1.4
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -128,9 +128,10 @@ enum class Position {
 };
 
 // Written from Wh_ModSettingsChanged on an arbitrary thread and read on the
-// confirmator's UI thread, so the members are atomic. There is nothing to tear
-// so it costs nothing here, and it keeps a settings change from being read
-// half-applied.
+// confirmator's UI thread, so the members are atomic. Each field is still read
+// separately, so a settings change landing mid-placement can put one indicator
+// on screen with a mix of old and new values. That was true before the atomics
+// too, and one misplaced indicator is the whole cost.
 struct {
     std::atomic<Position> position;
     std::atomic<int> offsetX;
@@ -151,7 +152,7 @@ struct WinrtRect {
 // `rect` comes back from the original function holding the size Windows chose
 // and the position it picked from the built-in setting; only the position is
 // replaced.
-void PlaceInArea(const WinrtRect& area, UINT dpiX, UINT dpiY, WinrtRect* rect) {
+void PlaceInArea(const WinrtRect& area, int offsetX, int offsetY, WinrtRect* rect) {
     float centerX = (area.Width - rect->Width) / 2;
     float right = area.Width - rect->Width;
 
@@ -200,11 +201,8 @@ void PlaceInArea(const WinrtRect& area, UINT dpiX, UINT dpiY, WinrtRect* rect) {
             break;
     }
 
-    // The rect is in the target monitor's physical pixels, so a raw offset
-    // would cover less ground the more the monitor is scaled up. Scaling by the
-    // monitor's DPI keeps the setting meaning the same distance everywhere.
-    rect->X += MulDiv(g_settings.offsetX.load(), dpiX, 96);
-    rect->Y += MulDiv(g_settings.offsetY.load(), dpiY, 96);
+    rect->X += offsetX;
+    rect->Y += offsetY;
 
     // An offset large enough to push the indicator out of the area would just
     // make it invisible with no way to tell why, so keep it inside.
@@ -231,22 +229,30 @@ HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
                                              const WinrtRect* rect) {
     Wh_Log(L">");
 
-    // Resolve the scaling of the monitor this rect belongs to, before the
-    // origin is shifted away.
-    UINT dpiX = 96;
-    UINT dpiY = 96;
-    RECT areaRect{
-        .left = (LONG)rect->X,
-        .top = (LONG)rect->Y,
-        .right = (LONG)(rect->X + rect->Width),
-        .bottom = (LONG)(rect->Y + rect->Height),
-    };
-    if (HMONITOR monitor = MonitorFromRect(&areaRect, MONITOR_DEFAULTTONEAREST)) {
-        UINT x = 96;
-        UINT y = 96;
-        if (SUCCEEDED(GetDpiForMonitor(monitor, MDT_DEFAULT, &x, &y)) && x && y) {
-            dpiX = x;
-            dpiY = y;
+    // Read the offsets once so the placement below uses one consistent pair.
+    int offsetSettingX = g_settings.offsetX.load();
+    int offsetSettingY = g_settings.offsetY.load();
+
+    // The rect is in the target monitor's physical pixels, so a raw offset would
+    // cover less ground the more that monitor is scaled up. Scaling by its DPI
+    // keeps the setting meaning the same distance everywhere. Both offsets are
+    // zero by default, and then there is nothing to scale and no reason to look
+    // the monitor up on every showing. Resolve it before the origin is shifted
+    // away.
+    if (offsetSettingX || offsetSettingY) {
+        RECT areaRect{
+            .left = (LONG)rect->X,
+            .top = (LONG)rect->Y,
+            .right = (LONG)(rect->X + rect->Width),
+            .bottom = (LONG)(rect->Y + rect->Height),
+        };
+        HMONITOR monitor = MonitorFromRect(&areaRect, MONITOR_DEFAULTTONEAREST);
+        UINT dpiX = 96;
+        UINT dpiY = 96;
+        if (SUCCEEDED(GetDpiForMonitor(monitor, MDT_DEFAULT, &dpiX, &dpiY)) &&
+            dpiX && dpiY) {
+            offsetSettingX = MulDiv(offsetSettingX, dpiX, 96);
+            offsetSettingY = MulDiv(offsetSettingY, dpiY, 96);
         }
     }
 
@@ -261,7 +267,7 @@ HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
         pThis, retval, &shiftedRect);
 
     if (result) {
-        PlaceInArea(shiftedRect, dpiX, dpiY, result);
+        PlaceInArea(shiftedRect, offsetSettingX, offsetSettingY, result);
 
         // Shift the result back.
         result->X += offsetX;


### PR DESCRIPTION
new mod. windows only gives you three spots for the volume/brightness indicator (top left, top center, bottom center) and i wanted it in a corner, so this opens it up to all nine plus pixel offsets and a monitor picker.

internally windows calls it the Hardware Confirmator. explorer draws it and the thread that owns the window names itself "HardwareConfirmator UI Thread", so the mod matches on that instead of a window class, since class names tend to move around between builds. placement runs in a MoveWindow hook, i hooked SetWindowPos too but nothing appears to go through it on 26200.

only tried it on 26200 x64 so far.

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
