### PR TITLE
SnapSentry 0.17.2

### DIFF
--- a/mods/snap-sentry.wh.cpp
+++ b/mods/snap-sentry.wh.cpp
@@ -2,7 +2,7 @@
 // @id              snap-sentry
 // @name            SnapSentry
 // @description     Watch your Screenshots folder or any folder you pick, then copy, rename, or delete each new screenshot, or choose from a notification.
-// @version         0.17.1
+// @version         0.17.2
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         windhawk.exe
@@ -43,24 +43,25 @@ what it shows instead of Screenshot (1). The file stays in the same folder.
 
 By default this is your Windows Screenshots folder, wherever Windows keeps it. In
 the settings you can type the full path to any folder instead, and shortcuts like
-%USERPROFILE% are filled in for you. Everything that arrives in the folder you
+%USERPROFILE% are filled in for you. Every new image that arrives in the folder you
 choose is treated the same way, so pick one where screenshots land rather than one
 that collects downloads.
 
 ## The notification
 
 The popup is a real Windows notification, so it matches your light or dark theme.
-While the popup is turned on, SnapSentry registers itself with Windows so the
-notification buttons work, and turning the popup off or disabling the mod removes
-that registration again. If the notification can't be shown, SnapSentry falls back
+While the popup is turned on, SnapSentry leaves two things on your machine so the
+notification buttons work, a SnapSentry shortcut in your Start Menu programs
+folder and one registry entry. Turning the popup off or disabling the mod removes
+both again. If the notification can't be shown, SnapSentry falls back
 to a standard dialog. If you have turned its notifications off, it takes that as a
 cue to stay quiet: it still copies to the clipboard but shows no dialog and never
 auto deletes.
 
 ## Privacy
 
-SnapSentry treats any supported image written into the watched folder within the
-last few seconds as a new screenshot. Files that were already there, and copies of
+SnapSentry treats any supported image written into the watched folder in about the
+last half minute as a new screenshot. Files that were already there, and copies of
 older images dragged in or synced from another device, are left alone. A brand new
 file saved or downloaded straight into the folder cannot be told apart from a
 capture, so avoid pointing the folder at a place where downloads land. By default a
@@ -95,12 +96,12 @@ stored in clipboard history, cloud sync, backups, or other programs.
   $description: Off by default, since deleting is the part you cannot undo. Removes the file once the copy has succeeded. Only applies when copying the picture or nothing, because copying the file or its location has to leave it in place.
 - recycle: true
   $name: Delete to the Recycle Bin
-  $description: The file goes to the Recycle Bin so you can get it back. Turn this off to delete for good.
+  $description: When something is deleted, whether automatically or from the popup buttons, the file goes to the Recycle Bin so you can get it back. Turn this off to delete for good.
 
 # ---- The popup ----
 - showActionPopup: false
   $name: Show a popup with buttons after each screenshot
-  $description: Each screenshot brings up a notification with Delete, Copy and delete, and Keep buttons, or a plain dialog if notifications are unavailable. This is the only setting that leaves anything outside the mod, namely a Start Menu entry so the buttons work, removed again when you turn it off or disable the mod. Left off, SnapSentry copies and leaves nothing behind.
+  $description: Each screenshot brings up a notification with Delete, Copy and delete, and Keep buttons, or a plain dialog if the notification cannot be set up on this machine. If you have turned SnapSentry's notifications off in Windows, it stays quiet instead, still copying but never prompting and never deleting. This is the only setting that leaves anything outside the mod, namely a Start Menu entry and a registry entry so the buttons work, both removed when you turn it off or disable the mod. Left off, SnapSentry copies and leaves nothing behind.
 - delaySeconds: 5
   $name: Seconds to wait before the automatic action
   $description: The countdown before the automatic action runs. With the popup on, 0 waits for you to click instead, giving up after 10 minutes so it cannot wait forever. With the popup off, 0 acts as soon as the copy is done. Screenshots are handled one at a time, so a long wait holds up the next one. Maximum 3600.
@@ -113,7 +114,7 @@ stored in clipboard history, cloud sync, backups, or other programs.
 # ---- Advanced ----
 - folder: ""
   $name: Folder to watch (leave empty for Screenshots)
-  $description: Empty watches your Windows Screenshots folder, wherever it is. To watch somewhere else, paste the full path to that folder here, for example C:\Users\You\Pictures\Captures or %USERPROFILE%\Desktop. Anything arriving in the folder you choose is handled the same way, so with deletion on, other images saved there are deleted too.
+  $description: Empty watches your Windows Screenshots folder, wherever it is. To watch somewhere else, paste the full path to that folder here, for example C:\Users\You\Pictures\Captures or %USERPROFILE%\Pictures\ShareX. Anything arriving in the folder you choose is handled the same way, so with deletion on, other images saved there are deleted too.
 - logDetails: false
   $name: Verbose logging (may include file paths)
   $description: Off keeps file paths out of the log. Turn this on only while troubleshooting.

--- a/mods/snap-sentry.wh.cpp
+++ b/mods/snap-sentry.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              snap-sentry
 // @name            SnapSentry
-// @description     Copy saved screenshots, delete them automatically, or choose what to do from a notification.
-// @version         0.16.0
+// @description     Watch your Screenshots folder or any folder you pick, then copy, rename, or delete each new screenshot, or choose from a notification.
+// @version         0.17.1
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         windhawk.exe
@@ -17,11 +17,12 @@
 /*
 # SnapSentry
 
-Watches your Windows **Screenshots** folder, wherever it is, and handles new
-screenshots as they are saved. Copy the image, delete the file after a delay, or
-choose what to do from a notification.
+Watches your Windows **Screenshots** folder, wherever it is, or any other folder
+you point it at, and handles new screenshots as they are saved. Copy the image,
+rename the file, delete it after a delay, or choose what to do from a
+notification.
 
-![The SnapSentry notification](https://raw.githubusercontent.com/mario0318/SnapSentry/32558d49a40d02fb03661abad0c2d9d313ae00e9/assets/notification.png)
+![The SnapSentry notification](https://raw.githubusercontent.com/mario0318/SnapSentry/9f28c82bb5b901c399d6773ea8a2e09195bc3f1a/assets/notification-rename.png)
 
 ## Clipboard modes
 
@@ -37,6 +38,14 @@ choose what to do from a notification.
 You can have SnapSentry rename each new screenshot from the window that was in
 front when it was taken, together with a timestamp, so a file ends up named for
 what it shows instead of Screenshot (1). The file stays in the same folder.
+
+## Which folder it watches
+
+By default this is your Windows Screenshots folder, wherever Windows keeps it. In
+the settings you can type the full path to any folder instead, and shortcuts like
+%USERPROFILE% are filled in for you. Everything that arrives in the folder you
+choose is treated the same way, so pick one where screenshots land rather than one
+that collects downloads.
 
 ## The notification
 
@@ -73,7 +82,7 @@ stored in clipboard history, cloud sync, backups, or other programs.
   - none: Leave the clipboard alone
 - pathFormat: plain
   $name: How to write the location
-  $description: Only used when the copy is set to the file's location. Plain is the bare path, Quoted wraps it in quotes, File link is a clickable link, and Markdown is an image tag for pasting into notes.
+  $description: Only used when copying the file's location. File link is clickable, and Markdown shows the picture when pasted into notes or a bug report.
   $options:
   - plain: Plain path
   - quoted: Quoted path
@@ -83,28 +92,28 @@ stored in clipboard history, cloud sync, backups, or other programs.
 # ---- Deleting the screenshot ----
 - deleteFile: false
   $name: Delete the screenshot after copying
-  $description: Off by default, because deleting is the part you cannot undo. Turn it on to have the file removed once it has been copied. This only applies when copying the picture or nothing; copying the file or its location never deletes.
+  $description: Off by default, since deleting is the part you cannot undo. Removes the file once the copy has succeeded. Only applies when copying the picture or nothing, because copying the file or its location has to leave it in place.
 - recycle: true
   $name: Delete to the Recycle Bin
-  $description: When deletion is on, the file goes to the Recycle Bin so it can be restored. Turn this off to delete for good.
+  $description: The file goes to the Recycle Bin so you can get it back. Turn this off to delete for good.
 
 # ---- The popup ----
 - showActionPopup: false
   $name: Show a popup with buttons after each screenshot
-  $description: Off by default. When on, each screenshot brings up a notification with Delete, Copy and delete, and Keep buttons, or a plain dialog if notifications are turned off. It is the only setting that leaves anything outside the mod, namely a Start Menu entry and a small registration so the buttons work, both removed when you turn it off again or disable the mod. Left off, SnapSentry just copies and leaves nothing behind.
+  $description: Each screenshot brings up a notification with Delete, Copy and delete, and Keep buttons, or a plain dialog if notifications are unavailable. This is the only setting that leaves anything outside the mod, namely a Start Menu entry so the buttons work, removed again when you turn it off or disable the mod. Left off, SnapSentry copies and leaves nothing behind.
 - delaySeconds: 5
   $name: Seconds to wait before the automatic action
-  $description: With the popup on, this is the countdown before the automatic action runs; set it to 0 to wait for you to click instead (it still gives up after 10 minutes so it cannot wait forever). With the popup off, 0 acts as soon as the copy is done. Screenshots are handled one at a time, so a long wait holds up the next one. Maximum 3600.
+  $description: The countdown before the automatic action runs. With the popup on, 0 waits for you to click instead, giving up after 10 minutes so it cannot wait forever. With the popup off, 0 acts as soon as the copy is done. Screenshots are handled one at a time, so a long wait holds up the next one. Maximum 3600.
 
 # ---- Renaming ----
 - renameFromWindow: false
   $name: Rename screenshots after the active window
-  $description: Renames each new screenshot to the title of the window that was in front, plus a timestamp, so they are easier to find later. The file stays in the same folder.
+  $description: Names each screenshot after the window that was in front when you took it, plus a timestamp, so you can find it later without opening it. The file stays in the same folder.
 
 # ---- Advanced ----
 - folder: ""
-  $name: Folder to watch (empty means Screenshots)
-  $description: Empty watches your Windows Screenshots folder, wherever it is. You can point this at a different folder, and things like %USERPROFILE% are filled in. Anything that lands in the folder you choose is handled the same way, so with deletion on, other images saved there are deleted too.
+  $name: Folder to watch (leave empty for Screenshots)
+  $description: Empty watches your Windows Screenshots folder, wherever it is. To watch somewhere else, paste the full path to that folder here, for example C:\Users\You\Pictures\Captures or %USERPROFILE%\Desktop. Anything arriving in the folder you choose is handled the same way, so with deletion on, other images saved there are deleted too.
 - logDetails: false
   $name: Verbose logging (may include file paths)
   $description: Off keeps file paths out of the log. Turn this on only while troubleshooting.


### PR DESCRIPTION
update to 0.17.2. mostly wording, plus a new screenshot.

the folder SnapSentry watches has always been settable but neither the mod description nor the readme ever said so, so people only ever saw the default Screenshots folder. both mention it now, the readme has a short section on it, and the setting itself shows example paths instead of just saying you can point it somewhere else. i also went through the rest of the settings descriptions and cut them down, they were accurate but nobody was going to read a paragraph per toggle.

the readme screenshot is new too. the old one predated the renaming option so the toast in it just showed Screenshot (1).png, the new one shows a file named after the window it was taken from, which is easier to understand than the paragraph explaining it.

then a 0.17.2 on top of that, because cutting the descriptions down took a few of them slightly off. the popup one never said what happens if you've turned SnapSentry's notifications off in windows, where it just stays quiet and still copies but won't prompt or delete. the recycle bin one read like it only covered the popup buttons rather than automatic deletions as well. and the line about what gets left on your machine had gone vague enough to be worse than the long version it replaced, so it names the two things outright now, a Start Menu shortcut and one registry entry. one of the descriptions had also picked up a colon, which breaks the settings yaml, so that's fixed too.

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Say that the watched folder can be your own, in the mod description, the readme, and the folder setting itself
* Shorten the settings descriptions
* New readme screenshot showing the notification with renaming turned on
* Fix a colon in a setting description that broke the settings YAML
* Say what happens when SnapSentry's notifications are turned off in Windows
* Make clear the Recycle Bin covers automatic deletions, not just the popup buttons
* Name the Start Menu shortcut and registry entry the popup leaves, instead of describing them vaguely

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
