### PR TITLE
Add taskbar-centered-start-split-icons mod

### DIFF
--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -1,0 +1,2404 @@
+// ==WindhawkMod==
+// @id              taskbar-centered-start-split-icons
+// @name            Taskbar Start Button Centered Origin
+// @description     Pins the Start button to the true horizontal center of the screen, and splits running-app taskbar buttons into two groups flanking it based on which side of the screen each window is currently on (Windows 11 only)
+// @version         0.1.0
+// @author          rick
+// @github          https://github.com/rycalvo
+// @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -lcomctl32 -ldwmapi -lole32 -loleaut32 -lruntimeobject -lshcore
+// @license         GPL-3.0
+// ==/WindhawkMod==
+
+// Source code is published under The GNU General Public License v3.0.
+
+// ==WindhawkModReadme==
+/*
+# Centered Start button with position-split taskbar icons
+
+Pins the Windows/Start button to the exact horizontal center of the primary
+monitor, regardless of how many taskbar icons are present. Running-app
+taskbar buttons are split into two groups that flank the Start button:
+
+- A button goes to the **left** group if its window's current on-screen
+  position is left of screen-center.
+- A button goes to the **right** group if its window is right of
+  screen-center.
+- Pinned-but-not-running apps have no window to check the position of, so
+  they're classified by the `leftApps`/`rightApps` name lists below, falling
+  back to `unresolvedAppsDefaultSide` if unlisted. Within whichever side
+  they land on, `pinnedAppsAnchor` picks whether they sit at the far edge
+  or right next to Start.
+
+When you drag a window across the center line of the screen, its taskbar
+button switches sides to follow it. Side-switching is driven by a global
+window-location-change listener and is best-effort: it happens shortly
+after a drag/move settles, not on every intermediate pixel of the drag.
+
+Search, Task View and Widgets can either stay at the far left edge, or move
+right next to Start on whichever side you prefer.
+
+## Known limitations (please read before reporting issues)
+
+- **Windows 11 only.** Windows 10's taskbar has no XAML layer to hook into.
+- **Primary monitor only.** Screen-center math and window-side classification
+  use the primary monitor. Taskbars on secondary displays are not specially
+  handled by this mod (their icons keep the default layout Windows gives
+  them) - the positioning hook explicitly checks which taskbar's XAML tree
+  an element belongs to and leaves anything outside the primary's alone.
+- **Undocumented internals.** This mod hooks private, unversioned classes
+  inside `taskbar.dll` and `Taskbar.View.dll` (via symbols resolved from
+  Microsoft's public symbol server at runtime, not hardcoded offsets). A
+  Windows update can change these internals and break the mod until it's
+  updated. If that happens, disable the mod rather than filing against
+  explorer.exe crashing.
+- The "resolve which HWND a taskbar button represents" step reuses a
+  technique from other taskbar-reordering mods (synchronously reporting a
+  sentinel "click" to the taskbar's internal click handler, which is
+  intercepted before it does anything, to read back the window handle). It
+  runs on a periodic timer rather than inline during layout, and Arrange
+  only ever reads whatever the timer has already cached - running it
+  synchronously from inside the taskbar's own layout pass was the
+  confirmed cause of an explorer.exe crash (specifically when Windows'
+  "show taskbar apps on" setting is anything other than "All taskbars",
+  since that's when a window moving across monitors structurally adds/
+  removes taskbar buttons rather than just repositioning them).
+
+## Changelog
+
+**Initial build (Aug 2026)**
+- Start button pinned to the primary monitor's true center, independent of
+  the number of taskbar icons.
+- Running-app icons split left/right of Start by live window position, with
+  drag-follow (a button switches sides shortly after its window crosses the
+  center line).
+- `taskListOrder`: icons ordered by distance from center, or by native
+  taskbar order.
+- Minimized windows keep their last known side instead of jumping (a
+  minimized window's reported position is off-screen nonsense, so it's
+  frozen at wherever it was before minimizing).
+- `leftApps`/`rightApps` name-based overrides, plus
+  `unresolvedAppsDefaultSide` for pinned-but-not-running apps with no
+  window to classify by.
+- `systemButtonsPlacement`/`systemButtonsAdjacentSide`: Search, Task View
+  and Widgets can sit at the far-left edge or adjacent to Start.
+
+**Feature follow-ups**
+- Support for "Combine taskbar buttons: Always" (grouped icons bind to a
+  different internal view model than individual windows, so this needed
+  its own resolution path).
+- Negative caching for HWND resolution, so a pinned-but-not-running app
+  (which will never resolve to a window) isn't retried on every single
+  layout pass.
+- Self-healing taskbar-window lookup, so the mod doesn't stay permanently
+  inert if Windhawk happens to inject before the taskbar itself exists yet
+  (observed right after a fresh boot).
+- `unresolvedAppsDefaultSide` gained a `contralateral-to-system-buttons`
+  option.
+- `pinnedAppsAnchor` setting: pinned-not-running apps can sit at the outer
+  edge of their side, or right next to Start.
+
+**Stability: cross-monitor moves**
+Moving a window to a second monitor repeatedly crashed explorer.exe across
+several iterations, each surfacing a different unsafe call path within the
+same underlying class of bug: a synchronous WinRT/XAML call made while the
+taskbar's own internal button list is mid-structural-mutation - reproducible
+specifically when Windows' "show taskbar apps on" setting isn't "All
+taskbars," since only then does a cross-monitor move add or remove taskbar
+buttons rather than just repositioning them. Root-caused via WinDbg
+crash-dump analysis after a few rounds of counter-based guessing didn't
+fully close it. Fixes along the way:
+- Corrected an unsafe cast that could throw while a fresh secondary-monitor
+  taskbar tree was still under construction.
+- Removed every forced-synchronous layout pass in favor of always deferring
+  to the XAML dispatcher's own next tick.
+- Scoped all positioning strictly to the primary taskbar's own XAML tree (a
+  process-wide hook was also seeing, and mis-positioning, secondary-monitor
+  taskbars).
+- Moved taskbar-button HWND resolution off the live layout pass entirely and
+  onto a periodic timer.
+- Added a brief "settling window" after any detected taskbar button-count
+  change, during which the mod holds off on the specific operations that
+  were still unsafe mid-mutation.
+
+**Settling-window polish**
+Once crash-free, the settling window itself produced two follow-on cosmetic
+issues, both fixed the same day:
+- The Start button no longer keeps re-centering while its neighbors are held
+  still during settling (previously caused a brief icons-over-Start overlap
+  on every cross-monitor move).
+- Fixed a bookkeeping bug that could make the settling window continuously
+  re-arm itself, making the taskbar look permanently reverted until some
+  unrelated event happened to nudge it back into place - now guaranteed to
+  resolve shortly after the triggering change instead.
+- Instead of snapping to Windows' native layout for the duration of the
+  settling window, the mod now holds every icon at its last known position
+  and only lets a genuinely new button show up unpositioned - much less
+  visually distracting on ordinary events like opening a new app.
+
+## Disclosures
+
+I am not a software developer. The present mod was developed using the
+Claude Code extension in VS Code. I cannot verify the external integrity of
+this mod on other systems and do not take responsibility for issues that
+may arise for its use. This mod was created for my own interests and
+shared for targeted development by members of the Windhawk community.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- gapPx: 12
+  $name: Gap size (px)
+  $description: >-
+    Horizontal gap, in pixels, between the Start button and each flanking
+    group of app icons (and between Start and Search/Task View/Widgets, if
+    those are set to sit adjacent to Start below).
+- systemButtonsPlacement: far-left
+  $name: Search / Task View / Widgets placement
+  $options:
+    - far-left: Far left edge of the taskbar
+    - adjacent-start: Right next to the Start button
+  $description: >-
+    Where the Search, Task View and Widgets buttons go. "Far left edge" keeps
+    them out of the way of the centered layout entirely. "Right next to
+    Start" tucks them against one side of the Start button instead (pick
+    which side below).
+- systemButtonsAdjacentSide: left
+  $name: Side to place them on
+  $options:
+    - left: Left of Start
+    - right: Right of Start
+  $description: >-
+    Only used when the placement above is "Right next to Start".
+- leftApps: ""
+  $name: Force these apps to the left
+  $description: >-
+    Comma-separated list of app name fragments (matched case-insensitively
+    against each taskbar button's accessible name, e.g. "chrome, notepad")
+    that should always be placed left of Start, regardless of where their
+    window is. Mainly useful for pinned apps that aren't running, since
+    those have no window position to classify by.
+- rightApps: ""
+  $name: Force these apps to the right
+  $description: Same idea as leftApps, but for the right side.
+- unresolvedAppsDefaultSide: left
+  $name: Default side for unclassified apps
+  $options:
+    - left: Left of Start
+    - right: Right of Start
+    - contralateral-to-system-buttons: Opposite side from Search/Task View/Widgets
+  $description: >-
+    Fallback for any taskbar button that isn't matched by leftApps/rightApps
+    and whose window position can't be determined (mainly pinned-but-not-
+    running apps you haven't listed above). "Opposite side from Search/Task
+    View/Widgets" tracks the systemButtonsAdjacentSide setting below when
+    those are placed next to Start; if they're instead left at the
+    taskbar's far-left edge, that still counts as their "side" for this
+    purpose, so it resolves to the right.
+- taskListOrder: distance-from-center
+  $name: App icon ordering within each side
+  $options:
+    - distance-from-center: Closer-to-center windows sit closer to Start
+    - taskbar-order: Preserve the existing taskbar order
+  $description: >-
+    How same-side app icons are ordered relative to each other. "Closer to
+    center" ranks each window by how close its own center is to the
+    screen's center line, so the nearest one ends up right next to Start.
+    Pinned/overridden apps with no live window position sort to whichever
+    end pinnedAppsAnchor below picks. Minimized windows keep the position
+    they last had before minimizing, rather than jumping around.
+- pinnedAppsAnchor: outer-edge
+  $name: Pinned (not running) app position within their side
+  $options:
+    - outer-edge: Far end, away from Start
+    - adjacent-to-start: Right next to Start
+  $description: >-
+    Where a pinned-but-not-running app's icon sits relative to the running
+    apps on the same side (leftApps/rightApps-forced apps included, since
+    those also have no window to rank by distance). Only has an effect
+    when "App icon ordering" above is "Closer to center" - with "Preserve
+    existing taskbar order" there's no outer-edge/adjacent-to-Start
+    distinction to begin with.
+*/
+// ==/WindhawkModSettings==
+
+#include <windhawk_utils.h>
+
+#include <atomic>
+#include <cmath>
+#include <functional>
+#include <limits>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <commctrl.h>
+#include <dwmapi.h>
+#include <roapi.h>
+#include <winstring.h>
+
+#undef GetCurrentTime
+
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.UI.Core.h>
+#include <winrt/Windows.UI.Xaml.Automation.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
+#include <winrt/Windows.UI.Xaml.Shapes.h>
+#include <winrt/Windows.UI.Xaml.h>
+#include <winrt/base.h>
+
+#define WH_WINRT_WINUI2
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+
+using namespace winrt::Windows::UI::Xaml;
+
+// ============================================================================
+// Settings
+// ============================================================================
+
+enum class Side { Left, Right };
+
+enum class SystemButtonsPlacement { FarLeft, AdjacentStart };
+
+enum class TaskListOrder { DistanceFromCenter, TaskbarOrder };
+
+enum class UnresolvedAppsDefaultSide {
+    Left,
+    Right,
+    ContralateralToSystemButtons,
+};
+
+// Where a pinned-but-not-running app's icon sits within its side's icon
+// group, relative to the other (running, position-classified) icons on the
+// same side. Only meaningful when taskListOrder is DistanceFromCenter -
+// TaskbarOrder has no notion of "outer edge" vs "adjacent to Start" to
+// begin with, since it doesn't rank icons by distance at all.
+enum class PinnedAppsAnchor { OuterEdge, AdjacentToStart };
+
+struct {
+    double gapPx;
+    SystemButtonsPlacement systemButtonsPlacement;
+    Side systemButtonsAdjacentSide;
+    std::vector<std::wstring> leftApps;
+    std::vector<std::wstring> rightApps;
+    UnresolvedAppsDefaultSide unresolvedAppsDefaultSide;
+    TaskListOrder taskListOrder;
+    PinnedAppsAnchor pinnedAppsAnchor;
+} g_settings;
+
+std::wstring ToLower(std::wstring s) {
+    for (auto& c : s) {
+        c = towlower(c);
+    }
+    return s;
+}
+
+// Splits a comma-separated settings string into trimmed, lowercased,
+// non-empty fragments for case-insensitive substring matching later.
+std::vector<std::wstring> ParseAppList(PCWSTR raw) {
+    std::vector<std::wstring> result;
+    if (!raw) {
+        return result;
+    }
+
+    std::wstring s(raw);
+    size_t start = 0;
+    while (start <= s.size()) {
+        size_t comma = s.find(L',', start);
+        size_t end = (comma == std::wstring::npos) ? s.size() : comma;
+
+        size_t first = s.find_first_not_of(L" \t", start);
+        size_t last = s.find_last_not_of(L" \t", end == start ? end : end - 1);
+        if (first != std::wstring::npos && first < end && last != std::wstring::npos &&
+            last >= first) {
+            result.push_back(ToLower(s.substr(first, last - first + 1)));
+        }
+
+        if (comma == std::wstring::npos) {
+            break;
+        }
+        start = comma + 1;
+    }
+
+    return result;
+}
+
+Side ParseSide(PCWSTR value, Side fallback) {
+    if (value && wcscmp(value, L"right") == 0) {
+        return Side::Right;
+    }
+    if (value && wcscmp(value, L"left") == 0) {
+        return Side::Left;
+    }
+    return fallback;
+}
+
+UnresolvedAppsDefaultSide ParseUnresolvedAppsDefaultSide(PCWSTR value) {
+    if (value && wcscmp(value, L"right") == 0) {
+        return UnresolvedAppsDefaultSide::Right;
+    }
+    if (value && wcscmp(value, L"contralateral-to-system-buttons") == 0) {
+        return UnresolvedAppsDefaultSide::ContralateralToSystemButtons;
+    }
+    return UnresolvedAppsDefaultSide::Left;
+}
+
+// Resolves the effective side for pinned-but-not-running apps that aren't
+// matched by leftApps/rightApps, per the unresolvedAppsDefaultSide setting.
+// The "contralateral" mode mirrors Search/Task View/Widgets' placement:
+// opposite of systemButtonsAdjacentSide when they sit next to Start, or the
+// right if they're left at the taskbar's far-left edge instead (still
+// their "side" for this purpose, since that edge is unambiguously left of
+// everything else).
+Side ResolveUnresolvedAppsDefaultSide() {
+    switch (g_settings.unresolvedAppsDefaultSide) {
+        case UnresolvedAppsDefaultSide::Right:
+            return Side::Right;
+        case UnresolvedAppsDefaultSide::ContralateralToSystemButtons:
+            if (g_settings.systemButtonsPlacement ==
+                    SystemButtonsPlacement::AdjacentStart &&
+                g_settings.systemButtonsAdjacentSide == Side::Right) {
+                return Side::Left;
+            }
+            return Side::Right;
+        case UnresolvedAppsDefaultSide::Left:
+        default:
+            return Side::Left;
+    }
+}
+
+PinnedAppsAnchor ParsePinnedAppsAnchor(PCWSTR value) {
+    if (value && wcscmp(value, L"adjacent-to-start") == 0) {
+        return PinnedAppsAnchor::AdjacentToStart;
+    }
+    return PinnedAppsAnchor::OuterEdge;
+}
+
+// The distance-from-center order key for a pinned-but-not-running app (one
+// with no window to measure a real distance from). Made -infinity instead
+// of the default +infinity when pinnedAppsAnchor is AdjacentToStart, since
+// ComputeTaskListButtonX's byDistance sort treats a smaller orderKey as
+// closer to Start - nothing can beat -infinity, so these always end up
+// innermost rather than outermost.
+double PinnedAppOrderKey() {
+    return g_settings.pinnedAppsAnchor == PinnedAppsAnchor::AdjacentToStart
+               ? -std::numeric_limits<double>::infinity()
+               : std::numeric_limits<double>::infinity();
+}
+
+void LoadSettings() {
+    g_settings.gapPx = Wh_GetIntSetting(L"gapPx");
+
+    PCWSTR placement = Wh_GetStringSetting(L"systemButtonsPlacement");
+    g_settings.systemButtonsPlacement =
+        (placement && wcscmp(placement, L"adjacent-start") == 0)
+            ? SystemButtonsPlacement::AdjacentStart
+            : SystemButtonsPlacement::FarLeft;
+    Wh_FreeStringSetting(placement);
+
+    PCWSTR adjacentSide = Wh_GetStringSetting(L"systemButtonsAdjacentSide");
+    g_settings.systemButtonsAdjacentSide = ParseSide(adjacentSide, Side::Left);
+    Wh_FreeStringSetting(adjacentSide);
+
+    PCWSTR leftApps = Wh_GetStringSetting(L"leftApps");
+    g_settings.leftApps = ParseAppList(leftApps);
+    Wh_FreeStringSetting(leftApps);
+
+    PCWSTR rightApps = Wh_GetStringSetting(L"rightApps");
+    g_settings.rightApps = ParseAppList(rightApps);
+    Wh_FreeStringSetting(rightApps);
+
+    PCWSTR defaultSide = Wh_GetStringSetting(L"unresolvedAppsDefaultSide");
+    g_settings.unresolvedAppsDefaultSide =
+        ParseUnresolvedAppsDefaultSide(defaultSide);
+    Wh_FreeStringSetting(defaultSide);
+
+    PCWSTR taskListOrder = Wh_GetStringSetting(L"taskListOrder");
+    g_settings.taskListOrder =
+        (taskListOrder && wcscmp(taskListOrder, L"taskbar-order") == 0)
+            ? TaskListOrder::TaskbarOrder
+            : TaskListOrder::DistanceFromCenter;
+    Wh_FreeStringSetting(taskListOrder);
+
+    PCWSTR pinnedAppsAnchor = Wh_GetStringSetting(L"pinnedAppsAnchor");
+    g_settings.pinnedAppsAnchor = ParsePinnedAppsAnchor(pinnedAppsAnchor);
+    Wh_FreeStringSetting(pinnedAppsAnchor);
+}
+
+// ============================================================================
+// Globals
+// ============================================================================
+
+std::atomic<bool> g_taskbarViewDllLoaded;
+std::atomic<bool> g_unloading;
+
+thread_local bool g_inTaskbarArrangeOverride;
+
+// GetTickCount64() deadline until which IUIElement_Arrange_Hook skips its
+// own repeater-traversal-based computation entirely (Start, task list
+// buttons, and the Search/TaskView/Widgets cluster alike) and instead
+// holds each element at its last legitimately-computed X via
+// ArrangeSettled/g_lastArrangedX (see that comment for why holding
+// position, not falling through to Windows' native layout, is both safe
+// and far less visually jarring). Set whenever the ArrangeOverride hook
+// detects the task list button count changed since the last pass (see its
+// call site) - i.e. right when a button is being structurally inserted
+// into or removed from an ItemsRepeater's data source, since that's the
+// confirmed trigger condition for a recurring explorer.exe crash (only
+// reproduces when Windows' "show taskbar apps on" setting causes a window
+// moving across monitors to change a taskbar's button *set*, not just
+// coordinates - see ResolveAndCacheButtonHwnd's comment for the fuller
+// history).
+//
+// Moving HWND resolution off the Arrange hook onto a timer measurably
+// helped (a confirmed crash-free stretch of real use, not just luck) but
+// didn't fully close the hole - the crash still recurs on cross-monitor
+// moves. Every synchronous WinRT call this file makes from inside Arrange
+// has, so far, turned out to belong to the same vulnerable class once
+// something structurally mutates the repeater mid-traversal, and none of
+// them ever show up as a catchable exception (see g_primaryXamlRootIdentity
+// and ResolveAndCacheButtonHwnd's comments for why - WinUI stows and
+// defers the report instead of throwing where the C++ call actually is).
+// Rather than hunt down and individually defer every remaining traversal
+// one crash at a time, this suppresses ALL of them for a settling window
+// after any detected structural change.
+//
+// Start's own positioning (ComputeStartButtonX) never touches a repeater,
+// so it isn't part of the crash-prone class and doesn't strictly need to be
+// gated - but it used to be left ungated anyway, and that was itself a bug:
+// with only its neighbors frozen, Start kept snapping to the forced screen
+// center every pass while nothing reserved that space around it, producing
+// a visible icons-overlaying-Start glitch on every structural change (e.g.
+// a window moving to another monitor). Gating Start too makes the whole
+// taskbar hold one consistent, already-correct-looking state through the
+// settling window instead of that mismatched hybrid.
+//
+// A pass genuinely needs to run once this deadline elapses, to give
+// everything a fresh Arrange reflecting whatever actually changed (new
+// button included) - see g_taskListSettlingRecoveryPending for how that's
+// actually guaranteed (the InvalidateTaskbarLayout() call made at the same
+// call site this is armed does NOT do it: that call lands, and gets
+// immediately re-skipped, *inside* the window it just opened, not after
+// it).
+thread_local ULONGLONG g_taskListSettlingUntil;
+
+// Set alongside g_taskListSettlingUntil whenever it's (re)armed; cleared
+// once a guaranteed post-settling InvalidateTaskbarLayout() has actually
+// fired (see ButtonHwndResolveTimerProc). Without this, recovery depended
+// entirely on some unrelated window happening to generate a location-change
+// event (or a taskbar button hwnd happening to need re-resolution) after
+// the settling window elapsed - both opportunistic, neither guaranteed -
+// which is what let the taskbar visibly sit un-refreshed (existing buttons
+// held at their last position, anything newly inserted mid-settling still
+// at its native one - see ArrangeSettled) for well past 1 second after a
+// cross-monitor window move, until something incidental finally kicked it
+// back into place.
+thread_local bool g_taskListSettlingRecoveryPending;
+
+HWND g_hTaskbarWnd;
+HWINEVENTHOOK g_locationChangeHook;
+std::atomic<int> g_winEventRawCount;
+std::atomic<int> g_winEventInvalidateCount;
+std::atomic<int> g_invalidateSkippedReentrant;
+std::atomic<int> g_invalidateExceptions;
+
+// ============================================================================
+// Generic taskbar/XAML helpers
+// (traversal helpers adapted from the "Start button always on the left"
+// Windhawk mod, which uses the same VisualTreeHelper/ItemsRepeater walking
+// pattern to reach taskbar elements)
+// ============================================================================
+
+HWND FindCurrentProcessTaskbarWnd() {
+    HWND hTaskbarWnd = nullptr;
+
+    EnumWindows(
+        [](HWND hWnd, LPARAM lParam) -> BOOL {
+            DWORD dwProcessId;
+            WCHAR className[32];
+            if (GetWindowThreadProcessId(hWnd, &dwProcessId) &&
+                dwProcessId == GetCurrentProcessId() &&
+                GetClassName(hWnd, className, ARRAYSIZE(className)) &&
+                _wcsicmp(className, L"Shell_TrayWnd") == 0) {
+                *reinterpret_cast<HWND*>(lParam) = hWnd;
+                return FALSE;
+            }
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&hTaskbarWnd));
+
+    return hTaskbarWnd;
+}
+
+FrameworkElement EnumChildElements(
+    FrameworkElement element,
+    const std::function<bool(FrameworkElement)>& enumCallback) {
+    int childrenCount = Media::VisualTreeHelper::GetChildrenCount(element);
+
+    for (int i = 0; i < childrenCount; i++) {
+        auto child = Media::VisualTreeHelper::GetChild(element, i)
+                         .try_as<FrameworkElement>();
+        if (!child) {
+            continue;
+        }
+
+        if (enumCallback(child)) {
+            return child;
+        }
+    }
+
+    return nullptr;
+}
+
+FrameworkElement FindChildByName(FrameworkElement element, PCWSTR name) {
+    return EnumChildElements(element, [name](FrameworkElement child) {
+        return child.Name() == name;
+    });
+}
+
+FrameworkElement FindChildByClassName(FrameworkElement element,
+                                       PCWSTR className) {
+    return EnumChildElements(element, [className](FrameworkElement child) {
+        return winrt::get_class_name(child) == className;
+    });
+}
+
+// Returns the ItemsRepeater's realized (non-virtualized) children in order.
+std::vector<FrameworkElement> GetRepeaterChildElements(
+    FrameworkElement repeaterElement) {
+    std::vector<FrameworkElement> result;
+
+    auto repeater =
+        repeaterElement
+            .try_as<winrt::Microsoft::UI::Xaml::Controls::ItemsRepeater>();
+    if (!repeater) {
+        return result;
+    }
+
+    auto itemsSourceView = repeater.ItemsSourceView();
+    int count = itemsSourceView ? itemsSourceView.Count() : 0;
+
+    for (int index = 0; index < count; index++) {
+        auto element = repeater.TryGetElement(index);
+        if (!element) {
+            continue;  // Virtualized away, not currently realized.
+        }
+
+        auto child = element.try_as<FrameworkElement>();
+        if (child) {
+            result.push_back(child);
+        }
+    }
+
+    return result;
+}
+
+// Returns `element`'s sibling FrameworkElements (element excluded), in
+// visual-tree order. Works whether the parent is an ItemsRepeater (uses the
+// data-bound realized items, same as GetRepeaterChildElements) or a plain
+// panel (falls back to raw VisualTreeHelper enumeration). Task list buttons'
+// exact parent container isn't confirmed to be the same repeater that hosts
+// the Start button, so this is deliberately hierarchy-agnostic rather than
+// assuming ItemsRepeater everywhere.
+std::vector<FrameworkElement> GetSiblingElements(FrameworkElement element) {
+    std::vector<FrameworkElement> result;
+
+    auto parent =
+        Media::VisualTreeHelper::GetParent(element).try_as<FrameworkElement>();
+    if (!parent) {
+        return result;
+    }
+
+    if (parent.try_as<winrt::Microsoft::UI::Xaml::Controls::ItemsRepeater>()) {
+        return GetRepeaterChildElements(parent);
+    }
+
+    int childrenCount = Media::VisualTreeHelper::GetChildrenCount(parent);
+    for (int i = 0; i < childrenCount; i++) {
+        auto child =
+            Media::VisualTreeHelper::GetChild(parent, i).try_as<FrameworkElement>();
+        if (child) {
+            result.push_back(child);
+        }
+    }
+
+    return result;
+}
+
+using RunFromWindowThreadProc_t = std::function<void()>;
+
+bool RunFromWindowThread(HWND hWnd, RunFromWindowThreadProc_t proc) {
+    static const UINT runFromWindowThreadRegisteredMsg = RegisterWindowMessage(
+        L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
+
+    DWORD dwThreadId = GetWindowThreadProcessId(hWnd, nullptr);
+    if (dwThreadId == 0) {
+        return false;
+    }
+
+    if (dwThreadId == GetCurrentThreadId()) {
+        proc();
+        return true;
+    }
+
+    HHOOK hook = SetWindowsHookEx(
+        WH_CALLWNDPROC,
+        [](int nCode, WPARAM wParam, LPARAM lParam) -> LRESULT {
+            if (nCode == HC_ACTION) {
+                const CWPSTRUCT* cwp = (const CWPSTRUCT*)lParam;
+                if (cwp->message == runFromWindowThreadRegisteredMsg) {
+                    auto* proc = (RunFromWindowThreadProc_t*)cwp->lParam;
+                    (*proc)();
+                }
+            }
+
+            return CallNextHookEx(nullptr, nCode, wParam, lParam);
+        },
+        nullptr, dwThreadId);
+    if (!hook) {
+        return false;
+    }
+
+    SendMessage(hWnd, runFromWindowThreadRegisteredMsg, 0, (LPARAM)&proc);
+
+    UnhookWindowsHookEx(hook);
+
+    return true;
+}
+
+// ============================================================================
+// taskbar.dll: locating the taskbar's XamlRoot
+// (verbatim technique from the "Start button always on the left" mod)
+// ============================================================================
+
+void* CTaskBand_ITaskListWndSite_vftable;
+
+using CTaskBand_GetTaskbarHost_t = void*(WINAPI*)(void* pThis, void** result);
+CTaskBand_GetTaskbarHost_t CTaskBand_GetTaskbarHost_Original;
+
+void* TaskbarHost_FrameHeight_Original;
+
+using std__Ref_count_base__Decref_t = void(WINAPI*)(void* pThis);
+std__Ref_count_base__Decref_t std__Ref_count_base__Decref_Original;
+
+XamlRoot XamlRootFromTaskbarHostSharedPtr(void* taskbarHostSharedPtr[2]) {
+    if (!taskbarHostSharedPtr[0] && !taskbarHostSharedPtr[1]) {
+        return nullptr;
+    }
+
+    size_t taskbarElementIUnknownOffset = 0x10;
+
+    // The offset of the XAML element pointer inside TaskbarHost isn't
+    // exposed by any symbol, so it's read out of the prologue of a
+    // neighboring function that's known to access it at a fixed offset.
+    // 48:83EC 28 | sub rsp,28
+    // 48:83C1 48 | add rcx,48
+    const BYTE* b = (const BYTE*)TaskbarHost_FrameHeight_Original;
+    if (b[0] == 0x48 && b[1] == 0x83 && b[2] == 0xEC && b[4] == 0x48 &&
+        b[5] == 0x83 && b[6] == 0xC1 && b[7] <= 0x7F) {
+        taskbarElementIUnknownOffset = b[7];
+    } else {
+        Wh_Log(L"Unsupported TaskbarHost::FrameHeight, using default offset");
+    }
+
+    auto* taskbarElementIUnknown =
+        *(IUnknown**)((BYTE*)taskbarHostSharedPtr[0] +
+                      taskbarElementIUnknownOffset);
+
+    FrameworkElement taskbarElement = nullptr;
+    taskbarElementIUnknown->QueryInterface(winrt::guid_of<FrameworkElement>(),
+                                            winrt::put_abi(taskbarElement));
+
+    auto result = taskbarElement ? taskbarElement.XamlRoot() : nullptr;
+
+    std__Ref_count_base__Decref_Original(taskbarHostSharedPtr[1]);
+
+    return result;
+}
+
+XamlRoot GetTaskbarXamlRoot(HWND hTaskbarWnd) {
+    HWND hTaskSwWnd = (HWND)GetProp(hTaskbarWnd, L"TaskbandHWND");
+    if (!hTaskSwWnd) {
+        return nullptr;
+    }
+
+    void* taskBand = (void*)GetWindowLongPtr(hTaskSwWnd, 0);
+    void* taskBandForTaskListWndSite = taskBand;
+    for (int i = 0; *(void**)taskBandForTaskListWndSite !=
+                    CTaskBand_ITaskListWndSite_vftable;
+         i++) {
+        if (i == 20) {
+            return nullptr;
+        }
+
+        taskBandForTaskListWndSite = (void**)taskBandForTaskListWndSite + 1;
+    }
+
+    void* taskbarHostSharedPtr[2]{};
+    CTaskBand_GetTaskbarHost_Original(taskBandForTaskListWndSite,
+                                      taskbarHostSharedPtr);
+
+    return XamlRootFromTaskbarHostSharedPtr(taskbarHostSharedPtr);
+}
+
+// Raw IUnknown* for `xamlRoot`, valid ONLY as an opaque identity token for
+// pointer comparison - never dereferenced as a live object. QueryInterface
+// to IUnknown is what gives this COM identity semantics (guaranteed stable
+// and unique per underlying object, regardless of which interface either
+// side started from), the same guarantee g_buttonHwndCache already relies
+// on by keying off winrt::get_abi(element) elsewhere in this file.
+void* XamlRootIdentity(XamlRoot xamlRoot) {
+    if (!xamlRoot) {
+        return nullptr;
+    }
+    return winrt::get_abi(xamlRoot.try_as<IUnknown>());
+}
+
+// Identity of the PRIMARY taskbar's XamlRoot, resolved lazily and cached
+// (GetTaskbarXamlRoot is too expensive - GetProp, GetWindowLongPtr, a
+// vftable walk, a cross-DLL call - to redo on every Arrange call). Exists
+// so IUIElement_Arrange_Hook can tell whether an element it's about to
+// reposition actually belongs to the primary taskbar's own XAML tree.
+//
+// This hook replaces a single process-wide IUIElement::Arrange vtable
+// slot, so it fires for every taskbar instance's tree - including a
+// secondary monitor's, once any window (and its taskbar button) lives
+// there. Without this check, a secondary-monitor taskbar button was being
+// arranged using position math computed relative to the PRIMARY monitor's
+// center (every Compute*ButtonX function implicitly assumes "the"
+// taskbar is g_hTaskbarWnd) - handing that tree a Rect it has no valid
+// context for. That's exactly the kind of internal invariant violation
+// WinUI's own ReportUnhandledError/fail-fast machinery exists to catch:
+// confirmed via a WinDbg crash dump analysis (STATUS_STOWED_EXCEPTION,
+// CXcpDispatcher::Tick -> ReportUnhandledError -> RaiseFailFastException)
+// showing the fail-fast originates entirely inside Windows' own XAML
+// dispatcher, on a LATER tick than whatever triggered it - which is also
+// why no try/catch anywhere in this file ever saw it: WinUI's internal
+// ABI-boundary handling stows the error before it ever reaches our frame
+// as a catchable C++ exception, regardless of where the catch is placed.
+std::atomic<void*> g_primaryXamlRootIdentity;
+
+// ============================================================================
+// taskbar.dll: resolving the HWND behind a taskbar button
+//
+// Individual (ungrouped) button:
+//   TaskListButton (XAML) -> TaskListWindowViewModel -> WindowsUdk ITaskItem
+//   -> (sentinel "click" through the taskbar's own click handler, which we
+//      intercept before it acts on it) -> native ITaskItem -> HWND.
+//
+// Grouped button (when "Combine taskbar buttons" is Always - each button can
+// represent multiple windows of one app, and isn't bound to a
+// TaskListWindowViewModel at all, so the above fails at the very first
+// step):
+//   TaskListButton (XAML) -> TaskListGroupViewModel -> (a second sentinel,
+//   piggybacked on TaskListGroupViewModel::IsMultiWindow's internal call to
+//   ITaskGroup::IsRunning, which we intercept the same way) -> WindowsUdk
+//   ITaskGroup -> (sentinel "click" again, this time on the group) -> native
+//   ITaskGroup -> its internal task-items array (located by exploiting
+//   CTaskGroup::GetNumItems' known-trivial implementation - see
+//   GetTaskItemsArray) -> first item's HWND, used as the group's
+//   representative position.
+//
+// Both of these are the same techniques used by taskbar-reordering and
+// per-app-volume-control mods to map a button back to a window/windows;
+// here they're reused read-only, purely to find out where a window
+// currently is on screen.
+// ============================================================================
+
+void* CImmersiveTaskItem_vftable;
+
+using CWindowTaskItem_GetWindow_t = HWND(WINAPI*)(void* pThis);
+CWindowTaskItem_GetWindow_t CWindowTaskItem_GetWindow_Original;
+
+using CImmersiveTaskItem_GetWindow_t = HWND(WINAPI*)(void* pThis);
+CImmersiveTaskItem_GetWindow_t CImmersiveTaskItem_GetWindow_Original;
+
+using CTaskListWnd_HandleClick_t = HRESULT(WINAPI*)(void* pThis,
+                                                     void* taskGroup,
+                                                     void* taskItem,
+                                                     void** launcherOptions);
+CTaskListWnd_HandleClick_t CTaskListWnd_HandleClick_Original;
+
+WCHAR g_clickSentinel[] = L"click-sentinel";
+void* g_clickSentinel_TaskItem;
+void* g_clickSentinel_TaskGroup;
+
+HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
+                                              void* taskGroup,
+                                              void* taskItem,
+                                              void** launcherOptions) {
+    if (launcherOptions && *launcherOptions == (void*)&g_clickSentinel) {
+        g_clickSentinel_TaskItem = taskItem;
+        g_clickSentinel_TaskGroup = taskGroup;
+        return S_OK;
+    }
+
+    return CTaskListWnd_HandleClick_Original(pThis, taskGroup, taskItem,
+                                              launcherOptions);
+}
+
+using TryGetItemFromContainer_TaskListWindowViewModel_t =
+    void(WINAPI*)(void* resultPut, void* uiElement);
+TryGetItemFromContainer_TaskListWindowViewModel_t
+    TryGetItemFromContainer_TaskListWindowViewModel_Original;
+
+using TaskListWindowViewModel_get_TaskItem_t = int(WINAPI*)(void* pThis,
+                                                             void** result);
+TaskListWindowViewModel_get_TaskItem_t
+    TaskListWindowViewModel_get_TaskItem_Original;
+
+using TaskItem_ReportClicked_t = int(WINAPI*)(void* pThis, void* param);
+TaskItem_ReportClicked_t TaskItem_ReportClicked_Original;
+
+using TryGetItemFromContainer_TaskListGroupViewModel_t =
+    void(WINAPI*)(void* resultPut, void* uiElement);
+TryGetItemFromContainer_TaskListGroupViewModel_t
+    TryGetItemFromContainer_TaskListGroupViewModel_Original;
+
+using TaskListGroupViewModel_IsMultiWindow_t = bool(WINAPI*)(void* pThis);
+TaskListGroupViewModel_IsMultiWindow_t
+    TaskListGroupViewModel_IsMultiWindow_Original;
+
+thread_local bool g_captureTaskGroup;
+thread_local void* g_capturedTaskGroup;
+
+using ITaskGroup_IsRunning_t = bool(WINAPI*)(void* pThis);
+ITaskGroup_IsRunning_t ITaskGroup_IsRunning_Original;
+bool WINAPI ITaskGroup_IsRunning_Hook(void* pThis) {
+    if (g_captureTaskGroup) {
+        g_capturedTaskGroup = *(void**)pThis;
+        return false;
+    }
+
+    return ITaskGroup_IsRunning_Original(pThis);
+}
+
+using CTaskGroup_GetNumItems_t = int(WINAPI*)(void* pThis);
+CTaskGroup_GetNumItems_t CTaskGroup_GetNumItems_Original;
+
+// CTaskGroup::GetNumItems' entire body is just `return
+// DPA_GetPtrCount(this->taskItemsArray);`, i.e. reading one int off `this`
+// at a fixed-but-undocumented offset. Calling it with a fake "this" that's
+// actually an array of pointers-to-sequential-ints turns that read into a
+// self-reporting probe: whatever offset it reads becomes the returned
+// value, revealing the real offset without needing the struct layout.
+// Adapted from the per-app volume control mod, which needs the same task
+// group -> item list access for an unrelated reason.
+size_t GetTaskItemsArrayOffset() {
+    static size_t offset = [] {
+        constexpr int kIntArraySize = 256;
+        int arrayOfInts[kIntArraySize];
+        int* arrayOfIntPtrs[kIntArraySize];
+        for (int i = 0; i < kIntArraySize; i++) {
+            arrayOfInts[i] = i;
+            arrayOfIntPtrs[i] = &arrayOfInts[i];
+        }
+        return CTaskGroup_GetNumItems_Original
+                   ? (size_t)CTaskGroup_GetNumItems_Original(arrayOfIntPtrs)
+                   : 0;
+    }();
+    return offset;
+}
+
+HDPA GetTaskItemsArray(void* taskGroup) {
+    if (!CTaskGroup_GetNumItems_Original) {
+        return nullptr;
+    }
+    return (HDPA)((void**)taskGroup)[GetTaskItemsArrayOffset()];
+}
+
+using TaskGroup_ReportClicked_t = int(WINAPI*)(void* pThis, void* param);
+TaskGroup_ReportClicked_t TaskGroup_ReportClicked_Original;
+
+// Diagnostics only: which stage of the WinRT -> native resolution chain
+// last failed, and how often, so a systemic failure (e.g. a different
+// view-model type when taskbar buttons are grouped/combined) is visible
+// without guessing.
+struct ResolveStats {
+    int success = 0;
+    int failViewModelNull = 0;
+    int failGetTaskItem = 0;
+    int failSentinelNoItem = 0;
+    int groupSuccess = 0;
+    int groupFailViewModelNull = 0;
+    int groupFailSentinelNoGroup = 0;
+    int groupFailNoItems = 0;
+};
+ResolveStats g_resolveStats;
+
+HWND GetWindowFromNativeTaskItem(void* nativeTaskItem) {
+    if (!nativeTaskItem) {
+        return nullptr;
+    }
+
+    if (CImmersiveTaskItem_vftable &&
+        *(void**)nativeTaskItem == CImmersiveTaskItem_vftable) {
+        return CImmersiveTaskItem_GetWindow_Original
+                   ? CImmersiveTaskItem_GetWindow_Original(nativeTaskItem)
+                   : nullptr;
+    }
+
+    return CWindowTaskItem_GetWindow_Original
+               ? CWindowTaskItem_GetWindow_Original(nativeTaskItem)
+               : nullptr;
+}
+
+HWND ResolveHwndFromIndividualTaskItem(FrameworkElement element) {
+    if (!TryGetItemFromContainer_TaskListWindowViewModel_Original ||
+        !TaskListWindowViewModel_get_TaskItem_Original ||
+        !TaskItem_ReportClicked_Original) {
+        return nullptr;
+    }
+
+    IUnknown* elementAbi = (IUnknown*)winrt::get_abi(element);
+
+    winrt::com_ptr<IUnknown> windowViewModel;
+    TryGetItemFromContainer_TaskListWindowViewModel_Original(
+        windowViewModel.put_void(), &elementAbi);
+    if (!windowViewModel) {
+        g_resolveStats.failViewModelNull++;
+        return nullptr;
+    }
+
+    winrt::com_ptr<IUnknown> windowsUdkTaskItem;
+    if (FAILED(TaskListWindowViewModel_get_TaskItem_Original(
+            windowViewModel.get(), windowsUdkTaskItem.put_void())) ||
+        !windowsUdkTaskItem) {
+        g_resolveStats.failGetTaskItem++;
+        return nullptr;
+    }
+
+    g_clickSentinel_TaskItem = nullptr;
+    TaskItem_ReportClicked_Original(windowsUdkTaskItem.get(),
+                                     &g_clickSentinel);
+
+    void* nativeTaskItem = g_clickSentinel_TaskItem;
+    g_clickSentinel_TaskItem = nullptr;
+    if (!nativeTaskItem) {
+        g_resolveStats.failSentinelNoItem++;
+        return nullptr;
+    }
+
+    g_resolveStats.success++;
+    return GetWindowFromNativeTaskItem(nativeTaskItem);
+}
+
+// Grouped button (all windows of one app collapsed under a single icon,
+// e.g. "Combine taskbar buttons" set to Always) - see the resolution
+// overview comment above this section for the full chain.
+HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
+    if (!TryGetItemFromContainer_TaskListGroupViewModel_Original ||
+        !TaskListGroupViewModel_IsMultiWindow_Original ||
+        !TaskGroup_ReportClicked_Original || !CTaskGroup_GetNumItems_Original) {
+        return nullptr;
+    }
+
+    IUnknown* elementAbi = (IUnknown*)winrt::get_abi(element);
+
+    winrt::com_ptr<IUnknown> groupViewModel;
+    TryGetItemFromContainer_TaskListGroupViewModel_Original(
+        groupViewModel.put_void(), &elementAbi);
+    if (!groupViewModel) {
+        g_resolveStats.groupFailViewModelNull++;
+        return nullptr;
+    }
+
+    g_capturedTaskGroup = nullptr;
+    g_captureTaskGroup = true;
+    // IsMultiWindow's implementation happens to call ITaskGroup::IsRunning
+    // internally, which is hooked above to capture its `this` (the native
+    // WindowsUdk task group) instead of really answering the question. The
+    // -1 adjusts from the interface pointer QueryInterface handed back to
+    // the adjacent vtable IsMultiWindow actually needs - a fixed ABI detail
+    // of this object, not a magic number specific to this mod.
+    TaskListGroupViewModel_IsMultiWindow_Original(
+        (void**)groupViewModel.get() - 1);
+    g_captureTaskGroup = false;
+
+    void* windowsUdkTaskGroup = g_capturedTaskGroup;
+    g_capturedTaskGroup = nullptr;
+    if (!windowsUdkTaskGroup) {
+        g_resolveStats.groupFailSentinelNoGroup++;
+        return nullptr;
+    }
+
+    g_clickSentinel_TaskGroup = nullptr;
+    TaskGroup_ReportClicked_Original(windowsUdkTaskGroup, &g_clickSentinel);
+    void* nativeTaskGroup = g_clickSentinel_TaskGroup;
+    g_clickSentinel_TaskGroup = nullptr;
+    if (!nativeTaskGroup) {
+        g_resolveStats.groupFailSentinelNoGroup++;
+        return nullptr;
+    }
+
+    HDPA taskItemsArray = GetTaskItemsArray(nativeTaskGroup);
+    if (!taskItemsArray || DPA_GetPtrCount(taskItemsArray) <= 0) {
+        g_resolveStats.groupFailNoItems++;
+        return nullptr;
+    }
+
+    // The group's first window stands in for the whole group's position -
+    // Windows itself doesn't expose a more meaningful "primary" window.
+    void* taskItem = DPA_GetPtr(taskItemsArray, 0);
+    HWND hwnd = GetWindowFromNativeTaskItem(taskItem);
+    if (hwnd) {
+        g_resolveStats.groupSuccess++;
+    }
+    return hwnd;
+}
+
+HWND ResolveHwndFromTaskListButton(FrameworkElement element) {
+    HWND hwnd = ResolveHwndFromIndividualTaskItem(element);
+    if (hwnd) {
+        return hwnd;
+    }
+
+    return ResolveHwndFromTaskGroup(element);
+}
+
+// Per-button HWND cache, keyed by the XAML element's ABI pointer. Avoids
+// running the (relatively expensive) resolution chain above on every single
+// layout pass for every button - only when we don't have a cached handle, or
+// the cached one has stopped being a valid window.
+//
+// Also negatively caches failures with a short TTL: a pinned-but-not-running
+// app's task group legitimately has zero windows, so its resolution will
+// fail forever until it's actually launched - without this, that button's
+// full multi-sentinel resolution chain gets retried on every single arrange
+// pass (confirmed via g_resolveStats climbing into the hundreds within a
+// couple of seconds for just one such button).
+struct ButtonHwndCacheEntry {
+    HWND hwnd = nullptr;
+    ULONGLONG lastAttempt = 0;
+};
+std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
+
+// Actually runs the resolution chain and updates the cache. Returns
+// whether the cached HWND changed (added, removed, or replaced) - used by
+// the timer that calls this (see ResolvePendingButtonHwnds) to decide
+// whether a relayout is worth triggering.
+//
+// Deliberately ONLY ever called from that timer, never from inside
+// GetButtonHwnd/an active Arrange pass - see the mod's own readme "Known
+// limitations" section, which flagged this exact risk before it was ever
+// hit in practice: the click-sentinel technique this chain uses
+// interacts with the taskbar's own internal click-handling machinery, and
+// running it synchronously while XAML is mid-layout - specifically while
+// a button is being structurally inserted into or removed from an
+// ItemsRepeater's data source, which happens whenever Windows' "show
+// taskbar apps on" setting is anything other than "All taskbars" and a
+// window moves across monitors - was confirmed (via WinDbg crash dump
+// analysis across several explorer.exe crash-loop sessions) to be
+// reachable in a way that fails fast with STATUS_STOWED_EXCEPTION. Only
+// "All taskbars" mode was stable, because there a window moving between
+// monitors never changes any taskbar's button set - no new/removed button
+// ever needs fresh resolution inline during layout. Moving resolution to
+// a timer restores the "normal" context this technique already assumed
+// (a standalone event, not nested inside a live layout pass), matching
+// where the pointer-release-based technique it's adapted from actually
+// runs in the mods it's borrowed from.
+bool ResolveAndCacheButtonHwnd(FrameworkElement element) {
+    void* key = winrt::get_abi(element);
+    HWND previous = nullptr;
+    auto it = g_buttonHwndCache.find(key);
+    if (it != g_buttonHwndCache.end()) {
+        previous = it->second.hwnd;
+    }
+
+    HWND hwnd = ResolveHwndFromTaskListButton(element);
+    g_buttonHwndCache[key] = {hwnd, GetTickCount64()};
+    return hwnd != previous;
+}
+
+// Read-only: never triggers resolution itself, only ever reads whatever
+// ResolveAndCacheButtonHwnd (via the timer) has already cached. A button
+// with no cache entry yet, or one whose cached window has since closed,
+// reads as unresolved here and falls back to the default-side
+// classification until the next timer tick catches up - see
+// ResolveAndCacheButtonHwnd's comment for why this can never call the
+// resolution chain directly.
+HWND GetButtonHwnd(FrameworkElement element) {
+    void* key = winrt::get_abi(element);
+
+    auto it = g_buttonHwndCache.find(key);
+    if (it == g_buttonHwndCache.end()) {
+        return nullptr;
+    }
+    if (it->second.hwnd && !IsWindow(it->second.hwnd)) {
+        return nullptr;
+    }
+    return it->second.hwnd;
+}
+
+// ResolvePendingButtonHwnds (which actually walks TaskListButtons and
+// calls ResolveAndCacheButtonHwnd above) is defined later, right after
+// FindTaskbarFrameRepeater and IsTaskListButton - it depends on both.
+// Forward-declared here so StartButtonHwndResolveTimer (Mod lifecycle
+// section) can reference it before that point.
+void ResolvePendingButtonHwnds();
+
+// ============================================================================
+// Screen-position math
+// ============================================================================
+
+struct WindowClassification {
+    Side side;
+    // Distance in screen px between the window's center and the screen's
+    // center line. Only meaningful for ordering same-side icons relative
+    // to each other; unresolved/overridden buttons get +infinity so they
+    // sort to the outer edge.
+    double distanceFromCenter = std::numeric_limits<double>::infinity();
+};
+
+// A minimized window's GetWindowRect returns a nonsense off-screen position
+// (classically around (-32000,-32000)), which would otherwise always
+// classify it as "left". Instead, freeze at the last known classification
+// from before it was minimized. Not pruned on window close - see note at
+// GetButtonHwnd's cache for why that's an acceptable tradeoff here too.
+std::unordered_map<HWND, WindowClassification> g_lastKnownWindowClassification;
+
+WindowClassification ClassifyByWindowPositionCached(HWND hwnd) {
+    if (IsIconic(hwnd)) {
+        auto it = g_lastKnownWindowClassification.find(hwnd);
+        if (it != g_lastKnownWindowClassification.end()) {
+            return it->second;
+        }
+        return {ResolveUnresolvedAppsDefaultSide()};
+    }
+
+    RECT wr;
+    HMONITOR mon = MonitorFromWindow(g_hTaskbarWnd, MONITOR_DEFAULTTOPRIMARY);
+    MONITORINFO mi{.cbSize = sizeof(mi)};
+    if (!hwnd || !GetWindowRect(hwnd, &wr) || !GetMonitorInfo(mon, &mi)) {
+        return {ResolveUnresolvedAppsDefaultSide()};
+    }
+
+    double windowCenterX = (wr.left + wr.right) / 2.0;
+    double screenCenterX = (mi.rcMonitor.left + mi.rcMonitor.right) / 2.0;
+
+    WindowClassification result;
+    result.side = windowCenterX < screenCenterX ? Side::Left : Side::Right;
+    result.distanceFromCenter = std::abs(windowCenterX - screenCenterX);
+
+    g_lastKnownWindowClassification[hwnd] = result;
+    return result;
+}
+
+// Taskbar buttons expose their app's display name as an accessibility
+// property (used by screen readers); reused here as a stable identifier
+// that works even for pinned-but-not-running apps, which have no HWND.
+std::wstring GetButtonAccessibleName(FrameworkElement element) {
+    auto name = Automation::AutomationProperties::GetName(element);
+    if (!name.empty()) {
+        return ToLower(std::wstring(name.c_str()));
+    }
+
+    auto elementName = element.Name();
+    if (!elementName.empty()) {
+        return ToLower(std::wstring(elementName.c_str()));
+    }
+
+    return L"";
+}
+
+bool ContainsAnyFragment(const std::wstring& haystack,
+                         const std::vector<std::wstring>& needles) {
+    if (haystack.empty()) {
+        return false;
+    }
+
+    for (auto& needle : needles) {
+        if (!needle.empty() && haystack.find(needle) != std::wstring::npos) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+struct ButtonClassification {
+    Side side;
+    double orderKey = std::numeric_limits<double>::infinity();
+    bool hwndResolved = false;
+};
+
+// Classification priority: explicit user override by app name, then live
+// window position, then the configured default (mainly hit by pinned apps
+// that aren't running and weren't listed in leftApps/rightApps).
+ButtonClassification ClassifyTaskListButton(FrameworkElement element) {
+    std::wstring name = GetButtonAccessibleName(element);
+
+    if (ContainsAnyFragment(name, g_settings.leftApps)) {
+        return {Side::Left, PinnedAppOrderKey()};
+    }
+    if (ContainsAnyFragment(name, g_settings.rightApps)) {
+        return {Side::Right, PinnedAppOrderKey()};
+    }
+
+    HWND hwnd = GetButtonHwnd(element);
+    if (hwnd) {
+        WindowClassification wc = ClassifyByWindowPositionCached(hwnd);
+        return {wc.side, wc.distanceFromCenter, true};
+    }
+
+    return {ResolveUnresolvedAppsDefaultSide(), PinnedAppOrderKey()};
+}
+
+// X coordinate (in the taskbar repeater's local DIPs) of the primary
+// monitor's horizontal center.
+double GetMonitorCenterXLocal() {
+    HMONITOR mon = MonitorFromWindow(g_hTaskbarWnd, MONITOR_DEFAULTTOPRIMARY);
+    MONITORINFO mi{.cbSize = sizeof(mi)};
+    if (!GetMonitorInfo(mon, &mi)) {
+        return 0;
+    }
+
+    RECT taskbarRect;
+    if (!GetWindowRect(g_hTaskbarWnd, &taskbarRect)) {
+        return 0;
+    }
+
+    UINT dpi = GetDpiForWindow(g_hTaskbarWnd);
+    double scale = dpi ? (96.0 / dpi) : 1.0;
+
+    double centerScreenPx = (mi.rcMonitor.left + mi.rcMonitor.right) / 2.0;
+    double localPx = centerScreenPx - taskbarRect.left;
+    return localPx * scale;
+}
+
+double FullFootprintWidth(FrameworkElement element) {
+    Thickness m = element.Margin();
+    return m.Left + element.ActualWidth() + m.Right;
+}
+
+// ============================================================================
+// Element identification
+// ============================================================================
+
+enum class SystemButton {
+    None,
+    Start,
+    Widgets,
+    Search,
+    TaskView,
+};
+
+SystemButton IdentifySystemButton(FrameworkElement element) {
+    auto className = winrt::get_class_name(element);
+
+    if (className == L"Taskbar.ExperienceToggleButton") {
+        auto automationId =
+            Automation::AutomationProperties::GetAutomationId(element);
+        if (automationId == L"StartButton") {
+            return SystemButton::Start;
+        }
+        if (automationId == L"TaskViewButton") {
+            return SystemButton::TaskView;
+        }
+    } else if (className == L"Taskbar.AugmentedEntryPointButton") {
+        if (element.Name() == L"AugmentedEntryPointButton") {
+            return SystemButton::Widgets;
+        }
+    } else if (className == L"Taskbar.TaskbarExtensionElement") {
+        return SystemButton::Search;
+    }
+
+    return SystemButton::None;
+}
+
+bool IsTaskListButton(FrameworkElement element) {
+    return winrt::get_class_name(element) == L"Taskbar.TaskListButton";
+}
+
+// ============================================================================
+// Layout: computing target X positions
+// ============================================================================
+
+double ComputeStartButtonX(FrameworkElement startElement) {
+    double centerX = GetMonitorCenterXLocal();
+    return centerX - startElement.ActualWidth() / 2.0;
+}
+
+int SystemButtonRank(SystemButton b) {
+    switch (b) {
+        case SystemButton::Search:
+            return 0;
+        case SystemButton::TaskView:
+            return 1;
+        case SystemButton::Widgets:
+            return 2;
+        default:
+            return -1;
+    }
+}
+
+// Total footprint of Search+TaskView+Widgets together, used both to lay
+// them out and to reserve room for them next to Start (in adjacent mode) so
+// task list buttons on that side don't overlap them. Updated whenever any
+// of the three arranges; read by task list button placement.
+double g_lastLeftSystemClusterWidth = 0;
+double g_lastRightSystemClusterWidth = 0;
+
+double SystemButtonClusterWidth(FrameworkElement repeater) {
+    double total = 0;
+    for (auto& child : GetRepeaterChildElements(repeater)) {
+        if (SystemButtonRank(IdentifySystemButton(child)) >= 0) {
+            total += FullFootprintWidth(child);
+        }
+    }
+    return total;
+}
+
+// Places Search/TaskView/Widgets either at the taskbar's far left edge, or
+// immediately adjacent to one side of the Start button, per
+// g_settings.systemButtonsPlacement.
+double ComputeSystemButtonX(FrameworkElement repeater,
+                            FrameworkElement targetElement,
+                            SystemButton target,
+                            double startCenterX,
+                            double startWidth) {
+    int targetRank = SystemButtonRank(target);
+    if (targetRank < 0) {
+        return 0;
+    }
+
+    double widthBefore = 0;
+    for (auto& child : GetRepeaterChildElements(repeater)) {
+        int r = SystemButtonRank(IdentifySystemButton(child));
+        if (r >= 0 && r < targetRank) {
+            widthBefore += FullFootprintWidth(child);
+        }
+    }
+
+    if (g_settings.systemButtonsPlacement == SystemButtonsPlacement::FarLeft) {
+        g_lastLeftSystemClusterWidth = 0;
+        g_lastRightSystemClusterWidth = 0;
+        return 8 + widthBefore;  // small left margin
+    }
+
+    double clusterWidth = SystemButtonClusterWidth(repeater);
+    double gap = g_settings.gapPx;
+    double ownWidth = FullFootprintWidth(targetElement);
+
+    if (g_settings.systemButtonsAdjacentSide == Side::Left) {
+        g_lastLeftSystemClusterWidth = clusterWidth;
+        g_lastRightSystemClusterWidth = 0;
+        // Stack right-to-left outward from Start: lowest rank closest.
+        double widthAfter = clusterWidth - widthBefore - ownWidth;
+        return startCenterX - startWidth / 2.0 - gap - widthAfter - ownWidth;
+    }
+
+    g_lastLeftSystemClusterWidth = 0;
+    g_lastRightSystemClusterWidth = clusterWidth;
+    return startCenterX + startWidth / 2.0 + gap + widthBefore;
+}
+
+// Updated whenever the Start button's own Arrange runs. Read by task list
+// button arrangement so it doesn't need to assume Start lives in the same
+// container as the task buttons (unconfirmed - see GetSiblingElements).
+double g_lastStartWidth = 48;
+
+// Diagnostics only: counts what got overridden during the current
+// ArrangeOverride pass, logged (throttled) from the pass's own hook.
+struct ArrangePassStats {
+    int totalArrangeCalls = 0;
+    int startHits = 0;
+    int pinnedHits = 0;
+    int taskListHits = 0;
+    int taskListHwndResolved = 0;
+    int taskListLeft = 0;
+    int taskListRight = 0;
+    int qiFailures = 0;
+    int noParent = 0;
+    int exceptions = 0;
+    int wrongTaskbarSkipped = 0;
+    int settlingSkipped = 0;
+};
+// thread_local: the ArrangeOverride hook runs once per taskbar instance's
+// XAML tree, process-wide - with a second monitor enabled that's the
+// primary taskbar and secondary-monitor taskbars potentially interleaving
+// on different threads. A single shared instance here was a data race
+// (unsynchronized concurrent reset/read of a non-atomic struct) that also
+// fed directly into the button-count self-correction logic below.
+thread_local ArrangePassStats g_passStats;
+
+double ComputeTaskListButtonX(FrameworkElement target,
+                               double startCenterX) {
+    ButtonClassification targetInfo = ClassifyTaskListButton(target);
+    if (targetInfo.hwndResolved) {
+        g_passStats.taskListHwndResolved++;
+    }
+    if (targetInfo.side == Side::Left) {
+        g_passStats.taskListLeft++;
+    } else {
+        g_passStats.taskListRight++;
+    }
+
+    void* targetAbi = winrt::get_abi(target);
+    bool byDistance =
+        g_settings.taskListOrder == TaskListOrder::DistanceFromCenter;
+
+    double sameSideWidthBefore = 0;
+    if (byDistance) {
+        // Rank by distance from screen-center rather than taskbar order, so
+        // the icon nearest Start corresponds to the window nearest center.
+        // Pointer-value tiebreak keeps ties stable frame to frame.
+        for (auto& child : GetSiblingElements(target)) {
+            if (!IsTaskListButton(child) || winrt::get_abi(child) == targetAbi) {
+                continue;
+            }
+            ButtonClassification childInfo = ClassifyTaskListButton(child);
+            if (childInfo.side != targetInfo.side) {
+                continue;
+            }
+            bool closer =
+                childInfo.orderKey < targetInfo.orderKey ||
+                (childInfo.orderKey == targetInfo.orderKey &&
+                 winrt::get_abi(child) < targetAbi);
+            if (closer) {
+                sameSideWidthBefore += FullFootprintWidth(child);
+            }
+        }
+    } else {
+        for (auto& child : GetSiblingElements(target)) {
+            if (winrt::get_abi(child) == targetAbi) {
+                break;
+            }
+            if (!IsTaskListButton(child)) {
+                continue;
+            }
+            if (ClassifyTaskListButton(child).side == targetInfo.side) {
+                sameSideWidthBefore += FullFootprintWidth(child);
+            }
+        }
+    }
+
+    double width = FullFootprintWidth(target);
+    double gap = g_settings.gapPx;
+    double startWidth = g_lastStartWidth;
+
+    bool adjacent =
+        g_settings.systemButtonsPlacement == SystemButtonsPlacement::AdjacentStart;
+    double leftExtra = (adjacent && g_settings.systemButtonsAdjacentSide == Side::Left)
+                            ? (g_lastLeftSystemClusterWidth + gap)
+                            : 0;
+    double rightExtra = (adjacent && g_settings.systemButtonsAdjacentSide == Side::Right)
+                             ? (g_lastRightSystemClusterWidth + gap)
+                             : 0;
+
+    if (targetInfo.side == Side::Left) {
+        return startCenterX - startWidth / 2.0 - gap - leftExtra -
+               sameSideWidthBefore - width;
+    }
+
+    return startCenterX + startWidth / 2.0 + gap + rightExtra +
+           sameSideWidthBefore;
+}
+
+// ============================================================================
+// XAML hooks
+// ============================================================================
+
+// Defined later (Live drag-follow section); forward-declared here because
+// the ArrangeOverride hook below uses it to self-correct when the button
+// set changes (new pin, app launched/closed) - see the comment at its call
+// site for why that's needed.
+//
+// Only ever marks the taskbar's layout dirty (InvalidateArrange/
+// InvalidateMeasure) - never forces a synchronous UpdateLayout() call. See
+// the comment on the definition for why: a forced synchronous pass here
+// was the confirmed cause of three separate explorer.exe crash-loop
+// incidents, each via a different call path landing while the thread was
+// already nested inside XAML-internal layout activity.
+void InvalidateTaskbarLayout();
+
+// Defined later (Mod lifecycle section); forward-declared here so
+// EnsureTaskbarWnd (below) can start the drag-follow WinEventHook as soon
+// as the taskbar window resolves, whether that happens at normal startup
+// or late (see EnsureTaskbarWnd's comment).
+void StartWinEventHook();
+
+// Defined later (Mod lifecycle section); forward-declared here for the
+// same reason as StartWinEventHook above - starts the timer that drives
+// ResolvePendingButtonHwnds.
+void StartButtonHwndResolveTimer();
+
+// g_hTaskbarWnd is normally resolved once, in Wh_ModAfterInit. But if
+// Windhawk injects into explorer.exe before Shell_TrayWnd has been created
+// yet - observed after a fresh boot, never after a manual mod disable/
+// re-enable since the taskbar is already fully up by then - that one-shot
+// lookup fails and g_hTaskbarWnd stays null forever, which silently
+// disables all positioning (IUIElement_Arrange_Hook and the position math
+// below both require it). Retried once per ArrangeOverride pass instead
+// (see call site) so the mod self-heals as soon as the taskbar exists,
+// rather than needing a manual toggle to re-run Wh_ModAfterInit.
+HWND EnsureTaskbarWnd() {
+    if (g_hTaskbarWnd) {
+        return g_hTaskbarWnd;
+    }
+
+    g_hTaskbarWnd = FindCurrentProcessTaskbarWnd();
+    if (g_hTaskbarWnd) {
+        Wh_Log(L"Resolved taskbar window: %p", g_hTaskbarWnd);
+        StartWinEventHook();
+        StartButtonHwndResolveTimer();
+    }
+
+    return g_hTaskbarWnd;
+}
+
+FrameworkElement FindTaskbarFrameRepeater(FrameworkElement anyDescendant) {
+    FrameworkElement child = anyDescendant;
+    if (child && (child = FindChildByClassName(child, L"Taskbar.TaskbarFrame")) &&
+        (child = FindChildByName(child, L"RootGrid")) &&
+        (child = FindChildByName(child, L"TaskbarFrameRepeater"))) {
+        return child;
+    }
+    return nullptr;
+}
+
+// Walks the primary taskbar's current TaskListButtons and (re)resolves any
+// whose cache entry is missing, stale (window closed), or past the
+// negative-cache TTL - see ResolveAndCacheButtonHwnd's comment for the
+// full story on why this runs on a timer (StartButtonHwndResolveTimer,
+// Mod lifecycle section) instead of inline during Arrange.
+//
+// Guarded against running while nested inside an active Arrange pass on
+// this thread - defense in depth, not the primary protection. Windows
+// generally doesn't deliver WM_TIMER re-entrantly mid-callback on the
+// same thread, but there's no hard guarantee of that documented, and the
+// check is nearly free.
+void ResolvePendingButtonHwnds() {
+    if (g_inTaskbarArrangeOverride || !g_hTaskbarWnd) {
+        return;
+    }
+
+    XamlRoot xamlRoot = GetTaskbarXamlRoot(g_hTaskbarWnd);
+    if (!xamlRoot) {
+        return;
+    }
+
+    FrameworkElement content = xamlRoot.Content().try_as<FrameworkElement>();
+    FrameworkElement repeater = FindTaskbarFrameRepeater(content);
+    if (!repeater) {
+        return;
+    }
+
+    ULONGLONG now = GetTickCount64();
+    bool anyChanged = false;
+
+    for (auto& child : GetRepeaterChildElements(repeater)) {
+        if (!IsTaskListButton(child)) {
+            continue;
+        }
+
+        void* key = winrt::get_abi(child);
+        auto it = g_buttonHwndCache.find(key);
+        bool needsResolve = it == g_buttonHwndCache.end();
+        if (!needsResolve) {
+            needsResolve = it->second.hwnd
+                               ? !IsWindow(it->second.hwnd)
+                               : (now - it->second.lastAttempt >= 2000);
+        }
+
+        if (needsResolve && ResolveAndCacheButtonHwnd(child)) {
+            anyChanged = true;
+        }
+    }
+
+    if (anyChanged) {
+        InvalidateTaskbarLayout();
+    }
+}
+
+using IUIElement_Arrange_t =
+    HRESULT(WINAPI*)(void* pThis, winrt::Windows::Foundation::Rect rect);
+IUIElement_Arrange_t IUIElement_Arrange_Original;
+
+// Last X each element (Start, a system button, or a task list button) was
+// legitimately arranged at by this mod - keyed by the XAML element's ABI
+// pointer, same identity technique as g_buttonHwndCache. Written only from
+// the non-gated path below (a real ComputeXX call, outside the settling
+// window); read only from the gated path, so a settling pass can hold
+// every already-known element exactly where it last legitimately was
+// instead of visibly snapping to Windows' native layout for up to a
+// second and back. Y/Width/Height still come from the CURRENT pass's
+// incoming rect, not this cache - those can legitimately change pass to
+// pass (DPI, taskbar height) independent of X, and freezing them too could
+// look wrong across e.g. a DPI change. A brand-new element (no entry yet -
+// necessarily the case for whatever just triggered this settling window,
+// since a just-inserted button can't have a prior legitimate X) has
+// nothing to fall back to and still shows at its native position until
+// settling clears, same as before this cache existed.
+//
+// Not pruned when a button disappears - same acceptable tradeoff as
+// g_buttonHwndCache; a stale entry just sits unread forever if that exact
+// element (identified by ABI pointer) never reappears.
+std::unordered_map<void*, double> g_lastArrangedX;
+
+// Used by every gated branch in IUIElement_Arrange_Hook below - see
+// g_lastArrangedX's comment. Deliberately does no repeater traversal (the
+// actual crash-prone operation the settling window guards against): a
+// map lookup and, at most, one more IUIElement::Arrange call, identical in
+// shape to what original() already does.
+HRESULT ArrangeSettled(void* pThis,
+                       winrt::Windows::Foundation::Rect rect,
+                       void* key) {
+    auto it = g_lastArrangedX.find(key);
+    if (it != g_lastArrangedX.end()) {
+        rect.X = it->second;
+    }
+    return IUIElement_Arrange_Original(pThis, rect);
+}
+
+HRESULT WINAPI IUIElement_Arrange_Hook(void* pThis,
+                                       winrt::Windows::Foundation::Rect rect) {
+    auto original = [=] { return IUIElement_Arrange_Original(pThis, rect); };
+
+    if (!g_inTaskbarArrangeOverride || g_unloading || !g_hTaskbarWnd) {
+        return original();
+    }
+
+    // This hook replaces the process-wide IUIElement::Arrange vtable slot,
+    // so it's invoked directly by XAML's own native call sites for every
+    // UIElement being arranged anywhere in explorer.exe - a raw ABI
+    // boundary with no C++/WinRT exception translation on the other side.
+    // A WinRT call throwing here (observed via a real crash: explorer.exe
+    // faulting in Windows.UI.Xaml.dll with STATUS_STOWED_EXCEPTION,
+    // 0xC000027B, at enabling a second monitor - a fresh secondary-taskbar
+    // XAML tree briefly has elements with no parent yet mid-construction,
+    // and .as<T>() throws on a null source where .try_as<T>() would just
+    // return null) crosses that boundary uncaught and fail-fasts the whole
+    // process. Catch anything and fall back to the real implementation
+    // rather than let that happen again.
+    try {
+        g_passStats.totalArrangeCalls++;
+
+        FrameworkElement element = nullptr;
+        ((IUnknown*)pThis)
+            ->QueryInterface(winrt::guid_of<FrameworkElement>(),
+                             winrt::put_abi(element));
+        if (!element) {
+            g_passStats.qiFailures++;
+            return original();
+        }
+
+        // Only reposition elements belonging to the PRIMARY taskbar's own
+        // XAML tree - see the comment on g_primaryXamlRootIdentity for why
+        // this check exists (it's the fix for a confirmed crash, not a
+        // defensive nicety). Resolved lazily and cached; if it hasn't
+        // resolved yet, fail safe by skipping rather than risking another
+        // misapplied Rect.
+        //
+        // The resolution call itself is ONLY attempted when confirmed to be
+        // running on the primary taskbar's own UI thread. element.XamlRoot()
+        // is always safe regardless of thread (XAML only ever invokes
+        // Arrange on an element's own thread), but GetTaskbarXamlRoot(
+        // g_hTaskbarWnd) reaches across to the PRIMARY's XAML object
+        // specifically - every other call site for it in this file
+        // marshals via RunFromWindowThread first. This one can't (Arrange
+        // needs a synchronous answer), so instead it skips the resolution
+        // attempt entirely on the wrong thread and retries next call - it's
+        // guaranteed to eventually run on the primary's own thread once
+        // primary's own elements arrange, no marshaling needed. Skipping
+        // this thread check on the first version of this fix was itself a
+        // second, unmarshaled cross-apartment WinRT call - i.e. a fresh
+        // instance of the very same crash class this whole check exists to
+        // prevent, which is why it could still crash with
+        // wrongTaskbarSkipped staying at 0 (the crash happened inside this
+        // resolution call, before ever reaching that counter).
+        void* primaryIdentity = g_primaryXamlRootIdentity.load();
+        if (!primaryIdentity) {
+            DWORD primaryThreadId = GetWindowThreadProcessId(g_hTaskbarWnd, nullptr);
+            if (primaryThreadId != 0 && primaryThreadId == GetCurrentThreadId()) {
+                primaryIdentity =
+                    XamlRootIdentity(GetTaskbarXamlRoot(g_hTaskbarWnd));
+                if (primaryIdentity) {
+                    g_primaryXamlRootIdentity.store(primaryIdentity);
+                }
+            }
+        }
+        void* elementIdentity = XamlRootIdentity(element.XamlRoot());
+        if (!primaryIdentity || !elementIdentity ||
+            elementIdentity != primaryIdentity) {
+            g_passStats.wrongTaskbarSkipped++;
+            return original();
+        }
+
+        auto repeater = Media::VisualTreeHelper::GetParent(element)
+                            .try_as<FrameworkElement>();
+        if (!repeater) {
+            g_passStats.noParent++;
+            return original();
+        }
+
+        SystemButton systemButton = IdentifySystemButton(element);
+
+        winrt::Windows::Foundation::Rect newRect = rect;
+
+        if (systemButton == SystemButton::Start) {
+            // Originally left ungated, on the reasoning that
+            // ComputeStartButtonX never touches a repeater so it isn't part
+            // of the crash-prone class the settling window guards against
+            // (see g_taskListSettlingUntil's comment). That missed a
+            // cosmetic consequence: gating the task list/system buttons but
+            // NOT Start meant Start kept snapping to the forced screen
+            // center every pass while its neighbors froze at wherever
+            // native XAML layout put them (which doesn't reserve center
+            // space for a repositioned Start) - the observed "icons overlay
+            // the centered Start button" glitch on every structural change,
+            // e.g. a window moving to another monitor. Gating Start too
+            // makes the whole taskbar fall back to one consistent state
+            // for the settling window instead of a mismatched hybrid;
+            // it's still safe to gate since this is only skipping our own
+            // Rect override, not adding a new repeater traversal.
+            if (GetTickCount64() < g_taskListSettlingUntil) {
+                g_passStats.settlingSkipped++;
+                return ArrangeSettled(pThis, rect, winrt::get_abi(element));
+            }
+            g_passStats.startHits++;
+            g_lastStartWidth = element.ActualWidth();
+            newRect.X = ComputeStartButtonX(element);
+            g_lastArrangedX[winrt::get_abi(element)] = newRect.X;
+        } else if (systemButton == SystemButton::Search ||
+                   systemButton == SystemButton::TaskView ||
+                   systemButton == SystemButton::Widgets) {
+            // See g_taskListSettlingUntil's comment: both this branch and
+            // the task list one below call into repeater traversal
+            // (SystemButtonClusterWidth / GetSiblingElements), which is
+            // suppressed for a short window after any detected
+            // structural change to the button set.
+            if (GetTickCount64() < g_taskListSettlingUntil) {
+                g_passStats.settlingSkipped++;
+                return ArrangeSettled(pThis, rect, winrt::get_abi(element));
+            }
+            g_passStats.pinnedHits++;
+            newRect.X = ComputeSystemButtonX(repeater, element, systemButton,
+                                             GetMonitorCenterXLocal(),
+                                             g_lastStartWidth);
+            g_lastArrangedX[winrt::get_abi(element)] = newRect.X;
+        } else if (IsTaskListButton(element)) {
+            if (GetTickCount64() < g_taskListSettlingUntil) {
+                g_passStats.settlingSkipped++;
+                return ArrangeSettled(pThis, rect, winrt::get_abi(element));
+            }
+            g_passStats.taskListHits++;
+            double startCenterX = GetMonitorCenterXLocal();
+            newRect.X = ComputeTaskListButtonX(element, startCenterX);
+            g_lastArrangedX[winrt::get_abi(element)] = newRect.X;
+        } else {
+            return original();
+        }
+
+        return IUIElement_Arrange_Original(pThis, newRect);
+    } catch (...) {
+        g_passStats.exceptions++;
+        return original();
+    }
+}
+
+using TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_t =
+    HRESULT(WINAPI*)(void* pThis,
+                     void* context,
+                     winrt::Windows::Foundation::Size size,
+                     winrt::Windows::Foundation::Size* resultSize);
+TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_t
+    TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original;
+HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
+    void* pThis,
+    void* context,
+    winrt::Windows::Foundation::Size size,
+    winrt::Windows::Foundation::Size* resultSize) {
+    [[maybe_unused]] static bool hooked = [] {
+        Shapes::Rectangle rectangle;
+        IUIElement element = rectangle;
+
+        void** vtable = *(void***)winrt::get_abi(element);
+        auto arrange = (IUIElement_Arrange_t)vtable[92];
+
+        WindhawkUtils::SetFunctionHook(arrange, IUIElement_Arrange_Hook,
+                                       &IUIElement_Arrange_Original);
+        Wh_ApplyHookOperations();
+        return true;
+    }();
+
+    static bool loggedFirstCall;
+    if (!loggedFirstCall) {
+        loggedFirstCall = true;
+        Wh_Log(L"ArrangeOverride hook is firing (first call)");
+    }
+
+    g_passStats = {};
+
+    EnsureTaskbarWnd();
+
+    g_inTaskbarArrangeOverride = true;
+
+    HRESULT ret = TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original(
+        pThis, context, size, resultSize);
+
+    g_inTaskbarArrangeOverride = false;
+
+    // The button count can change without any window moving (new pin, app
+    // launched/closed), and the taskbar's own virtualization bookkeeping
+    // doesn't reliably reconcile with our position overrides for a newly
+    // realized element - the symptom is a new pin not appearing at all
+    // until something forces a full fresh relayout. Self-correct by
+    // invalidating whenever the count changes, which is enough for the new
+    // element to settle on the XAML dispatcher's next tick. Guarded against
+    // recursing more than one level deep.
+    //
+    // thread_local rather than a single global: this hook runs process-wide
+    // for every taskbar instance's XAML tree (primary and, with a second
+    // monitor enabled, secondary-monitor taskbars too), and those can run
+    // on different threads with independently-changing button counts. A
+    // shared global here raced across instances - one taskbar's pass could
+    // see another's count change and misfire - which is exactly the
+    // condition (taskList count oscillating 4->1->4 across two passes)
+    // observed immediately preceding a crash-loop with a second monitor
+    // enabled.
+    static thread_local int lastTaskListButtonCount = -1;
+    static thread_local bool inCountChangeRetry;
+    int currentCount = g_passStats.taskListHits;
+    // A settling-gated pass reads currentCount as a synthetic 0 (every
+    // element that would've counted toward taskListHits returns early via
+    // the settlingSkipped branch instead - see IUIElement_Arrange_Hook).
+    // That's not a real reading of the button set, so it must never reach
+    // the comparison below or get written into lastTaskListButtonCount:
+    // doing so previously made the very moment settling naturally expired
+    // - the first pass to see the real count again - look like a SECOND
+    // structural change (real count vs. the stale synthetic 0), which
+    // re-armed settling right back on, ad infinitum. That produced a
+    // self-sustaining flash cycle with no further genuine trigger - the
+    // taskbar kept re-blanking every few seconds long after the one actual
+    // cross-monitor move, which is what made the mod look permanently
+    // stuck/disabled rather than settling once and recovering.
+    bool passWasGated = g_passStats.settlingSkipped > 0;
+    if (!passWasGated && currentCount != lastTaskListButtonCount) {
+        bool countChanged = lastTaskListButtonCount != -1;
+        lastTaskListButtonCount = currentCount;
+        if (countChanged) {
+            // See g_taskListSettlingUntil's comment: suppress our own
+            // repeater-traversal-based positioning for a bit after any
+            // detected structural change, regardless of the
+            // inCountChangeRetry guard below (that guard is only about
+            // not recursing the invalidate call itself).
+            g_taskListSettlingUntil = GetTickCount64() + 1000;
+            g_taskListSettlingRecoveryPending = true;
+            if (!inCountChangeRetry) {
+                inCountChangeRetry = true;
+                InvalidateTaskbarLayout();
+                inCountChangeRetry = false;
+            }
+        }
+    }
+
+    static ULONGLONG lastStatsLog;
+    ULONGLONG now = GetTickCount64();
+    if (now - lastStatsLog > 2000) {
+        lastStatsLog = now;
+        Wh_Log(
+            L"Arrange pass: total=%d start=%d pinned=%d taskList=%d "
+            L"(hwndResolved=%d left=%d right=%d) qiFail=%d noParent=%d "
+            L"wrongTaskbarSkipped=%d settlingSkipped=%d exceptions=%d | "
+            L"winEvents: raw=%d invalidated=%d skippedReentrant=%d "
+            L"invalidateExceptions=%d | resolve(individual): ok=%d "
+            L"viewModelNull=%d getTaskItemFail=%d sentinelNoItem=%d | "
+            L"resolve(group): ok=%d viewModelNull=%d sentinelNoGroup=%d "
+            L"noItems=%d",
+            g_passStats.totalArrangeCalls, g_passStats.startHits,
+            g_passStats.pinnedHits, g_passStats.taskListHits,
+            g_passStats.taskListHwndResolved, g_passStats.taskListLeft,
+            g_passStats.taskListRight, g_passStats.qiFailures,
+            g_passStats.noParent, g_passStats.wrongTaskbarSkipped,
+            g_passStats.settlingSkipped, g_passStats.exceptions,
+            (int)g_winEventRawCount,
+            (int)g_winEventInvalidateCount, (int)g_invalidateSkippedReentrant,
+            (int)g_invalidateExceptions, g_resolveStats.success,
+            g_resolveStats.failViewModelNull, g_resolveStats.failGetTaskItem,
+            g_resolveStats.failSentinelNoItem, g_resolveStats.groupSuccess,
+            g_resolveStats.groupFailViewModelNull,
+            g_resolveStats.groupFailSentinelNoGroup,
+            g_resolveStats.groupFailNoItems);
+        g_resolveStats = {};
+    }
+
+    return ret;
+}
+
+// ============================================================================
+// Live drag-follow: force a taskbar relayout when a top-level window moves
+// ============================================================================
+
+// Guards against reentering InvalidateTaskbarLayout itself on the
+// taskbar's own thread. WinEventProc can fire in rapid bursts (observed:
+// thousands of raw events within seconds while something on screen is
+// spamming EVENT_OBJECT_LOCATIONCHANGE).
+//
+// This lambda deliberately never calls UpdateLayout() - see the note on
+// InvalidateTaskbarLayout below for why forcing a synchronous layout pass
+// here is unsafe regardless of this guard.
+thread_local bool g_inInvalidateTaskbarLayout;
+
+// Marks the taskbar's layout dirty and lets the XAML dispatcher pick it up
+// on its own next tick, rather than forcing an immediate synchronous
+// UpdateLayout() call. An earlier version forced it (for drag-follow
+// snappiness), gated behind a reentrancy guard and a forceImmediate flag
+// that was false only for one specific call site. That was not enough:
+// this function's callers include a raw OS callback (WinEventProc) that
+// can itself fire while the thread is already nested inside XAML-internal
+// layout activity for reasons outside this mod's control (e.g. a taskbar
+// button structurally moving between two different monitors' XAML trees,
+// not just changing coordinates within one). A forced UpdateLayout() in
+// that state is a reentrant "layout cycle" from WinUI's perspective, and
+// it fails fast with STATUS_STOWED_EXCEPTION - the confirmed cause of
+// three separate explorer.exe crash-loop incidents (identical fault offset
+// in Windows.UI.Xaml.dll every time), each via a different trigger path,
+// even after two of those paths were individually guarded. Since new
+// trigger paths kept appearing, the only fix that actually closes the
+// whole class is to never force it anywhere: InvalidateArrange() +
+// InvalidateMeasure() alone are always safe to call from any context, and
+// the resulting delay before the dispatcher's own pass runs is at most
+// one composition frame - not perceptible for a drag-follow feature that
+// was already documented as best-effort ("shortly after a drag/move
+// settles, not on every intermediate pixel").
+//
+// Also important: that STATUS_STOWED_EXCEPTION is a raw SEH RaiseException,
+// not a thrown C++ exception. This mod's toolchain (Windhawk's clang/MinGW
+// build, no /EHa-style async exception handling) cannot catch it with
+// `catch(...)` no matter where it's placed - confirmed by
+// g_invalidateExceptions staying 0 across multiple full crash-loop
+// sessions. The try/catch below only covers genuine C++ exceptions from
+// the WinRT calls in this lambda (e.g. QueryInterface failures surfaced as
+// hresult_error) - it was never a safety net for the layout-cycle failure,
+// and no try/catch placement ever will be. Don't reintroduce a forced
+// UpdateLayout() here without a fundamentally different mechanism (e.g. a
+// genuinely async PostMessage-deferred call that's guaranteed to run only
+// once the current call stack has fully unwound).
+void InvalidateTaskbarLayout() {
+    if (!g_hTaskbarWnd) {
+        return;
+    }
+
+    bool posted = RunFromWindowThread(g_hTaskbarWnd, [] {
+        if (g_inInvalidateTaskbarLayout) {
+            g_invalidateSkippedReentrant++;
+            return;
+        }
+        g_inInvalidateTaskbarLayout = true;
+
+        try {
+            XamlRoot xamlRoot = GetTaskbarXamlRoot(g_hTaskbarWnd);
+            if (!xamlRoot) {
+                Wh_Log(L"InvalidateTaskbarLayout: GetTaskbarXamlRoot failed");
+                g_inInvalidateTaskbarLayout = false;
+                return;
+            }
+
+            FrameworkElement content =
+                xamlRoot.Content().try_as<FrameworkElement>();
+            FrameworkElement repeater = FindTaskbarFrameRepeater(content);
+            if (!repeater) {
+                Wh_Log(
+                    L"InvalidateTaskbarLayout: FindTaskbarFrameRepeater "
+                    L"failed");
+                g_inInvalidateTaskbarLayout = false;
+                return;
+            }
+
+            repeater.InvalidateArrange();
+            repeater.InvalidateMeasure();
+        } catch (...) {
+            g_invalidateExceptions++;
+        }
+
+        g_inInvalidateTaskbarLayout = false;
+    });
+    if (!posted) {
+        Wh_Log(L"InvalidateTaskbarLayout: RunFromWindowThread failed");
+    }
+}
+
+void CALLBACK WinEventProc(HWINEVENTHOOK hook,
+                           DWORD event,
+                           HWND hwnd,
+                           LONG idObject,
+                           LONG idChild,
+                           DWORD idEventThread,
+                           DWORD dwmsEventTime) {
+    g_winEventRawCount++;
+
+    if (g_unloading || idObject != OBJID_WINDOW || idChild != CHILDID_SELF ||
+        !hwnd || hwnd == g_hTaskbarWnd) {
+        return;
+    }
+
+    if (!IsWindowVisible(hwnd) || GetAncestor(hwnd, GA_ROOT) != hwnd ||
+        GetWindow(hwnd, GW_OWNER) != nullptr) {
+        return;
+    }
+
+    static ULONGLONG lastInvalidate;
+    ULONGLONG now = GetTickCount64();
+    if (now - lastInvalidate < 150) {
+        return;
+    }
+    lastInvalidate = now;
+
+    g_winEventInvalidateCount++;
+    InvalidateTaskbarLayout();
+}
+
+// ============================================================================
+// Module/symbol hooking plumbing
+// ============================================================================
+
+bool HookTaskbarDllSymbols() {
+    HMODULE module =
+        LoadLibraryEx(L"taskbar.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!module) {
+        Wh_Log(L"Failed to load taskbar.dll");
+        return false;
+    }
+
+    WindhawkUtils::SYMBOL_HOOK taskbarDllHooks[] = {
+        {
+            {LR"(const CTaskBand::`vftable'{for `ITaskListWndSite'})"},
+            &CTaskBand_ITaskListWndSite_vftable,
+        },
+        {
+            {LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CTaskBand::GetTaskbarHost(void)const )"},
+            &CTaskBand_GetTaskbarHost_Original,
+        },
+        {
+            {LR"(public: int __cdecl TaskbarHost::FrameHeight(void)const )"},
+            &TaskbarHost_FrameHeight_Original,
+        },
+        {
+            {LR"(public: void __cdecl std::_Ref_count_base::_Decref(void))"},
+            &std__Ref_count_base__Decref_Original,
+        },
+        {
+            {LR"(public: virtual long __cdecl CTaskListWnd::HandleClick(struct ITaskGroup *,struct ITaskItem *,struct winrt::Windows::System::LauncherOptions const &))"},
+            &CTaskListWnd_HandleClick_Original,
+            CTaskListWnd_HandleClick_Hook,
+        },
+        {
+            {LR"(public: virtual struct HWND__ * __cdecl CWindowTaskItem::GetWindow(void))"},
+            &CWindowTaskItem_GetWindow_Original,
+        },
+        {
+            {LR"(public: virtual struct HWND__ * __cdecl CImmersiveTaskItem::GetWindow(void))"},
+            &CImmersiveTaskItem_GetWindow_Original,
+        },
+        {
+            {LR"(const CImmersiveTaskItem::`vftable'{for `ITaskItem'})"},
+            &CImmersiveTaskItem_vftable,
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::WindowsUdk::UI::Shell::implementation::TaskItem,struct winrt::WindowsUdk::UI::Shell::ITaskItem>::ReportClicked(void *))"},
+            &TaskItem_ReportClicked_Original,
+            nullptr,
+            true,
+        },
+        {
+            {LR"(public: virtual int __cdecl CTaskGroup::GetNumItems(void))"},
+            &CTaskGroup_GetNumItems_Original,
+            nullptr,
+            true,
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::WindowsUdk::UI::Shell::implementation::TaskGroup,struct winrt::WindowsUdk::UI::Shell::ITaskGroup>::ReportClicked(void *))"},
+            &TaskGroup_ReportClicked_Original,
+            nullptr,
+            true,
+        },
+    };
+
+    bool ok = HookSymbols(module, taskbarDllHooks, ARRAYSIZE(taskbarDllHooks));
+    Wh_Log(L"HookTaskbarDllSymbols: %s", ok ? L"OK" : L"FAILED");
+    Wh_Log(L"  TaskItem::ReportClicked: %s",
+           TaskItem_ReportClicked_Original ? L"resolved" : L"MISSING");
+    Wh_Log(L"  CTaskGroup::GetNumItems: %s",
+           CTaskGroup_GetNumItems_Original ? L"resolved" : L"MISSING");
+    Wh_Log(L"  TaskGroup::ReportClicked: %s",
+           TaskGroup_ReportClicked_Original ? L"resolved" : L"MISSING");
+    return ok;
+}
+
+bool HookTaskbarViewDllSymbols(HMODULE module) {
+    // All marked optional so HookSymbols doesn't abort the whole batch on
+    // the first miss - we want a per-symbol report while bringing this mod
+    // up on a new Windows build, not just a single opaque FAILED.
+    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarCollapsibleLayout,struct winrt::Microsoft::UI::Xaml::Controls::IVirtualizingLayoutOverrides>::ArrangeOverride(void *,struct winrt::Windows::Foundation::Size,struct winrt::Windows::Foundation::Size *))"},
+            &TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original,
+            TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook,
+            true,
+        },
+        {
+            {LR"(struct winrt::Taskbar::TaskListWindowViewModel __cdecl TryGetItemFromContainer<struct winrt::Taskbar::TaskListWindowViewModel>(struct winrt::Windows::UI::Xaml::UIElement const &))"},
+            &TryGetItemFromContainer_TaskListWindowViewModel_Original,
+            nullptr,
+            true,
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListWindowViewModel,struct winrt::Taskbar::ITaskListWindowViewModel>::get_TaskItem(void * *))"},
+            &TaskListWindowViewModel_get_TaskItem_Original,
+            nullptr,
+            true,
+        },
+        {
+            {LR"(struct winrt::Taskbar::TaskListGroupViewModel __cdecl TryGetItemFromContainer<struct winrt::Taskbar::TaskListGroupViewModel>(struct winrt::Windows::UI::Xaml::UIElement const &))"},
+            &TryGetItemFromContainer_TaskListGroupViewModel_Original,
+            nullptr,
+            true,
+        },
+        {
+            {LR"(public: bool __cdecl winrt::Taskbar::implementation::TaskListGroupViewModel::IsMultiWindow(void)const )"},
+            &TaskListGroupViewModel_IsMultiWindow_Original,
+            nullptr,
+            true,
+        },
+        {
+            {LR"(public: __cdecl winrt::impl::consume_WindowsUdk_UI_Shell_ITaskGroup<struct winrt::WindowsUdk::UI::Shell::ITaskGroup>::IsRunning(void)const )"},
+            &ITaskGroup_IsRunning_Original,
+            ITaskGroup_IsRunning_Hook,
+            true,
+        },
+    };
+
+    bool ok = HookSymbols(module, symbolHooks, ARRAYSIZE(symbolHooks));
+    Wh_Log(L"HookTaskbarViewDllSymbols: %s", ok ? L"OK" : L"FAILED");
+    Wh_Log(L"  ArrangeOverride: %s",
+           TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original ? L"resolved"
+                                                                        : L"MISSING");
+    Wh_Log(L"  TryGetItemFromContainer<TaskListWindowViewModel>: %s",
+           TryGetItemFromContainer_TaskListWindowViewModel_Original ? L"resolved"
+                                                                     : L"MISSING");
+    Wh_Log(L"  TaskListWindowViewModel::get_TaskItem: %s",
+           TaskListWindowViewModel_get_TaskItem_Original ? L"resolved"
+                                                          : L"MISSING");
+    Wh_Log(L"  TryGetItemFromContainer<TaskListGroupViewModel>: %s",
+           TryGetItemFromContainer_TaskListGroupViewModel_Original ? L"resolved"
+                                                                    : L"MISSING");
+    Wh_Log(L"  TaskListGroupViewModel::IsMultiWindow: %s",
+           TaskListGroupViewModel_IsMultiWindow_Original ? L"resolved"
+                                                          : L"MISSING");
+    Wh_Log(L"  ITaskGroup::IsRunning: %s",
+           ITaskGroup_IsRunning_Original ? L"resolved" : L"MISSING");
+    return ok;
+}
+
+HMODULE GetTaskbarViewModuleHandle() {
+    HMODULE module = GetModuleHandle(L"Taskbar.View.dll");
+    if (!module) {
+        module = GetModuleHandle(L"ExplorerExtensions.dll");
+    }
+
+    return module;
+}
+
+void HandleLoadedModuleIfTaskbarView(HMODULE module, LPCWSTR lpLibFileName) {
+    if (!g_taskbarViewDllLoaded && GetTaskbarViewModuleHandle() == module &&
+        !g_taskbarViewDllLoaded.exchange(true)) {
+        Wh_Log(L"Loaded %s", lpLibFileName);
+
+        if (HookTaskbarViewDllSymbols(module)) {
+            Wh_ApplyHookOperations();
+        }
+    }
+}
+
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+LoadLibraryExW_t LoadLibraryExW_Original;
+HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
+                                   HANDLE hFile,
+                                   DWORD dwFlags) {
+    HMODULE module = LoadLibraryExW_Original(lpLibFileName, hFile, dwFlags);
+    if (module) {
+        HandleLoadedModuleIfTaskbarView(module, lpLibFileName);
+    }
+
+    return module;
+}
+
+// ============================================================================
+// Mod lifecycle
+// ============================================================================
+
+// WINEVENT_OUTOFCONTEXT delivers its callback on whichever thread called
+// SetWinEventHook, and only if that thread pumps messages. Wh_ModAfterInit
+// doesn't reliably run on the taskbar's own message-pumping UI thread (the
+// raw=0 counter in the logs confirms the callback never fired at all), so
+// registration is marshaled onto g_hTaskbarWnd's thread via
+// RunFromWindowThread, same technique already used for XAML tree access.
+void StartWinEventHook() {
+    if (g_locationChangeHook || !g_hTaskbarWnd) {
+        return;
+    }
+
+    RunFromWindowThread(g_hTaskbarWnd, [] {
+        if (g_locationChangeHook) {
+            return;
+        }
+
+        // Deliberately NOT using WINEVENT_SKIPOWNPROCESS: File Explorer
+        // windows often run inside explorer.exe's own process, and that
+        // flag would silently drop their location-change events too. The
+        // taskbar's own windows are already excluded explicitly in
+        // WinEventProc.
+        g_locationChangeHook = SetWinEventHook(
+            EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_LOCATIONCHANGE, nullptr,
+            WinEventProc, 0, 0, WINEVENT_OUTOFCONTEXT);
+        Wh_Log(L"StartWinEventHook: handle=%p (registered on taskbar thread "
+               L"%lu)",
+               g_locationChangeHook, GetCurrentThreadId());
+        if (!g_locationChangeHook) {
+            Wh_Log(L"Failed to register location-change hook - live "
+                   L"drag-follow will not work, but everything else still "
+                   L"will");
+        }
+    });
+}
+
+void StopWinEventHook() {
+    if (!g_locationChangeHook) {
+        return;
+    }
+
+    HWINEVENTHOOK hook = g_locationChangeHook;
+    g_locationChangeHook = nullptr;
+
+    if (g_hTaskbarWnd) {
+        RunFromWindowThread(g_hTaskbarWnd, [hook] { UnhookWinEvent(hook); });
+    } else {
+        UnhookWinEvent(hook);
+    }
+}
+
+// Arbitrary, only needs to be unique for calls against g_hTaskbarWnd.
+constexpr UINT_PTR kButtonHwndResolveTimerId = 1;
+
+void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
+                                         UINT uMsg,
+                                         UINT_PTR idEvent,
+                                         DWORD dwTime) {
+    // See g_taskListSettlingRecoveryPending's comment: guarantee a fresh
+    // Arrange pass actually happens once the settling window is over,
+    // instead of leaving recovery to whatever unrelated event happens to
+    // invalidate layout next. At most 500ms of extra staleness on top of
+    // the settling window itself, which is already the existing polling
+    // granularity for hwnd resolution below.
+    if (g_taskListSettlingRecoveryPending &&
+        GetTickCount64() >= g_taskListSettlingUntil) {
+        g_taskListSettlingRecoveryPending = false;
+        InvalidateTaskbarLayout();
+    }
+
+    ResolvePendingButtonHwnds();
+}
+
+// SetTimer's callback fires on whichever thread registered it, so this is
+// marshaled onto g_hTaskbarWnd's own thread just like StartWinEventHook -
+// both KillTimer and (for reliability) SetTimer itself are documented to
+// need to run on the thread that owns the timer.
+void StartButtonHwndResolveTimer() {
+    if (!g_hTaskbarWnd) {
+        return;
+    }
+
+    RunFromWindowThread(g_hTaskbarWnd, [] {
+        SetTimer(g_hTaskbarWnd, kButtonHwndResolveTimerId, 500,
+                 ButtonHwndResolveTimerProc);
+    });
+}
+
+void StopButtonHwndResolveTimer() {
+    if (!g_hTaskbarWnd) {
+        return;
+    }
+
+    RunFromWindowThread(g_hTaskbarWnd, [] {
+        KillTimer(g_hTaskbarWnd, kButtonHwndResolveTimerId);
+    });
+}
+
+BOOL Wh_ModInit() {
+    Wh_Log(L">");
+
+    LoadSettings();
+
+    if (!HookTaskbarDllSymbols()) {
+        return FALSE;
+    }
+
+    if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
+        Wh_Log(L"Taskbar view module already loaded at init time");
+        g_taskbarViewDllLoaded = true;
+        if (!HookTaskbarViewDllSymbols(taskbarViewModule)) {
+            return FALSE;
+        }
+    } else {
+        Wh_Log(L"Taskbar view module not loaded yet, will hook on load");
+
+        HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
+        auto pKernelBaseLoadLibraryExW =
+            (decltype(&LoadLibraryExW))GetProcAddress(kernelBaseModule,
+                                                       "LoadLibraryExW");
+        WindhawkUtils::SetFunctionHook(pKernelBaseLoadLibraryExW,
+                                       LoadLibraryExW_Hook,
+                                       &LoadLibraryExW_Original);
+    }
+
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    Wh_Log(L">");
+
+    if (!g_taskbarViewDllLoaded) {
+        if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
+            if (!g_taskbarViewDllLoaded.exchange(true)) {
+                if (HookTaskbarViewDllSymbols(taskbarViewModule)) {
+                    Wh_ApplyHookOperations();
+                }
+            }
+        }
+    }
+
+    EnsureTaskbarWnd();
+    Wh_Log(L"g_hTaskbarWnd = %p, g_taskbarViewDllLoaded = %d", g_hTaskbarWnd,
+           (int)g_taskbarViewDllLoaded);
+
+    InvalidateTaskbarLayout();
+}
+
+void Wh_ModBeforeUninit() {
+    Wh_Log(L">");
+
+    g_unloading = true;
+
+    StopWinEventHook();
+    StopButtonHwndResolveTimer();
+
+    InvalidateTaskbarLayout();
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L">");
+}
+
+BOOL Wh_ModSettingsChanged(BOOL* bReload) {
+    Wh_Log(L">");
+
+    LoadSettings();
+
+    InvalidateTaskbarLayout();
+
+    return TRUE;
+}

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -2132,10 +2132,10 @@ bool HookTaskbarDllSymbols() {
 bool HookTaskbarViewDllSymbols(HMODULE module) {
     // All marked optional so HookSymbols doesn't abort the whole batch on
     // the first miss - we want a per-symbol report while bringing this mod
-    // up on a new Windows build, not just a single opaque FAILED.
-    //
-    // Taskbar.View.dll, ExplorerExtensions.dll (see GetTaskbarViewModuleHandle
-    // - which of the two is actually loaded depends on the Windows build)
+    // up on a new Windows build, not just a single opaque FAILED. Which of
+    // the two modules below is actually loaded depends on the Windows
+    // build - see GetTaskbarViewModuleHandle.
+    // Taskbar.View.dll, ExplorerExtensions.dll
     WindhawkUtils::SYMBOL_HOOK taskbarViewDllHooks[] = {
         {
             {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarCollapsibleLayout,struct winrt::Microsoft::UI::Xaml::Controls::IVirtualizingLayoutOverrides>::ArrangeOverride(void *,struct winrt::Windows::Foundation::Size,struct winrt::Windows::Foundation::Size *))"},

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -2136,7 +2136,7 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
     // the two modules below is actually loaded depends on the Windows
     // build - see GetTaskbarViewModuleHandle.
     // Taskbar.View.dll, ExplorerExtensions.dll
-    WindhawkUtils::SYMBOL_HOOK taskbarViewDllHooks[] = {
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {
         {
             {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarCollapsibleLayout,struct winrt::Microsoft::UI::Xaml::Controls::IVirtualizingLayoutOverrides>::ArrangeOverride(void *,struct winrt::Windows::Foundation::Size,struct winrt::Windows::Foundation::Size *))"},
             &TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original,
@@ -2175,7 +2175,7 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
         },
     };
 
-    bool ok = HookSymbols(module, taskbarViewDllHooks, ARRAYSIZE(taskbarViewDllHooks));
+    bool ok = HookSymbols(module, hooks, ARRAYSIZE(hooks));
     Wh_Log(L"HookTaskbarViewDllSymbols: %s", ok ? L"OK" : L"FAILED");
     Wh_Log(L"  ArrangeOverride: %s",
            TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original ? L"resolved"

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -50,12 +50,42 @@ right next to Start on whichever side you prefer.
 ## Known limitations (please read before reporting issues)
 
 - **Windows 11 only.** Windows 10's taskbar has no XAML layer to hook into.
-- **Primary monitor only.** Screen-center math and window-side classification
-  use the primary monitor. Taskbars on secondary displays are not specially
-  handled by this mod (their icons keep the default layout Windows gives
-  them) - the mod's positioning plan is only ever computed on the primary
-  taskbar's own thread, so secondary-monitor elements are simply never
-  included in it and fall through to Windows' native positioning.
+- **Primary monitor only**, for both the Start button's position and
+  window-side classification - and on a multi-monitor setup this is a
+  bigger limitation than it might sound: a window's side is decided by
+  comparing its position against the *primary* monitor's center line, so
+  every window on a monitor entirely to one side of the primary reads as a
+  fixed left/right regardless of where on that monitor it actually sits -
+  only movement within the primary monitor (or across its center line) is
+  tracked per-pixel. Taskbars on secondary displays aren't specially
+  handled either (their icons keep Windows' default layout) - the mod's
+  positioning plan is only ever computed on the primary taskbar's own
+  thread, so secondary-monitor elements are simply never included in it
+  and fall through to Windows' native positioning.
+- **Don't enable alongside "Start button always on the left".** Both mods
+  hook the same process-wide `IUIElement::Arrange` vtable slot to force
+  the Start button's own X position; with both enabled, whichever one
+  installed its hook second wins, and the result is undefined. This mod's
+  `systemButtonsPlacement: far-left` setting covers the same "keep
+  everything else out of Start's way" goal that mod's
+  `otherSystemButtonsOnTheLeft` option does, so there's no reason to run
+  both together.
+- **A very crowded side compresses instead of overflowing cleanly.** If
+  enough app icons pile up on one side that they'd run into the system
+  tray/clock on the right (or, in "far left" placement, into Search/Task
+  View/Widgets on the left), icon spacing on that side is compressed just
+  enough to keep the whole group within bounds - icons still render at
+  full size, so once genuinely crowded they visually overlap each other
+  rather than being hidden or scrolled the way the taskbar's own overflow
+  handling would.
+- **Windows' own "Combine taskbar buttons and hide labels: When taskbar
+  is full" doesn't shrink icons under this mod** (icons stay full-size and
+  compress/overlap instead, per the point above) - "Always" isn't
+  affected and works normally. Likely because the "when full" decision is
+  made by native layout logic (this mod only overrides each button's
+  final X position afterward, it never touches sizing), evaluated against
+  the taskbar's native, unsplit layout rather than this mod's split one -
+  unconfirmed, not yet investigated further.
 - **Undocumented internals.** This mod hooks private, unversioned classes
   inside `taskbar.dll` and `Taskbar.View.dll` (via symbols resolved from
   Microsoft's public symbol server at runtime, not hardcoded offsets). A
@@ -223,7 +253,7 @@ enum class UnresolvedAppsDefaultSide {
 // begin with, since it doesn't rank icons by distance at all.
 enum class PinnedAppsAnchor { OuterEdge, AdjacentToStart };
 
-struct {
+struct ModSettings {
     double gapPx;
     SystemButtonsPlacement systemButtonsPlacement;
     Side systemButtonsAdjacentSide;
@@ -232,7 +262,8 @@ struct {
     UnresolvedAppsDefaultSide unresolvedAppsDefaultSide;
     TaskListOrder taskListOrder;
     PinnedAppsAnchor pinnedAppsAnchor;
-} g_settings;
+};
+ModSettings g_settings;
 
 std::wstring ToLower(std::wstring s) {
     for (auto& c : s) {
@@ -245,10 +276,6 @@ std::wstring ToLower(std::wstring s) {
 // non-empty fragments for case-insensitive substring matching later.
 std::vector<std::wstring> ParseAppList(PCWSTR raw) {
     std::vector<std::wstring> result;
-    if (!raw) {
-        return result;
-    }
-
     std::wstring s(raw);
     size_t start = 0;
     while (start <= s.size()) {
@@ -272,20 +299,20 @@ std::vector<std::wstring> ParseAppList(PCWSTR raw) {
 }
 
 Side ParseSide(PCWSTR value, Side fallback) {
-    if (value && wcscmp(value, L"right") == 0) {
+    if (wcscmp(value, L"right") == 0) {
         return Side::Right;
     }
-    if (value && wcscmp(value, L"left") == 0) {
+    if (wcscmp(value, L"left") == 0) {
         return Side::Left;
     }
     return fallback;
 }
 
 UnresolvedAppsDefaultSide ParseUnresolvedAppsDefaultSide(PCWSTR value) {
-    if (value && wcscmp(value, L"right") == 0) {
+    if (wcscmp(value, L"right") == 0) {
         return UnresolvedAppsDefaultSide::Right;
     }
-    if (value && wcscmp(value, L"contralateral-to-system-buttons") == 0) {
+    if (wcscmp(value, L"contralateral-to-system-buttons") == 0) {
         return UnresolvedAppsDefaultSide::ContralateralToSystemButtons;
     }
     return UnresolvedAppsDefaultSide::Left;
@@ -316,7 +343,7 @@ Side ResolveUnresolvedAppsDefaultSide() {
 }
 
 PinnedAppsAnchor ParsePinnedAppsAnchor(PCWSTR value) {
-    if (value && wcscmp(value, L"adjacent-to-start") == 0) {
+    if (wcscmp(value, L"adjacent-to-start") == 0) {
         return PinnedAppsAnchor::AdjacentToStart;
     }
     return PinnedAppsAnchor::OuterEdge;
@@ -334,43 +361,47 @@ double PinnedAppOrderKey() {
                : std::numeric_limits<double>::infinity();
 }
 
-void LoadSettings() {
-    g_settings.gapPx = Wh_GetIntSetting(L"gapPx");
+// Reads every setting into a fresh ModSettings, with no dependency on
+// which thread it runs on - Wh_Get/FreeStringSetting don't touch XAML or
+// COM, unlike almost everything else in this file. Kept separate from
+// LoadSettings/g_settings itself so Wh_ModSettingsChanged can do this part
+// on its own calling thread and marshal only the resulting struct's
+// assignment - see its comment for why.
+ModSettings LoadSettingsFromStore() {
+    ModSettings s;
+    s.gapPx = Wh_GetIntSetting(L"gapPx");
 
-    PCWSTR placement = Wh_GetStringSetting(L"systemButtonsPlacement");
-    g_settings.systemButtonsPlacement =
-        (placement && wcscmp(placement, L"adjacent-start") == 0)
+    auto placement = WindhawkUtils::StringSetting::make(L"systemButtonsPlacement");
+    s.systemButtonsPlacement =
+        (wcscmp(placement, L"adjacent-start") == 0)
             ? SystemButtonsPlacement::AdjacentStart
             : SystemButtonsPlacement::FarLeft;
-    Wh_FreeStringSetting(placement);
 
-    PCWSTR adjacentSide = Wh_GetStringSetting(L"systemButtonsAdjacentSide");
-    g_settings.systemButtonsAdjacentSide = ParseSide(adjacentSide, Side::Left);
-    Wh_FreeStringSetting(adjacentSide);
+    auto adjacentSide =
+        WindhawkUtils::StringSetting::make(L"systemButtonsAdjacentSide");
+    s.systemButtonsAdjacentSide = ParseSide(adjacentSide, Side::Left);
 
-    PCWSTR leftApps = Wh_GetStringSetting(L"leftApps");
-    g_settings.leftApps = ParseAppList(leftApps);
-    Wh_FreeStringSetting(leftApps);
+    s.leftApps =
+        ParseAppList(WindhawkUtils::StringSetting::make(L"leftApps"));
+    s.rightApps =
+        ParseAppList(WindhawkUtils::StringSetting::make(L"rightApps"));
 
-    PCWSTR rightApps = Wh_GetStringSetting(L"rightApps");
-    g_settings.rightApps = ParseAppList(rightApps);
-    Wh_FreeStringSetting(rightApps);
+    s.unresolvedAppsDefaultSide = ParseUnresolvedAppsDefaultSide(
+        WindhawkUtils::StringSetting::make(L"unresolvedAppsDefaultSide"));
 
-    PCWSTR defaultSide = Wh_GetStringSetting(L"unresolvedAppsDefaultSide");
-    g_settings.unresolvedAppsDefaultSide =
-        ParseUnresolvedAppsDefaultSide(defaultSide);
-    Wh_FreeStringSetting(defaultSide);
+    auto taskListOrder = WindhawkUtils::StringSetting::make(L"taskListOrder");
+    s.taskListOrder = (wcscmp(taskListOrder, L"taskbar-order") == 0)
+                           ? TaskListOrder::TaskbarOrder
+                           : TaskListOrder::DistanceFromCenter;
 
-    PCWSTR taskListOrder = Wh_GetStringSetting(L"taskListOrder");
-    g_settings.taskListOrder =
-        (taskListOrder && wcscmp(taskListOrder, L"taskbar-order") == 0)
-            ? TaskListOrder::TaskbarOrder
-            : TaskListOrder::DistanceFromCenter;
-    Wh_FreeStringSetting(taskListOrder);
+    s.pinnedAppsAnchor = ParsePinnedAppsAnchor(
+        WindhawkUtils::StringSetting::make(L"pinnedAppsAnchor"));
 
-    PCWSTR pinnedAppsAnchor = Wh_GetStringSetting(L"pinnedAppsAnchor");
-    g_settings.pinnedAppsAnchor = ParsePinnedAppsAnchor(pinnedAppsAnchor);
-    Wh_FreeStringSetting(pinnedAppsAnchor);
+    return s;
+}
+
+void LoadSettings() {
+    g_settings = LoadSettingsFromStore();
 }
 
 // ============================================================================
@@ -411,6 +442,11 @@ std::atomic<int> g_winEventRawCount;
 std::atomic<int> g_winEventInvalidateCount;
 std::atomic<int> g_invalidateSkippedReentrant;
 std::atomic<int> g_invalidateExceptions;
+
+// Only ever touched from the dedicated WinEventHook thread (see
+// StartWinEventHook) - both WinEventProc and DragFollowTrailingTimerProc
+// run there exclusively, so this needs no synchronization.
+UINT_PTR g_dragFollowTrailingTimerId;
 
 // ============================================================================
 // Generic taskbar/XAML helpers
@@ -696,8 +732,8 @@ using CTaskListWnd_HandleClick_t = HRESULT(WINAPI*)(void* pThis,
 CTaskListWnd_HandleClick_t CTaskListWnd_HandleClick_Original;
 
 WCHAR g_clickSentinel[] = L"click-sentinel";
-void* g_clickSentinel_TaskItem;
-void* g_clickSentinel_TaskGroup;
+thread_local void* g_clickSentinel_TaskItem;
+thread_local void* g_clickSentinel_TaskGroup;
 
 HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
                                               void* taskGroup,
@@ -1185,6 +1221,38 @@ double GetMonitorCenterXLocal() {
     return localPx * scale;
 }
 
+// Width of the taskbar window itself, in the repeater's local DIPs. Only
+// used as RecomputeLayoutPlan's fallback bound for the right-side task
+// list group (see its own comment) when the system tray's own element
+// can't be resolved - the taskbar's own frame is a much looser bound than
+// the tray's actual left edge, since the tray only occupies the last
+// portion of the taskbar's full width.
+double GetTaskbarWidthLocal() {
+    RECT taskbarRect;
+    if (!GetWindowRect(g_hTaskbarWnd, &taskbarRect)) {
+        return 0;
+    }
+
+    UINT dpi = GetDpiForWindow(g_hTaskbarWnd);
+    double scale = dpi ? (96.0 / dpi) : 1.0;
+    return (taskbarRect.right - taskbarRect.left) * scale;
+}
+
+// element's own left edge (top-left corner), mapped into relativeTo's
+// coordinate space - e.g. the system tray frame's left edge in the same
+// local DIP space startCenterX and friends already use, since content
+// (the XamlRoot's own root element) shares that space's origin.
+// TransformToVisual/TransformPoint is the same technique
+// taskbar-reorder-right-drag.wh.cpp (already a technique source for this
+// mod) uses to map between an element's own space and an ancestor's.
+double GetElementLeftXLocal(FrameworkElement element,
+                            FrameworkElement relativeTo) {
+    auto transform = element.TransformToVisual(relativeTo);
+    auto point =
+        transform.TransformPoint(winrt::Windows::Foundation::Point{0, 0});
+    return point.X;
+}
+
 double FullFootprintWidth(FrameworkElement element) {
     Thickness m = element.Margin();
     return m.Left + element.ActualWidth() + m.Right;
@@ -1232,6 +1300,14 @@ bool IsTaskListButton(FrameworkElement element) {
 // ============================================================================
 // Layout: computing target X positions
 // ============================================================================
+
+// Small breathing room between the taskbar's own left edge and the first
+// system button in "far left" placement mode.
+constexpr double kFarLeftSystemButtonMarginPx = 8;
+
+// Small breathing room between the right-side task list group and the
+// system tray's own left edge (see RecomputeLayoutPlan's rightBoundLocal).
+constexpr double kTrayMarginPx = 8;
 
 int SystemButtonRank(SystemButton b) {
     switch (b) {
@@ -1305,7 +1381,7 @@ double ComputeSystemButtonX(const std::vector<ChildInfo>& childInfos,
     }
 
     if (g_settings.systemButtonsPlacement == SystemButtonsPlacement::FarLeft) {
-        return 8 + widthBefore;  // small left margin
+        return kFarLeftSystemButtonMarginPx + widthBefore;
     }
 
     double gap = g_settings.gapPx;
@@ -1349,21 +1425,53 @@ struct TaskListPlanEntry {
 
 // Computes every task list button's target X in a single O(n) pass over
 // the repeater's already-enumerated children, classifying each button
-// exactly once. The previous version (ComputeTaskListButtonX, called once
-// per button from RecomputeLayoutPlan's loop) re-walked and re-classified
-// every sibling for every single button it placed - an O(n^2) pass over
-// the whole task list on every ArrangeOverride pass (~1600 classifications
-// at 40 icons), on the shell's layout critical path during a drag. It also
-// re-derived each target's sibling list via VisualTreeHelper::GetParent
-// instead of reusing `children`, so it re-walked the repeater itself once
-// per button too. This also closes a subtle consistency gap the O(n^2)
-// version had: a button classified while being visited as someone else's
-// *sibling* could in principle disagree with its own classification when
-// later visited as the *target* (e.g. its HWND resolving mid-pass), which
-// could produce two buttons at the same X or a gap - classifying once up
-// front removes that possibility entirely.
+// exactly once - avoids both re-walking the repeater and re-classifying
+// every sibling for every single button placed, and the same up-front
+// classification means a button's side/order can't disagree with itself
+// depending on whether it's being visited as a target or as someone
+// else's sibling.
+//
+// Every entry is always written into outPlan, regardless of how far a
+// side's group runs past the taskbar's own edge or under the system tray
+// when enough apps pile up on one side - a real gap (see the mod's own
+// "Known limitations"), but confirmed via live testing NOT to be fixable
+// by leaving overflowing entries out of outPlan and letting them fall
+// through to native Arrange: Start's position is still being forced to
+// true screen-center by this mod's own hook regardless, and native's
+// layout algorithm computes positions assuming the whole row is Windows'
+// own single centered block with no knowledge Start has been moved -
+// mixing forced-position elements with native-position elements in the
+// same pass produced a visually incoherent overlap (confirmed: all task
+// list icons collapsing toward center and overlapping Start whenever one
+// side's group didn't fit). This is the same class of bug as the
+// "gate Start too during settling" fix from the mod's earlier
+// crash-debugging history: forcing part of a layout while leaving the
+// rest native never produces something coherent, only a mix of two
+// incompatible coordinate systems.
+//
+// The actual fix: every icon always stays in this mod's own coordinate
+// system, and a side that doesn't fit gets its inter-icon spacing
+// proportionally compressed (icons rendering at their natural width still
+// visually overlap each other once genuinely crowded) rather than ever
+// falling through to native or running past its bound. leftBoundLocal/
+// rightBoundLocal are the outer edges (local DIPs, same space as
+// startCenterX) each side's group is compressed to fit within -
+// leftBoundLocal is the taskbar's left edge, pushed right by the
+// Search/Task View/Widgets cluster's width in "far left" placement mode;
+// rightBoundLocal is the system tray's own left edge (see
+// RecomputeLayoutPlan's comment for how that's resolved), falling back to
+// the taskbar's own outer edge only if the tray element can't be found
+// this pass. Every side is
+// walked innermost-first, starting exactly at Start's own edge (minus
+// gap) and moving outward - so the innermost icon on a side is always
+// placed at that fixed, bound-independent reference point regardless of
+// how much compression is applied elsewhere in the same side, which is
+// what guarantees Start itself can never be overlapped no matter how
+// severe the overflow is.
 void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
                          double startCenterX,
+                         double leftBoundLocal,
+                         double rightBoundLocal,
                          std::unordered_map<void*, double>& outPlan) {
     std::vector<TaskListPlanEntry> entries;
     for (int i = 0; i < (int)children.size(); i++) {
@@ -1401,16 +1509,25 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
                              ? (g_lastRightSystemClusterWidth + gap)
                              : 0;
 
+    // Innermost reference point for each side - Start's own edge, minus
+    // the gap. Every side's innermost icon is placed exactly here,
+    // regardless of compression (see the function comment for why that's
+    // the Start-overlap safety guarantee).
+    double leftInnerX = startCenterX - startWidth / 2.0 - gap - leftExtra;
+    double rightInnerX = startCenterX + startWidth / 2.0 + gap + rightExtra;
+
+    std::vector<TaskListPlanEntry*> left, right;
+    for (auto& entry : entries) {
+        (entry.info.side == Side::Left ? left : right).push_back(&entry);
+    }
+
     if (g_settings.taskListOrder == TaskListOrder::DistanceFromCenter) {
-        // Innermost (closest to Start) first on each side. Ties - e.g.
-        // multiple pinned/overridden buttons, which all share the same
-        // +/-infinity orderKey - now break on taskbar index instead of
-        // the previous ABI-pointer value: equally stable frame to frame,
-        // but a predictable order instead of an arbitrary one.
-        std::vector<TaskListPlanEntry*> left, right;
-        for (auto& entry : entries) {
-            (entry.info.side == Side::Left ? left : right).push_back(&entry);
-        }
+        // Sort each side closest-to-center-first, i.e. innermost-first -
+        // exactly the walk order used below. Ties - e.g. multiple
+        // pinned/overridden buttons, which all share the same
+        // +/-infinity orderKey - break on taskbar index instead of an
+        // ABI-pointer value: equally stable frame to frame, but a
+        // predictable order instead of an arbitrary one.
         auto byOrderKey = [](const TaskListPlanEntry* a,
                              const TaskListPlanEntry* b) {
             if (a->info.orderKey != b->info.orderKey) {
@@ -1420,40 +1537,57 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
         };
         std::sort(left.begin(), left.end(), byOrderKey);
         std::sort(right.begin(), right.end(), byOrderKey);
-
-        double widthBefore = 0;
-        for (auto* entry : left) {
-            outPlan[winrt::get_abi(entry->element)] =
-                startCenterX - startWidth / 2.0 - gap - leftExtra -
-                widthBefore - entry->width;
-            widthBefore += entry->width;
-        }
-        widthBefore = 0;
-        for (auto* entry : right) {
-            outPlan[winrt::get_abi(entry->element)] = startCenterX +
-                startWidth / 2.0 + gap + rightExtra + widthBefore;
-            widthBefore += entry->width;
-        }
     } else {
-        // Preserve taskbar order: walk `entries` in original (taskbar)
-        // order, accumulating each side's width independently. Unchanged
-        // from before this rewrite: the left side ends up mirrored rather
-        // than laid out outward-from-Start - a pre-existing ordering
-        // quirk (tracked separately in the review) that this efficiency
-        // rewrite deliberately preserves rather than also fixing.
-        double leftWidthBefore = 0, rightWidthBefore = 0;
-        for (auto& entry : entries) {
-            if (entry.info.side == Side::Left) {
-                outPlan[winrt::get_abi(entry.element)] =
-                    startCenterX - startWidth / 2.0 - gap - leftExtra -
-                    leftWidthBefore - entry.width;
-                leftWidthBefore += entry.width;
-            } else {
-                outPlan[winrt::get_abi(entry.element)] = startCenterX +
-                    startWidth / 2.0 + gap + rightExtra + rightWidthBefore;
-                rightWidthBefore += entry.width;
-            }
-        }
+        // Preserve taskbar order, read left-to-right the same way the
+        // native taskbar does: the earliest entry in taskbar order on a
+        // side sits at that side's outer edge, and later entries sit
+        // progressively closer to Start - i.e. innermost-last. `left`/
+        // `right` are already in taskbar order (entries was built that
+        // way); the right side's innermost-last order already matches
+        // the walk order used below (accumulating outward from Start),
+        // but the left side needs reversing to innermost-first - walking
+        // it in original taskbar order here would put the *earliest*
+        // entry innermost instead, mirroring the group relative to
+        // native order.
+        std::reverse(left.begin(), left.end());
+    }
+
+    double leftTotal = 0;
+    for (auto* entry : left) {
+        leftTotal += entry->width;
+    }
+    double rightTotal = 0;
+    for (auto* entry : right) {
+        rightTotal += entry->width;
+    }
+
+    // Scale <1 compresses inter-icon spacing (not each icon's own
+    // rendered width, which this mod never touches) so the outermost
+    // icon's own position never passes leftBoundLocal/rightBoundLocal,
+    // at the cost of consecutive icons visually overlapping each other
+    // once a side is genuinely too full to fit at natural spacing. A
+    // side with plenty of room keeps scale at 1 (identical to natural,
+    // uncompressed spacing).
+    double leftAvailable = leftInnerX - leftBoundLocal;
+    double leftScale = 1.0;
+    if (leftTotal > leftAvailable) {
+        leftScale = leftAvailable > 0 ? (leftAvailable / leftTotal) : 0.0;
+    }
+    double rightAvailable = rightBoundLocal - rightInnerX;
+    double rightScale = 1.0;
+    if (rightTotal > rightAvailable) {
+        rightScale = rightAvailable > 0 ? (rightAvailable / rightTotal) : 0.0;
+    }
+
+    double x = leftInnerX;
+    for (auto* entry : left) {
+        x -= entry->width * leftScale;
+        outPlan[winrt::get_abi(entry->element)] = x;
+    }
+    x = rightInnerX;
+    for (auto* entry : right) {
+        outPlan[winrt::get_abi(entry->element)] = x;
+        x += entry->width * rightScale;
     }
 }
 
@@ -1484,6 +1618,14 @@ void StartWinEventHook();
 // same reason as StartWinEventHook above - starts the timer that drives
 // ResolvePendingButtonHwnds.
 void StartButtonHwndResolveTimer();
+
+// Defined later (Mod lifecycle section); forward-declared here so the
+// ArrangeOverride hook below can request an immediate HWND-resolve attempt
+// (delayMs = 0) as soon as it notices the task list button count changed,
+// rather than waiting for whatever delay the timer last computed for
+// itself - see NextResolveDelayMs' comment for why it can't see a
+// brand-new button coming on its own.
+void ArmButtonHwndResolveTimer(DWORD delayMs);
 
 // g_hTaskbarWnd is normally resolved once, in Wh_ModAfterInit. But if
 // Windhawk injects into explorer.exe before Shell_TrayWnd has been created
@@ -1644,10 +1786,12 @@ struct ArrangePassStats {
 };
 // thread_local: the ArrangeOverride hook (and so this Arrange hook, which
 // only ever runs nested inside it) runs once per taskbar instance's XAML
-// tree, process-wide - with a second monitor enabled that's the primary
-// taskbar and secondary-monitor taskbars potentially interleaving on
-// different threads. A single shared instance here was previously a data
-// race (unsynchronized concurrent reset/read of a non-atomic struct).
+// tree, process-wide. In practice all of them - primary and any
+// secondary-monitor taskbars - run on the same Explorer UI thread (see
+// RecomputeLayoutPlan's comment for how that was confirmed), so a plain
+// global would work too; thread_local costs nothing extra here and stays
+// correct even if that ever stopped being true, so it's kept as cheap
+// insurance rather than because it's currently load-bearing.
 thread_local ArrangePassStats g_passStats;
 
 HRESULT WINAPI IUIElement_Arrange_Hook(void* pThis,
@@ -1777,7 +1921,17 @@ void RecomputeLayoutPlan() {
         // pass by the time they run, not the previous one.
         for (auto& info : childInfos) {
             if (info.systemButton == SystemButton::Start) {
-                g_lastStartWidth = info.element.ActualWidth();
+                // ActualWidth() reflects the previous arrange pass, and is
+                // 0 for a just-realized element - a freshly (re)created
+                // Start button would otherwise briefly clobber
+                // g_lastStartWidth to 0 and lay out the entire taskbar
+                // around a zero-width Start for that pass. Keep the last
+                // known-good width instead; it'll catch up to the real
+                // one within a pass or two once ActualWidth reports it.
+                double w = info.element.ActualWidth();
+                if (w > 0) {
+                    g_lastStartWidth = w;
+                }
                 newPlan[winrt::get_abi(info.element)] =
                     startCenterX - g_lastStartWidth / 2.0;
                 break;
@@ -1820,10 +1974,35 @@ void RecomputeLayoutPlan() {
                 g_lastStartWidth, systemClusterWidth);
         }
 
+        // Bounds each task list group is compressed to fit within - see
+        // PlanTaskListButtons' own comment for what these mean and why.
+        double leftBoundLocal =
+            (g_settings.systemButtonsPlacement == SystemButtonsPlacement::FarLeft)
+                ? (kFarLeftSystemButtonMarginPx + systemClusterWidth)
+                : 0;
+
+        // The system tray/clock (SystemTray.SystemTrayFrame in this
+        // taskbar's own XAML tree, a sibling of Taskbar.TaskbarFrame
+        // under the same root content) is a real, measurable bound,
+        // unlike the taskbar's own outer edge - the tray only occupies
+        // the last portion of the taskbar's full width, so bounding
+        // against the whole taskbar barely constrains anything in
+        // practice (confirmed via live testing: icons still visibly ran
+        // under the tray with that bound). Falls back to the taskbar's
+        // own width only if the tray frame can't be resolved this pass.
+        FrameworkElement systemTrayFrame =
+            FindChildByClassName(content, L"SystemTray.SystemTrayFrame");
+        double rightBoundLocal =
+            systemTrayFrame
+                ? (GetElementLeftXLocal(systemTrayFrame, content) -
+                   kTrayMarginPx)
+                : GetTaskbarWidthLocal();
+
         // Task list buttons last - see PlanTaskListButtons' own comment
         // for why this is a single O(n) pass over `children` rather than
         // calling a per-button compute function in a loop here.
-        PlanTaskListButtons(children, startCenterX, newPlan);
+        PlanTaskListButtons(children, startCenterX, leftBoundLocal,
+                            rightBoundLocal, newPlan);
 
         g_lastArrangedX = std::move(newPlan);
     } catch (...) {
@@ -1882,17 +2061,19 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
     // simply has no entry for it (see g_lastArrangedX's comment) and it
     // renders at its native position for one pass. Self-correct by
     // invalidating whenever the observed count changes, which is enough
-    // for RecomputeLayoutPlan to pick it up on the next pass. Unlike the
-    // old version of this same self-correction, there's nothing left to
-    // suppress or re-arm here - RecomputeLayoutPlan is safe to call as
-    // often as this triggers it - so this is a plain count comparison
-    // with no gating logic alongside it.
+    // for RecomputeLayoutPlan to pick it up on the next pass; also arm an
+    // immediate HWND-resolve attempt, since a newly-inserted button is
+    // exactly the case ResolvePendingButtonHwnds' own cache-only view
+    // (NextResolveDelayMs) can't see coming on its own. There's nothing
+    // left to suppress or re-arm beyond that - RecomputeLayoutPlan is safe
+    // to call as often as this triggers it - so this is a plain count
+    // comparison with no gating logic alongside it.
     //
     // thread_local: this hook runs process-wide for every taskbar
-    // instance's XAML tree (primary and, with a second monitor enabled,
-    // secondary-monitor taskbars too), which can run on different threads
-    // with independently-changing button counts - a shared global here
-    // previously raced across instances.
+    // instance's XAML tree. In practice they all run on the same Explorer
+    // UI thread (see RecomputeLayoutPlan's comment), so a plain global
+    // would work too - kept thread_local as cheap insurance, same
+    // reasoning as g_passStats above.
     static thread_local int lastPlanTaskListCount = -1;
     int currentTaskListCount = g_planStats.taskListTotal;
     if (currentTaskListCount != lastPlanTaskListCount) {
@@ -1900,15 +2081,25 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
         lastPlanTaskListCount = currentTaskListCount;
         if (countChanged) {
             InvalidateTaskbarLayout();
+            ArmButtonHwndResolveTimer(0);
         }
     }
 
-    g_inTaskbarArrangeOverride = true;
+    // RAII rather than a plain set/clear pair around the original call:
+    // if that call ever exited non-locally, a plain clear below it would
+    // never run, leaving this stuck true and routing every later Arrange
+    // on this thread through the plan lookup regardless of context.
+    struct ScopedArrangeOverrideFlag {
+        ScopedArrangeOverrideFlag() { g_inTaskbarArrangeOverride = true; }
+        ~ScopedArrangeOverrideFlag() { g_inTaskbarArrangeOverride = false; }
+    };
 
-    HRESULT ret = TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original(
-        pThis, context, size, resultSize);
-
-    g_inTaskbarArrangeOverride = false;
+    HRESULT ret;
+    {
+        ScopedArrangeOverrideFlag scopedFlag;
+        ret = TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original(
+            pThis, context, size, resultSize);
+    }
 
     static ULONGLONG lastStatsLog;
     ULONGLONG now = GetTickCount64();
@@ -2034,6 +2225,20 @@ void InvalidateTaskbarLayout() {
     }
 }
 
+// One-shot: fires once the throttle window below has gone quiet, applying
+// whatever position a drag/move most recently landed on. See its arm site
+// in WinEventProc for why this exists.
+void CALLBACK DragFollowTrailingTimerProc(HWND hwnd,
+                                          UINT uMsg,
+                                          UINT_PTR idEvent,
+                                          DWORD dwTime) {
+    KillTimer(nullptr, idEvent);
+    g_dragFollowTrailingTimerId = 0;
+
+    g_winEventInvalidateCount++;
+    InvalidateTaskbarLayout();
+}
+
 void CALLBACK WinEventProc(HWINEVENTHOOK hook,
                            DWORD event,
                            HWND hwnd,
@@ -2056,9 +2261,29 @@ void CALLBACK WinEventProc(HWINEVENTHOOK hook,
     static ULONGLONG lastInvalidate;
     ULONGLONG now = GetTickCount64();
     if (now - lastInvalidate < 150) {
+        // The throttle above is leading-edge only, so the final
+        // location-change event of a drag/move - the one carrying its
+        // actual release position - is routinely the one that lands
+        // inside this window and gets dropped, since a drag generates a
+        // continuous event stream right up to release. Without this, the
+        // icon can be left classified by a stale mid-drag position until
+        // some unrelated window happens to move. Re-arm a short one-shot
+        // timer on every throttled event so it always fires once the
+        // burst actually goes quiet, applying the final position. Runs on
+        // this same dedicated WinEventHook thread (see
+        // g_dragFollowTrailingTimerId's comment).
+        if (g_dragFollowTrailingTimerId) {
+            KillTimer(nullptr, g_dragFollowTrailingTimerId);
+        }
+        g_dragFollowTrailingTimerId =
+            SetTimer(nullptr, 0, 200, DragFollowTrailingTimerProc);
         return;
     }
     lastInvalidate = now;
+    if (g_dragFollowTrailingTimerId) {
+        KillTimer(nullptr, g_dragFollowTrailingTimerId);
+        g_dragFollowTrailingTimerId = 0;
+    }
 
     g_winEventInvalidateCount++;
     InvalidateTaskbarLayout();
@@ -2246,52 +2471,92 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
 // Mod lifecycle
 // ============================================================================
 
-// WINEVENT_OUTOFCONTEXT delivers its callback on whichever thread called
-// SetWinEventHook, and only if that thread pumps messages. Wh_ModAfterInit
-// doesn't reliably run on the taskbar's own message-pumping UI thread (the
-// raw=0 counter in the logs confirms the callback never fired at all), so
-// registration is marshaled onto g_hTaskbarWnd's thread via
-// RunFromWindowThread, same technique already used for XAML tree access.
+// EVENT_OBJECT_LOCATIONCHANGE fires for every window move on the entire
+// system, not just windows this mod cares about - "thousands of raw
+// events within seconds" has been observed from something on the system
+// spamming it. WINEVENT_OUTOFCONTEXT delivers those callbacks on whichever
+// thread called SetWinEventHook, and only if that thread pumps messages.
+// Registering on g_hTaskbarWnd's own thread (as an earlier version of this
+// function did, via RunFromWindowThread) put every one of those events -
+// plus WinEventProc's IsWindowVisible/GetAncestor/GetWindow calls on each
+// one, all before the 150ms throttle even applies - in direct contention
+// with the shell's own layout work on the one thread responsible for it.
+// A dedicated mod-owned thread with its own message loop (the pattern
+// taskbar-background-helper.wh.cpp and
+// taskbar-auto-hide-when-maximized.wh.cpp both use for the same kind of
+// global WinEventHook) keeps all of that off the shell's thread entirely -
+// InvalidateTaskbarLayout already marshals onto the taskbar thread for the
+// one thing that actually needs to run there.
+DWORD WINAPI WinEventHookThreadProc(LPVOID) {
+    // Forces this thread's message queue into existence before
+    // SetWinEventHook runs, so WINEVENT_OUTOFCONTEXT has somewhere to
+    // deliver callbacks to as soon as registration succeeds, rather than
+    // racing the GetMessage loop below into existence.
+    MSG msg;
+    PeekMessage(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+
+    // Deliberately NOT using WINEVENT_SKIPOWNPROCESS: File Explorer
+    // windows often run inside explorer.exe's own process, and that flag
+    // would silently drop their location-change events too. The taskbar's
+    // own windows are already excluded explicitly in WinEventProc.
+    g_locationChangeHook = SetWinEventHook(
+        EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_LOCATIONCHANGE, nullptr,
+        WinEventProc, 0, 0, WINEVENT_OUTOFCONTEXT);
+    Wh_Log(L"WinEventHookThreadProc: handle=%p (dedicated thread %lu)",
+           g_locationChangeHook, GetCurrentThreadId());
+    if (!g_locationChangeHook) {
+        Wh_Log(L"Failed to register location-change hook - live "
+               L"drag-follow will not work, but everything else still "
+               L"will");
+    }
+
+    // WM_APP (posted by StopWinEventHook) is this thread's shutdown
+    // signal - it has no window to route to, so it's read directly out of
+    // the queue rather than via a window procedure.
+    while (GetMessage(&msg, nullptr, 0, 0) > 0) {
+        if (msg.message == WM_APP) {
+            break;
+        }
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+    }
+
+    if (g_locationChangeHook) {
+        UnhookWinEvent(g_locationChangeHook);
+        g_locationChangeHook = nullptr;
+    }
+
+    return 0;
+}
+
+HANDLE g_winEventThread;
+DWORD g_winEventThreadId;
+
 void StartWinEventHook() {
-    if (g_locationChangeHook || !g_hTaskbarWnd) {
+    if (g_winEventThread) {
         return;
     }
 
-    RunFromWindowThread(g_hTaskbarWnd, [] {
-        if (g_locationChangeHook) {
-            return;
-        }
-
-        // Deliberately NOT using WINEVENT_SKIPOWNPROCESS: File Explorer
-        // windows often run inside explorer.exe's own process, and that
-        // flag would silently drop their location-change events too. The
-        // taskbar's own windows are already excluded explicitly in
-        // WinEventProc.
-        g_locationChangeHook = SetWinEventHook(
-            EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_LOCATIONCHANGE, nullptr,
-            WinEventProc, 0, 0, WINEVENT_OUTOFCONTEXT);
-        Wh_Log(L"StartWinEventHook: handle=%p (registered on taskbar thread "
-               L"%lu)",
-               g_locationChangeHook, GetCurrentThreadId());
-        if (!g_locationChangeHook) {
-            Wh_Log(L"Failed to register location-change hook - live "
-                   L"drag-follow will not work, but everything else still "
-                   L"will");
-        }
-    });
+    g_winEventThread = CreateThread(nullptr, 0, WinEventHookThreadProc,
+                                    nullptr, 0, &g_winEventThreadId);
+    if (!g_winEventThread) {
+        Wh_Log(L"StartWinEventHook: CreateThread failed");
+    }
 }
 
 // RunFromWindowThread can only fail two ways: the taskbar's thread is
 // already gone (GetWindowThreadProcessId returns 0 - in which case the
-// OS already tore down any timer/hook that thread owned, so there's
-// nothing left to clean up), or its own internal SetWindowsHookEx call
-// failed (rare, e.g. transient resource exhaustion) while the thread is
-// still very much alive. That second case is the dangerous one: nothing
-// under mod control runs on the taskbar thread to unregister the real
-// WinEventHook/timer, Wh_ModUninit returns anyway, Windhawk unmaps this
+// OS already tore down any timer that thread owned, so there's nothing
+// left to clean up), or its own internal SetWindowsHookEx call failed
+// (rare, e.g. transient resource exhaustion) while the thread is still
+// very much alive. That second case is the dangerous one: nothing under
+// mod control runs on the taskbar thread to unregister the real
+// HWND-resolve timer, Wh_ModUninit returns anyway, Windhawk unmaps this
 // module's code, and the still-alive thread's next tick calls into
 // unmapped memory. A few retries gives that transient failure a chance to
 // clear without risking an unbounded stall if the thread really is gone.
+// (The WinEventHook itself no longer goes through this - see
+// StopWinEventHook, which owns its thread outright instead.)
 bool RunFromWindowThreadWithRetry(HWND hWnd, RunFromWindowThreadProc_t proc) {
     for (int attempt = 0; attempt < 3; attempt++) {
         if (RunFromWindowThread(hWnd, proc)) {
@@ -2305,27 +2570,27 @@ bool RunFromWindowThreadWithRetry(HWND hWnd, RunFromWindowThreadProc_t proc) {
     return false;
 }
 
+// Unlike the RunFromWindowThread-based teardowns below (which depend on
+// g_hTaskbarWnd's thread still being alive and responsive), this thread is
+// entirely mod-owned: PostThreadMessage can't silently fail the way a
+// marshaled call onto someone else's thread can, and waiting for the
+// thread to actually exit (rather than just requesting it) guarantees
+// UnhookWinEvent has already run, on the thread that registered it, by
+// the time this returns - before Windhawk unmaps this module's code.
 void StopWinEventHook() {
-    if (!g_locationChangeHook) {
+    if (!g_winEventThread) {
         return;
     }
 
-    HWINEVENTHOOK hook = g_locationChangeHook;
-    g_locationChangeHook = nullptr;
-
-    if (g_hTaskbarWnd) {
-        // See RunFromWindowThreadWithRetry's comment for why a bounded
-        // retry, rather than falling back to an inline UnhookWinEvent
-        // here - that's documented as unsafe from the wrong thread, so
-        // it would just trade one crash class for another.
-        if (!RunFromWindowThreadWithRetry(g_hTaskbarWnd,
-                                          [hook] { UnhookWinEvent(hook); })) {
-            Wh_Log(L"StopWinEventHook: RunFromWindowThread failed, "
-                   L"location-change hook left registered");
-        }
-    } else {
-        UnhookWinEvent(hook);
+    PostThreadMessage(g_winEventThreadId, WM_APP, 0, 0);
+    if (WaitForSingleObject(g_winEventThread, 2000) != WAIT_OBJECT_0) {
+        Wh_Log(L"StopWinEventHook: thread did not exit in time, "
+               L"location-change hook may be left registered");
     }
+
+    CloseHandle(g_winEventThread);
+    g_winEventThread = nullptr;
+    g_winEventThreadId = 0;
 }
 
 // Not 1: this is a window (Shell_TrayWnd) the mod doesn't own, shared with
@@ -2336,29 +2601,89 @@ void StopWinEventHook() {
 // classic-taskbar-properties.wh.cpp's kTimerIdMasterLayout).
 constexpr UINT_PTR kButtonHwndResolveTimerId = 0x8C3F;
 
+// How long until the next resolve attempt could possibly do anything
+// useful, based only on g_buttonHwndCache's already-recorded state - no
+// XAML/tree access, just a scan of an in-memory map, so this is cheap
+// enough to call after every timer tick. Mirrors the same backoff formula
+// ResolvePendingButtonHwnds uses to decide needsResolve for an existing
+// entry. Returns INFINITE when nothing currently unresolved is cached, in
+// which case the timer simply doesn't re-arm and stays off until
+// something else requests an attempt - either the ArrangeOverride hook's
+// button-count-change check (a brand-new button isn't in this cache at
+// all yet, so this function has no way to know about it on its own) or a
+// live element's cache entry going stale.
+DWORD NextResolveDelayMs() {
+    ULONGLONG now = GetTickCount64();
+    bool anyPending = false;
+    ULONGLONG earliestDue = 0;
+
+    for (auto& kv : g_buttonHwndCache) {
+        const ButtonHwndCacheEntry& entry = kv.second;
+        if (entry.hwnd) {
+            continue;
+        }
+        int shift = std::min(entry.consecutiveFailures, 4);
+        ULONGLONG dueAt = entry.lastAttempt + (2000ULL << shift);
+        if (!anyPending || dueAt < earliestDue) {
+            earliestDue = dueAt;
+            anyPending = true;
+        }
+    }
+
+    if (!anyPending) {
+        return INFINITE;
+    }
+
+    return earliestDue > now ? (DWORD)(earliestDue - now) : 0;
+}
+
 void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
                                          UINT uMsg,
                                          UINT_PTR idEvent,
                                          DWORD dwTime) {
+    // Self-managing one-shot rather than a recurring interval: stop first,
+    // do the actual work, then only re-arm if there's a concrete reason
+    // to. Without this, the timer would fire at a fixed cadence forever -
+    // running the full resolve pass (XamlRoot lookup, a visual-tree walk,
+    // a click-sentinel probe per due button) even while everything is
+    // already resolved and nothing has changed, which was flagged as a
+    // real objection on submissions here.
+    KillTimer(hwnd, kButtonHwndResolveTimerId);
+
     ResolvePendingButtonHwnds();
+
+    DWORD delay = NextResolveDelayMs();
+    if (delay != INFINITE) {
+        SetTimer(hwnd, kButtonHwndResolveTimerId, delay,
+                 ButtonHwndResolveTimerProc);
+    }
 }
 
 // SetTimer's callback fires on whichever thread registered it, so this is
-// marshaled onto g_hTaskbarWnd's own thread just like StartWinEventHook -
-// both KillTimer and (for reliability) SetTimer itself are documented to
-// need to run on the thread that owns the timer.
-void StartButtonHwndResolveTimer() {
+// marshaled onto g_hTaskbarWnd's own thread - both KillTimer and (for
+// reliability) SetTimer itself are documented to need to run on the
+// thread that owns the timer.
+void ArmButtonHwndResolveTimer(DWORD delayMs) {
     if (!g_hTaskbarWnd) {
         return;
     }
 
-    if (!RunFromWindowThread(g_hTaskbarWnd, [] {
-            SetTimer(g_hTaskbarWnd, kButtonHwndResolveTimerId, 500,
+    if (!RunFromWindowThread(g_hTaskbarWnd, [delayMs] {
+            SetTimer(g_hTaskbarWnd, kButtonHwndResolveTimerId, delayMs,
                      ButtonHwndResolveTimerProc);
         })) {
-        Wh_Log(L"StartButtonHwndResolveTimer: RunFromWindowThread failed, "
+        Wh_Log(L"ArmButtonHwndResolveTimer: RunFromWindowThread failed, "
                L"HWND resolution will not run");
     }
+}
+
+// Kicks off an initial resolve attempt shortly after the taskbar window
+// resolves, so buttons already present at mod startup get picked up -
+// after that, NextResolveDelayMs and the ArrangeOverride hook's
+// button-count-change check keep the timer armed only for as long as
+// there's actually something to do.
+void StartButtonHwndResolveTimer() {
+    ArmButtonHwndResolveTimer(100);
 }
 
 void StopButtonHwndResolveTimer() {
@@ -2366,8 +2691,8 @@ void StopButtonHwndResolveTimer() {
         return;
     }
 
-    // See StopWinEventHook's comment - same reasoning against an inline
-    // fallback call applies to KillTimer from the wrong thread.
+    // See RunFromWindowThreadWithRetry's own comment for why a bounded
+    // retry rather than an inline KillTimer from the wrong thread here.
     if (!RunFromWindowThreadWithRetry(g_hTaskbarWnd, [] {
             KillTimer(g_hTaskbarWnd, kButtonHwndResolveTimerId);
         })) {
@@ -2444,14 +2769,25 @@ void Wh_ModUninit() {
 void Wh_ModSettingsChanged() {
     Wh_Log(L">");
 
-    // LoadSettings() reassigns g_settings.leftApps/rightApps
-    // (std::vector<std::wstring>) - marshaled onto the taskbar's own
-    // thread so a concurrent ContainsAnyFragment call during a layout
-    // pass on that thread can't read a vector mid-reassignment.
+    // Read every setting on this calling thread first -
+    // Wh_Get/FreeStringSetting don't touch XAML/COM, so they don't need
+    // to run on the taskbar thread at all. Only the final assignment into
+    // g_settings is marshaled: it reassigns leftApps/rightApps
+    // (std::vector<std::wstring>), which a concurrent ContainsAnyFragment
+    // call during a layout pass on the taskbar thread could otherwise
+    // read mid-reassignment. Doing the reads here means the RunFromWindowThread
+    // call below blocks the taskbar thread (which may be in the middle of
+    // handling this via WH_CALLWNDPROC/SendMessage) for a plain struct
+    // move instead of several setting reads plus string work.
+    ModSettings settings = LoadSettingsFromStore();
+
     if (g_hTaskbarWnd) {
-        RunFromWindowThread(g_hTaskbarWnd, [] { LoadSettings(); });
+        RunFromWindowThread(g_hTaskbarWnd,
+                            [settings = std::move(settings)]() mutable {
+                                g_settings = std::move(settings);
+                            });
     } else {
-        LoadSettings();
+        g_settings = std::move(settings);
     }
 
     InvalidateTaskbarLayout();

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -31,6 +31,14 @@ taskbar buttons are split into two groups that flank the Start button:
   they land on, `pinnedAppsAnchor` picks whether they sit at the far edge
   or right next to Start.
 
+![Window left of screen-center](https://raw.githubusercontent.com/rycalvo/w11tb_centerer/main/screenshots/leftside.png) \
+_The crosshair-marked window sits left of screen-center - its taskbar icon
+follows, landing left of Start._
+
+![Window right of screen-center](https://raw.githubusercontent.com/rycalvo/w11tb_centerer/main/screenshots/rightdefault.png) \
+_The same window moved right of screen-center - its icon moves with it,
+to the right of Start._
+
 When you drag a window across the center line of the screen, its taskbar
 button switches sides to follow it. Side-switching is driven by a global
 window-location-change listener and is best-effort: it happens shortly
@@ -45,8 +53,9 @@ right next to Start on whichever side you prefer.
 - **Primary monitor only.** Screen-center math and window-side classification
   use the primary monitor. Taskbars on secondary displays are not specially
   handled by this mod (their icons keep the default layout Windows gives
-  them) - the positioning hook explicitly checks which taskbar's XAML tree
-  an element belongs to and leaves anything outside the primary's alone.
+  them) - the mod's positioning plan is only ever computed on the primary
+  taskbar's own thread, so secondary-monitor elements are simply never
+  included in it and fall through to Windows' native positioning.
 - **Undocumented internals.** This mod hooks private, unversioned classes
   inside `taskbar.dll` and `Taskbar.View.dll` (via symbols resolved from
   Microsoft's public symbol server at runtime, not hardcoded offsets). A
@@ -64,6 +73,15 @@ right next to Start on whichever side you prefer.
   "show taskbar apps on" setting is anything other than "All taskbars",
   since that's when a window moving across monitors structurally adds/
   removes taskbar buttons rather than just repositioning them).
+- **Taskbar buttons can disappear when a display is deactivated** (via
+  Settings, unplugging, or a third-party display on/off tool) - if
+  "Taskbar behaviors > When using multiple displays, show my taskbar apps
+  on" isn't set to "All taskbars", Windows itself can drop a window's
+  taskbar button entirely until you switch to that window (e.g. via
+  Alt+Tab), rather than migrating it to the remaining taskbar. Reactivating
+  a display doesn't trigger this. This is native Explorer/taskbar.dll
+  behavior upstream of anything the mod hooks into, not something this mod
+  causes or can work around.
 
 ## Disclosures
 

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -7,7 +7,7 @@
 // @github          https://github.com/rycalvo
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lcomctl32 -ldwmapi -lole32 -loleaut32 -lruntimeobject -lshcore
+// @compilerOptions -lcomctl32 -lole32 -loleaut32 -lruntimeobject
 // @license         GPL-3.0
 // ==/WindhawkMod==
 
@@ -65,85 +65,12 @@ right next to Start on whichever side you prefer.
   since that's when a window moving across monitors structurally adds/
   removes taskbar buttons rather than just repositioning them).
 
-## Changelog
-
-**Initial build (Aug 2026)**
-- Start button pinned to the primary monitor's true center, independent of
-  the number of taskbar icons.
-- Running-app icons split left/right of Start by live window position, with
-  drag-follow (a button switches sides shortly after its window crosses the
-  center line).
-- `taskListOrder`: icons ordered by distance from center, or by native
-  taskbar order.
-- Minimized windows keep their last known side instead of jumping (a
-  minimized window's reported position is off-screen nonsense, so it's
-  frozen at wherever it was before minimizing).
-- `leftApps`/`rightApps` name-based overrides, plus
-  `unresolvedAppsDefaultSide` for pinned-but-not-running apps with no
-  window to classify by.
-- `systemButtonsPlacement`/`systemButtonsAdjacentSide`: Search, Task View
-  and Widgets can sit at the far-left edge or adjacent to Start.
-
-**Feature follow-ups**
-- Support for "Combine taskbar buttons: Always" (grouped icons bind to a
-  different internal view model than individual windows, so this needed
-  its own resolution path).
-- Negative caching for HWND resolution, so a pinned-but-not-running app
-  (which will never resolve to a window) isn't retried on every single
-  layout pass.
-- Self-healing taskbar-window lookup, so the mod doesn't stay permanently
-  inert if Windhawk happens to inject before the taskbar itself exists yet
-  (observed right after a fresh boot).
-- `unresolvedAppsDefaultSide` gained a `contralateral-to-system-buttons`
-  option.
-- `pinnedAppsAnchor` setting: pinned-not-running apps can sit at the outer
-  edge of their side, or right next to Start.
-
-**Stability: cross-monitor moves**
-Moving a window to a second monitor repeatedly crashed explorer.exe across
-several iterations, each surfacing a different unsafe call path within the
-same underlying class of bug: a synchronous WinRT/XAML call made while the
-taskbar's own internal button list is mid-structural-mutation - reproducible
-specifically when Windows' "show taskbar apps on" setting isn't "All
-taskbars," since only then does a cross-monitor move add or remove taskbar
-buttons rather than just repositioning them. Root-caused via WinDbg
-crash-dump analysis after a few rounds of counter-based guessing didn't
-fully close it. Fixes along the way:
-- Corrected an unsafe cast that could throw while a fresh secondary-monitor
-  taskbar tree was still under construction.
-- Removed every forced-synchronous layout pass in favor of always deferring
-  to the XAML dispatcher's own next tick.
-- Scoped all positioning strictly to the primary taskbar's own XAML tree (a
-  process-wide hook was also seeing, and mis-positioning, secondary-monitor
-  taskbars).
-- Moved taskbar-button HWND resolution off the live layout pass entirely and
-  onto a periodic timer.
-- Added a brief "settling window" after any detected taskbar button-count
-  change, during which the mod holds off on the specific operations that
-  were still unsafe mid-mutation.
-
-**Settling-window polish**
-Once crash-free, the settling window itself produced two follow-on cosmetic
-issues, both fixed the same day:
-- The Start button no longer keeps re-centering while its neighbors are held
-  still during settling (previously caused a brief icons-over-Start overlap
-  on every cross-monitor move).
-- Fixed a bookkeeping bug that could make the settling window continuously
-  re-arm itself, making the taskbar look permanently reverted until some
-  unrelated event happened to nudge it back into place - now guaranteed to
-  resolve shortly after the triggering change instead.
-- Instead of snapping to Windows' native layout for the duration of the
-  settling window, the mod now holds every icon at its last known position
-  and only lets a genuinely new button show up unpositioned - much less
-  visually distracting on ordinary events like opening a new app.
-
 ## Disclosures
 
 I am not a software developer. The present mod was developed using the
-Claude Code extension in VS Code. I cannot verify the external integrity of
-this mod on other systems and do not take responsibility for issues that
-may arise for its use. This mod was created for my own interests and
-shared for targeted development by members of the Windhawk community.
+Claude Code extension in VS Code. This mod was created for my own
+interests and shared for targeted development by members of the Windhawk
+community.
 */
 // ==/WindhawkModReadme==
 
@@ -228,21 +155,20 @@ shared for targeted development by members of the Windhawk community.
 
 #include <atomic>
 #include <cmath>
+#include <cwctype>
 #include <functional>
+#include <iterator>
 #include <limits>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <commctrl.h>
-#include <dwmapi.h>
-#include <roapi.h>
-#include <winstring.h>
 
 #undef GetCurrentTime
 
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Xaml.Automation.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
@@ -437,66 +363,28 @@ std::atomic<bool> g_unloading;
 
 thread_local bool g_inTaskbarArrangeOverride;
 
-// GetTickCount64() deadline until which IUIElement_Arrange_Hook skips its
-// own repeater-traversal-based computation entirely (Start, task list
-// buttons, and the Search/TaskView/Widgets cluster alike) and instead
-// holds each element at its last legitimately-computed X via
-// ArrangeSettled/g_lastArrangedX (see that comment for why holding
-// position, not falling through to Windows' native layout, is both safe
-// and far less visually jarring). Set whenever the ArrangeOverride hook
-// detects the task list button count changed since the last pass (see its
-// call site) - i.e. right when a button is being structurally inserted
-// into or removed from an ItemsRepeater's data source, since that's the
-// confirmed trigger condition for a recurring explorer.exe crash (only
-// reproduces when Windows' "show taskbar apps on" setting causes a window
-// moving across monitors to change a taskbar's button *set*, not just
-// coordinates - see ResolveAndCacheButtonHwnd's comment for the fuller
-// history).
+// A recurring explorer.exe crash (STATUS_STOWED_EXCEPTION, confirmed via
+// WinDbg crash-dump analysis across several sessions) traced back to every
+// synchronous WinRT repeater-traversal call this file makes - reading
+// sibling elements, classifying them, measuring widths - being made from
+// *inside* IUIElement::Arrange, while XAML's own layout system can be
+// mid-structural-mutation of that same repeater (only reproduces when
+// Windows' "show taskbar apps on" setting causes a window moving across
+// monitors to change a taskbar's button *set*, not just coordinates).
+// Earlier attempts suppressed that traversal for a timing window after a
+// detected change (a "settling window") rather than eliminating it - a
+// real mitigation, but complex (needed its own recovery-guarantee and
+// re-arm-loop bug fixes) and still not the actual fix.
 //
-// Moving HWND resolution off the Arrange hook onto a timer measurably
-// helped (a confirmed crash-free stretch of real use, not just luck) but
-// didn't fully close the hole - the crash still recurs on cross-monitor
-// moves. Every synchronous WinRT call this file makes from inside Arrange
-// has, so far, turned out to belong to the same vulnerable class once
-// something structurally mutates the repeater mid-traversal, and none of
-// them ever show up as a catchable exception (see g_primaryXamlRootIdentity
-// and ResolveAndCacheButtonHwnd's comments for why - WinUI stows and
-// defers the report instead of throwing where the C++ call actually is).
-// Rather than hunt down and individually defer every remaining traversal
-// one crash at a time, this suppresses ALL of them for a settling window
-// after any detected structural change.
-//
-// Start's own positioning (ComputeStartButtonX) never touches a repeater,
-// so it isn't part of the crash-prone class and doesn't strictly need to be
-// gated - but it used to be left ungated anyway, and that was itself a bug:
-// with only its neighbors frozen, Start kept snapping to the forced screen
-// center every pass while nothing reserved that space around it, producing
-// a visible icons-overlaying-Start glitch on every structural change (e.g.
-// a window moving to another monitor). Gating Start too makes the whole
-// taskbar hold one consistent, already-correct-looking state through the
-// settling window instead of that mismatched hybrid.
-//
-// A pass genuinely needs to run once this deadline elapses, to give
-// everything a fresh Arrange reflecting whatever actually changed (new
-// button included) - see g_taskListSettlingRecoveryPending for how that's
-// actually guaranteed (the InvalidateTaskbarLayout() call made at the same
-// call site this is armed does NOT do it: that call lands, and gets
-// immediately re-skipped, *inside* the window it just opened, not after
-// it).
-thread_local ULONGLONG g_taskListSettlingUntil;
-
-// Set alongside g_taskListSettlingUntil whenever it's (re)armed; cleared
-// once a guaranteed post-settling InvalidateTaskbarLayout() has actually
-// fired (see ButtonHwndResolveTimerProc). Without this, recovery depended
-// entirely on some unrelated window happening to generate a location-change
-// event (or a taskbar button hwnd happening to need re-resolution) after
-// the settling window elapsed - both opportunistic, neither guaranteed -
-// which is what let the taskbar visibly sit un-refreshed (existing buttons
-// held at their last position, anything newly inserted mid-settling still
-// at its native one - see ArrangeSettled) for well past 1 second after a
-// cross-monitor window move, until something incidental finally kicked it
-// back into place.
-thread_local bool g_taskListSettlingRecoveryPending;
+// The actual fix: never call any of that traversal from inside a nested
+// Arrange call at all. RecomputeLayoutPlan (below) does the entire
+// traversal ONCE per ArrangeOverride pass, up front, before
+// TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original is called
+// (i.e. before any nested Arrange calls happen), and writes every
+// element's target X into g_lastArrangedX. IUIElement_Arrange_Hook then
+// becomes a pure map lookup - no traversal, no WinRT calls beyond the one
+// QueryInterface needed to identify the element, so there's nothing left
+// for XAML's mid-mutation state to make unsafe.
 
 HWND g_hTaskbarWnd;
 HWINEVENTHOOK g_locationChangeHook;
@@ -689,19 +577,44 @@ XamlRoot XamlRootFromTaskbarHostSharedPtr(void* taskbarHostSharedPtr[2]) {
         return nullptr;
     }
 
-    size_t taskbarElementIUnknownOffset = 0x10;
-
     // The offset of the XAML element pointer inside TaskbarHost isn't
     // exposed by any symbol, so it's read out of the prologue of a
     // neighboring function that's known to access it at a fixed offset.
+    // @architecture x86-64 also covers ARM64 - explorer.exe is a predefined
+    // shell process, so the mod is built and loaded natively as ARM64 there
+    // too, and the two architectures' prologues need separate opcode
+    // patterns. Bailing out on a pattern mismatch (rather than proceeding
+    // with a guessed offset) since a wrong offset here means dereferencing
+    // whatever happens to live there and calling a virtual method through
+    // it.
+    size_t taskbarElementIUnknownOffset = 0;
+    bool patternMatched = false;
+#if defined(_M_X64)
     // 48:83EC 28 | sub rsp,28
     // 48:83C1 48 | add rcx,48
     const BYTE* b = (const BYTE*)TaskbarHost_FrameHeight_Original;
     if (b[0] == 0x48 && b[1] == 0x83 && b[2] == 0xEC && b[4] == 0x48 &&
         b[5] == 0x83 && b[6] == 0xC1 && b[7] <= 0x7F) {
         taskbarElementIUnknownOffset = b[7];
-    } else {
-        Wh_Log(L"Unsupported TaskbarHost::FrameHeight, using default offset");
+        patternMatched = true;
+    }
+#elif defined(_M_ARM64)
+    // 7f2303d5 pacibsp
+    // fd7bbfa9 stp     fp, lr, [sp, #-0x10]!
+    // fd030091 mov     fp, sp
+    // 080c41f8 ldr     x8, [x0, #0x10]!
+    const DWORD* p = (const DWORD*)TaskbarHost_FrameHeight_Original;
+    if (p[0] == 0xD503237F && (p[1] & 0xFFC07FFF) == 0xA9807BFD &&
+        p[2] == 0x910003FD && (p[3] & 0xFFF00FE0) == 0xF8400C00) {
+        taskbarElementIUnknownOffset = (p[3] >> 12) & 0xFF;
+        patternMatched = true;
+    }
+#else
+#error "Unsupported architecture"
+#endif
+    if (!patternMatched) {
+        Wh_Log(L"Unsupported TaskbarHost::FrameHeight");
+        return nullptr;
     }
 
     auto* taskbarElementIUnknown =
@@ -743,43 +656,6 @@ XamlRoot GetTaskbarXamlRoot(HWND hTaskbarWnd) {
 
     return XamlRootFromTaskbarHostSharedPtr(taskbarHostSharedPtr);
 }
-
-// Raw IUnknown* for `xamlRoot`, valid ONLY as an opaque identity token for
-// pointer comparison - never dereferenced as a live object. QueryInterface
-// to IUnknown is what gives this COM identity semantics (guaranteed stable
-// and unique per underlying object, regardless of which interface either
-// side started from), the same guarantee g_buttonHwndCache already relies
-// on by keying off winrt::get_abi(element) elsewhere in this file.
-void* XamlRootIdentity(XamlRoot xamlRoot) {
-    if (!xamlRoot) {
-        return nullptr;
-    }
-    return winrt::get_abi(xamlRoot.try_as<IUnknown>());
-}
-
-// Identity of the PRIMARY taskbar's XamlRoot, resolved lazily and cached
-// (GetTaskbarXamlRoot is too expensive - GetProp, GetWindowLongPtr, a
-// vftable walk, a cross-DLL call - to redo on every Arrange call). Exists
-// so IUIElement_Arrange_Hook can tell whether an element it's about to
-// reposition actually belongs to the primary taskbar's own XAML tree.
-//
-// This hook replaces a single process-wide IUIElement::Arrange vtable
-// slot, so it fires for every taskbar instance's tree - including a
-// secondary monitor's, once any window (and its taskbar button) lives
-// there. Without this check, a secondary-monitor taskbar button was being
-// arranged using position math computed relative to the PRIMARY monitor's
-// center (every Compute*ButtonX function implicitly assumes "the"
-// taskbar is g_hTaskbarWnd) - handing that tree a Rect it has no valid
-// context for. That's exactly the kind of internal invariant violation
-// WinUI's own ReportUnhandledError/fail-fast machinery exists to catch:
-// confirmed via a WinDbg crash dump analysis (STATUS_STOWED_EXCEPTION,
-// CXcpDispatcher::Tick -> ReportUnhandledError -> RaiseFailFastException)
-// showing the fail-fast originates entirely inside Windows' own XAML
-// dispatcher, on a LATER tick than whatever triggered it - which is also
-// why no try/catch anywhere in this file ever saw it: WinUI's internal
-// ABI-boundary handling stows the error before it ever reaches our frame
-// as a catchable C++ exception, regardless of where the catch is placed.
-std::atomic<void*> g_primaryXamlRootIdentity;
 
 // ============================================================================
 // taskbar.dll: resolving the HWND behind a taskbar button
@@ -1070,10 +946,27 @@ HWND ResolveHwndFromTaskListButton(FrameworkElement element) {
 // full multi-sentinel resolution chain gets retried on every single arrange
 // pass (confirmed via g_resolveStats climbing into the hundreds within a
 // couple of seconds for just one such button).
+//
+// consecutiveFailures caps that retry, rather than letting it run forever
+// at the TTL's cadence: the resolution chain ends with a synthetic
+// ReportClicked call against the taskbar's real internal click handler
+// (intercepted before it acts on it - see CTaskListWnd_HandleClick_Hook),
+// and for a button that can genuinely never resolve (the common case,
+// exactly the one this negative cache exists for) that was firing roughly
+// once every 2s, indefinitely, for as long as explorer runs. The
+// interception is what keeps that inert today, but there's no reason to
+// keep invoking taskbar-internal click machinery on a timer forever for a
+// button that's already told us three times in a row that it has nothing
+// to resolve to. A live element that's simply slow to resolve (e.g. the
+// window it belongs to hasn't finished appearing yet) still gets the fresh
+// retries above, since the counter only advances on an actual failure and
+// resets to 0 on the first success.
 struct ButtonHwndCacheEntry {
     HWND hwnd = nullptr;
     ULONGLONG lastAttempt = 0;
+    int consecutiveFailures = 0;
 };
+constexpr int kMaxConsecutiveResolveFailures = 3;
 std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
 
 // Actually runs the resolution chain and updates the cache. Returns
@@ -1103,13 +996,16 @@ std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
 bool ResolveAndCacheButtonHwnd(FrameworkElement element) {
     void* key = winrt::get_abi(element);
     HWND previous = nullptr;
+    int failures = 0;
     auto it = g_buttonHwndCache.find(key);
     if (it != g_buttonHwndCache.end()) {
         previous = it->second.hwnd;
+        failures = it->second.consecutiveFailures;
     }
 
     HWND hwnd = ResolveHwndFromTaskListButton(element);
-    g_buttonHwndCache[key] = {hwnd, GetTickCount64()};
+    failures = hwnd ? 0 : failures + 1;
+    g_buttonHwndCache[key] = {hwnd, GetTickCount64(), failures};
     return hwnd != previous;
 }
 
@@ -1401,40 +1297,31 @@ double ComputeSystemButtonX(FrameworkElement repeater,
 // container as the task buttons (unconfirmed - see GetSiblingElements).
 double g_lastStartWidth = 48;
 
-// Diagnostics only: counts what got overridden during the current
-// ArrangeOverride pass, logged (throttled) from the pass's own hook.
-struct ArrangePassStats {
-    int totalArrangeCalls = 0;
-    int startHits = 0;
-    int pinnedHits = 0;
-    int taskListHits = 0;
+// Diagnostics only, for RecomputeLayoutPlan's once-per-pass traversal.
+struct LayoutPlanStats {
+    int taskListTotal = 0;
     int taskListHwndResolved = 0;
     int taskListLeft = 0;
     int taskListRight = 0;
-    int qiFailures = 0;
-    int noParent = 0;
     int exceptions = 0;
-    int wrongTaskbarSkipped = 0;
-    int settlingSkipped = 0;
 };
-// thread_local: the ArrangeOverride hook runs once per taskbar instance's
-// XAML tree, process-wide - with a second monitor enabled that's the
-// primary taskbar and secondary-monitor taskbars potentially interleaving
-// on different threads. A single shared instance here was a data race
-// (unsynchronized concurrent reset/read of a non-atomic struct) that also
-// fed directly into the button-count self-correction logic below.
-thread_local ArrangePassStats g_passStats;
+// thread_local since RecomputeLayoutPlan only ever does real work on the
+// primary taskbar's own thread, but stays thread_local rather than a plain
+// global on general principle for anything read alongside a per-pass
+// reset - see g_passStats' comment for the concrete bug that caused
+// (unrelated struct, same underlying risk).
+thread_local LayoutPlanStats g_planStats;
 
 double ComputeTaskListButtonX(FrameworkElement target,
                                double startCenterX) {
     ButtonClassification targetInfo = ClassifyTaskListButton(target);
     if (targetInfo.hwndResolved) {
-        g_passStats.taskListHwndResolved++;
+        g_planStats.taskListHwndResolved++;
     }
     if (targetInfo.side == Side::Left) {
-        g_passStats.taskListLeft++;
+        g_planStats.taskListLeft++;
     } else {
-        g_passStats.taskListRight++;
+        g_planStats.taskListRight++;
     }
 
     void* targetAbi = winrt::get_abi(target);
@@ -1590,23 +1477,57 @@ void ResolvePendingButtonHwnds() {
     ULONGLONG now = GetTickCount64();
     bool anyChanged = false;
 
+    std::unordered_set<void*> liveTaskListButtons;
+
     for (auto& child : GetRepeaterChildElements(repeater)) {
         if (!IsTaskListButton(child)) {
             continue;
         }
-
         void* key = winrt::get_abi(child);
+        liveTaskListButtons.insert(key);
+
         auto it = g_buttonHwndCache.find(key);
         bool needsResolve = it == g_buttonHwndCache.end();
         if (!needsResolve) {
-            needsResolve = it->second.hwnd
-                               ? !IsWindow(it->second.hwnd)
-                               : (now - it->second.lastAttempt >= 2000);
+            needsResolve =
+                it->second.hwnd
+                    ? !IsWindow(it->second.hwnd)
+                    : (it->second.consecutiveFailures <
+                           kMaxConsecutiveResolveFailures &&
+                       now - it->second.lastAttempt >= 2000);
         }
 
         if (needsResolve && ResolveAndCacheButtonHwnd(child)) {
             anyChanged = true;
         }
+    }
+
+    // Prune g_buttonHwndCache entries for buttons that no longer exist.
+    // XAML routinely destroys and recreates TaskListButtons (unpin, app
+    // close, virtualization), and the allocator can reuse a destroyed
+    // element's address for a later, unrelated one - without this, that
+    // new element would silently inherit the destroyed one's cached HWND
+    // (the cache is keyed by raw ABI pointer with no reference held, so
+    // there's no way to detect this other than checking against a fresh
+    // enumeration like this one). g_lastArrangedX doesn't need the same
+    // treatment - RecomputeLayoutPlan already rebuilds it from scratch
+    // every ArrangeOverride pass, so a stale entry there can never
+    // outlive one pass regardless.
+    for (auto it = g_buttonHwndCache.begin(); it != g_buttonHwndCache.end();) {
+        it = liveTaskListButtons.find(it->first) == liveTaskListButtons.end()
+                 ? g_buttonHwndCache.erase(it)
+                 : std::next(it);
+    }
+
+    // Same idea one level up: g_lastKnownWindowClassification is keyed by
+    // HWND, which Windows also recycles, and it's only ever consulted for
+    // a minimized window's frozen side (ClassifyByWindowPositionCached) -
+    // so a brand-new window could otherwise inherit a closed window's
+    // stale classification.
+    for (auto it = g_lastKnownWindowClassification.begin();
+         it != g_lastKnownWindowClassification.end();) {
+        it = IsWindow(it->first) ? std::next(it)
+                                  : g_lastKnownWindowClassification.erase(it);
     }
 
     if (anyChanged) {
@@ -1618,41 +1539,35 @@ using IUIElement_Arrange_t =
     HRESULT(WINAPI*)(void* pThis, winrt::Windows::Foundation::Rect rect);
 IUIElement_Arrange_t IUIElement_Arrange_Original;
 
-// Last X each element (Start, a system button, or a task list button) was
-// legitimately arranged at by this mod - keyed by the XAML element's ABI
-// pointer, same identity technique as g_buttonHwndCache. Written only from
-// the non-gated path below (a real ComputeXX call, outside the settling
-// window); read only from the gated path, so a settling pass can hold
-// every already-known element exactly where it last legitimately was
-// instead of visibly snapping to Windows' native layout for up to a
-// second and back. Y/Width/Height still come from the CURRENT pass's
-// incoming rect, not this cache - those can legitimately change pass to
-// pass (DPI, taskbar height) independent of X, and freezing them too could
-// look wrong across e.g. a DPI change. A brand-new element (no entry yet -
-// necessarily the case for whatever just triggered this settling window,
-// since a just-inserted button can't have a prior legitimate X) has
-// nothing to fall back to and still shows at its native position until
-// settling clears, same as before this cache existed.
-//
-// Not pruned when a button disappears - same acceptable tradeoff as
-// g_buttonHwndCache; a stale entry just sits unread forever if that exact
-// element (identified by ABI pointer) never reappears.
+// Every Start/system-button/task-list-button's target X, keyed by the XAML
+// element's ABI pointer (same identity technique as g_buttonHwndCache).
+// Written only by RecomputeLayoutPlan, which rebuilds this map from
+// scratch on every ArrangeOverride pass (see its own comment) - so
+// IUIElement_Arrange_Hook below never needs to compute anything itself,
+// only look a value up. An element with no entry (a secondary-monitor
+// element, which RecomputeLayoutPlan never walks; or a primary element so
+// new it wasn't realized yet when this pass's plan was built) falls
+// through to Windows' own native positioning for that one pass, same as
+// any element this mod doesn't touch at all.
 std::unordered_map<void*, double> g_lastArrangedX;
 
-// Used by every gated branch in IUIElement_Arrange_Hook below - see
-// g_lastArrangedX's comment. Deliberately does no repeater traversal (the
-// actual crash-prone operation the settling window guards against): a
-// map lookup and, at most, one more IUIElement::Arrange call, identical in
-// shape to what original() already does.
-HRESULT ArrangeSettled(void* pThis,
-                       winrt::Windows::Foundation::Rect rect,
-                       void* key) {
-    auto it = g_lastArrangedX.find(key);
-    if (it != g_lastArrangedX.end()) {
-        rect.X = it->second;
-    }
-    return IUIElement_Arrange_Original(pThis, rect);
-}
+// Diagnostics only, for IUIElement_Arrange_Hook's own per-call work
+// (distinct from LayoutPlanStats, which covers RecomputeLayoutPlan's
+// once-per-pass traversal - two different phases now that the plan is
+// built up front rather than computed inline here).
+struct ArrangePassStats {
+    int totalArrangeCalls = 0;
+    int repositioned = 0;
+    int qiFailures = 0;
+    int exceptions = 0;
+};
+// thread_local: the ArrangeOverride hook (and so this Arrange hook, which
+// only ever runs nested inside it) runs once per taskbar instance's XAML
+// tree, process-wide - with a second monitor enabled that's the primary
+// taskbar and secondary-monitor taskbars potentially interleaving on
+// different threads. A single shared instance here was previously a data
+// race (unsynchronized concurrent reset/read of a non-atomic struct).
+thread_local ArrangePassStats g_passStats;
 
 HRESULT WINAPI IUIElement_Arrange_Hook(void* pThis,
                                        winrt::Windows::Foundation::Rect rect) {
@@ -1673,7 +1588,10 @@ HRESULT WINAPI IUIElement_Arrange_Hook(void* pThis,
     // and .as<T>() throws on a null source where .try_as<T>() would just
     // return null) crosses that boundary uncaught and fail-fasts the whole
     // process. Catch anything and fall back to the real implementation
-    // rather than let that happen again.
+    // rather than let that happen again. The QueryInterface below is the
+    // only WinRT call left in this function - everything else is a plain
+    // map lookup - so this net is mostly a leftover safety margin at this
+    // point rather than something expected to actually catch anything.
     try {
         g_passStats.totalArrangeCalls++;
 
@@ -1686,117 +1604,128 @@ HRESULT WINAPI IUIElement_Arrange_Hook(void* pThis,
             return original();
         }
 
-        // Only reposition elements belonging to the PRIMARY taskbar's own
-        // XAML tree - see the comment on g_primaryXamlRootIdentity for why
-        // this check exists (it's the fix for a confirmed crash, not a
-        // defensive nicety). Resolved lazily and cached; if it hasn't
-        // resolved yet, fail safe by skipping rather than risking another
-        // misapplied Rect.
-        //
-        // The resolution call itself is ONLY attempted when confirmed to be
-        // running on the primary taskbar's own UI thread. element.XamlRoot()
-        // is always safe regardless of thread (XAML only ever invokes
-        // Arrange on an element's own thread), but GetTaskbarXamlRoot(
-        // g_hTaskbarWnd) reaches across to the PRIMARY's XAML object
-        // specifically - every other call site for it in this file
-        // marshals via RunFromWindowThread first. This one can't (Arrange
-        // needs a synchronous answer), so instead it skips the resolution
-        // attempt entirely on the wrong thread and retries next call - it's
-        // guaranteed to eventually run on the primary's own thread once
-        // primary's own elements arrange, no marshaling needed. Skipping
-        // this thread check on the first version of this fix was itself a
-        // second, unmarshaled cross-apartment WinRT call - i.e. a fresh
-        // instance of the very same crash class this whole check exists to
-        // prevent, which is why it could still crash with
-        // wrongTaskbarSkipped staying at 0 (the crash happened inside this
-        // resolution call, before ever reaching that counter).
-        void* primaryIdentity = g_primaryXamlRootIdentity.load();
-        if (!primaryIdentity) {
-            DWORD primaryThreadId = GetWindowThreadProcessId(g_hTaskbarWnd, nullptr);
-            if (primaryThreadId != 0 && primaryThreadId == GetCurrentThreadId()) {
-                primaryIdentity =
-                    XamlRootIdentity(GetTaskbarXamlRoot(g_hTaskbarWnd));
-                if (primaryIdentity) {
-                    g_primaryXamlRootIdentity.store(primaryIdentity);
-                }
-            }
-        }
-        void* elementIdentity = XamlRootIdentity(element.XamlRoot());
-        if (!primaryIdentity || !elementIdentity ||
-            elementIdentity != primaryIdentity) {
-            g_passStats.wrongTaskbarSkipped++;
+        auto it = g_lastArrangedX.find(winrt::get_abi(element));
+        if (it == g_lastArrangedX.end()) {
             return original();
         }
 
-        auto repeater = Media::VisualTreeHelper::GetParent(element)
-                            .try_as<FrameworkElement>();
-        if (!repeater) {
-            g_passStats.noParent++;
-            return original();
-        }
-
-        SystemButton systemButton = IdentifySystemButton(element);
-
+        g_passStats.repositioned++;
         winrt::Windows::Foundation::Rect newRect = rect;
-
-        if (systemButton == SystemButton::Start) {
-            // Originally left ungated, on the reasoning that
-            // ComputeStartButtonX never touches a repeater so it isn't part
-            // of the crash-prone class the settling window guards against
-            // (see g_taskListSettlingUntil's comment). That missed a
-            // cosmetic consequence: gating the task list/system buttons but
-            // NOT Start meant Start kept snapping to the forced screen
-            // center every pass while its neighbors froze at wherever
-            // native XAML layout put them (which doesn't reserve center
-            // space for a repositioned Start) - the observed "icons overlay
-            // the centered Start button" glitch on every structural change,
-            // e.g. a window moving to another monitor. Gating Start too
-            // makes the whole taskbar fall back to one consistent state
-            // for the settling window instead of a mismatched hybrid;
-            // it's still safe to gate since this is only skipping our own
-            // Rect override, not adding a new repeater traversal.
-            if (GetTickCount64() < g_taskListSettlingUntil) {
-                g_passStats.settlingSkipped++;
-                return ArrangeSettled(pThis, rect, winrt::get_abi(element));
-            }
-            g_passStats.startHits++;
-            g_lastStartWidth = element.ActualWidth();
-            newRect.X = ComputeStartButtonX(element);
-            g_lastArrangedX[winrt::get_abi(element)] = newRect.X;
-        } else if (systemButton == SystemButton::Search ||
-                   systemButton == SystemButton::TaskView ||
-                   systemButton == SystemButton::Widgets) {
-            // See g_taskListSettlingUntil's comment: both this branch and
-            // the task list one below call into repeater traversal
-            // (SystemButtonClusterWidth / GetSiblingElements), which is
-            // suppressed for a short window after any detected
-            // structural change to the button set.
-            if (GetTickCount64() < g_taskListSettlingUntil) {
-                g_passStats.settlingSkipped++;
-                return ArrangeSettled(pThis, rect, winrt::get_abi(element));
-            }
-            g_passStats.pinnedHits++;
-            newRect.X = ComputeSystemButtonX(repeater, element, systemButton,
-                                             GetMonitorCenterXLocal(),
-                                             g_lastStartWidth);
-            g_lastArrangedX[winrt::get_abi(element)] = newRect.X;
-        } else if (IsTaskListButton(element)) {
-            if (GetTickCount64() < g_taskListSettlingUntil) {
-                g_passStats.settlingSkipped++;
-                return ArrangeSettled(pThis, rect, winrt::get_abi(element));
-            }
-            g_passStats.taskListHits++;
-            double startCenterX = GetMonitorCenterXLocal();
-            newRect.X = ComputeTaskListButtonX(element, startCenterX);
-            g_lastArrangedX[winrt::get_abi(element)] = newRect.X;
-        } else {
-            return original();
-        }
-
+        newRect.X = it->second;
         return IUIElement_Arrange_Original(pThis, newRect);
     } catch (...) {
         g_passStats.exceptions++;
         return original();
+    }
+}
+
+// Builds the complete layout plan in a single top-down pass over the
+// PRIMARY taskbar's own repeater - every Start/system-button/task-list-
+// button's target X, written into g_lastArrangedX - called from
+// TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook BEFORE it calls
+// into XAML's own ArrangeOverride, i.e. before any nested Arrange calls
+// (and so IUIElement_Arrange_Hook above) run at all for this pass. That
+// ordering is the actual fix for the crash class the old settling-window
+// mechanism used to paper over - see g_inTaskbarArrangeOverride's comment.
+//
+// Rebuilds g_lastArrangedX from scratch every call rather than updating
+// incrementally, so a destroyed element's stale entry can never outlive
+// it - no separate pruning pass needed for this map, unlike
+// g_buttonHwndCache/g_lastKnownWindowClassification (populated
+// independently by the HWND-resolve timer - see ResolvePendingButtonHwnds
+// for why those still need explicit pruning).
+//
+// MUST only run when confirmed to be on the primary taskbar's own thread:
+// GetTaskbarXamlRoot(g_hTaskbarWnd) reaches across to the PRIMARY's XAML
+// object specifically, which is an unsafe unmarshaled cross-apartment
+// WinRT call from any other thread. This hook is process-wide (also fires
+// for secondary-monitor taskbars, on their own threads), so without this
+// check a secondary-monitor pass calling this function would be exactly
+// the same crash class fixed elsewhere in this file by marshaling through
+// RunFromWindowThread - except Arrange can't marshal (it needs a
+// synchronous answer), so the only safe option is to skip the attempt
+// entirely on the wrong thread. That's fine here: this function is only
+// ever useful for the primary's own passes anyway (see g_lastArrangedX's
+// comment on why secondary-monitor elements are never meant to get an
+// entry), and it naturally gets called again on the primary's own next
+// pass with no special retry logic needed.
+void RecomputeLayoutPlan() {
+    if (!g_hTaskbarWnd) {
+        return;
+    }
+    DWORD primaryThreadId = GetWindowThreadProcessId(g_hTaskbarWnd, nullptr);
+    if (primaryThreadId == 0 || primaryThreadId != GetCurrentThreadId()) {
+        return;
+    }
+
+    g_planStats = {};
+
+    try {
+        XamlRoot xamlRoot = GetTaskbarXamlRoot(g_hTaskbarWnd);
+        if (!xamlRoot) {
+            return;
+        }
+        FrameworkElement content = xamlRoot.Content().try_as<FrameworkElement>();
+        FrameworkElement repeater = FindTaskbarFrameRepeater(content);
+        if (!repeater) {
+            return;
+        }
+
+        auto children = GetRepeaterChildElements(repeater);
+        double startCenterX = GetMonitorCenterXLocal();
+        std::unordered_map<void*, double> newPlan;
+
+        // Start first: ComputeSystemButtonX/ComputeTaskListButtonX below
+        // both read g_lastStartWidth, so it needs to already reflect this
+        // pass by the time they run, not the previous one. Inlined rather
+        // than calling ComputeStartButtonX (same formula) purely to reuse
+        // the startCenterX already computed once above, instead of that
+        // function re-deriving it via another GetMonitorCenterXLocal()
+        // call.
+        for (auto& child : children) {
+            if (IdentifySystemButton(child) == SystemButton::Start) {
+                g_lastStartWidth = child.ActualWidth();
+                newPlan[winrt::get_abi(child)] =
+                    startCenterX - g_lastStartWidth / 2.0;
+                break;
+            }
+        }
+
+        // Search/TaskView/Widgets next: ComputeTaskListButtonX reads
+        // g_lastLeftSystemClusterWidth/g_lastRightSystemClusterWidth
+        // (updated inside ComputeSystemButtonX), so these need to run
+        // before any task list button below for the same reason.
+        for (auto& child : children) {
+            SystemButton sb = IdentifySystemButton(child);
+            if (sb == SystemButton::None || sb == SystemButton::Start) {
+                continue;
+            }
+            newPlan[winrt::get_abi(child)] = ComputeSystemButtonX(
+                repeater, child, sb, startCenterX, g_lastStartWidth);
+        }
+
+        // Task list buttons last. ComputeTaskListButtonX still does its
+        // own O(n) walk of sibling buttons per button it's called for (an
+        // O(n^2) pass overall) - left as-is here since this change is
+        // scoped to fixing WHERE that traversal happens (never nested
+        // inside Arrange anymore), not also rewriting its algorithmic
+        // cost in the same pass.
+        for (auto& child : children) {
+            if (!IsTaskListButton(child)) {
+                continue;
+            }
+            g_planStats.taskListTotal++;
+            newPlan[winrt::get_abi(child)] =
+                ComputeTaskListButtonX(child, startCenterX);
+        }
+
+        g_lastArrangedX = std::move(newPlan);
+    } catch (...) {
+        g_planStats.exceptions++;
+        // g_lastArrangedX is left as whatever the last successful pass
+        // produced - IUIElement_Arrange_Hook's lookup-or-fall-through
+        // handles a stale/incomplete plan exactly like it already handles
+        // a brand-new not-yet-planned element.
     }
 }
 
@@ -1835,6 +1764,39 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
 
     EnsureTaskbarWnd();
 
+    // Builds this pass's whole plan up front - see RecomputeLayoutPlan's
+    // comment for why this ordering (before the original ArrangeOverride,
+    // and so before any nested Arrange calls) is what actually closes the
+    // crash class the old settling-window mechanism used to work around.
+    RecomputeLayoutPlan();
+
+    // The button count can change without any window moving (new pin, app
+    // launched/closed). If RecomputeLayoutPlan's repeater walk ran before
+    // XAML had realized a just-inserted button yet, this pass's plan
+    // simply has no entry for it (see g_lastArrangedX's comment) and it
+    // renders at its native position for one pass. Self-correct by
+    // invalidating whenever the observed count changes, which is enough
+    // for RecomputeLayoutPlan to pick it up on the next pass. Unlike the
+    // old version of this same self-correction, there's nothing left to
+    // suppress or re-arm here - RecomputeLayoutPlan is safe to call as
+    // often as this triggers it - so this is a plain count comparison
+    // with no gating logic alongside it.
+    //
+    // thread_local: this hook runs process-wide for every taskbar
+    // instance's XAML tree (primary and, with a second monitor enabled,
+    // secondary-monitor taskbars too), which can run on different threads
+    // with independently-changing button counts - a shared global here
+    // previously raced across instances.
+    static thread_local int lastPlanTaskListCount = -1;
+    int currentTaskListCount = g_planStats.taskListTotal;
+    if (currentTaskListCount != lastPlanTaskListCount) {
+        bool countChanged = lastPlanTaskListCount != -1;
+        lastPlanTaskListCount = currentTaskListCount;
+        if (countChanged) {
+            InvalidateTaskbarLayout();
+        }
+    }
+
     g_inTaskbarArrangeOverride = true;
 
     HRESULT ret = TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original(
@@ -1842,79 +1804,23 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
 
     g_inTaskbarArrangeOverride = false;
 
-    // The button count can change without any window moving (new pin, app
-    // launched/closed), and the taskbar's own virtualization bookkeeping
-    // doesn't reliably reconcile with our position overrides for a newly
-    // realized element - the symptom is a new pin not appearing at all
-    // until something forces a full fresh relayout. Self-correct by
-    // invalidating whenever the count changes, which is enough for the new
-    // element to settle on the XAML dispatcher's next tick. Guarded against
-    // recursing more than one level deep.
-    //
-    // thread_local rather than a single global: this hook runs process-wide
-    // for every taskbar instance's XAML tree (primary and, with a second
-    // monitor enabled, secondary-monitor taskbars too), and those can run
-    // on different threads with independently-changing button counts. A
-    // shared global here raced across instances - one taskbar's pass could
-    // see another's count change and misfire - which is exactly the
-    // condition (taskList count oscillating 4->1->4 across two passes)
-    // observed immediately preceding a crash-loop with a second monitor
-    // enabled.
-    static thread_local int lastTaskListButtonCount = -1;
-    static thread_local bool inCountChangeRetry;
-    int currentCount = g_passStats.taskListHits;
-    // A settling-gated pass reads currentCount as a synthetic 0 (every
-    // element that would've counted toward taskListHits returns early via
-    // the settlingSkipped branch instead - see IUIElement_Arrange_Hook).
-    // That's not a real reading of the button set, so it must never reach
-    // the comparison below or get written into lastTaskListButtonCount:
-    // doing so previously made the very moment settling naturally expired
-    // - the first pass to see the real count again - look like a SECOND
-    // structural change (real count vs. the stale synthetic 0), which
-    // re-armed settling right back on, ad infinitum. That produced a
-    // self-sustaining flash cycle with no further genuine trigger - the
-    // taskbar kept re-blanking every few seconds long after the one actual
-    // cross-monitor move, which is what made the mod look permanently
-    // stuck/disabled rather than settling once and recovering.
-    bool passWasGated = g_passStats.settlingSkipped > 0;
-    if (!passWasGated && currentCount != lastTaskListButtonCount) {
-        bool countChanged = lastTaskListButtonCount != -1;
-        lastTaskListButtonCount = currentCount;
-        if (countChanged) {
-            // See g_taskListSettlingUntil's comment: suppress our own
-            // repeater-traversal-based positioning for a bit after any
-            // detected structural change, regardless of the
-            // inCountChangeRetry guard below (that guard is only about
-            // not recursing the invalidate call itself).
-            g_taskListSettlingUntil = GetTickCount64() + 1000;
-            g_taskListSettlingRecoveryPending = true;
-            if (!inCountChangeRetry) {
-                inCountChangeRetry = true;
-                InvalidateTaskbarLayout();
-                inCountChangeRetry = false;
-            }
-        }
-    }
-
     static ULONGLONG lastStatsLog;
     ULONGLONG now = GetTickCount64();
     if (now - lastStatsLog > 2000) {
         lastStatsLog = now;
         Wh_Log(
-            L"Arrange pass: total=%d start=%d pinned=%d taskList=%d "
-            L"(hwndResolved=%d left=%d right=%d) qiFail=%d noParent=%d "
-            L"wrongTaskbarSkipped=%d settlingSkipped=%d exceptions=%d | "
-            L"winEvents: raw=%d invalidated=%d skippedReentrant=%d "
-            L"invalidateExceptions=%d | resolve(individual): ok=%d "
-            L"viewModelNull=%d getTaskItemFail=%d sentinelNoItem=%d | "
-            L"resolve(group): ok=%d viewModelNull=%d sentinelNoGroup=%d "
-            L"noItems=%d",
-            g_passStats.totalArrangeCalls, g_passStats.startHits,
-            g_passStats.pinnedHits, g_passStats.taskListHits,
-            g_passStats.taskListHwndResolved, g_passStats.taskListLeft,
-            g_passStats.taskListRight, g_passStats.qiFailures,
-            g_passStats.noParent, g_passStats.wrongTaskbarSkipped,
-            g_passStats.settlingSkipped, g_passStats.exceptions,
+            L"Arrange pass: arrangeCalls=%d repositioned=%d qiFail=%d "
+            L"exceptions=%d | plan: taskList=%d (hwndResolved=%d left=%d "
+            L"right=%d) planExceptions=%d | winEvents: raw=%d "
+            L"invalidated=%d skippedReentrant=%d invalidateExceptions=%d | "
+            L"resolve(individual): ok=%d viewModelNull=%d getTaskItemFail=%d "
+            L"sentinelNoItem=%d | resolve(group): ok=%d viewModelNull=%d "
+            L"sentinelNoGroup=%d noItems=%d",
+            g_passStats.totalArrangeCalls, g_passStats.repositioned,
+            g_passStats.qiFailures, g_passStats.exceptions,
+            g_planStats.taskListTotal, g_planStats.taskListHwndResolved,
+            g_planStats.taskListLeft, g_planStats.taskListRight,
+            g_planStats.exceptions,
             (int)g_winEventRawCount,
             (int)g_winEventInvalidateCount, (int)g_invalidateSkippedReentrant,
             (int)g_invalidateExceptions, g_resolveStats.success,
@@ -2278,31 +2184,32 @@ void StopWinEventHook() {
     g_locationChangeHook = nullptr;
 
     if (g_hTaskbarWnd) {
-        RunFromWindowThread(g_hTaskbarWnd, [hook] { UnhookWinEvent(hook); });
+        // If this fails to marshal (the taskbar window is somehow already
+        // gone), the hook is leaked rather than left dangling into
+        // unmapped memory after this module unloads - UnhookWinEvent from
+        // the wrong thread is documented as unsafe, so falling back to
+        // calling it inline here would trade one crash class for another.
+        if (!RunFromWindowThread(g_hTaskbarWnd, [hook] { UnhookWinEvent(hook); })) {
+            Wh_Log(L"StopWinEventHook: RunFromWindowThread failed, "
+                   L"location-change hook left registered");
+        }
     } else {
         UnhookWinEvent(hook);
     }
 }
 
-// Arbitrary, only needs to be unique for calls against g_hTaskbarWnd.
-constexpr UINT_PTR kButtonHwndResolveTimerId = 1;
+// Not 1: this is a window (Shell_TrayWnd) the mod doesn't own, shared with
+// Explorer's own timers and any other mod that also sets timers on it -
+// SetTimer with an already-used ID silently replaces that timer, so a
+// small/common value like 1 is a real collision risk. Arbitrary otherwise,
+// same pattern other mods use for shell-window timers (e.g.
+// classic-taskbar-properties.wh.cpp's kTimerIdMasterLayout).
+constexpr UINT_PTR kButtonHwndResolveTimerId = 0x8C3F;
 
 void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
                                          UINT uMsg,
                                          UINT_PTR idEvent,
                                          DWORD dwTime) {
-    // See g_taskListSettlingRecoveryPending's comment: guarantee a fresh
-    // Arrange pass actually happens once the settling window is over,
-    // instead of leaving recovery to whatever unrelated event happens to
-    // invalidate layout next. At most 500ms of extra staleness on top of
-    // the settling window itself, which is already the existing polling
-    // granularity for hwnd resolution below.
-    if (g_taskListSettlingRecoveryPending &&
-        GetTickCount64() >= g_taskListSettlingUntil) {
-        g_taskListSettlingRecoveryPending = false;
-        InvalidateTaskbarLayout();
-    }
-
     ResolvePendingButtonHwnds();
 }
 
@@ -2315,10 +2222,13 @@ void StartButtonHwndResolveTimer() {
         return;
     }
 
-    RunFromWindowThread(g_hTaskbarWnd, [] {
-        SetTimer(g_hTaskbarWnd, kButtonHwndResolveTimerId, 500,
-                 ButtonHwndResolveTimerProc);
-    });
+    if (!RunFromWindowThread(g_hTaskbarWnd, [] {
+            SetTimer(g_hTaskbarWnd, kButtonHwndResolveTimerId, 500,
+                     ButtonHwndResolveTimerProc);
+        })) {
+        Wh_Log(L"StartButtonHwndResolveTimer: RunFromWindowThread failed, "
+               L"HWND resolution will not run");
+    }
 }
 
 void StopButtonHwndResolveTimer() {
@@ -2326,9 +2236,14 @@ void StopButtonHwndResolveTimer() {
         return;
     }
 
-    RunFromWindowThread(g_hTaskbarWnd, [] {
-        KillTimer(g_hTaskbarWnd, kButtonHwndResolveTimerId);
-    });
+    // See StopWinEventHook's comment - same reasoning against an inline
+    // fallback call applies to KillTimer from the wrong thread.
+    if (!RunFromWindowThread(g_hTaskbarWnd, [] {
+            KillTimer(g_hTaskbarWnd, kButtonHwndResolveTimerId);
+        })) {
+        Wh_Log(L"StopButtonHwndResolveTimer: RunFromWindowThread failed, "
+               L"timer left running");
+    }
 }
 
 BOOL Wh_ModInit() {
@@ -2396,12 +2311,10 @@ void Wh_ModUninit() {
     Wh_Log(L">");
 }
 
-BOOL Wh_ModSettingsChanged(BOOL* bReload) {
+void Wh_ModSettingsChanged() {
     Wh_Log(L">");
 
     LoadSettings();
 
     InvalidateTaskbarLayout();
-
-    return TRUE;
 }

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -2133,7 +2133,10 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
     // All marked optional so HookSymbols doesn't abort the whole batch on
     // the first miss - we want a per-symbol report while bringing this mod
     // up on a new Windows build, not just a single opaque FAILED.
-    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+    //
+    // Taskbar.View.dll, ExplorerExtensions.dll (see GetTaskbarViewModuleHandle
+    // - which of the two is actually loaded depends on the Windows build)
+    WindhawkUtils::SYMBOL_HOOK taskbarViewDllHooks[] = {
         {
             {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarCollapsibleLayout,struct winrt::Microsoft::UI::Xaml::Controls::IVirtualizingLayoutOverrides>::ArrangeOverride(void *,struct winrt::Windows::Foundation::Size,struct winrt::Windows::Foundation::Size *))"},
             &TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original,
@@ -2172,7 +2175,7 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
         },
     };
 
-    bool ok = HookSymbols(module, symbolHooks, ARRAYSIZE(symbolHooks));
+    bool ok = HookSymbols(module, taskbarViewDllHooks, ARRAYSIZE(taskbarViewDllHooks));
     Wh_Log(L"HookTaskbarViewDllSymbols: %s", ok ? L"OK" : L"FAILED");
     Wh_Log(L"  ArrangeOverride: %s",
            TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original ? L"resolved"

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -168,7 +168,7 @@ community.
     Fallback for any taskbar button that isn't matched by leftApps/rightApps
     and whose window position can't be determined (mainly pinned-but-not-
     running apps you haven't listed above). "Opposite side from Search/Task
-    View/Widgets" tracks the systemButtonsAdjacentSide setting below when
+    View/Widgets" tracks the systemButtonsAdjacentSide setting above when
     those are placed next to Start; if they're instead left at the
     taskbar's far-left edge, that still counts as their "side" for this
     purpose, so it resolves to the right.
@@ -413,28 +413,19 @@ std::atomic<bool> g_unloading;
 
 thread_local bool g_inTaskbarArrangeOverride;
 
-// A recurring explorer.exe crash (STATUS_STOWED_EXCEPTION, confirmed via
-// WinDbg crash-dump analysis across several sessions) traced back to every
-// synchronous WinRT repeater-traversal call this file makes - reading
-// sibling elements, classifying them, measuring widths - being made from
-// *inside* IUIElement::Arrange, while XAML's own layout system can be
-// mid-structural-mutation of that same repeater (only reproduces when
+// Never traverse the taskbar's XAML tree (siblings, classification,
+// widths) from inside a nested IUIElement::Arrange call - XAML's own
+// layout system can be mid-structural-mutation of that same repeater
+// there (reproducible: explorer.exe crash, STATUS_STOWED_EXCEPTION, when
 // Windows' "show taskbar apps on" setting causes a window moving across
 // monitors to change a taskbar's button *set*, not just coordinates).
-// Earlier attempts suppressed that traversal for a timing window after a
-// detected change (a "settling window") rather than eliminating it - a
-// real mitigation, but complex (needed its own recovery-guarantee and
-// re-arm-loop bug fixes) and still not the actual fix.
-//
-// The actual fix: never call any of that traversal from inside a nested
-// Arrange call at all. RecomputeLayoutPlan (below) does the entire
-// traversal ONCE per ArrangeOverride pass, up front, before
-// TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original is called
-// (i.e. before any nested Arrange calls happen), and writes every
+// RecomputeLayoutPlan (below) does the entire traversal ONCE per
+// ArrangeOverride pass, up front, before
+// TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original is called -
+// i.e. before any nested Arrange calls happen - and writes every
 // element's target X into g_lastArrangedX. IUIElement_Arrange_Hook then
-// becomes a pure map lookup - no traversal, no WinRT calls beyond the one
-// QueryInterface needed to identify the element, so there's nothing left
-// for XAML's mid-mutation state to make unsafe.
+// becomes a pure map lookup, with nothing left for XAML's mid-mutation
+// state to make unsafe.
 
 HWND g_hTaskbarWnd;
 HWINEVENTHOOK g_locationChangeHook;
@@ -447,6 +438,14 @@ std::atomic<int> g_invalidateExceptions;
 // StartWinEventHook) - both WinEventProc and DragFollowTrailingTimerProc
 // run there exclusively, so this needs no synchronization.
 UINT_PTR g_dragFollowTrailingTimerId;
+
+// Same thread-ownership as g_dragFollowTrailingTimerId above. Hoisted out
+// of WinEventProc's own function-local static so DragFollowTrailingTimerProc
+// can update it too - a trailing-timer fire is itself an invalidate, so
+// the next WinEventProc event needs to see it as "now", not still throttle
+// against whatever raw event last landed outside the 150ms window before
+// the trailing timer took over.
+ULONGLONG g_lastDragFollowInvalidate;
 
 // ============================================================================
 // Generic taskbar/XAML helpers
@@ -822,19 +821,17 @@ HDPA GetTaskItemsArray(void* taskGroup) {
 using TaskGroup_ReportClicked_t = int(WINAPI*)(void* pThis, void* param);
 TaskGroup_ReportClicked_t TaskGroup_ReportClicked_Original;
 
-// Diagnostics only: which stage of the WinRT -> native resolution chain
-// last failed, and how often, so a systemic failure (e.g. a different
-// view-model type when taskbar buttons are grouped/combined) is visible
-// without guessing.
+// Diagnostics only: how often the HWND-resolution chain succeeds vs
+// fails, combined across both the individual and grouped-button paths -
+// LayoutPlanStats' own resolved/total count already gives the
+// steady-state health signal, this mainly confirms the chain is running
+// at all. A stage-by-stage breakdown (which specific step failed) was
+// useful while first bringing this technique up against a new Windows
+// build; worth re-adding locally for that kind of investigation rather
+// than carrying it permanently.
 struct ResolveStats {
     int success = 0;
-    int failViewModelNull = 0;
-    int failGetTaskItem = 0;
-    int failSentinelNoItem = 0;
-    int groupSuccess = 0;
-    int groupFailViewModelNull = 0;
-    int groupFailSentinelNoGroup = 0;
-    int groupFailNoItems = 0;
+    int failure = 0;
 };
 ResolveStats g_resolveStats;
 
@@ -868,7 +865,7 @@ HWND ResolveHwndFromIndividualTaskItem(FrameworkElement element) {
     TryGetItemFromContainer_TaskListWindowViewModel_Original(
         windowViewModel.put_void(), &elementAbi);
     if (!windowViewModel) {
-        g_resolveStats.failViewModelNull++;
+        g_resolveStats.failure++;
         return nullptr;
     }
 
@@ -876,7 +873,7 @@ HWND ResolveHwndFromIndividualTaskItem(FrameworkElement element) {
     if (FAILED(TaskListWindowViewModel_get_TaskItem_Original(
             windowViewModel.get(), windowsUdkTaskItem.put_void())) ||
         !windowsUdkTaskItem) {
-        g_resolveStats.failGetTaskItem++;
+        g_resolveStats.failure++;
         return nullptr;
     }
 
@@ -887,7 +884,7 @@ HWND ResolveHwndFromIndividualTaskItem(FrameworkElement element) {
     void* nativeTaskItem = g_clickSentinel_TaskItem;
     g_clickSentinel_TaskItem = nullptr;
     if (!nativeTaskItem) {
-        g_resolveStats.failSentinelNoItem++;
+        g_resolveStats.failure++;
         return nullptr;
     }
 
@@ -911,7 +908,7 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
     TryGetItemFromContainer_TaskListGroupViewModel_Original(
         groupViewModel.put_void(), &elementAbi);
     if (!groupViewModel) {
-        g_resolveStats.groupFailViewModelNull++;
+        g_resolveStats.failure++;
         return nullptr;
     }
 
@@ -930,7 +927,7 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
     void* windowsUdkTaskGroup = g_capturedTaskGroup;
     g_capturedTaskGroup = nullptr;
     if (!windowsUdkTaskGroup) {
-        g_resolveStats.groupFailSentinelNoGroup++;
+        g_resolveStats.failure++;
         return nullptr;
     }
 
@@ -939,13 +936,13 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
     void* nativeTaskGroup = g_clickSentinel_TaskGroup;
     g_clickSentinel_TaskGroup = nullptr;
     if (!nativeTaskGroup) {
-        g_resolveStats.groupFailSentinelNoGroup++;
+        g_resolveStats.failure++;
         return nullptr;
     }
 
     HDPA taskItemsArray = GetTaskItemsArray(nativeTaskGroup);
     if (!taskItemsArray || DPA_GetPtrCount(taskItemsArray) <= 0) {
-        g_resolveStats.groupFailNoItems++;
+        g_resolveStats.failure++;
         return nullptr;
     }
 
@@ -954,7 +951,7 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
     void* taskItem = DPA_GetPtr(taskItemsArray, 0);
     HWND hwnd = GetWindowFromNativeTaskItem(taskItem);
     if (hwnd) {
-        g_resolveStats.groupSuccess++;
+        g_resolveStats.success++;
     }
     return hwnd;
 }
@@ -1025,24 +1022,16 @@ std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
 // whether a relayout is worth triggering.
 //
 // Deliberately ONLY ever called from that timer, never from inside
-// GetButtonHwnd/an active Arrange pass - see the mod's own readme "Known
-// limitations" section, which flagged this exact risk before it was ever
-// hit in practice: the click-sentinel technique this chain uses
-// interacts with the taskbar's own internal click-handling machinery, and
-// running it synchronously while XAML is mid-layout - specifically while
-// a button is being structurally inserted into or removed from an
-// ItemsRepeater's data source, which happens whenever Windows' "show
-// taskbar apps on" setting is anything other than "All taskbars" and a
-// window moves across monitors - was confirmed (via WinDbg crash dump
-// analysis across several explorer.exe crash-loop sessions) to be
-// reachable in a way that fails fast with STATUS_STOWED_EXCEPTION. Only
-// "All taskbars" mode was stable, because there a window moving between
-// monitors never changes any taskbar's button set - no new/removed button
-// ever needs fresh resolution inline during layout. Moving resolution to
-// a timer restores the "normal" context this technique already assumed
-// (a standalone event, not nested inside a live layout pass), matching
-// where the pointer-release-based technique it's adapted from actually
-// runs in the mods it's borrowed from.
+// GetButtonHwnd/an active Arrange pass: the click-sentinel technique this
+// chain uses interacts with the taskbar's own internal click-handling
+// machinery, and running it while a button is being structurally
+// inserted into or removed from an ItemsRepeater's data source - which
+// happens whenever Windows' "show taskbar apps on" setting is anything
+// other than "All taskbars" and a window moves across monitors - reaches
+// STATUS_STOWED_EXCEPTION (confirmed via crash-dump analysis). Running
+// it from a timer instead restores the standalone-event context this
+// technique already assumes, matching where it runs in the mods it's
+// adapted from.
 bool ResolveAndCacheButtonHwnd(FrameworkElement element,
                                const std::wstring& identity) {
     void* key = winrt::get_abi(element);
@@ -1258,6 +1247,47 @@ double FullFootprintWidth(FrameworkElement element) {
     return m.Left + element.ActualWidth() + m.Right;
 }
 
+// Search, Task View and Widgets can each be individually hidden/shown
+// (settings, or Windows' own adaptive behavior), using a negative-margin
+// collapse trick - ActualWidth() includes that margin, so it never drops
+// below the collapsed width and grows on every layout pass once a
+// transition starts. Confirmed against taskbar-start-button-position.wh.cpp,
+// which hits the identical problem for these same button types and fixes
+// it the same way: read the content child's DesiredSize instead, which
+// doesn't depend on the button's own margin (falls back to ActualWidth()
+// if there's no realized child yet, matching that mod exactly).
+//
+// Deliberately NOT used for Start (see g_lastStartWidth's own read site)
+// or task list buttons (ordinary app icons, see FullFootprintWidth
+// above): Start is never hidden/shown the way these three can be, so it
+// was never actually exposed to the collapse-margin bug this exists to
+// fix, and applying this technique to it anyway was confirmed via live
+// testing to understate Start's true width - its own visual-tree
+// structure isn't necessarily the same shape this technique was
+// validated against. Task list buttons have no evidence of the same
+// collapse-margin mechanism either, and changing their much more heavily
+// used width source without that evidence isn't worth the risk.
+double SystemButtonContentWidth(FrameworkElement element) {
+    if (Media::VisualTreeHelper::GetChildrenCount(element) > 0) {
+        auto child = Media::VisualTreeHelper::GetChild(element, 0)
+                         .try_as<FrameworkElement>();
+        if (child) {
+            return child.DesiredSize().Width;
+        }
+    }
+    return element.ActualWidth();
+}
+
+// Same margin-inclusive shape as FullFootprintWidth, for the three
+// system buttons (Search/Task View/Widgets) that need the
+// SystemButtonContentWidth fix above. Start doesn't use this - its own
+// width is read bare (no margin added), matching how it was already
+// read before this fix, just with ActualWidth() swapped out.
+double SystemButtonFootprintWidth(FrameworkElement element) {
+    Thickness m = element.Margin();
+    return m.Left + SystemButtonContentWidth(element) + m.Right;
+}
+
 // ============================================================================
 // Element identification
 // ============================================================================
@@ -1376,7 +1406,7 @@ double ComputeSystemButtonX(const std::vector<ChildInfo>& childInfos,
     for (auto& info : childInfos) {
         int r = SystemButtonRank(info.systemButton);
         if (r >= 0 && r < targetRank) {
-            widthBefore += FullFootprintWidth(info.element);
+            widthBefore += SystemButtonFootprintWidth(info.element);
         }
     }
 
@@ -1385,7 +1415,7 @@ double ComputeSystemButtonX(const std::vector<ChildInfo>& childInfos,
     }
 
     double gap = g_settings.gapPx;
-    double ownWidth = FullFootprintWidth(targetElement);
+    double ownWidth = SystemButtonFootprintWidth(targetElement);
 
     if (g_settings.systemButtonsAdjacentSide == Side::Left) {
         // Stack right-to-left outward from Start: lowest rank closest.
@@ -1431,43 +1461,32 @@ struct TaskListPlanEntry {
 // depending on whether it's being visited as a target or as someone
 // else's sibling.
 //
-// Every entry is always written into outPlan, regardless of how far a
-// side's group runs past the taskbar's own edge or under the system tray
-// when enough apps pile up on one side - a real gap (see the mod's own
-// "Known limitations"), but confirmed via live testing NOT to be fixable
-// by leaving overflowing entries out of outPlan and letting them fall
-// through to native Arrange: Start's position is still being forced to
-// true screen-center by this mod's own hook regardless, and native's
-// layout algorithm computes positions assuming the whole row is Windows'
-// own single centered block with no knowledge Start has been moved -
-// mixing forced-position elements with native-position elements in the
-// same pass produced a visually incoherent overlap (confirmed: all task
-// list icons collapsing toward center and overlapping Start whenever one
-// side's group didn't fit). This is the same class of bug as the
-// "gate Start too during settling" fix from the mod's earlier
-// crash-debugging history: forcing part of a layout while leaving the
-// rest native never produces something coherent, only a mix of two
-// incompatible coordinate systems.
+// Every entry is always written into outPlan and stays in this mod's own
+// coordinate system, never falling through to native Arrange even when a
+// side overflows: Start's position is forced to true screen-center by
+// this mod's own hook regardless of what any individual task list button
+// does, and native's layout algorithm has no knowledge of that - mixing
+// forced-position elements with native-position elements in the same
+// pass produces a visually incoherent overlap. Instead, a side that
+// doesn't fit gets its inter-icon spacing proportionally compressed
+// (icons still render at natural width, so they visually overlap each
+// other once genuinely crowded). leftBoundLocal/rightBoundLocal are the
+// outer edges (local DIPs, same space as startCenterX) each side's group
+// is compressed to fit within - leftBoundLocal is the taskbar's left
+// edge, pushed right by the Search/Task View/Widgets cluster's width in
+// "far left" placement mode; rightBoundLocal is the system tray's own
+// left edge (see RecomputeLayoutPlan's comment), falling back to the
+// taskbar's own outer edge if the tray element can't be found this pass.
 //
-// The actual fix: every icon always stays in this mod's own coordinate
-// system, and a side that doesn't fit gets its inter-icon spacing
-// proportionally compressed (icons rendering at their natural width still
-// visually overlap each other once genuinely crowded) rather than ever
-// falling through to native or running past its bound. leftBoundLocal/
-// rightBoundLocal are the outer edges (local DIPs, same space as
-// startCenterX) each side's group is compressed to fit within -
-// leftBoundLocal is the taskbar's left edge, pushed right by the
-// Search/Task View/Widgets cluster's width in "far left" placement mode;
-// rightBoundLocal is the system tray's own left edge (see
-// RecomputeLayoutPlan's comment for how that's resolved), falling back to
-// the taskbar's own outer edge only if the tray element can't be found
-// this pass. Every side is
-// walked innermost-first, starting exactly at Start's own edge (minus
-// gap) and moving outward - so the innermost icon on a side is always
-// placed at that fixed, bound-independent reference point regardless of
-// how much compression is applied elsewhere in the same side, which is
-// what guarantees Start itself can never be overlapped no matter how
-// severe the overflow is.
+// Every side is walked innermost-first, starting exactly at Start's own
+// edge (minus gap) and moving outward. The Start-overlap guarantee: the
+// innermost icon's edge *facing Start* must sit at that fixed,
+// bound-independent reference point regardless of scale, so each icon's
+// own placement uses its unscaled width - only the running reference
+// point handed to the *next* icon advances by the scaled amount. Scaling
+// the placement itself (not just the step to the next icon) looks
+// equivalent at scale=1 but drifts the innermost icon into Start as
+// compression increases - do not reintroduce that.
 void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
                          double startCenterX,
                          double leftBoundLocal,
@@ -1568,21 +1587,59 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
     // once a side is genuinely too full to fit at natural spacing. A
     // side with plenty of room keeps scale at 1 (identical to natural,
     // uncompressed spacing).
+    //
+    // The outermost icon's own width (left.back()/right.back() - the
+    // walk loop below always processes them last, regardless of sort
+    // order) is deliberately excluded from both the total and the
+    // available space fed into the ratio. That icon is placed at its
+    // own full, unscaled width with nothing beyond it to compress
+    // against (mirroring the innermost icon's exact placement against
+    // Start - see the walk loop's own comment), so folding its width
+    // into the same pool as the compressible pitches double-counted it:
+    // once inside the ratio, again in full at the final placement. That
+    // under-compressed every pitch just enough for the outermost icon's
+    // own edge to overshoot the bound by width*(1-scale) - confirmed
+    // live as running-app icons overlapping the far-left system buttons
+    // (Task View), while Start itself was never overlapped since the
+    // innermost-icon side of this class of bug was already fixed.
     double leftAvailable = leftInnerX - leftBoundLocal;
     double leftScale = 1.0;
-    if (leftTotal > leftAvailable) {
-        leftScale = leftAvailable > 0 ? (leftAvailable / leftTotal) : 0.0;
+    if (!left.empty() && leftTotal > leftAvailable) {
+        double leftOuterWidth = left.back()->width;
+        double compressibleTotal = leftTotal - leftOuterWidth;
+        double compressibleAvailable = leftAvailable - leftOuterWidth;
+        leftScale = compressibleTotal > 0
+                        ? std::max(0.0, compressibleAvailable / compressibleTotal)
+                        : 1.0;
     }
     double rightAvailable = rightBoundLocal - rightInnerX;
     double rightScale = 1.0;
-    if (rightTotal > rightAvailable) {
-        rightScale = rightAvailable > 0 ? (rightAvailable / rightTotal) : 0.0;
+    if (!right.empty() && rightTotal > rightAvailable) {
+        double rightOuterWidth = right.back()->width;
+        double compressibleTotal = rightTotal - rightOuterWidth;
+        double compressibleAvailable = rightAvailable - rightOuterWidth;
+        rightScale = compressibleTotal > 0
+                         ? std::max(0.0, compressibleAvailable / compressibleTotal)
+                         : 1.0;
     }
 
+    // The innermost icon's position is placed using its own *unscaled*
+    // width (x - entry->width, not x - entry->width * leftScale) so its
+    // right edge lands exactly at leftInnerX regardless of scale - only
+    // x itself (the reference point carried to the *next* icon) advances
+    // by the scaled amount. An earlier version scaled the position too
+    // (x -= entry->width * leftScale; outPlan[...] = x), which is exactly
+    // right at scale=1 but drifts the innermost icon's right edge into
+    // Start by width*(1-scale) as compression increases - the exact
+    // Start-overlap this whole mechanism exists to prevent, caught by
+    // review rather than by testing since the two live-tested overflow
+    // scenarios both happened to stress the right side (which never had
+    // this bug - its innermost icon is placed at the unscaled rightInnerX
+    // directly, with no equivalent subtraction to get wrong).
     double x = leftInnerX;
     for (auto* entry : left) {
+        outPlan[winrt::get_abi(entry->element)] = x - entry->width;
         x -= entry->width * leftScale;
-        outPlan[winrt::get_abi(entry->element)] = x;
     }
     x = rightInnerX;
     for (auto* entry : right) {
@@ -1637,8 +1694,30 @@ void ArmButtonHwndResolveTimer(DWORD delayMs);
 // (see call site) so the mod self-heals as soon as the taskbar exists,
 // rather than needing a manual toggle to re-run Wh_ModAfterInit.
 HWND EnsureTaskbarWnd() {
+    // Shell_TrayWnd can in principle be recreated without explorer.exe
+    // itself restarting (not something this mod's own code causes, but
+    // not something it can rule out either) - without this check, a
+    // stale g_hTaskbarWnd would silently stop all positioning forever
+    // (every position-math function requires it) with no self-healing
+    // path, since the early return below would never let a fresh
+    // FindCurrentProcessTaskbarWnd() attempt happen again. Cheap enough
+    // to check unconditionally every pass.
+    if (g_hTaskbarWnd && !IsWindow(g_hTaskbarWnd)) {
+        g_hTaskbarWnd = nullptr;
+    }
+
     if (g_hTaskbarWnd) {
         return g_hTaskbarWnd;
+    }
+    if (g_unloading) {
+        // Guards against Wh_ModBeforeUninit's own InvalidateTaskbarLayout
+        // call (or a naturally-timed pass) landing while the mod's hooks
+        // are still installed but g_hTaskbarWnd was somehow never set -
+        // without this, resolving it here would call
+        // StartWinEventHook()/StartButtonHwndResolveTimer() and create a
+        // thread/timer with no later Wh_ModUninit call left to tear it
+        // down (Wh_ModBeforeUninit already ran).
+        return nullptr;
     }
 
     g_hTaskbarWnd = FindCurrentProcessTaskbarWnd();
@@ -1765,14 +1844,46 @@ IUIElement_Arrange_t IUIElement_Arrange_Original;
 // Every Start/system-button/task-list-button's target X, keyed by the XAML
 // element's ABI pointer (same identity technique as g_buttonHwndCache).
 // Written only by RecomputeLayoutPlan, which rebuilds this map from
-// scratch on every ArrangeOverride pass (see its own comment) - so
-// IUIElement_Arrange_Hook below never needs to compute anything itself,
-// only look a value up. An element with no entry (a secondary-monitor
-// element, which RecomputeLayoutPlan never walks; or a primary element so
-// new it wasn't realized yet when this pass's plan was built) falls
-// through to Windows' own native positioning for that one pass, same as
-// any element this mod doesn't touch at all.
+// scratch whenever g_planDirty says something might have changed since
+// the last rebuild (see its own comment) - so IUIElement_Arrange_Hook
+// below never needs to compute anything itself, only look a value up. An
+// element with no entry (a secondary-monitor element, which
+// RecomputeLayoutPlan never walks; or a primary element so new it wasn't
+// realized yet when this pass's plan was built) falls through to
+// Windows' own native positioning for that one pass, same as any element
+// this mod doesn't touch at all.
 std::unordered_map<void*, double> g_lastArrangedX;
+
+// Set whenever something might have changed that g_lastArrangedX doesn't
+// reflect yet - every InvalidateTaskbarLayout call covers every real
+// trigger this mod has (see its own top-of-function write): a window
+// moving, a button's HWND/side resolving, the ArrangeOverride hook's own
+// button-count-change check, a settings change, and mod startup. Starts
+// true so the very first ArrangeOverride pass always computes a real
+// plan rather than reusing an empty one. RecomputeLayoutPlan clears it
+// only after a genuinely successful recompute - left set on an exception
+// so a later pass retries rather than silently freezing on a broken or
+// incomplete plan. atomic: InvalidateTaskbarLayout can be called from
+// threads other than the taskbar's own (the dedicated WinEventHook
+// thread registers WinEventProc there, for one), while
+// RecomputeLayoutPlan only ever reads/clears this from the taskbar
+// thread itself (guarded the same way the rest of that function already
+// is).
+//
+// Previously this whole function - a taskbar.dll vtable scan and
+// TaskbarHost::FrameHeight prologue parse to reach the XamlRoot, a
+// VisualTreeHelper walk down to the repeater, a TryGetElement and
+// winrt::get_class_name per child - ran unconditionally on every single
+// ArrangeOverride pass, for every taskbar (primary and any
+// secondary-monitor ones, since they share the primary's own thread and
+// so pass the apartment-safety check this function already needed
+// regardless). This flag removes nearly all of that cost on the (very
+// common) passes where nothing this mod cares about actually changed,
+// without touching the plan-computation logic itself - it's a pure
+// short-circuit around code whose correctness properties have already
+// been fought for across several crash-debugging sessions, not a rewrite
+// of it.
+std::atomic<bool> g_planDirty{true};
 
 // Diagnostics only, for IUIElement_Arrange_Hook's own per-call work
 // (distinct from LayoutPlanStats, which covers RecomputeLayoutPlan's
@@ -1849,44 +1960,35 @@ HRESULT WINAPI IUIElement_Arrange_Hook(void* pThis,
 // button's target X, written into g_lastArrangedX - called from
 // TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook BEFORE it calls
 // into XAML's own ArrangeOverride, i.e. before any nested Arrange calls
-// (and so IUIElement_Arrange_Hook above) run at all for this pass. That
-// ordering is the actual fix for the crash class the old settling-window
-// mechanism used to paper over - see g_inTaskbarArrangeOverride's comment.
+// (and so IUIElement_Arrange_Hook above) run at all for this pass - see
+// g_inTaskbarArrangeOverride's comment for why that ordering matters.
 //
-// Rebuilds g_lastArrangedX from scratch every call rather than updating
-// incrementally, so a destroyed element's stale entry can never outlive
-// it - no separate pruning pass needed for this map, unlike
+// Rebuilds g_lastArrangedX from scratch every real recompute rather than
+// updating incrementally, so a destroyed element's stale entry can never
+// outlive it - no separate pruning pass needed for this map, unlike
 // g_buttonHwndCache/g_lastKnownWindowClassification (populated
 // independently by the HWND-resolve timer - see ResolvePendingButtonHwnds
 // for why those still need explicit pruning).
 //
 // MUST only run when confirmed to be on g_hTaskbarWnd's own thread:
 // GetTaskbarXamlRoot(g_hTaskbarWnd) reaches across to the PRIMARY's XAML
-// object specifically, which is an unsafe unmarshaled cross-apartment
-// WinRT call from any other thread.
-//
-// Note this check does NOT scope the (relatively expensive) rebuild to
-// primary-monitor passes only, despite an earlier version of this comment
-// claiming that - Shell_TrayWnd and Shell_SecondaryTrayWnd both run on
-// the SAME Explorer UI thread (the established pattern other taskbar mods
-// use to reach every monitor's taskbar is a single EnumThreadWindows on
-// that one thread), so this check passes for secondary-monitor
-// ArrangeOverride passes too, and the whole plan gets rebuilt redundantly
-// for each of them. It's still *correct* either way - secondary-monitor
-// elements never end up in g_lastArrangedX regardless of how many times
-// this runs, since it only ever walks the primary's own repeater - just
-// not free. This check exists purely as the apartment-safety guard
-// described above, not as a monitor-scoping mechanism. A real
-// scoping/caching optimization (skip the rebuild when nothing relevant
-// changed) is a separate, larger change left for its own review round
-// given how much this exact function's correctness properties have
-// already been fought for across several crash-debugging sessions.
+// object specifically, an unsafe unmarshaled cross-apartment WinRT call
+// from any other thread. Shell_TrayWnd and Shell_SecondaryTrayWnd both
+// run on the SAME Explorer UI thread, so this check passes for
+// secondary-monitor ArrangeOverride passes too - harmless either way,
+// since secondary-monitor elements never end up in g_lastArrangedX
+// regardless (this function only ever walks the primary's own
+// repeater); the check exists purely as the apartment-safety guard, not
+// a monitor-scoping mechanism.
 void RecomputeLayoutPlan() {
     if (!g_hTaskbarWnd) {
         return;
     }
     DWORD primaryThreadId = GetWindowThreadProcessId(g_hTaskbarWnd, nullptr);
     if (primaryThreadId == 0 || primaryThreadId != GetCurrentThreadId()) {
+        return;
+    }
+    if (!g_planDirty) {
         return;
     }
 
@@ -1921,13 +2023,31 @@ void RecomputeLayoutPlan() {
         // pass by the time they run, not the previous one.
         for (auto& info : childInfos) {
             if (info.systemButton == SystemButton::Start) {
-                // ActualWidth() reflects the previous arrange pass, and is
-                // 0 for a just-realized element - a freshly (re)created
-                // Start button would otherwise briefly clobber
+                // Deliberately bare ActualWidth() here, NOT
+                // SystemButtonContentWidth - confirmed via live testing
+                // that swapping this specific read to the content-child's
+                // DesiredSize() (done for Search/Task View/Widgets below,
+                // where it's genuinely needed) caused task list icons to
+                // visibly render on top of Start's own icon on the side
+                // that pushes toward it, meaning the content child's
+                // DesiredSize understates Start's true width - Start's own
+                // visual-tree structure isn't necessarily the same shape
+                // that technique was validated against. ActualWidth()'s
+                // collapse-margin growth problem (see
+                // SystemButtonContentWidth's comment) is specific to
+                // elements that actually get hidden/shown - Start never
+                // is, unlike Search/Task View/Widgets, so it was never
+                // actually exposed to that bug in the first place. Four
+                // full rounds of live testing never reported a Start-width
+                // problem before this specific swap was tried.
+                //
+                // ActualWidth() still reflects the previous arrange pass,
+                // and is 0 for a just-realized element - a freshly
+                // (re)created Start button would otherwise briefly clobber
                 // g_lastStartWidth to 0 and lay out the entire taskbar
                 // around a zero-width Start for that pass. Keep the last
-                // known-good width instead; it'll catch up to the real
-                // one within a pass or two once ActualWidth reports it.
+                // known-good width instead; it'll catch up to the real one
+                // within a pass or two.
                 double w = info.element.ActualWidth();
                 if (w > 0) {
                     g_lastStartWidth = w;
@@ -1948,7 +2068,7 @@ void RecomputeLayoutPlan() {
         double systemClusterWidth = 0;
         for (auto& info : childInfos) {
             if (SystemButtonRank(info.systemButton) >= 0) {
-                systemClusterWidth += FullFootprintWidth(info.element);
+                systemClusterWidth += SystemButtonFootprintWidth(info.element);
             }
         }
         bool systemButtonsAdjacent = g_settings.systemButtonsPlacement ==
@@ -2005,12 +2125,17 @@ void RecomputeLayoutPlan() {
                             rightBoundLocal, newPlan);
 
         g_lastArrangedX = std::move(newPlan);
+        g_planDirty = false;
     } catch (...) {
         g_planStats.exceptions++;
         // g_lastArrangedX is left as whatever the last successful pass
         // produced - IUIElement_Arrange_Hook's lookup-or-fall-through
         // handles a stale/incomplete plan exactly like it already handles
-        // a brand-new not-yet-planned element.
+        // a brand-new not-yet-planned element. g_planDirty deliberately
+        // stays true (not cleared) here, unlike the success path above -
+        // this pass didn't actually produce a plan reflecting current
+        // state, so a later pass should retry rather than treat this as
+        // "up to date" and skip forever.
     }
 }
 
@@ -2110,9 +2235,7 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
             L"exceptions=%d | plan: taskList=%d (hwndResolved=%d left=%d "
             L"right=%d) planExceptions=%d | winEvents: raw=%d "
             L"invalidated=%d skippedReentrant=%d invalidateExceptions=%d | "
-            L"resolve(individual): ok=%d viewModelNull=%d getTaskItemFail=%d "
-            L"sentinelNoItem=%d | resolve(group): ok=%d viewModelNull=%d "
-            L"sentinelNoGroup=%d noItems=%d",
+            L"resolve: ok=%d fail=%d",
             g_passStats.totalArrangeCalls, g_passStats.repositioned,
             g_passStats.qiFailures, g_passStats.exceptions,
             g_planStats.taskListTotal, g_planStats.taskListHwndResolved,
@@ -2121,11 +2244,7 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
             (int)g_winEventRawCount,
             (int)g_winEventInvalidateCount, (int)g_invalidateSkippedReentrant,
             (int)g_invalidateExceptions, g_resolveStats.success,
-            g_resolveStats.failViewModelNull, g_resolveStats.failGetTaskItem,
-            g_resolveStats.failSentinelNoItem, g_resolveStats.groupSuccess,
-            g_resolveStats.groupFailViewModelNull,
-            g_resolveStats.groupFailSentinelNoGroup,
-            g_resolveStats.groupFailNoItems);
+            g_resolveStats.failure);
         g_resolveStats = {};
     }
 
@@ -2148,43 +2267,43 @@ thread_local bool g_inInvalidateTaskbarLayout;
 
 // Marks the taskbar's layout dirty and lets the XAML dispatcher pick it up
 // on its own next tick, rather than forcing an immediate synchronous
-// UpdateLayout() call. An earlier version forced it (for drag-follow
-// snappiness), gated behind a reentrancy guard and a forceImmediate flag
-// that was false only for one specific call site. That was not enough:
-// this function's callers include a raw OS callback (WinEventProc) that
-// can itself fire while the thread is already nested inside XAML-internal
-// layout activity for reasons outside this mod's control (e.g. a taskbar
-// button structurally moving between two different monitors' XAML trees,
-// not just changing coordinates within one). A forced UpdateLayout() in
-// that state is a reentrant "layout cycle" from WinUI's perspective, and
-// it fails fast with STATUS_STOWED_EXCEPTION - the confirmed cause of
-// three separate explorer.exe crash-loop incidents (identical fault offset
-// in Windows.UI.Xaml.dll every time), each via a different trigger path,
-// even after two of those paths were individually guarded. Since new
-// trigger paths kept appearing, the only fix that actually closes the
-// whole class is to never force it anywhere: InvalidateArrange() +
-// InvalidateMeasure() alone are always safe to call from any context, and
-// the resulting delay before the dispatcher's own pass runs is at most
-// one composition frame - not perceptible for a drag-follow feature that
-// was already documented as best-effort ("shortly after a drag/move
-// settles, not on every intermediate pixel").
+// UpdateLayout() call. This function's callers include a raw OS callback
+// (WinEventProc) that can itself fire while the thread is already nested
+// inside XAML-internal layout activity for reasons outside this mod's
+// control (e.g. a taskbar button structurally moving between two
+// different monitors' XAML trees, not just changing coordinates within
+// one). A forced UpdateLayout() in that state is a reentrant "layout
+// cycle" from WinUI's perspective, and fails fast with
+// STATUS_STOWED_EXCEPTION - confirmed as the cause of several
+// explorer.exe crash-loop incidents, each via a different trigger path,
+// so the only fix that actually closes the whole class is to never force
+// it anywhere. InvalidateArrange() + InvalidateMeasure() alone are always
+// safe to call from any context; the resulting delay before the
+// dispatcher's own pass runs is at most one composition frame - not
+// perceptible for a drag-follow feature already documented as
+// best-effort.
 //
-// Also important: that STATUS_STOWED_EXCEPTION is a raw SEH RaiseException,
-// not a thrown C++ exception. This mod's toolchain (Windhawk's clang/MinGW
-// build, no /EHa-style async exception handling) cannot catch it with
-// `catch(...)` no matter where it's placed - confirmed by
-// g_invalidateExceptions staying 0 across multiple full crash-loop
-// sessions. The try/catch below only covers genuine C++ exceptions from
-// the WinRT calls in this lambda (e.g. QueryInterface failures surfaced as
-// hresult_error) - it was never a safety net for the layout-cycle failure,
-// and no try/catch placement ever will be. Don't reintroduce a forced
-// UpdateLayout() here without a fundamentally different mechanism (e.g. a
-// genuinely async PostMessage-deferred call that's guaranteed to run only
-// once the current call stack has fully unwound).
+// STATUS_STOWED_EXCEPTION is a raw SEH RaiseException, not a thrown C++
+// exception - this mod's toolchain (Windhawk's clang/MinGW build, no
+// /EHa-style async exception handling) cannot catch it with `catch(...)`
+// no matter where it's placed. The try/catch below only covers genuine
+// C++ exceptions from the WinRT calls in this lambda (e.g. QueryInterface
+// failures) - it is not, and never will be, a safety net for the
+// layout-cycle failure. Don't reintroduce a forced UpdateLayout() here
+// without a fundamentally different mechanism (e.g. a genuinely async
+// PostMessage-deferred call guaranteed to run only once the current call
+// stack has fully unwound).
 void InvalidateTaskbarLayout() {
     if (!g_hTaskbarWnd) {
         return;
     }
+
+    // Every real trigger for a layout change goes through this function
+    // (see g_planDirty's own comment for the full list), so marking the
+    // plan dirty here - unconditionally, before the marshal below, so it
+    // still happens even if the marshal itself fails - is the one place
+    // that needs to know about all of them.
+    g_planDirty = true;
 
     bool posted = RunFromWindowThread(g_hTaskbarWnd, [] {
         if (g_inInvalidateTaskbarLayout) {
@@ -2235,6 +2354,18 @@ void CALLBACK DragFollowTrailingTimerProc(HWND hwnd,
     KillTimer(nullptr, idEvent);
     g_dragFollowTrailingTimerId = 0;
 
+    // Same g_unloading check WinEventProc already has: InvalidateTaskbarLayout
+    // blocks in SendMessage until the taskbar thread pumps it, which
+    // StopWinEventHook's now-unconditional wait (see its own comment)
+    // would otherwise be stuck behind if this fired mid-teardown.
+    if (g_unloading) {
+        return;
+    }
+
+    // This fire is itself an invalidate - see g_lastDragFollowInvalidate's
+    // comment for why WinEventProc's throttle needs to know about it too.
+    g_lastDragFollowInvalidate = GetTickCount64();
+
     g_winEventInvalidateCount++;
     InvalidateTaskbarLayout();
 }
@@ -2258,9 +2389,8 @@ void CALLBACK WinEventProc(HWINEVENTHOOK hook,
         return;
     }
 
-    static ULONGLONG lastInvalidate;
     ULONGLONG now = GetTickCount64();
-    if (now - lastInvalidate < 150) {
+    if (now - g_lastDragFollowInvalidate < 150) {
         // The throttle above is leading-edge only, so the final
         // location-change event of a drag/move - the one carrying its
         // actual release position - is routinely the one that lands
@@ -2279,7 +2409,7 @@ void CALLBACK WinEventProc(HWINEVENTHOOK hook,
             SetTimer(nullptr, 0, 200, DragFollowTrailingTimerProc);
         return;
     }
-    lastInvalidate = now;
+    g_lastDragFollowInvalidate = now;
     if (g_dragFollowTrailingTimerId) {
         KillTimer(nullptr, g_dragFollowTrailingTimerId);
         g_dragFollowTrailingTimerId = 0;
@@ -2375,10 +2505,18 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
     // Taskbar.View.dll, ExplorerExtensions.dll
     WindhawkUtils::SYMBOL_HOOK hooks[] = {
         {
+            // Deliberately NOT optional, unlike every other entry below:
+            // this hook is the mod's entire function - if it can't be
+            // resolved, positioning silently does nothing. Every other
+            // symbol here is optional purely so HookSymbols doesn't abort
+            // the whole batch on the first miss (a per-symbol report is
+            // more useful than one opaque FAILED while bringing this mod
+            // up on a new Windows build), but a build where this one is
+            // missing should surface as a real failure in Windhawk, not a
+            // mod that "loads successfully" and does nothing.
             {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarCollapsibleLayout,struct winrt::Microsoft::UI::Xaml::Controls::IVirtualizingLayoutOverrides>::ArrangeOverride(void *,struct winrt::Windows::Foundation::Size,struct winrt::Windows::Foundation::Size *))"},
             &TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original,
             TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook,
-            true,
         },
         {
             {LR"(struct winrt::Taskbar::TaskListWindowViewModel __cdecl TryGetItemFromContainer<struct winrt::Taskbar::TaskListWindowViewModel>(struct winrt::Windows::UI::Xaml::UIElement const &))"},
@@ -2582,11 +2720,30 @@ void StopWinEventHook() {
         return;
     }
 
-    PostThreadMessage(g_winEventThreadId, WM_APP, 0, 0);
-    if (WaitForSingleObject(g_winEventThread, 2000) != WAIT_OBJECT_0) {
-        Wh_Log(L"StopWinEventHook: thread did not exit in time, "
-               L"location-change hook may be left registered");
+    // WinEventHookThreadProc's own first action creates its message
+    // queue via PeekMessage before doing anything else (see its
+    // comment), but there's still a small window right after
+    // CreateThread returns where the new thread hasn't run that yet -
+    // PostThreadMessage fails with ERROR_INVALID_THREAD_ID in that
+    // window, and StartWinEventHook is called lazily from
+    // EnsureTaskbarWnd, so thread creation isn't necessarily far from
+    // teardown. Retry briefly to bridge that narrow gap.
+    for (int attempt = 0; attempt < 50; attempt++) {
+        if (PostThreadMessage(g_winEventThreadId, WM_APP, 0, 0)) {
+            break;
+        }
+        Sleep(10);
     }
+
+    // Unconditional wait, not a bounded timeout - an earlier version
+    // gave up after 2s and returned anyway, which meant Wh_ModUninit
+    // could return, Windhawk unmaps this module's code via FreeLibrary
+    // right after, and the still-running thread's next instruction
+    // (its own return address, still inside this module's
+    // WinEventHookThreadProc) is now unmapped memory - a deferred
+    // crash, not a mitigated one. Matches the established teardown
+    // shape in taskbar-background-helper.wh.cpp.
+    WaitForSingleObject(g_winEventThread, INFINITE);
 
     CloseHandle(g_winEventThread);
     g_winEventThread = nullptr;
@@ -2601,25 +2758,31 @@ void StopWinEventHook() {
 // classic-taskbar-properties.wh.cpp's kTimerIdMasterLayout).
 constexpr UINT_PTR kButtonHwndResolveTimerId = 0x8C3F;
 
+// Idle re-check cadence once every cached button is already resolved -
+// see NextResolveDelayMs' comment for what this specifically exists to
+// catch. Deliberately not as tight as the 2s..32s backoff used for
+// buttons that still need resolving - this only ever runs
+// ResolvePendingButtonHwnds' comparison against already-known-good
+// state, not the (much more expensive, and the one actually worth
+// keeping rare) click-sentinel resolution chain.
+constexpr DWORD kIdleResolveTickMs = 8000;
+
 // How long until the next resolve attempt could possibly do anything
 // useful, based only on g_buttonHwndCache's already-recorded state - no
 // XAML/tree access, just a scan of an in-memory map, so this is cheap
 // enough to call after every timer tick. Mirrors the same backoff formula
 // ResolvePendingButtonHwnds uses to decide needsResolve for an existing
-// entry. Returns INFINITE when nothing currently unresolved is cached, in
-// which case the timer simply doesn't re-arm and stays off until
-// something else requests an attempt - either the ArrangeOverride hook's
-// button-count-change check (a brand-new button isn't in this cache at
-// all yet, so this function has no way to know about it on its own) or a
-// live element's cache entry going stale.
+// entry.
 DWORD NextResolveDelayMs() {
     ULONGLONG now = GetTickCount64();
     bool anyPending = false;
+    bool anyResolved = false;
     ULONGLONG earliestDue = 0;
 
     for (auto& kv : g_buttonHwndCache) {
         const ButtonHwndCacheEntry& entry = kv.second;
         if (entry.hwnd) {
+            anyResolved = true;
             continue;
         }
         int shift = std::min(entry.consecutiveFailures, 4);
@@ -2631,6 +2794,24 @@ DWORD NextResolveDelayMs() {
     }
 
     if (!anyPending) {
+        // Even once every cached button is resolved, ItemsRepeater can
+        // rebind an already-realized element to a *different* item (a
+        // drag-reorder of two running apps) without changing the total
+        // count - the one thing that otherwise re-arms this timer, via
+        // the ArrangeOverride hook's count-change check. Without some
+        // periodic re-check here, ResolvePendingButtonHwnds' identity
+        // comparison (the mechanism that exists specifically to catch a
+        // rebind - see ButtonHwndCacheEntry's comment) would never
+        // actually run again once everything first resolves, so a
+        // rebind could go undetected indefinitely. Only armed when at
+        // least one button is genuinely resolved - an all-pinned/
+        // not-running taskbar already gets its own periodic tick from
+        // the backoff loop above, no need to add a second one; the
+        // timer only truly goes idle (returns INFINITE, no re-arm at
+        // all) when the cache is completely empty.
+        if (anyResolved) {
+            return kIdleResolveTickMs;
+        }
         return INFINITE;
     }
 
@@ -2664,7 +2845,15 @@ void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
 // reliability) SetTimer itself are documented to need to run on the
 // thread that owns the timer.
 void ArmButtonHwndResolveTimer(DWORD delayMs) {
-    if (!g_hTaskbarWnd) {
+    if (!g_hTaskbarWnd || g_unloading) {
+        // See EnsureTaskbarWnd's g_unloading check - same reasoning: once
+        // Wh_ModBeforeUninit sets g_unloading, don't create a new
+        // SetTimer registration (whose TimerProc is in this module's own
+        // code) even though the Arrange hook that could still trigger
+        // this (the count-change branch) stays installed until
+        // Wh_ModBeforeUninit returns - StopButtonHwndResolveTimer doesn't
+        // run until the later Wh_ModUninit call, by which point the hook
+        // is gone and nothing could reach here to recreate it anyway.
         return;
     }
 
@@ -2756,14 +2945,33 @@ void Wh_ModBeforeUninit() {
 
     g_unloading = true;
 
-    StopWinEventHook();
-    StopButtonHwndResolveTimer();
-
+    // Deliberately NOT tearing down the WinEventHook thread/timer here -
+    // this mod's own hooks (IUIElement_Arrange_Hook,
+    // TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook) stay
+    // installed until this function *returns*, and ArrangeOverride isn't
+    // itself gated on g_unloading. If StopWinEventHook/
+    // StopButtonHwndResolveTimer ran here and a pass landed in the
+    // window before this function returns, EnsureTaskbarWnd could still
+    // call StartWinEventHook/StartButtonHwndResolveTimer again (if
+    // g_hTaskbarWnd somehow wasn't set yet) or the count-change branch
+    // could call ArmButtonHwndResolveTimer(0) - either creates a brand
+    // new thread/timer nobody would ever tear down, since Wh_ModUninit
+    // runs after this. This call still needs the Arrange hook alive
+    // (it's what restores native positioning), so it has to happen while
+    // the hooks are still installed - the actual teardown of the
+    // thread/timer that could otherwise be reawakened waits for
+    // Wh_ModUninit, after Windhawk has removed the hooks.
     InvalidateTaskbarLayout();
 }
 
 void Wh_ModUninit() {
     Wh_Log(L">");
+
+    // See Wh_ModBeforeUninit's comment for why this doesn't run there -
+    // the mod's own hooks are gone by the time Wh_ModUninit runs, so
+    // nothing can reawaken the thread/timer being torn down here.
+    StopWinEventHook();
+    StopButtonHwndResolveTimer();
 }
 
 void Wh_ModSettingsChanged() {
@@ -2782,10 +2990,13 @@ void Wh_ModSettingsChanged() {
     ModSettings settings = LoadSettingsFromStore();
 
     if (g_hTaskbarWnd) {
-        RunFromWindowThread(g_hTaskbarWnd,
-                            [settings = std::move(settings)]() mutable {
-                                g_settings = std::move(settings);
-                            });
+        if (!RunFromWindowThread(g_hTaskbarWnd,
+                                 [settings = std::move(settings)]() mutable {
+                                     g_settings = std::move(settings);
+                                 })) {
+            Wh_Log(L"Wh_ModSettingsChanged: RunFromWindowThread failed, "
+                   L"new settings not applied");
+        }
     } else {
         g_settings = std::move(settings);
     }

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -963,8 +963,21 @@ HWND ResolveHwndFromTaskListButton(FrameworkElement element) {
 // at a fixed rate forever. A live element that's simply slow to resolve
 // still gets the fast early retries, since the counter only advances on
 // an actual failure and resets to 0 on the first success.
+//
+// identity (the button's accessible name at the time it was last resolved)
+// guards against a different staleness case entirely: ItemsRepeater can
+// rebind an already-realized element to a *different* item (e.g. the user
+// drag-reorders two running apps' buttons) rather than destroying and
+// recreating it. Without a way to notice that, a cache entry keyed by the
+// element's ABI pointer would keep reporting the OLD item's HWND for the
+// element's new identity indefinitely - the "hwnd is still a valid window"
+// check alone can't catch this, since the old HWND is still alive, just no
+// longer what this element represents. ResolvePendingButtonHwnds compares
+// the live accessible name against this on every check and forces a
+// re-resolve on a mismatch.
 struct ButtonHwndCacheEntry {
     HWND hwnd = nullptr;
+    std::wstring identity;
     ULONGLONG lastAttempt = 0;
     int consecutiveFailures = 0;
 };
@@ -994,7 +1007,8 @@ std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
 // (a standalone event, not nested inside a live layout pass), matching
 // where the pointer-release-based technique it's adapted from actually
 // runs in the mods it's borrowed from.
-bool ResolveAndCacheButtonHwnd(FrameworkElement element) {
+bool ResolveAndCacheButtonHwnd(FrameworkElement element,
+                               const std::wstring& identity) {
     void* key = winrt::get_abi(element);
     HWND previous = nullptr;
     int failures = 0;
@@ -1006,7 +1020,7 @@ bool ResolveAndCacheButtonHwnd(FrameworkElement element) {
 
     HWND hwnd = ResolveHwndFromTaskListButton(element);
     failures = hwnd ? 0 : failures + 1;
-    g_buttonHwndCache[key] = {hwnd, GetTickCount64(), failures};
+    g_buttonHwndCache[key] = {hwnd, identity, GetTickCount64(), failures};
     return hwnd != previous;
 }
 
@@ -1124,15 +1138,20 @@ struct ButtonClassification {
 
 // Classification priority: explicit user override by app name, then live
 // window position, then the configured default (mainly hit by pinned apps
-// that aren't running and weren't listed in leftApps/rightApps).
+// that aren't running and weren't listed in leftApps/rightApps). Skips the
+// accessible-name lookup (an AutomationProperties::GetName call plus a
+// lowercasing string copy) entirely when there's nothing to match it
+// against - leftApps/rightApps are both empty by default, and this runs
+// for every task-list button on every single ArrangeOverride pass.
 ButtonClassification ClassifyTaskListButton(FrameworkElement element) {
-    std::wstring name = GetButtonAccessibleName(element);
-
-    if (ContainsAnyFragment(name, g_settings.leftApps)) {
-        return {Side::Left, PinnedAppOrderKey()};
-    }
-    if (ContainsAnyFragment(name, g_settings.rightApps)) {
-        return {Side::Right, PinnedAppOrderKey()};
+    if (!g_settings.leftApps.empty() || !g_settings.rightApps.empty()) {
+        std::wstring name = GetButtonAccessibleName(element);
+        if (ContainsAnyFragment(name, g_settings.leftApps)) {
+            return {Side::Left, PinnedAppOrderKey()};
+        }
+        if (ContainsAnyFragment(name, g_settings.rightApps)) {
+            return {Side::Right, PinnedAppOrderKey()};
+        }
     }
 
     HWND hwnd = GetButtonHwnd(element);
@@ -1214,11 +1233,6 @@ bool IsTaskListButton(FrameworkElement element) {
 // Layout: computing target X positions
 // ============================================================================
 
-double ComputeStartButtonX(FrameworkElement startElement) {
-    double centerX = GetMonitorCenterXLocal();
-    return centerX - startElement.ActualWidth() / 2.0;
-}
-
 int SystemButtonRank(SystemButton b) {
     switch (b) {
         case SystemButton::Search:
@@ -1234,62 +1248,75 @@ int SystemButtonRank(SystemButton b) {
 
 // Total footprint of Search+TaskView+Widgets together, used both to lay
 // them out and to reserve room for them next to Start (in adjacent mode) so
-// task list buttons on that side don't overlap them. Updated whenever any
-// of the three arranges; read by task list button placement.
+// task list buttons on that side don't overlap them. Computed once per
+// pass in RecomputeLayoutPlan (from the already-enumerated `children`) and
+// written here unconditionally on every pass - not as a side effect of
+// ComputeSystemButtonX running for a realized system button, which was the
+// previous approach and had a real bug: if none of the three are currently
+// realized in the repeater (all hidden, or a session that starts with them
+// hidden), ComputeSystemButtonX never ran and these kept whatever value an
+// earlier configuration left behind, permanently reserving that much dead
+// space next to Start in "adjacent" mode. Zero when the cluster is
+// genuinely empty now, always.
 double g_lastLeftSystemClusterWidth = 0;
 double g_lastRightSystemClusterWidth = 0;
 
-double SystemButtonClusterWidth(FrameworkElement repeater) {
-    double total = 0;
-    for (auto& child : GetRepeaterChildElements(repeater)) {
-        if (SystemButtonRank(IdentifySystemButton(child)) >= 0) {
-            total += FullFootprintWidth(child);
-        }
-    }
-    return total;
-}
+// A repeater child element paired with its SystemButton classification,
+// computed once per child per RecomputeLayoutPlan pass instead of
+// re-deriving IdentifySystemButton
+// (a winrt::get_class_name call - IInspectable::GetRuntimeClassName plus
+// an HSTRING allocation) every time it's needed. Previously recomputed up
+// to 4 times per child per pass: once each in the Start-finding, cluster-
+// width, and system-button-placement loops, plus once per child *again*
+// inside ComputeSystemButtonX's own widthBefore loop for every realized
+// system button (itself also re-walking the repeater via
+// GetRepeaterChildElements instead of reusing what RecomputeLayoutPlan
+// already enumerated).
+struct ChildInfo {
+    FrameworkElement element;
+    SystemButton systemButton;
+};
 
 // Places Search/TaskView/Widgets either at the taskbar's far left edge, or
 // immediately adjacent to one side of the Start button, per
-// g_settings.systemButtonsPlacement.
-double ComputeSystemButtonX(FrameworkElement repeater,
+// g_settings.systemButtonsPlacement. clusterWidth is the combined width of
+// all three, computed once by the caller (see g_lastLeftSystemClusterWidth's
+// comment for why it's no longer computed here as a side effect).
+// childInfos is the whole repeater's already-classified children (see
+// ChildInfo's comment) - avoids both re-walking the repeater and
+// re-deriving each child's SystemButton classification.
+double ComputeSystemButtonX(const std::vector<ChildInfo>& childInfos,
                             FrameworkElement targetElement,
                             SystemButton target,
                             double startCenterX,
-                            double startWidth) {
+                            double startWidth,
+                            double clusterWidth) {
     int targetRank = SystemButtonRank(target);
     if (targetRank < 0) {
         return 0;
     }
 
     double widthBefore = 0;
-    for (auto& child : GetRepeaterChildElements(repeater)) {
-        int r = SystemButtonRank(IdentifySystemButton(child));
+    for (auto& info : childInfos) {
+        int r = SystemButtonRank(info.systemButton);
         if (r >= 0 && r < targetRank) {
-            widthBefore += FullFootprintWidth(child);
+            widthBefore += FullFootprintWidth(info.element);
         }
     }
 
     if (g_settings.systemButtonsPlacement == SystemButtonsPlacement::FarLeft) {
-        g_lastLeftSystemClusterWidth = 0;
-        g_lastRightSystemClusterWidth = 0;
         return 8 + widthBefore;  // small left margin
     }
 
-    double clusterWidth = SystemButtonClusterWidth(repeater);
     double gap = g_settings.gapPx;
     double ownWidth = FullFootprintWidth(targetElement);
 
     if (g_settings.systemButtonsAdjacentSide == Side::Left) {
-        g_lastLeftSystemClusterWidth = clusterWidth;
-        g_lastRightSystemClusterWidth = 0;
         // Stack right-to-left outward from Start: lowest rank closest.
         double widthAfter = clusterWidth - widthBefore - ownWidth;
         return startCenterX - startWidth / 2.0 - gap - widthAfter - ownWidth;
     }
 
-    g_lastLeftSystemClusterWidth = 0;
-    g_lastRightSystemClusterWidth = clusterWidth;
     return startCenterX + startWidth / 2.0 + gap + widthBefore;
 }
 
@@ -1362,10 +1389,15 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
     double startWidth = g_lastStartWidth;
     bool adjacent =
         g_settings.systemButtonsPlacement == SystemButtonsPlacement::AdjacentStart;
-    double leftExtra = (adjacent && g_settings.systemButtonsAdjacentSide == Side::Left)
+    // Only add the gap when the cluster actually has width - otherwise an
+    // empty cluster (all three hidden) still reserved a bare gapPx of dead
+    // space next to Start for no reason.
+    double leftExtra = (adjacent && g_settings.systemButtonsAdjacentSide == Side::Left &&
+                        g_lastLeftSystemClusterWidth > 0)
                             ? (g_lastLeftSystemClusterWidth + gap)
                             : 0;
-    double rightExtra = (adjacent && g_settings.systemButtonsAdjacentSide == Side::Right)
+    double rightExtra = (adjacent && g_settings.systemButtonsAdjacentSide == Side::Right &&
+                         g_lastRightSystemClusterWidth > 0)
                              ? (g_lastRightSystemClusterWidth + gap)
                              : 0;
 
@@ -1526,11 +1558,19 @@ void ResolvePendingButtonHwnds() {
         void* key = winrt::get_abi(child);
         liveTaskListButtons.insert(key);
 
+        std::wstring identity = GetButtonAccessibleName(child);
+
         auto it = g_buttonHwndCache.find(key);
         bool needsResolve = it == g_buttonHwndCache.end();
         if (!needsResolve) {
             if (it->second.hwnd) {
-                needsResolve = !IsWindow(it->second.hwnd);
+                // Identity mismatch means ItemsRepeater rebound this
+                // element to a different item since we last resolved it -
+                // see ButtonHwndCacheEntry's comment. The old HWND is
+                // still a perfectly valid window, just no longer this
+                // element's, so IsWindow() alone can't catch this case.
+                needsResolve = !IsWindow(it->second.hwnd) ||
+                               identity != it->second.identity;
             } else {
                 int shift = std::min(it->second.consecutiveFailures, 4);
                 ULONGLONG backoffMs = 2000ULL << shift;  // 2s..32s
@@ -1538,7 +1578,7 @@ void ResolvePendingButtonHwnds() {
             }
         }
 
-        if (needsResolve && ResolveAndCacheButtonHwnd(child)) {
+        if (needsResolve && ResolveAndCacheButtonHwnd(child, identity)) {
             anyChanged = true;
         }
     }
@@ -1723,33 +1763,61 @@ void RecomputeLayoutPlan() {
         double startCenterX = GetMonitorCenterXLocal();
         std::unordered_map<void*, double> newPlan;
 
+        // Classify each child's SystemButton status exactly once - see
+        // ChildInfo's comment for why (was up to 4 redundant
+        // winrt::get_class_name calls per child per pass beforehand).
+        std::vector<ChildInfo> childInfos;
+        childInfos.reserve(children.size());
+        for (auto& child : children) {
+            childInfos.push_back({child, IdentifySystemButton(child)});
+        }
+
         // Start first: ComputeSystemButtonX/PlanTaskListButtons below
         // both read g_lastStartWidth, so it needs to already reflect this
-        // pass by the time they run, not the previous one. Inlined rather
-        // than calling ComputeStartButtonX (same formula) purely to reuse
-        // the startCenterX already computed once above, instead of that
-        // function re-deriving it via another GetMonitorCenterXLocal()
-        // call.
-        for (auto& child : children) {
-            if (IdentifySystemButton(child) == SystemButton::Start) {
-                g_lastStartWidth = child.ActualWidth();
-                newPlan[winrt::get_abi(child)] =
+        // pass by the time they run, not the previous one.
+        for (auto& info : childInfos) {
+            if (info.systemButton == SystemButton::Start) {
+                g_lastStartWidth = info.element.ActualWidth();
+                newPlan[winrt::get_abi(info.element)] =
                     startCenterX - g_lastStartWidth / 2.0;
                 break;
             }
         }
 
         // Search/TaskView/Widgets next: PlanTaskListButtons reads
-        // g_lastLeftSystemClusterWidth/g_lastRightSystemClusterWidth
-        // (updated inside ComputeSystemButtonX), so these need to run
-        // before any task list button below for the same reason.
-        for (auto& child : children) {
-            SystemButton sb = IdentifySystemButton(child);
-            if (sb == SystemButton::None || sb == SystemButton::Start) {
+        // g_lastLeftSystemClusterWidth/g_lastRightSystemClusterWidth, so
+        // these need to be set - unconditionally, every pass, so a
+        // cluster that's empty this pass reads as genuinely 0 rather than
+        // keeping a stale value from an earlier one (see
+        // g_lastLeftSystemClusterWidth's comment) - before any task list
+        // button below runs for the same reason.
+        double systemClusterWidth = 0;
+        for (auto& info : childInfos) {
+            if (SystemButtonRank(info.systemButton) >= 0) {
+                systemClusterWidth += FullFootprintWidth(info.element);
+            }
+        }
+        bool systemButtonsAdjacent = g_settings.systemButtonsPlacement ==
+                                     SystemButtonsPlacement::AdjacentStart;
+        g_lastLeftSystemClusterWidth =
+            (systemButtonsAdjacent &&
+             g_settings.systemButtonsAdjacentSide == Side::Left)
+                ? systemClusterWidth
+                : 0;
+        g_lastRightSystemClusterWidth =
+            (systemButtonsAdjacent &&
+             g_settings.systemButtonsAdjacentSide == Side::Right)
+                ? systemClusterWidth
+                : 0;
+
+        for (auto& info : childInfos) {
+            if (info.systemButton == SystemButton::None ||
+                info.systemButton == SystemButton::Start) {
                 continue;
             }
-            newPlan[winrt::get_abi(child)] = ComputeSystemButtonX(
-                repeater, child, sb, startCenterX, g_lastStartWidth);
+            newPlan[winrt::get_abi(info.element)] = ComputeSystemButtonX(
+                childInfos, info.element, info.systemButton, startCenterX,
+                g_lastStartWidth, systemClusterWidth);
         }
 
         // Task list buttons last - see PlanTaskListButtons' own comment

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -153,6 +153,7 @@ community.
 
 #include <windhawk_utils.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cmath>
 #include <cwctype>
@@ -306,8 +307,8 @@ PinnedAppsAnchor ParsePinnedAppsAnchor(PCWSTR value) {
 // The distance-from-center order key for a pinned-but-not-running app (one
 // with no window to measure a real distance from). Made -infinity instead
 // of the default +infinity when pinnedAppsAnchor is AdjacentToStart, since
-// ComputeTaskListButtonX's byDistance sort treats a smaller orderKey as
-// closer to Start - nothing can beat -infinity, so these always end up
+// PlanTaskListButtons' distance-from-center sort treats a smaller orderKey
+// as closer to Start - nothing can beat -infinity, so these always end up
 // innermost rather than outermost.
 double PinnedAppOrderKey() {
     return g_settings.pinnedAppsAnchor == PinnedAppsAnchor::AdjacentToStart
@@ -484,37 +485,6 @@ std::vector<FrameworkElement> GetRepeaterChildElements(
     return result;
 }
 
-// Returns `element`'s sibling FrameworkElements (element excluded), in
-// visual-tree order. Works whether the parent is an ItemsRepeater (uses the
-// data-bound realized items, same as GetRepeaterChildElements) or a plain
-// panel (falls back to raw VisualTreeHelper enumeration). Task list buttons'
-// exact parent container isn't confirmed to be the same repeater that hosts
-// the Start button, so this is deliberately hierarchy-agnostic rather than
-// assuming ItemsRepeater everywhere.
-std::vector<FrameworkElement> GetSiblingElements(FrameworkElement element) {
-    std::vector<FrameworkElement> result;
-
-    auto parent =
-        Media::VisualTreeHelper::GetParent(element).try_as<FrameworkElement>();
-    if (!parent) {
-        return result;
-    }
-
-    if (parent.try_as<winrt::Microsoft::UI::Xaml::Controls::ItemsRepeater>()) {
-        return GetRepeaterChildElements(parent);
-    }
-
-    int childrenCount = Media::VisualTreeHelper::GetChildrenCount(parent);
-    for (int i = 0; i < childrenCount; i++) {
-        auto child =
-            Media::VisualTreeHelper::GetChild(parent, i).try_as<FrameworkElement>();
-        if (child) {
-            result.push_back(child);
-        }
-    }
-
-    return result;
-}
 
 using RunFromWindowThreadProc_t = std::function<void()>;
 
@@ -577,6 +547,19 @@ XamlRoot XamlRootFromTaskbarHostSharedPtr(void* taskbarHostSharedPtr[2]) {
         return nullptr;
     }
 
+    // The shared_ptr's ref-count block (taskbarHostSharedPtr[1]) must be
+    // released on every path below, not just the one at the end of a
+    // fully successful call - every early return past this point used to
+    // leak a reference. That's worse than it looks now that
+    // RecomputeLayoutPlan calls this on every single ArrangeOverride
+    // pass: one leaked reference per pass, for the life of the process,
+    // on any Windows build where the prologue pattern below stops
+    // matching.
+    struct DecrefGuard {
+        void* ptr;
+        ~DecrefGuard() { std__Ref_count_base__Decref_Original(ptr); }
+    } decrefGuard{taskbarHostSharedPtr[1]};
+
     // The offset of the XAML element pointer inside TaskbarHost isn't
     // exposed by any symbol, so it's read out of the prologue of a
     // neighboring function that's known to access it at a fixed offset.
@@ -625,11 +608,7 @@ XamlRoot XamlRootFromTaskbarHostSharedPtr(void* taskbarHostSharedPtr[2]) {
     taskbarElementIUnknown->QueryInterface(winrt::guid_of<FrameworkElement>(),
                                             winrt::put_abi(taskbarElement));
 
-    auto result = taskbarElement ? taskbarElement.XamlRoot() : nullptr;
-
-    std__Ref_count_base__Decref_Original(taskbarHostSharedPtr[1]);
-
-    return result;
+    return taskbarElement ? taskbarElement.XamlRoot() : nullptr;
 }
 
 XamlRoot GetTaskbarXamlRoot(HWND hTaskbarWnd) {
@@ -947,26 +926,30 @@ HWND ResolveHwndFromTaskListButton(FrameworkElement element) {
 // pass (confirmed via g_resolveStats climbing into the hundreds within a
 // couple of seconds for just one such button).
 //
-// consecutiveFailures caps that retry, rather than letting it run forever
-// at the TTL's cadence: the resolution chain ends with a synthetic
-// ReportClicked call against the taskbar's real internal click handler
-// (intercepted before it acts on it - see CTaskListWnd_HandleClick_Hook),
-// and for a button that can genuinely never resolve (the common case,
-// exactly the one this negative cache exists for) that was firing roughly
-// once every 2s, indefinitely, for as long as explorer runs. The
-// interception is what keeps that inert today, but there's no reason to
-// keep invoking taskbar-internal click machinery on a timer forever for a
-// button that's already told us three times in a row that it has nothing
-// to resolve to. A live element that's simply slow to resolve (e.g. the
-// window it belongs to hasn't finished appearing yet) still gets the fresh
-// retries above, since the counter only advances on an actual failure and
-// resets to 0 on the first success.
+// consecutiveFailures drives a capped exponential backoff (2s, 4s, 8s,
+// 16s, then holding at 32s) instead of retrying at a fixed 2s interval
+// forever: the resolution chain ends with a synthetic ReportClicked call
+// against the taskbar's real internal click handler (intercepted before
+// it acts on it - see CTaskListWnd_HandleClick_Hook), and a button that
+// can genuinely never resolve (the common case, exactly the one this
+// negative cache exists for) would otherwise hammer that at a fixed 2s
+// cadence indefinitely. A hard stop after a few failures was tried first,
+// but ItemsRepeater typically recycles the same realized element (and so
+// the same cache entry) for a given index rather than creating a new one
+// - so a pinned-but-not-running app that fails a few times and is *then*
+// actually launched would never get its HWND resolved for as long as
+// that element stays realized, silently breaking the mod's own headline
+// feature (side-following) for that button. Backing off instead of
+// stopping keeps retrying, just less often, so a later launch is still
+// picked up (worst case within 32s) without hammering the click handler
+// at a fixed rate forever. A live element that's simply slow to resolve
+// still gets the fast early retries, since the counter only advances on
+// an actual failure and resets to 0 on the first success.
 struct ButtonHwndCacheEntry {
     HWND hwnd = nullptr;
     ULONGLONG lastAttempt = 0;
     int consecutiveFailures = 0;
 };
-constexpr int kMaxConsecutiveResolveFailures = 3;
 std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
 
 // Actually runs the resolution chain and updates the cache. Returns
@@ -1294,7 +1277,7 @@ double ComputeSystemButtonX(FrameworkElement repeater,
 
 // Updated whenever the Start button's own Arrange runs. Read by task list
 // button arrangement so it doesn't need to assume Start lives in the same
-// container as the task buttons (unconfirmed - see GetSiblingElements).
+// container as the task buttons.
 double g_lastStartWidth = 48;
 
 // Diagnostics only, for RecomputeLayoutPlan's once-per-pass traversal.
@@ -1312,61 +1295,53 @@ struct LayoutPlanStats {
 // (unrelated struct, same underlying risk).
 thread_local LayoutPlanStats g_planStats;
 
-double ComputeTaskListButtonX(FrameworkElement target,
-                               double startCenterX) {
-    ButtonClassification targetInfo = ClassifyTaskListButton(target);
-    if (targetInfo.hwndResolved) {
-        g_planStats.taskListHwndResolved++;
-    }
-    if (targetInfo.side == Side::Left) {
-        g_planStats.taskListLeft++;
-    } else {
-        g_planStats.taskListRight++;
-    }
+struct TaskListPlanEntry {
+    FrameworkElement element;
+    ButtonClassification info;
+    double width;
+    int index;  // Position within `children`, i.e. taskbar order.
+};
 
-    void* targetAbi = winrt::get_abi(target);
-    bool byDistance =
-        g_settings.taskListOrder == TaskListOrder::DistanceFromCenter;
-
-    double sameSideWidthBefore = 0;
-    if (byDistance) {
-        // Rank by distance from screen-center rather than taskbar order, so
-        // the icon nearest Start corresponds to the window nearest center.
-        // Pointer-value tiebreak keeps ties stable frame to frame.
-        for (auto& child : GetSiblingElements(target)) {
-            if (!IsTaskListButton(child) || winrt::get_abi(child) == targetAbi) {
-                continue;
-            }
-            ButtonClassification childInfo = ClassifyTaskListButton(child);
-            if (childInfo.side != targetInfo.side) {
-                continue;
-            }
-            bool closer =
-                childInfo.orderKey < targetInfo.orderKey ||
-                (childInfo.orderKey == targetInfo.orderKey &&
-                 winrt::get_abi(child) < targetAbi);
-            if (closer) {
-                sameSideWidthBefore += FullFootprintWidth(child);
-            }
-        }
-    } else {
-        for (auto& child : GetSiblingElements(target)) {
-            if (winrt::get_abi(child) == targetAbi) {
-                break;
-            }
-            if (!IsTaskListButton(child)) {
-                continue;
-            }
-            if (ClassifyTaskListButton(child).side == targetInfo.side) {
-                sameSideWidthBefore += FullFootprintWidth(child);
-            }
+// Computes every task list button's target X in a single O(n) pass over
+// the repeater's already-enumerated children, classifying each button
+// exactly once. The previous version (ComputeTaskListButtonX, called once
+// per button from RecomputeLayoutPlan's loop) re-walked and re-classified
+// every sibling for every single button it placed - an O(n^2) pass over
+// the whole task list on every ArrangeOverride pass (~1600 classifications
+// at 40 icons), on the shell's layout critical path during a drag. It also
+// re-derived each target's sibling list via VisualTreeHelper::GetParent
+// instead of reusing `children`, so it re-walked the repeater itself once
+// per button too. This also closes a subtle consistency gap the O(n^2)
+// version had: a button classified while being visited as someone else's
+// *sibling* could in principle disagree with its own classification when
+// later visited as the *target* (e.g. its HWND resolving mid-pass), which
+// could produce two buttons at the same X or a gap - classifying once up
+// front removes that possibility entirely.
+void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
+                         double startCenterX,
+                         std::unordered_map<void*, double>& outPlan) {
+    std::vector<TaskListPlanEntry> entries;
+    for (int i = 0; i < (int)children.size(); i++) {
+        if (IsTaskListButton(children[i])) {
+            entries.push_back({children[i], ClassifyTaskListButton(children[i]),
+                               FullFootprintWidth(children[i]), i});
         }
     }
 
-    double width = FullFootprintWidth(target);
+    g_planStats.taskListTotal = (int)entries.size();
+    for (auto& entry : entries) {
+        if (entry.info.hwndResolved) {
+            g_planStats.taskListHwndResolved++;
+        }
+        if (entry.info.side == Side::Left) {
+            g_planStats.taskListLeft++;
+        } else {
+            g_planStats.taskListRight++;
+        }
+    }
+
     double gap = g_settings.gapPx;
     double startWidth = g_lastStartWidth;
-
     bool adjacent =
         g_settings.systemButtonsPlacement == SystemButtonsPlacement::AdjacentStart;
     double leftExtra = (adjacent && g_settings.systemButtonsAdjacentSide == Side::Left)
@@ -1376,13 +1351,60 @@ double ComputeTaskListButtonX(FrameworkElement target,
                              ? (g_lastRightSystemClusterWidth + gap)
                              : 0;
 
-    if (targetInfo.side == Side::Left) {
-        return startCenterX - startWidth / 2.0 - gap - leftExtra -
-               sameSideWidthBefore - width;
-    }
+    if (g_settings.taskListOrder == TaskListOrder::DistanceFromCenter) {
+        // Innermost (closest to Start) first on each side. Ties - e.g.
+        // multiple pinned/overridden buttons, which all share the same
+        // +/-infinity orderKey - now break on taskbar index instead of
+        // the previous ABI-pointer value: equally stable frame to frame,
+        // but a predictable order instead of an arbitrary one.
+        std::vector<TaskListPlanEntry*> left, right;
+        for (auto& entry : entries) {
+            (entry.info.side == Side::Left ? left : right).push_back(&entry);
+        }
+        auto byOrderKey = [](const TaskListPlanEntry* a,
+                             const TaskListPlanEntry* b) {
+            if (a->info.orderKey != b->info.orderKey) {
+                return a->info.orderKey < b->info.orderKey;
+            }
+            return a->index < b->index;
+        };
+        std::sort(left.begin(), left.end(), byOrderKey);
+        std::sort(right.begin(), right.end(), byOrderKey);
 
-    return startCenterX + startWidth / 2.0 + gap + rightExtra +
-           sameSideWidthBefore;
+        double widthBefore = 0;
+        for (auto* entry : left) {
+            outPlan[winrt::get_abi(entry->element)] =
+                startCenterX - startWidth / 2.0 - gap - leftExtra -
+                widthBefore - entry->width;
+            widthBefore += entry->width;
+        }
+        widthBefore = 0;
+        for (auto* entry : right) {
+            outPlan[winrt::get_abi(entry->element)] = startCenterX +
+                startWidth / 2.0 + gap + rightExtra + widthBefore;
+            widthBefore += entry->width;
+        }
+    } else {
+        // Preserve taskbar order: walk `entries` in original (taskbar)
+        // order, accumulating each side's width independently. Unchanged
+        // from before this rewrite: the left side ends up mirrored rather
+        // than laid out outward-from-Start - a pre-existing ordering
+        // quirk (tracked separately in the review) that this efficiency
+        // rewrite deliberately preserves rather than also fixing.
+        double leftWidthBefore = 0, rightWidthBefore = 0;
+        for (auto& entry : entries) {
+            if (entry.info.side == Side::Left) {
+                outPlan[winrt::get_abi(entry.element)] =
+                    startCenterX - startWidth / 2.0 - gap - leftExtra -
+                    leftWidthBefore - entry.width;
+                leftWidthBefore += entry.width;
+            } else {
+                outPlan[winrt::get_abi(entry.element)] = startCenterX +
+                    startWidth / 2.0 + gap + rightExtra + rightWidthBefore;
+                rightWidthBefore += entry.width;
+            }
+        }
+    }
 }
 
 // ============================================================================
@@ -1489,12 +1511,13 @@ void ResolvePendingButtonHwnds() {
         auto it = g_buttonHwndCache.find(key);
         bool needsResolve = it == g_buttonHwndCache.end();
         if (!needsResolve) {
-            needsResolve =
-                it->second.hwnd
-                    ? !IsWindow(it->second.hwnd)
-                    : (it->second.consecutiveFailures <
-                           kMaxConsecutiveResolveFailures &&
-                       now - it->second.lastAttempt >= 2000);
+            if (it->second.hwnd) {
+                needsResolve = !IsWindow(it->second.hwnd);
+            } else {
+                int shift = std::min(it->second.consecutiveFailures, 4);
+                ULONGLONG backoffMs = 2000ULL << shift;  // 2s..32s
+                needsResolve = now - it->second.lastAttempt >= backoffMs;
+            }
         }
 
         if (needsResolve && ResolveAndCacheButtonHwnd(child)) {
@@ -1635,20 +1658,27 @@ HRESULT WINAPI IUIElement_Arrange_Hook(void* pThis,
 // independently by the HWND-resolve timer - see ResolvePendingButtonHwnds
 // for why those still need explicit pruning).
 //
-// MUST only run when confirmed to be on the primary taskbar's own thread:
+// MUST only run when confirmed to be on g_hTaskbarWnd's own thread:
 // GetTaskbarXamlRoot(g_hTaskbarWnd) reaches across to the PRIMARY's XAML
 // object specifically, which is an unsafe unmarshaled cross-apartment
-// WinRT call from any other thread. This hook is process-wide (also fires
-// for secondary-monitor taskbars, on their own threads), so without this
-// check a secondary-monitor pass calling this function would be exactly
-// the same crash class fixed elsewhere in this file by marshaling through
-// RunFromWindowThread - except Arrange can't marshal (it needs a
-// synchronous answer), so the only safe option is to skip the attempt
-// entirely on the wrong thread. That's fine here: this function is only
-// ever useful for the primary's own passes anyway (see g_lastArrangedX's
-// comment on why secondary-monitor elements are never meant to get an
-// entry), and it naturally gets called again on the primary's own next
-// pass with no special retry logic needed.
+// WinRT call from any other thread.
+//
+// Note this check does NOT scope the (relatively expensive) rebuild to
+// primary-monitor passes only, despite an earlier version of this comment
+// claiming that - Shell_TrayWnd and Shell_SecondaryTrayWnd both run on
+// the SAME Explorer UI thread (the established pattern other taskbar mods
+// use to reach every monitor's taskbar is a single EnumThreadWindows on
+// that one thread), so this check passes for secondary-monitor
+// ArrangeOverride passes too, and the whole plan gets rebuilt redundantly
+// for each of them. It's still *correct* either way - secondary-monitor
+// elements never end up in g_lastArrangedX regardless of how many times
+// this runs, since it only ever walks the primary's own repeater - just
+// not free. This check exists purely as the apartment-safety guard
+// described above, not as a monitor-scoping mechanism. A real
+// scoping/caching optimization (skip the rebuild when nothing relevant
+// changed) is a separate, larger change left for its own review round
+// given how much this exact function's correctness properties have
+// already been fought for across several crash-debugging sessions.
 void RecomputeLayoutPlan() {
     if (!g_hTaskbarWnd) {
         return;
@@ -1675,7 +1705,7 @@ void RecomputeLayoutPlan() {
         double startCenterX = GetMonitorCenterXLocal();
         std::unordered_map<void*, double> newPlan;
 
-        // Start first: ComputeSystemButtonX/ComputeTaskListButtonX below
+        // Start first: ComputeSystemButtonX/PlanTaskListButtons below
         // both read g_lastStartWidth, so it needs to already reflect this
         // pass by the time they run, not the previous one. Inlined rather
         // than calling ComputeStartButtonX (same formula) purely to reuse
@@ -1691,7 +1721,7 @@ void RecomputeLayoutPlan() {
             }
         }
 
-        // Search/TaskView/Widgets next: ComputeTaskListButtonX reads
+        // Search/TaskView/Widgets next: PlanTaskListButtons reads
         // g_lastLeftSystemClusterWidth/g_lastRightSystemClusterWidth
         // (updated inside ComputeSystemButtonX), so these need to run
         // before any task list button below for the same reason.
@@ -1704,20 +1734,10 @@ void RecomputeLayoutPlan() {
                 repeater, child, sb, startCenterX, g_lastStartWidth);
         }
 
-        // Task list buttons last. ComputeTaskListButtonX still does its
-        // own O(n) walk of sibling buttons per button it's called for (an
-        // O(n^2) pass overall) - left as-is here since this change is
-        // scoped to fixing WHERE that traversal happens (never nested
-        // inside Arrange anymore), not also rewriting its algorithmic
-        // cost in the same pass.
-        for (auto& child : children) {
-            if (!IsTaskListButton(child)) {
-                continue;
-            }
-            g_planStats.taskListTotal++;
-            newPlan[winrt::get_abi(child)] =
-                ComputeTaskListButtonX(child, startCenterX);
-        }
+        // Task list buttons last - see PlanTaskListButtons' own comment
+        // for why this is a single O(n) pass over `children` rather than
+        // calling a per-button compute function in a loop here.
+        PlanTaskListButtons(children, startCenterX, newPlan);
 
         g_lastArrangedX = std::move(newPlan);
     } catch (...) {
@@ -2175,6 +2195,30 @@ void StartWinEventHook() {
     });
 }
 
+// RunFromWindowThread can only fail two ways: the taskbar's thread is
+// already gone (GetWindowThreadProcessId returns 0 - in which case the
+// OS already tore down any timer/hook that thread owned, so there's
+// nothing left to clean up), or its own internal SetWindowsHookEx call
+// failed (rare, e.g. transient resource exhaustion) while the thread is
+// still very much alive. That second case is the dangerous one: nothing
+// under mod control runs on the taskbar thread to unregister the real
+// WinEventHook/timer, Wh_ModUninit returns anyway, Windhawk unmaps this
+// module's code, and the still-alive thread's next tick calls into
+// unmapped memory. A few retries gives that transient failure a chance to
+// clear without risking an unbounded stall if the thread really is gone.
+bool RunFromWindowThreadWithRetry(HWND hWnd, RunFromWindowThreadProc_t proc) {
+    for (int attempt = 0; attempt < 3; attempt++) {
+        if (RunFromWindowThread(hWnd, proc)) {
+            return true;
+        }
+        if (GetWindowThreadProcessId(hWnd, nullptr) == 0) {
+            break;
+        }
+        Sleep(20);
+    }
+    return false;
+}
+
 void StopWinEventHook() {
     if (!g_locationChangeHook) {
         return;
@@ -2184,12 +2228,12 @@ void StopWinEventHook() {
     g_locationChangeHook = nullptr;
 
     if (g_hTaskbarWnd) {
-        // If this fails to marshal (the taskbar window is somehow already
-        // gone), the hook is leaked rather than left dangling into
-        // unmapped memory after this module unloads - UnhookWinEvent from
-        // the wrong thread is documented as unsafe, so falling back to
-        // calling it inline here would trade one crash class for another.
-        if (!RunFromWindowThread(g_hTaskbarWnd, [hook] { UnhookWinEvent(hook); })) {
+        // See RunFromWindowThreadWithRetry's comment for why a bounded
+        // retry, rather than falling back to an inline UnhookWinEvent
+        // here - that's documented as unsafe from the wrong thread, so
+        // it would just trade one crash class for another.
+        if (!RunFromWindowThreadWithRetry(g_hTaskbarWnd,
+                                          [hook] { UnhookWinEvent(hook); })) {
             Wh_Log(L"StopWinEventHook: RunFromWindowThread failed, "
                    L"location-change hook left registered");
         }
@@ -2238,7 +2282,7 @@ void StopButtonHwndResolveTimer() {
 
     // See StopWinEventHook's comment - same reasoning against an inline
     // fallback call applies to KillTimer from the wrong thread.
-    if (!RunFromWindowThread(g_hTaskbarWnd, [] {
+    if (!RunFromWindowThreadWithRetry(g_hTaskbarWnd, [] {
             KillTimer(g_hTaskbarWnd, kButtonHwndResolveTimerId);
         })) {
         Wh_Log(L"StopButtonHwndResolveTimer: RunFromWindowThread failed, "
@@ -2314,7 +2358,15 @@ void Wh_ModUninit() {
 void Wh_ModSettingsChanged() {
     Wh_Log(L">");
 
-    LoadSettings();
+    // LoadSettings() reassigns g_settings.leftApps/rightApps
+    // (std::vector<std::wstring>) - marshaled onto the taskbar's own
+    // thread so a concurrent ContainsAnyFragment call during a layout
+    // pass on that thread can't read a vector mid-reassignment.
+    if (g_hTaskbarWnd) {
+        RunFromWindowThread(g_hTaskbarWnd, [] { LoadSettings(); });
+    } else {
+        LoadSettings();
+    }
 
     InvalidateTaskbarLayout();
 }

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -40,8 +40,8 @@ _The same window moved right of screen-center - its icon moves with it,
 to the right of Start._
 
 When you drag a window across the center line of the screen, its taskbar
-button switches sides to follow it. Side-switching is driven by a global
-window-location-change listener and is best-effort: it happens shortly
+button switches sides to follow it. Side-switching is driven by a periodic
+poll of tracked windows' positions and is best-effort: it happens shortly
 after a drag/move settles, not on every intermediate pixel of the drag.
 
 Search, Task View and Widgets can either stay at the far left edge, or move
@@ -50,7 +50,7 @@ right next to Start on whichever side you prefer.
 The window-tracking behind position-based splitting and drag-follow can be
 turned off entirely with `trackWindowPositions`, if you'd rather keep just
 the centered Start button and system-button placement with no background
-probing of taskbar buttons and no system-wide event hook - every app is
+probing of taskbar buttons and no periodic position polling - every app is
 then classified the same way as a pinned-but-not-running one instead.
 
 ## Known limitations (please read before reporting issues)
@@ -86,8 +86,10 @@ then classified the same way as a pinned-but-not-running one instead.
   "Center", the menu happens to open near screen-center anyway since
   that's where Windows expects it by default, but with alignment set to
   "Left", the button sits at true center while the menu still opens at the
-  left edge. There's no exposed way to move the menu's own anchor point
-  the way this mod moves the button.
+  left edge. This is a solvable limitation rather than a permanent one -
+  `taskbar-start-button-position.wh.cpp` repositions the menu itself by
+  hooking `StartMenuExperienceHost.exe` - just not something this mod
+  does today.
 - **A very crowded side compresses instead of overflowing cleanly.** If
   enough app icons pile up on one side that they'd run into the system
   tray/clock on the right (or, in "far left" placement, into Search/Task
@@ -141,10 +143,14 @@ then classified the same way as a pinned-but-not-running one instead.
   interception point, and any single miss after that latches this mod's
   probing off entirely on that path (see `Wh_Log` for which) - so a
   running app's icon may briefly show on its default side, rather than by
-  window position, until you click any taskbar button once, and if a
-  future Windows update ever changes how that interception works, the
-  worst case is icons freezing on their default side rather than the mod
-  silently clicking things on its own.
+  window position, until you click any taskbar button once. That gate
+  only covers *before* interception is ever confirmed working, though: if
+  a future Windows update breaks interception in a way that still lets a
+  probe reach the taskbar's real click handler afterward, the probe's
+  sentinel value gets delivered as that handler's real argument, and the
+  realistic worst case is a stray window activate/minimize or an access
+  violation in explorer.exe, not merely icons freezing on their default
+  side.
 - **Taskbar buttons can disappear when a display is deactivated** (via
   Settings, unplugging, or a third-party display on/off tool) - if
   "Taskbar behaviors > When using multiple displays, show my taskbar apps
@@ -244,17 +250,18 @@ community.
     When on, each running app's taskbar button is matched to its window so
     it can be classified by live position and follow it if it's dragged
     across the screen - this involves probing the taskbar's internal click
-    handler on a background timer and a system-wide window-event hook.
-    Turn off to disable all of that: every running app is then classified
-    the same way as a pinned-but-not-running one, via leftApps/rightApps/
+    handler on a background timer and periodically polling tracked
+    windows' positions. Turn off to disable all of that: every running app
+    is then classified the same way as a pinned-but-not-running one, via
+    leftApps/rightApps/
     "Default side for unclassified apps" above, with no drag-follow. Start
     centering and Search/Task View/Widgets placement are unaffected either
     way. Takes effect immediately, no need to reload the mod.
 */
 // ==/WindhawkModSettings==
 
-// Design rationale, history, and edge-case reasoning behind the comments
-// below that say "see RATIONALE.md":
+// Extended design rationale and round-by-round change history, for anyone
+// who wants more background than the comments below carry on their own:
 // https://github.com/rycalvo/w11tb_centerer/blob/main/RATIONALE.md
 
 #include <windhawk_utils.h>
@@ -472,11 +479,11 @@ thread_local bool g_inTaskbarArrangeOverride;
 // STATUS_STOWED_EXCEPTION was observed doing that when a window moves
 // across monitors while Windows' "show taskbar apps on" setting isn't
 // "All taskbars," since that structurally adds/removes taskbar buttons
-// mid-traversal. See RATIONALE.md.
+// mid-traversal.
 
 // Taskbar window handle, resolved by EnsureTaskbarWnd. atomic: written on
 // the taskbar thread (or Wh_ModAfterInit's thread at startup), read from
-// the dedicated WinEventHook thread. Callers with more than one read
+// the dedicated background worker thread. Callers with more than one read
 // snapshot it into a local first so all their reads agree on one value.
 std::atomic<HWND> g_hTaskbarWnd;
 
@@ -489,24 +496,19 @@ std::atomic<HWND> g_hTaskbarWnd;
 // synchronously regardless.
 std::atomic<bool> g_taskbarWndSubclassed;
 
-HWINEVENTHOOK g_locationChangeHook;
-std::atomic<int> g_winEventRawCount;
-std::atomic<int> g_winEventInvalidateCount;
+// How often DragFollowPollTimerProc has ticked and actually found a
+// tracked window's rect changed, respectively - see that function.
+std::atomic<int> g_dragFollowPollCount;
+std::atomic<int> g_dragFollowInvalidateCount;
 std::atomic<int> g_invalidateSkippedReentrant;
 std::atomic<int> g_invalidateExceptions;
 
-// Only touched from the dedicated WinEventHook thread (WinEventProc,
-// DragFollowTrailingTimerProc, ButtonHwndResolveTimerProc all run there
-// exclusively).
-UINT_PTR g_dragFollowTrailingTimerId;
+// Only touched from the dedicated background thread (DragFollowPollTimerProc,
+// ButtonHwndResolveTimerProc both run there exclusively).
+UINT_PTR g_dragFollowPollTimerId;
 
 // The HWND-resolve timer's own id, on the same dedicated thread.
 UINT_PTR g_buttonHwndResolveTimerId;
-
-// Last drag-follow invalidate tick. Also updated by
-// DragFollowTrailingTimerProc, since a trailing-timer fire is itself an
-// invalidate for WinEventProc's own throttle to see.
-ULONGLONG g_lastDragFollowInvalidate;
 
 // ============================================================================
 // Generic taskbar/XAML helpers
@@ -744,11 +746,11 @@ TaskListButton_get_IsRunning_t TaskListButton_get_IsRunning_Original;
 // full cost every retry only to reach the same answer. Optional (see
 // HookTaskbarViewDllSymbols); defaults to "assume running" - i.e. don't
 // skip anything - both when the symbol hasn't resolved at all, and when a
-// resolved call still fails (round 30 review finding: the HRESULT was
-// previously ignored, so a failed call left isRunning at its initialized
-// false and got treated as confirmed-not-running instead of falling back
-// the same way an unresolved symbol does), which is exactly this mod's
-// behavior before this optimization existed. See RATIONALE.md.
+// resolved call still fails (the failed call leaves isRunning at its
+// initialized false, so treating that as confirmed-not-running would
+// silently misclassify it instead of falling back the same way an
+// unresolved symbol does), which is exactly this mod's behavior before
+// this optimization existed.
 bool TaskListButtonIsRunning(FrameworkElement element) {
     if (!TaskListButton_get_IsRunning_Original) {
         return true;
@@ -784,8 +786,13 @@ thread_local void* g_clickSentinel_TaskGroup;
 // TaskGroup::ReportClicked, relying entirely on CTaskListWnd_HandleClick_Hook
 // below to recognize the sentinel and swallow it before the taskbar's real
 // HandleClick runs. Unlike reference mods (which only probe on an actual
-// user gesture), this mod probes unattended from a background timer - see
-// RATIONALE.md for the failure-mode analysis.
+// user gesture), this mod probes unattended from a background timer. If
+// interception ever stops recognizing the sentinel - the hook stays
+// installed but a probe click reaches the taskbar's actual HandleClick
+// unswallowed - &g_clickSentinel (a WCHAR[]) gets delivered as the real
+// winrt::Windows::System::LauncherOptions const& argument, so the
+// realistic worst case is a stray window activate/minimize or an access
+// violation in explorer.exe, not merely a resolution failure.
 //
 // Latched per path (item vs. group), not one shared flag, since the two
 // paths reach CTaskListWnd::HandleClick through different internal call
@@ -795,7 +802,7 @@ thread_local void* g_clickSentinel_TaskGroup;
 // enough to stop risking real clicks; the asymmetry (a false latch costs
 // position tracking, a false negative activates/minimizes windows the
 // user didn't touch) favors failing closed immediately rather than
-// tolerating more misses. See RATIONALE.md.
+// tolerating more misses.
 std::atomic<bool> g_clickSentinelItemConfirmed;
 std::atomic<bool> g_clickSentinelItemBroken;
 std::atomic<int> g_clickSentinelItemMisses;
@@ -814,13 +821,13 @@ thread_local bool g_clickSentinelProbingGroup;
 // gates the very first unattended sentinel probe of the session on proof
 // that CTaskListWnd::HandleClick's hook is actually installed and
 // dispatching real clicks through it correctly, before ever risking one
-// becoming a real click if interception is broken. See RATIONALE.md.
+// becoming a real click if interception is broken.
 std::atomic<bool> g_realTaskbarClickObserved;
 
 // Forward declarations: both are defined later (Per-button HWND cache /
 // Mod lifecycle sections), needed here so the first-real-click branch
 // below can nudge the resolve timer the instant that click is observed,
-// rather than waiting for the next backoff tick - see RATIONALE.md.
+// rather than waiting for the next backoff tick.
 extern std::atomic<bool> g_forceResolveUnresolved;
 void ArmButtonHwndResolveTimer(DWORD delayMs);
 
@@ -848,7 +855,7 @@ HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
     // the first time a real click confirms the interception point is
     // reachable - every button that was bailing out at
     // g_realTaskbarClickObserved's own check gets an immediate recheck
-    // instead of waiting for its next 2s backoff tick. See RATIONALE.md.
+    // instead of waiting for its next 2s backoff tick.
     if (!g_realTaskbarClickObserved.exchange(true)) {
         g_forceResolveUnresolved = true;
         ArmButtonHwndResolveTimer(0);
@@ -1084,7 +1091,6 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element,
     // interception itself is unaffected - it's GetTaskItemsArray's own
     // bounds check further down that always fails instead), turning every
     // attempt into a pure-waste ReportClicked with nothing to bound it.
-    // See RATIONALE.md.
     size_t taskItemsOffset = GetTaskItemsArrayOffset();
     if (taskItemsOffset == 0 || taskItemsOffset >= kTaskItemsArrayProbeSize) {
         g_resolveStats.failure++;
@@ -1174,9 +1180,9 @@ HWND ResolveHwndFromTaskListButton(FrameworkElement element,
     // not - would otherwise bail here anyway. Centralizing it lets the
     // caller cache "awaiting first click" as its own idle-worthy state,
     // instead of every such button polling at the fast backoff-0 cadence
-    // for as long as the session goes without a real taskbar click
-    // (round 30 review finding: this could be indefinite for a user who
-    // launches everything from Start/Alt+Tab). See RATIONALE.md.
+    // for as long as the session goes without a real taskbar click - which
+    // could otherwise be indefinite for a user who launches everything
+    // from Start/Alt+Tab rather than clicking a taskbar button directly.
     if (!g_realTaskbarClickObserved) {
         outAwaitingFirstClick = true;
         return nullptr;
@@ -1202,7 +1208,7 @@ HWND ResolveHwndFromTaskListButton(FrameworkElement element,
         // A dispatched-and-missed item-path click already proves this
         // button is bound to a TaskListWindowViewModel, not a group - the
         // group path would just dispatch a second, wholly redundant click
-        // for the same button. See RATIONALE.md.
+        // for the same button.
         outClickDispatched = itemDispatched;
         return hwnd;
     }
@@ -1231,16 +1237,15 @@ struct ButtonHwndCacheEntry {
     // NextResolveDelayMs treats this the same as a resolved or terminal
     // entry (idle cadence, not the fast backoff-0 schedule), since a
     // confirmed-not-running button won't change state until
-    // TaskListButton::UpdateVisualStates says otherwise. See RATIONALE.md.
+    // TaskListButton::UpdateVisualStates says otherwise.
     bool notRunning = false;
     // Set when the last resolve attempt bailed specifically because
     // g_realTaskbarClickObserved was still false - every button gets this
     // until the session's first real taskbar click, which could otherwise
     // mean an indefinite backoff-0 poll for a user who never happens to
-    // click one (round 30 review finding). Treated the same as notRunning
-    // by NextResolveDelayMs; cleared the instant a real click is observed,
-    // via CTaskListWnd_HandleClick_Hook's own force-resolve nudge. See
-    // RATIONALE.md.
+    // click one. Treated the same as notRunning by NextResolveDelayMs;
+    // cleared the instant a real click is observed, via
+    // CTaskListWnd_HandleClick_Hook's own force-resolve nudge.
     bool awaitingFirstClick = false;
 };
 std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
@@ -1248,8 +1253,16 @@ std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
 // Set by TaskListButton::UpdateVisualStates' hook and the ArrangeOverride
 // hook's count-change check to make the next resolve pass ignore a
 // negatively-cached entry's backoff - but only up to
-// kMaxForcedRetryFailures consecutive failures each (see RATIONALE.md for
-// why unconditional forcing was a real bug).
+// kMaxForcedRetryFailures consecutive failures each. Uncapped, this would
+// be a real bug: a RUNNING app's button can fail to resolve for reasons
+// that don't bail out early (ReportClicked failing internally, a task item
+// mid-teardown, GetTaskItemsArray coming back empty), and forcing every
+// retry unconditionally would dispatch a real ReportClicked on both paths
+// every forced pass, indefinitely - exactly the runaway-real-clicks
+// scenario the backoff schedule exists to bound. Capping it keeps the
+// "pinned app just launched" fast path intact (that case is still failing
+// 0 times when the fast path first fires) while letting the normal
+// backoff schedule take back over for an entry that keeps failing.
 std::atomic<bool> g_forceResolveUnresolved;
 constexpr int kMaxForcedRetryFailures = 3;
 
@@ -1262,7 +1275,7 @@ constexpr int kMaxForcedRetryFailures = 3;
 // by TaskListButton_UpdateVisualStates_Hook to skip nudging the resolve
 // timer once there's nothing left it could help - starts true so the
 // very first UpdateVisualStates call, before any pass has run yet,
-// doesn't get skipped. See RATIONALE.md.
+// doesn't get skipped.
 bool g_anyButtonNeedsRecheck = true;
 
 // Caps the per-entry backoff retry itself (not just the force-bypass
@@ -1281,13 +1294,15 @@ bool g_anyButtonNeedsRecheck = true;
 // ever dispatching one doesn't risk anything and must not count toward
 // this. NextResolveDelayMs must treat a terminal entry exactly like a
 // resolved one (idle cadence, not the backoff schedule) - see its own
-// comment for the busy-loop that requires. See RATIONALE.md.
+// comment for the busy-loop that requires.
 constexpr int kMaxResolveFailures = 8;
 
 // The HWNDs g_buttonHwndCache currently resolves to, rebuilt at the end of
-// every successful ResolvePendingButtonHwnds pass and read by WinEventProc
-// (a different thread) to filter drag-follow's LOCATIONCHANGE events.
-// Needs its own mutex since it's read cross-thread outside a marshal.
+// every successful ResolvePendingButtonHwnds pass and read by
+// DragFollowPollTimerProc (a different thread) as the small, known set of
+// windows worth polling for drag-follow, instead of listening for a
+// system-wide location-change event. Needs its own mutex since it's read
+// cross-thread outside a marshal.
 std::mutex g_resolvedHwndsMutex;
 std::unordered_set<HWND> g_resolvedHwnds;
 
@@ -1295,8 +1310,11 @@ std::unordered_set<HWND> g_resolvedHwnds;
 // called from the resolve timer, never from GetButtonHwnd or an active
 // Arrange pass - running the click-sentinel technique while a button is
 // mid-insertion/removal in an ItemsRepeater reaches STATUS_STOWED_EXCEPTION
-// and crashes explorer.exe (confirmed via crash-dump analysis; see
-// RATIONALE.md for the full trigger conditions).
+// and crashes explorer.exe (confirmed via crash-dump analysis), the same
+// underlying condition as the nested-Arrange-traversal crash noted above:
+// a window moving across monitors while Windows' "show taskbar apps on"
+// setting isn't "All taskbars" structurally adds/removes taskbar buttons
+// mid-pass.
 bool ResolveAndCacheButtonHwnd(FrameworkElement element,
                                const std::wstring& identity) {
     void* key = winrt::get_abi(element);
@@ -1317,8 +1335,8 @@ bool ResolveAndCacheButtonHwnd(FrameworkElement element,
     // kMaxResolveFailures' terminal cap - a bail-out before ever
     // dispatching one (not yet confirmed reachable, a view-model lookup
     // miss, a not-currently-running group) isn't a click-safety risk and
-    // must not count against a button that may resolve fine later. See
-    // RATIONALE.md. lastAttempt still advances either way, so a
+    // must not count against a button that may resolve fine later.
+    // lastAttempt still advances either way, so a
     // persistently-bailing-out entry keeps retrying at ResolveBackoffMs(0) -
     // a cheap, indefinite cadence - except a confirmed-not-running or
     // awaiting-first-click one, which NextResolveDelayMs instead idles
@@ -1422,7 +1440,7 @@ WindowClassification ClassifyByWindowPositionCached(HWND hwnd) {
 // of the same app produce two TaskListButtons with this same name, so an
 // ItemsRepeater rebind between those two specifically wouldn't be caught
 // by an identity mismatch - this only catches a rebind onto a
-// differently-named button. See RATIONALE.md.
+// differently-named button.
 std::wstring GetButtonAccessibleName(FrameworkElement element) {
     auto name = Automation::AutomationProperties::GetName(element);
     if (!name.empty()) {
@@ -1552,14 +1570,14 @@ double FullFootprintWidth(FrameworkElement element) {
 // (matching taskbar-start-button-position.wh.cpp), falling back to
 // ActualWidth() if no child is realized yet. NOT used for Start (never
 // hidden/shown, and DesiredSize() understates its true width) or task list
-// buttons (this file's hottest path, no evidence of the same bug) - see
-// RATIONALE.md.
+// buttons (this file's hottest path, no evidence of the same bug).
 //
-// Persists across calls (never rebuilt/pruned) rather than being folded
-// into one of the per-pass plan maps elsewhere in this file - at most 3
-// real elements ever populate it (Search/Task View/Widgets), so a stale
-// entry surviving a recreate costs nothing, and it specifically needs to
-// outlive a single pass to answer the question below.
+// Persists across calls rather than being folded into one of the per-pass
+// plan maps elsewhere in this file, since it specifically needs to outlive
+// a single pass to answer the question below - RecomputeLayoutPlan prunes
+// it down to the current pass's live system-button keys, since the key is
+// a recyclable ABI pointer and a stale entry could otherwise be served to
+// an unrelated new element at the same address.
 std::unordered_map<void*, double> g_lastSystemButtonContentWidth;
 double SystemButtonContentWidth(FrameworkElement element) {
     double contentWidth = element.ActualWidth();
@@ -1584,7 +1602,7 @@ double SystemButtonContentWidth(FrameworkElement element) {
     // signal for a genuine show/hide toggle (see this function's own
     // comment above), which has to keep working live, so it must NOT be
     // masked by a "last known good width" fallback the way this one is
-    // for the unmeasured case. See RATIONALE.md.
+    // for the unmeasured case.
     void* key = winrt::get_abi(element);
     if (contentWidth == 0 && element.ActualWidth() == 0) {
         auto it = g_lastSystemButtonContentWidth.find(key);
@@ -1683,7 +1701,7 @@ double ComputeSystemButtonX(const std::vector<ChildInfo>& childInfos,
     // Windows both classifies the same way (e.g. two
     // Taskbar.TaskbarExtensionElements) would get the same rank, compute
     // the same X, and render on top of each other. This degrades
-    // gracefully instead if that assumption ever breaks. See RATIONALE.md.
+    // gracefully instead if that assumption ever breaks.
     double widthBefore = 0;
     for (auto& info : childInfos) {
         if (info.element == targetElement) {
@@ -1704,8 +1722,9 @@ double ComputeSystemButtonX(const std::vector<ChildInfo>& childInfos,
 
     if (g_settings.systemButtonsAdjacentSide == Side::Left) {
         // Stack right-to-left outward from Start: taskbar-order-earliest
-        // button ends up closest to Start, so reading left-to-right still
-        // shows the same order as far-left mode does.
+        // button ends up farthest from Start (the outermost slot), so
+        // reading left-to-right still shows the same order as far-left
+        // mode does.
         double widthAfter = clusterWidth - widthBefore - ownWidth;
         return startCenterX - startWidth / 2.0 - gap - widthAfter - ownWidth;
     }
@@ -1875,8 +1894,7 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
     // for that one frame, falling through to native positioning instead -
     // safe since it's then also missing from g_lastArrangedX's coverage,
     // so RecomputeLayoutPlan's own staleness check forces a real recompute
-    // the very next pass once its real width is available. See
-    // RATIONALE.md.
+    // the very next pass once its real width is available.
     double x = leftInnerX;
     for (auto* entry : left) {
         if (entry->element.ActualWidth() > 0) {
@@ -1904,7 +1922,7 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
 // Defined later (Live drag-follow section). Only ever marks the taskbar's
 // layout dirty - never forces a synchronous UpdateLayout() (a forced call
 // from a nested callback reenters WinUI layout and raises
-// STATUS_STOWED_EXCEPTION; see its own definition and RATIONALE.md).
+// STATUS_STOWED_EXCEPTION; see its own definition below for detail).
 void InvalidateTaskbarLayout();
 
 // Idle re-check cadence once every cached button is resolved - keeps
@@ -1919,16 +1937,16 @@ constexpr DWORD kIdleResolveTickMs = 30000;
 constexpr DWORD kEnumerationFailedRetryMs = 1000;
 
 // Defined later (Mod lifecycle section).
-void StartWinEventHook();
+void StartBackgroundWorkerThread();
 
 // Defined later (Mod lifecycle section); lets a live trackWindowPositions
-// toggle stop the WinEventHook thread reversibly. A separate function from
-// StopWinEventHook specifically because that one also sets a permanent,
+// toggle stop the background worker thread reversibly. A separate function from
+// StopBackgroundWorkerThread specifically because that one also sets a permanent,
 // one-way latch meant only for mod teardown - reusing it here would have
 // silently bricked the setting after the first toggle-off, since turning
 // it back on would then refuse to start (caught during the user's own live
-// testing). See RATIONALE.md.
-void StopWinEventHookForToggle();
+// testing).
+void StopBackgroundWorkerThreadForToggle();
 
 // Defined later (Mod lifecycle section); lets the ArrangeOverride hook
 // request an immediate HWND-resolve attempt.
@@ -1956,8 +1974,7 @@ void ApplyPendingSettingsIfAny();
 // g_hTaskbarWnd permanently null, and a rare SetWindowSubclassFromAnyThread
 // failure would otherwise permanently disable drag-follow/HWND-resolution/
 // live-settings for the rest of the process (core centering/splitting
-// keeps working either way, since that's computed synchronously). See
-// RATIONALE.md.
+// keeps working either way, since that's computed synchronously).
 HWND EnsureTaskbarWnd() {
     // Snapshot once, per g_hTaskbarWnd's own comment - every read below,
     // including the final return, agrees with whichever writes this same
@@ -1982,7 +1999,7 @@ HWND EnsureTaskbarWnd() {
         if (g_unloading) {
             // Guards against a pass landing here after Wh_ModBeforeUninit
             // already ran, with no teardown left to stop a newly-created
-            // WinEventHook thread.
+            // background worker thread.
             return nullptr;
         }
         hTaskbarWnd = FindCurrentProcessTaskbarWnd();
@@ -1996,12 +2013,12 @@ HWND EnsureTaskbarWnd() {
         // Only checked here at initial resolve, not on every call; a live
         // settings change afterward is handled separately by
         // TaskbarWndSubclassProc's SettingsChangedMsg case, via
-        // StartWinEventHook/StopWinEventHookForToggle directly.
+        // StartBackgroundWorkerThread/StopBackgroundWorkerThreadForToggle directly.
         if (g_settings.trackWindowPositions) {
-            StartWinEventHook();
+            StartBackgroundWorkerThread();
         } else {
-            Wh_Log(L"trackWindowPositions is off - skipping the WinEventHook "
-                   L"thread and all HWND resolution");
+            Wh_Log(L"trackWindowPositions is off - skipping the background "
+                   L"worker thread and all HWND resolution");
         }
     }
 
@@ -2025,7 +2042,7 @@ HWND EnsureTaskbarWnd() {
         // afterward would stay wired into Shell_TrayWnd with no later
         // removal call, and Windhawk unmaps this module's code shortly
         // after Wh_ModUninit returns - a use-after-free the next time that
-        // window procedure runs. See RATIONALE.md.
+        // window procedure runs.
         if (g_unloading && g_taskbarWndSubclassed.exchange(false)) {
             WindhawkUtils::RemoveWindowSubclassFromAnyThread(
                 hTaskbarWnd, TaskbarWndSubclassProc);
@@ -2223,9 +2240,9 @@ void ResolvePendingButtonHwnds() {
                                       : g_lastKnownWindowClassification.erase(it);
         }
 
-        // Rebuild the published resolved-HWND set for WinEventProc's
-        // drag-follow filter - unconditionally, since it's cheap and needs
-        // to reflect this pass's pruning either way.
+        // Rebuild the published resolved-HWND set DragFollowPollTimerProc
+        // polls - unconditionally, since it's cheap and needs to reflect
+        // this pass's pruning either way.
         {
             std::unordered_set<HWND> resolvedNow;
             for (auto& kv : g_buttonHwndCache) {
@@ -2244,7 +2261,7 @@ void ResolvePendingButtonHwnds() {
         // (notRunning/awaitingFirstClick entries count as "still worth a
         // recheck" here even though NextResolveDelayMs treats them as
         // idle for polling-cadence purposes; those are two different
-        // questions - see RATIONALE.md).
+        // questions).
         g_anyButtonNeedsRecheck = false;
         for (auto& kv : g_buttonHwndCache) {
             if (!kv.second.hwnd &&
@@ -2277,7 +2294,7 @@ std::unordered_map<void*, double> g_lastArrangedX;
 // that computed g_lastArrangedX, keyed the same way. RecomputeLayoutPlan's
 // cheap staleness check uses this to catch a button whose width changed
 // without its count changing (e.g. a label populating shortly after a
-// freshly-launched button first appears icon-only) - see RATIONALE.md.
+// freshly-launched button first appears icon-only).
 std::unordered_map<void*, double> g_lastArrangedTaskListWidth;
 
 // Set whenever something might have changed that g_lastArrangedX doesn't
@@ -2376,13 +2393,13 @@ void RecomputeLayoutPlan() {
         // Hash lookup first; IsTaskListButton (a real class-name lookup)
         // only runs on that lookup's miss, so a non-task-list child never
         // pays for it. FullFootprintWidth is NOT similarly avoided for an
-        // already-covered task list button specifically (round 30 review
-        // finding: the && short-circuit only guards the g_lastArrangedX
-        // miss case above, not this one) - it runs unconditionally for
-        // every task list button on every cheap-path pass, two property
-        // reads each. Left as-is rather than added complexity to dodge
-        // it: both reads are cheap, and this is exactly the button this
-        // whole check exists to catch a width change on.
+        // already-covered task list button specifically - the && short-
+        // circuit only guards the g_lastArrangedX miss case above, not
+        // this one, so it runs unconditionally for every task list button
+        // on every cheap-path pass, two property reads each. Left as-is
+        // rather than added complexity to dodge it: both reads are cheap,
+        // and this is exactly the button this whole check exists to catch
+        // a width change on.
         bool planIsCurrent = true;
         try {
             if (FrameworkElement repeater = GetCachedTaskbarRepeater()) {
@@ -2412,7 +2429,7 @@ void RecomputeLayoutPlan() {
                     // (a drag, a count change) forces a real recompute.
                     // g_lastArrangedTaskListWidth only has entries for
                     // task list buttons, so this naturally no-ops for
-                    // Start/Search/TaskView/Widgets. See RATIONALE.md.
+                    // Start/Search/TaskView/Widgets.
                     auto widthIt = g_lastArrangedTaskListWidth.find(key);
                     if (widthIt != g_lastArrangedTaskListWidth.end() &&
                         std::abs(FullFootprintWidth(child) - widthIt->second) >
@@ -2465,6 +2482,27 @@ void RecomputeLayoutPlan() {
             childInfos.push_back({child, IdentifySystemButton(child)});
         }
 
+        // Prune g_lastSystemButtonContentWidth down to this pass's live
+        // system buttons - the map is keyed by raw ABI pointer with no
+        // reference held, so a destroyed element's key can be reused by an
+        // unrelated new element at a taskbar/XamlRoot recreate, which would
+        // otherwise silently inherit the destroyed one's stale width.
+        {
+            std::unordered_set<void*> liveSystemButtonKeys;
+            for (auto& info : childInfos) {
+                if (info.systemButton != SystemButton::None &&
+                    info.systemButton != SystemButton::Start) {
+                    liveSystemButtonKeys.insert(winrt::get_abi(info.element));
+                }
+            }
+            for (auto it = g_lastSystemButtonContentWidth.begin();
+                 it != g_lastSystemButtonContentWidth.end();) {
+                it = liveSystemButtonKeys.count(it->first)
+                         ? std::next(it)
+                         : g_lastSystemButtonContentWidth.erase(it);
+            }
+        }
+
         // Start first: ComputeSystemButtonX/PlanTaskListButtons below
         // both read g_lastStartWidth, so it must reflect this pass.
         for (auto& info : childInfos) {
@@ -2475,11 +2513,10 @@ void RecomputeLayoutPlan() {
                 // problem that fix exists for, and swapping to the content
                 // child's DesiredSize() instead would understate Start's
                 // true width - its own visual-tree shape doesn't match
-                // what that technique was validated against. See
-                // RATIONALE.md. Only updates g_lastStartWidth when
-                // positive, so a
-                // freshly (re)created Start keeps the last known-good
-                // width instead of collapsing around a zero-width Start.
+                // what that technique was validated against. Only updates
+                // g_lastStartWidth when positive, so a freshly (re)created
+                // Start keeps the last known-good width instead of
+                // collapsing around a zero-width Start.
                 double w = info.element.ActualWidth();
                 if (w > 0) {
                     g_lastStartWidth = w;
@@ -2636,7 +2673,7 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
         Wh_Log(
             L"Arrange pass: arrangeCalls=%d repositioned=%d qiFail=%d "
             L"exceptions=%d | plan: taskList=%d (hwndResolved=%d left=%d "
-            L"right=%d) planExceptions=%d | winEvents: raw=%d "
+            L"right=%d) planExceptions=%d | dragFollow: polls=%d "
             L"invalidated=%d skippedReentrant=%d invalidateExceptions=%d | "
             L"resolve: ok=%d fail=%d",
             g_passStats.totalArrangeCalls, g_passStats.repositioned,
@@ -2644,8 +2681,8 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
             g_planStats.taskListTotal, g_planStats.taskListHwndResolved,
             g_planStats.taskListLeft, g_planStats.taskListRight,
             g_planStats.exceptions,
-            (int)g_winEventRawCount,
-            (int)g_winEventInvalidateCount, (int)g_invalidateSkippedReentrant,
+            (int)g_dragFollowPollCount,
+            (int)g_dragFollowInvalidateCount, (int)g_invalidateSkippedReentrant,
             (int)g_invalidateExceptions, g_resolveStats.success,
             g_resolveStats.failure);
         g_resolveStats = {};
@@ -2663,7 +2700,7 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
 // second posted invalidate land reentrantly before the first returns. This
 // body also never calls UpdateLayout() itself - see InvalidateTaskbarLayout
 // below for why a forced synchronous layout pass here is unsafe regardless
-// of this guard (see RATIONALE.md for more).
+// of this guard.
 thread_local bool g_inInvalidateTaskbarLayout;
 
 // MUST only run on g_hTaskbarWnd's own thread - same constraint as
@@ -2738,10 +2775,15 @@ UINT DrainSettingsMsg() {
 // ever runs on the thread that owns the window, which is what lets
 // InvalidateTaskbarLayout/ResolvePendingButtonHwnds/ApplyLoadedSettings
 // use a plain, non-blocking PostMessage - no per-call SetWindowsHookEx/
-// SendMessage/UnhookWindowsHookEx dance needed, unlike an earlier design
-// this replaced (see RATIONALE.md). This is the SOLE way any of the four
-// private messages below reach the taskbar thread, with no fallback if
-// the subclass never installs. Everything else is forwarded to
+// SendMessage/UnhookWindowsHookEx dance needed, unlike RunFromWindowThread,
+// an earlier fallback design that did exactly that dance (a blocking
+// WH_CALLWNDPROC hook) for when the subclass install failed; it was
+// removed entirely since that failure is rare, the fallback added real
+// complexity for little benefit, and EnsureTaskbarWnd already retries the
+// subclass install on every call rather than just once. This is the SOLE
+// way any of the four private messages below reach the taskbar thread,
+// with no fallback if the subclass never installs. Everything else is
+// forwarded to
 // DefSubclassProc, which also lets comctl32 clean this subclass up via
 // WM_NCDESTROY if the window is destroyed before Wh_ModBeforeUninit
 // removes it.
@@ -2778,17 +2820,16 @@ LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
         // from just changed - has to happen exactly here, not by the
         // separate InvalidateTaskbarLayout() call Wh_ModSettingsChanged
         // also makes, since that one can't see the settings swap above.
-        // See RATIONALE.md.
         g_planDirty = true;
-        // Starts/stops the WinEventHook thread live on a trackWindowPositions
-        // change, rather than only at the next mod reload - StopWinEventHookForToggle,
-        // not StopWinEventHook, since the latter's own comment explains why
-        // that one would permanently brick this toggle. See RATIONALE.md.
+        // Starts/stops the background worker thread live on a trackWindowPositions
+        // change, rather than only at the next mod reload - StopBackgroundWorkerThreadForToggle,
+        // not StopBackgroundWorkerThread, since the latter's own comment explains why
+        // that one would permanently brick this toggle.
         if (g_settings.trackWindowPositions != wasTracking) {
             if (g_settings.trackWindowPositions) {
-                StartWinEventHook();
+                StartBackgroundWorkerThread();
             } else {
-                StopWinEventHookForToggle();
+                StopBackgroundWorkerThreadForToggle();
                 // Without this, an already-resolved button keeps using its
                 // last-known (now frozen) window position instead of
                 // immediately falling back to leftApps/rightApps/default -
@@ -2805,16 +2846,16 @@ LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
 
 // Schedules a relayout on the taskbar's own thread via PostMessage rather
 // than forcing a synchronous UpdateLayout() call. MUST stay async: a forced
-// UpdateLayout() from a nested callback (e.g. WinEventProc) reenters WinUI
-// layout and raises STATUS_STOWED_EXCEPTION, a raw SEH exception no
-// try/catch in this file can contain. Does not set g_planDirty itself,
-// since this marshal is asynchronous - a natural ArrangeOverride pass
-// could land on the taskbar thread between this call setting the flag and
-// the posted message being processed, see it already true, recompute with
-// stale state, and clear the flag, leaving the posted invalidate with
-// nothing left to do. Each real caller marks dirty at its own point
-// instead, at the moment its own state change becomes visible on the
-// taskbar thread. See RATIONALE.md.
+// UpdateLayout() from a nested callback (e.g. DragFollowPollTimerProc)
+// reenters WinUI layout and raises STATUS_STOWED_EXCEPTION, a raw SEH
+// exception no try/catch in this file can contain. Does not set
+// g_planDirty itself, since this marshal is asynchronous - a natural
+// ArrangeOverride pass could land on the taskbar thread between this call
+// setting the flag and the posted message being processed, see it already
+// true, recompute with stale state, and clear the flag, leaving the
+// posted invalidate with nothing left to do. Each real caller marks dirty
+// at its own point instead, at the moment its own state change becomes
+// visible on the taskbar thread.
 void InvalidateTaskbarLayout() {
     // Snapshot so a concurrent EnsureTaskbarWnd write can't change this
     // mid-function.
@@ -2831,91 +2872,95 @@ void InvalidateTaskbarLayout() {
     }
 }
 
-// One-shot: fires once the throttle window in WinEventProc has gone quiet,
-// applying whatever position a drag/move most recently landed on.
-void CALLBACK DragFollowTrailingTimerProc(HWND hwnd,
-                                          UINT uMsg,
-                                          UINT_PTR idEvent,
-                                          DWORD dwTime) {
-    KillTimer(nullptr, idEvent);
-    g_dragFollowTrailingTimerId = 0;
+// Polls g_resolvedHwnds directly via GetWindowRect on a fixed interval,
+// rather than listening for a system-wide EVENT_OBJECT_LOCATIONCHANGE
+// WinEventHook. That hook used idProcess=0 - every process on the desktop
+// - for one of the highest-volume WinEvents there is (cursor, caret,
+// every window move/size/scroll), so simply having it registered made
+// every unrelated process on the system generate and marshal a
+// notification this mod discarded almost all of anyway (thousands of raw
+// events/sec observed, per this file's own former diagnostics).
+// g_resolvedHwnds is typically a handful of windows, and GetWindowRect is
+// a direct win32k.sys read rather than a cross-process message send, so
+// polling it here moves the entire cost onto this mod's own dedicated
+// thread instead of externalizing it onto every other process. Only ever
+// touched from that thread.
+std::unordered_map<HWND, LONG> g_lastPolledCenterX;
 
-    // Cheap early-exit during teardown; InvalidateTaskbarLayout would
-    // already no-op safely either way.
+void CALLBACK DragFollowPollTimerProc(HWND hwnd,
+                                      UINT uMsg,
+                                      UINT_PTR idEvent,
+                                      DWORD dwTime) {
     if (g_unloading) {
         return;
     }
 
-    // This fire is itself an invalidate - WinEventProc's throttle needs to
-    // know about it too.
-    g_lastDragFollowInvalidate = GetTickCount64();
+    g_dragFollowPollCount++;
 
-    g_winEventInvalidateCount++;
-    InvalidateTaskbarLayout();
-}
-
-void CALLBACK WinEventProc(HWINEVENTHOOK hook,
-                           DWORD event,
-                           HWND hwnd,
-                           LONG idObject,
-                           LONG idChild,
-                           DWORD idEventThread,
-                           DWORD dwmsEventTime) {
-    g_winEventRawCount++;
-
-    if (g_unloading || idObject != OBJID_WINDOW || idChild != CHILDID_SELF ||
-        !hwnd || hwnd == g_hTaskbarWnd) {
-        return;
-    }
-
-    // Only a window this mod has resolved to a taskbar button can affect
-    // the layout on a move, so filter against that set before the
-    // cross-process USER32 calls below. This hook only ever registers for
-    // EVENT_OBJECT_LOCATIONCHANGE now - the newly-visible-window nudge a
-    // desktop-wide EVENT_OBJECT_SHOW hook used to provide is instead
-    // TaskListButton::UpdateVisualStates' job (see its hook), scoped to
-    // this taskbar's own buttons rather than every top-level window
-    // process-wide. See RATIONALE.md.
+    std::unordered_set<HWND> tracked;
     {
         std::lock_guard<std::mutex> guard(g_resolvedHwndsMutex);
-        if (!g_resolvedHwnds.count(hwnd)) {
-            return;
+        tracked = g_resolvedHwnds;
+    }
+
+    // Drop entries for windows no longer tracked - keeps this bounded to
+    // the actual live set rather than accumulating forever as buttons
+    // resolve/unresolve across a session. Windows also recycles HWNDs, so
+    // this also prevents a stale value from a closed window being compared
+    // against a new, unrelated window that happens to reuse the handle.
+    for (auto it = g_lastPolledCenterX.begin();
+         it != g_lastPolledCenterX.end();) {
+        it = tracked.count(it->first) ? std::next(it)
+                                      : g_lastPolledCenterX.erase(it);
+    }
+
+    // Only a window's horizontal center can affect this mod's layout:
+    // ClassifyByWindowPositionCached derives BOTH the side (center vs. the
+    // screen's center line) and distanceFromCenter (which orders same-side
+    // icons) from that one number and nothing else. So a vertical-only
+    // move, or a resize that leaves the center where it was, provably
+    // can't change any icon's placement - comparing whole rects here would
+    // fire a relayout for those anyway, on every tick of such a drag.
+    // Stored as (left + right), i.e. twice the true center: only equality
+    // matters, and staying integral keeps the comparison exact.
+    //
+    // A minimized window is skipped outright - GetWindowRect reports a
+    // nonsense off-screen position for one, and
+    // ClassifyByWindowPositionCached deliberately freezes at its last
+    // pre-minimize classification rather than using it, so polling a
+    // minimized window could only ever produce relayouts that change
+    // nothing (on minimize, and again on restore).
+    //
+    // A brand-new entry (nothing to compare against yet) is deliberately
+    // not treated as a change: ResolveAndCacheButtonHwnd already
+    // invalidates when a button first resolves to an HWND (see
+    // ResolvePendingButtonHwnds' own anyChanged), so counting it here
+    // would just be a redundant second invalidate for the same event.
+    bool anyChanged = false;
+    for (HWND trackedHwnd : tracked) {
+        if (IsIconic(trackedHwnd)) {
+            continue;
+        }
+        RECT rect;
+        if (!GetWindowRect(trackedHwnd, &rect)) {
+            continue;
+        }
+        LONG centerX = rect.left + rect.right;
+        auto it = g_lastPolledCenterX.find(trackedHwnd);
+        if (it == g_lastPolledCenterX.end()) {
+            g_lastPolledCenterX[trackedHwnd] = centerX;
+            continue;
+        }
+        if (it->second != centerX) {
+            it->second = centerX;
+            anyChanged = true;
         }
     }
 
-    if (!IsWindowVisible(hwnd) || GetAncestor(hwnd, GA_ROOT) != hwnd ||
-        GetWindow(hwnd, GW_OWNER) != nullptr) {
-        return;
+    if (anyChanged) {
+        g_dragFollowInvalidateCount++;
+        InvalidateTaskbarLayout();
     }
-
-    // Drag-follow.
-    ULONGLONG now = GetTickCount64();
-    if (now - g_lastDragFollowInvalidate < 150) {
-        // Leading-edge throttle, so the final location-change event of a
-        // drag/move - the one carrying its actual release position - is
-        // routinely the one that lands inside the throttle window and
-        // gets dropped, since a drag generates a continuous event stream
-        // right up to release. Without a trailing timer, the icon would
-        // stay classified by a stale mid-drag position until some
-        // unrelated window happened to move. Re-arming this short
-        // one-shot timer on every throttled event makes it always fire
-        // once the burst actually goes quiet, applying the final
-        // position. See RATIONALE.md.
-        if (g_dragFollowTrailingTimerId) {
-            KillTimer(nullptr, g_dragFollowTrailingTimerId);
-        }
-        g_dragFollowTrailingTimerId =
-            SetTimer(nullptr, 0, 200, DragFollowTrailingTimerProc);
-        return;
-    }
-    g_lastDragFollowInvalidate = now;
-    if (g_dragFollowTrailingTimerId) {
-        KillTimer(nullptr, g_dragFollowTrailingTimerId);
-        g_dragFollowTrailingTimerId = 0;
-    }
-
-    g_winEventInvalidateCount++;
-    InvalidateTaskbarLayout();
 }
 
 // ============================================================================
@@ -3001,10 +3046,28 @@ bool HookTaskbarDllSymbols() {
 
     bool ok = HookSymbols(module, taskbarDllHooks, ARRAYSIZE(taskbarDllHooks));
     Wh_Log(L"HookTaskbarDllSymbols: %s", ok ? L"OK" : L"FAILED");
-    // Only logged individually on failure - these three are optional (see
-    // the hooks table above), so there's nothing to report when ok is true.
-    if (!ok) {
-        Wh_Log(L"  Missing (optional, click-sentinel chain only): %s%s%s",
+    // Logged unconditionally rather than gated on ok: HookSymbols' return
+    // value only reflects the four required symbols above, so a missing
+    // optional symbol never affects it - gating this log on failure would
+    // mean it can never fire in the one scenario it exists for (an
+    // optional symbol quietly disappearing after a Windows update while
+    // every required symbol still resolves fine).
+    bool anyOptionalMissing = !CTaskListWnd_HandleClick_Original ||
+                              !CWindowTaskItem_GetWindow_Original ||
+                              !CImmersiveTaskItem_GetWindow_Original ||
+                              !CImmersiveTaskItem_vftable ||
+                              !TaskItem_ReportClicked_Original ||
+                              !CTaskGroup_GetNumItems_Original ||
+                              !TaskGroup_ReportClicked_Original;
+    if (anyOptionalMissing) {
+        Wh_Log(L"  Missing (optional, click-sentinel chain only): "
+               L"%s%s%s%s%s%s%s",
+               CTaskListWnd_HandleClick_Original ? L"" : L"CTaskListWnd::HandleClick ",
+               CWindowTaskItem_GetWindow_Original ? L"" : L"CWindowTaskItem::GetWindow ",
+               CImmersiveTaskItem_GetWindow_Original
+                   ? L""
+                   : L"CImmersiveTaskItem::GetWindow ",
+               CImmersiveTaskItem_vftable ? L"" : L"CImmersiveTaskItem vftable ",
                TaskItem_ReportClicked_Original ? L"" : L"TaskItem::ReportClicked ",
                CTaskGroup_GetNumItems_Original ? L"" : L"CTaskGroup::GetNumItems ",
                TaskGroup_ReportClicked_Original ? L"" : L"TaskGroup::ReportClicked ");
@@ -3017,29 +3080,32 @@ TaskListButton_UpdateVisualStates_t TaskListButton_UpdateVisualStates_Original;
 
 // Fires on every visual-state transition of a taskbar button, including a
 // pinned app's running/not-running change - replaces the old, desktop-wide
-// EVENT_OBJECT_SHOW WinEventHook (removed; see RATIONALE.md) as the fast
-// nudge for "something just changed, go re-check", scoped to this
-// taskbar's own buttons instead of every top-level window process-wide.
+// EVENT_OBJECT_SHOW WinEventHook (removed) as the fast nudge for
+// "something just changed, go re-check", scoped to this taskbar's own
+// buttons instead of every top-level window process-wide.
 // Optional (see the hooks table below) - if a future Windows build renames
 // this, resolution falls back to ResolveBackoffMs' own capped-backoff
 // schedule with no fast path, the same fallback already relied on for a
 // launch that reaches this hook through a path it doesn't expect.
 //
-// Unconditionally re-arms the resolve timer with a small delay rather
-// than gating on elapsed time (round 30 review finding) - this fires for
-// every visual-state transition of every taskbar button, not just
-// running/not-running (hover, press, focus, badges...), so a leading-edge
-// throttle can silently drop the one call that actually mattered if it
-// lands within the throttle window of an irrelevant one, with nothing
-// left to re-arm afterward. ArmButtonHwndResolveTimer's own KillTimer/
-// SetTimer re-arm makes this a lossless trailing-edge debounce for free:
-// each call resets the pending timer's countdown, so a burst of calls
-// collapses into exactly one resolve pass, 150ms after the burst actually
-// goes quiet - matching the same trailing-timer idea drag-follow already
-// uses, without needing a second timer variable. g_anyButtonNeedsRecheck
-// skips this entirely once nothing could benefit (the common steady
-// state, once every button is resolved or has given up), so hover churn
-// over an already-settled taskbar costs nothing. See RATIONALE.md.
+// Unconditionally re-arms the resolve timer with a small delay rather than
+// gating on elapsed time - this fires for every visual-state transition of
+// every taskbar button, not just running/not-running (hover, press,
+// focus, badges...), so a leading-edge throttle can silently drop the one
+// call that actually mattered if it lands within the throttle window of
+// an irrelevant one, with nothing left to re-arm afterward.
+// ArmButtonHwndResolveTimer's own KillTimer/SetTimer re-arm makes this a
+// lossless trailing-edge debounce for free: each call resets the pending
+// timer's countdown, so a burst of calls collapses into exactly one
+// resolve pass, 150ms after the burst actually goes quiet - matching the
+// same trailing-timer idea drag-follow already uses, without needing a
+// second timer variable. g_anyButtonNeedsRecheck skips this entirely once
+// nothing could benefit - in practice that's rarer than it sounds, since a
+// pinned-but-not-running button (present on essentially every real
+// Windows 11 taskbar by default) never advances past 0
+// consecutiveFailures and so keeps the flag true indefinitely; the skip
+// still matters for a taskbar with no pinned-not-running apps, and every
+// hover sweep that doesn't skip is a cheap pass regardless.
 void WINAPI TaskListButton_UpdateVisualStates_Hook(void* pThis) {
     TaskListButton_UpdateVisualStates_Original(pThis);
 
@@ -3053,7 +3119,8 @@ void WINAPI TaskListButton_UpdateVisualStates_Hook(void* pThis) {
 bool HookTaskbarViewDllSymbols(HMODULE module) {
     // Which of these two is actually loaded depends on the Windows build -
     // see GetTaskbarViewModuleHandle. Most entries are optional so a single
-    // missing symbol doesn't abort the whole batch - see RATIONALE.md.
+    // missing symbol doesn't abort the whole batch - see HookSymbols'
+    // optional-parameter doc comment.
     // Taskbar.View.dll, ExplorerExtensions.dll
     WindhawkUtils::SYMBOL_HOOK hooks[] = {
         {
@@ -3112,11 +3179,19 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
     Wh_Log(L"HookTaskbarViewDllSymbols: %s", ok ? L"OK" : L"FAILED");
     // ArrangeOverride is the one required symbol here, so it's always
     // worth confirming directly. The rest are optional (HWND-resolution
-    // chain only) - only worth naming individually on failure.
+    // chain only) - named individually below whenever any of them is
+    // actually missing, regardless of ArrangeOverride's own state.
     Wh_Log(L"  ArrangeOverride: %s",
            TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original ? L"resolved"
                                                                         : L"MISSING");
-    if (!ok) {
+    bool anyOptionalMissing = !TryGetItemFromContainer_TaskListWindowViewModel_Original ||
+                              !TaskListWindowViewModel_get_TaskItem_Original ||
+                              !TryGetItemFromContainer_TaskListGroupViewModel_Original ||
+                              !TaskListGroupViewModel_IsMultiWindow_Original ||
+                              !ITaskGroup_IsRunning_Original ||
+                              !TaskListButton_get_IsRunning_Original ||
+                              !TaskListButton_UpdateVisualStates_Original;
+    if (anyOptionalMissing) {
         Wh_Log(L"  Missing (optional, HWND-resolution chain only): "
                L"%s%s%s%s%s%s%s",
                TryGetItemFromContainer_TaskListWindowViewModel_Original
@@ -3157,12 +3232,14 @@ void HandleLoadedModuleIfTaskbarView(HMODULE module, LPCWSTR lpLibFileName) {
         Wh_Log(L"Loaded %s", lpLibFileName);
 
         // Applied unconditionally, not gated on HookTaskbarViewDllSymbols'
-        // return value - that value reflects whether EVERY symbol in its
-        // table resolved, optional ones included, so a single missing
-        // optional HWND-resolution symbol (exactly what optional=true
-        // exists to tolerate) would otherwise skip applying hooks for
-        // every symbol that DID resolve, ArrangeOverride included. See
-        // RATIONALE.md.
+        // own return value. That value only reflects whether
+        // ArrangeOverride, the sole required symbol in its table, was
+        // found - a missing optional HWND-resolution symbol never affects
+        // it (see HookSymbols' own optional-parameter doc comment). And by
+        // this point Wh_ModInit has already returned successfully - this
+        // callback runs later, from the LoadLibraryExW hook, so there's no
+        // "fail the mod's load" outcome available here regardless; hooks
+        // apply best-effort from here on.
         HookTaskbarViewDllSymbols(module);
         Wh_ApplyHookOperations();
     }
@@ -3185,14 +3262,15 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
 // Mod lifecycle
 // ============================================================================
 
-// WinEvent hooks run on a dedicated mod-owned thread rather than the
-// taskbar's own, to keep the high raw event volume off the shell's layout
-// thread - EVENT_OBJECT_LOCATIONCHANGE alone has been observed producing
-// thousands of raw events within seconds. WINEVENT_OUTOFCONTEXT delivers
-// callbacks on whichever thread called SetWinEventHook, so registering on
-// the taskbar's own thread would put all of that, plus this file's own
-// filtering on each one, in direct contention with the shell's own layout
-// work. See RATIONALE.md.
+// Hosts the HWND-resolve timer and the drag-follow poll timer on a
+// dedicated mod-owned thread rather than the taskbar's own, keeping both
+// off the shell's layout thread. Originally also hosted the
+// EVENT_OBJECT_SHOW and EVENT_OBJECT_LOCATIONCHANGE WinEventHooks this
+// mod used to register here (removed in favor of
+// TaskListButton::UpdateVisualStates and the drag-follow poll,
+// respectively) - the name stuck around across both removals since this
+// is still fundamentally "the dedicated background thread," just no
+// longer one that happens to run any actual WinEventHook.
 //
 // Private message this thread's own queue uses to let ArmButtonHwndResolveTimer
 // (called from the taskbar thread) re-arm the resolve timer, which lives
@@ -3205,27 +3283,19 @@ void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
                                          UINT_PTR idEvent,
                                          DWORD dwTime);
 
-DWORD WINAPI WinEventHookThreadProc(LPVOID) {
-    // Forces this thread's message queue into existence before
-    // SetWinEventHook runs, so WINEVENT_OUTOFCONTEXT has somewhere to
-    // deliver callbacks to immediately.
+// How often DragFollowPollTimerProc polls g_resolvedHwnds - see its own
+// comment for why this replaced a WinEventHook.
+constexpr UINT kDragFollowPollMs = 150;
+
+DWORD WINAPI BackgroundWorkerThreadProc(LPVOID) {
+    // Forces this thread's message queue into existence before SetTimer
+    // runs below, so the timers this thread owns have somewhere to
+    // deliver WM_TIMER messages to immediately.
     MSG msg;
     PeekMessage(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
 
-    // Not WINEVENT_SKIPOWNPROCESS: File Explorer windows often run inside
-    // explorer.exe's own process, and that flag would drop their
-    // location-change events too. The taskbar's own windows are excluded
-    // explicitly in WinEventProc instead.
-    g_locationChangeHook = SetWinEventHook(
-        EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_LOCATIONCHANGE, nullptr,
-        WinEventProc, 0, 0, WINEVENT_OUTOFCONTEXT);
-    Wh_Log(L"WinEventHookThreadProc: handle=%p (dedicated thread %lu)",
-           g_locationChangeHook, GetCurrentThreadId());
-    if (!g_locationChangeHook) {
-        Wh_Log(L"Failed to register location-change hook - live "
-               L"drag-follow will not work, but everything else still "
-               L"will");
-    }
+    Wh_Log(L"BackgroundWorkerThreadProc: dedicated thread %lu",
+           GetCurrentThreadId());
 
     // Kicks off the first HWND-resolve attempt so buttons already present
     // at mod startup get picked up; NextResolveDelayMs/
@@ -3233,7 +3303,12 @@ DWORD WINAPI WinEventHookThreadProc(LPVOID) {
     g_buttonHwndResolveTimerId =
         SetTimer(nullptr, 0, 100, ButtonHwndResolveTimerProc);
 
-    // WM_APP (posted by StopWinEventHook) is this thread's shutdown signal.
+    // Runs for as long as this thread does - see DragFollowPollTimerProc.
+    g_dragFollowPollTimerId =
+        SetTimer(nullptr, 0, kDragFollowPollMs, DragFollowPollTimerProc);
+
+    // WM_APP (posted by StopBackgroundWorkerThread) is this thread's
+    // shutdown signal.
     while (GetMessage(&msg, nullptr, 0, 0) > 0) {
         if (msg.message == WM_APP) {
             break;
@@ -3248,77 +3323,84 @@ DWORD WINAPI WinEventHookThreadProc(LPVOID) {
         DispatchMessage(&msg);
     }
 
-    if (g_locationChangeHook) {
-        UnhookWinEvent(g_locationChangeHook);
-        g_locationChangeHook = nullptr;
-    }
     if (g_buttonHwndResolveTimerId) {
         KillTimer(nullptr, g_buttonHwndResolveTimerId);
         g_buttonHwndResolveTimerId = 0;
     }
-    if (g_dragFollowTrailingTimerId) {
-        KillTimer(nullptr, g_dragFollowTrailingTimerId);
-        g_dragFollowTrailingTimerId = 0;
+    if (g_dragFollowPollTimerId) {
+        KillTimer(nullptr, g_dragFollowPollTimerId);
+        g_dragFollowPollTimerId = 0;
     }
 
     return 0;
 }
 
-HANDLE g_winEventThread;
-// Written under g_winEventThreadMutex, read without it (from the taskbar
+HANDLE g_backgroundWorkerThread;
+// Written under g_backgroundWorkerThreadMutex, read without it (from the taskbar
 // thread) in ArmButtonHwndResolveTimer - atomic makes that well-defined.
-std::atomic<DWORD> g_winEventThreadId;
+std::atomic<DWORD> g_backgroundWorkerThreadId;
 
-// Serializes StartWinEventHook/StopWinEventHook against each other: a
-// start call can still be inside CreateThread, before g_winEventThread is
+// Serializes StartBackgroundWorkerThread/StopBackgroundWorkerThread against each other: a
+// start call can still be inside CreateThread, before g_backgroundWorkerThread is
 // written, when a concurrent stop call checks it - without this mutex
 // making "is there a thread, and should one ever be created again" one
 // atomic question both functions agree on, the stop call could miss the
 // very thread it was meant to tear down, leaving it to crash the process
-// when Windhawk unmaps the module later. See RATIONALE.md.
-std::mutex g_winEventThreadMutex;
-bool g_winEventThreadStopped;
+// when Windhawk unmaps the module later.
+std::mutex g_backgroundWorkerThreadMutex;
+bool g_backgroundWorkerThreadStopped;
 
-void StartWinEventHook() {
-    std::lock_guard<std::mutex> guard(g_winEventThreadMutex);
-    if (g_winEventThreadStopped || g_winEventThread) {
+void StartBackgroundWorkerThread() {
+    std::lock_guard<std::mutex> guard(g_backgroundWorkerThreadMutex);
+    if (g_backgroundWorkerThreadStopped || g_backgroundWorkerThread) {
         return;
     }
 
     // CreateThread needs a plain DWORD* out-param, published to the
     // atomic once it returns.
     DWORD threadId = 0;
-    g_winEventThread = CreateThread(nullptr, 0, WinEventHookThreadProc,
+    g_backgroundWorkerThread = CreateThread(nullptr, 0, BackgroundWorkerThreadProc,
                                     nullptr, 0, &threadId);
-    if (!g_winEventThread) {
-        Wh_Log(L"StartWinEventHook: CreateThread failed");
+    if (!g_backgroundWorkerThread) {
+        Wh_Log(L"StartBackgroundWorkerThread: CreateThread failed");
     } else {
-        g_winEventThreadId = threadId;
+        g_backgroundWorkerThreadId = threadId;
     }
 }
 
-// Waits for the thread to fully exit, guaranteeing UnhookWinEvent and the
-// resolve timer's KillTimer have run before returning. Shared by
-// StopWinEventHook (permanent, mod-teardown) and StopWinEventHookForToggle
-// (reversible, live trackWindowPositions toggle) - see RATIONALE.md for why
-// only the former sets g_winEventThreadStopped.
-void StopWinEventHookInternal(bool permanent) {
+// Waits for the thread to fully exit, guaranteeing both of its owned
+// timers' KillTimer calls have run before returning. Shared by
+// StopBackgroundWorkerThread (permanent, mod-teardown) and StopBackgroundWorkerThreadForToggle
+// (reversible, live trackWindowPositions toggle) - see
+// StopBackgroundWorkerThreadForToggle's own forward-declaration comment
+// for why only the former sets g_backgroundWorkerThreadStopped.
+void StopBackgroundWorkerThreadInternal(bool permanent) {
+    // Serializes concurrent stop calls end-to-end, not just the
+    // g_backgroundWorkerThreadMutex-guarded read/null section below -
+    // without this, a second call arriving while an earlier one is already
+    // past that section (waiting on the thread handle) would see
+    // g_backgroundWorkerThread already null and return immediately,
+    // letting its caller (e.g. Wh_ModUninit) proceed while the worker
+    // thread is still executing mod code, right before Windhawk unmaps it.
+    static std::mutex teardownMutex;
+    std::lock_guard<std::mutex> teardownGuard(teardownMutex);
+
     HANDLE thread;
     DWORD threadId;
     {
-        std::lock_guard<std::mutex> guard(g_winEventThreadMutex);
-        // Set before releasing the lock, so a StartWinEventHook call
+        std::lock_guard<std::mutex> guard(g_backgroundWorkerThreadMutex);
+        // Set before releasing the lock, so a StartBackgroundWorkerThread call
         // arriving after this point can't recreate a thread nobody would
         // tear down. Unconditional (even if thread turns out already null
-        // below) so a concurrent StopWinEventHookForToggle racing this
+        // below) so a concurrent StopBackgroundWorkerThreadForToggle racing this
         // permanent stop can't leave the latch unset.
         if (permanent) {
-            g_winEventThreadStopped = true;
+            g_backgroundWorkerThreadStopped = true;
         }
-        thread = g_winEventThread;
-        threadId = g_winEventThreadId;
-        g_winEventThread = nullptr;
-        g_winEventThreadId = 0;
+        thread = g_backgroundWorkerThread;
+        threadId = g_backgroundWorkerThreadId;
+        g_backgroundWorkerThread = nullptr;
+        g_backgroundWorkerThreadId = 0;
     }
     if (!thread) {
         return;
@@ -3339,23 +3421,22 @@ void StopWinEventHookInternal(bool permanent) {
     CloseHandle(thread);
 }
 
-void StopWinEventHook() {
-    StopWinEventHookInternal(/*permanent=*/true);
+void StopBackgroundWorkerThread() {
+    StopBackgroundWorkerThreadInternal(/*permanent=*/true);
 }
 
 // Lets trackWindowPositions be turned off live, without tripping the
-// permanent g_winEventThreadStopped latch StopWinEventHook sets - a later
-// StartWinEventHook (from turning the setting back on) still works. See
-// RATIONALE.md.
-void StopWinEventHookForToggle() {
-    StopWinEventHookInternal(/*permanent=*/false);
+// permanent g_backgroundWorkerThreadStopped latch StopBackgroundWorkerThread sets - a later
+// StartBackgroundWorkerThread (from turning the setting back on) still works.
+void StopBackgroundWorkerThreadForToggle() {
+    StopBackgroundWorkerThreadInternal(/*permanent=*/false);
 }
 
 // Capped exponential backoff for the click-sentinel probe, shared by
 // ResolvePendingButtonHwnds and NextResolveDelayMs. Fallback safety net for
 // a launch that reaches TaskListButton::UpdateVisualStates through a path
 // this mod doesn't expect, or on a build where that hook didn't resolve at
-// all; see RATIONALE.md.
+// all.
 constexpr ULONGLONG kResolveBackoffCeilingMs = 30ULL * 60 * 1000;
 ULONGLONG ResolveBackoffMs(int consecutiveFailures) {
     int shift = std::min(consecutiveFailures, 16);  // keep the shift itself from overflowing
@@ -3377,11 +3458,11 @@ DWORD NextResolveDelayMs() {
     // TERMINAL case specifically - backoffElapsed has no branch of its
     // own for a terminal entry, it just structurally evaluates false
     // forever once consecutiveFailures reaches kMaxResolveFailures, so
-    // NextResolveDelayMs has to independently know to stop chasing it -
-    // see RATIONALE.md for the busy-loop this closes: without this, a
-    // terminal entry's fixed, no-longer-advancing dueAt falls further
-    // into the past every tick, pinning pendingDelay at 0 (SetTimer's
-    // 10ms floor) forever. notRunning/awaitingFirstClick entries are
+    // NextResolveDelayMs has to independently know to stop chasing it:
+    // without this, a terminal entry's fixed, no-longer-advancing dueAt
+    // falls further into the past every tick, pinning pendingDelay at 0
+    // (SetTimer's 10ms floor) forever. notRunning/awaitingFirstClick
+    // entries are
     // different: backoffElapsed has no special case for them either, but
     // unlike a terminal entry it naturally evaluates true for them too
     // once enough time passes (their consecutiveFailures never advances
@@ -3467,16 +3548,28 @@ void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
     }
 }
 
-// The resolve timer lives on the dedicated WinEventHook thread, so arming
-// it from the taskbar thread needs PostThreadMessage to ask that thread to
-// do it on its own queue.
+// The resolve timer lives on the dedicated background worker thread, so
+// arming it from the taskbar thread needs PostThreadMessage to ask that
+// thread to do it on its own queue.
 void ArmButtonHwndResolveTimer(DWORD delayMs) {
-    if (!g_winEventThreadId || g_unloading) {
+    if (!g_backgroundWorkerThreadId || g_unloading) {
         return;
     }
-    if (!PostThreadMessage(g_winEventThreadId, kArmResolveNowMsg, 0, delayMs)) {
-        Wh_Log(L"ArmButtonHwndResolveTimer: PostThreadMessage failed, "
-               L"error=%lu", GetLastError());
+    if (!PostThreadMessage(g_backgroundWorkerThreadId, kArmResolveNowMsg, 0, delayMs)) {
+        // ERROR_INVALID_THREAD_ID specifically is the benign startup race,
+        // not a real failure: StartBackgroundWorkerThread publishes the
+        // thread id as soon as CreateThread returns, but the thread only
+        // gets a message queue once its own PeekMessage runs, and
+        // EnsureTaskbarWnd reaches this call in the same pass that started
+        // it. Nothing is lost - BackgroundWorkerThreadProc arms the first
+        // resolve itself at startup, so this nudge was redundant anyway -
+        // and logging it would put a scary-looking error in every session's
+        // log for a condition that resolves itself microseconds later.
+        DWORD error = GetLastError();
+        if (error != ERROR_INVALID_THREAD_ID) {
+            Wh_Log(L"ArmButtonHwndResolveTimer: PostThreadMessage failed, "
+                   L"error=%lu", error);
+        }
     }
 }
 
@@ -3492,12 +3585,12 @@ BOOL Wh_ModInit() {
     if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
         Wh_Log(L"Taskbar view module already loaded at init time");
         g_taskbarViewDllLoaded = true;
-        // Not gated on HookTaskbarViewDllSymbols' own return value - it
-        // reflects optional symbols too, so a single missing optional
-        // HWND-resolution symbol would otherwise fail this ENTIRE mod's
-        // load, exactly the outcome optional=true exists to prevent. The
-        // one symbol that must load, ArrangeOverride, is checked directly
-        // below instead. See RATIONALE.md.
+        // Not gated on HookTaskbarViewDllSymbols' own return value - that
+        // value only reflects whether ArrangeOverride, the sole required
+        // symbol in its table, was found; a missing optional
+        // HWND-resolution symbol never affects it (see HookSymbols' own
+        // optional-parameter doc comment). ArrangeOverride itself is
+        // checked directly below instead.
         HookTaskbarViewDllSymbols(taskbarViewModule);
         if (!TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original) {
             return FALSE;
@@ -3549,8 +3642,8 @@ void Wh_ModBeforeUninit() {
 
     g_unloading = true;
 
-    // The WinEventHook thread is torn down later, in Wh_ModUninit - this
-    // mod's hooks (and so StartWinEventHook's own call paths) stay live
+    // The background worker thread is torn down later, in Wh_ModUninit - this
+    // mod's hooks (and so StartBackgroundWorkerThread's own call paths) stay live
     // until this function returns. Setting g_unloading first is what stops
     // the click-sentinel probe and makes IUIElement_Arrange_Hook fall
     // through to native positioning immediately.
@@ -3585,7 +3678,7 @@ void Wh_ModUninit() {
     // Runs here rather than in Wh_ModBeforeUninit - the mod's own hooks
     // are gone by this point, so nothing can reawaken the thread. Also
     // covers the HWND-resolve timer, which lives on the same thread.
-    StopWinEventHook();
+    StopBackgroundWorkerThread();
 }
 
 // Holds a settings change ApplyLoadedSettings couldn't hand off to the
@@ -3608,7 +3701,7 @@ ModSettings g_pendingSettings;
 // otherwise race EnsureTaskbarWnd resolving the taskbar (and a layout pass
 // starting to read g_settings) concurrently on another thread. No further
 // fallback if PostMessage itself fails - logged loudly rather than
-// silently dropped. See RATIONALE.md.
+// silently dropped.
 void ApplyLoadedSettings(ModSettings settings) {
     // Snapshot so both checks below agree.
     HWND hTaskbarWnd = g_hTaskbarWnd;

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -75,7 +75,19 @@ then classified the same way as a pinned-but-not-running one instead.
   Arrange call wins for that pass. This mod's `systemButtonsPlacement:
   far-left` setting covers the same "keep everything else out of Start's
   way" goal that mod's `otherSystemButtonsOnTheLeft` option does, so
-  there's no reason to run both together.
+  there's no reason to run both together. This mod is intentionally scoped
+  to true screen-center plus position-based icon splitting specifically -
+  not a general Start-position picker - so this conflict is a documented
+  incompatibility to avoid rather than something planned to be resolved by
+  merging the two mods or their positioning logic.
+- **The Start menu itself doesn't follow the repositioned Start button.**
+  This mod only moves the Start *button* - nothing decides where the Start
+  *menu* opens. With the taskbar's own "Taskbar alignment" set to
+  "Center", the menu happens to open near screen-center anyway since
+  that's where Windows expects it by default, but with alignment set to
+  "Left", the button sits at true center while the menu still opens at the
+  left edge. There's no exposed way to move the menu's own anchor point
+  the way this mod moves the button.
 - **A very crowded side compresses instead of overflowing cleanly.** If
   enough app icons pile up on one side that they'd run into the system
   tray/clock on the right (or, in "far left" placement, into Search/Task
@@ -113,19 +125,26 @@ then classified the same way as a pinned-but-not-running one instead.
 - The "resolve which HWND a taskbar button represents" step reuses a
   technique from other taskbar-reordering mods (synchronously reporting a
   sentinel "click" to the taskbar's internal click handler, which is
-  intercepted before it does anything, to read back the window handle). It
-  runs on a periodic timer rather than inline during layout, and Arrange
-  only ever reads whatever the timer has already cached - running it
-  synchronously from inside the taskbar's own layout pass was the
+  intercepted before it does anything, to read back the window handle) -
+  but unlike those mods, which only ever dispatch it from an actual user
+  gesture on one specific button, this mod dispatches it unattended, on
+  its own background timer, against every button it hasn't resolved yet.
+  It runs on a periodic timer rather than inline during layout, and
+  Arrange only ever reads whatever the timer has already cached - running
+  it synchronously from inside the taskbar's own layout pass was the
   confirmed cause of an explorer.exe crash (specifically when Windows'
   "show taskbar apps on" setting is anything other than "All taskbars",
   since that's when a window moving across monitors structurally adds/
   removes taskbar buttons rather than just repositioning them). As a
   further safeguard, the very first such probe of a session is held back
   until a real (non-sentinel) click has been seen passing through the same
-  interception point - so a running app's icon may briefly show on its
-  default side, rather than by window position, until you click any
-  taskbar button once.
+  interception point, and any single miss after that latches this mod's
+  probing off entirely on that path (see `Wh_Log` for which) - so a
+  running app's icon may briefly show on its default side, rather than by
+  window position, until you click any taskbar button once, and if a
+  future Windows update ever changes how that interception works, the
+  worst case is icons freezing on their default side rather than the mod
+  silently clicking things on its own.
 - **Taskbar buttons can disappear when a display is deactivated** (via
   Settings, unplugging, or a third-party display on/off tool) - if
   "Taskbar behaviors > When using multiple displays, show my taskbar apps
@@ -449,8 +468,11 @@ thread_local bool g_inTaskbarArrangeOverride;
 // RecomputeLayoutPlan does its entire XAML-tree traversal once per
 // ArrangeOverride pass, up front, writing every element's target X into
 // g_lastArrangedX - IUIElement_Arrange_Hook is then a pure map lookup.
-// Never traverse the tree from inside a nested Arrange call instead (see
-// RATIONALE.md).
+// Never traverse the tree from inside a nested Arrange call instead -
+// STATUS_STOWED_EXCEPTION was observed doing that when a window moves
+// across monitors while Windows' "show taskbar apps on" setting isn't
+// "All taskbars," since that structurally adds/removes taskbar buttons
+// mid-traversal. See RATIONALE.md.
 
 // Taskbar window handle, resolved by EnsureTaskbarWnd. atomic: written on
 // the taskbar thread (or Wh_ModAfterInit's thread at startup), read from
@@ -468,7 +490,6 @@ std::atomic<HWND> g_hTaskbarWnd;
 std::atomic<bool> g_taskbarWndSubclassed;
 
 HWINEVENTHOOK g_locationChangeHook;
-HWINEVENTHOOK g_showEventHook;
 std::atomic<int> g_winEventRawCount;
 std::atomic<int> g_winEventInvalidateCount;
 std::atomic<int> g_invalidateSkippedReentrant;
@@ -487,9 +508,11 @@ UINT_PTR g_buttonHwndResolveTimerId;
 // invalidate for WinEventProc's own throttle to see.
 ULONGLONG g_lastDragFollowInvalidate;
 
-// Leading-edge throttle for EVENT_OBJECT_SHOW, mirroring the
-// LOCATIONCHANGE throttle above.
-ULONGLONG g_lastShowEventArm;
+// Leading-edge throttle for TaskListButton::UpdateVisualStates - see its
+// hook. Touched exclusively from the taskbar/XAML UI thread that hook runs
+// on, unlike every other throttle variable above (which lives on the
+// dedicated WinEventHook thread instead).
+ULONGLONG g_lastUpdateVisualStatesArm;
 
 // ============================================================================
 // Generic taskbar/XAML helpers
@@ -716,6 +739,29 @@ XamlRoot GetTaskbarXamlRoot(HWND hTaskbarWnd) {
 // and per-app-volume-control mods, purely to find where a window is.
 // ============================================================================
 
+using TaskListButton_get_IsRunning_t = HRESULT(WINAPI*)(void* pThis,
+                                                         bool* running);
+TaskListButton_get_IsRunning_t TaskListButton_get_IsRunning_Original;
+
+// Cheap, direct read of the XAML button's own running-state - lets
+// ResolveHwndFromTaskListButton skip the whole click-sentinel chain
+// (TryGetItemFromContainer/IsMultiWindow/ITaskGroup::IsRunning and friends)
+// for a pinned-but-not-running button, rather than paying that chain's
+// full cost every retry only to reach the same answer. Optional (see
+// HookTaskbarViewDllSymbols); defaults to "assume running" - i.e. don't
+// skip anything - when the symbol hasn't resolved, which is exactly this
+// mod's behavior before this optimization existed. See RATIONALE.md.
+bool TaskListButtonIsRunning(FrameworkElement element) {
+    if (!TaskListButton_get_IsRunning_Original) {
+        return true;
+    }
+    bool isRunning = false;
+    TaskListButton_get_IsRunning_Original(
+        winrt::get_abi(element.as<winrt::Windows::Foundation::IUnknown>()),
+        &isRunning);
+    return isRunning;
+}
+
 void* CImmersiveTaskItem_vftable;
 
 using CWindowTaskItem_GetWindow_t = HWND(WINAPI*)(void* pThis);
@@ -743,18 +789,20 @@ thread_local void* g_clickSentinel_TaskGroup;
 //
 // Latched per path (item vs. group), not one shared flag, since the two
 // paths reach CTaskListWnd::HandleClick through different internal call
-// chains and a Windows update could break just one. Requires
-// kClickSentinelMissesBeforeBroken cumulative misses (the counter is never
-// reset) before latching "broken" (not just one - see
-// NoteUnconfirmedClickSentinelMiss for why), and that bound only holds
-// pre-confirmation - see RATIONALE.md.
+// chains and a Windows update could break just one. This latch only ever
+// applies pre-confirmation (see NoteUnconfirmedClickSentinelMiss) - with
+// zero evidence yet that interception works, a single miss is reason
+// enough to stop risking real clicks; the asymmetry (a false latch costs
+// position tracking, a false negative activates/minimizes windows the
+// user didn't touch) favors failing closed immediately rather than
+// tolerating more misses. See RATIONALE.md.
 std::atomic<bool> g_clickSentinelItemConfirmed;
 std::atomic<bool> g_clickSentinelItemBroken;
 std::atomic<int> g_clickSentinelItemMisses;
 std::atomic<bool> g_clickSentinelGroupConfirmed;
 std::atomic<bool> g_clickSentinelGroupBroken;
 std::atomic<int> g_clickSentinelGroupMisses;
-constexpr int kClickSentinelMissesBeforeBroken = 3;
+constexpr int kClickSentinelMissesBeforeBroken = 1;
 
 // Which path's probe is in flight on this thread - lets
 // CTaskListWnd_HandleClick_Hook below credit the right path's *Confirmed
@@ -795,9 +843,12 @@ HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
 }
 
 // Called right after a real ReportClicked probe comes back with no
-// capture - not proof the interception is broken by itself (the window
-// could have closed mid-probe, etc.), hence requiring a few misses rather
-// than latching on the first one.
+// capture. Latches "broken" on the first pre-confirmation miss (see
+// kClickSentinelMissesBeforeBroken's own comment for why); a no-longer-
+// pre-confirmation miss (the confirmed check below) is a no-op instead of
+// ever latching, since a miss after interception has already proven
+// itself once is far more likely innocent (window closed mid-probe, etc.)
+// than evidence of a break.
 void NoteUnconfirmedClickSentinelMiss(bool isGroupPath) {
     std::atomic<bool>& confirmed =
         isGroupPath ? g_clickSentinelGroupConfirmed : g_clickSentinelItemConfirmed;
@@ -1019,8 +1070,14 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element,
     }
 
     // Validated up front (memoized, side-effect-free) rather than only
-    // after dispatching a click - see RATIONALE.md for why that ordering
-    // matters.
+    // after dispatching a click: without this, a build where
+    // CTaskGroup::GetNumItems stopped being the trivial form this offset
+    // probe relies on would still dispatch a click on every single group
+    // resolution attempt (the sentinel latch never trips, since
+    // interception itself is unaffected - it's GetTaskItemsArray's own
+    // bounds check further down that always fails instead), turning every
+    // attempt into a pure-waste ReportClicked with nothing to bound it.
+    // See RATIONALE.md.
     size_t taskItemsOffset = GetTaskItemsArrayOffset();
     if (taskItemsOffset == 0 || taskItemsOffset >= kTaskItemsArrayProbeSize) {
         g_resolveStats.failure++;
@@ -1096,7 +1153,20 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element,
 }
 
 HWND ResolveHwndFromTaskListButton(FrameworkElement element,
-                                   bool& outClickDispatched) {
+                                   bool& outClickDispatched,
+                                   bool& outNotRunning) {
+    outNotRunning = false;
+
+    // Cheapest possible check first: skips the entire click-sentinel chain
+    // below (both paths) for a button that isn't running right now, rather
+    // than discovering that only after running it. See
+    // TaskListButtonIsRunning.
+    if (!TaskListButtonIsRunning(element)) {
+        outClickDispatched = false;
+        outNotRunning = true;
+        return nullptr;
+    }
+
     // Each path bails out once its own sentinel is known broken, rather
     // than dispatching more genuine clicks - see g_clickSentinelItemBroken/
     // g_clickSentinelGroupBroken.
@@ -1132,10 +1202,17 @@ struct ButtonHwndCacheEntry {
     std::wstring identity;
     ULONGLONG lastAttempt = 0;
     int consecutiveFailures = 0;
+    // Set when the last resolve attempt bailed via TaskListButtonIsRunning's
+    // cheap pre-check specifically, rather than any other bail-out reason.
+    // NextResolveDelayMs treats this the same as a resolved or terminal
+    // entry (idle cadence, not the fast backoff-0 schedule), since a
+    // confirmed-not-running button won't change state until
+    // TaskListButton::UpdateVisualStates says otherwise. See RATIONALE.md.
+    bool notRunning = false;
 };
 std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
 
-// Set by WinEventProc's EVENT_OBJECT_SHOW branch and the ArrangeOverride
+// Set by TaskListButton::UpdateVisualStates' hook and the ArrangeOverride
 // hook's count-change check to make the next resolve pass ignore a
 // negatively-cached entry's backoff - but only up to
 // kMaxForcedRetryFailures consecutive failures each (see RATIONALE.md for
@@ -1187,21 +1264,25 @@ bool ResolveAndCacheButtonHwnd(FrameworkElement element,
     }
 
     bool clickDispatched = false;
-    HWND hwnd = ResolveHwndFromTaskListButton(element, clickDispatched);
+    bool notRunning = false;
+    HWND hwnd =
+        ResolveHwndFromTaskListButton(element, clickDispatched, notRunning);
     // Only a genuinely dispatched-and-missed click counts toward
     // kMaxResolveFailures' terminal cap - a bail-out before ever
     // dispatching one (not yet confirmed reachable, a view-model lookup
     // miss, a not-currently-running group) isn't a click-safety risk and
     // must not count against a button that may resolve fine later. See
     // RATIONALE.md. lastAttempt still advances either way, so a
-    // persistently-bailing-out entry keeps retrying at ResolveBackoffMs(0)
-    // - a cheap, indefinite cadence - rather than escalating toward the cap.
+    // persistently-bailing-out entry keeps retrying at ResolveBackoffMs(0) -
+    // a cheap, indefinite cadence - except a confirmed-not-running one,
+    // which NextResolveDelayMs instead idles (see ButtonHwndCacheEntry).
     if (hwnd) {
         failures = 0;
     } else if (clickDispatched) {
         failures = failures + 1;
     }
-    g_buttonHwndCache[key] = {hwnd, identity, GetTickCount64(), failures};
+    g_buttonHwndCache[key] = {hwnd, identity, GetTickCount64(), failures,
+                              notRunning};
     return hwnd != previous;
 }
 
@@ -1290,6 +1371,11 @@ WindowClassification ClassifyByWindowPositionCached(HWND hwnd) {
 // Taskbar buttons expose their app's display name as an accessibility
 // property (used by screen readers); reused here as a stable identifier
 // that works even for pinned-but-not-running apps, which have no HWND.
+// Blind spot: with "Combine taskbar buttons" set to "Never", two windows
+// of the same app produce two TaskListButtons with this same name, so an
+// ItemsRepeater rebind between those two specifically wouldn't be caught
+// by an identity mismatch - this only catches a rebind onto a
+// differently-named button. See RATIONALE.md.
 std::wstring GetButtonAccessibleName(FrameworkElement element) {
     auto name = Automation::AutomationProperties::GetName(element);
     if (!name.empty()) {
@@ -1416,15 +1502,44 @@ double FullFootprintWidth(FrameworkElement element) {
 // hidden/shown, and DesiredSize() understates its true width) or task list
 // buttons (this file's hottest path, no evidence of the same bug) - see
 // RATIONALE.md.
+//
+// Persists across calls (never rebuilt/pruned) rather than being folded
+// into one of the per-pass plan maps elsewhere in this file - at most 3
+// real elements ever populate it (Search/Task View/Widgets), so a stale
+// entry surviving a recreate costs nothing, and it specifically needs to
+// outlive a single pass to answer the question below.
+std::unordered_map<void*, double> g_lastSystemButtonContentWidth;
 double SystemButtonContentWidth(FrameworkElement element) {
+    double contentWidth = element.ActualWidth();
     if (Media::VisualTreeHelper::GetChildrenCount(element) > 0) {
         auto child = Media::VisualTreeHelper::GetChild(element, 0)
                          .try_as<FrameworkElement>();
         if (child) {
-            return child.DesiredSize().Width;
+            contentWidth = child.DesiredSize().Width;
         }
     }
-    return element.ActualWidth();
+
+    // element.ActualWidth() (the OUTER element, not the content child
+    // above) reflects the previous Arrange pass and is 0 for one pass
+    // right after the element first appears - the same race Start and
+    // task list buttons already guard against elsewhere in this file. In
+    // that same window the content child usually hasn't been measured
+    // yet either, so its DesiredSize reads 0 even though the button will
+    // end up with real content - without this, the reserved gap next to
+    // Start would collapse to 0 for that one frame. Once the outer
+    // element has gone through a real Arrange pass (ActualWidth() > 0), a
+    // content width of 0 is trustworthy - that's this function's only
+    // signal for a genuine show/hide toggle (see this function's own
+    // comment above), which has to keep working live, so it must NOT be
+    // masked by a "last known good width" fallback the way this one is
+    // for the unmeasured case. See RATIONALE.md.
+    void* key = winrt::get_abi(element);
+    if (contentWidth == 0 && element.ActualWidth() == 0) {
+        auto it = g_lastSystemButtonContentWidth.find(key);
+        return it != g_lastSystemButtonContentWidth.end() ? it->second : 0;
+    }
+    g_lastSystemButtonContentWidth[key] = contentWidth;
+    return contentWidth;
 }
 
 // Same margin-inclusive shape as FullFootprintWidth, for Search/Task
@@ -1511,8 +1626,12 @@ double ComputeSystemButtonX(const std::vector<ChildInfo>& childInfos,
     // Sums every other system button's footprint that appears earlier than
     // targetElement in taskbar order - tracks whatever order the taskbar
     // itself presents these in, rather than a fixed Search/TaskView/Widgets
-    // table, so this stays correct even if a build ever surfaces more than
-    // one of a given button type. See RATIONALE.md.
+    // rank table (this replaced one): a fixed table assumes at most one
+    // instance of each SystemButton value ever exists, so two elements
+    // Windows both classifies the same way (e.g. two
+    // Taskbar.TaskbarExtensionElements) would get the same rank, compute
+    // the same X, and render on top of each other. This degrades
+    // gracefully instead if that assumption ever breaks. See RATIONALE.md.
     double widthBefore = 0;
     for (auto& info : childInfos) {
         if (info.element == targetElement) {
@@ -1590,7 +1709,8 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
                          double startCenterX,
                          double leftBoundLocal,
                          double rightBoundLocal,
-                         std::unordered_map<void*, double>& outPlan) {
+                         std::unordered_map<void*, double>& outPlan,
+                         std::unordered_map<void*, double>& outWidths) {
     std::vector<TaskListPlanEntry> entries;
     for (int i = 0; i < (int)children.size(); i++) {
         if (IsTaskListButton(children[i])) {
@@ -1698,20 +1818,28 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
     // icon's edge lands exactly at leftInnerX/rightInnerX regardless of
     // scale - only `x` itself advances by the scaled amount. A
     // just-realized button's ActualWidth() is 0 for one pass (Margin
-    // isn't, so entry->width alone isn't a reliable zero-width signal -
-    // see RATIONALE.md); skipping its outPlan entry then avoids
-    // stacking it on its neighbor for that one frame.
+    // isn't, so entry->width alone isn't a reliable zero-width signal);
+    // skipping its outPlan entry then avoids stacking it on its neighbor
+    // for that one frame, falling through to native positioning instead -
+    // safe since it's then also missing from g_lastArrangedX's coverage,
+    // so RecomputeLayoutPlan's own staleness check forces a real recompute
+    // the very next pass once its real width is available. See
+    // RATIONALE.md.
     double x = leftInnerX;
     for (auto* entry : left) {
         if (entry->element.ActualWidth() > 0) {
-            outPlan[winrt::get_abi(entry->element)] = x - entry->width;
+            void* key = winrt::get_abi(entry->element);
+            outPlan[key] = x - entry->width;
+            outWidths[key] = entry->width;
         }
         x -= entry->width * leftScale;
     }
     x = rightInnerX;
     for (auto* entry : right) {
         if (entry->element.ActualWidth() > 0) {
-            outPlan[winrt::get_abi(entry->element)] = x;
+            void* key = winrt::get_abi(entry->element);
+            outPlan[key] = x;
+            outWidths[key] = entry->width;
         }
         x += entry->width * rightScale;
     }
@@ -1722,8 +1850,9 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
 // ============================================================================
 
 // Defined later (Live drag-follow section). Only ever marks the taskbar's
-// layout dirty - never forces a synchronous UpdateLayout() (see
-// RATIONALE.md).
+// layout dirty - never forces a synchronous UpdateLayout() (a forced call
+// from a nested callback reenters WinUI layout and raises
+// STATUS_STOWED_EXCEPTION; see its own definition and RATIONALE.md).
 void InvalidateTaskbarLayout();
 
 // Idle re-check cadence once every cached button is resolved - keeps
@@ -1741,7 +1870,12 @@ constexpr DWORD kEnumerationFailedRetryMs = 1000;
 void StartWinEventHook();
 
 // Defined later (Mod lifecycle section); lets a live trackWindowPositions
-// toggle stop the WinEventHook thread reversibly - see RATIONALE.md.
+// toggle stop the WinEventHook thread reversibly. A separate function from
+// StopWinEventHook specifically because that one also sets a permanent,
+// one-way latch meant only for mod teardown - reusing it here would have
+// silently bricked the setting after the first toggle-off, since turning
+// it back on would then refuse to start (caught during the user's own live
+// testing). See RATIONALE.md.
 void StopWinEventHookForToggle();
 
 // Defined later (Mod lifecycle section); lets the ArrangeOverride hook
@@ -1764,12 +1898,27 @@ void ApplyPendingSettingsIfAny();
 
 // Resolves g_hTaskbarWnd and installs the taskbar-window subclass,
 // self-healing on every ArrangeOverride pass rather than a one-shot
-// Wh_ModAfterInit lookup - see RATIONALE.md for why both parts need to
-// keep retrying rather than running once.
+// Wh_ModAfterInit lookup. Two independent reasons both parts need to keep
+// retrying rather than running once: a fresh-boot race where Windhawk
+// injects before Shell_TrayWnd exists yet would otherwise leave
+// g_hTaskbarWnd permanently null, and a rare SetWindowSubclassFromAnyThread
+// failure would otherwise permanently disable drag-follow/HWND-resolution/
+// live-settings for the rest of the process (core centering/splitting
+// keeps working either way, since that's computed synchronously). See
+// RATIONALE.md.
 HWND EnsureTaskbarWnd() {
+    // Snapshot once, per g_hTaskbarWnd's own comment - every read below,
+    // including the final return, agrees with whichever writes this same
+    // call already made, rather than each re-reading the atomic
+    // independently (this function is g_hTaskbarWnd's sole writer, so
+    // that's benign today, but the snapshot keeps the code matching the
+    // contract the variable's own comment states).
+    HWND hTaskbarWnd = g_hTaskbarWnd;
+
     // Shell_TrayWnd can in principle be recreated without explorer.exe
     // restarting. Cheap enough to check unconditionally every pass.
-    if (g_hTaskbarWnd && !IsWindow(g_hTaskbarWnd)) {
+    if (hTaskbarWnd && !IsWindow(hTaskbarWnd)) {
+        hTaskbarWnd = nullptr;
         g_hTaskbarWnd = nullptr;
         // comctl32 tears the old subclass down on WM_NCDESTROY already -
         // this just keeps the flag in step so a fresh install is attempted
@@ -1777,18 +1926,19 @@ HWND EnsureTaskbarWnd() {
         g_taskbarWndSubclassed = false;
     }
 
-    if (!g_hTaskbarWnd) {
+    if (!hTaskbarWnd) {
         if (g_unloading) {
             // Guards against a pass landing here after Wh_ModBeforeUninit
             // already ran, with no teardown left to stop a newly-created
             // WinEventHook thread.
             return nullptr;
         }
-        g_hTaskbarWnd = FindCurrentProcessTaskbarWnd();
-        if (!g_hTaskbarWnd) {
+        hTaskbarWnd = FindCurrentProcessTaskbarWnd();
+        if (!hTaskbarWnd) {
             return nullptr;
         }
-        Wh_Log(L"Resolved taskbar window: %p", (HWND)g_hTaskbarWnd);
+        g_hTaskbarWnd = hTaskbarWnd;
+        Wh_Log(L"Resolved taskbar window: %p", hTaskbarWnd);
         // Starting this thread is what turns on window-position tracking
         // at all - see trackWindowPositions' own settings description.
         // Only checked here at initial resolve, not on every call; a live
@@ -1804,23 +1954,29 @@ HWND EnsureTaskbarWnd() {
     }
 
     // Retried on every call until it succeeds, not just the pass that
-    // first resolves g_hTaskbarWnd above - see RATIONALE.md for why that
-    // matters. Cheap on the common ArrangeOverride call path, since that
+    // first resolves g_hTaskbarWnd above (see this function's own comment
+    // for why). Cheap on the common ArrangeOverride call path, since that
     // already runs on the taskbar's own thread and
     // SetWindowSubclassFromAnyThread takes its same-thread fast path there
     // (the Wh_ModAfterInit call site runs on Windhawk's own thread instead,
     // so it takes the real cross-thread marshal, but only once at startup).
     if (!g_taskbarWndSubclassed && !g_unloading &&
         WindhawkUtils::SetWindowSubclassFromAnyThread(
-            g_hTaskbarWnd, TaskbarWndSubclassProc, 0)) {
+            hTaskbarWnd, TaskbarWndSubclassProc, 0)) {
         g_taskbarWndSubclassed = true;
 
         // Undo immediately if Wh_ModBeforeUninit's removal pass already
-        // ran with the subclass not yet installed - see RATIONALE.md for
-        // the crash this closes.
+        // ran with the subclass not yet installed (reachable right after a
+        // Shell_TrayWnd recreate, or a fresh-boot race, catches
+        // EnsureTaskbarWnd still resolving as unload begins) - that
+        // removal pass only ever runs once, so a subclass installed here
+        // afterward would stay wired into Shell_TrayWnd with no later
+        // removal call, and Windhawk unmaps this module's code shortly
+        // after Wh_ModUninit returns - a use-after-free the next time that
+        // window procedure runs. See RATIONALE.md.
         if (g_unloading && g_taskbarWndSubclassed.exchange(false)) {
             WindhawkUtils::RemoveWindowSubclassFromAnyThread(
-                g_hTaskbarWnd, TaskbarWndSubclassProc);
+                hTaskbarWnd, TaskbarWndSubclassProc);
         } else {
             // Kicks the resolve timer and a relayout awake - needed since
             // nothing else restarts them once a subclass install has
@@ -1833,7 +1989,7 @@ HWND EnsureTaskbarWnd() {
         }
     }
 
-    return g_hTaskbarWnd;
+    return hTaskbarWnd;
 }
 
 FrameworkElement FindTaskbarFrameRepeater(FrameworkElement anyDescendant) {
@@ -1884,7 +2040,7 @@ FrameworkElement GetCachedTaskbarRepeater() {
 //
 // g_unloading gates this first - once the mod's hooks are gone, a click-
 // sentinel probe here reaches the taskbar's real HandleClick with a
-// garbage pointer instead of being intercepted (see RATIONALE.md).
+// garbage pointer instead of being intercepted.
 //
 // Reentrancy guard (RAII, since this has several early returns): calling
 // into taskbar.dll/WinRT here can pump messages, letting a second posted
@@ -2048,6 +2204,13 @@ IUIElement_Arrange_t IUIElement_Arrange_Original;
 // in this pass's plan) falls through to native positioning.
 std::unordered_map<void*, double> g_lastArrangedX;
 
+// Each task list button's own FullFootprintWidth() as of the same pass
+// that computed g_lastArrangedX, keyed the same way. RecomputeLayoutPlan's
+// cheap staleness check uses this to catch a button whose width changed
+// without its count changing (e.g. a label populating shortly after a
+// freshly-launched button first appears icon-only) - see RATIONALE.md.
+std::unordered_map<void*, double> g_lastArrangedTaskListWidth;
+
 // Set whenever something might have changed that g_lastArrangedX doesn't
 // reflect yet, at the point that change becomes visible on the taskbar
 // thread. Starts true so the first pass always computes a real plan.
@@ -2138,22 +2301,46 @@ void RecomputeLayoutPlan() {
     if (!g_planDirty &&
         GetTickCount64() - g_lastPlanRecomputeTick < kMaxPlanStalenessMs) {
         // Cheap staleness check: if any live task list button isn't in
-        // g_lastArrangedX, or the live child count doesn't match the last
+        // g_lastArrangedX, an already-covered one's own width has since
+        // changed, or the live child count doesn't match the last
         // recompute's, the plan is stale regardless of the dirty flag.
-        // Hash lookup first, IsTaskListButton (a real class-name lookup)
-        // second and short-circuited, so the common "nothing changed"
-        // case never pays for it.
+        // Hash lookups first, IsTaskListButton/FullFootprintWidth (real
+        // class-name/property reads) second and short-circuited, so the
+        // common "nothing changed" case never pays for them.
         bool planIsCurrent = true;
         try {
             if (FrameworkElement repeater = GetCachedTaskbarRepeater()) {
                 int liveChildCount = 0;
                 for (auto& child : GetRepeaterChildElements(repeater)) {
                     liveChildCount++;
-                    if (!g_lastArrangedX.count(winrt::get_abi(child)) &&
-                        IsTaskListButton(child)) {
-                        // A live task list button the plan doesn't cover
-                        // yet. Scoped to task list buttons since a
-                        // brand-new system button can't reach this branch.
+                    void* key = winrt::get_abi(child);
+                    if (!g_lastArrangedX.count(key)) {
+                        if (IsTaskListButton(child)) {
+                            // A live task list button the plan doesn't
+                            // cover yet. Scoped to task list buttons since
+                            // a brand-new system button can't reach this
+                            // branch.
+                            planIsCurrent = false;
+                            break;
+                        }
+                        continue;
+                    }
+                    // Already covered - but for a task list button
+                    // specifically, its own width can still have changed
+                    // since the plan was computed without the button
+                    // count changing at all (e.g. a freshly-launched
+                    // button first renders icon-only, then grows once its
+                    // label populates a moment later) - that wouldn't
+                    // otherwise mark the plan dirty, leaving a stale,
+                    // too-narrow X in effect until something unrelated
+                    // (a drag, a count change) forces a real recompute.
+                    // g_lastArrangedTaskListWidth only has entries for
+                    // task list buttons, so this naturally no-ops for
+                    // Start/Search/TaskView/Widgets. See RATIONALE.md.
+                    auto widthIt = g_lastArrangedTaskListWidth.find(key);
+                    if (widthIt != g_lastArrangedTaskListWidth.end() &&
+                        std::abs(FullFootprintWidth(child) - widthIt->second) >
+                            0.5) {
                         planIsCurrent = false;
                         break;
                     }
@@ -2192,6 +2379,7 @@ void RecomputeLayoutPlan() {
         auto children = GetRepeaterChildElements(repeater);
         double startCenterX = GetMonitorCenterXLocal();
         std::unordered_map<void*, double> newPlan;
+        std::unordered_map<void*, double> newTaskListWidths;
 
         // Classify each child's SystemButton status exactly once - see
         // ChildInfo's comment for why.
@@ -2205,9 +2393,15 @@ void RecomputeLayoutPlan() {
         // both read g_lastStartWidth, so it must reflect this pass.
         for (auto& info : childInfos) {
             if (info.systemButton == SystemButton::Start) {
-                // Bare ActualWidth(), NOT SystemButtonContentWidth - see
-                // RATIONALE.md for why that fix doesn't apply to Start.
-                // Only updates g_lastStartWidth when positive, so a
+                // Bare ActualWidth(), NOT SystemButtonContentWidth: Start
+                // is never hidden/shown the way Search/Task View/Widgets
+                // are, so it was never exposed to the collapse-margin
+                // problem that fix exists for, and swapping to the content
+                // child's DesiredSize() instead would understate Start's
+                // true width - its own visual-tree shape doesn't match
+                // what that technique was validated against. See
+                // RATIONALE.md. Only updates g_lastStartWidth when
+                // positive, so a
                 // freshly (re)created Start keeps the last known-good
                 // width instead of collapsing around a zero-width Start.
                 double w = info.element.ActualWidth();
@@ -2277,9 +2471,10 @@ void RecomputeLayoutPlan() {
         // Task list buttons last - see PlanTaskListButtons for the
         // single-O(n)-pass reasoning.
         PlanTaskListButtons(children, startCenterX, leftBoundLocal,
-                            rightBoundLocal, newPlan);
+                            rightBoundLocal, newPlan, newTaskListWidths);
 
         g_lastArrangedX = std::move(newPlan);
+        g_lastArrangedTaskListWidth = std::move(newTaskListWidths);
         g_planChildCount = (int)children.size();
         g_planDirty = false;
     } catch (...) {
@@ -2435,7 +2630,8 @@ UINT InvalidateTaskbarLayoutMsg() {
 }
 
 // Same idea as InvalidateTaskbarLayoutMsg, for ButtonHwndResolveTimerProc
-// (up to ~7/sec while EVENT_OBJECT_SHOW events are bursting).
+// (can arrive in a burst while TaskListButton::UpdateVisualStates fires
+// repeatedly, e.g. several buttons changing state at once).
 UINT ResolveButtonHwndsMsg() {
     static const UINT msg =
         RegisterWindowMessage(L"Windhawk_ResolveButtonHwnds_" WH_MOD_ID);
@@ -2462,11 +2658,17 @@ UINT DrainSettingsMsg() {
     return msg;
 }
 
-// Installed on g_hTaskbarWnd by EnsureTaskbarWnd. Handles the four private
-// messages above and forwards everything else to DefSubclassProc (which
-// also lets comctl32 clean this subclass up via WM_NCDESTROY if the window
-// is destroyed before Wh_ModBeforeUninit removes it). See RATIONALE.md for
-// why this is the sole path onto the taskbar thread, with no fallback.
+// Installed on g_hTaskbarWnd by EnsureTaskbarWnd. A subclass proc only
+// ever runs on the thread that owns the window, which is what lets
+// InvalidateTaskbarLayout/ResolvePendingButtonHwnds/ApplyLoadedSettings
+// use a plain, non-blocking PostMessage - no per-call SetWindowsHookEx/
+// SendMessage/UnhookWindowsHookEx dance needed, unlike an earlier design
+// this replaced (see RATIONALE.md). This is the SOLE way any of the four
+// private messages below reach the taskbar thread, with no fallback if
+// the subclass never installs. Everything else is forwarded to
+// DefSubclassProc, which also lets comctl32 clean this subclass up via
+// WM_NCDESTROY if the window is destroyed before Wh_ModBeforeUninit
+// removes it.
 LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
                                         UINT uMsg,
                                         WPARAM wParam,
@@ -2497,10 +2699,15 @@ LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
         bool wasTracking = g_settings.trackWindowPositions;
         g_settings = std::move(*heapSettings);
         // Marks the previous plan stale now that the settings it was built
-        // from just changed. See RATIONALE.md.
+        // from just changed - has to happen exactly here, not by the
+        // separate InvalidateTaskbarLayout() call Wh_ModSettingsChanged
+        // also makes, since that one can't see the settings swap above.
+        // See RATIONALE.md.
         g_planDirty = true;
         // Starts/stops the WinEventHook thread live on a trackWindowPositions
-        // change, rather than only at the next mod reload - see RATIONALE.md.
+        // change, rather than only at the next mod reload - StopWinEventHookForToggle,
+        // not StopWinEventHook, since the latter's own comment explains why
+        // that one would permanently brick this toggle. See RATIONALE.md.
         if (g_settings.trackWindowPositions != wasTracking) {
             if (g_settings.trackWindowPositions) {
                 StartWinEventHook();
@@ -2524,8 +2731,14 @@ LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
 // than forcing a synchronous UpdateLayout() call. MUST stay async: a forced
 // UpdateLayout() from a nested callback (e.g. WinEventProc) reenters WinUI
 // layout and raises STATUS_STOWED_EXCEPTION, a raw SEH exception no
-// try/catch in this file can contain. Does not set g_planDirty itself -
-// see RATIONALE.md; each real caller marks dirty at its own point instead.
+// try/catch in this file can contain. Does not set g_planDirty itself,
+// since this marshal is asynchronous - a natural ArrangeOverride pass
+// could land on the taskbar thread between this call setting the flag and
+// the posted message being processed, see it already true, recompute with
+// stale state, and clear the flag, leaving the posted invalidate with
+// nothing left to do. Each real caller marks dirty at its own point
+// instead, at the moment its own state change becomes visible on the
+// taskbar thread. See RATIONALE.md.
 void InvalidateTaskbarLayout() {
     // Snapshot so a concurrent EnsureTaskbarWnd write can't change this
     // mid-function.
@@ -2580,19 +2793,16 @@ void CALLBACK WinEventProc(HWINEVENTHOOK hook,
     }
 
     // Only a window this mod has resolved to a taskbar button can affect
-    // the layout on a move, so filter LOCATIONCHANGE against that set
-    // before the cross-process USER32 calls below. Not applied to SHOW: a
-    // newly-shown window can't be resolved yet by definition - instead,
-    // its own leading-edge throttle is checked here too, before those same
-    // USER32 calls, since SHOW is otherwise unthrottled and can arrive in
-    // bursts.
-    if (event == EVENT_OBJECT_LOCATIONCHANGE) {
+    // the layout on a move, so filter against that set before the
+    // cross-process USER32 calls below. This hook only ever registers for
+    // EVENT_OBJECT_LOCATIONCHANGE now - the newly-visible-window nudge a
+    // desktop-wide EVENT_OBJECT_SHOW hook used to provide is instead
+    // TaskListButton::UpdateVisualStates' job (see its hook), scoped to
+    // this taskbar's own buttons rather than every top-level window
+    // process-wide. See RATIONALE.md.
+    {
         std::lock_guard<std::mutex> guard(g_resolvedHwndsMutex);
         if (!g_resolvedHwnds.count(hwnd)) {
-            return;
-        }
-    } else if (event == EVENT_OBJECT_SHOW) {
-        if (GetTickCount64() - g_lastShowEventArm < 150) {
             return;
         }
     }
@@ -2602,24 +2812,19 @@ void CALLBACK WinEventProc(HWINEVENTHOOK hook,
         return;
     }
 
-    if (event == EVENT_OBJECT_SHOW) {
-        // A newly-visible top-level window is what a pinned-but-not-running
-        // app launching looks like - nudge the resolve timer to run now,
-        // bypassing each entry's own backoff. No trailing timer needed
-        // since a single arm(0) picks up every pending button regardless
-        // of which SHOW event triggered it. See RATIONALE.md.
-        g_lastShowEventArm = GetTickCount64();
-        g_forceResolveUnresolved = true;
-        ArmButtonHwndResolveTimer(0);
-        return;
-    }
-
-    // event == EVENT_OBJECT_LOCATIONCHANGE from here on - drag-follow.
+    // Drag-follow.
     ULONGLONG now = GetTickCount64();
     if (now - g_lastDragFollowInvalidate < 150) {
-        // Leading-edge throttle, so re-arm a trailing one-shot timer on
-        // every throttled event to catch the drag/move's final position
-        // once the burst goes quiet. See RATIONALE.md.
+        // Leading-edge throttle, so the final location-change event of a
+        // drag/move - the one carrying its actual release position - is
+        // routinely the one that lands inside the throttle window and
+        // gets dropped, since a drag generates a continuous event stream
+        // right up to release. Without a trailing timer, the icon would
+        // stay classified by a stale mid-drag position until some
+        // unrelated window happened to move. Re-arming this short
+        // one-shot timer on every throttled event makes it always fire
+        // once the burst actually goes quiet, applying the final
+        // position. See RATIONALE.md.
         if (g_dragFollowTrailingTimerId) {
             KillTimer(nullptr, g_dragFollowTrailingTimerId);
         }
@@ -2731,6 +2936,31 @@ bool HookTaskbarDllSymbols() {
     return ok;
 }
 
+using TaskListButton_UpdateVisualStates_t = void(WINAPI*)(void* pThis);
+TaskListButton_UpdateVisualStates_t TaskListButton_UpdateVisualStates_Original;
+
+// Fires on every visual-state transition of a taskbar button, including a
+// pinned app's running/not-running change - replaces the old, desktop-wide
+// EVENT_OBJECT_SHOW WinEventHook (removed; see RATIONALE.md) as the fast
+// nudge for "something just changed, go re-check", scoped to this
+// taskbar's own buttons instead of every top-level window process-wide.
+// Optional (see the hooks table below) - if a future Windows build renames
+// this, resolution falls back to ResolveBackoffMs' own capped-backoff
+// schedule with no fast path, the same fallback already relied on for a
+// launch that reaches this hook through a path it doesn't expect.
+// Leading-edge throttled the same way EVENT_OBJECT_SHOW was, since this
+// can fire far more often (hover/press states too, not just running).
+void WINAPI TaskListButton_UpdateVisualStates_Hook(void* pThis) {
+    TaskListButton_UpdateVisualStates_Original(pThis);
+
+    if (GetTickCount64() - g_lastUpdateVisualStatesArm < 150) {
+        return;
+    }
+    g_lastUpdateVisualStatesArm = GetTickCount64();
+    g_forceResolveUnresolved = true;
+    ArmButtonHwndResolveTimer(0);
+}
+
 bool HookTaskbarViewDllSymbols(HMODULE module) {
     // Which of these two is actually loaded depends on the Windows build -
     // see GetTaskbarViewModuleHandle. Most entries are optional so a single
@@ -2775,6 +3005,18 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
             ITaskGroup_IsRunning_Hook,
             true,
         },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListButton,struct winrt::Taskbar::ITaskListButton>::get_IsRunning(bool *))"},
+            &TaskListButton_get_IsRunning_Original,
+            nullptr,
+            true,
+        },
+        {
+            {LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateVisualStates(void))"},
+            &TaskListButton_UpdateVisualStates_Original,
+            TaskListButton_UpdateVisualStates_Hook,
+            true,
+        },
     };
 
     bool ok = HookSymbols(module, hooks, ARRAYSIZE(hooks));
@@ -2787,7 +3029,7 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
                                                                         : L"MISSING");
     if (!ok) {
         Wh_Log(L"  Missing (optional, HWND-resolution chain only): "
-               L"%s%s%s%s%s",
+               L"%s%s%s%s%s%s%s",
                TryGetItemFromContainer_TaskListWindowViewModel_Original
                    ? L""
                    : L"TryGetItemFromContainer<TaskListWindowViewModel> ",
@@ -2800,7 +3042,13 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
                TaskListGroupViewModel_IsMultiWindow_Original
                    ? L""
                    : L"TaskListGroupViewModel::IsMultiWindow ",
-               ITaskGroup_IsRunning_Original ? L"" : L"ITaskGroup::IsRunning ");
+               ITaskGroup_IsRunning_Original ? L"" : L"ITaskGroup::IsRunning ",
+               TaskListButton_get_IsRunning_Original
+                   ? L""
+                   : L"TaskListButton::get_IsRunning ",
+               TaskListButton_UpdateVisualStates_Original
+                   ? L""
+                   : L"TaskListButton::UpdateVisualStates ");
     }
     return ok;
 }
@@ -2820,8 +3068,12 @@ void HandleLoadedModuleIfTaskbarView(HMODULE module, LPCWSTR lpLibFileName) {
         Wh_Log(L"Loaded %s", lpLibFileName);
 
         // Applied unconditionally, not gated on HookTaskbarViewDllSymbols'
-        // return value - see RATIONALE.md for why a missing optional
-        // symbol shouldn't discard hooks that did resolve.
+        // return value - that value reflects whether EVERY symbol in its
+        // table resolved, optional ones included, so a single missing
+        // optional HWND-resolution symbol (exactly what optional=true
+        // exists to tolerate) would otherwise skip applying hooks for
+        // every symbol that DID resolve, ArrangeOverride included. See
+        // RATIONALE.md.
         HookTaskbarViewDllSymbols(module);
         Wh_ApplyHookOperations();
     }
@@ -2846,7 +3098,12 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
 
 // WinEvent hooks run on a dedicated mod-owned thread rather than the
 // taskbar's own, to keep the high raw event volume off the shell's layout
-// thread. See RATIONALE.md.
+// thread - EVENT_OBJECT_LOCATIONCHANGE alone has been observed producing
+// thousands of raw events within seconds. WINEVENT_OUTOFCONTEXT delivers
+// callbacks on whichever thread called SetWinEventHook, so registering on
+// the taskbar's own thread would put all of that, plus this file's own
+// filtering on each one, in direct contention with the shell's own layout
+// work. See RATIONALE.md.
 //
 // Private message this thread's own queue uses to let ArmButtonHwndResolveTimer
 // (called from the taskbar thread) re-arm the resolve timer, which lives
@@ -2881,18 +3138,6 @@ DWORD WINAPI WinEventHookThreadProc(LPVOID) {
                L"will");
     }
 
-    // Separate hook since the two event IDs aren't adjacent - a single
-    // range spanning both would also pick up unrelated event types.
-    g_showEventHook = SetWinEventHook(EVENT_OBJECT_SHOW, EVENT_OBJECT_SHOW,
-                                      nullptr, WinEventProc, 0, 0,
-                                      WINEVENT_OUTOFCONTEXT);
-    if (!g_showEventHook) {
-        Wh_Log(L"Failed to register show-event hook - a newly launched "
-               L"pinned app's icon will only start following it once the "
-               L"resolve timer's own backoff schedule catches up, rather "
-               L"than immediately");
-    }
-
     // Kicks off the first HWND-resolve attempt so buttons already present
     // at mod startup get picked up; NextResolveDelayMs/
     // ArmButtonHwndResolveTimer keep it armed afterward only as needed.
@@ -2918,10 +3163,6 @@ DWORD WINAPI WinEventHookThreadProc(LPVOID) {
         UnhookWinEvent(g_locationChangeHook);
         g_locationChangeHook = nullptr;
     }
-    if (g_showEventHook) {
-        UnhookWinEvent(g_showEventHook);
-        g_showEventHook = nullptr;
-    }
     if (g_buttonHwndResolveTimerId) {
         KillTimer(nullptr, g_buttonHwndResolveTimerId);
         g_buttonHwndResolveTimerId = 0;
@@ -2939,8 +3180,13 @@ HANDLE g_winEventThread;
 // thread) in ArmButtonHwndResolveTimer - atomic makes that well-defined.
 std::atomic<DWORD> g_winEventThreadId;
 
-// Serializes StartWinEventHook/StopWinEventHook against each other - see
-// RATIONALE.md for the race this prevents.
+// Serializes StartWinEventHook/StopWinEventHook against each other: a
+// start call can still be inside CreateThread, before g_winEventThread is
+// written, when a concurrent stop call checks it - without this mutex
+// making "is there a thread, and should one ever be created again" one
+// atomic question both functions agree on, the stop call could miss the
+// very thread it was meant to tear down, leaving it to crash the process
+// when Windhawk unmaps the module later. See RATIONALE.md.
 std::mutex g_winEventThreadMutex;
 bool g_winEventThreadStopped;
 
@@ -3018,7 +3264,9 @@ void StopWinEventHookForToggle() {
 
 // Capped exponential backoff for the click-sentinel probe, shared by
 // ResolvePendingButtonHwnds and NextResolveDelayMs. Fallback safety net for
-// launches that don't produce EVENT_OBJECT_SHOW; see RATIONALE.md.
+// a launch that reaches TaskListButton::UpdateVisualStates through a path
+// this mod doesn't expect, or on a build where that hook didn't resolve at
+// all; see RATIONALE.md.
 constexpr ULONGLONG kResolveBackoffCeilingMs = 30ULL * 60 * 1000;
 ULONGLONG ResolveBackoffMs(int consecutiveFailures) {
     int shift = std::min(consecutiveFailures, 16);  // keep the shift itself from overflowing
@@ -3031,20 +3279,22 @@ ULONGLONG ResolveBackoffMs(int consecutiveFailures) {
 DWORD NextResolveDelayMs() {
     ULONGLONG now = GetTickCount64();
     bool anyPending = false;
-    // True for a resolved entry OR a terminal one (consecutiveFailures at
-    // kMaxResolveFailures) - either way, only the slow idle-rebind cadence
-    // below still applies to it, never the backoff schedule. Must exactly
-    // match ResolvePendingButtonHwnds' own backoffElapsed check, which
-    // never retries a terminal entry - see RATIONALE.md for the busy-loop
-    // this closes: without this, a terminal entry's fixed, no-longer-
-    // advancing dueAt falls further into the past every tick, pinning
-    // pendingDelay at 0 (SetTimer's 10ms floor) forever.
+    // True for a resolved entry, a terminal one (consecutiveFailures at
+    // kMaxResolveFailures), or a confirmed-not-running one (see
+    // ButtonHwndCacheEntry::notRunning) - in every case, only the slow
+    // idle-rebind cadence below still applies to it, never the backoff
+    // schedule. Must exactly match ResolvePendingButtonHwnds' own
+    // backoffElapsed check, which never retries a terminal entry - see
+    // RATIONALE.md for the busy-loop this closes: without this, a terminal
+    // entry's fixed, no-longer-advancing dueAt falls further into the past
+    // every tick, pinning pendingDelay at 0 (SetTimer's 10ms floor) forever.
     bool anyIdleWorthy = false;
     ULONGLONG earliestDue = 0;
 
     for (auto& kv : g_buttonHwndCache) {
         const ButtonHwndCacheEntry& entry = kv.second;
-        if (entry.hwnd || entry.consecutiveFailures >= kMaxResolveFailures) {
+        if (entry.hwnd || entry.notRunning ||
+            entry.consecutiveFailures >= kMaxResolveFailures) {
             anyIdleWorthy = true;
             continue;
         }
@@ -3141,10 +3391,12 @@ BOOL Wh_ModInit() {
     if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
         Wh_Log(L"Taskbar view module already loaded at init time");
         g_taskbarViewDllLoaded = true;
-        // Not gated on HookTaskbarViewDllSymbols' own return value (which
-        // reflects optional symbols too) - see RATIONALE.md. The one
-        // symbol that must load, ArrangeOverride, is checked directly
-        // below instead.
+        // Not gated on HookTaskbarViewDllSymbols' own return value - it
+        // reflects optional symbols too, so a single missing optional
+        // HWND-resolution symbol would otherwise fail this ENTIRE mod's
+        // load, exactly the outcome optional=true exists to prevent. The
+        // one symbol that must load, ArrangeOverride, is checked directly
+        // below instead. See RATIONALE.md.
         HookTaskbarViewDllSymbols(taskbarViewModule);
         if (!TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original) {
             return FALSE;
@@ -3202,12 +3454,15 @@ void Wh_ModBeforeUninit() {
     // the click-sentinel probe and makes IUIElement_Arrange_Hook fall
     // through to native positioning immediately.
 
-    // Forces an immediate snap-back to native positions before removing
-    // the subclass below - hooks are still live and g_unloading is already
-    // set, so IUIElement_Arrange_Hook falls through to native positioning
-    // for this pass. Must be SendMessage, not PostMessage:
-    // RemoveWindowSubclassFromAnyThread below is itself a SendMessage, and
-    // a merely posted invalidate would arrive after the subclass is gone.
+    // Requests a relayout before removing the subclass below - not itself
+    // an immediate snap-back (InvalidateArrange/InvalidateMeasure only
+    // mark the tree dirty; the actual re-Arrange runs whenever XAML gets
+    // around to its next layout pass), but by the time that pass runs,
+    // IUIElement_Arrange_Hook already falls through to native positioning
+    // since g_unloading is set, so the end result is the same. Must be
+    // SendMessage, not PostMessage: RemoveWindowSubclassFromAnyThread
+    // below is itself a SendMessage, and a merely posted invalidate would
+    // arrive after the subclass is gone, with nothing left to dispatch it.
     HWND hTaskbarWnd = g_hTaskbarWnd;
     if (hTaskbarWnd && g_taskbarWndSubclassed) {
         SendMessage(hTaskbarWnd, InvalidateTaskbarLayoutMsg(), 0, 0);

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -213,6 +213,10 @@ community.
 */
 // ==/WindhawkModSettings==
 
+// Design rationale, history, and edge-case reasoning behind the comments
+// below that say "see RATIONALE.md":
+// https://github.com/rycalvo/w11tb_centerer/blob/main/RATIONALE.md
+
 #include <windhawk_utils.h>
 
 #include <algorithm>
@@ -1080,8 +1084,9 @@ std::unordered_set<HWND> g_resolvedHwnds;
 // Runs the resolution chain and updates the cache. Deliberately ONLY ever
 // called from the resolve timer, never from GetButtonHwnd or an active
 // Arrange pass - running the click-sentinel technique while a button is
-// mid-insertion/removal in an ItemsRepeater crashes explorer.exe (see
-// RATIONALE.md).
+// mid-insertion/removal in an ItemsRepeater reaches STATUS_STOWED_EXCEPTION
+// and crashes explorer.exe (confirmed via crash-dump analysis; see
+// RATIONALE.md for the full trigger conditions).
 bool ResolveAndCacheButtonHwnd(FrameworkElement element,
                                const std::wstring& identity) {
     void* key = winrt::get_abi(element);
@@ -1314,8 +1319,10 @@ double FullFootprintWidth(FrameworkElement element) {
 // hidden/shown - ActualWidth() includes that margin, so it never drops
 // below the collapsed width. Reads the content child's DesiredSize instead
 // (matching taskbar-start-button-position.wh.cpp), falling back to
-// ActualWidth() if no child is realized yet. NOT used for Start or task
-// list buttons - see RATIONALE.md.
+// ActualWidth() if no child is realized yet. NOT used for Start (never
+// hidden/shown, and DesiredSize() understates its true width) or task list
+// buttons (this file's hottest path, no evidence of the same bug) - see
+// RATIONALE.md.
 double SystemButtonContentWidth(FrameworkElement element) {
     if (Media::VisualTreeHelper::GetChildrenCount(element) > 0) {
         auto child = Media::VisualTreeHelper::GetChild(element, 0)
@@ -2262,8 +2269,12 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
 // Live drag-follow: force a taskbar relayout when a top-level window moves
 // ============================================================================
 
-// Guards against reentering this body on the taskbar's own thread. See
-// RATIONALE.md for why it's needed and why this never calls UpdateLayout().
+// Guards against reentering this body on the taskbar's own thread - a
+// nested WinRT/taskbar.dll call inside it can pump messages and let a
+// second posted invalidate land reentrantly before the first returns. This
+// body also never calls UpdateLayout() itself - see InvalidateTaskbarLayout
+// below for why a forced synchronous layout pass here is unsafe regardless
+// of this guard (see RATIONALE.md for more).
 thread_local bool g_inInvalidateTaskbarLayout;
 
 // MUST only run on g_hTaskbarWnd's own thread - same constraint as
@@ -2560,9 +2571,10 @@ bool HookTaskbarDllSymbols() {
 }
 
 bool HookTaskbarViewDllSymbols(HMODULE module) {
-    // Hooks for Taskbar.View.dll / ExplorerExtensions.dll (see
-    // GetTaskbarViewModuleHandle). Most entries are optional so a single
+    // Which of these two is actually loaded depends on the Windows build -
+    // see GetTaskbarViewModuleHandle. Most entries are optional so a single
     // missing symbol doesn't abort the whole batch - see RATIONALE.md.
+    // Taskbar.View.dll, ExplorerExtensions.dll
     WindhawkUtils::SYMBOL_HOOK hooks[] = {
         {
             // Not optional, unlike every entry below: this hook is the

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -1149,9 +1149,12 @@ constexpr int kMaxForcedRetryFailures = 3;
 // different internal handler while the rest of the taskbar still reaches
 // CTaskListWnd::HandleClick, so the click-sentinel latch itself never
 // trips) would keep dispatching a real ReportClicked on this entry every
-// ResolveBackoffMs interval, forever. A button whose identity changes, or
-// that gets pruned and recreated, still gets a fresh consecutiveFailures
-// count and resumes retrying normally. Only counts a genuinely dispatched-
+// ResolveBackoffMs interval, forever. A button that gets pruned and
+// recreated gets a fresh cache entry (and so a fresh consecutiveFailures
+// count) - an identity change alone does NOT reset it, since
+// ResolveAndCacheButtonHwnd seeds failures from the existing entry
+// regardless of identity, only clearing it on an actual successful
+// resolve. Only counts a genuinely dispatched-
 // and-missed click (see ResolveAndCacheButtonHwnd) - a bail-out before
 // ever dispatching one doesn't risk anything and must not count toward
 // this. NextResolveDelayMs must treat a terminal entry exactly like a
@@ -1218,13 +1221,6 @@ HWND GetButtonHwnd(FrameworkElement element) {
     }
     return it->second.hwnd;
 }
-
-// ResolvePendingButtonHwnds (which actually walks TaskListButtons and
-// calls ResolveAndCacheButtonHwnd above) is defined later, right after
-// FindTaskbarFrameRepeater and IsTaskListButton - it depends on both.
-// Forward-declared here so WinEventHookThreadProc (Mod lifecycle section)
-// can reference it before that point.
-void ResolvePendingButtonHwnds();
 
 // Defined later (Mod lifecycle section) alongside NextResolveDelayMs,
 // which shares this same backoff formula - forward-declared here so

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -1155,6 +1155,22 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
         return nullptr;
     }
 
+    // GetTaskItemsArrayOffset() is a memoized, side-effect-free probe -
+    // safe to validate up front rather than only after the fact. Without
+    // this, a build where CTaskGroup::GetNumItems stopped being the
+    // trivial form the offset probe relies on would still dispatch a
+    // click below on every single group probe (the sentinel interception
+    // itself is unaffected, so the click-sentinel latch never trips -
+    // it's GetTaskItemsArray's own bounds check further down that always
+    // fails instead), turning every group resolution attempt into a
+    // pure-waste ReportClicked into the taskbar's click machinery,
+    // forever, with nothing to bound it.
+    size_t taskItemsOffset = GetTaskItemsArrayOffset();
+    if (taskItemsOffset == 0 || taskItemsOffset >= kTaskItemsArrayProbeSize) {
+        g_resolveStats.failure++;
+        return nullptr;
+    }
+
     IUnknown* elementAbi = (IUnknown*)winrt::get_abi(element);
 
     winrt::com_ptr<IUnknown> groupViewModel;
@@ -1290,11 +1306,29 @@ std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
 // sooner doesn't by itself bypass a negatively-cached entry's own backoff
 // gate (see ButtonHwndCacheEntry's comment for why that backoff can be
 // long-lived). Consumed once per pass in ResolvePendingButtonHwnds to
-// force every negatively-cached entry to retry regardless of backoff.
-// Safe to force unconditionally: a still-not-running group bails at
-// ResolveHwndFromTaskGroup's IsRunning check before ever dispatching a
-// click, so this never risks an extra synthetic click.
+// force a negatively-cached entry to retry regardless of backoff - but
+// only up to kMaxForcedRetryFailures consecutive failures (see there for
+// why this is capped, not unconditional).
 std::atomic<bool> g_forceResolveUnresolved;
+
+// A group with no running windows can never yield an HWND and bails at
+// ResolveHwndFromTaskGroup's IsRunning check before ever dispatching a
+// click - g_forceResolveUnresolved's whole justification for bypassing
+// backoff assumes THAT is the only reason a negatively-cached entry keeps
+// failing (a pinned app that just launched, still catching up to its own
+// EVENT_OBJECT_SHOW). But a RUNNING app's button can also fail to resolve
+// for reasons that don't bail out early - ReportClicked failing
+// internally, a task item mid-teardown, GetTaskItemsArray coming back
+// empty - and for those, forcing every retry unconditionally means
+// dispatching a real ReportClicked on both paths on every forced pass,
+// indefinitely, at up to the ~7Hz EVENT_OBJECT_SHOW can arm this at -
+// exactly the runaway-real-clicks scenario the backoff schedule exists to
+// bound. Capping the force-bypass to entries that have only failed a few
+// times keeps the "pinned app just launched" fast path intact (that case
+// is still failing 0 times when EVENT_OBJECT_SHOW first fires) while
+// letting the normal backoff schedule take back over for an entry that's
+// failed repeatedly, the same way it already would with no force at all.
+constexpr int kMaxForcedRetryFailures = 3;
 
 // The HWNDs g_buttonHwndCache currently resolves to, rebuilt at the end
 // of every successful ResolvePendingButtonHwnds pass (taskbar thread) and
@@ -2250,12 +2284,17 @@ void ResolvePendingButtonHwnds() {
                     // app, is the entire session) - by the time it's
                     // actually launched, the backoff could be minutes away,
                     // silently defeating EVENT_OBJECT_SHOW's whole purpose
-                    // of triggering an immediate resolve. See
-                    // g_forceResolveUnresolved's own comment.
-                    needsResolve = forceResolve ||
-                                   identity != it->second.identity ||
-                                   now - it->second.lastAttempt >=
-                                       ResolveBackoffMs(it->second.consecutiveFailures);
+                    // of triggering an immediate resolve. Bounded to
+                    // consecutiveFailures < kMaxForcedRetryFailures - see
+                    // its own comment for why an unconditional force here
+                    // was a real bug, not just belt-and-suspenders.
+                    bool backoffElapsed =
+                        now - it->second.lastAttempt >=
+                        ResolveBackoffMs(it->second.consecutiveFailures);
+                    needsResolve =
+                        identity != it->second.identity || backoffElapsed ||
+                        (forceResolve && it->second.consecutiveFailures <
+                                             kMaxForcedRetryFailures);
                 }
             }
 
@@ -3256,9 +3295,17 @@ void HandleLoadedModuleIfTaskbarView(HMODULE module, LPCWSTR lpLibFileName) {
         !g_taskbarViewDllLoaded.exchange(true)) {
         Wh_Log(L"Loaded %s", lpLibFileName);
 
-        if (HookTaskbarViewDllSymbols(module)) {
-            Wh_ApplyHookOperations();
-        }
+        // Applied unconditionally, not gated on HookTaskbarViewDllSymbols'
+        // own return value: that value reflects whether EVERY symbol in
+        // its table resolved, optional ones included, so a single missing
+        // optional HWND-resolution symbol - exactly the case that table's
+        // `optional = true` entries exist to tolerate - would otherwise
+        // skip applying hooks for every symbol that DID resolve, ArrangeOverride
+        // included. The per-symbol resolved/MISSING logging already
+        // reports what to investigate; there's nothing to gain from also
+        // discarding the hooks that succeeded.
+        HookTaskbarViewDllSymbols(module);
+        Wh_ApplyHookOperations();
     }
 }
 
@@ -3637,7 +3684,21 @@ BOOL Wh_ModInit() {
     if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
         Wh_Log(L"Taskbar view module already loaded at init time");
         g_taskbarViewDllLoaded = true;
-        if (!HookTaskbarViewDllSymbols(taskbarViewModule)) {
+        // Deliberately NOT checking HookTaskbarViewDllSymbols' own return
+        // value here: it reflects whether EVERY symbol in its table
+        // resolved, optional ones included, so a single missing optional
+        // HWND-resolution symbol would fail this ENTIRE mod's load -
+        // exactly the outcome `optional = true` on those entries exists
+        // to prevent (see that table's own comment, and
+        // HandleLoadedModuleIfTaskbarView's identical reasoning for why
+        // its hook-apply call isn't gated on this return value either).
+        // ArrangeOverride is the one truly required symbol in that table
+        // - the mod's entire function depends on it - so that's checked
+        // directly below instead, matching HookTaskbarDllSymbols' own
+        // check above (safe to trust as-is, since every symbol load-
+        // gating that check is genuinely required, not optional).
+        HookTaskbarViewDllSymbols(taskbarViewModule);
+        if (!TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original) {
             return FALSE;
         }
     } else {
@@ -3667,9 +3728,11 @@ void Wh_ModAfterInit() {
     if (!g_taskbarViewDllLoaded) {
         if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
             if (!g_taskbarViewDllLoaded.exchange(true)) {
-                if (HookTaskbarViewDllSymbols(taskbarViewModule)) {
-                    Wh_ApplyHookOperations();
-                }
+                // See HandleLoadedModuleIfTaskbarView's identical comment -
+                // applied unconditionally so a missing optional symbol
+                // doesn't also discard the hooks that did resolve.
+                HookTaskbarViewDllSymbols(taskbarViewModule);
+                Wh_ApplyHookOperations();
             }
         }
     }

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -272,9 +272,12 @@ struct ModSettings {
 };
 ModSettings g_settings;
 
+// CharLowerBuffW, not towlower per-character: towlower only maps ASCII in
+// the default C locale, making leftApps/rightApps matching effectively
+// case-sensitive for any non-ASCII app name.
 std::wstring ToLower(std::wstring s) {
-    for (auto& c : s) {
-        c = towlower(c);
+    if (!s.empty()) {
+        CharLowerBuffW(s.data(), (DWORD)s.size());
     }
     return s;
 }
@@ -426,16 +429,28 @@ thread_local bool g_inTaskbarArrangeOverride;
 // Never traverse the taskbar's XAML tree (siblings, classification,
 // widths) from inside a nested IUIElement::Arrange call - XAML's layout
 // system can be mid-structural-mutation of that same repeater there
-// (reproducible crash: STATUS_STOWED_EXCEPTION, when Windows' "show
-// taskbar apps on" setting causes a window moving across monitors to
-// change a taskbar's button set, not just coordinates). RecomputeLayoutPlan
+// (STATUS_STOWED_EXCEPTION when a window moves across monitors while
+// Windows' "show taskbar apps on" setting isn't "All taskbars", since
+// that structurally adds/removes taskbar buttons). RecomputeLayoutPlan
 // does the entire traversal once per ArrangeOverride pass, up front,
-// before any nested Arrange calls happen, writing every element's target
-// X into g_lastArrangedX - IUIElement_Arrange_Hook then becomes a pure
-// map lookup, with nothing left for XAML's mid-mutation state to make
-// unsafe.
+// writing every element's target X into g_lastArrangedX -
+// IUIElement_Arrange_Hook then becomes a pure map lookup.
 
-HWND g_hTaskbarWnd;
+// atomic: written from EnsureTaskbarWnd (the taskbar thread, or
+// Wh_ModAfterInit's thread at startup) and read from the dedicated
+// WinEventHook thread (WinEventProc, InvalidateTaskbarLayout,
+// ButtonHwndResolveTimerProc) - a plain HWND here was an oversight, not a
+// decision, given g_taskbarWndSubclassed right below already needed the
+// same treatment for the same reason. Beyond the formal race, a stale
+// read passing a null-check right before EnsureTaskbarWnd clears it to
+// nullptr has a real consequence: PostMessage(nullptr, ...) is not a
+// no-op, it posts to the *calling* thread's own queue and returns TRUE -
+// silently misdirecting the message instead of failing loudly. Callers
+// with more than one read of this value snapshot it into a local first
+// (see InvalidateTaskbarLayout, ButtonHwndResolveTimerProc,
+// ApplyLoadedSettings, RecomputeLayoutPlan) so all their reads agree on
+// one value even if a concurrent write lands mid-function.
+std::atomic<HWND> g_hTaskbarWnd;
 
 // Whether TaskbarWndSubclassProc is currently installed on g_hTaskbarWnd -
 // see EnsureTaskbarWnd (where it's installed) and InvalidateTaskbarLayout
@@ -660,13 +675,9 @@ XamlRoot XamlRootFromTaskbarHostSharedPtr(void* taskbarHostSharedPtr[2]) {
     }
 
     // The shared_ptr's ref-count block (taskbarHostSharedPtr[1]) must be
-    // released on every path below, not just the one at the end of a
-    // fully successful call - every early return past this point used to
-    // leak a reference. That's worse than it looks now that
-    // RecomputeLayoutPlan calls this on every single ArrangeOverride
-    // pass: one leaked reference per pass, for the life of the process,
-    // on any Windows build where the prologue pattern below stops
-    // matching.
+    // released on every path below, not just a fully successful call -
+    // this runs on every ArrangeOverride pass, so a leaked reference here
+    // is one per pass for the life of the process.
     struct DecrefGuard {
         void* ptr;
         ~DecrefGuard() { std__Ref_count_base__Decref_Original(ptr); }
@@ -829,24 +840,37 @@ thread_local void* g_clickSentinel_TaskGroup;
 // identical to an ordinary resolution failure).
 //
 // The interception either works on this Windows build or it doesn't - it
-// isn't a per-button thing - so one confirmed capture is proof it works,
-// and one probe that reaches ReportClicked with zero capture, before any
-// capture has ever been confirmed, is proof it doesn't. Latched per path
-// (item vs. group), not as one shared flag: the two paths reach
-// CTaskListWnd::HandleClick through different internal call chains
-// (TaskItem::ReportClicked vs. TaskGroup::ReportClicked), so a Windows
-// update could break only one of them - a shared flag would let a still-
-// working item-path confirmation mask a broken group path, which matters
-// most because the group path is the one a pinned-but-not-running app's
-// button keeps retrying (see ResolveHwndFromTaskGroup's IsRunning check
-// for how that retry is now also avoided at the source). Each *Broken
-// latch permanently gates its own path in ResolveHwndFromTaskListButton -
-// once set, that path never calls ReportClicked again, rather than
-// retrying a mechanism now known to dispatch real clicks.
+// isn't a per-button thing. Latched per path (item vs. group), not as one
+// shared flag: the two paths reach CTaskListWnd::HandleClick through
+// different internal call chains (TaskItem::ReportClicked vs.
+// TaskGroup::ReportClicked), so a Windows update could break only one of
+// them - a shared flag would let a still-working item-path confirmation
+// mask a broken group path, which matters most because the group path is
+// the one a pinned-but-not-running app's button keeps retrying (see
+// ResolveHwndFromTaskGroup's IsRunning check for how that retry is now
+// also avoided at the source). Each *Broken latch permanently gates its
+// own path in ResolveHwndFromTaskListButton - once set, that path never
+// calls ReportClicked again, rather than retrying a mechanism now known
+// to dispatch real clicks.
+//
+// A single unconfirmed miss is NOT proof the interception is broken - a
+// probe can also fail to reach HandleClick because the window closed
+// between resolving the task item and dispatching the click, ReportClicked
+// failed internally, or the item was mid-teardown during a taskbar
+// rebuild. Latching a whole path dead on the first miss of a session
+// risked exactly that: an early unlucky miss on the item path (the common
+// path, used by every ungrouped button) would silently degrade every
+// button on the taskbar to unresolvedAppsDefaultSide, for the rest of the
+// session, with only a log line as the symptom. kClickSentinelMissesBeforeBroken
+// requires a few misses (still a bounded cost if the mechanism really is
+// broken) before actually latching - see NoteUnconfirmedClickSentinelMiss.
 std::atomic<bool> g_clickSentinelItemConfirmed;
 std::atomic<bool> g_clickSentinelItemBroken;
+std::atomic<int> g_clickSentinelItemMisses;
 std::atomic<bool> g_clickSentinelGroupConfirmed;
 std::atomic<bool> g_clickSentinelGroupBroken;
+std::atomic<int> g_clickSentinelGroupMisses;
+constexpr int kClickSentinelMissesBeforeBroken = 3;
 
 // Which path's probe is in flight on this thread when a sentinel click
 // might land in CTaskListWnd_HandleClick_Hook below - the hook only sees
@@ -863,10 +887,19 @@ HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
     if (launcherOptions && *launcherOptions == (void*)&g_clickSentinel) {
         g_clickSentinel_TaskItem = taskItem;
         g_clickSentinel_TaskGroup = taskGroup;
-        if (g_clickSentinelProbingGroup) {
-            g_clickSentinelGroupConfirmed = true;
-        } else {
-            g_clickSentinelItemConfirmed = true;
+        // .exchange rather than plain assignment purely so the log fires
+        // exactly once, the first time this path is ever confirmed -
+        // gives a concrete, observable answer (for the PR record and any
+        // future debugging) to "does the group path actually get
+        // exercised/intercepted on this build", which resolve-stats alone
+        // can't distinguish from the item path.
+        bool alreadyConfirmed =
+            g_clickSentinelProbingGroup
+                ? g_clickSentinelGroupConfirmed.exchange(true)
+                : g_clickSentinelItemConfirmed.exchange(true);
+        if (!alreadyConfirmed) {
+            Wh_Log(L"Click-sentinel interception confirmed working (%s path)",
+                   g_clickSentinelProbingGroup ? L"group" : L"item");
         }
         return S_OK;
     }
@@ -876,24 +909,29 @@ HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
 }
 
 // Called right after a real ReportClicked probe comes back with no
-// capture - the one point where "no capture" is actually evidence about
-// the interception itself, as opposed to an earlier, unrelated failure
-// (missing view-model, no task item) that never reached ReportClicked at
-// all. See g_clickSentinelItemBroken/g_clickSentinelGroupBroken's own
-// comment for the full reasoning and why this is tracked per path.
+// capture - one of the ways "no capture" can happen, alongside the
+// unrelated cases described above (closed window, internal failure,
+// teardown timing), which is exactly why this requires a few misses
+// rather than latching on the first one.
 void NoteUnconfirmedClickSentinelMiss(bool isGroupPath) {
     std::atomic<bool>& confirmed =
         isGroupPath ? g_clickSentinelGroupConfirmed : g_clickSentinelItemConfirmed;
+    std::atomic<int>& misses =
+        isGroupPath ? g_clickSentinelGroupMisses : g_clickSentinelItemMisses;
     std::atomic<bool>& broken =
         isGroupPath ? g_clickSentinelGroupBroken : g_clickSentinelItemBroken;
-    if (!confirmed && !broken.exchange(true)) {
+    if (confirmed) {
+        return;
+    }
+    if (misses.fetch_add(1) + 1 >= kClickSentinelMissesBeforeBroken &&
+        !broken.exchange(true)) {
         Wh_Log(L"Click-sentinel interception (%s path) never confirmed "
-               L"working - disabling further HWND-resolution probes on "
-               L"this path to avoid dispatching real clicks. This usually "
-               L"means a Windows update changed CTaskListWnd::HandleClick's "
-               L"internal call path; consider disabling this mod until "
-               L"it's updated.",
-               isGroupPath ? L"group" : L"item");
+               L"working after %d unconfirmed probes - disabling further "
+               L"HWND-resolution probes on this path to avoid dispatching "
+               L"real clicks. This usually means a Windows update changed "
+               L"CTaskListWnd::HandleClick's internal call path; consider "
+               L"disabling this mod until it's updated.",
+               isGroupPath ? L"group" : L"item", kClickSentinelMissesBeforeBroken);
     }
 }
 
@@ -1646,11 +1684,9 @@ struct LayoutPlanStats {
     int taskListRight = 0;
     int exceptions = 0;
 };
-// thread_local since RecomputeLayoutPlan only ever does real work on the
-// primary taskbar's own thread, but stays thread_local rather than a plain
-// global on general principle for anything read alongside a per-pass
-// reset - see g_passStats' comment for the concrete bug that caused
-// (unrelated struct, same underlying risk).
+// thread_local: RecomputeLayoutPlan only ever does real work on the
+// primary taskbar's own thread, but this stays correct even if that ever
+// changed - same reasoning as g_passStats.
 thread_local LayoutPlanStats g_planStats;
 
 struct TaskListPlanEntry {
@@ -1829,66 +1865,37 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
 // XAML hooks
 // ============================================================================
 
-// Defined later (Live drag-follow section); forward-declared here because
-// the ArrangeOverride hook below uses it to self-correct when the button
-// set changes (new pin, app launched/closed) - see the comment at its call
-// site for why that's needed.
-//
-// Only ever marks the taskbar's layout dirty (InvalidateArrange/
-// InvalidateMeasure) - never forces a synchronous UpdateLayout() call. See
-// the comment on the definition for why: a forced synchronous pass here
-// was the confirmed cause of three separate explorer.exe crash-loop
-// incidents, each via a different call path landing while the thread was
-// already nested inside XAML-internal layout activity.
+// Defined later (Live drag-follow section). Only ever marks the taskbar's
+// layout dirty (InvalidateArrange/InvalidateMeasure) - never forces a
+// synchronous UpdateLayout() call, which reenters WinUI layout while
+// already nested inside it and fails fast with STATUS_STOWED_EXCEPTION.
 void InvalidateTaskbarLayout();
 
-// Idle re-check cadence once every cached button is already resolved -
-// see NextResolveDelayMs' comment (Mod lifecycle section) for what this
-// specifically exists to catch (a drag-reorder rebind, which isn't
-// latency-sensitive). Kept well above the 2s..32s backoff used for
-// buttons that still need resolving: even at idle, each tick still
-// resolves the taskbar's XamlRoot and walks its visual tree on Explorer's
-// UI thread, and this runs indefinitely for the life of the session. Also
-// used by ResolvePendingButtonHwnds (below) as a "something's not right
-// yet, check back soon" fallback delay for passes that bail out before
-// confirming the live button set - moved up here (out of the Mod
-// lifecycle section it's otherwise grouped with) so it's declared before
-// that use.
+// Idle re-check cadence once every cached button is already resolved - an
+// ItemsRepeater rebind (e.g. a drag-reorder) can change which item an
+// already-resolved element represents without changing the button count,
+// so this keeps identity re-checked periodically even at steady state.
+// Also used by ResolvePendingButtonHwnds as a fallback delay for passes
+// that bail out before confirming the live button set.
 constexpr DWORD kIdleResolveTickMs = 30000;
 
-// Defined later (Mod lifecycle section); forward-declared here so
-// EnsureTaskbarWnd (below) can start the drag-follow WinEventHook as soon
-// as the taskbar window resolves, whether that happens at normal startup
-// or late (see EnsureTaskbarWnd's comment). This also starts the
-// HWND-resolve timer now that it lives on the same dedicated thread - see
-// WinEventHookThreadProc.
+// Defined later (Mod lifecycle section).
 void StartWinEventHook();
 
-// Defined later (Mod lifecycle section); forward-declared here so the
-// ArrangeOverride hook below can request an immediate HWND-resolve attempt
-// (delayMs = 0) as soon as it notices the task list button count changed,
-// rather than waiting for whatever delay the timer last computed for
-// itself - see NextResolveDelayMs' comment for why it can't see a
-// brand-new button coming on its own.
+// Defined later (Mod lifecycle section); lets the ArrangeOverride hook
+// request an immediate HWND-resolve attempt (delayMs = 0) as soon as it
+// notices the task list button count changed, rather than waiting for the
+// timer's own backoff schedule to catch up.
 void ArmButtonHwndResolveTimer(DWORD delayMs);
 
-// Defined later (Mod lifecycle section, right before ButtonHwndResolveTimerProc);
-// forward-declared here so ResolvePendingButtonHwnds (below) can compute
-// and arm its own next tick at the end of a pass, on whichever thread that
-// pass actually ran on - see ResolvePendingButtonHwnds' own
-// ScheduleNextResolveTick comment for why it can't be computed by the
-// timer callback itself anymore.
+// Defined later (Mod lifecycle section).
 DWORD NextResolveDelayMs();
 
-// Defined later (Live drag-follow section, alongside InvalidateTaskbarLayout
-// itself); forward-declared here so EnsureTaskbarWnd (below) can install it
-// on g_hTaskbarWnd as soon as the window resolves - see
-// InvalidateTaskbarLayout's own comment for why a subclass is what lets it
-// use a non-blocking PostMessage instead of RunFromWindowThread's per-call
-// blocking marshal. WindhawkUtils::SetWindowSubclassFromAnyThread/
-// RemoveWindowSubclassFromAnyThread key the subclass by this proc's own
-// address, not by dwRefData (unused, passed as 0) - there's no separate id
-// parameter the way raw SetWindowSubclass/RemoveWindowSubclass have.
+// Defined later (Live drag-follow section). WindhawkUtils::
+// SetWindowSubclassFromAnyThread/RemoveWindowSubclassFromAnyThread key the
+// subclass by this proc's own address, not by dwRefData (unused, passed
+// as 0) - there's no separate id parameter the way raw SetWindowSubclass/
+// RemoveWindowSubclass have.
 LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
                                         UINT uMsg,
                                         WPARAM wParam,
@@ -1939,7 +1946,7 @@ HWND EnsureTaskbarWnd() {
 
     g_hTaskbarWnd = FindCurrentProcessTaskbarWnd();
     if (g_hTaskbarWnd) {
-        Wh_Log(L"Resolved taskbar window: %p", g_hTaskbarWnd);
+        Wh_Log(L"Resolved taskbar window: %p", (HWND)g_hTaskbarWnd);
         StartWinEventHook();
 
         // Lets InvalidateTaskbarLayout notify this window with a
@@ -2038,31 +2045,22 @@ FrameworkElement GetCachedTaskbarRepeater() {
 // Also guarded against running while nested inside an active Arrange
 // pass on this thread - defense in depth, not the primary protection.
 void ResolvePendingButtonHwnds() {
-    // Computes and arms this function's own next tick on destruction -
-    // i.e. whenever this function returns, by any path (the early-return
-    // guards below included, not just a full successful pass), always on
-    // this same thread right after this pass's own cache reads/writes are
-    // actually done. ButtonHwndResolveTimerProc used to do this itself
-    // immediately after kicking off the resolve call, which was safe only
-    // because that call used to be a blocking RunFromWindowThread marshal
-    // - now that the common path is an async PostMessage to the taskbar's
-    // subclass (see ButtonHwndResolveTimerProc), computing the delay right
-    // after posting would read g_buttonHwndCache concurrently with this
-    // function's own insert/erase calls on the taskbar thread - a real
-    // use-after-free, not just stale data. Moving the computation here
-    // closes that regardless of which path (post or the RunFromWindowThread
-    // fallback) invoked this pass.
+    // Computes and arms this function's own next tick on destruction, on
+    // every return path, always on this thread right after this pass's
+    // own cache reads/writes are done - computing it from
+    // ButtonHwndResolveTimerProc instead would read g_buttonHwndCache
+    // concurrently with this function's own insert/erase calls on the
+    // taskbar thread, a use-after-free.
     //
     // NextResolveDelayMs' INFINITE answer is only trustworthy once a pass
     // has actually confirmed the live button set - an empty
     // g_buttonHwndCache from a pass that bailed out before enumerating
     // anything (every early-return guard below, or no repeater yet) looks
     // identical to a genuinely empty taskbar otherwise, and the timer
-    // would then never be armed again except by incidental luck (some
-    // unrelated EVENT_OBJECT_SHOW or count-change nudging
-    // ArmButtonHwndResolveTimer). `enumerated` tracks whether the walk
-    // below actually ran to completion; the destructor falls back to
-    // kIdleResolveTickMs instead of trusting INFINITE when it didn't.
+    // would then never be armed again except by incidental luck.
+    // `enumerated` tracks whether the walk below actually ran to
+    // completion; the destructor falls back to kIdleResolveTickMs instead
+    // of trusting INFINITE when it didn't.
     bool enumerated = false;
     struct ScheduleNextResolveTick {
         bool* enumerated;
@@ -2251,22 +2249,16 @@ ULONGLONG g_lastPlanRecomputeTick;
 
 // Diagnostics only, for IUIElement_Arrange_Hook's own per-call work
 // (distinct from LayoutPlanStats, which covers RecomputeLayoutPlan's
-// once-per-pass traversal - two different phases now that the plan is
-// built up front rather than computed inline here).
+// once-per-pass traversal).
 struct ArrangePassStats {
     int totalArrangeCalls = 0;
     int repositioned = 0;
     int qiFailures = 0;
     int exceptions = 0;
 };
-// thread_local: the ArrangeOverride hook (and so this Arrange hook, which
-// only ever runs nested inside it) runs once per taskbar instance's XAML
-// tree, process-wide. In practice all of them - primary and any
-// secondary-monitor taskbars - run on the same Explorer UI thread (see
-// RecomputeLayoutPlan's comment for how that was confirmed), so a plain
-// global would work too; thread_local costs nothing extra here and stays
-// correct even if that ever stopped being true, so it's kept as cheap
-// insurance rather than because it's currently load-bearing.
+// thread_local: this hook runs once per taskbar instance's XAML tree,
+// process-wide - in practice all on the same Explorer UI thread, but this
+// stays correct even if that ever changed.
 thread_local ArrangePassStats g_passStats;
 
 HRESULT WINAPI IUIElement_Arrange_Hook(void* pThis,
@@ -2277,15 +2269,11 @@ HRESULT WINAPI IUIElement_Arrange_Hook(void* pThis,
         return original();
     }
 
-    // This hook replaces the process-wide IUIElement::Arrange vtable slot,
-    // invoked by XAML's own native call sites for every UIElement in
-    // explorer.exe - a raw ABI boundary with no C++/WinRT exception
-    // translation on the other side. A WinRT call throwing here crosses
-    // that boundary uncaught and fail-fasts the whole process (previously
-    // hit via .as<T>() throwing on a null source during a fresh
-    // secondary-monitor tree's construction). The QueryInterface below is
-    // the only WinRT call left in this function - everything else is a
-    // plain map lookup - so this net is mostly a leftover safety margin.
+    // This hook replaces the process-wide IUIElement::Arrange vtable slot -
+    // a raw ABI boundary with no C++/WinRT exception translation, so an
+    // uncaught throw here fail-fasts the whole process. The QueryInterface
+    // below is the only WinRT call left in this function; everything else
+    // is a plain map lookup.
     try {
         g_passStats.totalArrangeCalls++;
 
@@ -2335,28 +2323,25 @@ HRESULT WINAPI IUIElement_Arrange_Hook(void* pThis,
 // regardless; the check is purely the apartment-safety guard, not a
 // monitor-scoping mechanism.
 void RecomputeLayoutPlan() {
-    if (!g_hTaskbarWnd) {
+    // Snapshot once - see g_hTaskbarWnd's own comment.
+    HWND hTaskbarWnd = g_hTaskbarWnd;
+    if (!hTaskbarWnd) {
         return;
     }
-    DWORD primaryThreadId = GetWindowThreadProcessId(g_hTaskbarWnd, nullptr);
+    DWORD primaryThreadId = GetWindowThreadProcessId(hTaskbarWnd, nullptr);
     if (primaryThreadId == 0 || primaryThreadId != GetCurrentThreadId()) {
         return;
     }
     if (!g_planDirty &&
         GetTickCount64() - g_lastPlanRecomputeTick < kMaxPlanStalenessMs) {
         // This backstop only bounds staleness while ArrangeOverride keeps
-        // getting called at least this often - once XAML stops producing
-        // layout passes, this early return would never get reevaluated
-        // again, so a change that landed in a skipped pass (see
-        // g_planDirty's own comment) could then sit stale indefinitely
-        // instead of just kMaxPlanStalenessMs (concretely: a pin/unpin on
-        // an otherwise-idle desktop). The repeater is cached now (see
-        // GetCachedTaskbarRepeater), so checking the realized task-list-
-        // button set against what the plan actually covers is affordable
-        // every time this branch is taken - if any live button isn't in
-        // g_lastArrangedX, the plan is stale regardless of the dirty flag
-        // or the clock, and this pass needs to fall through to a real
-        // recompute rather than trust the backstop.
+        // getting called at least this often - a change landing in a
+        // skipped pass on an otherwise-idle desktop (e.g. a pin/unpin)
+        // could sit stale indefinitely otherwise. GetCachedTaskbarRepeater
+        // makes checking the realized task-list-button set against what
+        // the plan actually covers affordable every time this branch is
+        // taken - if any live button isn't in g_lastArrangedX, the plan is
+        // stale regardless of the dirty flag or the clock.
         bool planCoversLiveTaskListButtons = true;
         try {
             if (FrameworkElement repeater = GetCachedTaskbarRepeater()) {
@@ -2405,8 +2390,7 @@ void RecomputeLayoutPlan() {
         std::unordered_map<void*, double> newPlan;
 
         // Classify each child's SystemButton status exactly once - see
-        // ChildInfo's comment for why (was up to 4 redundant
-        // winrt::get_class_name calls per child per pass beforehand).
+        // ChildInfo's comment for why.
         std::vector<ChildInfo> childInfos;
         childInfos.reserve(children.size());
         for (auto& child : children) {
@@ -2569,29 +2553,17 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
 
     // Builds this pass's whole plan up front - see RecomputeLayoutPlan's
     // comment for why this ordering (before the original ArrangeOverride,
-    // and so before any nested Arrange calls) is what actually closes the
-    // crash class the old settling-window mechanism used to work around.
+    // so before any nested Arrange calls) is what keeps this safe.
     RecomputeLayoutPlan();
 
     // The button count can change without any window moving (new pin, app
     // launched/closed). If RecomputeLayoutPlan's repeater walk ran before
-    // XAML had realized a just-inserted button yet, this pass's plan
-    // simply has no entry for it (see g_lastArrangedX's comment) and it
-    // renders at its native position for one pass. Self-correct by
-    // invalidating whenever the observed count changes, which is enough
-    // for RecomputeLayoutPlan to pick it up on the next pass; also arm an
-    // immediate HWND-resolve attempt, since a newly-inserted button is
-    // exactly the case ResolvePendingButtonHwnds' own cache-only view
-    // (NextResolveDelayMs) can't see coming on its own. There's nothing
-    // left to suppress or re-arm beyond that - RecomputeLayoutPlan is safe
-    // to call as often as this triggers it - so this is a plain count
-    // comparison with no gating logic alongside it.
-    //
-    // thread_local: this hook runs process-wide for every taskbar
-    // instance's XAML tree. In practice they all run on the same Explorer
-    // UI thread (see RecomputeLayoutPlan's comment), so a plain global
-    // would work too - kept thread_local as cheap insurance, same
-    // reasoning as g_passStats above.
+    // XAML had realized a just-inserted button yet, this pass's plan has
+    // no entry for it and it renders at its native position for one pass.
+    // Self-correct by invalidating whenever the observed count changes,
+    // and arm an immediate HWND-resolve attempt, since a newly-inserted
+    // button is exactly what ResolvePendingButtonHwnds' cache-only view
+    // (NextResolveDelayMs) can't see coming on its own.
     static thread_local int lastPlanTaskListCount = -1;
     int currentTaskListCount = g_planStats.taskListTotal;
     if (currentTaskListCount != lastPlanTaskListCount) {
@@ -2766,32 +2738,32 @@ LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
     return DefSubclassProc(hWnd, uMsg, wParam, lParam);
 }
 
-// Lets the XAML dispatcher pick up a relayout on its own next tick,
-// rather than forcing a synchronous UpdateLayout() call: this function's
-// callers include a raw OS callback (WinEventProc) that can fire while
-// already nested inside XAML-internal layout activity, and a forced
-// UpdateLayout() there reenters WinUI layout and fails fast with
-// STATUS_STOWED_EXCEPTION - a raw SEH RaiseException, not a C++
-// exception, so no try/catch anywhere in this file can contain it. Don't
-// reintroduce a forced call here without a fundamentally different
-// mechanism (e.g. a genuinely async, post-unwind-only deferred call).
+// Lets the XAML dispatcher pick up a relayout on its own next tick rather
+// than forcing a synchronous UpdateLayout() call: callers include a raw
+// OS callback (WinEventProc) that can fire while already nested inside
+// XAML-internal layout activity, and a forced UpdateLayout() there
+// reenters WinUI layout and fails fast with STATUS_STOWED_EXCEPTION - a
+// raw SEH RaiseException, not a C++ exception, so no try/catch anywhere
+// in this file can contain it. Don't reintroduce a forced call here
+// without a fundamentally different (genuinely async, post-unwind-only)
+// mechanism.
 //
-// Deliberately does NOT set g_planDirty itself, even though every real
-// trigger for a layout change goes through here - marking dirty on this
-// function's OWN calling thread would be premature when the marshal below
-// is asynchronous (the common PostMessage case): a natural ArrangeOverride
-// pass can land on the taskbar thread between this call setting the flag
-// and the posted message actually being processed, see it already true,
-// recompute with whatever state existed before the real change (settings
-// not yet applied, an HWND not yet re-cached), and clear the flag - so the
-// posted invalidate that finally runs afterward finds g_planDirty already
-// false and skips the recompute the change actually needed. Each real
-// caller marks dirty itself, at the point its own state change becomes
-// visible on the taskbar thread: PerformTaskbarLayoutInvalidate (the
-// PostMessage/RunFromWindowThread call this function makes) and the
-// SettingsChangedMsg dispatch case in TaskbarWndSubclassProc.
+// Deliberately does NOT set g_planDirty itself: the marshal below is
+// usually asynchronous (PostMessage), so a natural ArrangeOverride pass
+// could land on the taskbar thread between this call setting the flag and
+// the posted message being processed, see it already true, recompute
+// with stale state, and clear the flag - leaving the posted invalidate
+// with nothing to do. Each real caller marks dirty itself instead, at the
+// point its own state change becomes visible on the taskbar thread:
+// PerformTaskbarLayoutInvalidate and the SettingsChangedMsg dispatch case
+// in TaskbarWndSubclassProc.
 void InvalidateTaskbarLayout() {
-    if (!g_hTaskbarWnd) {
+    // Snapshot once so every read below agrees, even if EnsureTaskbarWnd
+    // writes a new value on another thread mid-function - see
+    // g_hTaskbarWnd's own comment for why that matters here specifically
+    // (a stale nullptr reaching PostMessage is not a no-op).
+    HWND hTaskbarWnd = g_hTaskbarWnd;
+    if (!hTaskbarWnd) {
         return;
     }
 
@@ -2803,7 +2775,7 @@ void InvalidateTaskbarLayout() {
         // below, which installs a WH_CALLWNDPROC hook and blocks in
         // SendMessage until that thread processes it - a real cost at
         // this frequency, even though it's fine for a one-shot call.
-        if (!PostMessage(g_hTaskbarWnd, InvalidateTaskbarLayoutMsg(), 0, 0)) {
+        if (!PostMessage(hTaskbarWnd, InvalidateTaskbarLayoutMsg(), 0, 0)) {
             Wh_Log(L"InvalidateTaskbarLayout: PostMessage failed, error=%lu",
                    GetLastError());
         }
@@ -2814,7 +2786,7 @@ void InvalidateTaskbarLayout() {
     // was never successfully subclassed - still gets the job done, just
     // without the non-blocking benefit above.
     bool posted =
-        RunFromWindowThread(g_hTaskbarWnd, PerformTaskbarLayoutInvalidate);
+        RunFromWindowThread(hTaskbarWnd, PerformTaskbarLayoutInvalidate);
     if (!posted) {
         Wh_Log(L"InvalidateTaskbarLayout: RunFromWindowThread failed");
     }
@@ -3388,15 +3360,12 @@ DWORD NextResolveDelayMs() {
     if (anyResolved) {
         // Mixed cache: some buttons resolved (need the same periodic
         // rebind re-check as the anyPending==false branch above), others
-        // still pending on their own backoff schedule - which, since
-        // that ceiling was extended to 30 minutes to cut down on
-        // synthetic clicks against pinned-not-running apps, could
-        // otherwise silently starve rebind detection for everyone else
-        // for just as long. Capping at kIdleResolveTickMs here doesn't
-        // resolve the pending entry any earlier (ResolvePendingButtonHwnds
-        // still checks its own backoff before actually retrying it), it
-        // only ensures the already-resolved entries keep getting their
-        // identity re-checked on the normal idle cadence.
+        // still pending on their own up-to-30-minute backoff schedule,
+        // which could otherwise silently starve rebind detection for
+        // everyone else. Capping at kIdleResolveTickMs here doesn't
+        // resolve the pending entry any earlier, it only ensures the
+        // already-resolved entries keep getting their identity re-checked
+        // on the normal idle cadence.
         return std::min(pendingDelay, kIdleResolveTickMs);
     }
     return pendingDelay;
@@ -3420,6 +3389,22 @@ void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
         return;
     }
 
+    // Snapshot once so both branches below (and the fallback log message)
+    // agree on one value - see g_hTaskbarWnd's own comment for why a
+    // stale nullptr reaching PostMessage isn't a no-op. Named distinctly
+    // from this callback's own `hwnd` parameter (the timer's owning
+    // window, always nullptr for this thread-owned timer, unrelated to
+    // the taskbar window).
+    HWND hTaskbarWnd = g_hTaskbarWnd;
+    if (!hTaskbarWnd) {
+        // The taskbar window went away (recreate) between this timer
+        // being armed and firing - EnsureTaskbarWnd will re-resolve it on
+        // its own next pass. Retry later rather than let a null reach
+        // PostMessage/RunFromWindowThread below.
+        ArmButtonHwndResolveTimer(kIdleResolveTickMs);
+        return;
+    }
+
     // Prefer the subclass's non-blocking PostMessage (see
     // ResolveButtonHwndsMsg) - this can fire several times a second
     // during an EVENT_OBJECT_SHOW burst, the same hot-path cost
@@ -3438,12 +3423,12 @@ void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
     // re-arm if the message never arrives, so retry after a fixed
     // fallback delay rather than leaving the timer silently dead.
     if (g_taskbarWndSubclassed) {
-        if (!PostMessage(g_hTaskbarWnd, ResolveButtonHwndsMsg(), 0, 0)) {
+        if (!PostMessage(hTaskbarWnd, ResolveButtonHwndsMsg(), 0, 0)) {
             Wh_Log(L"ButtonHwndResolveTimerProc: PostMessage failed, "
                    L"error=%lu", GetLastError());
             ArmButtonHwndResolveTimer(kIdleResolveTickMs);
         }
-    } else if (!RunFromWindowThread(g_hTaskbarWnd, ResolvePendingButtonHwnds)) {
+    } else if (!RunFromWindowThread(hTaskbarWnd, ResolvePendingButtonHwnds)) {
         // Same "nothing will call back" concern as the PostMessage failure
         // above - a marshal failure here (SetWindowsHookEx failing, or
         // g_hTaskbarWnd going stale/null mid-taskbar-recreate) means
@@ -3518,8 +3503,8 @@ void Wh_ModAfterInit() {
     }
 
     EnsureTaskbarWnd();
-    Wh_Log(L"g_hTaskbarWnd = %p, g_taskbarViewDllLoaded = %d", g_hTaskbarWnd,
-           (int)g_taskbarViewDllLoaded);
+    Wh_Log(L"g_hTaskbarWnd = %p, g_taskbarViewDllLoaded = %d",
+           (HWND)g_hTaskbarWnd, (int)g_taskbarViewDllLoaded);
 
     InvalidateTaskbarLayout();
 }
@@ -3533,30 +3518,22 @@ void Wh_ModBeforeUninit() {
     // mod's hooks stay installed until this function returns, and
     // ArrangeOverride isn't gated on g_unloading - a pass landing in that
     // window could still call StartWinEventHook via EnsureTaskbarWnd,
-    // creating a thread nobody would tear down since Wh_ModUninit runs
-    // after this (StartWinEventHook's own atomic guard prevents a second
-    // thread if one already exists, but not a first one if none does
-    // yet). This call still needs the Arrange hook alive to restore
-    // native positioning, so it has to run while the hooks are
-    // installed - actual teardown waits for Wh_ModUninit, after Windhawk
-    // has removed them. g_unloading being set here (before that) is what
-    // keeps ResolvePendingButtonHwnds' click-sentinel probe from running
-    // once the hooks it depends on are gone - see its own comment.
+    // creating a thread nobody would tear down (Wh_ModUninit, which does
+    // the actual teardown, runs after this). The Arrange hook also needs
+    // to stay alive here to restore native positioning below. g_unloading
+    // being set first is what keeps ResolvePendingButtonHwnds' click-
+    // sentinel probe from running once its hooks are gone.
 
     // Removed here, before the final InvalidateTaskbarLayout() call below,
-    // for two reasons: it makes that call fall back to RunFromWindowThread's
-    // blocking marshal instead of the normally non-blocking PostMessage
-    // path, restoring this function's "runs before Wh_ModBeforeUninit
-    // returns" guarantee for this last invalidate exactly as it was before
-    // the subclass existed; and it gets TaskbarWndSubclassProc off
-    // Shell_TrayWnd as early as it's safe to, rather than leaving it wired
-    // in for the rest of teardown. RemoveWindowSubclassFromAnyThread (like
-    // SetWindowSubclassFromAnyThread) already marshals itself onto the
-    // owning thread internally, so this doesn't need RunFromWindowThread's
-    // own marshal wrapped around it.
-    if (g_hTaskbarWnd && g_taskbarWndSubclassed.exchange(false)) {
+    // so that call falls back to the blocking RunFromWindowThread marshal
+    // instead of a PostMessage nothing will dispatch once the subclass is
+    // gone, and so TaskbarWndSubclassProc comes off Shell_TrayWnd as early
+    // as it's safe to rather than staying wired in for the rest of
+    // teardown.
+    HWND hTaskbarWnd = g_hTaskbarWnd;
+    if (hTaskbarWnd && g_taskbarWndSubclassed.exchange(false)) {
         WindhawkUtils::RemoveWindowSubclassFromAnyThread(
-            g_hTaskbarWnd, TaskbarWndSubclassProc);
+            hTaskbarWnd, TaskbarWndSubclassProc);
     }
 
     InvalidateTaskbarLayout();
@@ -3584,7 +3561,12 @@ void Wh_ModUninit() {
 // marshal if PostMessage itself fails, not only when the subclass was
 // never installed at all.
 void ApplyLoadedSettings(ModSettings settings) {
-    if (!g_hTaskbarWnd) {
+    // Snapshot once so every read below agrees - see g_hTaskbarWnd's own
+    // comment for why a stale nullptr reaching PostMessage isn't a no-op
+    // (here, it would mean the heap ModSettings gets release()d and
+    // leaked while the settings change is silently dropped).
+    HWND hTaskbarWnd = g_hTaskbarWnd;
+    if (!hTaskbarWnd) {
         g_settings = std::move(settings);
         return;
     }
@@ -3596,7 +3578,7 @@ void ApplyLoadedSettings(ModSettings settings) {
         // actually queued it, and reclaimed by TaskbarWndSubclassProc's
         // SettingsChangedMsg case on the dispatch side.
         auto heapSettings = std::make_unique<ModSettings>(std::move(settings));
-        if (PostMessage(g_hTaskbarWnd, SettingsChangedMsg(), 0,
+        if (PostMessage(hTaskbarWnd, SettingsChangedMsg(), 0,
                         (LPARAM)heapSettings.get())) {
             heapSettings.release();
             return;
@@ -3608,7 +3590,7 @@ void ApplyLoadedSettings(ModSettings settings) {
         settings = std::move(*heapSettings);
     }
 
-    if (!RunFromWindowThread(g_hTaskbarWnd,
+    if (!RunFromWindowThread(hTaskbarWnd,
                              [settings = std::move(settings)]() mutable {
                                  g_settings = std::move(settings);
                              })) {

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -566,6 +566,25 @@ std::vector<FrameworkElement> GetRepeaterChildElements(
 
 using RunFromWindowThreadProc_t = std::function<void()>;
 
+// A second, concurrent RunFromWindowThread call targeting the same thread
+// installs a second WH_CALLWNDPROC hook in the same chain. Both hooks
+// only ever check the message id (there's exactly one, shared by every
+// call), so when either call's SendMessage lands, every currently-
+// installed hook for this thread fires and blindly casts cwp->lParam -
+// which points at whichever call actually sent that specific message - to
+// its own proc pointer. That means an unrelated concurrent call's proc can
+// run in place of (or in addition to) the intended one. The `done` flag
+// caps this at exactly one real invocation per SendMessage regardless of
+// how many hooks are chained and firing for it: whichever hook proc
+// happens to run first for a given message wins, the rest see done==true
+// and no-op. Plain bool, not atomic - all hooks that fire for one message
+// do so synchronously, one after another, on the single thread receiving
+// that message, never concurrently with each other.
+struct RunFromWindowThreadParam {
+    RunFromWindowThreadProc_t* proc;
+    bool done = false;
+};
+
 bool RunFromWindowThread(HWND hWnd, RunFromWindowThreadProc_t proc) {
     static const UINT runFromWindowThreadRegisteredMsg = RegisterWindowMessage(
         L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
@@ -580,14 +599,19 @@ bool RunFromWindowThread(HWND hWnd, RunFromWindowThreadProc_t proc) {
         return true;
     }
 
+    RunFromWindowThreadParam param{&proc};
+
     HHOOK hook = SetWindowsHookEx(
         WH_CALLWNDPROC,
         [](int nCode, WPARAM wParam, LPARAM lParam) -> LRESULT {
             if (nCode == HC_ACTION) {
                 const CWPSTRUCT* cwp = (const CWPSTRUCT*)lParam;
                 if (cwp->message == runFromWindowThreadRegisteredMsg) {
-                    auto* proc = (RunFromWindowThreadProc_t*)cwp->lParam;
-                    (*proc)();
+                    auto* param = (RunFromWindowThreadParam*)cwp->lParam;
+                    if (!param->done) {
+                        param->done = true;
+                        (*param->proc)();
+                    }
                 }
             }
 
@@ -598,7 +622,7 @@ bool RunFromWindowThread(HWND hWnd, RunFromWindowThreadProc_t proc) {
         return false;
     }
 
-    SendMessage(hWnd, runFromWindowThreadRegisteredMsg, 0, (LPARAM)&proc);
+    SendMessage(hWnd, runFromWindowThreadRegisteredMsg, 0, (LPARAM)&param);
 
     UnhookWindowsHookEx(hook);
 
@@ -1143,6 +1167,16 @@ WindowClassification ClassifyByWindowPositionCached(HWND hwnd) {
             return {ResolveUnresolvedAppsDefaultSide()};
         }
         wr = wp.rcNormalPosition;
+        // rcNormalPosition is in workspace coordinates (relative to
+        // rcWork, which excludes the taskbar/appbars), while screenCenterX
+        // below is computed from rcMonitor. Identical on a normal
+        // bottom-docked taskbar (rcWork.left == rcMonitor.left), but a
+        // left-docked appbar shifts rcWork.left right of rcMonitor.left -
+        // without this offset a window near the boundary could classify
+        // to the wrong side.
+        LONG workOffsetX = mi.rcWork.left - mi.rcMonitor.left;
+        wr.left += workOffsetX;
+        wr.right += workOffsetX;
     } else if (!hwnd || !GetWindowRect(hwnd, &wr) || !GetMonitorInfo(mon, &mi)) {
         return {ResolveUnresolvedAppsDefaultSide()};
     }
@@ -1433,7 +1467,9 @@ double ComputeSystemButtonX(const std::vector<ChildInfo>& childInfos,
     double ownWidth = SystemButtonFootprintWidth(targetElement);
 
     if (g_settings.systemButtonsAdjacentSide == Side::Left) {
-        // Stack right-to-left outward from Start: lowest rank closest.
+        // Stack right-to-left outward from Start: highest rank closest to
+        // Start, so reading left-to-right still shows the same low-to-high
+        // rank order (Search, Task View, Widgets) as far-left mode does.
         double widthAfter = clusterWidth - widthBefore - ownWidth;
         return startCenterX - startWidth / 2.0 - gap - widthAfter - ownWidth;
     }
@@ -1566,8 +1602,9 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
         // was built that way); the right side's walk below (accumulating
         // outward from Start) already puts its earliest entry innermost,
         // but the left side needs reversing first - walking it in
-        // original taskbar order would put the *latest* entry innermost
-        // instead, backwards from what preserves reading order there.
+        // original taskbar order would put the *earliest* entry innermost
+        // instead, backwards from what preserves reading order there
+        // (earliest belongs at the outer edge on the left side).
         std::reverse(left.begin(), left.end());
     }
 
@@ -1670,19 +1707,15 @@ void ArmButtonHwndResolveTimer(DWORD delayMs);
 // on g_hTaskbarWnd as soon as the window resolves - see
 // InvalidateTaskbarLayout's own comment for why a subclass is what lets it
 // use a non-blocking PostMessage instead of RunFromWindowThread's per-call
-// blocking marshal.
+// blocking marshal. WindhawkUtils::SetWindowSubclassFromAnyThread/
+// RemoveWindowSubclassFromAnyThread key the subclass by this proc's own
+// address, not by dwRefData (unused, passed as 0) - there's no separate id
+// parameter the way raw SetWindowSubclass/RemoveWindowSubclass have.
 LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
                                         UINT uMsg,
                                         WPARAM wParam,
                                         LPARAM lParam,
-                                        UINT_PTR uIdSubclass,
                                         DWORD_PTR dwRefData);
-
-// Passed to both SetWindowSubclassFromAnyThread (EnsureTaskbarWnd) and
-// RemoveWindowSubclass (Wh_ModBeforeUninit) - only needs to be unique among
-// subclasses this mod installs on the same window, and it only ever
-// installs this one.
-constexpr UINT_PTR kTaskbarWndSubclassId = 1;
 
 // g_hTaskbarWnd is normally resolved once, in Wh_ModAfterInit. But if
 // Windhawk injects into explorer.exe before Shell_TrayWnd has been created
@@ -1740,7 +1773,7 @@ HWND EnsureTaskbarWnd() {
         // per-event cost on the hot invalidate path this is meant to
         // avoid, not one-shot setup.
         if (WindhawkUtils::SetWindowSubclassFromAnyThread(
-                g_hTaskbarWnd, TaskbarWndSubclassProc, kTaskbarWndSubclassId)) {
+                g_hTaskbarWnd, TaskbarWndSubclassProc, 0)) {
             g_taskbarWndSubclassed = true;
         } else {
             Wh_Log(L"EnsureTaskbarWnd: SetWindowSubclassFromAnyThread "
@@ -2405,24 +2438,50 @@ void PerformTaskbarLayoutInvalidate() {
 const UINT g_invalidateTaskbarLayoutMsg =
     RegisterWindowMessage(L"Windhawk_InvalidateTaskbarLayout_" WH_MOD_ID);
 
+// Same idea as g_invalidateTaskbarLayoutMsg, for ButtonHwndResolveTimerProc
+// - lets it post instead of going through RunFromWindowThread on every
+// tick (up to ~7/sec while EVENT_OBJECT_SHOW events are bursting).
+const UINT g_resolveButtonHwndsMsg =
+    RegisterWindowMessage(L"Windhawk_ResolveButtonHwnds_" WH_MOD_ID);
+
+// Same idea again, for a settings change. Unlike the two above this one
+// carries a payload: lParam is a heap-allocated ModSettings* that the
+// dispatch case below takes ownership of and deletes - PostMessage is
+// asynchronous, so the settings can't just live on the posting call's own
+// stack the way a plain signal can. See ApplyLoadedSettings.
+const UINT g_settingsChangedMsg =
+    RegisterWindowMessage(L"Windhawk_SettingsChanged_" WH_MOD_ID);
+
 // Installed on g_hTaskbarWnd by EnsureTaskbarWnd via
 // SetWindowSubclassFromAnyThread. A subclass proc only ever runs on the
-// thread that owns the window, which is what lets InvalidateTaskbarLayout
-// use a plain PostMessage here instead of RunFromWindowThread's
+// thread that owns the window, which is what lets these call paths use a
+// plain PostMessage here instead of RunFromWindowThread's
 // SetWindowsHookEx/SendMessage/UnhookWindowsHookEx dance on every single
-// call. Everything other than the private message is forwarded to
-// DefSubclassProc, which is also what lets comctl32 clean this subclass up
-// automatically via WM_NCDESTROY if the window is ever destroyed out from
-// under the mod without Wh_ModBeforeUninit's explicit RemoveWindowSubclass
-// call running first.
+// call - and, since a subclass proc is dispatched directly by that
+// thread's own message loop rather than through a possibly-multiply-
+// chained hook, it can't suffer the double-invocation risk RunFromWindowThread
+// has to guard against instead. Everything other than these private
+// messages is forwarded to DefSubclassProc, which is also what lets
+// comctl32 clean this subclass up automatically via WM_NCDESTROY if the
+// window is ever destroyed out from under the mod without
+// Wh_ModBeforeUninit's explicit removal call running first.
 LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
                                         UINT uMsg,
                                         WPARAM wParam,
                                         LPARAM lParam,
-                                        UINT_PTR uIdSubclass,
                                         DWORD_PTR dwRefData) {
     if (uMsg == g_invalidateTaskbarLayoutMsg) {
         PerformTaskbarLayoutInvalidate();
+        return 0;
+    }
+    if (uMsg == g_resolveButtonHwndsMsg) {
+        ResolvePendingButtonHwnds();
+        return 0;
+    }
+    if (uMsg == g_settingsChangedMsg) {
+        auto* heapSettings = reinterpret_cast<ModSettings*>(lParam);
+        g_settings = std::move(*heapSettings);
+        delete heapSettings;
         return 0;
     }
     return DefSubclassProc(hWnd, uMsg, wParam, lParam);
@@ -2484,8 +2543,9 @@ void CALLBACK DragFollowTrailingTimerProc(HWND hwnd,
     KillTimer(nullptr, idEvent);
     g_dragFollowTrailingTimerId = 0;
 
-    // Same g_unloading check WinEventProc already has: InvalidateTaskbarLayout
-    // blocks in SendMessage until the taskbar thread pumps it, which
+    // Same g_unloading check WinEventProc already has: on the fallback
+    // path (subclass never installed), InvalidateTaskbarLayout blocks in
+    // SendMessage until the taskbar thread pumps it, which
     // StopWinEventHook's now-unconditional wait (see its own comment)
     // would otherwise be stuck behind if this fired mid-teardown.
     if (g_unloading) {
@@ -3048,8 +3108,7 @@ void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
     // Runs on this thread directly now (a per-thread SetTimer with
     // hWnd=nullptr), so no cross-thread marshal is needed to arm/disarm
     // it - only the actual XAML work inside ResolvePendingButtonHwnds
-    // needs marshaling onto the taskbar thread, which it does itself via
-    // RunFromWindowThread.
+    // needs marshaling onto the taskbar thread.
     KillTimer(nullptr, idEvent);
     g_buttonHwndResolveTimerId = 0;
 
@@ -3057,7 +3116,25 @@ void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
         return;
     }
 
-    RunFromWindowThread(g_hTaskbarWnd, ResolvePendingButtonHwnds);
+    // Prefer the subclass's non-blocking PostMessage (see
+    // g_resolveButtonHwndsMsg) - this can fire several times a second
+    // during an EVENT_OBJECT_SHOW burst, the same hot-path cost
+    // InvalidateTaskbarLayout avoids via PostMessage instead of
+    // RunFromWindowThread's per-call hook install. Only fall back to the
+    // blocking marshal in the (should stay rare) case the subclass was
+    // never successfully installed - a missed PostMessage here just means
+    // this tick's resolve is skipped, and the next scheduled tick (or the
+    // ArrangeOverride count-change path via ArmButtonHwndResolveTimer)
+    // will retry, so no fallback is needed for a PostMessage failure
+    // specifically.
+    if (g_taskbarWndSubclassed) {
+        if (!PostMessage(g_hTaskbarWnd, g_resolveButtonHwndsMsg, 0, 0)) {
+            Wh_Log(L"ButtonHwndResolveTimerProc: PostMessage failed, "
+                   L"error=%lu", GetLastError());
+        }
+    } else {
+        RunFromWindowThread(g_hTaskbarWnd, ResolvePendingButtonHwnds);
+    }
 
     DWORD delay = NextResolveDelayMs();
     if (!g_unloading && delay != INFINITE) {
@@ -3162,20 +3239,13 @@ void Wh_ModBeforeUninit() {
     // returns" guarantee for this last invalidate exactly as it was before
     // the subclass existed; and it gets TaskbarWndSubclassProc off
     // Shell_TrayWnd as early as it's safe to, rather than leaving it wired
-    // in for the rest of teardown. RemoveWindowSubclass isn't safe to call
-    // across threads any more than SetWindowSubclass is, so this reuses
-    // RunFromWindowThread's existing marshal rather than calling it
-    // directly - safe here since RunFromWindowThread only depends on raw
-    // Win32 APIs, not on any of this mod's own hooks (which are still
-    // installed at this point regardless).
+    // in for the rest of teardown. RemoveWindowSubclassFromAnyThread (like
+    // SetWindowSubclassFromAnyThread) already marshals itself onto the
+    // owning thread internally, so this doesn't need RunFromWindowThread's
+    // own marshal wrapped around it.
     if (g_hTaskbarWnd && g_taskbarWndSubclassed.exchange(false)) {
-        if (!RunFromWindowThread(g_hTaskbarWnd, [] {
-                RemoveWindowSubclass(g_hTaskbarWnd, TaskbarWndSubclassProc,
-                                     kTaskbarWndSubclassId);
-            })) {
-            Wh_Log(L"Wh_ModBeforeUninit: RunFromWindowThread failed, "
-                   L"taskbar subclass not removed");
-        }
+        WindhawkUtils::RemoveWindowSubclassFromAnyThread(
+            g_hTaskbarWnd, TaskbarWndSubclassProc);
     }
 
     InvalidateTaskbarLayout();
@@ -3192,32 +3262,56 @@ void Wh_ModUninit() {
     StopWinEventHook();
 }
 
+// Applies a freshly-loaded settings struct on the taskbar's own thread -
+// needed since it reassigns leftApps/rightApps (std::vector<std::wstring>),
+// which a concurrent ContainsAnyFragment call during a layout pass on that
+// thread could otherwise read mid-reassignment. Prefers the subclass's
+// PostMessage over RunFromWindowThread for the same non-blocking reason as
+// InvalidateTaskbarLayout/the HWND-resolve tick, but unlike those two a
+// dropped settings change is a real loss (not just a delayed retry), so
+// this - unlike them - does fall back to the blocking RunFromWindowThread
+// marshal if PostMessage itself fails, not only when the subclass was
+// never installed at all.
+void ApplyLoadedSettings(ModSettings settings) {
+    if (!g_hTaskbarWnd) {
+        g_settings = std::move(settings);
+        return;
+    }
+
+    if (g_taskbarWndSubclassed) {
+        // PostMessage is async, so the settings can't live on this
+        // function's own stack - ownership transfers to the heap pointer,
+        // and TaskbarWndSubclassProc's g_settingsChangedMsg case deletes
+        // it after moving out of it.
+        auto* heapSettings = new ModSettings(std::move(settings));
+        if (PostMessage(g_hTaskbarWnd, g_settingsChangedMsg, 0,
+                        (LPARAM)heapSettings)) {
+            return;
+        }
+        Wh_Log(L"ApplyLoadedSettings: PostMessage failed, error=%lu, "
+               L"falling back to RunFromWindowThread", GetLastError());
+        // Reclaim ownership before falling through to the blocking path.
+        settings = std::move(*heapSettings);
+        delete heapSettings;
+    }
+
+    if (!RunFromWindowThread(g_hTaskbarWnd,
+                             [settings = std::move(settings)]() mutable {
+                                 g_settings = std::move(settings);
+                             })) {
+        Wh_Log(L"ApplyLoadedSettings: RunFromWindowThread failed, "
+               L"new settings not applied");
+    }
+}
+
 void Wh_ModSettingsChanged() {
     Wh_Log(L">");
 
-    // Read every setting on this calling thread first -
-    // Wh_Get/FreeStringSetting don't touch XAML/COM, so they don't need
-    // to run on the taskbar thread at all. Only the final assignment into
-    // g_settings is marshaled: it reassigns leftApps/rightApps
-    // (std::vector<std::wstring>), which a concurrent ContainsAnyFragment
-    // call during a layout pass on the taskbar thread could otherwise
-    // read mid-reassignment. Doing the reads here means the RunFromWindowThread
-    // call below blocks the taskbar thread (which may be in the middle of
-    // handling this via WH_CALLWNDPROC/SendMessage) for a plain struct
-    // move instead of several setting reads plus string work.
-    ModSettings settings = LoadSettingsFromStore();
-
-    if (g_hTaskbarWnd) {
-        if (!RunFromWindowThread(g_hTaskbarWnd,
-                                 [settings = std::move(settings)]() mutable {
-                                     g_settings = std::move(settings);
-                                 })) {
-            Wh_Log(L"Wh_ModSettingsChanged: RunFromWindowThread failed, "
-                   L"new settings not applied");
-        }
-    } else {
-        g_settings = std::move(settings);
-    }
+    // Read every setting on this calling thread - Wh_Get/FreeStringSetting
+    // don't touch XAML/COM, so they don't need to run on the taskbar
+    // thread at all, only the final assignment into g_settings does (see
+    // ApplyLoadedSettings).
+    ApplyLoadedSettings(LoadSettingsFromStore());
 
     InvalidateTaskbarLayout();
 }

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -1060,6 +1060,18 @@ struct ButtonHwndCacheEntry {
 };
 std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
 
+// The HWNDs g_buttonHwndCache currently resolves to, rebuilt at the end
+// of every successful ResolvePendingButtonHwnds pass (taskbar thread) and
+// read by WinEventProc (the dedicated WinEventHook thread) to filter drag
+// -follow's EVENT_OBJECT_LOCATIONCHANGE events - a window that never
+// resolved to a taskbar button can't change this mod's layout, so there's
+// no reason to pay for a relayout on its account. Needs its own mutex
+// (not covered by the arrange-hook thread confinement the rest of this
+// cache enjoys) since it's the one piece of resolve state genuinely read
+// cross-thread outside a marshal.
+std::mutex g_resolvedHwndsMutex;
+std::unordered_set<HWND> g_resolvedHwnds;
+
 // Actually runs the resolution chain and updates the cache. Returns
 // whether the cached HWND changed - used by the caller to decide whether
 // a relayout is worth triggering.
@@ -1686,6 +1698,20 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
 // already nested inside XAML-internal layout activity.
 void InvalidateTaskbarLayout();
 
+// Idle re-check cadence once every cached button is already resolved -
+// see NextResolveDelayMs' comment (Mod lifecycle section) for what this
+// specifically exists to catch (a drag-reorder rebind, which isn't
+// latency-sensitive). Kept well above the 2s..32s backoff used for
+// buttons that still need resolving: even at idle, each tick still
+// resolves the taskbar's XamlRoot and walks its visual tree on Explorer's
+// UI thread, and this runs indefinitely for the life of the session. Also
+// used by ResolvePendingButtonHwnds (below) as a "something's not right
+// yet, check back soon" fallback delay for passes that bail out before
+// confirming the live button set - moved up here (out of the Mod
+// lifecycle section it's otherwise grouped with) so it's declared before
+// that use.
+constexpr DWORD kIdleResolveTickMs = 30000;
+
 // Defined later (Mod lifecycle section); forward-declared here so
 // EnsureTaskbarWnd (below) can start the drag-follow WinEventHook as soon
 // as the taskbar window resolves, whether that happens at normal startup
@@ -1882,9 +1908,23 @@ void ResolvePendingButtonHwnds() {
     // use-after-free, not just stale data. Moving the computation here
     // closes that regardless of which path (post or the RunFromWindowThread
     // fallback) invoked this pass.
+    //
+    // NextResolveDelayMs' INFINITE answer is only trustworthy once a pass
+    // has actually confirmed the live button set - an empty
+    // g_buttonHwndCache from a pass that bailed out before enumerating
+    // anything (every early-return guard below, or no repeater yet) looks
+    // identical to a genuinely empty taskbar otherwise, and the timer
+    // would then never be armed again except by incidental luck (some
+    // unrelated EVENT_OBJECT_SHOW or count-change nudging
+    // ArmButtonHwndResolveTimer). `enumerated` tracks whether the walk
+    // below actually ran to completion; the destructor falls back to
+    // kIdleResolveTickMs instead of trusting INFINITE when it didn't.
+    bool enumerated = false;
     struct ScheduleNextResolveTick {
+        bool* enumerated;
         ~ScheduleNextResolveTick() {
-            DWORD delay = NextResolveDelayMs();
+            DWORD delay =
+                *enumerated ? NextResolveDelayMs() : kIdleResolveTickMs;
             if (delay != INFINITE) {
                 // Posts to the WinEventHook thread's own queue - safe to
                 // call unconditionally, including during unload
@@ -1892,7 +1932,7 @@ void ResolvePendingButtonHwnds() {
                 ArmButtonHwndResolveTimer(delay);
             }
         }
-    } scheduleNextTick;
+    } scheduleNextTick{&enumerated};
 
     if (g_unloading || g_inTaskbarArrangeOverride || !g_hTaskbarWnd) {
         return;
@@ -1956,6 +1996,7 @@ void ResolvePendingButtonHwnds() {
                 anyChanged = true;
             }
         }
+        enumerated = true;
 
         // Prune g_buttonHwndCache entries for buttons that no longer exist.
         // XAML routinely destroys and recreates TaskListButtons (unpin, app
@@ -1989,6 +2030,22 @@ void ResolvePendingButtonHwnds() {
              it != g_lastKnownWindowClassification.end();) {
             it = IsWindow(it->first) ? std::next(it)
                                       : g_lastKnownWindowClassification.erase(it);
+        }
+
+        // Rebuild the published resolved-HWND set from g_buttonHwndCache's
+        // just-finished state, for WinEventProc's drag-follow filter (see
+        // g_resolvedHwnds' own comment) - unconditionally, not just when
+        // anyChanged, since it's cheap and needs to reflect this pass's
+        // pruning even when nothing else about the plan changed.
+        {
+            std::unordered_set<HWND> resolvedNow;
+            for (auto& kv : g_buttonHwndCache) {
+                if (kv.second.hwnd) {
+                    resolvedNow.insert(kv.second.hwnd);
+                }
+            }
+            std::lock_guard<std::mutex> guard(g_resolvedHwndsMutex);
+            g_resolvedHwnds = std::move(resolvedNow);
         }
 
         if (anyChanged) {
@@ -2675,6 +2732,23 @@ void CALLBACK WinEventProc(HWINEVENTHOOK hook,
     }
 
     // event == EVENT_OBJECT_LOCATIONCHANGE from here on - drag-follow.
+    // Only a window this mod has actually resolved to a taskbar button
+    // can change the layout; every other moving window on the system
+    // (there are a lot of them - see this function's own comment on raw
+    // event volume) would trigger a full RecomputeLayoutPlan pass for
+    // nothing. Checked before the throttle below, not after, so an
+    // untracked window's events don't even arm the trailing timer or
+    // touch g_lastDragFollowInvalidate. Lock released before
+    // InvalidateTaskbarLayout() is ever reached - its fallback path
+    // blocks in SendMessage on the taskbar thread, which must never run
+    // while this thread is holding g_resolvedHwndsMutex.
+    {
+        std::lock_guard<std::mutex> guard(g_resolvedHwndsMutex);
+        if (!g_resolvedHwnds.count(hwnd)) {
+            return;
+        }
+    }
+
     ULONGLONG now = GetTickCount64();
     if (now - g_lastDragFollowInvalidate < 150) {
         // The throttle above is leading-edge only, so the final
@@ -3080,15 +3154,6 @@ void StopWinEventHook() {
     CloseHandle(thread);
 }
 
-// Idle re-check cadence once every cached button is already resolved -
-// see NextResolveDelayMs' comment for what this specifically exists to
-// catch (a drag-reorder rebind, which isn't latency-sensitive). Kept
-// well above the 2s..32s backoff used for buttons that still need
-// resolving: even at idle, each tick still resolves the taskbar's
-// XamlRoot and walks its visual tree on Explorer's UI thread, and this
-// runs indefinitely for the life of the session.
-constexpr DWORD kIdleResolveTickMs = 30000;
-
 // Capped exponential backoff for the click-sentinel probe, shared by
 // ResolvePendingButtonHwnds and NextResolveDelayMs: a fallback safety net
 // for a pinned-but-not-running app's button, in case its launch is ever
@@ -3202,8 +3267,14 @@ void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
                    L"error=%lu", GetLastError());
             ArmButtonHwndResolveTimer(kIdleResolveTickMs);
         }
-    } else {
-        RunFromWindowThread(g_hTaskbarWnd, ResolvePendingButtonHwnds);
+    } else if (!RunFromWindowThread(g_hTaskbarWnd, ResolvePendingButtonHwnds)) {
+        // Same "nothing will call back" concern as the PostMessage failure
+        // above - a marshal failure here (SetWindowsHookEx failing, or
+        // g_hTaskbarWnd going stale/null mid-taskbar-recreate) means
+        // ResolvePendingButtonHwnds never ran at all, so its own
+        // ScheduleNextResolveTick guard never gets a chance to re-arm.
+        Wh_Log(L"ButtonHwndResolveTimerProc: RunFromWindowThread failed");
+        ArmButtonHwndResolveTimer(kIdleResolveTickMs);
     }
 }
 

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -426,6 +426,15 @@ thread_local bool g_inTaskbarArrangeOverride;
 // unsafe.
 
 HWND g_hTaskbarWnd;
+
+// Whether TaskbarWndSubclassProc is currently installed on g_hTaskbarWnd -
+// see EnsureTaskbarWnd (where it's installed) and InvalidateTaskbarLayout
+// (which checks it to pick PostMessage vs. the RunFromWindowThread
+// fallback). atomic: set from Explorer's UI thread (EnsureTaskbarWnd) or
+// Wh_ModAfterInit's thread, read from InvalidateTaskbarLayout's callers,
+// which include the dedicated WinEventHook thread.
+std::atomic<bool> g_taskbarWndSubclassed;
+
 HWINEVENTHOOK g_locationChangeHook;
 HWINEVENTHOOK g_showEventHook;
 std::atomic<int> g_winEventRawCount;
@@ -453,6 +462,15 @@ UINT_PTR g_buttonHwndResolveTimerId;
 // against whatever raw event last landed outside the 150ms window before
 // the trailing timer took over.
 ULONGLONG g_lastDragFollowInvalidate;
+
+// Leading-edge throttle for EVENT_OBJECT_SHOW, mirroring the
+// LOCATIONCHANGE throttle above - a top-level window becoming visible
+// fires this event just as often system-wide, and a single arm(0) call is
+// enough to catch every button that's currently pending regardless of how
+// many SHOW events land in the same burst (unlike drag-follow, there's no
+// "final position" that specifically needs the trailing event, so no
+// trailing timer is needed here).
+ULONGLONG g_lastShowEventArm;
 
 // ============================================================================
 // Generic taskbar/XAML helpers
@@ -1647,6 +1665,25 @@ void StartWinEventHook();
 // brand-new button coming on its own.
 void ArmButtonHwndResolveTimer(DWORD delayMs);
 
+// Defined later (Live drag-follow section, alongside InvalidateTaskbarLayout
+// itself); forward-declared here so EnsureTaskbarWnd (below) can install it
+// on g_hTaskbarWnd as soon as the window resolves - see
+// InvalidateTaskbarLayout's own comment for why a subclass is what lets it
+// use a non-blocking PostMessage instead of RunFromWindowThread's per-call
+// blocking marshal.
+LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
+                                        UINT uMsg,
+                                        WPARAM wParam,
+                                        LPARAM lParam,
+                                        UINT_PTR uIdSubclass,
+                                        DWORD_PTR dwRefData);
+
+// Passed to both SetWindowSubclassFromAnyThread (EnsureTaskbarWnd) and
+// RemoveWindowSubclass (Wh_ModBeforeUninit) - only needs to be unique among
+// subclasses this mod installs on the same window, and it only ever
+// installs this one.
+constexpr UINT_PTR kTaskbarWndSubclassId = 1;
+
 // g_hTaskbarWnd is normally resolved once, in Wh_ModAfterInit. But if
 // Windhawk injects into explorer.exe before Shell_TrayWnd has been created
 // yet - observed after a fresh boot, never after a manual mod disable/
@@ -1667,6 +1704,13 @@ HWND EnsureTaskbarWnd() {
     // to check unconditionally every pass.
     if (g_hTaskbarWnd && !IsWindow(g_hTaskbarWnd)) {
         g_hTaskbarWnd = nullptr;
+        // The old window's subclass chain goes with it (comctl32 tears it
+        // down via WM_NCDESTROY, which TaskbarWndSubclassProc already
+        // forwards to DefSubclassProc for every message it doesn't
+        // otherwise handle) - this just keeps the flag in step so a fresh
+        // resolve below knows to install a subclass on the new window
+        // rather than assuming the old one still covers it.
+        g_taskbarWndSubclassed = false;
     }
 
     if (g_hTaskbarWnd) {
@@ -1686,6 +1730,23 @@ HWND EnsureTaskbarWnd() {
     if (g_hTaskbarWnd) {
         Wh_Log(L"Resolved taskbar window: %p", g_hTaskbarWnd);
         StartWinEventHook();
+
+        // Lets InvalidateTaskbarLayout notify this window with a
+        // non-blocking PostMessage instead of RunFromWindowThread's
+        // per-call SetWindowsHookEx/SendMessage/UnhookWindowsHookEx dance -
+        // see its own comment. A one-time blocking install here (via
+        // SetWindowSubclassFromAnyThread's own marshal, if this isn't
+        // already running on the taskbar thread) is fine; it's the
+        // per-event cost on the hot invalidate path this is meant to
+        // avoid, not one-shot setup.
+        if (WindhawkUtils::SetWindowSubclassFromAnyThread(
+                g_hTaskbarWnd, TaskbarWndSubclassProc, kTaskbarWndSubclassId)) {
+            g_taskbarWndSubclassed = true;
+        } else {
+            Wh_Log(L"EnsureTaskbarWnd: SetWindowSubclassFromAnyThread "
+                   L"failed, InvalidateTaskbarLayout will use the blocking "
+                   L"fallback instead");
+        }
     }
 
     return g_hTaskbarWnd;
@@ -1699,6 +1760,42 @@ FrameworkElement FindTaskbarFrameRepeater(FrameworkElement anyDescendant) {
         return child;
     }
     return nullptr;
+}
+
+// Caches the resolved repeater across calls instead of every caller
+// redoing GetTaskbarXamlRoot's resolution chain (taskband HWND -> vtable
+// scan -> TaskbarHost::FrameHeight prologue parse -> QueryInterface) plus
+// FindTaskbarFrameRepeater's three-level tree walk from scratch - this used
+// to run independently in RecomputeLayoutPlan, InvalidateTaskbarLayout, and
+// ResolvePendingButtonHwnds on every single call.
+//
+// A weak_ref is enough to know when to re-resolve: XAML's own visual tree
+// holds the only strong reference to the repeater, so once the taskbar's
+// tree is torn down and rebuilt (Explorer restart, a DPI/monitor change),
+// the old instance is destructed and the weak_ref naturally comes back
+// empty - exactly the signal to redo the real resolution. No separate
+// "is this still attached" check is needed on top of that.
+//
+// MUST only run when confirmed to be on g_hTaskbarWnd's own thread - same
+// constraint as GetTaskbarXamlRoot itself, which this wraps.
+winrt::weak_ref<FrameworkElement> g_cachedTaskbarRepeaterWeak;
+
+FrameworkElement GetCachedTaskbarRepeater() {
+    if (FrameworkElement cached = g_cachedTaskbarRepeaterWeak.get()) {
+        return cached;
+    }
+
+    XamlRoot xamlRoot = GetTaskbarXamlRoot(g_hTaskbarWnd);
+    if (!xamlRoot) {
+        return nullptr;
+    }
+
+    FrameworkElement content = xamlRoot.Content().try_as<FrameworkElement>();
+    FrameworkElement repeater = FindTaskbarFrameRepeater(content);
+    if (repeater) {
+        g_cachedTaskbarRepeaterWeak = repeater;
+    }
+    return repeater;
 }
 
 // Walks the primary taskbar's current TaskListButtons and (re)resolves any
@@ -1733,13 +1830,7 @@ void ResolvePendingButtonHwnds() {
     // tree is being recreated - an uncaught throw here crosses the boundary
     // and fail-fasts explorer.exe.
     try {
-        XamlRoot xamlRoot = GetTaskbarXamlRoot(g_hTaskbarWnd);
-        if (!xamlRoot) {
-            return;
-        }
-
-        FrameworkElement content = xamlRoot.Content().try_as<FrameworkElement>();
-        FrameworkElement repeater = FindTaskbarFrameRepeater(content);
+        FrameworkElement repeater = GetCachedTaskbarRepeater();
         if (!repeater) {
             return;
         }
@@ -1973,20 +2064,52 @@ void RecomputeLayoutPlan() {
     }
     if (!g_planDirty &&
         GetTickCount64() - g_lastPlanRecomputeTick < kMaxPlanStalenessMs) {
-        return;
+        // This backstop only bounds staleness while ArrangeOverride keeps
+        // getting called at least this often - once XAML stops producing
+        // layout passes, this early return would never get reevaluated
+        // again, so a change that landed in a skipped pass (see
+        // g_planDirty's own comment) could then sit stale indefinitely
+        // instead of just kMaxPlanStalenessMs (concretely: a pin/unpin on
+        // an otherwise-idle desktop). The repeater is cached now (see
+        // GetCachedTaskbarRepeater), so checking the realized task-list-
+        // button set against what the plan actually covers is affordable
+        // every time this branch is taken - if any live button isn't in
+        // g_lastArrangedX, the plan is stale regardless of the dirty flag
+        // or the clock, and this pass needs to fall through to a real
+        // recompute rather than trust the backstop.
+        bool planCoversLiveTaskListButtons = true;
+        try {
+            if (FrameworkElement repeater = GetCachedTaskbarRepeater()) {
+                for (auto& child : GetRepeaterChildElements(repeater)) {
+                    if (IsTaskListButton(child) &&
+                        !g_lastArrangedX.count(winrt::get_abi(child))) {
+                        planCoversLiveTaskListButtons = false;
+                        break;
+                    }
+                }
+            }
+        } catch (...) {
+            // Conservative default: treat an exception here as "can't
+            // confirm the plan is current" and fall through to the real
+            // recompute below, which has its own exception handling.
+            planCoversLiveTaskListButtons = false;
+        }
+        if (planCoversLiveTaskListButtons) {
+            return;
+        }
     }
     g_lastPlanRecomputeTick = GetTickCount64();
 
     g_planStats = {};
 
     try {
-        XamlRoot xamlRoot = GetTaskbarXamlRoot(g_hTaskbarWnd);
-        if (!xamlRoot) {
+        FrameworkElement repeater = GetCachedTaskbarRepeater();
+        if (!repeater) {
             return;
         }
-        FrameworkElement content = xamlRoot.Content().try_as<FrameworkElement>();
-        FrameworkElement repeater = FindTaskbarFrameRepeater(content);
-        if (!repeater) {
+        FrameworkElement content =
+            repeater.XamlRoot().Content().try_as<FrameworkElement>();
+        if (!content) {
             return;
         }
 
@@ -2238,15 +2361,72 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
 // Live drag-follow: force a taskbar relayout when a top-level window moves
 // ============================================================================
 
-// Guards against reentering InvalidateTaskbarLayout itself on the
-// taskbar's own thread. WinEventProc can fire in rapid bursts (observed:
-// thousands of raw events within seconds while something on screen is
-// spamming EVENT_OBJECT_LOCATIONCHANGE).
+// Guards against reentering the invalidate body itself on the taskbar's
+// own thread. WinEventProc can fire in rapid bursts (observed: thousands
+// of raw events within seconds while something on screen is spamming
+// EVENT_OBJECT_LOCATIONCHANGE), and both call paths below
+// (TaskbarWndSubclassProc's dispatch and RunFromWindowThread's fallback)
+// land on that same thread, so one thread_local flag covers either.
 //
-// This lambda deliberately never calls UpdateLayout() - see the note on
+// This deliberately never calls UpdateLayout() - see the note on
 // InvalidateTaskbarLayout below for why forcing a synchronous layout pass
 // here is unsafe regardless of this guard.
 thread_local bool g_inInvalidateTaskbarLayout;
+
+// The actual invalidate work, shared by both of InvalidateTaskbarLayout's
+// call paths below. MUST only run on g_hTaskbarWnd's own thread - same
+// constraint as GetCachedTaskbarRepeater, which this uses.
+void PerformTaskbarLayoutInvalidate() {
+    if (g_inInvalidateTaskbarLayout) {
+        g_invalidateSkippedReentrant++;
+        return;
+    }
+    g_inInvalidateTaskbarLayout = true;
+
+    try {
+        FrameworkElement repeater = GetCachedTaskbarRepeater();
+        if (!repeater) {
+            Wh_Log(L"InvalidateTaskbarLayout: GetCachedTaskbarRepeater failed");
+        } else {
+            repeater.InvalidateArrange();
+            repeater.InvalidateMeasure();
+        }
+    } catch (...) {
+        g_invalidateExceptions++;
+    }
+
+    g_inInvalidateTaskbarLayout = false;
+}
+
+// Private message InvalidateTaskbarLayout posts to run
+// PerformTaskbarLayoutInvalidate on the taskbar's own thread without
+// blocking the caller - see InvalidateTaskbarLayout's own comment for why
+// that matters on this specific call path.
+const UINT g_invalidateTaskbarLayoutMsg =
+    RegisterWindowMessage(L"Windhawk_InvalidateTaskbarLayout_" WH_MOD_ID);
+
+// Installed on g_hTaskbarWnd by EnsureTaskbarWnd via
+// SetWindowSubclassFromAnyThread. A subclass proc only ever runs on the
+// thread that owns the window, which is what lets InvalidateTaskbarLayout
+// use a plain PostMessage here instead of RunFromWindowThread's
+// SetWindowsHookEx/SendMessage/UnhookWindowsHookEx dance on every single
+// call. Everything other than the private message is forwarded to
+// DefSubclassProc, which is also what lets comctl32 clean this subclass up
+// automatically via WM_NCDESTROY if the window is ever destroyed out from
+// under the mod without Wh_ModBeforeUninit's explicit RemoveWindowSubclass
+// call running first.
+LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
+                                        UINT uMsg,
+                                        WPARAM wParam,
+                                        LPARAM lParam,
+                                        UINT_PTR uIdSubclass,
+                                        DWORD_PTR dwRefData) {
+    if (uMsg == g_invalidateTaskbarLayoutMsg) {
+        PerformTaskbarLayoutInvalidate();
+        return 0;
+    }
+    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
 
 // Marks the layout dirty and lets the XAML dispatcher pick it up on its
 // own next tick, rather than forcing a synchronous UpdateLayout() call:
@@ -2269,40 +2449,26 @@ void InvalidateTaskbarLayout() {
     // that needs to know about all of them.
     g_planDirty = true;
 
-    bool posted = RunFromWindowThread(g_hTaskbarWnd, [] {
-        if (g_inInvalidateTaskbarLayout) {
-            g_invalidateSkippedReentrant++;
-            return;
+    if (g_taskbarWndSubclassed) {
+        // The hot path: called from WinEventProc's drag-follow throttle
+        // at up to ~7 times/sec while any window on the system is being
+        // dragged, plus every resolve tick. PostMessage doesn't block on
+        // Explorer's UI thread pumping it, unlike RunFromWindowThread
+        // below, which installs a WH_CALLWNDPROC hook and blocks in
+        // SendMessage until that thread processes it - a real cost at
+        // this frequency, even though it's fine for a one-shot call.
+        if (!PostMessage(g_hTaskbarWnd, g_invalidateTaskbarLayoutMsg, 0, 0)) {
+            Wh_Log(L"InvalidateTaskbarLayout: PostMessage failed, error=%lu",
+                   GetLastError());
         }
-        g_inInvalidateTaskbarLayout = true;
+        return;
+    }
 
-        try {
-            XamlRoot xamlRoot = GetTaskbarXamlRoot(g_hTaskbarWnd);
-            if (!xamlRoot) {
-                Wh_Log(L"InvalidateTaskbarLayout: GetTaskbarXamlRoot failed");
-                g_inInvalidateTaskbarLayout = false;
-                return;
-            }
-
-            FrameworkElement content =
-                xamlRoot.Content().try_as<FrameworkElement>();
-            FrameworkElement repeater = FindTaskbarFrameRepeater(content);
-            if (!repeater) {
-                Wh_Log(
-                    L"InvalidateTaskbarLayout: FindTaskbarFrameRepeater "
-                    L"failed");
-                g_inInvalidateTaskbarLayout = false;
-                return;
-            }
-
-            repeater.InvalidateArrange();
-            repeater.InvalidateMeasure();
-        } catch (...) {
-            g_invalidateExceptions++;
-        }
-
-        g_inInvalidateTaskbarLayout = false;
-    });
+    // Fallback for the (should stay rare) case where the taskbar window
+    // was never successfully subclassed - still gets the job done, just
+    // without the non-blocking benefit above.
+    bool posted =
+        RunFromWindowThread(g_hTaskbarWnd, PerformTaskbarLayoutInvalidate);
     if (!posted) {
         Wh_Log(L"InvalidateTaskbarLayout: RunFromWindowThread failed");
     }
@@ -2363,6 +2529,23 @@ void CALLBACK WinEventProc(HWINEVENTHOOK hook,
         // this is a fast path on top of it, not a replacement for it, in
         // case a launch is ever reached through a code path that
         // legitimately doesn't produce this event.
+        //
+        // Leading-edge throttled the same way the location-change branch
+        // below is: this event fires for every top-level window becoming
+        // visible anywhere on the system, unthrottled, so an app that
+        // opens several windows at once (or a burst of unrelated launches)
+        // would otherwise schedule a full resolve pass - a blocking
+        // marshal onto Explorer's UI thread plus a repeater walk and an
+        // AutomationProperties::GetName per button - for every single one.
+        // No trailing timer is needed the way drag-follow has one: unlike
+        // a window's final drop position, arm(0) just needs to run once to
+        // pick up every currently-pending button, so missing the last
+        // event in a burst costs nothing.
+        ULONGLONG nowShow = GetTickCount64();
+        if (nowShow - g_lastShowEventArm < 150) {
+            return;
+        }
+        g_lastShowEventArm = nowShow;
         ArmButtonHwndResolveTimer(0);
         return;
     }
@@ -2971,6 +3154,30 @@ void Wh_ModBeforeUninit() {
     // has removed them. g_unloading being set here (before that) is what
     // keeps ResolvePendingButtonHwnds' click-sentinel probe from running
     // once the hooks it depends on are gone - see its own comment.
+
+    // Removed here, before the final InvalidateTaskbarLayout() call below,
+    // for two reasons: it makes that call fall back to RunFromWindowThread's
+    // blocking marshal instead of the normally non-blocking PostMessage
+    // path, restoring this function's "runs before Wh_ModBeforeUninit
+    // returns" guarantee for this last invalidate exactly as it was before
+    // the subclass existed; and it gets TaskbarWndSubclassProc off
+    // Shell_TrayWnd as early as it's safe to, rather than leaving it wired
+    // in for the rest of teardown. RemoveWindowSubclass isn't safe to call
+    // across threads any more than SetWindowSubclass is, so this reuses
+    // RunFromWindowThread's existing marshal rather than calling it
+    // directly - safe here since RunFromWindowThread only depends on raw
+    // Win32 APIs, not on any of this mod's own hooks (which are still
+    // installed at this point regardless).
+    if (g_hTaskbarWnd && g_taskbarWndSubclassed.exchange(false)) {
+        if (!RunFromWindowThread(g_hTaskbarWnd, [] {
+                RemoveWindowSubclass(g_hTaskbarWnd, TaskbarWndSubclassProc,
+                                     kTaskbarWndSubclassId);
+            })) {
+            Wh_Log(L"Wh_ModBeforeUninit: RunFromWindowThread failed, "
+                   L"taskbar subclass not removed");
+        }
+    }
+
     InvalidateTaskbarLayout();
 }
 

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -2950,8 +2950,10 @@ std::unordered_map<HWND, LONG> g_lastPolledCenterX;
 constexpr UINT kDragFollowPollActiveMs = 150;
 constexpr UINT kDragFollowPollIdleMs = 1000;
 // How long the fast cadence persists after the last detected change.
-// Covers the gap between two drags of the same window (and a drag that
-// pauses mid-move) without dropping to the idle rate in between.
+// Bridges short gaps - a brief pause mid-drag, or the moment between two
+// drags of the same window - so those don't drop to the idle rate and
+// straight back. A pause longer than this does fall back to idle, which
+// costs up to one idle interval before the fast rate resumes.
 constexpr ULONGLONG kDragFollowActiveWindowMs = 2000;
 
 // Both worker-thread-exclusive, like g_lastPolledCenterX itself.
@@ -3068,11 +3070,28 @@ void CALLBACK DragFollowPollTimerProc(HWND hwnd,
 // A thread-owned SetTimer mints a fresh id, so g_dragFollowPollTimerId has
 // to be updated alongside or teardown would kill the wrong one.
 void SetDragFollowPollInterval(UINT intervalMs) {
+    // Arm the replacement BEFORE killing the old one. Killing first and
+    // then failing to re-arm would leave no timer at all, and since this
+    // function's only repeat caller is the poll callback itself, nothing
+    // would ever run to try again - drag-follow would be silently and
+    // permanently dead for the session. Keeping the old timer on failure
+    // means the poll keeps running at the previous cadence and simply
+    // retries this switch on its next tick. The two timers overlap for
+    // the instant between these calls, which at worst costs one extra
+    // poll pass.
+    UINT_PTR newTimerId =
+        SetTimer(nullptr, 0, intervalMs, DragFollowPollTimerProc);
+    if (!newTimerId) {
+        Wh_Log(L"SetDragFollowPollInterval: SetTimer failed, error=%lu - "
+               L"keeping the current %u ms cadence",
+               GetLastError(), g_dragFollowPollCurrentMs);
+        return;
+    }
+
     if (g_dragFollowPollTimerId) {
         KillTimer(nullptr, g_dragFollowPollTimerId);
     }
-    g_dragFollowPollTimerId =
-        SetTimer(nullptr, 0, intervalMs, DragFollowPollTimerProc);
+    g_dragFollowPollTimerId = newTimerId;
     g_dragFollowPollCurrentMs = intervalMs;
 }
 

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -1702,6 +1702,14 @@ void StartWinEventHook();
 // brand-new button coming on its own.
 void ArmButtonHwndResolveTimer(DWORD delayMs);
 
+// Defined later (Mod lifecycle section, right before ButtonHwndResolveTimerProc);
+// forward-declared here so ResolvePendingButtonHwnds (below) can compute
+// and arm its own next tick at the end of a pass, on whichever thread that
+// pass actually ran on - see ResolvePendingButtonHwnds' own
+// ScheduleNextResolveTick comment for why it can't be computed by the
+// timer callback itself anymore.
+DWORD NextResolveDelayMs();
+
 // Defined later (Live drag-follow section, alongside InvalidateTaskbarLayout
 // itself); forward-declared here so EnsureTaskbarWnd (below) can install it
 // on g_hTaskbarWnd as soon as the window resolves - see
@@ -1802,12 +1810,14 @@ FrameworkElement FindTaskbarFrameRepeater(FrameworkElement anyDescendant) {
 // to run independently in RecomputeLayoutPlan, InvalidateTaskbarLayout, and
 // ResolvePendingButtonHwnds on every single call.
 //
-// A weak_ref is enough to know when to re-resolve: XAML's own visual tree
-// holds the only strong reference to the repeater, so once the taskbar's
-// tree is torn down and rebuilt (Explorer restart, a DPI/monitor change),
-// the old instance is destructed and the weak_ref naturally comes back
-// empty - exactly the signal to redo the real resolution. No separate
-// "is this still attached" check is needed on top of that.
+// A weak_ref alone isn't a reliable "still live" signal: the repeater's
+// own layout, ItemsSourceView and the animation machinery can each hold a
+// reference of their own, so if any of those outlives the taskbar's tree
+// even briefly (a taskbar recreate, a DPI/monitor change), the weak_ref
+// still resolves to a now-detached element - one with a null XamlRoot,
+// since that's only ever non-null while actually attached to a tree.
+// GetCachedTaskbarRepeater checks that explicitly below rather than
+// trusting the weak_ref by itself.
 //
 // MUST only run when confirmed to be on g_hTaskbarWnd's own thread - same
 // constraint as GetTaskbarXamlRoot itself, which this wraps.
@@ -1815,7 +1825,15 @@ winrt::weak_ref<FrameworkElement> g_cachedTaskbarRepeaterWeak;
 
 FrameworkElement GetCachedTaskbarRepeater() {
     if (FrameworkElement cached = g_cachedTaskbarRepeaterWeak.get()) {
-        return cached;
+        if (cached.XamlRoot()) {
+            return cached;
+        }
+        // Detached - see g_cachedTaskbarRepeaterWeak's comment. Every
+        // caller of this function eventually dereferences XamlRoot() (or
+        // relies on the repeater actually being the live one), so
+        // returning it anyway would be a null deref down the line rather
+        // than here. Clear it and fall through to a fresh resolution.
+        g_cachedTaskbarRepeaterWeak = nullptr;
     }
 
     XamlRoot xamlRoot = GetTaskbarXamlRoot(g_hTaskbarWnd);
@@ -1850,6 +1868,32 @@ FrameworkElement GetCachedTaskbarRepeater() {
 // Also guarded against running while nested inside an active Arrange
 // pass on this thread - defense in depth, not the primary protection.
 void ResolvePendingButtonHwnds() {
+    // Computes and arms this function's own next tick on destruction -
+    // i.e. whenever this function returns, by any path (the early-return
+    // guards below included, not just a full successful pass), always on
+    // this same thread right after this pass's own cache reads/writes are
+    // actually done. ButtonHwndResolveTimerProc used to do this itself
+    // immediately after kicking off the resolve call, which was safe only
+    // because that call used to be a blocking RunFromWindowThread marshal
+    // - now that the common path is an async PostMessage to the taskbar's
+    // subclass (see ButtonHwndResolveTimerProc), computing the delay right
+    // after posting would read g_buttonHwndCache concurrently with this
+    // function's own insert/erase calls on the taskbar thread - a real
+    // use-after-free, not just stale data. Moving the computation here
+    // closes that regardless of which path (post or the RunFromWindowThread
+    // fallback) invoked this pass.
+    struct ScheduleNextResolveTick {
+        ~ScheduleNextResolveTick() {
+            DWORD delay = NextResolveDelayMs();
+            if (delay != INFINITE) {
+                // Posts to the WinEventHook thread's own queue - safe to
+                // call unconditionally, including during unload
+                // (ArmButtonHwndResolveTimer itself no-ops on g_unloading).
+                ArmButtonHwndResolveTimer(delay);
+            }
+        }
+    } scheduleNextTick;
+
     if (g_unloading || g_inTaskbarArrangeOverride || !g_hTaskbarWnd) {
         return;
     }
@@ -2114,8 +2158,15 @@ void RecomputeLayoutPlan() {
         try {
             if (FrameworkElement repeater = GetCachedTaskbarRepeater()) {
                 for (auto& child : GetRepeaterChildElements(repeater)) {
-                    if (IsTaskListButton(child) &&
-                        !g_lastArrangedX.count(winrt::get_abi(child))) {
+                    // Map lookup first: every element the plan covers is
+                    // already a key in g_lastArrangedX, so this is a plain
+                    // hash lookup for the common case. IsTaskListButton
+                    // (winrt::get_class_name - a GetRuntimeClassName round
+                    // trip plus an HSTRING allocation) then only runs for
+                    // the rare child that isn't in the plan yet, which is
+                    // exactly the case this check exists to catch.
+                    if (!g_lastArrangedX.count(winrt::get_abi(child)) &&
+                        IsTaskListButton(child)) {
                         planCoversLiveTaskListButtons = false;
                         break;
                     }
@@ -2434,23 +2485,36 @@ void PerformTaskbarLayoutInvalidate() {
 // Private message InvalidateTaskbarLayout posts to run
 // PerformTaskbarLayoutInvalidate on the taskbar's own thread without
 // blocking the caller - see InvalidateTaskbarLayout's own comment for why
-// that matters on this specific call path.
-const UINT g_invalidateTaskbarLayoutMsg =
-    RegisterWindowMessage(L"Windhawk_InvalidateTaskbarLayout_" WH_MOD_ID);
+// that matters on this specific call path. Function-local static (like
+// RunFromWindowThread's own registered message) rather than a
+// namespace-scope variable, so RegisterWindowMessage runs lazily on first
+// real use instead of from a dynamic initializer under DllMain's loader
+// lock.
+UINT InvalidateTaskbarLayoutMsg() {
+    static const UINT msg =
+        RegisterWindowMessage(L"Windhawk_InvalidateTaskbarLayout_" WH_MOD_ID);
+    return msg;
+}
 
-// Same idea as g_invalidateTaskbarLayoutMsg, for ButtonHwndResolveTimerProc
+// Same idea as InvalidateTaskbarLayoutMsg, for ButtonHwndResolveTimerProc
 // - lets it post instead of going through RunFromWindowThread on every
 // tick (up to ~7/sec while EVENT_OBJECT_SHOW events are bursting).
-const UINT g_resolveButtonHwndsMsg =
-    RegisterWindowMessage(L"Windhawk_ResolveButtonHwnds_" WH_MOD_ID);
+UINT ResolveButtonHwndsMsg() {
+    static const UINT msg =
+        RegisterWindowMessage(L"Windhawk_ResolveButtonHwnds_" WH_MOD_ID);
+    return msg;
+}
 
 // Same idea again, for a settings change. Unlike the two above this one
 // carries a payload: lParam is a heap-allocated ModSettings* that the
 // dispatch case below takes ownership of and deletes - PostMessage is
 // asynchronous, so the settings can't just live on the posting call's own
 // stack the way a plain signal can. See ApplyLoadedSettings.
-const UINT g_settingsChangedMsg =
-    RegisterWindowMessage(L"Windhawk_SettingsChanged_" WH_MOD_ID);
+UINT SettingsChangedMsg() {
+    static const UINT msg =
+        RegisterWindowMessage(L"Windhawk_SettingsChanged_" WH_MOD_ID);
+    return msg;
+}
 
 // Installed on g_hTaskbarWnd by EnsureTaskbarWnd via
 // SetWindowSubclassFromAnyThread. A subclass proc only ever runs on the
@@ -2470,15 +2534,15 @@ LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
                                         WPARAM wParam,
                                         LPARAM lParam,
                                         DWORD_PTR dwRefData) {
-    if (uMsg == g_invalidateTaskbarLayoutMsg) {
+    if (uMsg == InvalidateTaskbarLayoutMsg()) {
         PerformTaskbarLayoutInvalidate();
         return 0;
     }
-    if (uMsg == g_resolveButtonHwndsMsg) {
+    if (uMsg == ResolveButtonHwndsMsg()) {
         ResolvePendingButtonHwnds();
         return 0;
     }
-    if (uMsg == g_settingsChangedMsg) {
+    if (uMsg == SettingsChangedMsg()) {
         auto* heapSettings = reinterpret_cast<ModSettings*>(lParam);
         g_settings = std::move(*heapSettings);
         delete heapSettings;
@@ -2516,7 +2580,7 @@ void InvalidateTaskbarLayout() {
         // below, which installs a WH_CALLWNDPROC hook and blocks in
         // SendMessage until that thread processes it - a real cost at
         // this frequency, even though it's fine for a one-shot call.
-        if (!PostMessage(g_hTaskbarWnd, g_invalidateTaskbarLayoutMsg, 0, 0)) {
+        if (!PostMessage(g_hTaskbarWnd, InvalidateTaskbarLayoutMsg(), 0, 0)) {
             Wh_Log(L"InvalidateTaskbarLayout: PostMessage failed, error=%lu",
                    GetLastError());
         }
@@ -3101,14 +3165,13 @@ void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
                                          UINT uMsg,
                                          UINT_PTR idEvent,
                                          DWORD dwTime) {
-    // Self-managing one-shot rather than a recurring interval: stop
-    // first, do the actual work, then only re-arm if there's a concrete
-    // reason to - otherwise this would run the full resolve pass forever
-    // even once everything is already resolved and nothing has changed.
-    // Runs on this thread directly now (a per-thread SetTimer with
-    // hWnd=nullptr), so no cross-thread marshal is needed to arm/disarm
-    // it - only the actual XAML work inside ResolvePendingButtonHwnds
-    // needs marshaling onto the taskbar thread.
+    // Self-managing one-shot rather than a recurring interval - stop
+    // first, kick off the resolve pass, and let that pass decide for
+    // itself whether (and when) to re-arm (see
+    // ResolvePendingButtonHwnds' ScheduleNextResolveTick), rather than
+    // running forever even once everything is resolved and nothing has
+    // changed. Runs on this thread directly (a per-thread SetTimer with
+    // hWnd=nullptr), so KillTimer here needs no cross-thread marshal.
     KillTimer(nullptr, idEvent);
     g_buttonHwndResolveTimerId = 0;
 
@@ -3117,29 +3180,30 @@ void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
     }
 
     // Prefer the subclass's non-blocking PostMessage (see
-    // g_resolveButtonHwndsMsg) - this can fire several times a second
+    // ResolveButtonHwndsMsg) - this can fire several times a second
     // during an EVENT_OBJECT_SHOW burst, the same hot-path cost
     // InvalidateTaskbarLayout avoids via PostMessage instead of
     // RunFromWindowThread's per-call hook install. Only fall back to the
     // blocking marshal in the (should stay rare) case the subclass was
-    // never successfully installed - a missed PostMessage here just means
-    // this tick's resolve is skipped, and the next scheduled tick (or the
-    // ArrangeOverride count-change path via ArmButtonHwndResolveTimer)
-    // will retry, so no fallback is needed for a PostMessage failure
-    // specifically.
+    // never successfully installed.
+    //
+    // Neither branch computes/arms the next delay here anymore -
+    // ResolvePendingButtonHwnds does that itself now, at the very end of
+    // whichever pass this triggers (see its own ScheduleNextResolveTick
+    // comment for why: computing it here, right after an async
+    // PostMessage, would read g_buttonHwndCache concurrently with that
+    // pass's own writes to it). The one case that still needs handling
+    // here is a PostMessage failure - nothing will ever call back to
+    // re-arm if the message never arrives, so retry after a fixed
+    // fallback delay rather than leaving the timer silently dead.
     if (g_taskbarWndSubclassed) {
-        if (!PostMessage(g_hTaskbarWnd, g_resolveButtonHwndsMsg, 0, 0)) {
+        if (!PostMessage(g_hTaskbarWnd, ResolveButtonHwndsMsg(), 0, 0)) {
             Wh_Log(L"ButtonHwndResolveTimerProc: PostMessage failed, "
                    L"error=%lu", GetLastError());
+            ArmButtonHwndResolveTimer(kIdleResolveTickMs);
         }
     } else {
         RunFromWindowThread(g_hTaskbarWnd, ResolvePendingButtonHwnds);
-    }
-
-    DWORD delay = NextResolveDelayMs();
-    if (!g_unloading && delay != INFINITE) {
-        g_buttonHwndResolveTimerId =
-            SetTimer(nullptr, 0, delay, ButtonHwndResolveTimerProc);
     }
 }
 
@@ -3281,10 +3345,10 @@ void ApplyLoadedSettings(ModSettings settings) {
     if (g_taskbarWndSubclassed) {
         // PostMessage is async, so the settings can't live on this
         // function's own stack - ownership transfers to the heap pointer,
-        // and TaskbarWndSubclassProc's g_settingsChangedMsg case deletes
+        // and TaskbarWndSubclassProc's SettingsChangedMsg case deletes
         // it after moving out of it.
         auto* heapSettings = new ModSettings(std::move(settings));
-        if (PostMessage(g_hTaskbarWnd, g_settingsChangedMsg, 0,
+        if (PostMessage(g_hTaskbarWnd, SettingsChangedMsg(), 0,
                         (LPARAM)heapSettings)) {
             return;
         }

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -1,7 +1,7 @@
 // ==WindhawkMod==
 // @id              taskbar-centered-start-split-icons
 // @name            Taskbar Start Button Centered Origin
-// @description     Pins the Start button to the true horizontal center of the screen, and splits running-app taskbar buttons into two groups flanking it based on which side of the screen each window is currently on (Windows 11 only)
+// @description     Pins the Start button to the true horizontal center of the screen, and splits running-app taskbar buttons into two groups flanking it based on which side of the screen each window is currently on (Windows 11 only, incompatible with "Start button always on the left")
 // @version         0.1.0
 // @author          rick
 // @github          https://github.com/rycalvo
@@ -671,6 +671,14 @@ XamlRoot GetTaskbarXamlRoot(HWND hTaskbarWnd) {
     }
 
     void* taskBand = (void*)GetWindowLongPtr(hTaskSwWnd, 0);
+    if (!taskBand) {
+        // Null while the taskband window exists but its extra data isn't
+        // populated yet (e.g. mid-creation after a taskbar recreate). This
+        // runs on every dirty arrange pass and from a periodic timer, so
+        // skipping here matters - a null deref is a raw access violation,
+        // not a C++ exception, so no try/catch in any caller can contain it.
+        return nullptr;
+    }
     void* taskBandForTaskListWndSite = taskBand;
     for (int i = 0; *(void**)taskBandForTaskListWndSite !=
                     CTaskBand_ITaskListWndSite_vftable;
@@ -966,48 +974,24 @@ HWND ResolveHwndFromTaskListButton(FrameworkElement element) {
 }
 
 // Per-button HWND cache, keyed by the XAML element's ABI pointer. Avoids
-// running the (relatively expensive) resolution chain above on every single
-// layout pass for every button - only when we don't have a cached handle, or
-// the cached one has stopped being a valid window.
+// re-running the resolution chain every pass, and negatively caches
+// failures (a pinned-but-not-running app's task group legitimately has
+// zero windows, so resolution fails until it's actually launched).
 //
-// Also negatively caches failures with a short TTL: a pinned-but-not-running
-// app's task group legitimately has zero windows, so its resolution will
-// fail forever until it's actually launched - without this, that button's
-// full multi-sentinel resolution chain gets retried on every single arrange
-// pass (confirmed via g_resolveStats climbing into the hundreds within a
-// couple of seconds for just one such button).
+// consecutiveFailures drives capped exponential backoff (2s..32s) rather
+// than a fixed retry: the resolution chain ends in a synthetic click
+// against the taskbar's real click handler, and ItemsRepeater recycles
+// the same element/cache entry for a given index rather than creating a
+// new one, so a hard stop would permanently break side-following for a
+// pinned app that's later launched. Backing off keeps retrying (worst
+// case within 32s) without hammering the click handler forever.
 //
-// consecutiveFailures drives a capped exponential backoff (2s, 4s, 8s,
-// 16s, then holding at 32s) instead of retrying at a fixed 2s interval
-// forever: the resolution chain ends with a synthetic ReportClicked call
-// against the taskbar's real internal click handler (intercepted before
-// it acts on it - see CTaskListWnd_HandleClick_Hook), and a button that
-// can genuinely never resolve (the common case, exactly the one this
-// negative cache exists for) would otherwise hammer that at a fixed 2s
-// cadence indefinitely. A hard stop after a few failures was tried first,
-// but ItemsRepeater typically recycles the same realized element (and so
-// the same cache entry) for a given index rather than creating a new one
-// - so a pinned-but-not-running app that fails a few times and is *then*
-// actually launched would never get its HWND resolved for as long as
-// that element stays realized, silently breaking the mod's own headline
-// feature (side-following) for that button. Backing off instead of
-// stopping keeps retrying, just less often, so a later launch is still
-// picked up (worst case within 32s) without hammering the click handler
-// at a fixed rate forever. A live element that's simply slow to resolve
-// still gets the fast early retries, since the counter only advances on
-// an actual failure and resets to 0 on the first success.
-//
-// identity (the button's accessible name at the time it was last resolved)
-// guards against a different staleness case entirely: ItemsRepeater can
-// rebind an already-realized element to a *different* item (e.g. the user
-// drag-reorders two running apps' buttons) rather than destroying and
-// recreating it. Without a way to notice that, a cache entry keyed by the
-// element's ABI pointer would keep reporting the OLD item's HWND for the
-// element's new identity indefinitely - the "hwnd is still a valid window"
-// check alone can't catch this, since the old HWND is still alive, just no
-// longer what this element represents. ResolvePendingButtonHwnds compares
-// the live accessible name against this on every check and forces a
-// re-resolve on a mismatch.
+// identity (the button's accessible name at resolve time) catches a
+// different case: ItemsRepeater can rebind an already-realized element
+// to a different item (e.g. a drag-reorder) without destroying it. The
+// old HWND stays valid, just no longer this element's, so an IsWindow()
+// check alone can't detect it - ResolvePendingButtonHwnds compares
+// identity on every check and forces a re-resolve on mismatch.
 struct ButtonHwndCacheEntry {
     HWND hwnd = nullptr;
     std::wstring identity;
@@ -1097,18 +1081,32 @@ struct WindowClassification {
 std::unordered_map<HWND, WindowClassification> g_lastKnownWindowClassification;
 
 WindowClassification ClassifyByWindowPositionCached(HWND hwnd) {
+    RECT wr;
+    HMONITOR mon = MonitorFromWindow(g_hTaskbarWnd, MONITOR_DEFAULTTOPRIMARY);
+    MONITORINFO mi{.cbSize = sizeof(mi)};
+
     if (IsIconic(hwnd)) {
         auto it = g_lastKnownWindowClassification.find(hwnd);
         if (it != g_lastKnownWindowClassification.end()) {
             return it->second;
         }
-        return {ResolveUnresolvedAppsDefaultSide()};
-    }
 
-    RECT wr;
-    HMONITOR mon = MonitorFromWindow(g_hTaskbarWnd, MONITOR_DEFAULTTOPRIMARY);
-    MONITORINFO mi{.cbSize = sizeof(mi)};
-    if (!hwnd || !GetWindowRect(hwnd, &wr) || !GetMonitorInfo(mon, &mi)) {
+        // No prior classification to freeze at - this window has been
+        // minimized since before we ever saw it (e.g. an app that
+        // auto-launches straight to a minimized/tray state, common among
+        // startup apps right after login). GetWindowPlacement's
+        // rcNormalPosition still reports the window's restored position
+        // while minimized (unlike GetWindowRect, which is why the branch
+        // above exists at all - it returns nonsense off-screen
+        // coordinates for a minimized window), so this can classify it
+        // correctly on first sight instead of permanently defaulting.
+        WINDOWPLACEMENT wp{.length = sizeof(wp)};
+        if (!hwnd || !GetWindowPlacement(hwnd, &wp) ||
+            !GetMonitorInfo(mon, &mi)) {
+            return {ResolveUnresolvedAppsDefaultSide()};
+        }
+        wr = wp.rcNormalPosition;
+    } else if (!hwnd || !GetWindowRect(hwnd, &wr) || !GetMonitorInfo(mon, &mi)) {
         return {ResolveUnresolvedAppsDefaultSide()};
     }
 
@@ -1248,25 +1246,19 @@ double FullFootprintWidth(FrameworkElement element) {
 }
 
 // Search, Task View and Widgets can each be individually hidden/shown
-// (settings, or Windows' own adaptive behavior), using a negative-margin
-// collapse trick - ActualWidth() includes that margin, so it never drops
-// below the collapsed width and grows on every layout pass once a
-// transition starts. Confirmed against taskbar-start-button-position.wh.cpp,
-// which hits the identical problem for these same button types and fixes
-// it the same way: read the content child's DesiredSize instead, which
-// doesn't depend on the button's own margin (falls back to ActualWidth()
-// if there's no realized child yet, matching that mod exactly).
+// using a negative-margin collapse trick - ActualWidth() includes that
+// margin, so it never drops below the collapsed width and grows on every
+// layout pass once a transition starts. Reads the content child's
+// DesiredSize instead (falls back to ActualWidth() if no child is
+// realized yet), matching taskbar-start-button-position.wh.cpp's fix for
+// the same problem on the same button types.
 //
-// Deliberately NOT used for Start (see g_lastStartWidth's own read site)
-// or task list buttons (ordinary app icons, see FullFootprintWidth
-// above): Start is never hidden/shown the way these three can be, so it
-// was never actually exposed to the collapse-margin bug this exists to
-// fix, and applying this technique to it anyway was confirmed via live
-// testing to understate Start's true width - its own visual-tree
-// structure isn't necessarily the same shape this technique was
-// validated against. Task list buttons have no evidence of the same
-// collapse-margin mechanism either, and changing their much more heavily
-// used width source without that evidence isn't worth the risk.
+// Deliberately NOT used for Start or task list buttons: Start is never
+// hidden/shown, so it was never exposed to this bug, and swapping its
+// width source anyway understated its true width (see the Start-width
+// comment in RecomputeLayoutPlan). Task list buttons have no evidence of
+// the same collapse-margin mechanism, and they're this file's hottest
+// path.
 double SystemButtonContentWidth(FrameworkElement element) {
     if (Media::VisualTreeHelper::GetChildrenCount(element) > 0) {
         auto child = Media::VisualTreeHelper::GetChild(element, 0)
@@ -1353,31 +1345,18 @@ int SystemButtonRank(SystemButton b) {
 }
 
 // Total footprint of Search+TaskView+Widgets together, used both to lay
-// them out and to reserve room for them next to Start (in adjacent mode) so
-// task list buttons on that side don't overlap them. Computed once per
-// pass in RecomputeLayoutPlan (from the already-enumerated `children`) and
-// written here unconditionally on every pass - not as a side effect of
-// ComputeSystemButtonX running for a realized system button, which was the
-// previous approach and had a real bug: if none of the three are currently
-// realized in the repeater (all hidden, or a session that starts with them
-// hidden), ComputeSystemButtonX never ran and these kept whatever value an
-// earlier configuration left behind, permanently reserving that much dead
-// space next to Start in "adjacent" mode. Zero when the cluster is
-// genuinely empty now, always.
+// them out and to reserve room for them next to Start (in adjacent mode).
+// Computed unconditionally every RecomputeLayoutPlan pass so an empty
+// cluster (all three hidden) reads as genuinely 0 rather than keeping a
+// stale nonzero value that would permanently reserve dead space.
 double g_lastLeftSystemClusterWidth = 0;
 double g_lastRightSystemClusterWidth = 0;
 
-// A repeater child element paired with its SystemButton classification,
-// computed once per child per RecomputeLayoutPlan pass instead of
-// re-deriving IdentifySystemButton
-// (a winrt::get_class_name call - IInspectable::GetRuntimeClassName plus
-// an HSTRING allocation) every time it's needed. Previously recomputed up
-// to 4 times per child per pass: once each in the Start-finding, cluster-
-// width, and system-button-placement loops, plus once per child *again*
-// inside ComputeSystemButtonX's own widthBefore loop for every realized
-// system button (itself also re-walking the repeater via
-// GetRepeaterChildElements instead of reusing what RecomputeLayoutPlan
-// already enumerated).
+// A repeater child paired with its SystemButton classification, computed
+// once per child per RecomputeLayoutPlan pass and reused across the
+// Start-finding, cluster-width, and system-button-placement loops rather
+// than re-deriving IdentifySystemButton (a winrt::get_class_name call)
+// separately in each.
 struct ChildInfo {
     FrameworkElement element;
     SystemButton systemButton;
@@ -1463,30 +1442,27 @@ struct TaskListPlanEntry {
 //
 // Every entry is always written into outPlan and stays in this mod's own
 // coordinate system, never falling through to native Arrange even when a
-// side overflows: Start's position is forced to true screen-center by
-// this mod's own hook regardless of what any individual task list button
-// does, and native's layout algorithm has no knowledge of that - mixing
-// forced-position elements with native-position elements in the same
-// pass produces a visually incoherent overlap. Instead, a side that
-// doesn't fit gets its inter-icon spacing proportionally compressed
-// (icons still render at natural width, so they visually overlap each
-// other once genuinely crowded). leftBoundLocal/rightBoundLocal are the
-// outer edges (local DIPs, same space as startCenterX) each side's group
-// is compressed to fit within - leftBoundLocal is the taskbar's left
-// edge, pushed right by the Search/Task View/Widgets cluster's width in
-// "far left" placement mode; rightBoundLocal is the system tray's own
-// left edge (see RecomputeLayoutPlan's comment), falling back to the
-// taskbar's own outer edge if the tray element can't be found this pass.
+// side overflows: Start is forced to true screen-center regardless, and
+// native's layout has no knowledge of that, so mixing forced- and
+// native-position elements in the same pass produces a visually
+// incoherent overlap. Instead, an overflowing side's inter-icon spacing
+// is proportionally compressed (icons still render at natural width, so
+// they overlap each other once genuinely crowded).
+// leftBoundLocal/rightBoundLocal are the outer edges (local DIPs) each
+// side compresses to fit within - leftBoundLocal is the taskbar's left
+// edge pushed right by the Search/Task View/Widgets cluster in "far
+// left" mode; rightBoundLocal is the system tray's left edge (see
+// RecomputeLayoutPlan), falling back to the taskbar's own edge if the
+// tray can't be resolved.
 //
-// Every side is walked innermost-first, starting exactly at Start's own
-// edge (minus gap) and moving outward. The Start-overlap guarantee: the
-// innermost icon's edge *facing Start* must sit at that fixed,
-// bound-independent reference point regardless of scale, so each icon's
-// own placement uses its unscaled width - only the running reference
-// point handed to the *next* icon advances by the scaled amount. Scaling
-// the placement itself (not just the step to the next icon) looks
-// equivalent at scale=1 but drifts the innermost icon into Start as
-// compression increases - do not reintroduce that.
+// Every side is walked innermost-first from Start's own edge outward.
+// The Start-overlap guarantee: the innermost icon's edge facing Start
+// sits at that fixed reference point regardless of scale, since each
+// icon's own placement uses its unscaled width - only the running
+// reference point handed to the next icon advances by the scaled
+// amount. Scaling the placement itself instead looks equivalent at
+// scale=1 but drifts the innermost icon into Start as compression
+// increases - do not reintroduce that.
 void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
                          double startCenterX,
                          double leftBoundLocal,
@@ -1581,27 +1557,18 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
     }
 
     // Scale <1 compresses inter-icon spacing (not each icon's own
-    // rendered width, which this mod never touches) so the outermost
-    // icon's own position never passes leftBoundLocal/rightBoundLocal,
-    // at the cost of consecutive icons visually overlapping each other
-    // once a side is genuinely too full to fit at natural spacing. A
-    // side with plenty of room keeps scale at 1 (identical to natural,
-    // uncompressed spacing).
+    // rendered width) so the outermost icon's own edge never passes
+    // leftBoundLocal/rightBoundLocal, at the cost of icons overlapping
+    // each other once a side is too full for natural spacing. A side
+    // with plenty of room keeps scale at 1.
     //
     // The outermost icon's own width (left.back()/right.back() - the
-    // walk loop below always processes them last, regardless of sort
-    // order) is deliberately excluded from both the total and the
-    // available space fed into the ratio. That icon is placed at its
-    // own full, unscaled width with nothing beyond it to compress
-    // against (mirroring the innermost icon's exact placement against
-    // Start - see the walk loop's own comment), so folding its width
-    // into the same pool as the compressible pitches double-counted it:
-    // once inside the ratio, again in full at the final placement. That
-    // under-compressed every pitch just enough for the outermost icon's
-    // own edge to overshoot the bound by width*(1-scale) - confirmed
-    // live as running-app icons overlapping the far-left system buttons
-    // (Task View), while Start itself was never overlapped since the
-    // innermost-icon side of this class of bug was already fixed.
+    // walk loop below always processes them last) is excluded from both
+    // the total and the available space fed into the ratio: that icon is
+    // placed at full, unscaled width with nothing beyond it to compress
+    // against, so folding its width into the compressible pool would
+    // double-count it and let its own edge overshoot the bound by
+    // width*(1-scale).
     double leftAvailable = leftInnerX - leftBoundLocal;
     double leftScale = 1.0;
     if (!left.empty() && leftTotal > leftAvailable) {
@@ -1623,19 +1590,12 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
                          : 1.0;
     }
 
-    // The innermost icon's position is placed using its own *unscaled*
-    // width (x - entry->width, not x - entry->width * leftScale) so its
-    // right edge lands exactly at leftInnerX regardless of scale - only
-    // x itself (the reference point carried to the *next* icon) advances
-    // by the scaled amount. An earlier version scaled the position too
-    // (x -= entry->width * leftScale; outPlan[...] = x), which is exactly
-    // right at scale=1 but drifts the innermost icon's right edge into
-    // Start by width*(1-scale) as compression increases - the exact
-    // Start-overlap this whole mechanism exists to prevent, caught by
-    // review rather than by testing since the two live-tested overflow
-    // scenarios both happened to stress the right side (which never had
-    // this bug - its innermost icon is placed at the unscaled rightInnerX
-    // directly, with no equivalent subtraction to get wrong).
+    // Each icon's own placement uses its unscaled width (x - entry->width,
+    // not x - entry->width * leftScale), so the innermost icon's edge
+    // lands exactly at leftInnerX/rightInnerX regardless of scale - only
+    // x itself (the reference point carried to the next icon) advances by
+    // the scaled amount. Scaling the placement itself instead would drift
+    // the innermost icon into Start as compression increases.
     double x = leftInnerX;
     for (auto* entry : left) {
         outPlan[winrt::get_abi(entry->element)] = x - entry->width;
@@ -1783,6 +1743,15 @@ void ResolvePendingButtonHwnds() {
 
         auto it = g_buttonHwndCache.find(key);
         bool needsResolve = it == g_buttonHwndCache.end();
+        if (needsResolve) {
+            // A brand-new button in the live set - even if it fails to
+            // resolve an HWND right away (e.g. a just-pinned app with no
+            // window yet), its mere appearance means g_lastArrangedX has
+            // no entry for it and the plan needs rebuilding regardless of
+            // whether ResolveAndCacheButtonHwnd's own HWND-changed check
+            // fires below.
+            anyChanged = true;
+        }
         if (!needsResolve) {
             if (it->second.hwnd) {
                 // Identity mismatch means ItemsRepeater rebound this
@@ -1816,9 +1785,15 @@ void ResolvePendingButtonHwnds() {
     // every ArrangeOverride pass, so a stale entry there can never
     // outlive one pass regardless.
     for (auto it = g_buttonHwndCache.begin(); it != g_buttonHwndCache.end();) {
-        it = liveTaskListButtons.find(it->first) == liveTaskListButtons.end()
-                 ? g_buttonHwndCache.erase(it)
-                 : std::next(it);
+        if (liveTaskListButtons.find(it->first) == liveTaskListButtons.end()) {
+            // A button disappeared (unpin, app close) - its old absolute X
+            // in g_lastArrangedX would otherwise sit stale (nothing else
+            // occupies that slot), leaving a hole where it used to be.
+            it = g_buttonHwndCache.erase(it);
+            anyChanged = true;
+        } else {
+            it = std::next(it);
+        }
     }
 
     // Same idea one level up: g_lastKnownWindowClassification is keyed by
@@ -1856,34 +1831,33 @@ std::unordered_map<void*, double> g_lastArrangedX;
 
 // Set whenever something might have changed that g_lastArrangedX doesn't
 // reflect yet - every InvalidateTaskbarLayout call covers every real
-// trigger this mod has (see its own top-of-function write): a window
-// moving, a button's HWND/side resolving, the ArrangeOverride hook's own
-// button-count-change check, a settings change, and mod startup. Starts
-// true so the very first ArrangeOverride pass always computes a real
-// plan rather than reusing an empty one. RecomputeLayoutPlan clears it
-// only after a genuinely successful recompute - left set on an exception
-// so a later pass retries rather than silently freezing on a broken or
-// incomplete plan. atomic: InvalidateTaskbarLayout can be called from
-// threads other than the taskbar's own (the dedicated WinEventHook
-// thread registers WinEventProc there, for one), while
-// RecomputeLayoutPlan only ever reads/clears this from the taskbar
-// thread itself (guarded the same way the rest of that function already
-// is).
+// trigger (a window moving, a button's HWND/side resolving, the
+// ArrangeOverride hook's button-count-change check, a settings change,
+// mod startup). Starts true so the first ArrangeOverride pass always
+// computes a real plan. RecomputeLayoutPlan clears it only after a
+// genuinely successful recompute - left set on an exception so a later
+// pass retries rather than freezing on a broken plan. atomic: it can be
+// set from threads other than the taskbar's own (the dedicated
+// WinEventHook thread, for one), while RecomputeLayoutPlan only ever
+// reads/clears it from the taskbar thread itself.
 //
-// Previously this whole function - a taskbar.dll vtable scan and
-// TaskbarHost::FrameHeight prologue parse to reach the XamlRoot, a
-// VisualTreeHelper walk down to the repeater, a TryGetElement and
-// winrt::get_class_name per child - ran unconditionally on every single
-// ArrangeOverride pass, for every taskbar (primary and any
-// secondary-monitor ones, since they share the primary's own thread and
-// so pass the apartment-safety check this function already needed
-// regardless). This flag removes nearly all of that cost on the (very
-// common) passes where nothing this mod cares about actually changed,
-// without touching the plan-computation logic itself - it's a pure
-// short-circuit around code whose correctness properties have already
-// been fought for across several crash-debugging sessions, not a rewrite
-// of it.
+// This flag skips RecomputeLayoutPlan's full traversal (a taskbar.dll
+// vtable scan, a VisualTreeHelper walk, a classification per child) on
+// the very common passes where nothing this mod cares about changed -
+// a pure short-circuit around already-correct plan-computation logic,
+// not a rewrite of it.
 std::atomic<bool> g_planDirty{true};
+
+// Staleness backstop for g_planDirty: some real triggers for a layout
+// change (Search/Task View/Widgets visibility, taskbar geometry/DPI/
+// monitor changes, a button appearing/disappearing between two dirty
+// passes with nothing else invalidating in between) aren't guaranteed to
+// call InvalidateTaskbarLayout. Rather than track every such trigger
+// individually, RecomputeLayoutPlan forces a real recompute at least this
+// often regardless of g_planDirty, bounding how long the plan can disagree
+// with reality instead of only reacting to known triggers.
+constexpr ULONGLONG kMaxPlanStalenessMs = 500;
+ULONGLONG g_lastPlanRecomputeTick;
 
 // Diagnostics only, for IUIElement_Arrange_Hook's own per-call work
 // (distinct from LayoutPlanStats, which covers RecomputeLayoutPlan's
@@ -1914,20 +1888,14 @@ HRESULT WINAPI IUIElement_Arrange_Hook(void* pThis,
     }
 
     // This hook replaces the process-wide IUIElement::Arrange vtable slot,
-    // so it's invoked directly by XAML's own native call sites for every
-    // UIElement being arranged anywhere in explorer.exe - a raw ABI
-    // boundary with no C++/WinRT exception translation on the other side.
-    // A WinRT call throwing here (observed via a real crash: explorer.exe
-    // faulting in Windows.UI.Xaml.dll with STATUS_STOWED_EXCEPTION,
-    // 0xC000027B, at enabling a second monitor - a fresh secondary-taskbar
-    // XAML tree briefly has elements with no parent yet mid-construction,
-    // and .as<T>() throws on a null source where .try_as<T>() would just
-    // return null) crosses that boundary uncaught and fail-fasts the whole
-    // process. Catch anything and fall back to the real implementation
-    // rather than let that happen again. The QueryInterface below is the
-    // only WinRT call left in this function - everything else is a plain
-    // map lookup - so this net is mostly a leftover safety margin at this
-    // point rather than something expected to actually catch anything.
+    // invoked by XAML's own native call sites for every UIElement in
+    // explorer.exe - a raw ABI boundary with no C++/WinRT exception
+    // translation on the other side. A WinRT call throwing here crosses
+    // that boundary uncaught and fail-fasts the whole process (previously
+    // hit via .as<T>() throwing on a null source during a fresh
+    // secondary-monitor tree's construction). The QueryInterface below is
+    // the only WinRT call left in this function - everything else is a
+    // plain map lookup - so this net is mostly a leftover safety margin.
     try {
         g_passStats.totalArrangeCalls++;
 
@@ -1958,28 +1926,24 @@ HRESULT WINAPI IUIElement_Arrange_Hook(void* pThis,
 // Builds the complete layout plan in a single top-down pass over the
 // PRIMARY taskbar's own repeater - every Start/system-button/task-list-
 // button's target X, written into g_lastArrangedX - called from
-// TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook BEFORE it calls
-// into XAML's own ArrangeOverride, i.e. before any nested Arrange calls
-// (and so IUIElement_Arrange_Hook above) run at all for this pass - see
+// TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook BEFORE XAML's
+// own ArrangeOverride, i.e. before any nested Arrange calls (and so
+// IUIElement_Arrange_Hook) run at all this pass - see
 // g_inTaskbarArrangeOverride's comment for why that ordering matters.
 //
-// Rebuilds g_lastArrangedX from scratch every real recompute rather than
-// updating incrementally, so a destroyed element's stale entry can never
-// outlive it - no separate pruning pass needed for this map, unlike
-// g_buttonHwndCache/g_lastKnownWindowClassification (populated
-// independently by the HWND-resolve timer - see ResolvePendingButtonHwnds
-// for why those still need explicit pruning).
+// Rebuilds g_lastArrangedX from scratch every recompute, so a destroyed
+// element's stale entry can never outlive it - no pruning pass needed
+// here, unlike g_buttonHwndCache/g_lastKnownWindowClassification (see
+// ResolvePendingButtonHwnds for why those need it).
 //
 // MUST only run when confirmed to be on g_hTaskbarWnd's own thread:
-// GetTaskbarXamlRoot(g_hTaskbarWnd) reaches across to the PRIMARY's XAML
-// object specifically, an unsafe unmarshaled cross-apartment WinRT call
-// from any other thread. Shell_TrayWnd and Shell_SecondaryTrayWnd both
-// run on the SAME Explorer UI thread, so this check passes for
-// secondary-monitor ArrangeOverride passes too - harmless either way,
+// GetTaskbarXamlRoot reaches the PRIMARY's XAML object specifically, an
+// unsafe unmarshaled cross-apartment call from any other thread.
+// Shell_TrayWnd and Shell_SecondaryTrayWnd share one Explorer UI thread,
+// so this check also passes for secondary-monitor passes - harmless,
 // since secondary-monitor elements never end up in g_lastArrangedX
-// regardless (this function only ever walks the primary's own
-// repeater); the check exists purely as the apartment-safety guard, not
-// a monitor-scoping mechanism.
+// regardless; the check is purely the apartment-safety guard, not a
+// monitor-scoping mechanism.
 void RecomputeLayoutPlan() {
     if (!g_hTaskbarWnd) {
         return;
@@ -1988,9 +1952,11 @@ void RecomputeLayoutPlan() {
     if (primaryThreadId == 0 || primaryThreadId != GetCurrentThreadId()) {
         return;
     }
-    if (!g_planDirty) {
+    if (!g_planDirty &&
+        GetTickCount64() - g_lastPlanRecomputeTick < kMaxPlanStalenessMs) {
         return;
     }
+    g_lastPlanRecomputeTick = GetTickCount64();
 
     g_planStats = {};
 
@@ -2023,37 +1989,35 @@ void RecomputeLayoutPlan() {
         // pass by the time they run, not the previous one.
         for (auto& info : childInfos) {
             if (info.systemButton == SystemButton::Start) {
-                // Deliberately bare ActualWidth() here, NOT
-                // SystemButtonContentWidth - confirmed via live testing
-                // that swapping this specific read to the content-child's
-                // DesiredSize() (done for Search/Task View/Widgets below,
-                // where it's genuinely needed) caused task list icons to
-                // visibly render on top of Start's own icon on the side
-                // that pushes toward it, meaning the content child's
-                // DesiredSize understates Start's true width - Start's own
-                // visual-tree structure isn't necessarily the same shape
-                // that technique was validated against. ActualWidth()'s
-                // collapse-margin growth problem (see
-                // SystemButtonContentWidth's comment) is specific to
-                // elements that actually get hidden/shown - Start never
-                // is, unlike Search/Task View/Widgets, so it was never
-                // actually exposed to that bug in the first place. Four
-                // full rounds of live testing never reported a Start-width
-                // problem before this specific swap was tried.
+                // Deliberately bare ActualWidth(), NOT
+                // SystemButtonContentWidth: Start is never hidden/shown
+                // the way Search/Task View/Widgets are, so it was never
+                // exposed to ActualWidth()'s collapse-margin growth
+                // problem (see SystemButtonContentWidth's comment) -
+                // swapping to the content child's DesiredSize() here
+                // instead understated Start's true width, since Start's
+                // own visual-tree shape doesn't match what that technique
+                // was validated against.
                 //
-                // ActualWidth() still reflects the previous arrange pass,
-                // and is 0 for a just-realized element - a freshly
-                // (re)created Start button would otherwise briefly clobber
-                // g_lastStartWidth to 0 and lay out the entire taskbar
-                // around a zero-width Start for that pass. Keep the last
-                // known-good width instead; it'll catch up to the real one
-                // within a pass or two.
+                // ActualWidth() still reflects the previous arrange pass
+                // and is 0 for a just-realized element, so
+                // g_lastStartWidth only updates when it's actually
+                // positive - a freshly (re)created Start button keeps the
+                // last known-good width instead of collapsing the whole
+                // taskbar around a zero-width Start for one pass.
                 double w = info.element.ActualWidth();
                 if (w > 0) {
                     g_lastStartWidth = w;
                 }
+                // The X handed to Arrange sets the layout slot's left
+                // edge; XAML then insets the rendered content by the
+                // element's own Margin.Left. Without subtracting it here,
+                // Start's rendered icon centers at startCenterX +
+                // Margin.Left instead of true screen-center - a no-op
+                // when the margin happens to be 0, but wrong otherwise.
                 newPlan[winrt::get_abi(info.element)] =
-                    startCenterX - g_lastStartWidth / 2.0;
+                    startCenterX - info.element.Margin().Left -
+                    g_lastStartWidth / 2.0;
                 break;
             }
         }
@@ -2696,38 +2660,37 @@ void StartWinEventHook() {
 // (The WinEventHook itself no longer goes through this - see
 // StopWinEventHook, which owns its thread outright instead.)
 bool RunFromWindowThreadWithRetry(HWND hWnd, RunFromWindowThreadProc_t proc) {
-    for (int attempt = 0; attempt < 3; attempt++) {
-        if (RunFromWindowThread(hWnd, proc)) {
-            return true;
-        }
+    // Unbounded, not capped at a few attempts: giving up early and letting
+    // the caller log-and-continue would leave a WM_TIMER registration
+    // pointing at this module's code after Wh_ModUninit returns and
+    // Windhawk unmaps it - a deferred crash, not a mitigated one. Only
+    // stop retrying once the target thread is confirmed gone, since at
+    // that point the OS has already torn down anything it owned.
+    while (!RunFromWindowThread(hWnd, proc)) {
         if (GetWindowThreadProcessId(hWnd, nullptr) == 0) {
-            break;
+            return false;
         }
         Sleep(20);
     }
-    return false;
+    return true;
 }
 
 // Unlike the RunFromWindowThread-based teardowns below (which depend on
 // g_hTaskbarWnd's thread still being alive and responsive), this thread is
 // entirely mod-owned: PostThreadMessage can't silently fail the way a
 // marshaled call onto someone else's thread can, and waiting for the
-// thread to actually exit (rather than just requesting it) guarantees
-// UnhookWinEvent has already run, on the thread that registered it, by
-// the time this returns - before Windhawk unmaps this module's code.
+// thread to actually exit guarantees UnhookWinEvent has already run
+// before Windhawk unmaps this module's code.
 void StopWinEventHook() {
     if (!g_winEventThread) {
         return;
     }
 
-    // WinEventHookThreadProc's own first action creates its message
-    // queue via PeekMessage before doing anything else (see its
-    // comment), but there's still a small window right after
-    // CreateThread returns where the new thread hasn't run that yet -
-    // PostThreadMessage fails with ERROR_INVALID_THREAD_ID in that
-    // window, and StartWinEventHook is called lazily from
-    // EnsureTaskbarWnd, so thread creation isn't necessarily far from
-    // teardown. Retry briefly to bridge that narrow gap.
+    // PostThreadMessage fails with ERROR_INVALID_THREAD_ID if the new
+    // thread hasn't created its message queue yet (WinEventHookThreadProc
+    // does that as its first action) - StartWinEventHook is called lazily
+    // from EnsureTaskbarWnd, so teardown isn't necessarily far behind
+    // thread creation. Retry briefly to bridge that gap.
     for (int attempt = 0; attempt < 50; attempt++) {
         if (PostThreadMessage(g_winEventThreadId, WM_APP, 0, 0)) {
             break;
@@ -2735,14 +2698,9 @@ void StopWinEventHook() {
         Sleep(10);
     }
 
-    // Unconditional wait, not a bounded timeout - an earlier version
-    // gave up after 2s and returned anyway, which meant Wh_ModUninit
-    // could return, Windhawk unmaps this module's code via FreeLibrary
-    // right after, and the still-running thread's next instruction
-    // (its own return address, still inside this module's
-    // WinEventHookThreadProc) is now unmapped memory - a deferred
-    // crash, not a mitigated one. Matches the established teardown
-    // shape in taskbar-background-helper.wh.cpp.
+    // Unconditional wait, not a bounded timeout: giving up early would let
+    // Wh_ModUninit return and Windhawk unmap this module's code while the
+    // thread is still inside it - a deferred crash, not a mitigated one.
     WaitForSingleObject(g_winEventThread, INFINITE);
 
     CloseHandle(g_winEventThread);
@@ -2760,12 +2718,12 @@ constexpr UINT_PTR kButtonHwndResolveTimerId = 0x8C3F;
 
 // Idle re-check cadence once every cached button is already resolved -
 // see NextResolveDelayMs' comment for what this specifically exists to
-// catch. Deliberately not as tight as the 2s..32s backoff used for
-// buttons that still need resolving - this only ever runs
-// ResolvePendingButtonHwnds' comparison against already-known-good
-// state, not the (much more expensive, and the one actually worth
-// keeping rare) click-sentinel resolution chain.
-constexpr DWORD kIdleResolveTickMs = 8000;
+// catch (a drag-reorder rebind, which isn't latency-sensitive). Kept
+// well above the 2s..32s backoff used for buttons that still need
+// resolving: even at idle, each tick still resolves the taskbar's
+// XamlRoot and walks its visual tree on Explorer's UI thread, and this
+// runs indefinitely for the life of the session.
+constexpr DWORD kIdleResolveTickMs = 30000;
 
 // How long until the next resolve attempt could possibly do anything
 // useful, based only on g_buttonHwndCache's already-recorded state - no
@@ -2880,8 +2838,9 @@ void StopButtonHwndResolveTimer() {
         return;
     }
 
-    // See RunFromWindowThreadWithRetry's own comment for why a bounded
-    // retry rather than an inline KillTimer from the wrong thread here.
+    // See RunFromWindowThreadWithRetry's own comment for why this retries
+    // until success or a confirmed-dead thread, rather than an inline
+    // KillTimer from the wrong thread here.
     if (!RunFromWindowThreadWithRetry(g_hTaskbarWnd, [] {
             KillTimer(g_hTaskbarWnd, kButtonHwndResolveTimerId);
         })) {
@@ -2910,8 +2869,14 @@ BOOL Wh_ModInit() {
 
         HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
         auto pKernelBaseLoadLibraryExW =
-            (decltype(&LoadLibraryExW))GetProcAddress(kernelBaseModule,
-                                                       "LoadLibraryExW");
+            kernelBaseModule
+                ? (decltype(&LoadLibraryExW))GetProcAddress(
+                      kernelBaseModule, "LoadLibraryExW")
+                : nullptr;
+        if (!pKernelBaseLoadLibraryExW) {
+            Wh_Log(L"Failed to resolve kernelbase.dll!LoadLibraryExW");
+            return FALSE;
+        }
         WindhawkUtils::SetFunctionHook(pKernelBaseLoadLibraryExW,
                                        LoadLibraryExW_Hook,
                                        &LoadLibraryExW_Original);
@@ -2945,22 +2910,16 @@ void Wh_ModBeforeUninit() {
 
     g_unloading = true;
 
-    // Deliberately NOT tearing down the WinEventHook thread/timer here -
-    // this mod's own hooks (IUIElement_Arrange_Hook,
-    // TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook) stay
-    // installed until this function *returns*, and ArrangeOverride isn't
-    // itself gated on g_unloading. If StopWinEventHook/
-    // StopButtonHwndResolveTimer ran here and a pass landed in the
-    // window before this function returns, EnsureTaskbarWnd could still
-    // call StartWinEventHook/StartButtonHwndResolveTimer again (if
-    // g_hTaskbarWnd somehow wasn't set yet) or the count-change branch
-    // could call ArmButtonHwndResolveTimer(0) - either creates a brand
-    // new thread/timer nobody would ever tear down, since Wh_ModUninit
-    // runs after this. This call still needs the Arrange hook alive
-    // (it's what restores native positioning), so it has to happen while
-    // the hooks are still installed - the actual teardown of the
-    // thread/timer that could otherwise be reawakened waits for
-    // Wh_ModUninit, after Windhawk has removed the hooks.
+    // Deliberately NOT tearing down the WinEventHook thread/timer here:
+    // this mod's hooks stay installed until this function returns, and
+    // ArrangeOverride isn't gated on g_unloading - a pass landing in that
+    // window could still call StartWinEventHook/StartButtonHwndResolveTimer
+    // (via EnsureTaskbarWnd) or ArmButtonHwndResolveTimer(0) (the
+    // count-change branch), creating a thread/timer nobody would tear
+    // down since Wh_ModUninit runs after this. This call still needs the
+    // Arrange hook alive to restore native positioning, so it has to run
+    // while the hooks are installed - actual teardown waits for
+    // Wh_ModUninit, after Windhawk has removed them.
     InvalidateTaskbarLayout();
 }
 

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -222,7 +222,6 @@ community.
 #include <algorithm>
 #include <atomic>
 #include <cmath>
-#include <cwctype>
 #include <functional>
 #include <iterator>
 #include <limits>
@@ -721,9 +720,10 @@ thread_local void* g_clickSentinel_TaskGroup;
 // Latched per path (item vs. group), not one shared flag, since the two
 // paths reach CTaskListWnd::HandleClick through different internal call
 // chains and a Windows update could break just one. Requires
-// kClickSentinelMissesBeforeBroken consecutive misses before latching
-// "broken" (not just one - see NoteUnconfirmedClickSentinelMiss for why),
-// and that bound only holds pre-confirmation - see RATIONALE.md.
+// kClickSentinelMissesBeforeBroken cumulative misses (the counter is never
+// reset) before latching "broken" (not just one - see
+// NoteUnconfirmedClickSentinelMiss for why), and that bound only holds
+// pre-confirmation - see RATIONALE.md.
 std::atomic<bool> g_clickSentinelItemConfirmed;
 std::atomic<bool> g_clickSentinelItemBroken;
 std::atomic<int> g_clickSentinelItemMisses;
@@ -1074,6 +1074,17 @@ std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
 std::atomic<bool> g_forceResolveUnresolved;
 constexpr int kMaxForcedRetryFailures = 3;
 
+// Caps the per-entry backoff retry itself (not just the force-bypass
+// above) - without this, a button whose interception path is genuinely,
+// permanently broken (e.g. a future Windows update routes it through a
+// different internal handler while the rest of the taskbar still reaches
+// CTaskListWnd::HandleClick, so the click-sentinel latch itself never
+// trips) would keep dispatching a real ReportClicked on this entry every
+// ResolveBackoffMs interval, forever. A button whose identity changes, or
+// that gets pruned and recreated, still gets a fresh consecutiveFailures
+// count and resumes retrying normally.
+constexpr int kMaxResolveFailures = 8;
+
 // The HWNDs g_buttonHwndCache currently resolves to, rebuilt at the end of
 // every successful ResolvePendingButtonHwnds pass and read by WinEventProc
 // (a different thread) to filter drag-follow's LOCATIONCHANGE events.
@@ -1167,8 +1178,7 @@ WindowClassification ClassifyByWindowPositionCached(HWND hwnd) {
         // reports the restored position while minimized (unlike
         // GetWindowRect).
         WINDOWPLACEMENT wp{.length = sizeof(wp)};
-        if (!hwnd || !GetWindowPlacement(hwnd, &wp) ||
-            !GetMonitorInfo(mon, &mi)) {
+        if (!GetWindowPlacement(hwnd, &wp) || !GetMonitorInfo(mon, &mi)) {
             return {ResolveUnresolvedAppsDefaultSide()};
         }
         wr = wp.rcNormalPosition;
@@ -1179,7 +1189,7 @@ WindowClassification ClassifyByWindowPositionCached(HWND hwnd) {
         LONG workOffsetX = mi.rcWork.left - mi.rcMonitor.left;
         wr.left += workOffsetX;
         wr.right += workOffsetX;
-    } else if (!hwnd || !GetWindowRect(hwnd, &wr) || !GetMonitorInfo(mon, &mi)) {
+    } else if (!GetWindowRect(hwnd, &wr) || !GetMonitorInfo(mon, &mi)) {
         return {ResolveUnresolvedAppsDefaultSide()};
     }
 
@@ -1666,6 +1676,10 @@ LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
                                         LPARAM lParam,
                                         DWORD_PTR dwRefData);
 
+// Defined later (Mod lifecycle section); applies a settings change
+// ApplyLoadedSettings couldn't hand off to the taskbar thread earlier.
+void ApplyPendingSettingsIfAny();
+
 // Resolves g_hTaskbarWnd and installs the taskbar-window subclass,
 // self-healing on every ArrangeOverride pass rather than a one-shot
 // Wh_ModAfterInit lookup - see RATIONALE.md for why both parts need to
@@ -1698,8 +1712,11 @@ HWND EnsureTaskbarWnd() {
 
     // Retried on every call until it succeeds, not just the pass that
     // first resolves g_hTaskbarWnd above - see RATIONALE.md for why that
-    // matters. Cheap: this runs on the taskbar's own thread, so
-    // SetWindowSubclassFromAnyThread takes its same-thread fast path.
+    // matters. Cheap on the common ArrangeOverride call path, since that
+    // already runs on the taskbar's own thread and
+    // SetWindowSubclassFromAnyThread takes its same-thread fast path there
+    // (the Wh_ModAfterInit call site runs on Windhawk's own thread instead,
+    // so it takes the real cross-thread marshal, but only once at startup).
     if (!g_taskbarWndSubclassed && !g_unloading &&
         WindhawkUtils::SetWindowSubclassFromAnyThread(
             g_hTaskbarWnd, TaskbarWndSubclassProc, 0)) {
@@ -1714,9 +1731,12 @@ HWND EnsureTaskbarWnd() {
         } else {
             // Kicks the resolve timer and a relayout awake - needed since
             // nothing else restarts them once a subclass install has
-            // failed for a while (see ButtonHwndResolveTimerProc).
+            // failed for a while (see ButtonHwndResolveTimerProc). Also
+            // applies any settings change that arrived before this point
+            // could hand it off to the taskbar thread.
             ArmButtonHwndResolveTimer(0);
             InvalidateTaskbarLayout();
+            ApplyPendingSettingsIfAny();
         }
     }
 
@@ -1859,8 +1879,10 @@ void ResolvePendingButtonHwnds() {
                 } else {
                     // forceResolve: bounded to
                     // consecutiveFailures < kMaxForcedRetryFailures - see
-                    // its own comment.
+                    // its own comment. backoffElapsed itself stops
+                    // retrying past kMaxResolveFailures - see its comment.
                     bool backoffElapsed =
+                        it->second.consecutiveFailures < kMaxResolveFailures &&
                         now - it->second.lastAttempt >=
                         ResolveBackoffMs(it->second.consecutiveFailures);
                     needsResolve =
@@ -2333,7 +2355,18 @@ UINT SettingsChangedMsg() {
     return msg;
 }
 
-// Installed on g_hTaskbarWnd by EnsureTaskbarWnd. Handles the three private
+// Sent (not posted) by Wh_ModBeforeUninit right before removing the
+// subclass, to reclaim a SettingsChangedMsg that was posted but never got
+// dispatched (e.g. settings changed immediately before disable) - without
+// this, that message would fall through to Shell_TrayWnd's real WndProc
+// once the subclass is gone, and its heap ModSettings would leak.
+UINT DrainSettingsMsg() {
+    static const UINT msg =
+        RegisterWindowMessage(L"Windhawk_DrainSettings_" WH_MOD_ID);
+    return msg;
+}
+
+// Installed on g_hTaskbarWnd by EnsureTaskbarWnd. Handles the four private
 // messages above and forwards everything else to DefSubclassProc (which
 // also lets comctl32 clean this subclass up via WM_NCDESTROY if the window
 // is destroyed before Wh_ModBeforeUninit removes it). See RATIONALE.md for
@@ -2349,6 +2382,17 @@ LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
     }
     if (uMsg == ResolveButtonHwndsMsg()) {
         ResolvePendingButtonHwnds();
+        return 0;
+    }
+    if (uMsg == DrainSettingsMsg()) {
+        // Runs on this thread (SendMessage from Wh_ModBeforeUninit), so
+        // PeekMessage here scans this thread's own queue - the one
+        // SettingsChangedMsg was posted to.
+        MSG queuedMsg;
+        while (PeekMessage(&queuedMsg, hWnd, SettingsChangedMsg(),
+                           SettingsChangedMsg(), PM_REMOVE)) {
+            delete reinterpret_cast<ModSettings*>(queuedMsg.lParam);
+        }
         return 0;
     }
     if (uMsg == SettingsChangedMsg()) {
@@ -2425,10 +2469,17 @@ void CALLBACK WinEventProc(HWINEVENTHOOK hook,
     // Only a window this mod has resolved to a taskbar button can affect
     // the layout on a move, so filter LOCATIONCHANGE against that set
     // before the cross-process USER32 calls below. Not applied to SHOW: a
-    // newly-shown window can't be resolved yet by definition.
+    // newly-shown window can't be resolved yet by definition - instead,
+    // its own leading-edge throttle is checked here too, before those same
+    // USER32 calls, since SHOW is otherwise unthrottled and can arrive in
+    // bursts.
     if (event == EVENT_OBJECT_LOCATIONCHANGE) {
         std::lock_guard<std::mutex> guard(g_resolvedHwndsMutex);
         if (!g_resolvedHwnds.count(hwnd)) {
+            return;
+        }
+    } else if (event == EVENT_OBJECT_SHOW) {
+        if (GetTickCount64() - g_lastShowEventArm < 150) {
             return;
         }
     }
@@ -2441,15 +2492,10 @@ void CALLBACK WinEventProc(HWINEVENTHOOK hook,
     if (event == EVENT_OBJECT_SHOW) {
         // A newly-visible top-level window is what a pinned-but-not-running
         // app launching looks like - nudge the resolve timer to run now,
-        // bypassing each entry's own backoff. Leading-edge throttled since
-        // this event is unthrottled and can arrive in bursts; no trailing
-        // timer needed since a single arm(0) picks up every pending button
-        // regardless of which SHOW event triggered it. See RATIONALE.md.
-        ULONGLONG nowShow = GetTickCount64();
-        if (nowShow - g_lastShowEventArm < 150) {
-            return;
-        }
-        g_lastShowEventArm = nowShow;
+        // bypassing each entry's own backoff. No trailing timer needed
+        // since a single arm(0) picks up every pending button regardless
+        // of which SHOW event triggered it. See RATIONALE.md.
+        g_lastShowEventArm = GetTickCount64();
         g_forceResolveUnresolved = true;
         ArmButtonHwndResolveTimer(0);
         return;
@@ -2927,7 +2973,10 @@ void ArmButtonHwndResolveTimer(DWORD delayMs) {
     if (!g_winEventThreadId || g_unloading) {
         return;
     }
-    PostThreadMessage(g_winEventThreadId, kArmResolveNowMsg, 0, delayMs);
+    if (!PostThreadMessage(g_winEventThreadId, kArmResolveNowMsg, 0, delayMs)) {
+        Wh_Log(L"ArmButtonHwndResolveTimer: PostThreadMessage failed, "
+               L"error=%lu", GetLastError());
+    }
 }
 
 BOOL Wh_ModInit() {
@@ -3003,12 +3052,21 @@ void Wh_ModBeforeUninit() {
     // the click-sentinel probe and makes IUIElement_Arrange_Hook fall
     // through to native positioning immediately.
 
-    // Removes the subclass as early as it's safe to. This is the sole
-    // marshal onto the taskbar thread (see g_taskbarWndSubclassed), so
-    // once it's gone there's no way to force an immediate visual
-    // snap-back on disable - native positions apply cosmetically late
-    // instead, next time XAML re-runs Arrange on its own. See RATIONALE.md.
+    // Forces an immediate snap-back to native positions before removing
+    // the subclass below - hooks are still live and g_unloading is already
+    // set, so IUIElement_Arrange_Hook falls through to native positioning
+    // for this pass. Must be SendMessage, not PostMessage:
+    // RemoveWindowSubclassFromAnyThread below is itself a SendMessage, and
+    // a merely posted invalidate would arrive after the subclass is gone.
     HWND hTaskbarWnd = g_hTaskbarWnd;
+    if (hTaskbarWnd && g_taskbarWndSubclassed) {
+        SendMessage(hTaskbarWnd, InvalidateTaskbarLayoutMsg(), 0, 0);
+        // Reclaims a SettingsChangedMsg posted but not yet dispatched -
+        // see DrainSettingsMsg's own comment.
+        SendMessage(hTaskbarWnd, DrainSettingsMsg(), 0, 0);
+    }
+    // Removes the subclass as early as it's safe to - the sole marshal
+    // onto the taskbar thread (see g_taskbarWndSubclassed).
     if (hTaskbarWnd && g_taskbarWndSubclassed.exchange(false)) {
         WindhawkUtils::RemoveWindowSubclassFromAnyThread(
             hTaskbarWnd, TaskbarWndSubclassProc);
@@ -3024,23 +3082,34 @@ void Wh_ModUninit() {
     StopWinEventHook();
 }
 
+// Holds a settings change ApplyLoadedSettings couldn't hand off to the
+// taskbar thread yet (no taskbar window resolved, or its subclass isn't
+// installed) - EnsureTaskbarWnd applies it via ApplyPendingSettingsIfAny
+// once its own next successful subclass install makes that handoff
+// possible. Guarded by a mutex: ApplyLoadedSettings runs on
+// Wh_ModSettingsChanged's arbitrary calling thread, while
+// ApplyPendingSettingsIfAny runs on whichever thread called
+// EnsureTaskbarWnd.
+std::mutex g_pendingSettingsMutex;
+bool g_hasPendingSettings;
+ModSettings g_pendingSettings;
+
 // Applies a freshly-loaded settings struct on the taskbar's own thread,
 // since it reassigns leftApps/rightApps while a concurrent layout pass
-// could be reading them. No fallback if the subclass isn't installed or
-// PostMessage fails - logged loudly rather than silently dropped, since
-// unlike InvalidateTaskbarLayout there's no periodic retry for a missed
-// settings change. See RATIONALE.md.
+// could be reading them. If the taskbar window isn't resolved yet or its
+// subclass isn't installed, stashes the settings above instead of
+// assigning g_settings directly here - a foreign-thread write to it could
+// otherwise race EnsureTaskbarWnd resolving the taskbar (and a layout pass
+// starting to read g_settings) concurrently on another thread. No further
+// fallback if PostMessage itself fails - logged loudly rather than
+// silently dropped. See RATIONALE.md.
 void ApplyLoadedSettings(ModSettings settings) {
-    // Snapshot so every read below agrees.
+    // Snapshot so both checks below agree.
     HWND hTaskbarWnd = g_hTaskbarWnd;
-    if (!hTaskbarWnd) {
-        g_settings = std::move(settings);
-        return;
-    }
-
-    if (!g_taskbarWndSubclassed) {
-        Wh_Log(L"ApplyLoadedSettings: no taskbar subclass installed, "
-               L"new settings not applied");
+    if (!hTaskbarWnd || !g_taskbarWndSubclassed) {
+        std::lock_guard<std::mutex> guard(g_pendingSettingsMutex);
+        g_pendingSettings = std::move(settings);
+        g_hasPendingSettings = true;
         return;
     }
 
@@ -3055,6 +3124,19 @@ void ApplyLoadedSettings(ModSettings settings) {
     }
     Wh_Log(L"ApplyLoadedSettings: PostMessage failed, error=%lu, "
            L"new settings not applied", GetLastError());
+}
+
+void ApplyPendingSettingsIfAny() {
+    ModSettings settings;
+    {
+        std::lock_guard<std::mutex> guard(g_pendingSettingsMutex);
+        if (!g_hasPendingSettings) {
+            return;
+        }
+        settings = std::move(g_pendingSettings);
+        g_hasPendingSettings = false;
+    }
+    ApplyLoadedSettings(std::move(settings));
 }
 
 void Wh_ModSettingsChanged() {

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -2044,7 +2044,34 @@ FrameworkElement GetCachedTaskbarRepeater() {
 //
 // Also guarded against running while nested inside an active Arrange
 // pass on this thread - defense in depth, not the primary protection.
+// Reentrancy guard: this function is reachable from two independent
+// dispatch paths on the taskbar thread (the posted ResolveButtonHwndsMsg
+// via TaskbarWndSubclassProc, and RunFromWindowThread's sent message via
+// its WH_CALLWNDPROC hook), and it mutates g_buttonHwndCache/
+// g_lastKnownWindowClassification with erase-while-iterating prune loops.
+// If a cross-thread SendMessage gets pumped while a call is already in
+// progress here (it calls into taskbar.dll and WinRT, either of which
+// could pump), a nested call's inserts would invalidate the outer loop's
+// iterator - undefined behavior, not just wasted work. RAII rather than a
+// plain set/clear, same reasoning as ScopedArrangeOverrideFlag: this
+// function has several early returns a plain clear at the end would never
+// reach.
+thread_local bool g_inResolvePendingButtonHwnds;
+struct ScopedResolvePendingButtonHwndsFlag {
+    ScopedResolvePendingButtonHwndsFlag() {
+        g_inResolvePendingButtonHwnds = true;
+    }
+    ~ScopedResolvePendingButtonHwndsFlag() {
+        g_inResolvePendingButtonHwnds = false;
+    }
+};
+
 void ResolvePendingButtonHwnds() {
+    if (g_inResolvePendingButtonHwnds) {
+        return;
+    }
+    ScopedResolvePendingButtonHwndsFlag scopedReentrancyFlag;
+
     // Computes and arms this function's own next tick on destruction, on
     // every return path, always on this thread right after this pass's
     // own cache reads/writes are done - computing it from
@@ -2947,21 +2974,36 @@ bool HookTaskbarDllSymbols() {
             &std__Ref_count_base__Decref_Original,
         },
         {
+            // Optional, like everything below: these four only power the
+            // button->HWND resolution chain (icons following windows), not
+            // the mod's core centering/split positioning - a future Windows
+            // build renaming one of them should degrade to
+            // unresolvedAppsDefaultSide classification, not refuse to load
+            // the whole mod. The null checks already present in
+            // GetWindowFromNativeTaskItem/ResolveHwndFromIndividualTaskItem
+            // exist specifically to handle that.
             {LR"(public: virtual long __cdecl CTaskListWnd::HandleClick(struct ITaskGroup *,struct ITaskItem *,struct winrt::Windows::System::LauncherOptions const &))"},
             &CTaskListWnd_HandleClick_Original,
             CTaskListWnd_HandleClick_Hook,
+            true,
         },
         {
             {LR"(public: virtual struct HWND__ * __cdecl CWindowTaskItem::GetWindow(void))"},
             &CWindowTaskItem_GetWindow_Original,
+            nullptr,
+            true,
         },
         {
             {LR"(public: virtual struct HWND__ * __cdecl CImmersiveTaskItem::GetWindow(void))"},
             &CImmersiveTaskItem_GetWindow_Original,
+            nullptr,
+            true,
         },
         {
             {LR"(const CImmersiveTaskItem::`vftable'{for `ITaskItem'})"},
             &CImmersiveTaskItem_vftable,
+            nullptr,
+            true,
         },
         {
             {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::WindowsUdk::UI::Shell::implementation::TaskItem,struct winrt::WindowsUdk::UI::Shell::ITaskItem>::ReportClicked(void *))"},

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -85,7 +85,13 @@ right next to Start on whichever side you prefer.
   made by native layout logic (this mod only overrides each button's
   final X position afterward, it never touches sizing), evaluated against
   the taskbar's native, unsplit layout rather than this mod's split one -
-  unconfirmed, not yet investigated further.
+  unconfirmed, not yet investigated further. **Separately reported:** with
+  "Always" enabled, multiple windows of the same app have been observed
+  not combining into one button at all, appearing as separate icons
+  regardless of count. This mod has no code path that could cause that -
+  grouping is a native decision made before this mod's hooks ever see a
+  button - but it's flagged here as a planned follow-up pending
+  confirmation of whether it reproduces with the mod disabled.
 - **Undocumented internals.** This mod hooks private, unversioned classes
   inside `taskbar.dll` and `Taskbar.View.dll` (via symbols resolved from
   Microsoft's public symbol server at runtime, not hardcoded offsets). A
@@ -208,6 +214,7 @@ community.
 #include <functional>
 #include <iterator>
 #include <limits>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -369,7 +376,10 @@ double PinnedAppOrderKey() {
 // assignment - see its comment for why.
 ModSettings LoadSettingsFromStore() {
     ModSettings s;
-    s.gapPx = Wh_GetIntSetting(L"gapPx");
+    // Clamped rather than trusted as-is: a negative value from the
+    // settings UI would otherwise pull the flanking icon groups into the
+    // Start button instead of away from it.
+    s.gapPx = std::max(0, Wh_GetIntSetting(L"gapPx"));
 
     auto placement = WindhawkUtils::StringSetting::make(L"systemButtonsPlacement");
     s.systemButtonsPlacement =
@@ -821,12 +831,30 @@ thread_local void* g_clickSentinel_TaskGroup;
 // The interception either works on this Windows build or it doesn't - it
 // isn't a per-button thing - so one confirmed capture is proof it works,
 // and one probe that reaches ReportClicked with zero capture, before any
-// capture has ever been confirmed, is proof it doesn't. g_clickSentinelBroken
-// latches that verdict permanently: ResolveHwndFromTaskListButton bails
-// out before ever calling ReportClicked again once it's set, rather than
+// capture has ever been confirmed, is proof it doesn't. Latched per path
+// (item vs. group), not as one shared flag: the two paths reach
+// CTaskListWnd::HandleClick through different internal call chains
+// (TaskItem::ReportClicked vs. TaskGroup::ReportClicked), so a Windows
+// update could break only one of them - a shared flag would let a still-
+// working item-path confirmation mask a broken group path, which matters
+// most because the group path is the one a pinned-but-not-running app's
+// button keeps retrying (see ResolveHwndFromTaskGroup's IsRunning check
+// for how that retry is now also avoided at the source). Each *Broken
+// latch permanently gates its own path in ResolveHwndFromTaskListButton -
+// once set, that path never calls ReportClicked again, rather than
 // retrying a mechanism now known to dispatch real clicks.
-std::atomic<bool> g_clickSentinelConfirmed;
-std::atomic<bool> g_clickSentinelBroken;
+std::atomic<bool> g_clickSentinelItemConfirmed;
+std::atomic<bool> g_clickSentinelItemBroken;
+std::atomic<bool> g_clickSentinelGroupConfirmed;
+std::atomic<bool> g_clickSentinelGroupBroken;
+
+// Which path's probe is in flight on this thread when a sentinel click
+// might land in CTaskListWnd_HandleClick_Hook below - the hook only sees
+// the click itself, not which resolve function dispatched it, so this is
+// what lets it credit the right path's *Confirmed flag. Set immediately
+// before dispatching a probe, alongside the existing reset-before/read-
+// after g_clickSentinel_TaskItem/_TaskGroup pattern.
+thread_local bool g_clickSentinelProbingGroup;
 
 HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
                                               void* taskGroup,
@@ -835,7 +863,11 @@ HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
     if (launcherOptions && *launcherOptions == (void*)&g_clickSentinel) {
         g_clickSentinel_TaskItem = taskItem;
         g_clickSentinel_TaskGroup = taskGroup;
-        g_clickSentinelConfirmed = true;
+        if (g_clickSentinelProbingGroup) {
+            g_clickSentinelGroupConfirmed = true;
+        } else {
+            g_clickSentinelItemConfirmed = true;
+        }
         return S_OK;
     }
 
@@ -847,14 +879,21 @@ HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
 // capture - the one point where "no capture" is actually evidence about
 // the interception itself, as opposed to an earlier, unrelated failure
 // (missing view-model, no task item) that never reached ReportClicked at
-// all. See g_clickSentinelBroken's own comment for the full reasoning.
-void NoteUnconfirmedClickSentinelMiss() {
-    if (!g_clickSentinelConfirmed && !g_clickSentinelBroken.exchange(true)) {
-        Wh_Log(L"Click-sentinel interception never confirmed working - "
-               L"disabling further HWND-resolution probes to avoid "
-               L"dispatching real clicks. This usually means a Windows "
-               L"update changed CTaskListWnd::HandleClick's internal call "
-               L"path; consider disabling this mod until it's updated.");
+// all. See g_clickSentinelItemBroken/g_clickSentinelGroupBroken's own
+// comment for the full reasoning and why this is tracked per path.
+void NoteUnconfirmedClickSentinelMiss(bool isGroupPath) {
+    std::atomic<bool>& confirmed =
+        isGroupPath ? g_clickSentinelGroupConfirmed : g_clickSentinelItemConfirmed;
+    std::atomic<bool>& broken =
+        isGroupPath ? g_clickSentinelGroupBroken : g_clickSentinelItemBroken;
+    if (!confirmed && !broken.exchange(true)) {
+        Wh_Log(L"Click-sentinel interception (%s path) never confirmed "
+               L"working - disabling further HWND-resolution probes on "
+               L"this path to avoid dispatching real clicks. This usually "
+               L"means a Windows update changed CTaskListWnd::HandleClick's "
+               L"internal call path; consider disabling this mod until "
+               L"it's updated.",
+               isGroupPath ? L"group" : L"item");
     }
 }
 
@@ -882,6 +921,19 @@ TaskListGroupViewModel_IsMultiWindow_t
 
 thread_local bool g_captureTaskGroup;
 thread_local void* g_capturedTaskGroup;
+
+// RAII around g_captureTaskGroup's set/clear pair - if the IsMultiWindow
+// call between them ever exited non-locally, a plain set/clear (the
+// original form) would leave this stuck true, and ITaskGroup_IsRunning_Hook
+// would then answer every subsequent real IsRunning call with a hardcoded
+// false instead of forwarding to Original - a wrong answer to a question
+// the taskbar itself uses for real decisions (running indicators, click
+// behavior), for the rest of the session. Same reasoning as
+// ScopedArrangeOverrideFlag elsewhere in this file.
+struct ScopedCaptureTaskGroup {
+    ScopedCaptureTaskGroup() { g_captureTaskGroup = true; }
+    ~ScopedCaptureTaskGroup() { g_captureTaskGroup = false; }
+};
 
 using ITaskGroup_IsRunning_t = bool(WINAPI*)(void* pThis);
 ITaskGroup_IsRunning_t ITaskGroup_IsRunning_Original;
@@ -1003,13 +1055,14 @@ HWND ResolveHwndFromIndividualTaskItem(FrameworkElement element) {
     }
 
     g_clickSentinel_TaskItem = nullptr;
+    g_clickSentinelProbingGroup = false;
     TaskItem_ReportClicked_Original(windowsUdkTaskItem.get(),
                                      &g_clickSentinel);
 
     void* nativeTaskItem = g_clickSentinel_TaskItem;
     g_clickSentinel_TaskItem = nullptr;
     if (!nativeTaskItem) {
-        NoteUnconfirmedClickSentinelMiss();
+        NoteUnconfirmedClickSentinelMiss(/*isGroupPath=*/false);
         g_resolveStats.failure++;
         return nullptr;
     }
@@ -1039,16 +1092,18 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
     }
 
     g_capturedTaskGroup = nullptr;
-    g_captureTaskGroup = true;
-    // IsMultiWindow's implementation happens to call ITaskGroup::IsRunning
-    // internally, which is hooked above to capture its `this` (the native
-    // WindowsUdk task group) instead of really answering the question. The
-    // -1 adjusts from the interface pointer QueryInterface handed back to
-    // the adjacent vtable IsMultiWindow actually needs - a fixed ABI detail
-    // of this object, not a magic number specific to this mod.
-    TaskListGroupViewModel_IsMultiWindow_Original(
-        (void**)groupViewModel.get() - 1);
-    g_captureTaskGroup = false;
+    {
+        // IsMultiWindow's implementation happens to call
+        // ITaskGroup::IsRunning internally, which is hooked above to
+        // capture its `this` (the native WindowsUdk task group) instead
+        // of really answering the question. The -1 adjusts from the
+        // interface pointer QueryInterface handed back to the adjacent
+        // vtable IsMultiWindow actually needs - a fixed ABI detail of
+        // this object, not a magic number specific to this mod.
+        ScopedCaptureTaskGroup scopedCapture;
+        TaskListGroupViewModel_IsMultiWindow_Original(
+            (void**)groupViewModel.get() - 1);
+    }
 
     void* windowsUdkTaskGroup = g_capturedTaskGroup;
     g_capturedTaskGroup = nullptr;
@@ -1057,12 +1112,31 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
         return nullptr;
     }
 
+    // A group with no running windows (a pinned-but-not-running app) can
+    // never yield an HWND - its task items array is legitimately empty,
+    // so GetTaskItemsArray's check below always fails for it anyway -
+    // and it's exactly the group that would otherwise get re-probed
+    // forever at the backoff ceiling for the life of the session. Bail
+    // out before dispatching a click at it at all, rather than detecting
+    // the failure after the fact. IsRunning is a sibling method on the
+    // same interface already captured above; the "consume" calling
+    // convention it was hooked under (see ITaskGroup_IsRunning_Hook's
+    // *(void**)pThis capture) expects a pointer to a variable holding the
+    // interface pointer, not the interface pointer itself - hence
+    // &windowsUdkTaskGroup here, matching how it was captured.
+    if (ITaskGroup_IsRunning_Original &&
+        !ITaskGroup_IsRunning_Original(&windowsUdkTaskGroup)) {
+        g_resolveStats.failure++;
+        return nullptr;
+    }
+
     g_clickSentinel_TaskGroup = nullptr;
+    g_clickSentinelProbingGroup = true;
     TaskGroup_ReportClicked_Original(windowsUdkTaskGroup, &g_clickSentinel);
     void* nativeTaskGroup = g_clickSentinel_TaskGroup;
     g_clickSentinel_TaskGroup = nullptr;
     if (!nativeTaskGroup) {
-        NoteUnconfirmedClickSentinelMiss();
+        NoteUnconfirmedClickSentinelMiss(/*isGroupPath=*/true);
         g_resolveStats.failure++;
         return nullptr;
     }
@@ -1084,19 +1158,22 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
 }
 
 HWND ResolveHwndFromTaskListButton(FrameworkElement element) {
-    // See g_clickSentinelBroken's comment - once the sentinel is known not
-    // to be intercepted on this build, every further probe would be a
-    // genuine click rather than a resolution attempt, so this bails out
-    // before either resolution path can call ReportClicked again.
-    if (g_clickSentinelBroken) {
-        return nullptr;
-    }
-
-    HWND hwnd = ResolveHwndFromIndividualTaskItem(element);
+    // See g_clickSentinelItemBroken/g_clickSentinelGroupBroken's comment -
+    // once a path's sentinel is known not to be intercepted on this
+    // build, every further probe on that path would be a genuine click
+    // rather than a resolution attempt, so each path bails out before
+    // calling its own ReportClicked again. The other path is unaffected,
+    // since a Windows update could break just one of the two call chains.
+    HWND hwnd = g_clickSentinelItemBroken
+                    ? nullptr
+                    : ResolveHwndFromIndividualTaskItem(element);
     if (hwnd) {
         return hwnd;
     }
 
+    if (g_clickSentinelGroupBroken) {
+        return nullptr;
+    }
     return ResolveHwndFromTaskGroup(element);
 }
 
@@ -2675,9 +2752,9 @@ LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
         return 0;
     }
     if (uMsg == SettingsChangedMsg()) {
-        auto* heapSettings = reinterpret_cast<ModSettings*>(lParam);
+        std::unique_ptr<ModSettings> heapSettings(
+            reinterpret_cast<ModSettings*>(lParam));
         g_settings = std::move(*heapSettings);
-        delete heapSettings;
         // The plan the previous recompute produced was built from the
         // settings that just got replaced - see InvalidateTaskbarLayout's
         // comment for why this needs to be set exactly here, not by the
@@ -3169,7 +3246,11 @@ DWORD WINAPI WinEventHookThreadProc(LPVOID) {
 }
 
 HANDLE g_winEventThread;
-DWORD g_winEventThreadId;
+// Written under g_winEventThreadMutex (Start/StopWinEventHook), but read
+// without it in ArmButtonHwndResolveTimer from the taskbar thread -
+// atomic makes that well-defined, matching g_taskbarWndSubclassed's own
+// treatment elsewhere in this file.
+std::atomic<DWORD> g_winEventThreadId;
 
 // Serializes StartWinEventHook/StopWinEventHook against each other.
 // EnsureTaskbarWnd can call StartWinEventHook from either Wh_ModAfterInit's
@@ -3192,10 +3273,16 @@ void StartWinEventHook() {
         return;
     }
 
+    // CreateThread's out-parameter needs a plain DWORD*, not
+    // atomic<DWORD>* - written through the local and then published to
+    // the atomic once CreateThread returns.
+    DWORD threadId = 0;
     g_winEventThread = CreateThread(nullptr, 0, WinEventHookThreadProc,
-                                    nullptr, 0, &g_winEventThreadId);
+                                    nullptr, 0, &threadId);
     if (!g_winEventThread) {
         Wh_Log(L"StartWinEventHook: CreateThread failed");
+    } else {
+        g_winEventThreadId = threadId;
     }
 }
 
@@ -3504,19 +3591,21 @@ void ApplyLoadedSettings(ModSettings settings) {
 
     if (g_taskbarWndSubclassed) {
         // PostMessage is async, so the settings can't live on this
-        // function's own stack - ownership transfers to the heap pointer,
-        // and TaskbarWndSubclassProc's SettingsChangedMsg case deletes
-        // it after moving out of it.
-        auto* heapSettings = new ModSettings(std::move(settings));
+        // function's own stack - ownership transfers to the heap
+        // allocation, released via .release() only once PostMessage has
+        // actually queued it, and reclaimed by TaskbarWndSubclassProc's
+        // SettingsChangedMsg case on the dispatch side.
+        auto heapSettings = std::make_unique<ModSettings>(std::move(settings));
         if (PostMessage(g_hTaskbarWnd, SettingsChangedMsg(), 0,
-                        (LPARAM)heapSettings)) {
+                        (LPARAM)heapSettings.get())) {
+            heapSettings.release();
             return;
         }
         Wh_Log(L"ApplyLoadedSettings: PostMessage failed, error=%lu, "
                L"falling back to RunFromWindowThread", GetLastError());
-        // Reclaim ownership before falling through to the blocking path.
+        // Reclaim ownership before falling through to the blocking path;
+        // heapSettings frees the now-moved-from struct automatically.
         settings = std::move(*heapSettings);
-        delete heapSettings;
     }
 
     if (!RunFromWindowThread(g_hTaskbarWnd,

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -50,7 +50,7 @@ right next to Start on whichever side you prefer.
 The window-tracking behind position-based splitting and drag-follow can be
 turned off entirely with `trackWindowPositions`, if you'd rather keep just
 the centered Start button and system-button placement with no background
-probing of taskbar buttons and no system-wide event hooks - every app is
+probing of taskbar buttons and no system-wide event hook - every app is
 then classified the same way as a pinned-but-not-running one instead.
 
 ## Known limitations (please read before reporting issues)
@@ -244,7 +244,7 @@ community.
     When on, each running app's taskbar button is matched to its window so
     it can be classified by live position and follow it if it's dragged
     across the screen - this involves probing the taskbar's internal click
-    handler on a background timer and two system-wide window-event hooks.
+    handler on a background timer and a system-wide window-event hook.
     Turn off to disable all of that: every running app is then classified
     the same way as a pinned-but-not-running one, via leftApps/rightApps/
     "Default side for unclassified apps" above, with no drag-follow. Start
@@ -508,12 +508,6 @@ UINT_PTR g_buttonHwndResolveTimerId;
 // invalidate for WinEventProc's own throttle to see.
 ULONGLONG g_lastDragFollowInvalidate;
 
-// Leading-edge throttle for TaskListButton::UpdateVisualStates - see its
-// hook. Touched exclusively from the taskbar/XAML UI thread that hook runs
-// on, unlike every other throttle variable above (which lives on the
-// dedicated WinEventHook thread instead).
-ULONGLONG g_lastUpdateVisualStatesArm;
-
 // ============================================================================
 // Generic taskbar/XAML helpers
 // (traversal helpers adapted from the "Start button always on the left"
@@ -749,16 +743,22 @@ TaskListButton_get_IsRunning_t TaskListButton_get_IsRunning_Original;
 // for a pinned-but-not-running button, rather than paying that chain's
 // full cost every retry only to reach the same answer. Optional (see
 // HookTaskbarViewDllSymbols); defaults to "assume running" - i.e. don't
-// skip anything - when the symbol hasn't resolved, which is exactly this
-// mod's behavior before this optimization existed. See RATIONALE.md.
+// skip anything - both when the symbol hasn't resolved at all, and when a
+// resolved call still fails (round 30 review finding: the HRESULT was
+// previously ignored, so a failed call left isRunning at its initialized
+// false and got treated as confirmed-not-running instead of falling back
+// the same way an unresolved symbol does), which is exactly this mod's
+// behavior before this optimization existed. See RATIONALE.md.
 bool TaskListButtonIsRunning(FrameworkElement element) {
     if (!TaskListButton_get_IsRunning_Original) {
         return true;
     }
     bool isRunning = false;
-    TaskListButton_get_IsRunning_Original(
-        winrt::get_abi(element.as<winrt::Windows::Foundation::IUnknown>()),
-        &isRunning);
+    if (FAILED(TaskListButton_get_IsRunning_Original(
+            winrt::get_abi(element.as<winrt::Windows::Foundation::IUnknown>()),
+            &isRunning))) {
+        return true;
+    }
     return isRunning;
 }
 
@@ -817,6 +817,13 @@ thread_local bool g_clickSentinelProbingGroup;
 // becoming a real click if interception is broken. See RATIONALE.md.
 std::atomic<bool> g_realTaskbarClickObserved;
 
+// Forward declarations: both are defined later (Per-button HWND cache /
+// Mod lifecycle sections), needed here so the first-real-click branch
+// below can nudge the resolve timer the instant that click is observed,
+// rather than waiting for the next backoff tick - see RATIONALE.md.
+extern std::atomic<bool> g_forceResolveUnresolved;
+void ArmButtonHwndResolveTimer(DWORD delayMs);
+
 HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
                                               void* taskGroup,
                                               void* taskItem,
@@ -837,7 +844,15 @@ HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
         return S_OK;
     }
 
-    g_realTaskbarClickObserved = true;
+    // .exchange so the force-resolve nudge below only ever fires once,
+    // the first time a real click confirms the interception point is
+    // reachable - every button that was bailing out at
+    // g_realTaskbarClickObserved's own check gets an immediate recheck
+    // instead of waiting for its next 2s backoff tick. See RATIONALE.md.
+    if (!g_realTaskbarClickObserved.exchange(true)) {
+        g_forceResolveUnresolved = true;
+        ArmButtonHwndResolveTimer(0);
+    }
     return CTaskListWnd_HandleClick_Original(pThis, taskGroup, taskItem,
                                               launcherOptions);
 }
@@ -1000,13 +1015,9 @@ HWND ResolveHwndFromIndividualTaskItem(FrameworkElement element,
         return nullptr;
     }
 
-    // Bails out before dispatching a click if the interception point
-    // hasn't proven reachable this session yet - see
-    // g_realTaskbarClickObserved's own comment.
-    if (!g_realTaskbarClickObserved) {
-        g_resolveStats.failure++;
-        return nullptr;
-    }
+    // g_realTaskbarClickObserved is checked once, centrally, by the sole
+    // caller (ResolveHwndFromTaskListButton) before either path here ever
+    // runs - see its own comment.
 
     IUnknown* elementAbi = (IUnknown*)winrt::get_abi(element);
 
@@ -1061,13 +1072,9 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element,
         return nullptr;
     }
 
-    // Bails out before dispatching a click if the interception point
-    // hasn't proven reachable this session yet - see
-    // g_realTaskbarClickObserved's own comment.
-    if (!g_realTaskbarClickObserved) {
-        g_resolveStats.failure++;
-        return nullptr;
-    }
+    // g_realTaskbarClickObserved is checked once, centrally, by the sole
+    // caller (ResolveHwndFromTaskListButton) before either path here ever
+    // runs - see its own comment.
 
     // Validated up front (memoized, side-effect-free) rather than only
     // after dispatching a click: without this, a build where
@@ -1154,15 +1161,32 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element,
 
 HWND ResolveHwndFromTaskListButton(FrameworkElement element,
                                    bool& outClickDispatched,
-                                   bool& outNotRunning) {
+                                   bool& outNotRunning,
+                                   bool& outAwaitingFirstClick) {
     outNotRunning = false;
+    outAwaitingFirstClick = false;
+    outClickDispatched = false;
 
-    // Cheapest possible check first: skips the entire click-sentinel chain
+    // Checked first, above even TaskListButtonIsRunning: neither path
+    // below can do anything until the interception point has proven
+    // reachable this session (see g_realTaskbarClickObserved's own
+    // comment), so every resolve attempt for every button - running or
+    // not - would otherwise bail here anyway. Centralizing it lets the
+    // caller cache "awaiting first click" as its own idle-worthy state,
+    // instead of every such button polling at the fast backoff-0 cadence
+    // for as long as the session goes without a real taskbar click
+    // (round 30 review finding: this could be indefinite for a user who
+    // launches everything from Start/Alt+Tab). See RATIONALE.md.
+    if (!g_realTaskbarClickObserved) {
+        outAwaitingFirstClick = true;
+        return nullptr;
+    }
+
+    // Cheapest possible check next: skips the entire click-sentinel chain
     // below (both paths) for a button that isn't running right now, rather
     // than discovering that only after running it. See
     // TaskListButtonIsRunning.
     if (!TaskListButtonIsRunning(element)) {
-        outClickDispatched = false;
         outNotRunning = true;
         return nullptr;
     }
@@ -1209,6 +1233,15 @@ struct ButtonHwndCacheEntry {
     // confirmed-not-running button won't change state until
     // TaskListButton::UpdateVisualStates says otherwise. See RATIONALE.md.
     bool notRunning = false;
+    // Set when the last resolve attempt bailed specifically because
+    // g_realTaskbarClickObserved was still false - every button gets this
+    // until the session's first real taskbar click, which could otherwise
+    // mean an indefinite backoff-0 poll for a user who never happens to
+    // click one (round 30 review finding). Treated the same as notRunning
+    // by NextResolveDelayMs; cleared the instant a real click is observed,
+    // via CTaskListWnd_HandleClick_Hook's own force-resolve nudge. See
+    // RATIONALE.md.
+    bool awaitingFirstClick = false;
 };
 std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
 
@@ -1219,6 +1252,18 @@ std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
 // why unconditional forcing was a real bug).
 std::atomic<bool> g_forceResolveUnresolved;
 constexpr int kMaxForcedRetryFailures = 3;
+
+// Whether any live button still needs a recheck - true for anything not
+// yet resolved that also hasn't hit the terminal kMaxResolveFailures cap
+// (this includes notRunning/awaitingFirstClick entries, which are worth
+// rechecking on an event even though they idle for polling purposes -
+// see ButtonHwndCacheEntry). Recomputed at the end of every
+// ResolvePendingButtonHwnds pass; read (same thread, no marshal needed)
+// by TaskListButton_UpdateVisualStates_Hook to skip nudging the resolve
+// timer once there's nothing left it could help - starts true so the
+// very first UpdateVisualStates call, before any pass has run yet,
+// doesn't get skipped. See RATIONALE.md.
+bool g_anyButtonNeedsRecheck = true;
 
 // Caps the per-entry backoff retry itself (not just the force-bypass
 // above) - without this, a button whose interception path is genuinely,
@@ -1265,8 +1310,9 @@ bool ResolveAndCacheButtonHwnd(FrameworkElement element,
 
     bool clickDispatched = false;
     bool notRunning = false;
-    HWND hwnd =
-        ResolveHwndFromTaskListButton(element, clickDispatched, notRunning);
+    bool awaitingFirstClick = false;
+    HWND hwnd = ResolveHwndFromTaskListButton(element, clickDispatched,
+                                              notRunning, awaitingFirstClick);
     // Only a genuinely dispatched-and-missed click counts toward
     // kMaxResolveFailures' terminal cap - a bail-out before ever
     // dispatching one (not yet confirmed reachable, a view-model lookup
@@ -1274,15 +1320,16 @@ bool ResolveAndCacheButtonHwnd(FrameworkElement element,
     // must not count against a button that may resolve fine later. See
     // RATIONALE.md. lastAttempt still advances either way, so a
     // persistently-bailing-out entry keeps retrying at ResolveBackoffMs(0) -
-    // a cheap, indefinite cadence - except a confirmed-not-running one,
-    // which NextResolveDelayMs instead idles (see ButtonHwndCacheEntry).
+    // a cheap, indefinite cadence - except a confirmed-not-running or
+    // awaiting-first-click one, which NextResolveDelayMs instead idles
+    // (see ButtonHwndCacheEntry).
     if (hwnd) {
         failures = 0;
     } else if (clickDispatched) {
         failures = failures + 1;
     }
     g_buttonHwndCache[key] = {hwnd, identity, GetTickCount64(), failures,
-                              notRunning};
+                              notRunning, awaitingFirstClick};
     return hwnd != previous;
 }
 
@@ -1438,18 +1485,21 @@ ButtonClassification ClassifyTaskListButton(FrameworkElement element) {
 // X coordinate (in the taskbar repeater's local DIPs) of the primary
 // monitor's horizontal center.
 double GetMonitorCenterXLocal() {
-    HMONITOR mon = MonitorFromWindow(g_hTaskbarWnd, MONITOR_DEFAULTTOPRIMARY);
+    // Snapshot once, per g_hTaskbarWnd's own comment - three reads below
+    // otherwise each independently re-read the atomic.
+    HWND hTaskbarWnd = g_hTaskbarWnd;
+    HMONITOR mon = MonitorFromWindow(hTaskbarWnd, MONITOR_DEFAULTTOPRIMARY);
     MONITORINFO mi{.cbSize = sizeof(mi)};
     if (!GetMonitorInfo(mon, &mi)) {
         return 0;
     }
 
     RECT taskbarRect;
-    if (!GetWindowRect(g_hTaskbarWnd, &taskbarRect)) {
+    if (!GetWindowRect(hTaskbarWnd, &taskbarRect)) {
         return 0;
     }
 
-    UINT dpi = GetDpiForWindow(g_hTaskbarWnd);
+    UINT dpi = GetDpiForWindow(hTaskbarWnd);
     double scale = dpi ? (96.0 / dpi) : 1.0;
 
     double centerScreenPx = (mi.rcMonitor.left + mi.rcMonitor.right) / 2.0;
@@ -1464,12 +1514,14 @@ double GetMonitorCenterXLocal() {
 // the tray's actual left edge, since the tray only occupies the last
 // portion of the taskbar's full width.
 double GetTaskbarWidthLocal() {
+    // Snapshot once, per g_hTaskbarWnd's own comment.
+    HWND hTaskbarWnd = g_hTaskbarWnd;
     RECT taskbarRect;
-    if (!GetWindowRect(g_hTaskbarWnd, &taskbarRect)) {
+    if (!GetWindowRect(hTaskbarWnd, &taskbarRect)) {
         return 0;
     }
 
-    UINT dpi = GetDpiForWindow(g_hTaskbarWnd);
+    UINT dpi = GetDpiForWindow(hTaskbarWnd);
     double scale = dpi ? (96.0 / dpi) : 1.0;
     return (taskbarRect.right - taskbarRect.left) * scale;
 }
@@ -2185,6 +2237,23 @@ void ResolvePendingButtonHwnds() {
             g_resolvedHwnds = std::move(resolvedNow);
         }
 
+        // Recomputed every pass for TaskListButton_UpdateVisualStates_Hook
+        // (same thread, no marshal needed) to skip nudging the resolve
+        // timer at all once there's nothing left it could possibly help -
+        // true for any entry that isn't resolved and hasn't given up
+        // (notRunning/awaitingFirstClick entries count as "still worth a
+        // recheck" here even though NextResolveDelayMs treats them as
+        // idle for polling-cadence purposes; those are two different
+        // questions - see RATIONALE.md).
+        g_anyButtonNeedsRecheck = false;
+        for (auto& kv : g_buttonHwndCache) {
+            if (!kv.second.hwnd &&
+                kv.second.consecutiveFailures < kMaxResolveFailures) {
+                g_anyButtonNeedsRecheck = true;
+                break;
+            }
+        }
+
         if (anyChanged) {
             InvalidateTaskbarLayout();
         }
@@ -2304,9 +2373,16 @@ void RecomputeLayoutPlan() {
         // g_lastArrangedX, an already-covered one's own width has since
         // changed, or the live child count doesn't match the last
         // recompute's, the plan is stale regardless of the dirty flag.
-        // Hash lookups first, IsTaskListButton/FullFootprintWidth (real
-        // class-name/property reads) second and short-circuited, so the
-        // common "nothing changed" case never pays for them.
+        // Hash lookup first; IsTaskListButton (a real class-name lookup)
+        // only runs on that lookup's miss, so a non-task-list child never
+        // pays for it. FullFootprintWidth is NOT similarly avoided for an
+        // already-covered task list button specifically (round 30 review
+        // finding: the && short-circuit only guards the g_lastArrangedX
+        // miss case above, not this one) - it runs unconditionally for
+        // every task list button on every cheap-path pass, two property
+        // reads each. Left as-is rather than added complexity to dodge
+        // it: both reads are cheap, and this is exactly the button this
+        // whole check exists to catch a width change on.
         bool planIsCurrent = true;
         try {
             if (FrameworkElement repeater = GetCachedTaskbarRepeater()) {
@@ -2948,17 +3024,30 @@ TaskListButton_UpdateVisualStates_t TaskListButton_UpdateVisualStates_Original;
 // this, resolution falls back to ResolveBackoffMs' own capped-backoff
 // schedule with no fast path, the same fallback already relied on for a
 // launch that reaches this hook through a path it doesn't expect.
-// Leading-edge throttled the same way EVENT_OBJECT_SHOW was, since this
-// can fire far more often (hover/press states too, not just running).
+//
+// Unconditionally re-arms the resolve timer with a small delay rather
+// than gating on elapsed time (round 30 review finding) - this fires for
+// every visual-state transition of every taskbar button, not just
+// running/not-running (hover, press, focus, badges...), so a leading-edge
+// throttle can silently drop the one call that actually mattered if it
+// lands within the throttle window of an irrelevant one, with nothing
+// left to re-arm afterward. ArmButtonHwndResolveTimer's own KillTimer/
+// SetTimer re-arm makes this a lossless trailing-edge debounce for free:
+// each call resets the pending timer's countdown, so a burst of calls
+// collapses into exactly one resolve pass, 150ms after the burst actually
+// goes quiet - matching the same trailing-timer idea drag-follow already
+// uses, without needing a second timer variable. g_anyButtonNeedsRecheck
+// skips this entirely once nothing could benefit (the common steady
+// state, once every button is resolved or has given up), so hover churn
+// over an already-settled taskbar costs nothing. See RATIONALE.md.
 void WINAPI TaskListButton_UpdateVisualStates_Hook(void* pThis) {
     TaskListButton_UpdateVisualStates_Original(pThis);
 
-    if (GetTickCount64() - g_lastUpdateVisualStatesArm < 150) {
+    if (!g_anyButtonNeedsRecheck) {
         return;
     }
-    g_lastUpdateVisualStatesArm = GetTickCount64();
     g_forceResolveUnresolved = true;
-    ArmButtonHwndResolveTimer(0);
+    ArmButtonHwndResolveTimer(150);
 }
 
 bool HookTaskbarViewDllSymbols(HMODULE module) {
@@ -3280,20 +3369,32 @@ DWORD NextResolveDelayMs() {
     ULONGLONG now = GetTickCount64();
     bool anyPending = false;
     // True for a resolved entry, a terminal one (consecutiveFailures at
-    // kMaxResolveFailures), or a confirmed-not-running one (see
-    // ButtonHwndCacheEntry::notRunning) - in every case, only the slow
-    // idle-rebind cadence below still applies to it, never the backoff
-    // schedule. Must exactly match ResolvePendingButtonHwnds' own
-    // backoffElapsed check, which never retries a terminal entry - see
-    // RATIONALE.md for the busy-loop this closes: without this, a terminal
-    // entry's fixed, no-longer-advancing dueAt falls further into the past
-    // every tick, pinning pendingDelay at 0 (SetTimer's 10ms floor) forever.
+    // kMaxResolveFailures), or a confirmed-not-running/awaiting-first-
+    // click one (ButtonHwndCacheEntry::notRunning/awaitingFirstClick) -
+    // in every case, only the slow idle-rebind cadence below still
+    // applies to it, not the fast backoff-0 cadence. This must exactly
+    // match ResolvePendingButtonHwnds' own backoffElapsed check for the
+    // TERMINAL case specifically - backoffElapsed has no branch of its
+    // own for a terminal entry, it just structurally evaluates false
+    // forever once consecutiveFailures reaches kMaxResolveFailures, so
+    // NextResolveDelayMs has to independently know to stop chasing it -
+    // see RATIONALE.md for the busy-loop this closes: without this, a
+    // terminal entry's fixed, no-longer-advancing dueAt falls further
+    // into the past every tick, pinning pendingDelay at 0 (SetTimer's
+    // 10ms floor) forever. notRunning/awaitingFirstClick entries are
+    // different: backoffElapsed has no special case for them either, but
+    // unlike a terminal entry it naturally evaluates true for them too
+    // once enough time passes (their consecutiveFailures never advances
+    // past 0), so they're never excluded from a real re-resolve - they
+    // just get one at the slower idle cadence instead of every 2s, since
+    // that's what a confirmed-not-running or still-unconfirmed button
+    // needs, not a permanent exclusion the way a terminal entry does.
     bool anyIdleWorthy = false;
     ULONGLONG earliestDue = 0;
 
     for (auto& kv : g_buttonHwndCache) {
         const ButtonHwndCacheEntry& entry = kv.second;
-        if (entry.hwnd || entry.notRunning ||
+        if (entry.hwnd || entry.notRunning || entry.awaitingFirstClick ||
             entry.consecutiveFailures >= kMaxResolveFailures) {
             anyIdleWorthy = true;
             continue;

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -1068,7 +1068,18 @@ HWND GetWindowFromNativeTaskItem(void* nativeTaskItem) {
 }
 
 HWND ResolveHwndFromIndividualTaskItem(FrameworkElement element) {
-    if (!TryGetItemFromContainer_TaskListWindowViewModel_Original ||
+    // CTaskListWnd_HandleClick_Original is what proves the interception
+    // hook is actually installed - it's optional in HookTaskbarDllSymbols
+    // (see that symbol table's comment), so on a build where it didn't
+    // resolve, CTaskListWnd_HandleClick_Hook never gets installed and the
+    // ReportClicked call below would be a genuine click on a live window
+    // rather than an intercepted sentinel. Checked here specifically
+    // (not just implied by the other symbols below) since this is the one
+    // way the probe can be unsafe that's knowable up front, rather than
+    // only discoverable via NoteUnconfirmedClickSentinelMiss's runtime
+    // miss-counting.
+    if (!CTaskListWnd_HandleClick_Original ||
+        !TryGetItemFromContainer_TaskListWindowViewModel_Original ||
         !TaskListWindowViewModel_get_TaskItem_Original ||
         !TaskItem_ReportClicked_Original) {
         return nullptr;
@@ -1113,7 +1124,11 @@ HWND ResolveHwndFromIndividualTaskItem(FrameworkElement element) {
 // e.g. "Combine taskbar buttons" set to Always) - see the resolution
 // overview comment above this section for the full chain.
 HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
-    if (!TryGetItemFromContainer_TaskListGroupViewModel_Original ||
+    // See ResolveHwndFromIndividualTaskItem's comment - same reasoning,
+    // same interception hook (CTaskListWnd::HandleClick handles both the
+    // item and group ReportClicked paths).
+    if (!CTaskListWnd_HandleClick_Original ||
+        !TryGetItemFromContainer_TaskListGroupViewModel_Original ||
         !TaskListGroupViewModel_IsMultiWindow_Original ||
         !TaskGroup_ReportClicked_Original || !CTaskGroup_GetNumItems_Original) {
         return nullptr;
@@ -2407,19 +2422,38 @@ void RecomputeLayoutPlan() {
         bool planCoversLiveTaskListButtons = true;
         try {
             if (FrameworkElement repeater = GetCachedTaskbarRepeater()) {
+                int liveTaskListCount = 0;
                 for (auto& child : GetRepeaterChildElements(repeater)) {
                     // Map lookup first: every element the plan covers is
                     // already a key in g_lastArrangedX, so this is a plain
                     // hash lookup for the common case. IsTaskListButton
                     // (winrt::get_class_name - a GetRuntimeClassName round
-                    // trip plus an HSTRING allocation) then only runs for
-                    // the rare child that isn't in the plan yet, which is
-                    // exactly the case this check exists to catch.
-                    if (!g_lastArrangedX.count(winrt::get_abi(child)) &&
-                        IsTaskListButton(child)) {
+                    // trip plus an HSTRING allocation) only runs once per
+                    // child, hoisted into a local rather than called twice.
+                    bool isTaskListButton = IsTaskListButton(child);
+                    if (!isTaskListButton) {
+                        continue;
+                    }
+                    liveTaskListCount++;
+                    if (!g_lastArrangedX.count(winrt::get_abi(child))) {
+                        // A live button the plan doesn't cover yet (just
+                        // realized after the last recompute) - the case
+                        // this check was originally added for.
                         planCoversLiveTaskListButtons = false;
                         break;
                     }
+                }
+                // A button *disappearing* (unpin, app closed) adds nothing
+                // new to g_lastArrangedX's coverage - every remaining live
+                // button is still a key in it - so the loop above alone
+                // can't catch it, and it would otherwise sit at its old X
+                // (a visible hole) until the resolve timer's own prune
+                // eventually invalidates, up to kIdleResolveTickMs or the
+                // backoff schedule away. This count comparison catches
+                // that direction too.
+                if (planCoversLiveTaskListButtons &&
+                    liveTaskListCount != g_planStats.taskListTotal) {
+                    planCoversLiveTaskListButtons = false;
                 }
             }
         } catch (...) {

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -1220,20 +1220,26 @@ HWND ResolveHwndFromTaskListButton(FrameworkElement element) {
 // failures (a pinned-but-not-running app's task group legitimately has
 // zero windows, so resolution fails until it's actually launched).
 //
-// consecutiveFailures drives capped exponential backoff (2s..32s) rather
-// than a fixed retry: the resolution chain ends in a synthetic click
-// against the taskbar's real click handler, and ItemsRepeater recycles
-// the same element/cache entry for a given index rather than creating a
-// new one, so a hard stop would permanently break side-following for a
-// pinned app that's later launched. Backing off keeps retrying (worst
-// case within 32s) without hammering the click handler forever.
+// consecutiveFailures drives capped exponential backoff (2s up to the
+// 30-minute kResolveBackoffCeilingMs) rather than a fixed retry: the
+// resolution chain ends in a synthetic click against the taskbar's real
+// click handler, and ItemsRepeater recycles the same element/cache entry
+// for a given index rather than creating a new one, so a hard stop would
+// permanently break side-following for a pinned app that's later
+// launched. A negatively-cached element's failures accumulate for as
+// long as its button exists, so a long-idle session's backoff can be
+// close to the ceiling by the time the app is actually launched -
+// g_forceResolveUnresolved exists specifically to bypass that when
+// there's real evidence (a window just appeared) that a retry is worth
+// trying regardless of the schedule.
 //
 // identity (the button's accessible name at resolve time) catches a
 // different case: ItemsRepeater can rebind an already-realized element
 // to a different item (e.g. a drag-reorder) without destroying it. The
 // old HWND stays valid, just no longer this element's, so an IsWindow()
 // check alone can't detect it - ResolvePendingButtonHwnds compares
-// identity on every check and forces a re-resolve on mismatch.
+// identity on every check (both the resolved and negatively-cached
+// branches) and forces a re-resolve on mismatch.
 struct ButtonHwndCacheEntry {
     HWND hwnd = nullptr;
     std::wstring identity;
@@ -1241,6 +1247,18 @@ struct ButtonHwndCacheEntry {
     int consecutiveFailures = 0;
 };
 std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
+
+// Set by WinEventProc's EVENT_OBJECT_SHOW branch and the ArrangeOverride
+// hook's button-count-change check - both call ArmButtonHwndResolveTimer(0)
+// to make the next resolve pass run immediately, but arming the timer
+// sooner doesn't by itself bypass a negatively-cached entry's own backoff
+// gate (see ButtonHwndCacheEntry's comment for why that backoff can be
+// long-lived). Consumed once per pass in ResolvePendingButtonHwnds to
+// force every negatively-cached entry to retry regardless of backoff.
+// Safe to force unconditionally: a still-not-running group bails at
+// ResolveHwndFromTaskGroup's IsRunning check before ever dispatching a
+// click, so this never risks an extra synthetic click.
+std::atomic<bool> g_forceResolveUnresolved;
 
 // The HWNDs g_buttonHwndCache currently resolves to, rebuilt at the end
 // of every successful ResolvePendingButtonHwnds pass (taskbar thread) and
@@ -2123,6 +2141,7 @@ void ResolvePendingButtonHwnds() {
 
         ULONGLONG now = GetTickCount64();
         bool anyChanged = false;
+        bool forceResolve = g_forceResolveUnresolved.exchange(false);
 
         std::unordered_set<void*> liveTaskListButtons;
 
@@ -2147,17 +2166,33 @@ void ResolvePendingButtonHwnds() {
                 anyChanged = true;
             }
             if (!needsResolve) {
+                // Identity mismatch means ItemsRepeater rebound this element
+                // to a different item since we last resolved it - see
+                // ButtonHwndCacheEntry's comment. Checked on both branches
+                // below, not just the resolved one: a rebind onto a
+                // negatively-cached element (e.g. drag-reordering a pinned-
+                // not-running app past a running one) is just as real a
+                // rebind, and without this check here it would inherit the
+                // old entry's accumulated backoff instead of resolving.
                 if (it->second.hwnd) {
-                    // Identity mismatch means ItemsRepeater rebound this
-                    // element to a different item since we last resolved it -
-                    // see ButtonHwndCacheEntry's comment. The old HWND is
-                    // still a perfectly valid window, just no longer this
-                    // element's, so IsWindow() alone can't catch this case.
+                    // The old HWND is still a perfectly valid window, just
+                    // no longer this element's, so IsWindow() alone can't
+                    // catch a rebind.
                     needsResolve = !IsWindow(it->second.hwnd) ||
                                    identity != it->second.identity;
                 } else {
-                    needsResolve = now - it->second.lastAttempt >=
-                                   ResolveBackoffMs(it->second.consecutiveFailures);
+                    // forceResolve: a negatively-cached element's own
+                    // consecutiveFailures keeps accumulating for as long as
+                    // its button exists (which, for a pinned-but-not-running
+                    // app, is the entire session) - by the time it's
+                    // actually launched, the backoff could be minutes away,
+                    // silently defeating EVENT_OBJECT_SHOW's whole purpose
+                    // of triggering an immediate resolve. See
+                    // g_forceResolveUnresolved's own comment.
+                    needsResolve = forceResolve ||
+                                   identity != it->second.identity ||
+                                   now - it->second.lastAttempt >=
+                                       ResolveBackoffMs(it->second.consecutiveFailures);
                 }
             }
 
@@ -2598,6 +2633,7 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
         lastPlanTaskListCount = currentTaskListCount;
         if (countChanged) {
             InvalidateTaskbarLayout();
+            g_forceResolveUnresolved = true;
             ArmButtonHwndResolveTimer(0);
         }
     }
@@ -2883,13 +2919,14 @@ void CALLBACK WinEventProc(HWINEVENTHOOK hook,
     if (event == EVENT_OBJECT_SHOW) {
         // A real top-level window (per the filtering above) becoming
         // visible is what a pinned-but-not-running app launching looks
-        // like - nudge the resolve timer to run right away instead of
-        // leaving it to its own backoff schedule (which, for a button
-        // that's failed before, can be up to kResolveBackoffCeilingMs
-        // away). The backoff schedule itself is kept as a fallback -
-        // this is a fast path on top of it, not a replacement for it, in
-        // case a launch is ever reached through a code path that
-        // legitimately doesn't produce this event.
+        // like - nudge the resolve timer to run right away, and force it
+        // to ignore each negatively-cached entry's own backoff (see
+        // g_forceResolveUnresolved's comment for why arming the timer
+        // alone isn't enough), instead of leaving it to the backoff
+        // schedule. That schedule is kept as a fallback - this is a fast
+        // path on top of it, not a replacement for it, in case a launch
+        // is ever reached through a code path that legitimately doesn't
+        // produce this event.
         //
         // Leading-edge throttled the same way the location-change branch
         // below is: this event fires for every top-level window becoming
@@ -2907,6 +2944,7 @@ void CALLBACK WinEventProc(HWINEVENTHOOK hook,
             return;
         }
         g_lastShowEventArm = nowShow;
+        g_forceResolveUnresolved = true;
         ArmButtonHwndResolveTimer(0);
         return;
     }

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -15,7 +15,7 @@
 
 // ==WindhawkModReadme==
 /*
-# Centered Start button with position-split taskbar icons
+# Taskbar Start Button Centered Origin
 
 Pins the Windows/Start button to the exact horizontal center of the primary
 monitor, regardless of how many taskbar icons are present. Running-app
@@ -140,10 +140,11 @@ then classified the same way as a pinned-but-not-running one instead.
   removes taskbar buttons rather than just repositioning them). As a
   further safeguard, the very first such probe of a session is held back
   until a real (non-sentinel) click has been seen passing through the same
-  interception point, and any single miss after that latches this mod's
-  probing off entirely on that path (see `Wh_Log` for which) - so a
-  running app's icon may briefly show on its default side, rather than by
-  window position, until you click any taskbar button once. That gate
+  interception point, and three misses on a path that has never once
+  succeeded latch this mod's probing off entirely on that path (see
+  `Wh_Log` for which) - so a running app's icon may briefly show on its
+  default side, rather than by window position, until you click any
+  taskbar button once. That gate
   only covers *before* interception is ever confirmed working, though: if
   a future Windows update breaks interception in a way that still lets a
   probe reach the taskbar's real click handler afterward, the probe's
@@ -743,7 +744,10 @@ TaskListButton_get_IsRunning_t TaskListButton_get_IsRunning_Original;
 // ResolveHwndFromTaskListButton skip the whole click-sentinel chain
 // (TryGetItemFromContainer/IsMultiWindow/ITaskGroup::IsRunning and friends)
 // for a pinned-but-not-running button, rather than paying that chain's
-// full cost every retry only to reach the same answer. Optional (see
+// full cost every retry only to reach the same answer. Adapted from
+// taskbar-labels.wh.cpp's TaskListButton_IsRunning, down to the
+// element.as<IUnknown>() form used to get the ABI pointer (that mod is
+// GPL-3.0, same as this one). Optional (see
 // HookTaskbarViewDllSymbols); defaults to "assume running" - i.e. don't
 // skip anything - both when the symbol hasn't resolved at all, and when a
 // resolved call still fails (the failed call leaves isRunning at its
@@ -797,19 +801,33 @@ thread_local void* g_clickSentinel_TaskGroup;
 // Latched per path (item vs. group), not one shared flag, since the two
 // paths reach CTaskListWnd::HandleClick through different internal call
 // chains and a Windows update could break just one. This latch only ever
-// applies pre-confirmation (see NoteUnconfirmedClickSentinelMiss) - with
-// zero evidence yet that interception works, a single miss is reason
-// enough to stop risking real clicks; the asymmetry (a false latch costs
-// position tracking, a false negative activates/minimizes windows the
-// user didn't touch) favors failing closed immediately rather than
-// tolerating more misses.
+// applies pre-confirmation (see NoteUnconfirmedClickSentinelMiss).
+//
+// The threshold is deliberately NOT 1, even though the asymmetry here
+// (a false latch costs position tracking, a false negative
+// activates/minimizes windows the user didn't touch) argues for failing
+// closed early. By the time any probe runs at all,
+// g_realTaskbarClickObserved is already true - and that flag is set
+// inside CTaskListWnd_HandleClick_Hook itself, so the interception point
+// is provably installed and provably reached by real clicks. A miss
+// after that isn't strong evidence of a broken hook; it's most likely
+// the same transient this file already calls "usually innocent" for the
+// post-confirmation case (the window closed mid-probe, or a taskbar
+// rebuild caught the item mid-teardown), and the first probes of a
+// session are exactly when those transients are most likely, since
+// buttons are still realizing. Latching on one of those would silently
+// disable position tracking for the rest of the session - every running
+// app piling onto one side of Start - recoverable only by reloading the
+// mod. Three bounds the worst case at three stray clicks per path,
+// still well short of a runaway, while making an accidental permanent
+// latch on startup churn much less likely.
 std::atomic<bool> g_clickSentinelItemConfirmed;
 std::atomic<bool> g_clickSentinelItemBroken;
 std::atomic<int> g_clickSentinelItemMisses;
 std::atomic<bool> g_clickSentinelGroupConfirmed;
 std::atomic<bool> g_clickSentinelGroupBroken;
 std::atomic<int> g_clickSentinelGroupMisses;
-constexpr int kClickSentinelMissesBeforeBroken = 1;
+constexpr int kClickSentinelMissesBeforeBroken = 3;
 
 // Which path's probe is in flight on this thread - lets
 // CTaskListWnd_HandleClick_Hook below credit the right path's *Confirmed
@@ -848,6 +866,16 @@ HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
             Wh_Log(L"Click-sentinel interception confirmed working (%s path)",
                    g_clickSentinelProbingGroup ? L"group" : L"item");
         }
+        // Clears this path's accumulated misses: a capture proves the
+        // interception point works, so whatever missed earlier was a
+        // transient rather than evidence against it. Belt-and-suspenders
+        // as the code stands, since NoteUnconfirmedClickSentinelMiss
+        // already stops counting once Confirmed is set (which just
+        // happened above) - but it keeps "counts consecutive unconfirmed
+        // misses" true of the counter on its own, rather than only of
+        // these two flags read together.
+        (g_clickSentinelProbingGroup ? g_clickSentinelGroupMisses
+                                     : g_clickSentinelItemMisses) = 0;
         return S_OK;
     }
 
@@ -865,12 +893,13 @@ HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
 }
 
 // Called right after a real ReportClicked probe comes back with no
-// capture. Latches "broken" on the first pre-confirmation miss (see
-// kClickSentinelMissesBeforeBroken's own comment for why); a no-longer-
-// pre-confirmation miss (the confirmed check below) is a no-op instead of
-// ever latching, since a miss after interception has already proven
-// itself once is far more likely innocent (window closed mid-probe, etc.)
-// than evidence of a break.
+// capture. Latches "broken" once a path accumulates
+// kClickSentinelMissesBeforeBroken misses without ever having captured
+// (see that constant's own comment for the threshold's reasoning); a
+// no-longer-pre-confirmation miss (the confirmed check below) is a no-op
+// instead of ever latching, since a miss after interception has already
+// proven itself once is far more likely innocent (window closed
+// mid-probe, etc.) than evidence of a break.
 void NoteUnconfirmedClickSentinelMiss(bool isGroupPath) {
     std::atomic<bool>& confirmed =
         isGroupPath ? g_clickSentinelGroupConfirmed : g_clickSentinelItemConfirmed;
@@ -1252,17 +1281,13 @@ std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
 
 // Set by TaskListButton::UpdateVisualStates' hook and the ArrangeOverride
 // hook's count-change check to make the next resolve pass ignore a
-// negatively-cached entry's backoff - but only up to
-// kMaxForcedRetryFailures consecutive failures each. Uncapped, this would
-// be a real bug: a RUNNING app's button can fail to resolve for reasons
-// that don't bail out early (ReportClicked failing internally, a task item
-// mid-teardown, GetTaskItemsArray coming back empty), and forcing every
-// retry unconditionally would dispatch a real ReportClicked on both paths
-// every forced pass, indefinitely - exactly the runaway-real-clicks
-// scenario the backoff schedule exists to bound. Capping it keeps the
-// "pinned app just launched" fast path intact (that case is still failing
-// 0 times when the fast path first fires) while letting the normal
-// backoff schedule take back over for an entry that keeps failing.
+// negatively-cached entry's backoff - capped at kMaxForcedRetryFailures
+// failures each. The cap is load-bearing: a running app's button can keep
+// failing for reasons that never bail out early, and forcing every retry
+// would dispatch a real ReportClicked on both paths every forced pass,
+// indefinitely - the runaway the backoff schedule exists to bound. It
+// still leaves the "pinned app just launched" fast path intact, since
+// that case has 0 failures when the fast path first fires.
 std::atomic<bool> g_forceResolveUnresolved;
 constexpr int kMaxForcedRetryFailures = 3;
 
@@ -1278,23 +1303,18 @@ constexpr int kMaxForcedRetryFailures = 3;
 // doesn't get skipped.
 bool g_anyButtonNeedsRecheck = true;
 
-// Caps the per-entry backoff retry itself (not just the force-bypass
-// above) - without this, a button whose interception path is genuinely,
-// permanently broken (e.g. a future Windows update routes it through a
-// different internal handler while the rest of the taskbar still reaches
-// CTaskListWnd::HandleClick, so the click-sentinel latch itself never
-// trips) would keep dispatching a real ReportClicked on this entry every
-// ResolveBackoffMs interval, forever. A button that gets pruned and
-// recreated gets a fresh cache entry (and so a fresh consecutiveFailures
-// count) - an identity change alone does NOT reset it, since
-// ResolveAndCacheButtonHwnd seeds failures from the existing entry
-// regardless of identity, only clearing it on an actual successful
-// resolve. Only counts a genuinely dispatched-
-// and-missed click (see ResolveAndCacheButtonHwnd) - a bail-out before
-// ever dispatching one doesn't risk anything and must not count toward
-// this. NextResolveDelayMs must treat a terminal entry exactly like a
-// resolved one (idle cadence, not the backoff schedule) - see its own
-// comment for the busy-loop that requires.
+// Terminal cap on per-entry retries (distinct from the force-bypass cap
+// above) - without it, a button whose interception path is permanently
+// broken would keep dispatching a real ReportClicked every
+// ResolveBackoffMs interval, forever. Only a genuinely dispatched-and-
+// missed click counts toward it (see ResolveAndCacheButtonHwnd); a
+// bail-out before dispatching risks nothing and must not count. A pruned
+// and recreated button gets a fresh entry and so a fresh count, but an
+// identity change alone does NOT reset it - ResolveAndCacheButtonHwnd
+// seeds failures from the existing entry regardless of identity, clearing
+// them only on a successful resolve. NextResolveDelayMs must treat a
+// terminal entry exactly like a resolved one - see its own comment for
+// the busy-loop that requires.
 constexpr int kMaxResolveFailures = 8;
 
 // The HWNDs g_buttonHwndCache currently resolves to, rebuilt at the end of
@@ -1309,12 +1329,9 @@ std::unordered_set<HWND> g_resolvedHwnds;
 // Runs the resolution chain and updates the cache. Deliberately ONLY ever
 // called from the resolve timer, never from GetButtonHwnd or an active
 // Arrange pass - running the click-sentinel technique while a button is
-// mid-insertion/removal in an ItemsRepeater reaches STATUS_STOWED_EXCEPTION
-// and crashes explorer.exe (confirmed via crash-dump analysis), the same
-// underlying condition as the nested-Arrange-traversal crash noted above:
-// a window moving across monitors while Windows' "show taskbar apps on"
-// setting isn't "All taskbars" structurally adds/removes taskbar buttons
-// mid-pass.
+// mid-insertion/removal in an ItemsRepeater crashes explorer.exe with
+// STATUS_STOWED_EXCEPTION (confirmed via crash-dump analysis), under the
+// same condition described at g_inTaskbarArrangeOverride above.
 bool ResolveAndCacheButtonHwnd(FrameworkElement element,
                                const std::wstring& identity) {
     void* key = winrt::get_abi(element);
@@ -1391,10 +1408,15 @@ struct WindowClassification {
 // it was minimized instead.
 std::unordered_map<HWND, WindowClassification> g_lastKnownWindowClassification;
 
-WindowClassification ClassifyByWindowPositionCached(HWND hwnd) {
+// mi is the primary monitor's info, resolved once per plan recompute by
+// RecomputeLayoutPlan and threaded down rather than looked up here - this
+// runs once per resolved task list button per pass, and every call would
+// otherwise repeat the same MonitorFromWindow/GetMonitorInfo pair for the
+// same monitor. Null if that lookup failed, handled exactly like the
+// per-call failure it replaced: fall back to the default side.
+WindowClassification ClassifyByWindowPositionCached(HWND hwnd,
+                                                    const MONITORINFO* mi) {
     RECT wr;
-    HMONITOR mon = MonitorFromWindow(g_hTaskbarWnd, MONITOR_DEFAULTTOPRIMARY);
-    MONITORINFO mi{.cbSize = sizeof(mi)};
 
     if (IsIconic(hwnd)) {
         auto it = g_lastKnownWindowClassification.find(hwnd);
@@ -1407,7 +1429,7 @@ WindowClassification ClassifyByWindowPositionCached(HWND hwnd) {
         // reports the restored position while minimized (unlike
         // GetWindowRect).
         WINDOWPLACEMENT wp{.length = sizeof(wp)};
-        if (!GetWindowPlacement(hwnd, &wp) || !GetMonitorInfo(mon, &mi)) {
+        if (!mi || !GetWindowPlacement(hwnd, &wp)) {
             return {ResolveUnresolvedAppsDefaultSide()};
         }
         wr = wp.rcNormalPosition;
@@ -1415,15 +1437,15 @@ WindowClassification ClassifyByWindowPositionCached(HWND hwnd) {
         // rcWork), while screenCenterX below is computed from rcMonitor -
         // a left-docked appbar shifts these apart, so this offset keeps a
         // boundary window from classifying to the wrong side.
-        LONG workOffsetX = mi.rcWork.left - mi.rcMonitor.left;
+        LONG workOffsetX = mi->rcWork.left - mi->rcMonitor.left;
         wr.left += workOffsetX;
         wr.right += workOffsetX;
-    } else if (!GetWindowRect(hwnd, &wr) || !GetMonitorInfo(mon, &mi)) {
+    } else if (!mi || !GetWindowRect(hwnd, &wr)) {
         return {ResolveUnresolvedAppsDefaultSide()};
     }
 
     double windowCenterX = (wr.left + wr.right) / 2.0;
-    double screenCenterX = (mi.rcMonitor.left + mi.rcMonitor.right) / 2.0;
+    double screenCenterX = (mi->rcMonitor.left + mi->rcMonitor.right) / 2.0;
 
     WindowClassification result;
     result.side = windowCenterX < screenCenterX ? Side::Left : Side::Right;
@@ -1480,7 +1502,8 @@ struct ButtonClassification {
 // window position, then the configured default. Skips the accessible-name
 // lookup entirely when leftApps/rightApps are both empty (the default) -
 // this runs for every task-list button on every ArrangeOverride pass.
-ButtonClassification ClassifyTaskListButton(FrameworkElement element) {
+ButtonClassification ClassifyTaskListButton(FrameworkElement element,
+                                            const MONITORINFO* mi) {
     if (!g_settings.leftApps.empty() || !g_settings.rightApps.empty()) {
         std::wstring name = GetButtonAccessibleName(element);
         if (ContainsAnyFragment(name, g_settings.leftApps)) {
@@ -1493,7 +1516,7 @@ ButtonClassification ClassifyTaskListButton(FrameworkElement element) {
 
     HWND hwnd = GetButtonHwnd(element);
     if (hwnd) {
-        WindowClassification wc = ClassifyByWindowPositionCached(hwnd);
+        WindowClassification wc = ClassifyByWindowPositionCached(hwnd, mi);
         return {wc.side, wc.distanceFromCenter, true};
     }
 
@@ -1780,12 +1803,14 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
                          double startCenterX,
                          double leftBoundLocal,
                          double rightBoundLocal,
+                         const MONITORINFO* mi,
                          std::unordered_map<void*, double>& outPlan,
                          std::unordered_map<void*, double>& outWidths) {
     std::vector<TaskListPlanEntry> entries;
     for (int i = 0; i < (int)children.size(); i++) {
         if (IsTaskListButton(children[i])) {
-            entries.push_back({children[i], ClassifyTaskListButton(children[i]),
+            entries.push_back({children[i],
+                               ClassifyTaskListButton(children[i], mi),
                                FullFootprintWidth(children[i]), i});
         }
     }
@@ -1966,6 +1991,10 @@ LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
 // ApplyLoadedSettings couldn't hand off to the taskbar thread earlier.
 void ApplyPendingSettingsIfAny();
 
+// Minimum gap between FindCurrentProcessTaskbarWnd attempts while the
+// taskbar window is still unresolved - see EnsureTaskbarWnd.
+constexpr ULONGLONG kTaskbarWndEnumRetryMs = 1000;
+
 // Resolves g_hTaskbarWnd and installs the taskbar-window subclass,
 // self-healing on every ArrangeOverride pass rather than a one-shot
 // Wh_ModAfterInit lookup. Two independent reasons both parts need to keep
@@ -2002,6 +2031,23 @@ HWND EnsureTaskbarWnd() {
             // background worker thread.
             return nullptr;
         }
+        // FindCurrentProcessTaskbarWnd runs an EnumWindows over every
+        // top-level window on the desktop. While g_hTaskbarWnd is
+        // unresolved this branch is reached on every ArrangeOverride pass
+        // - and a secondary taskbar's own passes can fire before
+        // Shell_TrayWnd resolves - so the retry is throttled rather than
+        // enumerating the whole desktop at layout frequency. Costs
+        // nothing once resolved, since the branch is skipped entirely
+        // then. atomic because this function also runs on
+        // Wh_ModAfterInit's thread, not just the taskbar's.
+        static std::atomic<ULONGLONG> lastEnumTick;
+        ULONGLONG nowTick = GetTickCount64();
+        ULONGLONG lastTick = lastEnumTick.load();
+        if (lastTick != 0 && nowTick - lastTick < kTaskbarWndEnumRetryMs) {
+            return nullptr;
+        }
+        lastEnumTick.store(nowTick);
+
         hTaskbarWnd = FindCurrentProcessTaskbarWnd();
         if (!hTaskbarWnd) {
             return nullptr;
@@ -2581,10 +2627,20 @@ void RecomputeLayoutPlan() {
                    kTrayMarginPx)
                 : GetTaskbarWidthLocal();
 
+        // Resolved once here and threaded down rather than per button -
+        // every task list button's classification needs the same primary
+        // monitor's rect. See ClassifyByWindowPositionCached.
+        MONITORINFO monitorInfo{.cbSize = sizeof(monitorInfo)};
+        bool monitorInfoValid = GetMonitorInfo(
+            MonitorFromWindow(hTaskbarWnd, MONITOR_DEFAULTTOPRIMARY),
+            &monitorInfo);
+
         // Task list buttons last - see PlanTaskListButtons for the
         // single-O(n)-pass reasoning.
         PlanTaskListButtons(children, startCenterX, leftBoundLocal,
-                            rightBoundLocal, newPlan, newTaskListWidths);
+                            rightBoundLocal,
+                            monitorInfoValid ? &monitorInfo : nullptr, newPlan,
+                            newTaskListWidths);
 
         g_lastArrangedX = std::move(newPlan);
         g_lastArrangedTaskListWidth = std::move(newTaskListWidths);
@@ -2887,6 +2943,24 @@ void InvalidateTaskbarLayout() {
 // touched from that thread.
 std::unordered_map<HWND, LONG> g_lastPolledCenterX;
 
+// Poll cadence, switched between adaptively - see the tail of
+// DragFollowPollTimerProc. Fast enough during an actual drag to keep
+// icons following live, slow enough at rest that an idle desktop isn't
+// paying for a sub-second timer in the shell process.
+constexpr UINT kDragFollowPollActiveMs = 150;
+constexpr UINT kDragFollowPollIdleMs = 1000;
+// How long the fast cadence persists after the last detected change.
+// Covers the gap between two drags of the same window (and a drag that
+// pauses mid-move) without dropping to the idle rate in between.
+constexpr ULONGLONG kDragFollowActiveWindowMs = 2000;
+
+// Both worker-thread-exclusive, like g_lastPolledCenterX itself.
+UINT g_dragFollowPollCurrentMs;
+ULONGLONG g_lastDragFollowChangeTick;
+
+// Defined just below DragFollowPollTimerProc, which calls it.
+void SetDragFollowPollInterval(UINT intervalMs);
+
 void CALLBACK DragFollowPollTimerProc(HWND hwnd,
                                       UINT uMsg,
                                       UINT_PTR idEvent,
@@ -2957,10 +3031,49 @@ void CALLBACK DragFollowPollTimerProc(HWND hwnd,
         }
     }
 
+    ULONGLONG now = GetTickCount64();
     if (anyChanged) {
         g_dragFollowInvalidateCount++;
+        g_lastDragFollowChangeTick = now;
         InvalidateTaskbarLayout();
     }
+
+    // Adaptive cadence: poll fast only while something is actually
+    // moving. A drag produces a change on nearly every tick, so this
+    // holds the fast rate for the whole drag plus
+    // kDragFollowActiveWindowMs after it settles, then drops to the idle
+    // rate - which is where an ordinary desktop sits essentially all of
+    // the time. A fixed fast rate would instead keep explorer.exe waking
+    // ~7x/second for the entire time the mod is enabled, including with
+    // nothing tracked at all, with the click-sentinel path latched off,
+    // and with the user away from the machine; a constant sub-second
+    // timer in the shell process is a real cost to impose for that.
+    // Nothing is missed at the idle rate - it still does the same
+    // GetWindowRect comparison per tracked window, so a new drag is
+    // picked up within one idle interval and snaps straight back to the
+    // fast rate for the rest of it.
+    UINT wanted = (now - g_lastDragFollowChangeTick < kDragFollowActiveWindowMs)
+                      ? kDragFollowPollActiveMs
+                      : kDragFollowPollIdleMs;
+    if (wanted != g_dragFollowPollCurrentMs) {
+        SetDragFollowPollInterval(wanted);
+    }
+}
+
+// Switches the drag-follow poll to a new interval. Only ever called from
+// the dedicated worker thread, which owns this timer - from
+// BackgroundWorkerThreadProc at startup, and from DragFollowPollTimerProc
+// itself (killing and re-arming a thread-owned timer from inside its own
+// callback is fine, and ButtonHwndResolveTimerProc already does the same).
+// A thread-owned SetTimer mints a fresh id, so g_dragFollowPollTimerId has
+// to be updated alongside or teardown would kill the wrong one.
+void SetDragFollowPollInterval(UINT intervalMs) {
+    if (g_dragFollowPollTimerId) {
+        KillTimer(nullptr, g_dragFollowPollTimerId);
+    }
+    g_dragFollowPollTimerId =
+        SetTimer(nullptr, 0, intervalMs, DragFollowPollTimerProc);
+    g_dragFollowPollCurrentMs = intervalMs;
 }
 
 // ============================================================================
@@ -3079,33 +3192,23 @@ using TaskListButton_UpdateVisualStates_t = void(WINAPI*)(void* pThis);
 TaskListButton_UpdateVisualStates_t TaskListButton_UpdateVisualStates_Original;
 
 // Fires on every visual-state transition of a taskbar button, including a
-// pinned app's running/not-running change - replaces the old, desktop-wide
-// EVENT_OBJECT_SHOW WinEventHook (removed) as the fast nudge for
-// "something just changed, go re-check", scoped to this taskbar's own
-// buttons instead of every top-level window process-wide.
-// Optional (see the hooks table below) - if a future Windows build renames
-// this, resolution falls back to ResolveBackoffMs' own capped-backoff
-// schedule with no fast path, the same fallback already relied on for a
-// launch that reaches this hook through a path it doesn't expect.
+// pinned app's running/not-running change - the fast "something changed,
+// go re-check" nudge, scoped to this taskbar's own buttons (it replaced a
+// desktop-wide EVENT_OBJECT_SHOW WinEventHook). Optional: if a future
+// Windows build renames it, resolution falls back to ResolveBackoffMs'
+// capped-backoff schedule with no fast path.
 //
-// Unconditionally re-arms the resolve timer with a small delay rather than
-// gating on elapsed time - this fires for every visual-state transition of
-// every taskbar button, not just running/not-running (hover, press,
-// focus, badges...), so a leading-edge throttle can silently drop the one
-// call that actually mattered if it lands within the throttle window of
-// an irrelevant one, with nothing left to re-arm afterward.
-// ArmButtonHwndResolveTimer's own KillTimer/SetTimer re-arm makes this a
-// lossless trailing-edge debounce for free: each call resets the pending
-// timer's countdown, so a burst of calls collapses into exactly one
-// resolve pass, 150ms after the burst actually goes quiet - matching the
-// same trailing-timer idea drag-follow already uses, without needing a
-// second timer variable. g_anyButtonNeedsRecheck skips this entirely once
-// nothing could benefit - in practice that's rarer than it sounds, since a
-// pinned-but-not-running button (present on essentially every real
-// Windows 11 taskbar by default) never advances past 0
-// consecutiveFailures and so keeps the flag true indefinitely; the skip
-// still matters for a taskbar with no pinned-not-running apps, and every
-// hover sweep that doesn't skip is a cheap pass regardless.
+// Re-arms unconditionally rather than gating on elapsed time. This also
+// fires for hover, press, focus and badge transitions, so a leading-edge
+// throttle could silently drop the one call that mattered when it landed
+// behind an irrelevant one, with nothing left to re-arm. Arming instead
+// gives a lossless trailing-edge debounce for free, since
+// ArmButtonHwndResolveTimer's own KillTimer/SetTimer resets the pending
+// countdown: a burst collapses into one pass 150ms after it goes quiet.
+// g_anyButtonNeedsRecheck skips the nudge when nothing could benefit,
+// though one pinned-but-not-running button keeps it true indefinitely -
+// so on a typical taskbar the skip rarely fires, and the pass it would
+// have avoided is cheap anyway.
 void WINAPI TaskListButton_UpdateVisualStates_Hook(void* pThis) {
     TaskListButton_UpdateVisualStates_Original(pThis);
 
@@ -3283,10 +3386,6 @@ void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
                                          UINT_PTR idEvent,
                                          DWORD dwTime);
 
-// How often DragFollowPollTimerProc polls g_resolvedHwnds - see its own
-// comment for why this replaced a WinEventHook.
-constexpr UINT kDragFollowPollMs = 150;
-
 DWORD WINAPI BackgroundWorkerThreadProc(LPVOID) {
     // Forces this thread's message queue into existence before SetTimer
     // runs below, so the timers this thread owns have somewhere to
@@ -3303,9 +3402,14 @@ DWORD WINAPI BackgroundWorkerThreadProc(LPVOID) {
     g_buttonHwndResolveTimerId =
         SetTimer(nullptr, 0, 100, ButtonHwndResolveTimerProc);
 
-    // Runs for as long as this thread does - see DragFollowPollTimerProc.
-    g_dragFollowPollTimerId =
-        SetTimer(nullptr, 0, kDragFollowPollMs, DragFollowPollTimerProc);
+    // Runs for as long as this thread does, switching between the fast
+    // and idle cadences on its own - see DragFollowPollTimerProc's tail.
+    // Starts fast, with the active window seeded from now, so a drag in
+    // the first couple of seconds after the mod loads is followed live
+    // rather than waiting out an idle interval first; it settles to the
+    // idle rate on its own if nothing moves.
+    g_lastDragFollowChangeTick = GetTickCount64();
+    SetDragFollowPollInterval(kDragFollowPollActiveMs);
 
     // WM_APP (posted by StopBackgroundWorkerThread) is this thread's
     // shutdown signal.
@@ -3330,6 +3434,11 @@ DWORD WINAPI BackgroundWorkerThreadProc(LPVOID) {
     if (g_dragFollowPollTimerId) {
         KillTimer(nullptr, g_dragFollowPollTimerId);
         g_dragFollowPollTimerId = 0;
+        // A live trackWindowPositions toggle can start this thread again
+        // later; SetDragFollowPollInterval sets this unconditionally on
+        // the way back up, but leaving a stale cadence behind here would
+        // be misleading to read.
+        g_dragFollowPollCurrentMs = 0;
     }
 
     return 0;
@@ -3449,27 +3558,19 @@ ULONGLONG ResolveBackoffMs(int consecutiveFailures) {
 DWORD NextResolveDelayMs() {
     ULONGLONG now = GetTickCount64();
     bool anyPending = false;
-    // True for a resolved entry, a terminal one (consecutiveFailures at
-    // kMaxResolveFailures), or a confirmed-not-running/awaiting-first-
-    // click one (ButtonHwndCacheEntry::notRunning/awaitingFirstClick) -
-    // in every case, only the slow idle-rebind cadence below still
-    // applies to it, not the fast backoff-0 cadence. This must exactly
-    // match ResolvePendingButtonHwnds' own backoffElapsed check for the
-    // TERMINAL case specifically - backoffElapsed has no branch of its
-    // own for a terminal entry, it just structurally evaluates false
-    // forever once consecutiveFailures reaches kMaxResolveFailures, so
-    // NextResolveDelayMs has to independently know to stop chasing it:
-    // without this, a terminal entry's fixed, no-longer-advancing dueAt
-    // falls further into the past every tick, pinning pendingDelay at 0
+    // True for an entry that only the slow idle-rebind cadence still
+    // applies to: resolved, terminal (consecutiveFailures at
+    // kMaxResolveFailures), or confirmed-not-running/awaiting-first-click
+    // (see ButtonHwndCacheEntry). The terminal case is load-bearing -
+    // ResolvePendingButtonHwnds' backoffElapsed check structurally
+    // evaluates false forever once the cap is reached, so if this didn't
+    // independently stop chasing such an entry, its fixed dueAt would
+    // fall further into the past every tick and pin the delay at 0
     // (SetTimer's 10ms floor) forever. notRunning/awaitingFirstClick
-    // entries are
-    // different: backoffElapsed has no special case for them either, but
-    // unlike a terminal entry it naturally evaluates true for them too
-    // once enough time passes (their consecutiveFailures never advances
-    // past 0), so they're never excluded from a real re-resolve - they
-    // just get one at the slower idle cadence instead of every 2s, since
-    // that's what a confirmed-not-running or still-unconfirmed button
-    // needs, not a permanent exclusion the way a terminal entry does.
+    // entries are only slowed, not excluded: their consecutiveFailures
+    // never advances, so backoffElapsed does come true for them again in
+    // time, which is what a not-running or still-unconfirmed button
+    // wants.
     bool anyIdleWorthy = false;
     ULONGLONG earliestDue = 0;
 

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -47,6 +47,12 @@ after a drag/move settles, not on every intermediate pixel of the drag.
 Search, Task View and Widgets can either stay at the far left edge, or move
 right next to Start on whichever side you prefer.
 
+The window-tracking behind position-based splitting and drag-follow can be
+turned off entirely with `trackWindowPositions`, if you'd rather keep just
+the centered Start button and system-button placement with no background
+probing of taskbar buttons and no system-wide event hooks - every app is
+then classified the same way as a pinned-but-not-running one instead.
+
 ## Known limitations (please read before reporting issues)
 
 - **Windows 11 only.** Windows 10's taskbar has no XAML layer to hook into.
@@ -85,13 +91,7 @@ right next to Start on whichever side you prefer.
   made by native layout logic (this mod only overrides each button's
   final X position afterward, it never touches sizing), evaluated against
   the taskbar's native, unsplit layout rather than this mod's split one -
-  unconfirmed, not yet investigated further. **Separately reported:** with
-  "Always" enabled, multiple windows of the same app have been observed
-  not combining into one button at all, appearing as separate icons
-  regardless of count. This mod has no code path that could cause that -
-  grouping is a native decision made before this mod's hooks ever see a
-  button - but it's flagged here as a planned follow-up pending
-  confirmation of whether it reproduces with the mod disabled.
+  unconfirmed, not yet investigated further.
 - **A grouped button (multiple windows combined under one icon) follows
   only its first window.** With "Combine taskbar buttons" set to "Always",
   a group's side and ordering are both decided by whichever of its windows
@@ -100,6 +100,10 @@ right next to Start on whichever side you prefer.
   won't visually reflect all of them. There's no exposed way to pick a
   more meaningful "primary" window for a group, so this is a documented
   tradeoff rather than a bug.
+- **The taskbar's own overflow button, when it appears on a crowded
+  taskbar, keeps its native position** rather than being classified and
+  placed like the buttons around it - this mod doesn't give it a slot in
+  the split layout.
 - **Undocumented internals.** This mod hooks private, unversioned classes
   inside `taskbar.dll` and `Taskbar.View.dll` (via symbols resolved from
   Microsoft's public symbol server at runtime, not hardcoded offsets). A
@@ -116,7 +120,12 @@ right next to Start on whichever side you prefer.
   confirmed cause of an explorer.exe crash (specifically when Windows'
   "show taskbar apps on" setting is anything other than "All taskbars",
   since that's when a window moving across monitors structurally adds/
-  removes taskbar buttons rather than just repositioning them).
+  removes taskbar buttons rather than just repositioning them). As a
+  further safeguard, the very first such probe of a session is held back
+  until a real (non-sentinel) click has been seen passing through the same
+  interception point - so a running app's icon may briefly show on its
+  default side, rather than by window position, until you click any
+  taskbar button once.
 - **Taskbar buttons can disappear when a display is deactivated** (via
   Settings, unplugging, or a third-party display on/off tool) - if
   "Taskbar behaviors > When using multiple displays, show my taskbar apps
@@ -172,7 +181,7 @@ community.
 - rightApps: ""
   $name: Force these apps to the right
   $description: Same idea as leftApps, but for the right side.
-- unresolvedAppsDefaultSide: left
+- unresolvedAppsDefaultSide: contralateral-to-system-buttons
   $name: Default side for unclassified apps
   $options:
     - left: Left of Start
@@ -210,6 +219,18 @@ community.
     when "App icon ordering" above is "Closer to center" - with "Preserve
     existing taskbar order" there's no outer-edge/adjacent-to-Start
     distinction to begin with.
+- trackWindowPositions: true
+  $name: Track window positions
+  $description: >-
+    When on, each running app's taskbar button is matched to its window so
+    it can be classified by live position and follow it if it's dragged
+    across the screen - this involves probing the taskbar's internal click
+    handler on a background timer and two system-wide window-event hooks.
+    Turn off to disable all of that: every running app is then classified
+    the same way as a pinned-but-not-running one, via leftApps/rightApps/
+    "Default side for unclassified apps" below, with no drag-follow. Start
+    centering and Search/Task View/Widgets placement are unaffected either
+    way. Takes effect immediately, no need to reload the mod.
 */
 // ==/WindhawkModSettings==
 
@@ -277,6 +298,7 @@ struct ModSettings {
     UnresolvedAppsDefaultSide unresolvedAppsDefaultSide;
     TaskListOrder taskListOrder;
     PinnedAppsAnchor pinnedAppsAnchor;
+    bool trackWindowPositions;
 };
 ModSettings g_settings;
 
@@ -405,6 +427,8 @@ ModSettings LoadSettingsFromStore() {
 
     s.pinnedAppsAnchor = ParsePinnedAppsAnchor(
         WindhawkUtils::StringSetting::make(L"pinnedAppsAnchor"));
+
+    s.trackWindowPositions = Wh_GetIntSetting(L"trackWindowPositions") != 0;
 
     return s;
 }
@@ -738,6 +762,13 @@ constexpr int kClickSentinelMissesBeforeBroken = 3;
 // dispatched it.
 thread_local bool g_clickSentinelProbingGroup;
 
+// Set the first time a genuine (non-sentinel) click reaches this hook -
+// gates the very first unattended sentinel probe of the session on proof
+// that CTaskListWnd::HandleClick's hook is actually installed and
+// dispatching real clicks through it correctly, before ever risking one
+// becoming a real click if interception is broken. See RATIONALE.md.
+std::atomic<bool> g_realTaskbarClickObserved;
+
 HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
                                               void* taskGroup,
                                               void* taskItem,
@@ -758,6 +789,7 @@ HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
         return S_OK;
     }
 
+    g_realTaskbarClickObserved = true;
     return CTaskListWnd_HandleClick_Original(pThis, taskGroup, taskItem,
                                               launcherOptions);
 }
@@ -910,6 +942,14 @@ HWND ResolveHwndFromIndividualTaskItem(FrameworkElement element) {
         return nullptr;
     }
 
+    // Bails out before dispatching a click if the interception point
+    // hasn't proven reachable this session yet - see
+    // g_realTaskbarClickObserved's own comment.
+    if (!g_realTaskbarClickObserved) {
+        g_resolveStats.failure++;
+        return nullptr;
+    }
+
     IUnknown* elementAbi = (IUnknown*)winrt::get_abi(element);
 
     winrt::com_ptr<IUnknown> windowViewModel;
@@ -955,6 +995,14 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
         !TryGetItemFromContainer_TaskListGroupViewModel_Original ||
         !TaskListGroupViewModel_IsMultiWindow_Original ||
         !TaskGroup_ReportClicked_Original || !CTaskGroup_GetNumItems_Original) {
+        return nullptr;
+    }
+
+    // Bails out before dispatching a click if the interception point
+    // hasn't proven reachable this session yet - see
+    // g_realTaskbarClickObserved's own comment.
+    if (!g_realTaskbarClickObserved) {
+        g_resolveStats.failure++;
         return nullptr;
     }
 
@@ -1402,19 +1450,6 @@ constexpr double kFarLeftSystemButtonMarginPx = 8;
 // system tray's own left edge (see RecomputeLayoutPlan's rightBoundLocal).
 constexpr double kTrayMarginPx = 8;
 
-int SystemButtonRank(SystemButton b) {
-    switch (b) {
-        case SystemButton::Search:
-            return 0;
-        case SystemButton::TaskView:
-            return 1;
-        case SystemButton::Widgets:
-            return 2;
-        default:
-            return -1;
-    }
-}
-
 // Total footprint of Search+TaskView+Widgets together, used both to lay
 // them out and to reserve room for them next to Start (adjacent mode).
 // Recomputed every pass so a hidden cluster reads as genuinely 0.
@@ -1435,19 +1470,21 @@ struct ChildInfo {
 // already-classified children (avoids re-walking/re-classifying).
 double ComputeSystemButtonX(const std::vector<ChildInfo>& childInfos,
                             FrameworkElement targetElement,
-                            SystemButton target,
                             double startCenterX,
                             double startWidth,
                             double clusterWidth) {
-    int targetRank = SystemButtonRank(target);
-    if (targetRank < 0) {
-        return 0;
-    }
-
+    // Sums every other system button's footprint that appears earlier than
+    // targetElement in taskbar order - tracks whatever order the taskbar
+    // itself presents these in, rather than a fixed Search/TaskView/Widgets
+    // table, so this stays correct even if a build ever surfaces more than
+    // one of a given button type. See RATIONALE.md.
     double widthBefore = 0;
     for (auto& info : childInfos) {
-        int r = SystemButtonRank(info.systemButton);
-        if (r >= 0 && r < targetRank) {
+        if (info.element == targetElement) {
+            break;
+        }
+        if (info.systemButton != SystemButton::None &&
+            info.systemButton != SystemButton::Start) {
             widthBefore += SystemButtonFootprintWidth(info.element);
         }
     }
@@ -1460,9 +1497,9 @@ double ComputeSystemButtonX(const std::vector<ChildInfo>& childInfos,
     double ownWidth = SystemButtonFootprintWidth(targetElement);
 
     if (g_settings.systemButtonsAdjacentSide == Side::Left) {
-        // Stack right-to-left outward from Start: highest rank closest to
-        // Start, so reading left-to-right still shows the same low-to-high
-        // rank order (Search, Task View, Widgets) as far-left mode does.
+        // Stack right-to-left outward from Start: taskbar-order-earliest
+        // button ends up closest to Start, so reading left-to-right still
+        // shows the same order as far-left mode does.
         double widthAfter = clusterWidth - widthBefore - ownWidth;
         return startCenterX - startWidth / 2.0 - gap - widthAfter - ownWidth;
     }
@@ -1659,8 +1696,18 @@ void InvalidateTaskbarLayout();
 // which item an element represents without changing the button count).
 constexpr DWORD kIdleResolveTickMs = 30000;
 
+// Retry cadence for a pass that couldn't enumerate the live button set at
+// all (e.g. a taskbar rebuild transiently breaks GetCachedTaskbarRepeater).
+// Much shorter than kIdleResolveTickMs, which is only meant for a pass that
+// actually confirmed the live set - see ScheduleNextResolveTick.
+constexpr DWORD kEnumerationFailedRetryMs = 1000;
+
 // Defined later (Mod lifecycle section).
 void StartWinEventHook();
+
+// Defined later (Mod lifecycle section); lets a live trackWindowPositions
+// toggle stop the WinEventHook thread reversibly - see RATIONALE.md.
+void StopWinEventHookForToggle();
 
 // Defined later (Mod lifecycle section); lets the ArrangeOverride hook
 // request an immediate HWND-resolve attempt.
@@ -1707,7 +1754,18 @@ HWND EnsureTaskbarWnd() {
             return nullptr;
         }
         Wh_Log(L"Resolved taskbar window: %p", (HWND)g_hTaskbarWnd);
-        StartWinEventHook();
+        // Starting this thread is what turns on window-position tracking
+        // at all - see trackWindowPositions' own settings description.
+        // Only checked here at initial resolve, not on every call; a live
+        // settings change afterward is handled separately by
+        // TaskbarWndSubclassProc's SettingsChangedMsg case, via
+        // StartWinEventHook/StopWinEventHookForToggle directly.
+        if (g_settings.trackWindowPositions) {
+            StartWinEventHook();
+        } else {
+            Wh_Log(L"trackWindowPositions is off - skipping the WinEventHook "
+                   L"thread and all HWND resolution");
+        }
     }
 
     // Retried on every call until it succeeds, not just the pass that
@@ -1818,14 +1876,16 @@ void ResolvePendingButtonHwnds() {
     // are done (doing it from ButtonHwndResolveTimerProc instead would
     // race g_buttonHwndCache). `enumerated` tracks whether the walk below
     // actually completed, since NextResolveDelayMs' INFINITE answer is
-    // only trustworthy then - the destructor falls back to
-    // kIdleResolveTickMs otherwise.
+    // only trustworthy then - the destructor falls back to the much
+    // shorter kEnumerationFailedRetryMs otherwise, so a transient failure
+    // (e.g. a taskbar rebuild) recovers quickly rather than leaving every
+    // button on its default-side classification for up to 30s.
     bool enumerated = false;
     struct ScheduleNextResolveTick {
         bool* enumerated;
         ~ScheduleNextResolveTick() {
-            DWORD delay =
-                *enumerated ? NextResolveDelayMs() : kIdleResolveTickMs;
+            DWORD delay = *enumerated ? NextResolveDelayMs()
+                                      : kEnumerationFailedRetryMs;
             if (delay != INFINITE) {
                 ArmButtonHwndResolveTimer(delay);
             }
@@ -2133,7 +2193,8 @@ void RecomputeLayoutPlan() {
         // so an empty cluster reads as genuinely 0.
         double systemClusterWidth = 0;
         for (auto& info : childInfos) {
-            if (SystemButtonRank(info.systemButton) >= 0) {
+            if (info.systemButton != SystemButton::None &&
+                info.systemButton != SystemButton::Start) {
                 systemClusterWidth += SystemButtonFootprintWidth(info.element);
             }
         }
@@ -2156,7 +2217,7 @@ void RecomputeLayoutPlan() {
                 continue;
             }
             newPlan[winrt::get_abi(info.element)] = ComputeSystemButtonX(
-                childInfos, info.element, info.systemButton, startCenterX,
+                childInfos, info.element, startCenterX,
                 g_lastStartWidth, systemClusterWidth);
         }
 
@@ -2398,10 +2459,27 @@ LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
     if (uMsg == SettingsChangedMsg()) {
         std::unique_ptr<ModSettings> heapSettings(
             reinterpret_cast<ModSettings*>(lParam));
+        bool wasTracking = g_settings.trackWindowPositions;
         g_settings = std::move(*heapSettings);
         // Marks the previous plan stale now that the settings it was built
         // from just changed. See RATIONALE.md.
         g_planDirty = true;
+        // Starts/stops the WinEventHook thread live on a trackWindowPositions
+        // change, rather than only at the next mod reload - see RATIONALE.md.
+        if (g_settings.trackWindowPositions != wasTracking) {
+            if (g_settings.trackWindowPositions) {
+                StartWinEventHook();
+            } else {
+                StopWinEventHookForToggle();
+                // Without this, an already-resolved button keeps using its
+                // last-known (now frozen) window position instead of
+                // immediately falling back to leftApps/rightApps/default -
+                // GetButtonHwnd would otherwise keep finding a stale entry
+                // here. Safe to clear directly: every other access to this
+                // cache also runs on this same taskbar thread.
+                g_buttonHwndCache.clear();
+            }
+        }
         return 0;
     }
     return DefSubclassProc(hWnd, uMsg, wParam, lParam);
@@ -2607,12 +2685,14 @@ bool HookTaskbarDllSymbols() {
 
     bool ok = HookSymbols(module, taskbarDllHooks, ARRAYSIZE(taskbarDllHooks));
     Wh_Log(L"HookTaskbarDllSymbols: %s", ok ? L"OK" : L"FAILED");
-    Wh_Log(L"  TaskItem::ReportClicked: %s",
-           TaskItem_ReportClicked_Original ? L"resolved" : L"MISSING");
-    Wh_Log(L"  CTaskGroup::GetNumItems: %s",
-           CTaskGroup_GetNumItems_Original ? L"resolved" : L"MISSING");
-    Wh_Log(L"  TaskGroup::ReportClicked: %s",
-           TaskGroup_ReportClicked_Original ? L"resolved" : L"MISSING");
+    // Only logged individually on failure - these three are optional (see
+    // the hooks table above), so there's nothing to report when ok is true.
+    if (!ok) {
+        Wh_Log(L"  Missing (optional, click-sentinel chain only): %s%s%s",
+               TaskItem_ReportClicked_Original ? L"" : L"TaskItem::ReportClicked ",
+               CTaskGroup_GetNumItems_Original ? L"" : L"CTaskGroup::GetNumItems ",
+               TaskGroup_ReportClicked_Original ? L"" : L"TaskGroup::ReportClicked ");
+    }
     return ok;
 }
 
@@ -2664,23 +2744,29 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
 
     bool ok = HookSymbols(module, hooks, ARRAYSIZE(hooks));
     Wh_Log(L"HookTaskbarViewDllSymbols: %s", ok ? L"OK" : L"FAILED");
+    // ArrangeOverride is the one required symbol here, so it's always
+    // worth confirming directly. The rest are optional (HWND-resolution
+    // chain only) - only worth naming individually on failure.
     Wh_Log(L"  ArrangeOverride: %s",
            TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original ? L"resolved"
                                                                         : L"MISSING");
-    Wh_Log(L"  TryGetItemFromContainer<TaskListWindowViewModel>: %s",
-           TryGetItemFromContainer_TaskListWindowViewModel_Original ? L"resolved"
-                                                                     : L"MISSING");
-    Wh_Log(L"  TaskListWindowViewModel::get_TaskItem: %s",
-           TaskListWindowViewModel_get_TaskItem_Original ? L"resolved"
-                                                          : L"MISSING");
-    Wh_Log(L"  TryGetItemFromContainer<TaskListGroupViewModel>: %s",
-           TryGetItemFromContainer_TaskListGroupViewModel_Original ? L"resolved"
-                                                                    : L"MISSING");
-    Wh_Log(L"  TaskListGroupViewModel::IsMultiWindow: %s",
-           TaskListGroupViewModel_IsMultiWindow_Original ? L"resolved"
-                                                          : L"MISSING");
-    Wh_Log(L"  ITaskGroup::IsRunning: %s",
-           ITaskGroup_IsRunning_Original ? L"resolved" : L"MISSING");
+    if (!ok) {
+        Wh_Log(L"  Missing (optional, HWND-resolution chain only): "
+               L"%s%s%s%s%s",
+               TryGetItemFromContainer_TaskListWindowViewModel_Original
+                   ? L""
+                   : L"TryGetItemFromContainer<TaskListWindowViewModel> ",
+               TaskListWindowViewModel_get_TaskItem_Original
+                   ? L""
+                   : L"TaskListWindowViewModel::get_TaskItem ",
+               TryGetItemFromContainer_TaskListGroupViewModel_Original
+                   ? L""
+                   : L"TryGetItemFromContainer<TaskListGroupViewModel> ",
+               TaskListGroupViewModel_IsMultiWindow_Original
+                   ? L""
+                   : L"TaskListGroupViewModel::IsMultiWindow ",
+               ITaskGroup_IsRunning_Original ? L"" : L"ITaskGroup::IsRunning ");
+    }
     return ok;
 }
 
@@ -2842,16 +2928,23 @@ void StartWinEventHook() {
 }
 
 // Waits for the thread to fully exit, guaranteeing UnhookWinEvent and the
-// resolve timer's KillTimer have run before Windhawk unmaps this module.
-void StopWinEventHook() {
+// resolve timer's KillTimer have run before returning. Shared by
+// StopWinEventHook (permanent, mod-teardown) and StopWinEventHookForToggle
+// (reversible, live trackWindowPositions toggle) - see RATIONALE.md for why
+// only the former sets g_winEventThreadStopped.
+void StopWinEventHookInternal(bool permanent) {
     HANDLE thread;
     DWORD threadId;
     {
         std::lock_guard<std::mutex> guard(g_winEventThreadMutex);
         // Set before releasing the lock, so a StartWinEventHook call
         // arriving after this point can't recreate a thread nobody would
-        // tear down.
-        g_winEventThreadStopped = true;
+        // tear down. Unconditional (even if thread turns out already null
+        // below) so a concurrent StopWinEventHookForToggle racing this
+        // permanent stop can't leave the latch unset.
+        if (permanent) {
+            g_winEventThreadStopped = true;
+        }
         thread = g_winEventThread;
         threadId = g_winEventThreadId;
         g_winEventThread = nullptr;
@@ -2874,6 +2967,18 @@ void StopWinEventHook() {
     // module's code while the thread is still running inside it.
     WaitForSingleObject(thread, INFINITE);
     CloseHandle(thread);
+}
+
+void StopWinEventHook() {
+    StopWinEventHookInternal(/*permanent=*/true);
+}
+
+// Lets trackWindowPositions be turned off live, without tripping the
+// permanent g_winEventThreadStopped latch StopWinEventHook sets - a later
+// StartWinEventHook (from turning the setting back on) still works. See
+// RATIONALE.md.
+void StopWinEventHookForToggle() {
+    StopWinEventHookInternal(/*permanent=*/false);
 }
 
 // Capped exponential backoff for the click-sentinel probe, shared by

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -228,7 +228,7 @@ community.
     handler on a background timer and two system-wide window-event hooks.
     Turn off to disable all of that: every running app is then classified
     the same way as a pinned-but-not-running one, via leftApps/rightApps/
-    "Default side for unclassified apps" below, with no drag-follow. Start
+    "Default side for unclassified apps" above, with no drag-follow. Start
     centering and Search/Task View/Widgets placement are unaffected either
     way. Takes effect immediately, no need to reload the mod.
 */
@@ -3269,7 +3269,11 @@ void ApplyLoadedSettings(ModSettings settings) {
     auto heapSettings = std::make_unique<ModSettings>(std::move(settings));
     if (PostMessage(hTaskbarWnd, SettingsChangedMsg(), 0,
                     (LPARAM)heapSettings.get())) {
-        heapSettings.release();
+        // The pointer itself was already captured via .get() above; this
+        // call's own return value is the same pointer, discarded here on
+        // purpose - release() is invoked purely so the unique_ptr's
+        // destructor doesn't free what PostMessage's receiver now owns.
+        (void)heapSettings.release();
         return;
     }
     Wh_Log(L"ApplyLoadedSettings: PostMessage failed, error=%lu, "

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -461,11 +461,20 @@ thread_local bool g_inTaskbarArrangeOverride;
 std::atomic<HWND> g_hTaskbarWnd;
 
 // Whether TaskbarWndSubclassProc is currently installed on g_hTaskbarWnd -
-// see EnsureTaskbarWnd (where it's installed) and InvalidateTaskbarLayout
-// (which checks it to pick PostMessage vs. the RunFromWindowThread
-// fallback). atomic: set from Explorer's UI thread (EnsureTaskbarWnd) or
-// Wh_ModAfterInit's thread, read from InvalidateTaskbarLayout's callers,
-// which include the dedicated WinEventHook thread.
+// see EnsureTaskbarWnd (where it's installed) and InvalidateTaskbarLayout/
+// ButtonHwndResolveTimerProc/ApplyLoadedSettings (which all check it before
+// posting to the taskbar thread). This is the SOLE way any of those reach
+// the taskbar thread - there is no fallback marshal if the subclass never
+// installed (SetWindowSubclassFromAnyThread failing is rare - see
+// EnsureTaskbarWnd's own log line for that case): live drag-follow,
+// HWND resolution, and live settings updates are simply unavailable until
+// the taskbar recreates and a fresh subclass attempt succeeds. The mod's
+// core centering/splitting is unaffected either way, since that's computed
+// synchronously inside RecomputeLayoutPlan on whatever ArrangeOverride
+// passes XAML triggers on its own. atomic: set from Explorer's UI thread
+// (EnsureTaskbarWnd) or Wh_ModAfterInit's thread, read from
+// InvalidateTaskbarLayout's callers, which include the dedicated
+// WinEventHook thread.
 std::atomic<bool> g_taskbarWndSubclassed;
 
 HWINEVENTHOOK g_locationChangeHook;
@@ -596,71 +605,6 @@ std::vector<FrameworkElement> GetRepeaterChildElements(
     return result;
 }
 
-
-using RunFromWindowThreadProc_t = std::function<void()>;
-
-// A second, concurrent RunFromWindowThread call targeting the same thread
-// installs a second WH_CALLWNDPROC hook in the same chain. Both hooks
-// only ever check the message id (there's exactly one, shared by every
-// call), so when either call's SendMessage lands, every currently-
-// installed hook for this thread fires and blindly casts cwp->lParam -
-// which points at whichever call actually sent that specific message - to
-// its own proc pointer. That means an unrelated concurrent call's proc can
-// run in place of (or in addition to) the intended one. The `done` flag
-// caps this at exactly one real invocation per SendMessage regardless of
-// how many hooks are chained and firing for it: whichever hook proc
-// happens to run first for a given message wins, the rest see done==true
-// and no-op. Plain bool, not atomic - all hooks that fire for one message
-// do so synchronously, one after another, on the single thread receiving
-// that message, never concurrently with each other.
-struct RunFromWindowThreadParam {
-    RunFromWindowThreadProc_t* proc;
-    bool done = false;
-};
-
-bool RunFromWindowThread(HWND hWnd, RunFromWindowThreadProc_t proc) {
-    static const UINT runFromWindowThreadRegisteredMsg = RegisterWindowMessage(
-        L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
-
-    DWORD dwThreadId = GetWindowThreadProcessId(hWnd, nullptr);
-    if (dwThreadId == 0) {
-        return false;
-    }
-
-    if (dwThreadId == GetCurrentThreadId()) {
-        proc();
-        return true;
-    }
-
-    RunFromWindowThreadParam param{&proc};
-
-    HHOOK hook = SetWindowsHookEx(
-        WH_CALLWNDPROC,
-        [](int nCode, WPARAM wParam, LPARAM lParam) -> LRESULT {
-            if (nCode == HC_ACTION) {
-                const CWPSTRUCT* cwp = (const CWPSTRUCT*)lParam;
-                if (cwp->message == runFromWindowThreadRegisteredMsg) {
-                    auto* param = (RunFromWindowThreadParam*)cwp->lParam;
-                    if (!param->done) {
-                        param->done = true;
-                        (*param->proc)();
-                    }
-                }
-            }
-
-            return CallNextHookEx(nullptr, nCode, wParam, lParam);
-        },
-        nullptr, dwThreadId);
-    if (!hook) {
-        return false;
-    }
-
-    SendMessage(hWnd, runFromWindowThreadRegisteredMsg, 0, (LPARAM)&param);
-
-    UnhookWindowsHookEx(hook);
-
-    return true;
-}
 
 // ============================================================================
 // taskbar.dll: locating the taskbar's XamlRoot
@@ -2064,21 +2008,54 @@ HWND EnsureTaskbarWnd() {
         Wh_Log(L"Resolved taskbar window: %p", (HWND)g_hTaskbarWnd);
         StartWinEventHook();
 
-        // Lets InvalidateTaskbarLayout notify this window with a
-        // non-blocking PostMessage instead of RunFromWindowThread's
-        // per-call SetWindowsHookEx/SendMessage/UnhookWindowsHookEx dance -
-        // see its own comment. A one-time blocking install here (via
-        // SetWindowSubclassFromAnyThread's own marshal, if this isn't
-        // already running on the taskbar thread) is fine; it's the
+        // Lets InvalidateTaskbarLayout/ButtonHwndResolveTimerProc/
+        // ApplyLoadedSettings notify this window with a non-blocking
+        // PostMessage - see g_taskbarWndSubclassed's own comment for why
+        // there's no fallback if this fails. A one-time blocking install
+        // here (via SetWindowSubclassFromAnyThread's own marshal, if this
+        // isn't already running on the taskbar thread) is fine; it's the
         // per-event cost on the hot invalidate path this is meant to
         // avoid, not one-shot setup.
         if (WindhawkUtils::SetWindowSubclassFromAnyThread(
                 g_hTaskbarWnd, TaskbarWndSubclassProc, 0)) {
             g_taskbarWndSubclassed = true;
+
+            // Wh_ModBeforeUninit's own removal pass only runs once, gated
+            // by this same g_taskbarWndSubclassed.exchange(false) latch -
+            // if it already ran with g_hTaskbarWnd still null (reachable:
+            // right after a Shell_TrayWnd recreate, or a fresh-boot
+            // startup where the one-shot Wh_ModAfterInit lookup failed,
+            // is exactly when EnsureTaskbarWnd can still be resolving
+            // this for the first time as unload begins), it can never run
+            // again - a subclass installed here after that point would
+            // stay wired into Shell_TrayWnd with no later removal call,
+            // and Windhawk unmaps this module's code shortly after
+            // Wh_ModUninit returns. Re-checking g_unloading immediately
+            // after install and undoing it right here closes that window;
+            // StartWinEventHook above needs no equivalent recheck since
+            // its own start/stop pair is already serialized by
+            // g_winEventThreadMutex/g_winEventThreadStopped.
+            if (g_unloading && g_taskbarWndSubclassed.exchange(false)) {
+                WindhawkUtils::RemoveWindowSubclassFromAnyThread(
+                    g_hTaskbarWnd, TaskbarWndSubclassProc);
+            } else {
+                // With no fallback marshal, a subclass that installs
+                // successfully on a LATER call (e.g. after an earlier
+                // attempt failed and the taskbar has since recreated)
+                // needs an explicit kick - ButtonHwndResolveTimerProc's
+                // own self-rearming stopped entirely while unsubclassed
+                // (see its comment), so nothing else would restart it.
+                // Harmless to call unconditionally on the very first
+                // successful resolve too, alongside Wh_ModAfterInit's own
+                // InvalidateTaskbarLayout() call right after this returns.
+                ArmButtonHwndResolveTimer(0);
+                InvalidateTaskbarLayout();
+            }
         } else {
             Wh_Log(L"EnsureTaskbarWnd: SetWindowSubclassFromAnyThread "
-                   L"failed, InvalidateTaskbarLayout will use the blocking "
-                   L"fallback instead");
+                   L"failed - live drag-follow, HWND resolution, and live "
+                   L"settings updates will be unavailable until the "
+                   L"taskbar recreates and a fresh attempt succeeds");
         }
     }
 
@@ -2159,15 +2136,14 @@ FrameworkElement GetCachedTaskbarRepeater() {
 //
 // Also guarded against running while nested inside an active Arrange
 // pass on this thread - defense in depth, not the primary protection.
-// Reentrancy guard: this function is reachable from two independent
-// dispatch paths on the taskbar thread (the posted ResolveButtonHwndsMsg
-// via TaskbarWndSubclassProc, and RunFromWindowThread's sent message via
-// its WH_CALLWNDPROC hook), and it mutates g_buttonHwndCache/
-// g_lastKnownWindowClassification with erase-while-iterating prune loops.
-// If a cross-thread SendMessage gets pumped while a call is already in
-// progress here (it calls into taskbar.dll and WinRT, either of which
-// could pump), a nested call's inserts would invalidate the outer loop's
-// iterator - undefined behavior, not just wasted work. RAII rather than a
+// Reentrancy guard: this function runs dispatched from the posted
+// ResolveButtonHwndsMsg via TaskbarWndSubclassProc, and it mutates
+// g_buttonHwndCache/g_lastKnownWindowClassification with
+// erase-while-iterating prune loops. It calls into taskbar.dll and WinRT,
+// either of which could pump messages - if another posted
+// ResolveButtonHwndsMsg gets dispatched reentrantly while a call is
+// already in progress here, a nested call's inserts would invalidate the
+// outer loop's iterator - undefined behavior, not just wasted work. RAII rather than a
 // plain set/clear, same reasoning as ScopedArrangeOverrideFlag: this
 // function has several early returns a plain clear at the end would never
 // reach.
@@ -2222,10 +2198,10 @@ void ResolvePendingButtonHwnds() {
         return;
     }
 
-    // Runs marshaled through RunFromWindowThread's WH_CALLWNDPROC hook - a
-    // raw Win32 callback boundary with no C++/WinRT exception translation
-    // on the other side, same as IUIElement_Arrange_Hook/RecomputeLayoutPlan/
-    // InvalidateTaskbarLayout's lambda. Every WinRT property access below
+    // Runs dispatched via TaskbarWndSubclassProc, a raw Win32 callback
+    // boundary with no C++/WinRT exception translation on the other side,
+    // same as IUIElement_Arrange_Hook/RecomputeLayoutPlan/
+    // PerformTaskbarLayoutInvalidate. Every WinRT property access below
     // (Content(), ItemsSourceView(), get_class_name, GetName, XamlRoot())
     // can throw winrt::hresult_error, most likely exactly when the taskbar
     // tree is being recreated - an uncaught throw here crosses the boundary
@@ -2817,9 +2793,12 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
 // Guards against reentering the invalidate body itself on the taskbar's
 // own thread. WinEventProc can fire in rapid bursts (observed: thousands
 // of raw events within seconds while something on screen is spamming
-// EVENT_OBJECT_LOCATIONCHANGE), and both call paths below
-// (TaskbarWndSubclassProc's dispatch and RunFromWindowThread's fallback)
-// land on that same thread, so one thread_local flag covers either.
+// EVENT_OBJECT_LOCATIONCHANGE), each one posting another
+// InvalidateTaskbarLayoutMsg dispatched via TaskbarWndSubclassProc - a
+// nested WinRT/taskbar.dll call inside this function's own body (GetCached
+// TaskbarRepeater, InvalidateArrange/InvalidateMeasure) could pump
+// messages and let a second posted message land reentrantly on this same
+// thread before the first call returns.
 //
 // This deliberately never calls UpdateLayout() - see the note on
 // InvalidateTaskbarLayout below for why forcing a synchronous layout pass
@@ -2860,11 +2839,10 @@ void PerformTaskbarLayoutInvalidate() {
 // Private message InvalidateTaskbarLayout posts to run
 // PerformTaskbarLayoutInvalidate on the taskbar's own thread without
 // blocking the caller - see InvalidateTaskbarLayout's own comment for why
-// that matters on this specific call path. Function-local static (like
-// RunFromWindowThread's own registered message) rather than a
-// namespace-scope variable, so RegisterWindowMessage runs lazily on first
-// real use instead of from a dynamic initializer under DllMain's loader
-// lock.
+// that matters on this specific call path. Function-local static rather
+// than a namespace-scope variable, so RegisterWindowMessage runs lazily on
+// first real use instead of from a dynamic initializer under DllMain's
+// loader lock.
 UINT InvalidateTaskbarLayoutMsg() {
     static const UINT msg =
         RegisterWindowMessage(L"Windhawk_InvalidateTaskbarLayout_" WH_MOD_ID);
@@ -2872,8 +2850,7 @@ UINT InvalidateTaskbarLayoutMsg() {
 }
 
 // Same idea as InvalidateTaskbarLayoutMsg, for ButtonHwndResolveTimerProc
-// - lets it post instead of going through RunFromWindowThread on every
-// tick (up to ~7/sec while EVENT_OBJECT_SHOW events are bursting).
+// (up to ~7/sec while EVENT_OBJECT_SHOW events are bursting).
 UINT ResolveButtonHwndsMsg() {
     static const UINT msg =
         RegisterWindowMessage(L"Windhawk_ResolveButtonHwnds_" WH_MOD_ID);
@@ -2894,16 +2871,15 @@ UINT SettingsChangedMsg() {
 // Installed on g_hTaskbarWnd by EnsureTaskbarWnd via
 // SetWindowSubclassFromAnyThread. A subclass proc only ever runs on the
 // thread that owns the window, which is what lets these call paths use a
-// plain PostMessage here instead of RunFromWindowThread's
-// SetWindowsHookEx/SendMessage/UnhookWindowsHookEx dance on every single
-// call - and, since a subclass proc is dispatched directly by that
-// thread's own message loop rather than through a possibly-multiply-
-// chained hook, it can't suffer the double-invocation risk RunFromWindowThread
-// has to guard against instead. Everything other than these private
-// messages is forwarded to DefSubclassProc, which is also what lets
-// comctl32 clean this subclass up automatically via WM_NCDESTROY if the
-// window is ever destroyed out from under the mod without
-// Wh_ModBeforeUninit's explicit removal call running first.
+// plain, non-blocking PostMessage - no per-call SetWindowsHookEx/
+// SendMessage/UnhookWindowsHookEx dance needed. This is also the SOLE way
+// any of these three messages reach the taskbar thread; if this subclass
+// never installs (see g_taskbarWndSubclassed's own comment), there is no
+// fallback. Everything other than these private messages is forwarded to
+// DefSubclassProc, which is also what lets comctl32 clean this subclass up
+// automatically via WM_NCDESTROY if the window is ever destroyed out from
+// under the mod without Wh_ModBeforeUninit's explicit removal call running
+// first.
 LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
                                         UINT uMsg,
                                         WPARAM wParam,
@@ -2957,32 +2933,18 @@ void InvalidateTaskbarLayout() {
     // g_hTaskbarWnd's own comment for why that matters here specifically
     // (a stale nullptr reaching PostMessage is not a no-op).
     HWND hTaskbarWnd = g_hTaskbarWnd;
-    if (!hTaskbarWnd) {
+    // No fallback if the subclass never installed - see
+    // g_taskbarWndSubclassed's own comment for why. Called from
+    // WinEventProc's drag-follow throttle at up to ~7 times/sec while any
+    // window on the system is being dragged, plus every resolve tick, so
+    // this is a hot path - PostMessage doesn't block on Explorer's UI
+    // thread pumping it.
+    if (!hTaskbarWnd || !g_taskbarWndSubclassed) {
         return;
     }
-
-    if (g_taskbarWndSubclassed) {
-        // The hot path: called from WinEventProc's drag-follow throttle
-        // at up to ~7 times/sec while any window on the system is being
-        // dragged, plus every resolve tick. PostMessage doesn't block on
-        // Explorer's UI thread pumping it, unlike RunFromWindowThread
-        // below, which installs a WH_CALLWNDPROC hook and blocks in
-        // SendMessage until that thread processes it - a real cost at
-        // this frequency, even though it's fine for a one-shot call.
-        if (!PostMessage(hTaskbarWnd, InvalidateTaskbarLayoutMsg(), 0, 0)) {
-            Wh_Log(L"InvalidateTaskbarLayout: PostMessage failed, error=%lu",
-                   GetLastError());
-        }
-        return;
-    }
-
-    // Fallback for the (should stay rare) case where the taskbar window
-    // was never successfully subclassed - still gets the job done, just
-    // without the non-blocking benefit above.
-    bool posted =
-        RunFromWindowThread(hTaskbarWnd, PerformTaskbarLayoutInvalidate);
-    if (!posted) {
-        Wh_Log(L"InvalidateTaskbarLayout: RunFromWindowThread failed");
+    if (!PostMessage(hTaskbarWnd, InvalidateTaskbarLayoutMsg(), 0, 0)) {
+        Wh_Log(L"InvalidateTaskbarLayout: PostMessage failed, error=%lu",
+               GetLastError());
     }
 }
 
@@ -3619,42 +3581,35 @@ void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
         // The taskbar window went away (recreate) between this timer
         // being armed and firing - EnsureTaskbarWnd will re-resolve it on
         // its own next pass. Retry later rather than let a null reach
-        // PostMessage/RunFromWindowThread below.
+        // PostMessage below.
         ArmButtonHwndResolveTimer(kIdleResolveTickMs);
         return;
     }
 
-    // Prefer the subclass's non-blocking PostMessage (see
-    // ResolveButtonHwndsMsg) - this can fire several times a second
-    // during an EVENT_OBJECT_SHOW burst, the same hot-path cost
-    // InvalidateTaskbarLayout avoids via PostMessage instead of
-    // RunFromWindowThread's per-call hook install. Only fall back to the
-    // blocking marshal in the (should stay rare) case the subclass was
-    // never successfully installed.
+    // No fallback if the subclass never installed - see
+    // g_taskbarWndSubclassed's own comment for why. In that case,
+    // ResolvePendingButtonHwnds simply never runs and this timer stops
+    // re-arming itself entirely; EnsureTaskbarWnd explicitly kicks both
+    // this timer and InvalidateTaskbarLayout the moment a subclass
+    // install eventually succeeds (its own comment explains why that
+    // kick is needed with no fallback marshal to have kept this ticking
+    // in the meantime).
     //
-    // Neither branch computes/arms the next delay here anymore -
-    // ResolvePendingButtonHwnds does that itself now, at the very end of
-    // whichever pass this triggers (see its own ScheduleNextResolveTick
-    // comment for why: computing it here, right after an async
-    // PostMessage, would read g_buttonHwndCache concurrently with that
-    // pass's own writes to it). The one case that still needs handling
-    // here is a PostMessage failure - nothing will ever call back to
-    // re-arm if the message never arrives, so retry after a fixed
-    // fallback delay rather than leaving the timer silently dead.
+    // ResolvePendingButtonHwnds computes/arms the next delay itself, at
+    // the very end of whichever pass this triggers (see its own
+    // ScheduleNextResolveTick comment for why: computing it here, right
+    // after an async PostMessage, would read g_buttonHwndCache
+    // concurrently with that pass's own writes to it). The one case that
+    // still needs handling here is a PostMessage failure - nothing will
+    // ever call back to re-arm if the message never arrives, so retry
+    // after a fixed fallback delay rather than leaving the timer silently
+    // dead.
     if (g_taskbarWndSubclassed) {
         if (!PostMessage(hTaskbarWnd, ResolveButtonHwndsMsg(), 0, 0)) {
             Wh_Log(L"ButtonHwndResolveTimerProc: PostMessage failed, "
                    L"error=%lu", GetLastError());
             ArmButtonHwndResolveTimer(kIdleResolveTickMs);
         }
-    } else if (!RunFromWindowThread(hTaskbarWnd, ResolvePendingButtonHwnds)) {
-        // Same "nothing will call back" concern as the PostMessage failure
-        // above - a marshal failure here (SetWindowsHookEx failing, or
-        // g_hTaskbarWnd going stale/null mid-taskbar-recreate) means
-        // ResolvePendingButtonHwnds never ran at all, so its own
-        // ScheduleNextResolveTick guard never gets a chance to re-arm.
-        Wh_Log(L"ButtonHwndResolveTimerProc: RunFromWindowThread failed");
-        ArmButtonHwndResolveTimer(kIdleResolveTickMs);
     }
 }
 
@@ -3754,24 +3709,26 @@ void Wh_ModBeforeUninit() {
     // ArrangeOverride isn't gated on g_unloading - a pass landing in that
     // window could still call StartWinEventHook via EnsureTaskbarWnd,
     // creating a thread nobody would tear down (Wh_ModUninit, which does
-    // the actual teardown, runs after this). The Arrange hook also needs
-    // to stay alive here to restore native positioning below. g_unloading
-    // being set first is what keeps ResolvePendingButtonHwnds' click-
-    // sentinel probe from running once its hooks are gone.
+    // the actual teardown, runs after this). g_unloading being set first
+    // is what keeps ResolvePendingButtonHwnds' click-sentinel probe from
+    // running once its hooks are gone, and makes IUIElement_Arrange_Hook
+    // fall through to native positioning immediately regardless of
+    // whether anything below forces a relayout.
 
-    // Removed here, before the final InvalidateTaskbarLayout() call below,
-    // so that call falls back to the blocking RunFromWindowThread marshal
-    // instead of a PostMessage nothing will dispatch once the subclass is
-    // gone, and so TaskbarWndSubclassProc comes off Shell_TrayWnd as early
-    // as it's safe to rather than staying wired in for the rest of
-    // teardown.
+    // Comes off Shell_TrayWnd as early as it's safe to, rather than
+    // staying wired in for the rest of teardown. With no fallback marshal
+    // once this is gone (see g_taskbarWndSubclassed's own comment), there
+    // is no reliable way left to force an immediate visual snap-back to
+    // native positions on disable - g_unloading above already guarantees
+    // the mod stops overriding anything, so this is a cosmetic timing
+    // difference only: native positions apply as soon as anything next
+    // triggers XAML to re-run Arrange on its own (opening/closing an app,
+    // a resize, etc.), rather than instantly.
     HWND hTaskbarWnd = g_hTaskbarWnd;
     if (hTaskbarWnd && g_taskbarWndSubclassed.exchange(false)) {
         WindhawkUtils::RemoveWindowSubclassFromAnyThread(
             hTaskbarWnd, TaskbarWndSubclassProc);
     }
-
-    InvalidateTaskbarLayout();
 }
 
 void Wh_ModUninit() {
@@ -3788,13 +3745,14 @@ void Wh_ModUninit() {
 // Applies a freshly-loaded settings struct on the taskbar's own thread -
 // needed since it reassigns leftApps/rightApps (std::vector<std::wstring>),
 // which a concurrent ContainsAnyFragment call during a layout pass on that
-// thread could otherwise read mid-reassignment. Prefers the subclass's
-// PostMessage over RunFromWindowThread for the same non-blocking reason as
-// InvalidateTaskbarLayout/the HWND-resolve tick, but unlike those two a
-// dropped settings change is a real loss (not just a delayed retry), so
-// this - unlike them - does fall back to the blocking RunFromWindowThread
-// marshal if PostMessage itself fails, not only when the subclass was
-// never installed at all.
+// thread could otherwise read mid-reassignment. No fallback if the
+// subclass never installed or PostMessage itself fails - see
+// g_taskbarWndSubclassed's own comment for why. Unlike
+// InvalidateTaskbarLayout/the HWND-resolve tick, a dropped settings change
+// here is a real loss rather than a delayed retry (there's no periodic
+// mechanism that would naturally pick it up later), so it's logged loudly
+// rather than silently swallowed - the new settings just don't take effect
+// until the taskbar recreates and a fresh subclass attempt succeeds.
 void ApplyLoadedSettings(ModSettings settings) {
     // Snapshot once so every read below agrees - see g_hTaskbarWnd's own
     // comment for why a stale nullptr reaching PostMessage isn't a no-op
@@ -3806,32 +3764,25 @@ void ApplyLoadedSettings(ModSettings settings) {
         return;
     }
 
-    if (g_taskbarWndSubclassed) {
-        // PostMessage is async, so the settings can't live on this
-        // function's own stack - ownership transfers to the heap
-        // allocation, released via .release() only once PostMessage has
-        // actually queued it, and reclaimed by TaskbarWndSubclassProc's
-        // SettingsChangedMsg case on the dispatch side.
-        auto heapSettings = std::make_unique<ModSettings>(std::move(settings));
-        if (PostMessage(hTaskbarWnd, SettingsChangedMsg(), 0,
-                        (LPARAM)heapSettings.get())) {
-            heapSettings.release();
-            return;
-        }
-        Wh_Log(L"ApplyLoadedSettings: PostMessage failed, error=%lu, "
-               L"falling back to RunFromWindowThread", GetLastError());
-        // Reclaim ownership before falling through to the blocking path;
-        // heapSettings frees the now-moved-from struct automatically.
-        settings = std::move(*heapSettings);
+    if (!g_taskbarWndSubclassed) {
+        Wh_Log(L"ApplyLoadedSettings: no taskbar subclass installed, "
+               L"new settings not applied");
+        return;
     }
 
-    if (!RunFromWindowThread(hTaskbarWnd,
-                             [settings = std::move(settings)]() mutable {
-                                 g_settings = std::move(settings);
-                             })) {
-        Wh_Log(L"ApplyLoadedSettings: RunFromWindowThread failed, "
-               L"new settings not applied");
+    // PostMessage is async, so the settings can't live on this function's
+    // own stack - ownership transfers to the heap allocation, released via
+    // .release() only once PostMessage has actually queued it, and
+    // reclaimed by TaskbarWndSubclassProc's SettingsChangedMsg case on the
+    // dispatch side.
+    auto heapSettings = std::make_unique<ModSettings>(std::move(settings));
+    if (PostMessage(hTaskbarWnd, SettingsChangedMsg(), 0,
+                    (LPARAM)heapSettings.get())) {
+        heapSettings.release();
+        return;
     }
+    Wh_Log(L"ApplyLoadedSettings: PostMessage failed, error=%lu, "
+           L"new settings not applied", GetLastError());
 }
 
 void Wh_ModSettingsChanged() {

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -435,9 +435,17 @@ std::atomic<int> g_invalidateSkippedReentrant;
 std::atomic<int> g_invalidateExceptions;
 
 // Only ever touched from the dedicated WinEventHook thread (see
-// StartWinEventHook) - both WinEventProc and DragFollowTrailingTimerProc
-// run there exclusively, so this needs no synchronization.
+// StartWinEventHook) - WinEventProc, DragFollowTrailingTimerProc and
+// ButtonHwndResolveTimerProc all run there exclusively, so none of this
+// needs synchronization.
 UINT_PTR g_dragFollowTrailingTimerId;
+
+// The HWND-resolve timer's own id - lives on this same dedicated thread
+// (see ButtonHwndResolveTimerProc) rather than on a window the mod
+// doesn't own, so teardown is covered by the same thread join that
+// already tears down the WinEvent hook, with no separate marshal that
+// could fail during unload.
+UINT_PTR g_buttonHwndResolveTimerId;
 
 // Same thread-ownership as g_dragFollowTrailingTimerId above. Hoisted out
 // of WinEventProc's own function-local static so DragFollowTrailingTimerProc
@@ -613,6 +621,14 @@ XamlRoot XamlRootFromTaskbarHostSharedPtr(void* taskbarHostSharedPtr[2]) {
         ~DecrefGuard() { std__Ref_count_base__Decref_Original(ptr); }
     } decrefGuard{taskbarHostSharedPtr[1]};
 
+    // The top-level null check above only rules out *both* slots being
+    // null - slot 0 can still be null while slot 1 isn't, and it's
+    // dereferenced below. Bail out here (after the guard above is
+    // already constructed, so [1] still gets released).
+    if (!taskbarHostSharedPtr[0]) {
+        return nullptr;
+    }
+
     // The offset of the XAML element pointer inside TaskbarHost isn't
     // exposed by any symbol, so it's read out of the prologue of a
     // neighboring function that's known to access it at a fixed offset.
@@ -656,6 +672,9 @@ XamlRoot XamlRootFromTaskbarHostSharedPtr(void* taskbarHostSharedPtr[2]) {
     auto* taskbarElementIUnknown =
         *(IUnknown**)((BYTE*)taskbarHostSharedPtr[0] +
                       taskbarElementIUnknownOffset);
+    if (!taskbarElementIUnknown) {
+        return nullptr;
+    }
 
     FrameworkElement taskbarElement = nullptr;
     taskbarElementIUnknown->QueryInterface(winrt::guid_of<FrameworkElement>(),
@@ -1056,9 +1075,14 @@ HWND GetButtonHwnd(FrameworkElement element) {
 // ResolvePendingButtonHwnds (which actually walks TaskListButtons and
 // calls ResolveAndCacheButtonHwnd above) is defined later, right after
 // FindTaskbarFrameRepeater and IsTaskListButton - it depends on both.
-// Forward-declared here so StartButtonHwndResolveTimer (Mod lifecycle
-// section) can reference it before that point.
+// Forward-declared here so WinEventHookThreadProc (Mod lifecycle section)
+// can reference it before that point.
 void ResolvePendingButtonHwnds();
+
+// Defined later (Mod lifecycle section) alongside NextResolveDelayMs,
+// which shares this same backoff formula - forward-declared here so
+// ResolvePendingButtonHwnds' own needsResolve check (below) can use it.
+ULONGLONG ResolveBackoffMs(int consecutiveFailures);
 
 // ============================================================================
 // Screen-position math
@@ -1533,17 +1557,20 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
         std::sort(left.begin(), left.end(), byOrderKey);
         std::sort(right.begin(), right.end(), byOrderKey);
     } else {
-        // Preserve taskbar order, read left-to-right the same way the
-        // native taskbar does: the earliest entry in taskbar order on a
-        // side sits at that side's outer edge, and later entries sit
-        // progressively closer to Start - i.e. innermost-last. `left`/
-        // `right` are already in taskbar order (entries was built that
-        // way); the right side's innermost-last order already matches
-        // the walk order used below (accumulating outward from Start),
-        // but the left side needs reversing to innermost-first - walking
-        // it in original taskbar order here would put the *earliest*
-        // entry innermost instead, mirroring the group relative to
-        // native order.
+        // Preserve taskbar order, read left-to-right across the whole
+        // split layout the way native taskbar order reads: on the left
+        // side, the earliest entry sits at the outer (leftmost) edge and
+        // later entries sit progressively closer to Start; on the right
+        // side it's the opposite - the earliest entry sits innermost
+        // (right next to Start) and later entries sit progressively
+        // farther out. Together these reproduce native left-to-right
+        // order across the whole taskbar once Start is inserted in the
+        // middle. `left`/`right` are already in taskbar order (entries
+        // was built that way); the right side's walk below (accumulating
+        // outward from Start) already puts its earliest entry innermost,
+        // but the left side needs reversing first - walking it in
+        // original taskbar order would put the *latest* entry innermost
+        // instead, backwards from what preserves reading order there.
         std::reverse(left.begin(), left.end());
     }
 
@@ -1628,13 +1655,10 @@ void InvalidateTaskbarLayout();
 // Defined later (Mod lifecycle section); forward-declared here so
 // EnsureTaskbarWnd (below) can start the drag-follow WinEventHook as soon
 // as the taskbar window resolves, whether that happens at normal startup
-// or late (see EnsureTaskbarWnd's comment).
+// or late (see EnsureTaskbarWnd's comment). This also starts the
+// HWND-resolve timer now that it lives on the same dedicated thread - see
+// WinEventHookThreadProc.
 void StartWinEventHook();
-
-// Defined later (Mod lifecycle section); forward-declared here for the
-// same reason as StartWinEventHook above - starts the timer that drives
-// ResolvePendingButtonHwnds.
-void StartButtonHwndResolveTimer();
 
 // Defined later (Mod lifecycle section); forward-declared here so the
 // ArrangeOverride hook below can request an immediate HWND-resolve attempt
@@ -1673,10 +1697,9 @@ HWND EnsureTaskbarWnd() {
         // Guards against Wh_ModBeforeUninit's own InvalidateTaskbarLayout
         // call (or a naturally-timed pass) landing while the mod's hooks
         // are still installed but g_hTaskbarWnd was somehow never set -
-        // without this, resolving it here would call
-        // StartWinEventHook()/StartButtonHwndResolveTimer() and create a
-        // thread/timer with no later Wh_ModUninit call left to tear it
-        // down (Wh_ModBeforeUninit already ran).
+        // without this, resolving it here would call StartWinEventHook()
+        // and create a thread with no later teardown call left to stop it
+        // (Wh_ModBeforeUninit already ran).
         return nullptr;
     }
 
@@ -1684,7 +1707,6 @@ HWND EnsureTaskbarWnd() {
     if (g_hTaskbarWnd) {
         Wh_Log(L"Resolved taskbar window: %p", g_hTaskbarWnd);
         StartWinEventHook();
-        StartButtonHwndResolveTimer();
     }
 
     return g_hTaskbarWnd;
@@ -1703,16 +1725,23 @@ FrameworkElement FindTaskbarFrameRepeater(FrameworkElement anyDescendant) {
 // Walks the primary taskbar's current TaskListButtons and (re)resolves any
 // whose cache entry is missing, stale (window closed), or past the
 // negative-cache TTL - see ResolveAndCacheButtonHwnd's comment for the
-// full story on why this runs on a timer (StartButtonHwndResolveTimer,
-// Mod lifecycle section) instead of inline during Arrange.
+// full story on why this runs on a timer instead of inline during Arrange.
 //
-// Guarded against running while nested inside an active Arrange pass on
-// this thread - defense in depth, not the primary protection. Windows
-// generally doesn't deliver WM_TIMER re-entrantly mid-callback on the
-// same thread, but there's no hard guarantee of that documented, and the
-// check is nearly free.
+// g_unloading gates this before anything else: the click-sentinel probe
+// only stays safe while CTaskListWnd_HandleClick_Hook is installed to
+// intercept it, and that hook (like all of this mod's hooks) can be gone
+// before Wh_ModUninit actually stops the timer that calls this - without
+// this gate, a probe landing in that window reaches the taskbar's real
+// HandleClick with a garbage LauncherOptions pointer (the sentinel
+// string reinterpreted as a vtable), an access violation plus a
+// genuinely dispatched click. g_unloading is set at the top of
+// Wh_ModBeforeUninit, before the hooks are removed, so this closes the
+// window regardless of exactly when the timer's next tick lands.
+//
+// Also guarded against running while nested inside an active Arrange
+// pass on this thread - defense in depth, not the primary protection.
 void ResolvePendingButtonHwnds() {
-    if (g_inTaskbarArrangeOverride || !g_hTaskbarWnd) {
+    if (g_unloading || g_inTaskbarArrangeOverride || !g_hTaskbarWnd) {
         return;
     }
 
@@ -1762,9 +1791,8 @@ void ResolvePendingButtonHwnds() {
                 needsResolve = !IsWindow(it->second.hwnd) ||
                                identity != it->second.identity;
             } else {
-                int shift = std::min(it->second.consecutiveFailures, 4);
-                ULONGLONG backoffMs = 2000ULL << shift;  // 2s..32s
-                needsResolve = now - it->second.lastAttempt >= backoffMs;
+                needsResolve = now - it->second.lastAttempt >=
+                               ResolveBackoffMs(it->second.consecutiveFailures);
             }
         }
 
@@ -2589,6 +2617,25 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
 // global WinEventHook) keeps all of that off the shell's thread entirely -
 // InvalidateTaskbarLayout already marshals onto the taskbar thread for the
 // one thing that actually needs to run there.
+// kArmResolveNowMsg (like WM_APP below) is a private signal on this
+// thread's own message queue, not routed through any window - posted by
+// ArmButtonHwndResolveTimer to request an immediate HWND-resolve
+// attempt. Needed because the resolve timer itself now lives on this
+// thread (see g_buttonHwndResolveTimerId) but callers of
+// ArmButtonHwndResolveTimer run on the taskbar thread, and a per-thread
+// SetTimer/KillTimer registered with hWnd=nullptr can only be armed from
+// the thread that owns it - PostThreadMessage is how a different thread
+// asks this one to do that on its behalf.
+constexpr UINT kArmResolveNowMsg = WM_APP + 1;
+
+// Defined later in this section, alongside NextResolveDelayMs -
+// forward-declared here so WinEventHookThreadProc (right below) can
+// start/re-arm it directly on its own thread.
+void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
+                                         UINT uMsg,
+                                         UINT_PTR idEvent,
+                                         DWORD dwTime);
+
 DWORD WINAPI WinEventHookThreadProc(LPVOID) {
     // Forces this thread's message queue into existence before
     // SetWinEventHook runs, so WINEVENT_OUTOFCONTEXT has somewhere to
@@ -2612,12 +2659,26 @@ DWORD WINAPI WinEventHookThreadProc(LPVOID) {
                L"will");
     }
 
+    // Kicks off the first HWND-resolve attempt shortly after this thread
+    // (and so the taskbar window) is up, so buttons already present at
+    // mod startup get picked up - after that, NextResolveDelayMs and
+    // ArmButtonHwndResolveTimer keep it armed only for as long as
+    // there's actually something to do.
+    g_buttonHwndResolveTimerId =
+        SetTimer(nullptr, 0, 100, ButtonHwndResolveTimerProc);
+
     // WM_APP (posted by StopWinEventHook) is this thread's shutdown
     // signal - it has no window to route to, so it's read directly out of
     // the queue rather than via a window procedure.
     while (GetMessage(&msg, nullptr, 0, 0) > 0) {
         if (msg.message == WM_APP) {
             break;
+        }
+        if (msg.message == kArmResolveNowMsg) {
+            KillTimer(nullptr, g_buttonHwndResolveTimerId);
+            g_buttonHwndResolveTimerId =
+                SetTimer(nullptr, 0, (UINT)msg.lParam, ButtonHwndResolveTimerProc);
+            continue;
         }
         TranslateMessage(&msg);
         DispatchMessage(&msg);
@@ -2627,6 +2688,14 @@ DWORD WINAPI WinEventHookThreadProc(LPVOID) {
         UnhookWinEvent(g_locationChangeHook);
         g_locationChangeHook = nullptr;
     }
+    if (g_buttonHwndResolveTimerId) {
+        KillTimer(nullptr, g_buttonHwndResolveTimerId);
+        g_buttonHwndResolveTimerId = 0;
+    }
+    if (g_dragFollowTrailingTimerId) {
+        KillTimer(nullptr, g_dragFollowTrailingTimerId);
+        g_dragFollowTrailingTimerId = 0;
+    }
 
     return 0;
 }
@@ -2635,7 +2704,15 @@ HANDLE g_winEventThread;
 DWORD g_winEventThreadId;
 
 void StartWinEventHook() {
-    if (g_winEventThread) {
+    // Guards against EnsureTaskbarWnd running concurrently on two
+    // threads - Wh_ModAfterInit's own thread and, once hooks are live,
+    // Explorer's UI thread via the ArrangeOverride hook both call this
+    // once g_hTaskbarWnd first resolves. A plain check-then-act on
+    // g_winEventThread let both create a thread, orphaning one that's
+    // never joined - a deferred crash when Windhawk unmaps the module
+    // while that thread is still parked in GetMessage.
+    static std::atomic<bool> started;
+    if (started.exchange(true)) {
         return;
     }
 
@@ -2646,41 +2723,11 @@ void StartWinEventHook() {
     }
 }
 
-// RunFromWindowThread can only fail two ways: the taskbar's thread is
-// already gone (GetWindowThreadProcessId returns 0 - in which case the
-// OS already tore down any timer that thread owned, so there's nothing
-// left to clean up), or its own internal SetWindowsHookEx call failed
-// (rare, e.g. transient resource exhaustion) while the thread is still
-// very much alive. That second case is the dangerous one: nothing under
-// mod control runs on the taskbar thread to unregister the real
-// HWND-resolve timer, Wh_ModUninit returns anyway, Windhawk unmaps this
-// module's code, and the still-alive thread's next tick calls into
-// unmapped memory. A few retries gives that transient failure a chance to
-// clear without risking an unbounded stall if the thread really is gone.
-// (The WinEventHook itself no longer goes through this - see
-// StopWinEventHook, which owns its thread outright instead.)
-bool RunFromWindowThreadWithRetry(HWND hWnd, RunFromWindowThreadProc_t proc) {
-    // Unbounded, not capped at a few attempts: giving up early and letting
-    // the caller log-and-continue would leave a WM_TIMER registration
-    // pointing at this module's code after Wh_ModUninit returns and
-    // Windhawk unmaps it - a deferred crash, not a mitigated one. Only
-    // stop retrying once the target thread is confirmed gone, since at
-    // that point the OS has already torn down anything it owned.
-    while (!RunFromWindowThread(hWnd, proc)) {
-        if (GetWindowThreadProcessId(hWnd, nullptr) == 0) {
-            return false;
-        }
-        Sleep(20);
-    }
-    return true;
-}
-
-// Unlike the RunFromWindowThread-based teardowns below (which depend on
-// g_hTaskbarWnd's thread still being alive and responsive), this thread is
-// entirely mod-owned: PostThreadMessage can't silently fail the way a
-// marshaled call onto someone else's thread can, and waiting for the
-// thread to actually exit guarantees UnhookWinEvent has already run
-// before Windhawk unmaps this module's code.
+// This thread is entirely mod-owned: PostThreadMessage can't silently
+// fail the way a marshaled call onto someone else's thread can, and
+// waiting for the thread to actually exit guarantees UnhookWinEvent (and
+// the resolve timer's own KillTimer, now that it lives here too) has
+// already run before Windhawk unmaps this module's code.
 void StopWinEventHook() {
     if (!g_winEventThread) {
         return;
@@ -2708,14 +2755,6 @@ void StopWinEventHook() {
     g_winEventThreadId = 0;
 }
 
-// Not 1: this is a window (Shell_TrayWnd) the mod doesn't own, shared with
-// Explorer's own timers and any other mod that also sets timers on it -
-// SetTimer with an already-used ID silently replaces that timer, so a
-// small/common value like 1 is a real collision risk. Arbitrary otherwise,
-// same pattern other mods use for shell-window timers (e.g.
-// classic-taskbar-properties.wh.cpp's kTimerIdMasterLayout).
-constexpr UINT_PTR kButtonHwndResolveTimerId = 0x8C3F;
-
 // Idle re-check cadence once every cached button is already resolved -
 // see NextResolveDelayMs' comment for what this specifically exists to
 // catch (a drag-reorder rebind, which isn't latency-sensitive). Kept
@@ -2725,12 +2764,29 @@ constexpr UINT_PTR kButtonHwndResolveTimerId = 0x8C3F;
 // runs indefinitely for the life of the session.
 constexpr DWORD kIdleResolveTickMs = 30000;
 
+// Capped exponential backoff for the click-sentinel probe: 2s, 4s, 8s,
+// ... up to a 30-minute ceiling, shared by ResolvePendingButtonHwnds
+// (deciding whether an entry needsResolve) and NextResolveDelayMs
+// (scheduling the next tick). A pinned-but-not-running app's button
+// never resolves until it's actually launched, and ItemsRepeater
+// recycles the same element/cache entry rather than creating a new one -
+// so this runs for the life of the session for that one button, with no
+// cheaper existing signal (identity change, button count change) to
+// re-arm on instead, since launching a pinned app changes neither. The
+// ceiling exists to bound how often a synthetic click fires against the
+// taskbar's real click handler while still eventually catching a later
+// launch - previously capped at 32s (shift<=4), which was flagged as a
+// permanent background click loop.
+constexpr ULONGLONG kResolveBackoffCeilingMs = 30ULL * 60 * 1000;
+ULONGLONG ResolveBackoffMs(int consecutiveFailures) {
+    int shift = std::min(consecutiveFailures, 16);  // keep the shift itself from overflowing
+    return std::min(2000ULL << shift, kResolveBackoffCeilingMs);
+}
+
 // How long until the next resolve attempt could possibly do anything
 // useful, based only on g_buttonHwndCache's already-recorded state - no
 // XAML/tree access, just a scan of an in-memory map, so this is cheap
-// enough to call after every timer tick. Mirrors the same backoff formula
-// ResolvePendingButtonHwnds uses to decide needsResolve for an existing
-// entry.
+// enough to call after every timer tick.
 DWORD NextResolveDelayMs() {
     ULONGLONG now = GetTickCount64();
     bool anyPending = false;
@@ -2743,8 +2799,8 @@ DWORD NextResolveDelayMs() {
             anyResolved = true;
             continue;
         }
-        int shift = std::min(entry.consecutiveFailures, 4);
-        ULONGLONG dueAt = entry.lastAttempt + (2000ULL << shift);
+        ULONGLONG dueAt =
+            entry.lastAttempt + ResolveBackoffMs(entry.consecutiveFailures);
         if (!anyPending || dueAt < earliestDue) {
             earliestDue = dueAt;
             anyPending = true;
@@ -2773,80 +2829,65 @@ DWORD NextResolveDelayMs() {
         return INFINITE;
     }
 
-    return earliestDue > now ? (DWORD)(earliestDue - now) : 0;
+    DWORD pendingDelay = earliestDue > now ? (DWORD)(earliestDue - now) : 0;
+    if (anyResolved) {
+        // Mixed cache: some buttons resolved (need the same periodic
+        // rebind re-check as the anyPending==false branch above), others
+        // still pending on their own backoff schedule - which, since
+        // that ceiling was extended to 30 minutes to cut down on
+        // synthetic clicks against pinned-not-running apps, could
+        // otherwise silently starve rebind detection for everyone else
+        // for just as long. Capping at kIdleResolveTickMs here doesn't
+        // resolve the pending entry any earlier (ResolvePendingButtonHwnds
+        // still checks its own backoff before actually retrying it), it
+        // only ensures the already-resolved entries keep getting their
+        // identity re-checked on the normal idle cadence.
+        return std::min(pendingDelay, kIdleResolveTickMs);
+    }
+    return pendingDelay;
 }
 
 void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
                                          UINT uMsg,
                                          UINT_PTR idEvent,
                                          DWORD dwTime) {
-    // Self-managing one-shot rather than a recurring interval: stop first,
-    // do the actual work, then only re-arm if there's a concrete reason
-    // to. Without this, the timer would fire at a fixed cadence forever -
-    // running the full resolve pass (XamlRoot lookup, a visual-tree walk,
-    // a click-sentinel probe per due button) even while everything is
-    // already resolved and nothing has changed, which was flagged as a
-    // real objection on submissions here.
-    KillTimer(hwnd, kButtonHwndResolveTimerId);
+    // Self-managing one-shot rather than a recurring interval: stop
+    // first, do the actual work, then only re-arm if there's a concrete
+    // reason to - otherwise this would run the full resolve pass forever
+    // even once everything is already resolved and nothing has changed.
+    // Runs on this thread directly now (a per-thread SetTimer with
+    // hWnd=nullptr), so no cross-thread marshal is needed to arm/disarm
+    // it - only the actual XAML work inside ResolvePendingButtonHwnds
+    // needs marshaling onto the taskbar thread, which it does itself via
+    // RunFromWindowThread.
+    KillTimer(nullptr, idEvent);
+    g_buttonHwndResolveTimerId = 0;
 
-    ResolvePendingButtonHwnds();
+    if (g_unloading) {
+        return;
+    }
+
+    RunFromWindowThread(g_hTaskbarWnd, ResolvePendingButtonHwnds);
 
     DWORD delay = NextResolveDelayMs();
-    if (delay != INFINITE) {
-        SetTimer(hwnd, kButtonHwndResolveTimerId, delay,
-                 ButtonHwndResolveTimerProc);
+    if (!g_unloading && delay != INFINITE) {
+        g_buttonHwndResolveTimerId =
+            SetTimer(nullptr, 0, delay, ButtonHwndResolveTimerProc);
     }
 }
 
-// SetTimer's callback fires on whichever thread registered it, so this is
-// marshaled onto g_hTaskbarWnd's own thread - both KillTimer and (for
-// reliability) SetTimer itself are documented to need to run on the
-// thread that owns the timer.
+// The resolve timer lives on the dedicated WinEventHook thread (see
+// g_buttonHwndResolveTimerId), not on a window this mod doesn't own, so
+// arming it from the taskbar thread (where every caller of this function
+// runs) needs to ask that thread to do it on its own message queue -
+// PostThreadMessage can't silently fail the way a window-based marshal
+// can, and there's nothing left to leak if it does (the thread just
+// doesn't get the nudge, and its own next scheduled tick catches up).
 void ArmButtonHwndResolveTimer(DWORD delayMs) {
-    if (!g_hTaskbarWnd || g_unloading) {
-        // See EnsureTaskbarWnd's g_unloading check - same reasoning: once
-        // Wh_ModBeforeUninit sets g_unloading, don't create a new
-        // SetTimer registration (whose TimerProc is in this module's own
-        // code) even though the Arrange hook that could still trigger
-        // this (the count-change branch) stays installed until
-        // Wh_ModBeforeUninit returns - StopButtonHwndResolveTimer doesn't
-        // run until the later Wh_ModUninit call, by which point the hook
-        // is gone and nothing could reach here to recreate it anyway.
+    if (!g_winEventThreadId || g_unloading) {
         return;
     }
-
-    if (!RunFromWindowThread(g_hTaskbarWnd, [delayMs] {
-            SetTimer(g_hTaskbarWnd, kButtonHwndResolveTimerId, delayMs,
-                     ButtonHwndResolveTimerProc);
-        })) {
-        Wh_Log(L"ArmButtonHwndResolveTimer: RunFromWindowThread failed, "
-               L"HWND resolution will not run");
-    }
-}
-
-// Kicks off an initial resolve attempt shortly after the taskbar window
-// resolves, so buttons already present at mod startup get picked up -
-// after that, NextResolveDelayMs and the ArrangeOverride hook's
-// button-count-change check keep the timer armed only for as long as
-// there's actually something to do.
-void StartButtonHwndResolveTimer() {
-    ArmButtonHwndResolveTimer(100);
-}
-
-void StopButtonHwndResolveTimer() {
-    if (!g_hTaskbarWnd) {
-        return;
-    }
-
-    // See RunFromWindowThreadWithRetry's own comment for why this retries
-    // until success or a confirmed-dead thread, rather than an inline
-    // KillTimer from the wrong thread here.
-    if (!RunFromWindowThreadWithRetry(g_hTaskbarWnd, [] {
-            KillTimer(g_hTaskbarWnd, kButtonHwndResolveTimerId);
-        })) {
-        Wh_Log(L"StopButtonHwndResolveTimer: RunFromWindowThread failed, "
-               L"timer left running");
-    }
+    PostThreadMessage(g_winEventThreadId, kArmResolveNowMsg, 0, delayMs);
 }
 
 BOOL Wh_ModInit() {
@@ -2910,16 +2951,19 @@ void Wh_ModBeforeUninit() {
 
     g_unloading = true;
 
-    // Deliberately NOT tearing down the WinEventHook thread/timer here:
-    // this mod's hooks stay installed until this function returns, and
+    // Deliberately NOT tearing down the WinEventHook thread here: this
+    // mod's hooks stay installed until this function returns, and
     // ArrangeOverride isn't gated on g_unloading - a pass landing in that
-    // window could still call StartWinEventHook/StartButtonHwndResolveTimer
-    // (via EnsureTaskbarWnd) or ArmButtonHwndResolveTimer(0) (the
-    // count-change branch), creating a thread/timer nobody would tear
-    // down since Wh_ModUninit runs after this. This call still needs the
-    // Arrange hook alive to restore native positioning, so it has to run
-    // while the hooks are installed - actual teardown waits for
-    // Wh_ModUninit, after Windhawk has removed them.
+    // window could still call StartWinEventHook via EnsureTaskbarWnd,
+    // creating a thread nobody would tear down since Wh_ModUninit runs
+    // after this (StartWinEventHook's own atomic guard prevents a second
+    // thread if one already exists, but not a first one if none does
+    // yet). This call still needs the Arrange hook alive to restore
+    // native positioning, so it has to run while the hooks are
+    // installed - actual teardown waits for Wh_ModUninit, after Windhawk
+    // has removed them. g_unloading being set here (before that) is what
+    // keeps ResolvePendingButtonHwnds' click-sentinel probe from running
+    // once the hooks it depends on are gone - see its own comment.
     InvalidateTaskbarLayout();
 }
 
@@ -2928,9 +2972,10 @@ void Wh_ModUninit() {
 
     // See Wh_ModBeforeUninit's comment for why this doesn't run there -
     // the mod's own hooks are gone by the time Wh_ModUninit runs, so
-    // nothing can reawaken the thread/timer being torn down here.
+    // nothing can reawaken the thread being torn down here. This one
+    // join now also covers the HWND-resolve timer, which lives on the
+    // same thread.
     StopWinEventHook();
-    StopButtonHwndResolveTimer();
 }
 
 void Wh_ModSettingsChanged() {

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -208,6 +208,7 @@ community.
 #include <functional>
 #include <iterator>
 #include <limits>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -219,7 +220,6 @@ community.
 
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.UI.Xaml.Automation.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.Shapes.h>
 #include <winrt/Windows.UI.Xaml.h>
@@ -414,21 +414,20 @@ std::atomic<bool> g_unloading;
 thread_local bool g_inTaskbarArrangeOverride;
 
 // Never traverse the taskbar's XAML tree (siblings, classification,
-// widths) from inside a nested IUIElement::Arrange call - XAML's own
-// layout system can be mid-structural-mutation of that same repeater
-// there (reproducible: explorer.exe crash, STATUS_STOWED_EXCEPTION, when
-// Windows' "show taskbar apps on" setting causes a window moving across
-// monitors to change a taskbar's button *set*, not just coordinates).
-// RecomputeLayoutPlan (below) does the entire traversal ONCE per
-// ArrangeOverride pass, up front, before
-// TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original is called -
-// i.e. before any nested Arrange calls happen - and writes every
-// element's target X into g_lastArrangedX. IUIElement_Arrange_Hook then
-// becomes a pure map lookup, with nothing left for XAML's mid-mutation
-// state to make unsafe.
+// widths) from inside a nested IUIElement::Arrange call - XAML's layout
+// system can be mid-structural-mutation of that same repeater there
+// (reproducible crash: STATUS_STOWED_EXCEPTION, when Windows' "show
+// taskbar apps on" setting causes a window moving across monitors to
+// change a taskbar's button set, not just coordinates). RecomputeLayoutPlan
+// does the entire traversal once per ArrangeOverride pass, up front,
+// before any nested Arrange calls happen, writing every element's target
+// X into g_lastArrangedX - IUIElement_Arrange_Hook then becomes a pure
+// map lookup, with nothing left for XAML's mid-mutation state to make
+// unsafe.
 
 HWND g_hTaskbarWnd;
 HWINEVENTHOOK g_locationChangeHook;
+HWINEVENTHOOK g_showEventHook;
 std::atomic<int> g_winEventRawCount;
 std::atomic<int> g_winEventInvalidateCount;
 std::atomic<int> g_invalidateSkippedReentrant;
@@ -1020,21 +1019,17 @@ struct ButtonHwndCacheEntry {
 std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
 
 // Actually runs the resolution chain and updates the cache. Returns
-// whether the cached HWND changed (added, removed, or replaced) - used by
-// the timer that calls this (see ResolvePendingButtonHwnds) to decide
-// whether a relayout is worth triggering.
+// whether the cached HWND changed - used by the caller to decide whether
+// a relayout is worth triggering.
 //
-// Deliberately ONLY ever called from that timer, never from inside
-// GetButtonHwnd/an active Arrange pass: the click-sentinel technique this
-// chain uses interacts with the taskbar's own internal click-handling
-// machinery, and running it while a button is being structurally
-// inserted into or removed from an ItemsRepeater's data source - which
-// happens whenever Windows' "show taskbar apps on" setting is anything
-// other than "All taskbars" and a window moves across monitors - reaches
-// STATUS_STOWED_EXCEPTION (confirmed via crash-dump analysis). Running
-// it from a timer instead restores the standalone-event context this
-// technique already assumes, matching where it runs in the mods it's
-// adapted from.
+// Deliberately ONLY ever called from the resolve timer, never from
+// GetButtonHwnd or an active Arrange pass: the click-sentinel technique
+// interacts with the taskbar's internal click-handling machinery, and
+// running it while a button is being structurally inserted/removed from
+// an ItemsRepeater's data source reaches STATUS_STOWED_EXCEPTION
+// (confirmed via crash-dump analysis) - which happens whenever Windows'
+// "show taskbar apps on" setting isn't "All taskbars" and a window moves
+// across monitors.
 bool ResolveAndCacheButtonHwnd(FrameworkElement element,
                                const std::wstring& identity) {
     void* key = winrt::get_abi(element);
@@ -1273,16 +1268,15 @@ double FullFootprintWidth(FrameworkElement element) {
 // using a negative-margin collapse trick - ActualWidth() includes that
 // margin, so it never drops below the collapsed width and grows on every
 // layout pass once a transition starts. Reads the content child's
-// DesiredSize instead (falls back to ActualWidth() if no child is
-// realized yet), matching taskbar-start-button-position.wh.cpp's fix for
-// the same problem on the same button types.
+// DesiredSize instead (matching taskbar-start-button-position.wh.cpp's
+// fix for the same button types), falling back to ActualWidth() if no
+// child is realized yet.
 //
 // Deliberately NOT used for Start or task list buttons: Start is never
-// hidden/shown, so it was never exposed to this bug, and swapping its
-// width source anyway understated its true width (see the Start-width
-// comment in RecomputeLayoutPlan). Task list buttons have no evidence of
-// the same collapse-margin mechanism, and they're this file's hottest
-// path.
+// hidden/shown, so it was never exposed to this bug (and swapping its
+// width source anyway understated it - see RecomputeLayoutPlan's
+// Start-width comment); task list buttons have no evidence of the same
+// mechanism and are this file's hottest path.
 double SystemButtonContentWidth(FrameworkElement element) {
     if (Media::VisualTreeHelper::GetChildrenCount(element) > 0) {
         auto child = Media::VisualTreeHelper::GetChild(element, 0)
@@ -1456,37 +1450,22 @@ struct TaskListPlanEntry {
     int index;  // Position within `children`, i.e. taskbar order.
 };
 
-// Computes every task list button's target X in a single O(n) pass over
-// the repeater's already-enumerated children, classifying each button
-// exactly once - avoids both re-walking the repeater and re-classifying
-// every sibling for every single button placed, and the same up-front
-// classification means a button's side/order can't disagree with itself
-// depending on whether it's being visited as a target or as someone
-// else's sibling.
+// Computes every task list button's target X in one O(n) pass, classifying
+// each button exactly once. Every entry is written into outPlan and stays
+// in this mod's own coordinate system - never falls through to native
+// Arrange, since Start is forced to true center regardless and mixing
+// forced- and native-position elements produces a visible overlap.
+// Instead, an overflowing side's inter-icon spacing compresses (icons
+// stay full width) to fit within leftBoundLocal/rightBoundLocal - the
+// taskbar's left edge past the system-button cluster, and the system
+// tray's left edge, respectively.
 //
-// Every entry is always written into outPlan and stays in this mod's own
-// coordinate system, never falling through to native Arrange even when a
-// side overflows: Start is forced to true screen-center regardless, and
-// native's layout has no knowledge of that, so mixing forced- and
-// native-position elements in the same pass produces a visually
-// incoherent overlap. Instead, an overflowing side's inter-icon spacing
-// is proportionally compressed (icons still render at natural width, so
-// they overlap each other once genuinely crowded).
-// leftBoundLocal/rightBoundLocal are the outer edges (local DIPs) each
-// side compresses to fit within - leftBoundLocal is the taskbar's left
-// edge pushed right by the Search/Task View/Widgets cluster in "far
-// left" mode; rightBoundLocal is the system tray's left edge (see
-// RecomputeLayoutPlan), falling back to the taskbar's own edge if the
-// tray can't be resolved.
-//
-// Every side is walked innermost-first from Start's own edge outward.
-// The Start-overlap guarantee: the innermost icon's edge facing Start
-// sits at that fixed reference point regardless of scale, since each
-// icon's own placement uses its unscaled width - only the running
-// reference point handed to the next icon advances by the scaled
-// amount. Scaling the placement itself instead looks equivalent at
-// scale=1 but drifts the innermost icon into Start as compression
-// increases - do not reintroduce that.
+// Each side is walked innermost-first from Start's own edge outward,
+// using each icon's *unscaled* width for its own placement (only the
+// running reference point advances by the scaled amount) - this is what
+// guarantees the innermost icon's edge never drifts into Start under
+// compression. Scaling the placement itself looks equivalent at scale=1
+// but breaks that guarantee - do not reintroduce it.
 void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
                          double startCenterX,
                          double leftBoundLocal,
@@ -1745,98 +1724,110 @@ void ResolvePendingButtonHwnds() {
         return;
     }
 
-    XamlRoot xamlRoot = GetTaskbarXamlRoot(g_hTaskbarWnd);
-    if (!xamlRoot) {
-        return;
-    }
-
-    FrameworkElement content = xamlRoot.Content().try_as<FrameworkElement>();
-    FrameworkElement repeater = FindTaskbarFrameRepeater(content);
-    if (!repeater) {
-        return;
-    }
-
-    ULONGLONG now = GetTickCount64();
-    bool anyChanged = false;
-
-    std::unordered_set<void*> liveTaskListButtons;
-
-    for (auto& child : GetRepeaterChildElements(repeater)) {
-        if (!IsTaskListButton(child)) {
-            continue;
+    // Runs marshaled through RunFromWindowThread's WH_CALLWNDPROC hook - a
+    // raw Win32 callback boundary with no C++/WinRT exception translation
+    // on the other side, same as IUIElement_Arrange_Hook/RecomputeLayoutPlan/
+    // InvalidateTaskbarLayout's lambda. Every WinRT property access below
+    // (Content(), ItemsSourceView(), get_class_name, GetName, XamlRoot())
+    // can throw winrt::hresult_error, most likely exactly when the taskbar
+    // tree is being recreated - an uncaught throw here crosses the boundary
+    // and fail-fasts explorer.exe.
+    try {
+        XamlRoot xamlRoot = GetTaskbarXamlRoot(g_hTaskbarWnd);
+        if (!xamlRoot) {
+            return;
         }
-        void* key = winrt::get_abi(child);
-        liveTaskListButtons.insert(key);
 
-        std::wstring identity = GetButtonAccessibleName(child);
-
-        auto it = g_buttonHwndCache.find(key);
-        bool needsResolve = it == g_buttonHwndCache.end();
-        if (needsResolve) {
-            // A brand-new button in the live set - even if it fails to
-            // resolve an HWND right away (e.g. a just-pinned app with no
-            // window yet), its mere appearance means g_lastArrangedX has
-            // no entry for it and the plan needs rebuilding regardless of
-            // whether ResolveAndCacheButtonHwnd's own HWND-changed check
-            // fires below.
-            anyChanged = true;
+        FrameworkElement content = xamlRoot.Content().try_as<FrameworkElement>();
+        FrameworkElement repeater = FindTaskbarFrameRepeater(content);
+        if (!repeater) {
+            return;
         }
-        if (!needsResolve) {
-            if (it->second.hwnd) {
-                // Identity mismatch means ItemsRepeater rebound this
-                // element to a different item since we last resolved it -
-                // see ButtonHwndCacheEntry's comment. The old HWND is
-                // still a perfectly valid window, just no longer this
-                // element's, so IsWindow() alone can't catch this case.
-                needsResolve = !IsWindow(it->second.hwnd) ||
-                               identity != it->second.identity;
-            } else {
-                needsResolve = now - it->second.lastAttempt >=
-                               ResolveBackoffMs(it->second.consecutiveFailures);
+
+        ULONGLONG now = GetTickCount64();
+        bool anyChanged = false;
+
+        std::unordered_set<void*> liveTaskListButtons;
+
+        for (auto& child : GetRepeaterChildElements(repeater)) {
+            if (!IsTaskListButton(child)) {
+                continue;
+            }
+            void* key = winrt::get_abi(child);
+            liveTaskListButtons.insert(key);
+
+            std::wstring identity = GetButtonAccessibleName(child);
+
+            auto it = g_buttonHwndCache.find(key);
+            bool needsResolve = it == g_buttonHwndCache.end();
+            if (needsResolve) {
+                // A brand-new button in the live set - even if it fails to
+                // resolve an HWND right away (e.g. a just-pinned app with no
+                // window yet), its mere appearance means g_lastArrangedX has
+                // no entry for it and the plan needs rebuilding regardless of
+                // whether ResolveAndCacheButtonHwnd's own HWND-changed check
+                // fires below.
+                anyChanged = true;
+            }
+            if (!needsResolve) {
+                if (it->second.hwnd) {
+                    // Identity mismatch means ItemsRepeater rebound this
+                    // element to a different item since we last resolved it -
+                    // see ButtonHwndCacheEntry's comment. The old HWND is
+                    // still a perfectly valid window, just no longer this
+                    // element's, so IsWindow() alone can't catch this case.
+                    needsResolve = !IsWindow(it->second.hwnd) ||
+                                   identity != it->second.identity;
+                } else {
+                    needsResolve = now - it->second.lastAttempt >=
+                                   ResolveBackoffMs(it->second.consecutiveFailures);
+                }
+            }
+
+            if (needsResolve && ResolveAndCacheButtonHwnd(child, identity)) {
+                anyChanged = true;
             }
         }
 
-        if (needsResolve && ResolveAndCacheButtonHwnd(child, identity)) {
-            anyChanged = true;
+        // Prune g_buttonHwndCache entries for buttons that no longer exist.
+        // XAML routinely destroys and recreates TaskListButtons (unpin, app
+        // close, virtualization), and the allocator can reuse a destroyed
+        // element's address for a later, unrelated one - without this, that
+        // new element would silently inherit the destroyed one's cached HWND
+        // (the cache is keyed by raw ABI pointer with no reference held, so
+        // there's no way to detect this other than checking against a fresh
+        // enumeration like this one). g_lastArrangedX doesn't need the same
+        // treatment - RecomputeLayoutPlan already rebuilds it from scratch
+        // every ArrangeOverride pass, so a stale entry there can never
+        // outlive one pass regardless.
+        for (auto it = g_buttonHwndCache.begin(); it != g_buttonHwndCache.end();) {
+            if (liveTaskListButtons.find(it->first) == liveTaskListButtons.end()) {
+                // A button disappeared (unpin, app close) - its old absolute X
+                // in g_lastArrangedX would otherwise sit stale (nothing else
+                // occupies that slot), leaving a hole where it used to be.
+                it = g_buttonHwndCache.erase(it);
+                anyChanged = true;
+            } else {
+                it = std::next(it);
+            }
         }
-    }
 
-    // Prune g_buttonHwndCache entries for buttons that no longer exist.
-    // XAML routinely destroys and recreates TaskListButtons (unpin, app
-    // close, virtualization), and the allocator can reuse a destroyed
-    // element's address for a later, unrelated one - without this, that
-    // new element would silently inherit the destroyed one's cached HWND
-    // (the cache is keyed by raw ABI pointer with no reference held, so
-    // there's no way to detect this other than checking against a fresh
-    // enumeration like this one). g_lastArrangedX doesn't need the same
-    // treatment - RecomputeLayoutPlan already rebuilds it from scratch
-    // every ArrangeOverride pass, so a stale entry there can never
-    // outlive one pass regardless.
-    for (auto it = g_buttonHwndCache.begin(); it != g_buttonHwndCache.end();) {
-        if (liveTaskListButtons.find(it->first) == liveTaskListButtons.end()) {
-            // A button disappeared (unpin, app close) - its old absolute X
-            // in g_lastArrangedX would otherwise sit stale (nothing else
-            // occupies that slot), leaving a hole where it used to be.
-            it = g_buttonHwndCache.erase(it);
-            anyChanged = true;
-        } else {
-            it = std::next(it);
+        // Same idea one level up: g_lastKnownWindowClassification is keyed by
+        // HWND, which Windows also recycles, and it's only ever consulted for
+        // a minimized window's frozen side (ClassifyByWindowPositionCached) -
+        // so a brand-new window could otherwise inherit a closed window's
+        // stale classification.
+        for (auto it = g_lastKnownWindowClassification.begin();
+             it != g_lastKnownWindowClassification.end();) {
+            it = IsWindow(it->first) ? std::next(it)
+                                      : g_lastKnownWindowClassification.erase(it);
         }
-    }
 
-    // Same idea one level up: g_lastKnownWindowClassification is keyed by
-    // HWND, which Windows also recycles, and it's only ever consulted for
-    // a minimized window's frozen side (ClassifyByWindowPositionCached) -
-    // so a brand-new window could otherwise inherit a closed window's
-    // stale classification.
-    for (auto it = g_lastKnownWindowClassification.begin();
-         it != g_lastKnownWindowClassification.end();) {
-        it = IsWindow(it->first) ? std::next(it)
-                                  : g_lastKnownWindowClassification.erase(it);
-    }
-
-    if (anyChanged) {
-        InvalidateTaskbarLayout();
+        if (anyChanged) {
+            InvalidateTaskbarLayout();
+        }
+    } catch (...) {
+        Wh_Log(L"ResolvePendingButtonHwnds: exception");
     }
 }
 
@@ -2257,34 +2248,15 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
 // here is unsafe regardless of this guard.
 thread_local bool g_inInvalidateTaskbarLayout;
 
-// Marks the taskbar's layout dirty and lets the XAML dispatcher pick it up
-// on its own next tick, rather than forcing an immediate synchronous
-// UpdateLayout() call. This function's callers include a raw OS callback
-// (WinEventProc) that can itself fire while the thread is already nested
-// inside XAML-internal layout activity for reasons outside this mod's
-// control (e.g. a taskbar button structurally moving between two
-// different monitors' XAML trees, not just changing coordinates within
-// one). A forced UpdateLayout() in that state is a reentrant "layout
-// cycle" from WinUI's perspective, and fails fast with
-// STATUS_STOWED_EXCEPTION - confirmed as the cause of several
-// explorer.exe crash-loop incidents, each via a different trigger path,
-// so the only fix that actually closes the whole class is to never force
-// it anywhere. InvalidateArrange() + InvalidateMeasure() alone are always
-// safe to call from any context; the resulting delay before the
-// dispatcher's own pass runs is at most one composition frame - not
-// perceptible for a drag-follow feature already documented as
-// best-effort.
-//
-// STATUS_STOWED_EXCEPTION is a raw SEH RaiseException, not a thrown C++
-// exception - this mod's toolchain (Windhawk's clang/MinGW build, no
-// /EHa-style async exception handling) cannot catch it with `catch(...)`
-// no matter where it's placed. The try/catch below only covers genuine
-// C++ exceptions from the WinRT calls in this lambda (e.g. QueryInterface
-// failures) - it is not, and never will be, a safety net for the
-// layout-cycle failure. Don't reintroduce a forced UpdateLayout() here
-// without a fundamentally different mechanism (e.g. a genuinely async
-// PostMessage-deferred call guaranteed to run only once the current call
-// stack has fully unwound).
+// Marks the layout dirty and lets the XAML dispatcher pick it up on its
+// own next tick, rather than forcing a synchronous UpdateLayout() call:
+// this function's callers include a raw OS callback (WinEventProc) that
+// can fire while already nested inside XAML-internal layout activity, and
+// a forced UpdateLayout() there reenters WinUI layout and fails fast with
+// STATUS_STOWED_EXCEPTION - a raw SEH RaiseException, not a C++
+// exception, so no try/catch anywhere in this file can contain it. Don't
+// reintroduce a forced call here without a fundamentally different
+// mechanism (e.g. a genuinely async, post-unwind-only deferred call).
 void InvalidateTaskbarLayout() {
     if (!g_hTaskbarWnd) {
         return;
@@ -2381,6 +2353,21 @@ void CALLBACK WinEventProc(HWINEVENTHOOK hook,
         return;
     }
 
+    if (event == EVENT_OBJECT_SHOW) {
+        // A real top-level window (per the filtering above) becoming
+        // visible is what a pinned-but-not-running app launching looks
+        // like - nudge the resolve timer to run right away instead of
+        // leaving it to its own backoff schedule (which, for a button
+        // that's failed before, can be up to kResolveBackoffCeilingMs
+        // away). The backoff schedule itself is kept as a fallback -
+        // this is a fast path on top of it, not a replacement for it, in
+        // case a launch is ever reached through a code path that
+        // legitimately doesn't produce this event.
+        ArmButtonHwndResolveTimer(0);
+        return;
+    }
+
+    // event == EVENT_OBJECT_LOCATIONCHANGE from here on - drag-follow.
     ULONGLONG now = GetTickCount64();
     if (now - g_lastDragFollowInvalidate < 150) {
         // The throttle above is leading-edge only, so the final
@@ -2602,30 +2589,23 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
 // ============================================================================
 
 // EVENT_OBJECT_LOCATIONCHANGE fires for every window move on the entire
-// system, not just windows this mod cares about - "thousands of raw
-// events within seconds" has been observed from something on the system
-// spamming it. WINEVENT_OUTOFCONTEXT delivers those callbacks on whichever
-// thread called SetWinEventHook, and only if that thread pumps messages.
-// Registering on g_hTaskbarWnd's own thread (as an earlier version of this
-// function did, via RunFromWindowThread) put every one of those events -
-// plus WinEventProc's IsWindowVisible/GetAncestor/GetWindow calls on each
-// one, all before the 150ms throttle even applies - in direct contention
-// with the shell's own layout work on the one thread responsible for it.
-// A dedicated mod-owned thread with its own message loop (the pattern
-// taskbar-background-helper.wh.cpp and
-// taskbar-auto-hide-when-maximized.wh.cpp both use for the same kind of
-// global WinEventHook) keeps all of that off the shell's thread entirely -
-// InvalidateTaskbarLayout already marshals onto the taskbar thread for the
-// one thing that actually needs to run there.
+// system - "thousands of raw events within seconds" has been observed -
+// and EVENT_OBJECT_SHOW (added for the resolve-timer fast path, see
+// WinEventProc) is nearly as frequent. WINEVENT_OUTOFCONTEXT delivers
+// callbacks on whichever thread called SetWinEventHook, and only if that
+// thread pumps messages; registering on g_hTaskbarWnd's own thread would
+// put all of that - plus WinEventProc's own filtering calls on each one -
+// in direct contention with the shell's own layout work. This dedicated
+// mod-owned thread (the pattern taskbar-background-helper.wh.cpp and
+// taskbar-auto-hide-when-maximized.wh.cpp both use) keeps it off the
+// shell's thread entirely.
+//
 // kArmResolveNowMsg (like WM_APP below) is a private signal on this
-// thread's own message queue, not routed through any window - posted by
-// ArmButtonHwndResolveTimer to request an immediate HWND-resolve
-// attempt. Needed because the resolve timer itself now lives on this
-// thread (see g_buttonHwndResolveTimerId) but callers of
-// ArmButtonHwndResolveTimer run on the taskbar thread, and a per-thread
-// SetTimer/KillTimer registered with hWnd=nullptr can only be armed from
-// the thread that owns it - PostThreadMessage is how a different thread
-// asks this one to do that on its behalf.
+// thread's own message queue: the resolve timer lives here too (see
+// g_buttonHwndResolveTimerId), but callers of ArmButtonHwndResolveTimer
+// run on the taskbar thread, and a per-thread SetTimer/KillTimer can only
+// be touched from the thread that owns it - PostThreadMessage is how a
+// different thread asks this one to do that on its behalf.
 constexpr UINT kArmResolveNowMsg = WM_APP + 1;
 
 // Defined later in this section, alongside NextResolveDelayMs -
@@ -2659,6 +2639,20 @@ DWORD WINAPI WinEventHookThreadProc(LPVOID) {
                L"will");
     }
 
+    // A second, separate hook rather than widening the range above: the
+    // two event IDs aren't adjacent, and a single range spanning both
+    // would also pick up several unrelated event types in between. See
+    // WinEventProc's own EVENT_OBJECT_SHOW branch for what this is for.
+    g_showEventHook = SetWinEventHook(EVENT_OBJECT_SHOW, EVENT_OBJECT_SHOW,
+                                      nullptr, WinEventProc, 0, 0,
+                                      WINEVENT_OUTOFCONTEXT);
+    if (!g_showEventHook) {
+        Wh_Log(L"Failed to register show-event hook - a newly launched "
+               L"pinned app's icon will only start following it once the "
+               L"resolve timer's own backoff schedule catches up, rather "
+               L"than immediately");
+    }
+
     // Kicks off the first HWND-resolve attempt shortly after this thread
     // (and so the taskbar window) is up, so buttons already present at
     // mod startup get picked up - after that, NextResolveDelayMs and
@@ -2688,6 +2682,10 @@ DWORD WINAPI WinEventHookThreadProc(LPVOID) {
         UnhookWinEvent(g_locationChangeHook);
         g_locationChangeHook = nullptr;
     }
+    if (g_showEventHook) {
+        UnhookWinEvent(g_showEventHook);
+        g_showEventHook = nullptr;
+    }
     if (g_buttonHwndResolveTimerId) {
         KillTimer(nullptr, g_buttonHwndResolveTimerId);
         g_buttonHwndResolveTimerId = 0;
@@ -2703,16 +2701,24 @@ DWORD WINAPI WinEventHookThreadProc(LPVOID) {
 HANDLE g_winEventThread;
 DWORD g_winEventThreadId;
 
+// Serializes StartWinEventHook/StopWinEventHook against each other.
+// EnsureTaskbarWnd can call StartWinEventHook from either Wh_ModAfterInit's
+// own thread or Explorer's UI thread (via the ArrangeOverride hook) once
+// g_hTaskbarWnd first resolves, and that call can still be inside
+// CreateThread - before g_winEventThread is written - when Wh_ModUninit
+// calls StopWinEventHook concurrently: a plain check-then-act (even an
+// atomic one guarding just the CreateThread call) can't stop
+// StopWinEventHook from checking g_winEventThread before StartWinEventHook
+// has finished writing it, missing the very thread it was meant to tear
+// down and leaving it to crash the process when Windhawk unmaps the
+// module later. The mutex makes "is there a thread, and should one ever
+// be created again" one atomic question both functions agree on.
+std::mutex g_winEventThreadMutex;
+bool g_winEventThreadStopped;
+
 void StartWinEventHook() {
-    // Guards against EnsureTaskbarWnd running concurrently on two
-    // threads - Wh_ModAfterInit's own thread and, once hooks are live,
-    // Explorer's UI thread via the ArrangeOverride hook both call this
-    // once g_hTaskbarWnd first resolves. A plain check-then-act on
-    // g_winEventThread let both create a thread, orphaning one that's
-    // never joined - a deferred crash when Windhawk unmaps the module
-    // while that thread is still parked in GetMessage.
-    static std::atomic<bool> started;
-    if (started.exchange(true)) {
+    std::lock_guard<std::mutex> guard(g_winEventThreadMutex);
+    if (g_winEventThreadStopped || g_winEventThread) {
         return;
     }
 
@@ -2729,30 +2735,42 @@ void StartWinEventHook() {
 // the resolve timer's own KillTimer, now that it lives here too) has
 // already run before Windhawk unmaps this module's code.
 void StopWinEventHook() {
-    if (!g_winEventThread) {
+    HANDLE thread;
+    DWORD threadId;
+    {
+        std::lock_guard<std::mutex> guard(g_winEventThreadMutex);
+        // Set before releasing the lock, not after the thread is confirmed
+        // gone below - this is what stops a StartWinEventHook call that
+        // arrives after this point (e.g. a late ArrangeOverride pass) from
+        // recreating a thread nobody would be left to tear down.
+        g_winEventThreadStopped = true;
+        thread = g_winEventThread;
+        threadId = g_winEventThreadId;
+        g_winEventThread = nullptr;
+        g_winEventThreadId = 0;
+    }
+    if (!thread) {
         return;
     }
 
-    // PostThreadMessage fails with ERROR_INVALID_THREAD_ID if the new
-    // thread hasn't created its message queue yet (WinEventHookThreadProc
-    // does that as its first action) - StartWinEventHook is called lazily
-    // from EnsureTaskbarWnd, so teardown isn't necessarily far behind
-    // thread creation. Retry briefly to bridge that gap.
-    for (int attempt = 0; attempt < 50; attempt++) {
-        if (PostThreadMessage(g_winEventThreadId, WM_APP, 0, 0)) {
-            break;
+    // PostThreadMessage fails with ERROR_INVALID_THREAD_ID if the thread
+    // hasn't created its message queue yet (WinEventHookThreadProc does
+    // that as its first action) - retry rather than give up, but tie the
+    // retry to the thread's own liveness rather than a fixed attempt
+    // count: giving up after N tries and falling through to the
+    // unconditional wait below with the signal never delivered would hang
+    // Wh_ModUninit forever, since nothing else can wake that wait.
+    while (!PostThreadMessage(threadId, WM_APP, 0, 0)) {
+        if (WaitForSingleObject(thread, 10) == WAIT_OBJECT_0) {
+            break;  // Thread exited on its own before ever seeing WM_APP.
         }
-        Sleep(10);
     }
 
     // Unconditional wait, not a bounded timeout: giving up early would let
     // Wh_ModUninit return and Windhawk unmap this module's code while the
     // thread is still inside it - a deferred crash, not a mitigated one.
-    WaitForSingleObject(g_winEventThread, INFINITE);
-
-    CloseHandle(g_winEventThread);
-    g_winEventThread = nullptr;
-    g_winEventThreadId = 0;
+    WaitForSingleObject(thread, INFINITE);
+    CloseHandle(thread);
 }
 
 // Idle re-check cadence once every cached button is already resolved -
@@ -2764,19 +2782,13 @@ void StopWinEventHook() {
 // runs indefinitely for the life of the session.
 constexpr DWORD kIdleResolveTickMs = 30000;
 
-// Capped exponential backoff for the click-sentinel probe: 2s, 4s, 8s,
-// ... up to a 30-minute ceiling, shared by ResolvePendingButtonHwnds
-// (deciding whether an entry needsResolve) and NextResolveDelayMs
-// (scheduling the next tick). A pinned-but-not-running app's button
-// never resolves until it's actually launched, and ItemsRepeater
-// recycles the same element/cache entry rather than creating a new one -
-// so this runs for the life of the session for that one button, with no
-// cheaper existing signal (identity change, button count change) to
-// re-arm on instead, since launching a pinned app changes neither. The
-// ceiling exists to bound how often a synthetic click fires against the
-// taskbar's real click handler while still eventually catching a later
-// launch - previously capped at 32s (shift<=4), which was flagged as a
-// permanent background click loop.
+// Capped exponential backoff for the click-sentinel probe, shared by
+// ResolvePendingButtonHwnds and NextResolveDelayMs: a fallback safety net
+// for a pinned-but-not-running app's button, in case its launch is ever
+// reached through a path that doesn't produce EVENT_OBJECT_SHOW
+// (WinEventProc's fast path normally re-resolves it immediately - see its
+// own comment). The 30-minute ceiling keeps this fallback from becoming a
+// source of frequent synthetic clicks itself.
 constexpr ULONGLONG kResolveBackoffCeilingMs = 30ULL * 60 * 1000;
 ULONGLONG ResolveBackoffMs(int consecutiveFailures) {
     int shift = std::min(consecutiveFailures, 16);  // keep the shift itself from overflowing
@@ -2809,20 +2821,15 @@ DWORD NextResolveDelayMs() {
 
     if (!anyPending) {
         // Even once every cached button is resolved, ItemsRepeater can
-        // rebind an already-realized element to a *different* item (a
-        // drag-reorder of two running apps) without changing the total
-        // count - the one thing that otherwise re-arms this timer, via
-        // the ArrangeOverride hook's count-change check. Without some
-        // periodic re-check here, ResolvePendingButtonHwnds' identity
-        // comparison (the mechanism that exists specifically to catch a
-        // rebind - see ButtonHwndCacheEntry's comment) would never
-        // actually run again once everything first resolves, so a
-        // rebind could go undetected indefinitely. Only armed when at
-        // least one button is genuinely resolved - an all-pinned/
-        // not-running taskbar already gets its own periodic tick from
-        // the backoff loop above, no need to add a second one; the
-        // timer only truly goes idle (returns INFINITE, no re-arm at
-        // all) when the cache is completely empty.
+        // rebind an already-realized element to a different item (a
+        // drag-reorder) without changing the total count - the one other
+        // thing that re-arms this timer. Without a periodic re-check
+        // here, ResolvePendingButtonHwnds' identity comparison (see
+        // ButtonHwndCacheEntry) would never run again once everything
+        // first resolves. Only armed when something is actually resolved
+        // - an all-pinned taskbar already gets its own tick from the
+        // backoff loop above; this only truly goes idle (INFINITE) when
+        // the cache is empty.
         if (anyResolved) {
             return kIdleResolveTickMs;
         }

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -1,7 +1,7 @@
 // ==WindhawkMod==
 // @id              taskbar-centered-start-split-icons
 // @name            Taskbar Start Button Centered Origin
-// @description     Pins the Start button to the true horizontal center of the screen, and splits running-app taskbar buttons into two groups flanking it based on which side of the screen each window is currently on (Windows 11 only, incompatible with "Start button always on the left")
+// @description     Pins the Start button to true screen-center and splits running-app taskbar buttons into two groups flanking it by which side of the screen each window is on (Windows 11 only; incompatible with "Start button always on the left")
 // @version         0.1.0
 // @author          rick
 // @github          https://github.com/rycalvo

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -63,13 +63,13 @@ right next to Start on whichever side you prefer.
   thread, so secondary-monitor elements are simply never included in it
   and fall through to Windows' native positioning.
 - **Don't enable alongside "Start button always on the left".** Both mods
-  hook the same process-wide `IUIElement::Arrange` vtable slot to force
-  the Start button's own X position; with both enabled, whichever one
-  installed its hook second wins, and the result is undefined. This mod's
-  `systemButtonsPlacement: far-left` setting covers the same "keep
-  everything else out of Start's way" goal that mod's
-  `otherSystemButtonsOnTheLeft` option does, so there's no reason to run
-  both together.
+  hook the same process-wide `IUIElement::Arrange` vtable slot, and both
+  write their own X position for the Start button - with both enabled,
+  they simply disagree, and whichever one's hook runs last for a given
+  Arrange call wins for that pass. This mod's `systemButtonsPlacement:
+  far-left` setting covers the same "keep everything else out of Start's
+  way" goal that mod's `otherSystemButtonsOnTheLeft` option does, so
+  there's no reason to run both together.
 - **A very crowded side compresses instead of overflowing cleanly.** If
   enough app icons pile up on one side that they'd run into the system
   tray/clock on the right (or, in "far left" placement, into Search/Task
@@ -802,6 +802,32 @@ WCHAR g_clickSentinel[] = L"click-sentinel";
 thread_local void* g_clickSentinel_TaskItem;
 thread_local void* g_clickSentinel_TaskGroup;
 
+// The click-sentinel resolution technique (see the section comment above)
+// dispatches a REAL click through TaskItem::ReportClicked/
+// TaskGroup::ReportClicked, relying entirely on this hook recognizing the
+// sentinel and swallowing it before the taskbar's real HandleClick ever
+// runs. Reference mods using the same technique only fire it in response
+// to an actual user gesture on one specific button, so a broken
+// interception there just means the user's own click happens twice. This
+// mod instead fires it unattended, from a background timer, against every
+// button it hasn't resolved yet - if a future Windows update changes
+// ReportClicked's internal call path so it stops reaching this hook, every
+// one of those probes silently becomes a genuine click, which for the
+// buttons actually retried (pinned-but-not-running apps) means Explorer
+// spontaneously launching them on a timer, forever, with no user action
+// and no visible sign anything is wrong (an unintercepted probe looks
+// identical to an ordinary resolution failure).
+//
+// The interception either works on this Windows build or it doesn't - it
+// isn't a per-button thing - so one confirmed capture is proof it works,
+// and one probe that reaches ReportClicked with zero capture, before any
+// capture has ever been confirmed, is proof it doesn't. g_clickSentinelBroken
+// latches that verdict permanently: ResolveHwndFromTaskListButton bails
+// out before ever calling ReportClicked again once it's set, rather than
+// retrying a mechanism now known to dispatch real clicks.
+std::atomic<bool> g_clickSentinelConfirmed;
+std::atomic<bool> g_clickSentinelBroken;
+
 HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
                                               void* taskGroup,
                                               void* taskItem,
@@ -809,11 +835,27 @@ HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
     if (launcherOptions && *launcherOptions == (void*)&g_clickSentinel) {
         g_clickSentinel_TaskItem = taskItem;
         g_clickSentinel_TaskGroup = taskGroup;
+        g_clickSentinelConfirmed = true;
         return S_OK;
     }
 
     return CTaskListWnd_HandleClick_Original(pThis, taskGroup, taskItem,
                                               launcherOptions);
+}
+
+// Called right after a real ReportClicked probe comes back with no
+// capture - the one point where "no capture" is actually evidence about
+// the interception itself, as opposed to an earlier, unrelated failure
+// (missing view-model, no task item) that never reached ReportClicked at
+// all. See g_clickSentinelBroken's own comment for the full reasoning.
+void NoteUnconfirmedClickSentinelMiss() {
+    if (!g_clickSentinelConfirmed && !g_clickSentinelBroken.exchange(true)) {
+        Wh_Log(L"Click-sentinel interception never confirmed working - "
+               L"disabling further HWND-resolution probes to avoid "
+               L"dispatching real clicks. This usually means a Windows "
+               L"update changed CTaskListWnd::HandleClick's internal call "
+               L"path; consider disabling this mod until it's updated.");
+    }
 }
 
 using TryGetItemFromContainer_TaskListWindowViewModel_t =
@@ -863,12 +905,15 @@ CTaskGroup_GetNumItems_t CTaskGroup_GetNumItems_Original;
 // value, revealing the real offset without needing the struct layout.
 // Adapted from the per-app volume control mod, which needs the same task
 // group -> item list access for an unrelated reason.
+// Shared with GetTaskItemsArray's bounds check below - the probe can
+// never legitimately return an offset at or past this size.
+constexpr int kTaskItemsArrayProbeSize = 256;
+
 size_t GetTaskItemsArrayOffset() {
     static size_t offset = [] {
-        constexpr int kIntArraySize = 256;
-        int arrayOfInts[kIntArraySize];
-        int* arrayOfIntPtrs[kIntArraySize];
-        for (int i = 0; i < kIntArraySize; i++) {
+        int arrayOfInts[kTaskItemsArrayProbeSize];
+        int* arrayOfIntPtrs[kTaskItemsArrayProbeSize];
+        for (int i = 0; i < kTaskItemsArrayProbeSize; i++) {
             arrayOfInts[i] = i;
             arrayOfIntPtrs[i] = &arrayOfInts[i];
         }
@@ -883,7 +928,19 @@ HDPA GetTaskItemsArray(void* taskGroup) {
     if (!CTaskGroup_GetNumItems_Original) {
         return nullptr;
     }
-    return (HDPA)((void**)taskGroup)[GetTaskItemsArrayOffset()];
+    size_t offset = GetTaskItemsArrayOffset();
+    // Offset 0 is the vtable slot, so the probe can never legitimately
+    // land there - either GetNumItems' implementation stopped being the
+    // trivial "return DPA_GetPtrCount(this->taskItemsArray)" form this
+    // technique relies on, or the probe array (kTaskItemsArrayProbeSize
+    // ints) was too small to reach the real offset. Either way, trusting
+    // an out-of-range offset here means dereferencing whatever happens to
+    // be there and handing it to DPA_GetPtrCount as if it were a real
+    // array - a wild read on a background timer, not a user gesture.
+    if (offset == 0 || offset >= kTaskItemsArrayProbeSize) {
+        return nullptr;
+    }
+    return (HDPA)((void**)taskGroup)[offset];
 }
 
 using TaskGroup_ReportClicked_t = int(WINAPI*)(void* pThis, void* param);
@@ -952,6 +1009,7 @@ HWND ResolveHwndFromIndividualTaskItem(FrameworkElement element) {
     void* nativeTaskItem = g_clickSentinel_TaskItem;
     g_clickSentinel_TaskItem = nullptr;
     if (!nativeTaskItem) {
+        NoteUnconfirmedClickSentinelMiss();
         g_resolveStats.failure++;
         return nullptr;
     }
@@ -1004,6 +1062,7 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
     void* nativeTaskGroup = g_clickSentinel_TaskGroup;
     g_clickSentinel_TaskGroup = nullptr;
     if (!nativeTaskGroup) {
+        NoteUnconfirmedClickSentinelMiss();
         g_resolveStats.failure++;
         return nullptr;
     }
@@ -1025,6 +1084,14 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
 }
 
 HWND ResolveHwndFromTaskListButton(FrameworkElement element) {
+    // See g_clickSentinelBroken's comment - once the sentinel is known not
+    // to be intercepted on this build, every further probe would be a
+    // genuine click rather than a resolution attempt, so this bails out
+    // before either resolution path can call ReportClicked again.
+    if (g_clickSentinelBroken) {
+        return nullptr;
+    }
+
     HWND hwnd = ResolveHwndFromIndividualTaskItem(element);
     if (hwnd) {
         return hwnd;
@@ -2074,16 +2141,18 @@ IUIElement_Arrange_t IUIElement_Arrange_Original;
 std::unordered_map<void*, double> g_lastArrangedX;
 
 // Set whenever something might have changed that g_lastArrangedX doesn't
-// reflect yet - every InvalidateTaskbarLayout call covers every real
-// trigger (a window moving, a button's HWND/side resolving, the
-// ArrangeOverride hook's button-count-change check, a settings change,
-// mod startup). Starts true so the first ArrangeOverride pass always
+// reflect yet - a window moving, a button's HWND/side resolving, the
+// ArrangeOverride hook's button-count-change check, a settings change, or
+// mod startup, each setting it at the point that specific change actually
+// becomes visible on the taskbar thread (see InvalidateTaskbarLayout's own
+// comment for why it can't be set any earlier, at the calling thread's
+// call site). Starts true so the first ArrangeOverride pass always
 // computes a real plan. RecomputeLayoutPlan clears it only after a
 // genuinely successful recompute - left set on an exception so a later
-// pass retries rather than freezing on a broken plan. atomic: it can be
-// set from threads other than the taskbar's own (the dedicated
-// WinEventHook thread, for one), while RecomputeLayoutPlan only ever
-// reads/clears it from the taskbar thread itself.
+// pass retries rather than freezing on a broken plan. Every read and write
+// now happens on the taskbar thread only, so plain bool would be
+// sufficient - kept atomic as low-risk insurance rather than downgrading
+// it while touching this area for an unrelated fix.
 //
 // This flag skips RecomputeLayoutPlan's full traversal (a taskbar.dll
 // vtable scan, a VisualTreeHelper walk, a classification per child) on
@@ -2524,6 +2593,12 @@ void PerformTaskbarLayoutInvalidate() {
     }
     g_inInvalidateTaskbarLayout = true;
 
+    // Set here, not in InvalidateTaskbarLayout - see that function's own
+    // comment for why marking dirty has to happen at the point a change
+    // actually becomes visible on the taskbar thread, not at the calling
+    // thread's call site.
+    g_planDirty = true;
+
     try {
         FrameworkElement repeater = GetCachedTaskbarRepeater();
         if (!repeater) {
@@ -2603,31 +2678,45 @@ LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
         auto* heapSettings = reinterpret_cast<ModSettings*>(lParam);
         g_settings = std::move(*heapSettings);
         delete heapSettings;
+        // The plan the previous recompute produced was built from the
+        // settings that just got replaced - see InvalidateTaskbarLayout's
+        // comment for why this needs to be set exactly here, not by the
+        // separate InvalidateTaskbarLayout() call Wh_ModSettingsChanged
+        // also makes.
+        g_planDirty = true;
         return 0;
     }
     return DefSubclassProc(hWnd, uMsg, wParam, lParam);
 }
 
-// Marks the layout dirty and lets the XAML dispatcher pick it up on its
-// own next tick, rather than forcing a synchronous UpdateLayout() call:
-// this function's callers include a raw OS callback (WinEventProc) that
-// can fire while already nested inside XAML-internal layout activity, and
-// a forced UpdateLayout() there reenters WinUI layout and fails fast with
+// Lets the XAML dispatcher pick up a relayout on its own next tick,
+// rather than forcing a synchronous UpdateLayout() call: this function's
+// callers include a raw OS callback (WinEventProc) that can fire while
+// already nested inside XAML-internal layout activity, and a forced
+// UpdateLayout() there reenters WinUI layout and fails fast with
 // STATUS_STOWED_EXCEPTION - a raw SEH RaiseException, not a C++
 // exception, so no try/catch anywhere in this file can contain it. Don't
 // reintroduce a forced call here without a fundamentally different
 // mechanism (e.g. a genuinely async, post-unwind-only deferred call).
+//
+// Deliberately does NOT set g_planDirty itself, even though every real
+// trigger for a layout change goes through here - marking dirty on this
+// function's OWN calling thread would be premature when the marshal below
+// is asynchronous (the common PostMessage case): a natural ArrangeOverride
+// pass can land on the taskbar thread between this call setting the flag
+// and the posted message actually being processed, see it already true,
+// recompute with whatever state existed before the real change (settings
+// not yet applied, an HWND not yet re-cached), and clear the flag - so the
+// posted invalidate that finally runs afterward finds g_planDirty already
+// false and skips the recompute the change actually needed. Each real
+// caller marks dirty itself, at the point its own state change becomes
+// visible on the taskbar thread: PerformTaskbarLayoutInvalidate (the
+// PostMessage/RunFromWindowThread call this function makes) and the
+// SettingsChangedMsg dispatch case in TaskbarWndSubclassProc.
 void InvalidateTaskbarLayout() {
     if (!g_hTaskbarWnd) {
         return;
     }
-
-    // Every real trigger for a layout change goes through this function
-    // (see g_planDirty's own comment for the full list), so marking the
-    // plan dirty here - unconditionally, before the marshal below, so it
-    // still happens even if the marshal itself fails - is the one place
-    // that needs to know about all of them.
-    g_planDirty = true;
 
     if (g_taskbarWndSubclassed) {
         // The hot path: called from WinEventProc's drag-follow throttle
@@ -2695,6 +2784,21 @@ void CALLBACK WinEventProc(HWINEVENTHOOK hook,
         return;
     }
 
+    // For LOCATIONCHANGE specifically, this is the cheapest and most
+    // selective filter available - only a window this mod has actually
+    // resolved to a taskbar button can change the layout, and checking a
+    // hashset first skips the three cross-process USER32 calls below for
+    // every other moving window on the system (there are a lot of them -
+    // see this function's own comment on raw event volume further down).
+    // Not applied to SHOW: a newly-shown window that's about to become a
+    // taskbar button's target is, by definition, not resolved yet.
+    if (event == EVENT_OBJECT_LOCATIONCHANGE) {
+        std::lock_guard<std::mutex> guard(g_resolvedHwndsMutex);
+        if (!g_resolvedHwnds.count(hwnd)) {
+            return;
+        }
+    }
+
     if (!IsWindowVisible(hwnd) || GetAncestor(hwnd, GA_ROOT) != hwnd ||
         GetWindow(hwnd, GW_OWNER) != nullptr) {
         return;
@@ -2732,23 +2836,8 @@ void CALLBACK WinEventProc(HWINEVENTHOOK hook,
     }
 
     // event == EVENT_OBJECT_LOCATIONCHANGE from here on - drag-follow.
-    // Only a window this mod has actually resolved to a taskbar button
-    // can change the layout; every other moving window on the system
-    // (there are a lot of them - see this function's own comment on raw
-    // event volume) would trigger a full RecomputeLayoutPlan pass for
-    // nothing. Checked before the throttle below, not after, so an
-    // untracked window's events don't even arm the trailing timer or
-    // touch g_lastDragFollowInvalidate. Lock released before
-    // InvalidateTaskbarLayout() is ever reached - its fallback path
-    // blocks in SendMessage on the taskbar thread, which must never run
-    // while this thread is holding g_resolvedHwndsMutex.
-    {
-        std::lock_guard<std::mutex> guard(g_resolvedHwndsMutex);
-        if (!g_resolvedHwnds.count(hwnd)) {
-            return;
-        }
-    }
-
+    // (Already filtered against g_resolvedHwnds above, before the
+    // top-level-window checks.)
     ULONGLONG now = GetTickCount64();
     if (now - g_lastDragFollowInvalidate < 150) {
         // The throttle above is leading-edge only, so the final

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -261,11 +261,8 @@ enum class UnresolvedAppsDefaultSide {
     ContralateralToSystemButtons,
 };
 
-// Where a pinned-but-not-running app's icon sits within its side's icon
-// group, relative to the other (running, position-classified) icons on the
-// same side. Only meaningful when taskListOrder is DistanceFromCenter -
-// TaskbarOrder has no notion of "outer edge" vs "adjacent to Start" to
-// begin with, since it doesn't rank icons by distance at all.
+// Where a pinned-but-not-running app's icon sits within its side. Only
+// meaningful when taskListOrder is DistanceFromCenter.
 enum class PinnedAppsAnchor { OuterEdge, AdjacentToStart };
 
 struct ModSettings {
@@ -336,13 +333,8 @@ UnresolvedAppsDefaultSide ParseUnresolvedAppsDefaultSide(PCWSTR value) {
     return UnresolvedAppsDefaultSide::Left;
 }
 
-// Resolves the effective side for pinned-but-not-running apps that aren't
-// matched by leftApps/rightApps, per the unresolvedAppsDefaultSide setting.
-// The "contralateral" mode mirrors Search/Task View/Widgets' placement:
-// opposite of systemButtonsAdjacentSide when they sit next to Start, or the
-// right if they're left at the taskbar's far-left edge instead (still
-// their "side" for this purpose, since that edge is unambiguously left of
-// everything else).
+// Resolves the effective side for pinned-but-not-running apps not matched
+// by leftApps/rightApps, per the unresolvedAppsDefaultSide setting.
 Side ResolveUnresolvedAppsDefaultSide() {
     switch (g_settings.unresolvedAppsDefaultSide) {
         case UnresolvedAppsDefaultSide::Right:
@@ -367,29 +359,22 @@ PinnedAppsAnchor ParsePinnedAppsAnchor(PCWSTR value) {
     return PinnedAppsAnchor::OuterEdge;
 }
 
-// The distance-from-center order key for a pinned-but-not-running app (one
-// with no window to measure a real distance from). Made -infinity instead
-// of the default +infinity when pinnedAppsAnchor is AdjacentToStart, since
-// PlanTaskListButtons' distance-from-center sort treats a smaller orderKey
-// as closer to Start - nothing can beat -infinity, so these always end up
-// innermost rather than outermost.
+// Order key for a pinned-but-not-running app (no window to measure a
+// distance from). -infinity sorts innermost, +infinity sorts outermost.
 double PinnedAppOrderKey() {
     return g_settings.pinnedAppsAnchor == PinnedAppsAnchor::AdjacentToStart
                ? -std::numeric_limits<double>::infinity()
                : std::numeric_limits<double>::infinity();
 }
 
-// Reads every setting into a fresh ModSettings, with no dependency on
-// which thread it runs on - Wh_Get/FreeStringSetting don't touch XAML or
-// COM, unlike almost everything else in this file. Kept separate from
-// LoadSettings/g_settings itself so Wh_ModSettingsChanged can do this part
-// on its own calling thread and marshal only the resulting struct's
-// assignment - see its comment for why.
+// Reads every setting into a fresh ModSettings. Doesn't touch XAML/COM, so
+// it has no thread requirement - kept separate from g_settings itself so
+// Wh_ModSettingsChanged can do this part on its own calling thread and
+// marshal only the resulting struct's assignment (see ApplyLoadedSettings).
 ModSettings LoadSettingsFromStore() {
     ModSettings s;
-    // Clamped rather than trusted as-is: a negative value from the
-    // settings UI would otherwise pull the flanking icon groups into the
-    // Start button instead of away from it.
+    // Clamped: a negative value would pull the icon groups toward Start
+    // instead of away from it.
     s.gapPx = std::max(0, Wh_GetIntSetting(L"gapPx"));
 
     auto placement = WindhawkUtils::StringSetting::make(L"systemButtonsPlacement");
@@ -434,47 +419,25 @@ std::atomic<bool> g_unloading;
 
 thread_local bool g_inTaskbarArrangeOverride;
 
-// Never traverse the taskbar's XAML tree (siblings, classification,
-// widths) from inside a nested IUIElement::Arrange call - XAML's layout
-// system can be mid-structural-mutation of that same repeater there
-// (STATUS_STOWED_EXCEPTION when a window moves across monitors while
-// Windows' "show taskbar apps on" setting isn't "All taskbars", since
-// that structurally adds/removes taskbar buttons). RecomputeLayoutPlan
-// does the entire traversal once per ArrangeOverride pass, up front,
-// writing every element's target X into g_lastArrangedX -
-// IUIElement_Arrange_Hook then becomes a pure map lookup.
+// RecomputeLayoutPlan does its entire XAML-tree traversal once per
+// ArrangeOverride pass, up front, writing every element's target X into
+// g_lastArrangedX - IUIElement_Arrange_Hook is then a pure map lookup.
+// Never traverse the tree from inside a nested Arrange call instead (see
+// RATIONALE.md).
 
-// atomic: written from EnsureTaskbarWnd (the taskbar thread, or
-// Wh_ModAfterInit's thread at startup) and read from the dedicated
-// WinEventHook thread (WinEventProc, InvalidateTaskbarLayout,
-// ButtonHwndResolveTimerProc) - a plain HWND here was an oversight, not a
-// decision, given g_taskbarWndSubclassed right below already needed the
-// same treatment for the same reason. Beyond the formal race, a stale
-// read passing a null-check right before EnsureTaskbarWnd clears it to
-// nullptr has a real consequence: PostMessage(nullptr, ...) is not a
-// no-op, it posts to the *calling* thread's own queue and returns TRUE -
-// silently misdirecting the message instead of failing loudly. Callers
-// with more than one read of this value snapshot it into a local first
-// (see InvalidateTaskbarLayout, ButtonHwndResolveTimerProc,
-// ApplyLoadedSettings, RecomputeLayoutPlan) so all their reads agree on
-// one value even if a concurrent write lands mid-function.
+// Taskbar window handle, resolved by EnsureTaskbarWnd. atomic: written on
+// the taskbar thread (or Wh_ModAfterInit's thread at startup), read from
+// the dedicated WinEventHook thread. Callers with more than one read
+// snapshot it into a local first so all their reads agree on one value.
 std::atomic<HWND> g_hTaskbarWnd;
 
-// Whether TaskbarWndSubclassProc is currently installed on g_hTaskbarWnd -
-// see EnsureTaskbarWnd (where it's installed) and InvalidateTaskbarLayout/
-// ButtonHwndResolveTimerProc/ApplyLoadedSettings (which all check it before
-// posting to the taskbar thread). This is the SOLE way any of those reach
-// the taskbar thread - there is no fallback marshal if the subclass never
-// installed (SetWindowSubclassFromAnyThread failing is rare - see
-// EnsureTaskbarWnd's own log line for that case): live drag-follow,
-// HWND resolution, and live settings updates are simply unavailable until
-// the taskbar recreates and a fresh subclass attempt succeeds. The mod's
-// core centering/splitting is unaffected either way, since that's computed
-// synchronously inside RecomputeLayoutPlan on whatever ArrangeOverride
-// passes XAML triggers on its own. atomic: set from Explorer's UI thread
-// (EnsureTaskbarWnd) or Wh_ModAfterInit's thread, read from
-// InvalidateTaskbarLayout's callers, which include the dedicated
-// WinEventHook thread.
+// Whether TaskbarWndSubclassProc is installed on g_hTaskbarWnd - see
+// EnsureTaskbarWnd (which retries the install every call until it
+// succeeds) and InvalidateTaskbarLayout/ButtonHwndResolveTimerProc/
+// ApplyLoadedSettings (which check it before posting to the taskbar
+// thread; there is no fallback marshal). Core centering/splitting is
+// unaffected either way, since RecomputeLayoutPlan computes that
+// synchronously regardless.
 std::atomic<bool> g_taskbarWndSubclassed;
 
 HWINEVENTHOOK g_locationChangeHook;
@@ -484,34 +447,21 @@ std::atomic<int> g_winEventInvalidateCount;
 std::atomic<int> g_invalidateSkippedReentrant;
 std::atomic<int> g_invalidateExceptions;
 
-// Only ever touched from the dedicated WinEventHook thread (see
-// StartWinEventHook) - WinEventProc, DragFollowTrailingTimerProc and
-// ButtonHwndResolveTimerProc all run there exclusively, so none of this
-// needs synchronization.
+// Only touched from the dedicated WinEventHook thread (WinEventProc,
+// DragFollowTrailingTimerProc, ButtonHwndResolveTimerProc all run there
+// exclusively).
 UINT_PTR g_dragFollowTrailingTimerId;
 
-// The HWND-resolve timer's own id - lives on this same dedicated thread
-// (see ButtonHwndResolveTimerProc) rather than on a window the mod
-// doesn't own, so teardown is covered by the same thread join that
-// already tears down the WinEvent hook, with no separate marshal that
-// could fail during unload.
+// The HWND-resolve timer's own id, on the same dedicated thread.
 UINT_PTR g_buttonHwndResolveTimerId;
 
-// Same thread-ownership as g_dragFollowTrailingTimerId above. Hoisted out
-// of WinEventProc's own function-local static so DragFollowTrailingTimerProc
-// can update it too - a trailing-timer fire is itself an invalidate, so
-// the next WinEventProc event needs to see it as "now", not still throttle
-// against whatever raw event last landed outside the 150ms window before
-// the trailing timer took over.
+// Last drag-follow invalidate tick. Also updated by
+// DragFollowTrailingTimerProc, since a trailing-timer fire is itself an
+// invalidate for WinEventProc's own throttle to see.
 ULONGLONG g_lastDragFollowInvalidate;
 
 // Leading-edge throttle for EVENT_OBJECT_SHOW, mirroring the
-// LOCATIONCHANGE throttle above - a top-level window becoming visible
-// fires this event just as often system-wide, and a single arm(0) call is
-// enough to catch every button that's currently pending regardless of how
-// many SHOW events land in the same burst (unlike drag-follow, there's no
-// "final position" that specifically needs the trailing event, so no
-// trailing timer is needed here).
+// LOCATIONCHANGE throttle above.
 ULONGLONG g_lastShowEventArm;
 
 // ============================================================================
@@ -626,33 +576,23 @@ XamlRoot XamlRootFromTaskbarHostSharedPtr(void* taskbarHostSharedPtr[2]) {
         return nullptr;
     }
 
-    // The shared_ptr's ref-count block (taskbarHostSharedPtr[1]) must be
-    // released on every path below, not just a fully successful call -
-    // this runs on every ArrangeOverride pass, so a leaked reference here
-    // is one per pass for the life of the process.
+    // The shared_ptr's ref-count block must be released on every path
+    // below, not just a fully successful call.
     struct DecrefGuard {
         void* ptr;
         ~DecrefGuard() { std__Ref_count_base__Decref_Original(ptr); }
     } decrefGuard{taskbarHostSharedPtr[1]};
 
-    // The top-level null check above only rules out *both* slots being
-    // null - slot 0 can still be null while slot 1 isn't, and it's
-    // dereferenced below. Bail out here (after the guard above is
-    // already constructed, so [1] still gets released).
+    // Slot 0 can still be null even though the top-level check passed.
     if (!taskbarHostSharedPtr[0]) {
         return nullptr;
     }
 
-    // The offset of the XAML element pointer inside TaskbarHost isn't
-    // exposed by any symbol, so it's read out of the prologue of a
-    // neighboring function that's known to access it at a fixed offset.
-    // @architecture x86-64 also covers ARM64 - explorer.exe is a predefined
-    // shell process, so the mod is built and loaded natively as ARM64 there
-    // too, and the two architectures' prologues need separate opcode
-    // patterns. Bailing out on a pattern mismatch (rather than proceeding
-    // with a guessed offset) since a wrong offset here means dereferencing
-    // whatever happens to live there and calling a virtual method through
-    // it.
+    // The XAML element pointer's offset inside TaskbarHost isn't exposed
+    // by any symbol, so it's read out of a neighboring function's
+    // prologue instead. x86-64 and ARM64 need separate opcode patterns
+    // (explorer.exe runs natively as ARM64 too). Bails out on a pattern
+    // mismatch rather than proceeding with a guessed offset.
     size_t taskbarElementIUnknownOffset = 0;
     bool patternMatched = false;
 #if defined(_M_X64)
@@ -706,10 +646,9 @@ XamlRoot GetTaskbarXamlRoot(HWND hTaskbarWnd) {
     void* taskBand = (void*)GetWindowLongPtr(hTaskSwWnd, 0);
     if (!taskBand) {
         // Null while the taskband window exists but its extra data isn't
-        // populated yet (e.g. mid-creation after a taskbar recreate). This
-        // runs on every dirty arrange pass and from a periodic timer, so
-        // skipping here matters - a null deref is a raw access violation,
-        // not a C++ exception, so no try/catch in any caller can contain it.
+        // populated yet (e.g. mid-creation after a taskbar recreate) - a
+        // null deref here is a raw access violation, not a catchable
+        // C++ exception.
         return nullptr;
     }
     void* taskBandForTaskListWndSite = taskBand;
@@ -735,26 +674,19 @@ XamlRoot GetTaskbarXamlRoot(HWND hTaskbarWnd) {
 //
 // Individual (ungrouped) button:
 //   TaskListButton (XAML) -> TaskListWindowViewModel -> WindowsUdk ITaskItem
-//   -> (sentinel "click" through the taskbar's own click handler, which we
-//      intercept before it acts on it) -> native ITaskItem -> HWND.
+//   -> (sentinel click, intercepted before it does anything) -> native
+//   ITaskItem -> HWND.
 //
-// Grouped button (when "Combine taskbar buttons" is Always - each button can
-// represent multiple windows of one app, and isn't bound to a
-// TaskListWindowViewModel at all, so the above fails at the very first
-// step):
-//   TaskListButton (XAML) -> TaskListGroupViewModel -> (a second sentinel,
-//   piggybacked on TaskListGroupViewModel::IsMultiWindow's internal call to
-//   ITaskGroup::IsRunning, which we intercept the same way) -> WindowsUdk
-//   ITaskGroup -> (sentinel "click" again, this time on the group) -> native
-//   ITaskGroup -> its internal task-items array (located by exploiting
-//   CTaskGroup::GetNumItems' known-trivial implementation - see
-//   GetTaskItemsArray) -> first item's HWND, used as the group's
+// Grouped button ("Combine taskbar buttons: Always" - not bound to a
+// TaskListWindowViewModel, so the above doesn't apply):
+//   TaskListButton (XAML) -> TaskListGroupViewModel -> (second sentinel, via
+//   IsMultiWindow's internal ITaskGroup::IsRunning call) -> WindowsUdk
+//   ITaskGroup -> (sentinel click) -> native ITaskGroup -> its task-items
+//   array (see GetTaskItemsArray) -> first item's HWND, the group's
 //   representative position.
 //
-// Both of these are the same techniques used by taskbar-reordering and
-// per-app-volume-control mods to map a button back to a window/windows;
-// here they're reused read-only, purely to find out where a window
-// currently is on screen.
+// Read-only reuse of the click-sentinel technique from taskbar-reordering
+// and per-app-volume-control mods, purely to find where a window is.
 // ============================================================================
 
 void* CImmersiveTaskItem_vftable;
@@ -775,60 +707,19 @@ WCHAR g_clickSentinel[] = L"click-sentinel";
 thread_local void* g_clickSentinel_TaskItem;
 thread_local void* g_clickSentinel_TaskGroup;
 
-// The click-sentinel resolution technique (see the section comment above)
-// dispatches a REAL click through TaskItem::ReportClicked/
-// TaskGroup::ReportClicked, relying entirely on this hook recognizing the
-// sentinel and swallowing it before the taskbar's real HandleClick ever
-// runs. Reference mods using the same technique only fire it in response
-// to an actual user gesture on one specific button, so a broken
-// interception there just means the user's own click happens twice. This
-// mod instead fires it unattended, from a background timer, against every
-// button it hasn't resolved yet - if a future Windows update changes
-// ReportClicked's internal call path so it stops reaching this hook, every
-// one of those probes silently becomes a genuine click, which for the
-// buttons actually retried (pinned-but-not-running apps) means Explorer
-// spontaneously launching them on a timer, forever, with no user action
-// and no visible sign anything is wrong (an unintercepted probe looks
-// identical to an ordinary resolution failure).
+// Dispatches a REAL click through TaskItem::ReportClicked/
+// TaskGroup::ReportClicked, relying entirely on CTaskListWnd_HandleClick_Hook
+// below to recognize the sentinel and swallow it before the taskbar's real
+// HandleClick runs. Unlike reference mods (which only probe on an actual
+// user gesture), this mod probes unattended from a background timer - see
+// RATIONALE.md for the failure-mode analysis.
 //
-// The interception either works on this Windows build or it doesn't - it
-// isn't a per-button thing. Latched per path (item vs. group), not as one
-// shared flag: the two paths reach CTaskListWnd::HandleClick through
-// different internal call chains (TaskItem::ReportClicked vs.
-// TaskGroup::ReportClicked), so a Windows update could break only one of
-// them - a shared flag would let a still-working item-path confirmation
-// mask a broken group path, which matters most because the group path is
-// the one a pinned-but-not-running app's button keeps retrying (see
-// ResolveHwndFromTaskGroup's IsRunning check for how that retry is now
-// also avoided at the source). Each *Broken latch permanently gates its
-// own path in ResolveHwndFromTaskListButton - once set, that path never
-// calls ReportClicked again, rather than retrying a mechanism now known
-// to dispatch real clicks.
-//
-// A single unconfirmed miss is NOT proof the interception is broken - a
-// probe can also fail to reach HandleClick because the window closed
-// between resolving the task item and dispatching the click, ReportClicked
-// failed internally, or the item was mid-teardown during a taskbar
-// rebuild. Latching a whole path dead on the first miss of a session
-// risked exactly that: an early unlucky miss on the item path (the common
-// path, used by every ungrouped button) would silently degrade every
-// button on the taskbar to unresolvedAppsDefaultSide, for the rest of the
-// session, with only a log line as the symptom. kClickSentinelMissesBeforeBroken
-// requires a few misses (still a bounded cost if the mechanism really is
-// broken) before actually latching - see NoteUnconfirmedClickSentinelMiss.
-//
-// This bound only holds pre-confirmation: NoteUnconfirmedClickSentinelMiss
-// returns immediately once a path is confirmed, by design (a post-
-// confirmation miss is routinely innocent - see above - so counting it
-// would risk latching a working path dead over an unrelated timing
-// hiccup). So "at most kClickSentinelMissesBeforeBroken real clicks per
-// path, per session" is the guarantee before first confirmation, not a
-// session-wide cap. Also note ResolveHwndFromTaskListButton tries the
-// item path first and falls through to the group path on a miss, so one
-// unresolvable button can burn a probe on BOTH paths in a single attempt
-// - the worst case before both latches trip is
-// 2 * kClickSentinelMissesBeforeBroken (6, at the current constant)
-// dispatched clicks, not kClickSentinelMissesBeforeBroken.
+// Latched per path (item vs. group), not one shared flag, since the two
+// paths reach CTaskListWnd::HandleClick through different internal call
+// chains and a Windows update could break just one. Requires
+// kClickSentinelMissesBeforeBroken consecutive misses before latching
+// "broken" (not just one - see NoteUnconfirmedClickSentinelMiss for why),
+// and that bound only holds pre-confirmation - see RATIONALE.md.
 std::atomic<bool> g_clickSentinelItemConfirmed;
 std::atomic<bool> g_clickSentinelItemBroken;
 std::atomic<int> g_clickSentinelItemMisses;
@@ -837,12 +728,10 @@ std::atomic<bool> g_clickSentinelGroupBroken;
 std::atomic<int> g_clickSentinelGroupMisses;
 constexpr int kClickSentinelMissesBeforeBroken = 3;
 
-// Which path's probe is in flight on this thread when a sentinel click
-// might land in CTaskListWnd_HandleClick_Hook below - the hook only sees
-// the click itself, not which resolve function dispatched it, so this is
-// what lets it credit the right path's *Confirmed flag. Set immediately
-// before dispatching a probe, alongside the existing reset-before/read-
-// after g_clickSentinel_TaskItem/_TaskGroup pattern.
+// Which path's probe is in flight on this thread - lets
+// CTaskListWnd_HandleClick_Hook below credit the right path's *Confirmed
+// flag, since it only sees the click itself, not which resolve function
+// dispatched it.
 thread_local bool g_clickSentinelProbingGroup;
 
 HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
@@ -852,12 +741,8 @@ HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
     if (launcherOptions && *launcherOptions == (void*)&g_clickSentinel) {
         g_clickSentinel_TaskItem = taskItem;
         g_clickSentinel_TaskGroup = taskGroup;
-        // .exchange rather than plain assignment purely so the log fires
-        // exactly once, the first time this path is ever confirmed -
-        // gives a concrete, observable answer (for the PR record and any
-        // future debugging) to "does the group path actually get
-        // exercised/intercepted on this build", which resolve-stats alone
-        // can't distinguish from the item path.
+        // .exchange so the log fires exactly once, the first time this
+        // path is confirmed.
         bool alreadyConfirmed =
             g_clickSentinelProbingGroup
                 ? g_clickSentinelGroupConfirmed.exchange(true)
@@ -874,10 +759,9 @@ HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
 }
 
 // Called right after a real ReportClicked probe comes back with no
-// capture - one of the ways "no capture" can happen, alongside the
-// unrelated cases described above (closed window, internal failure,
-// teardown timing), which is exactly why this requires a few misses
-// rather than latching on the first one.
+// capture - not proof the interception is broken by itself (the window
+// could have closed mid-probe, etc.), hence requiring a few misses rather
+// than latching on the first one.
 void NoteUnconfirmedClickSentinelMiss(bool isGroupPath) {
     std::atomic<bool>& confirmed =
         isGroupPath ? g_clickSentinelGroupConfirmed : g_clickSentinelItemConfirmed;
@@ -925,14 +809,9 @@ TaskListGroupViewModel_IsMultiWindow_t
 thread_local bool g_captureTaskGroup;
 thread_local void* g_capturedTaskGroup;
 
-// RAII around g_captureTaskGroup's set/clear pair - if the IsMultiWindow
-// call between them ever exited non-locally, a plain set/clear (the
-// original form) would leave this stuck true, and ITaskGroup_IsRunning_Hook
-// would then answer every subsequent real IsRunning call with a hardcoded
-// false instead of forwarding to Original - a wrong answer to a question
-// the taskbar itself uses for real decisions (running indicators, click
-// behavior), for the rest of the session. Same reasoning as
-// ScopedArrangeOverrideFlag elsewhere in this file.
+// RAII around g_captureTaskGroup's set/clear pair - a non-local exit
+// between them would otherwise leave ITaskGroup_IsRunning_Hook permanently
+// answering every real IsRunning call with a hardcoded false.
 struct ScopedCaptureTaskGroup {
     ScopedCaptureTaskGroup() { g_captureTaskGroup = true; }
     ~ScopedCaptureTaskGroup() { g_captureTaskGroup = false; }
@@ -952,16 +831,10 @@ bool WINAPI ITaskGroup_IsRunning_Hook(void* pThis) {
 using CTaskGroup_GetNumItems_t = int(WINAPI*)(void* pThis);
 CTaskGroup_GetNumItems_t CTaskGroup_GetNumItems_Original;
 
-// CTaskGroup::GetNumItems' entire body is just `return
-// DPA_GetPtrCount(this->taskItemsArray);`, i.e. reading one int off `this`
-// at a fixed-but-undocumented offset. Calling it with a fake "this" that's
-// actually an array of pointers-to-sequential-ints turns that read into a
-// self-reporting probe: whatever offset it reads becomes the returned
-// value, revealing the real offset without needing the struct layout.
-// Adapted from the per-app volume control mod, which needs the same task
-// group -> item list access for an unrelated reason.
-// Shared with GetTaskItemsArray's bounds check below - the probe can
-// never legitimately return an offset at or past this size.
+// CTaskGroup::GetNumItems' body is just `return
+// DPA_GetPtrCount(this->taskItemsArray);` - calling it with a fake "this"
+// that's actually an array of pointers-to-sequential-ints turns that read
+// into a self-reporting probe for the real offset.
 constexpr int kTaskItemsArrayProbeSize = 256;
 
 size_t GetTaskItemsArrayOffset() {
@@ -984,14 +857,9 @@ HDPA GetTaskItemsArray(void* taskGroup) {
         return nullptr;
     }
     size_t offset = GetTaskItemsArrayOffset();
-    // Offset 0 is the vtable slot, so the probe can never legitimately
-    // land there - either GetNumItems' implementation stopped being the
-    // trivial "return DPA_GetPtrCount(this->taskItemsArray)" form this
-    // technique relies on, or the probe array (kTaskItemsArrayProbeSize
-    // ints) was too small to reach the real offset. Either way, trusting
-    // an out-of-range offset here means dereferencing whatever happens to
-    // be there and handing it to DPA_GetPtrCount as if it were a real
-    // array - a wild read on a background timer, not a user gesture.
+    // Offset 0 is the vtable slot, so a legitimate probe never lands there -
+    // an out-of-range offset means GetNumItems isn't the trivial form this
+    // relies on, and trusting it would be a wild read.
     if (offset == 0 || offset >= kTaskItemsArrayProbeSize) {
         return nullptr;
     }
@@ -1002,13 +870,7 @@ using TaskGroup_ReportClicked_t = int(WINAPI*)(void* pThis, void* param);
 TaskGroup_ReportClicked_t TaskGroup_ReportClicked_Original;
 
 // Diagnostics only: how often the HWND-resolution chain succeeds vs
-// fails, combined across both the individual and grouped-button paths -
-// LayoutPlanStats' own resolved/total count already gives the
-// steady-state health signal, this mainly confirms the chain is running
-// at all. A stage-by-stage breakdown (which specific step failed) was
-// useful while first bringing this technique up against a new Windows
-// build; worth re-adding locally for that kind of investigation rather
-// than carrying it permanently.
+// fails, across both paths combined.
 struct ResolveStats {
     int success = 0;
     int failure = 0;
@@ -1033,16 +895,10 @@ HWND GetWindowFromNativeTaskItem(void* nativeTaskItem) {
 }
 
 HWND ResolveHwndFromIndividualTaskItem(FrameworkElement element) {
-    // CTaskListWnd_HandleClick_Original is what proves the interception
-    // hook is actually installed - it's optional in HookTaskbarDllSymbols
-    // (see that symbol table's comment), so on a build where it didn't
-    // resolve, CTaskListWnd_HandleClick_Hook never gets installed and the
-    // ReportClicked call below would be a genuine click on a live window
-    // rather than an intercepted sentinel. Checked here specifically
-    // (not just implied by the other symbols below) since this is the one
-    // way the probe can be unsafe that's knowable up front, rather than
-    // only discoverable via NoteUnconfirmedClickSentinelMiss's runtime
-    // miss-counting.
+    // CTaskListWnd_HandleClick_Original proves the interception hook is
+    // actually installed - it's optional (see HookTaskbarDllSymbols), so
+    // on a build where it didn't resolve, the ReportClicked call below
+    // would be a genuine click rather than an intercepted sentinel.
     if (!CTaskListWnd_HandleClick_Original ||
         !TryGetItemFromContainer_TaskListWindowViewModel_Original ||
         !TaskListWindowViewModel_get_TaskItem_Original ||
@@ -1089,9 +945,8 @@ HWND ResolveHwndFromIndividualTaskItem(FrameworkElement element) {
 // e.g. "Combine taskbar buttons" set to Always) - see the resolution
 // overview comment above this section for the full chain.
 HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
-    // See ResolveHwndFromIndividualTaskItem's comment - same reasoning,
-    // same interception hook (CTaskListWnd::HandleClick handles both the
-    // item and group ReportClicked paths).
+    // Same interception hook as ResolveHwndFromIndividualTaskItem
+    // (CTaskListWnd::HandleClick handles both item and group paths).
     if (!CTaskListWnd_HandleClick_Original ||
         !TryGetItemFromContainer_TaskListGroupViewModel_Original ||
         !TaskListGroupViewModel_IsMultiWindow_Original ||
@@ -1099,16 +954,9 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
         return nullptr;
     }
 
-    // GetTaskItemsArrayOffset() is a memoized, side-effect-free probe -
-    // safe to validate up front rather than only after the fact. Without
-    // this, a build where CTaskGroup::GetNumItems stopped being the
-    // trivial form the offset probe relies on would still dispatch a
-    // click below on every single group probe (the sentinel interception
-    // itself is unaffected, so the click-sentinel latch never trips -
-    // it's GetTaskItemsArray's own bounds check further down that always
-    // fails instead), turning every group resolution attempt into a
-    // pure-waste ReportClicked into the taskbar's click machinery,
-    // forever, with nothing to bound it.
+    // Validated up front (memoized, side-effect-free) rather than only
+    // after dispatching a click - see RATIONALE.md for why that ordering
+    // matters.
     size_t taskItemsOffset = GetTaskItemsArrayOffset();
     if (taskItemsOffset == 0 || taskItemsOffset >= kTaskItemsArrayProbeSize) {
         g_resolveStats.failure++;
@@ -1127,13 +975,11 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
 
     g_capturedTaskGroup = nullptr;
     {
-        // IsMultiWindow's implementation happens to call
-        // ITaskGroup::IsRunning internally, which is hooked above to
-        // capture its `this` (the native WindowsUdk task group) instead
-        // of really answering the question. The -1 adjusts from the
-        // interface pointer QueryInterface handed back to the adjacent
-        // vtable IsMultiWindow actually needs - a fixed ABI detail of
-        // this object, not a magic number specific to this mod.
+        // IsMultiWindow's implementation calls ITaskGroup::IsRunning
+        // internally, hooked above to capture its `this` instead of
+        // really answering. The -1 adjusts from the QueryInterface
+        // pointer to the adjacent vtable IsMultiWindow needs (a fixed
+        // ABI detail, not a magic number).
         ScopedCaptureTaskGroup scopedCapture;
         TaskListGroupViewModel_IsMultiWindow_Original(
             (void**)groupViewModel.get() - 1);
@@ -1146,18 +992,11 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
         return nullptr;
     }
 
-    // A group with no running windows (a pinned-but-not-running app) can
-    // never yield an HWND - its task items array is legitimately empty,
-    // so GetTaskItemsArray's check below always fails for it anyway -
-    // and it's exactly the group that would otherwise get re-probed
-    // forever at the backoff ceiling for the life of the session. Bail
-    // out before dispatching a click at it at all, rather than detecting
-    // the failure after the fact. IsRunning is a sibling method on the
-    // same interface already captured above; the "consume" calling
-    // convention it was hooked under (see ITaskGroup_IsRunning_Hook's
-    // *(void**)pThis capture) expects a pointer to a variable holding the
-    // interface pointer, not the interface pointer itself - hence
-    // &windowsUdkTaskGroup here, matching how it was captured.
+    // A group with no running windows (pinned-but-not-running) can never
+    // yield an HWND - bail out before dispatching a click at all, rather
+    // than detecting the failure after the fact. &windowsUdkTaskGroup
+    // (not the pointer itself) matches how ITaskGroup_IsRunning_Hook's
+    // "consume" calling convention captured it.
     if (ITaskGroup_IsRunning_Original &&
         !ITaskGroup_IsRunning_Original(&windowsUdkTaskGroup)) {
         g_resolveStats.failure++;
@@ -1192,12 +1031,9 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
 }
 
 HWND ResolveHwndFromTaskListButton(FrameworkElement element) {
-    // See g_clickSentinelItemBroken/g_clickSentinelGroupBroken's comment -
-    // once a path's sentinel is known not to be intercepted on this
-    // build, every further probe on that path would be a genuine click
-    // rather than a resolution attempt, so each path bails out before
-    // calling its own ReportClicked again. The other path is unaffected,
-    // since a Windows update could break just one of the two call chains.
+    // Each path bails out once its own sentinel is known broken, rather
+    // than dispatching more genuine clicks - see g_clickSentinelItemBroken/
+    // g_clickSentinelGroupBroken.
     HWND hwnd = g_clickSentinelItemBroken
                     ? nullptr
                     : ResolveHwndFromIndividualTaskItem(element);
@@ -1213,29 +1049,11 @@ HWND ResolveHwndFromTaskListButton(FrameworkElement element) {
 
 // Per-button HWND cache, keyed by the XAML element's ABI pointer. Avoids
 // re-running the resolution chain every pass, and negatively caches
-// failures (a pinned-but-not-running app's task group legitimately has
-// zero windows, so resolution fails until it's actually launched).
-//
-// consecutiveFailures drives capped exponential backoff (2s up to the
-// 30-minute kResolveBackoffCeilingMs) rather than a fixed retry: the
-// resolution chain ends in a synthetic click against the taskbar's real
-// click handler, and ItemsRepeater recycles the same element/cache entry
-// for a given index rather than creating a new one, so a hard stop would
-// permanently break side-following for a pinned app that's later
-// launched. A negatively-cached element's failures accumulate for as
-// long as its button exists, so a long-idle session's backoff can be
-// close to the ceiling by the time the app is actually launched -
-// g_forceResolveUnresolved exists specifically to bypass that when
-// there's real evidence (a window just appeared) that a retry is worth
-// trying regardless of the schedule.
-//
-// identity (the button's accessible name at resolve time) catches a
-// different case: ItemsRepeater can rebind an already-realized element
-// to a different item (e.g. a drag-reorder) without destroying it. The
-// old HWND stays valid, just no longer this element's, so an IsWindow()
-// check alone can't detect it - ResolvePendingButtonHwnds compares
-// identity on every check (both the resolved and negatively-cached
-// branches) and forces a re-resolve on mismatch.
+// failures. consecutiveFailures drives capped exponential backoff (see
+// ResolveBackoffMs) rather than a fixed retry. identity catches
+// ItemsRepeater rebinding an already-realized element to a different item
+// (e.g. a drag-reorder) - ResolvePendingButtonHwnds forces a re-resolve on
+// mismatch.
 struct ButtonHwndCacheEntry {
     HWND hwnd = nullptr;
     std::wstring identity;
@@ -1245,59 +1063,25 @@ struct ButtonHwndCacheEntry {
 std::unordered_map<void*, ButtonHwndCacheEntry> g_buttonHwndCache;
 
 // Set by WinEventProc's EVENT_OBJECT_SHOW branch and the ArrangeOverride
-// hook's button-count-change check - both call ArmButtonHwndResolveTimer(0)
-// to make the next resolve pass run immediately, but arming the timer
-// sooner doesn't by itself bypass a negatively-cached entry's own backoff
-// gate (see ButtonHwndCacheEntry's comment for why that backoff can be
-// long-lived). Consumed once per pass in ResolvePendingButtonHwnds to
-// force a negatively-cached entry to retry regardless of backoff - but
-// only up to kMaxForcedRetryFailures consecutive failures (see there for
-// why this is capped, not unconditional).
+// hook's count-change check to make the next resolve pass ignore a
+// negatively-cached entry's backoff - but only up to
+// kMaxForcedRetryFailures consecutive failures each (see RATIONALE.md for
+// why unconditional forcing was a real bug).
 std::atomic<bool> g_forceResolveUnresolved;
-
-// A group with no running windows can never yield an HWND and bails at
-// ResolveHwndFromTaskGroup's IsRunning check before ever dispatching a
-// click - g_forceResolveUnresolved's whole justification for bypassing
-// backoff assumes THAT is the only reason a negatively-cached entry keeps
-// failing (a pinned app that just launched, still catching up to its own
-// EVENT_OBJECT_SHOW). But a RUNNING app's button can also fail to resolve
-// for reasons that don't bail out early - ReportClicked failing
-// internally, a task item mid-teardown, GetTaskItemsArray coming back
-// empty - and for those, forcing every retry unconditionally means
-// dispatching a real ReportClicked on both paths on every forced pass,
-// indefinitely, at up to the ~7Hz EVENT_OBJECT_SHOW can arm this at -
-// exactly the runaway-real-clicks scenario the backoff schedule exists to
-// bound. Capping the force-bypass to entries that have only failed a few
-// times keeps the "pinned app just launched" fast path intact (that case
-// is still failing 0 times when EVENT_OBJECT_SHOW first fires) while
-// letting the normal backoff schedule take back over for an entry that's
-// failed repeatedly, the same way it already would with no force at all.
 constexpr int kMaxForcedRetryFailures = 3;
 
-// The HWNDs g_buttonHwndCache currently resolves to, rebuilt at the end
-// of every successful ResolvePendingButtonHwnds pass (taskbar thread) and
-// read by WinEventProc (the dedicated WinEventHook thread) to filter drag
-// -follow's EVENT_OBJECT_LOCATIONCHANGE events - a window that never
-// resolved to a taskbar button can't change this mod's layout, so there's
-// no reason to pay for a relayout on its account. Needs its own mutex
-// (not covered by the arrange-hook thread confinement the rest of this
-// cache enjoys) since it's the one piece of resolve state genuinely read
-// cross-thread outside a marshal.
+// The HWNDs g_buttonHwndCache currently resolves to, rebuilt at the end of
+// every successful ResolvePendingButtonHwnds pass and read by WinEventProc
+// (a different thread) to filter drag-follow's LOCATIONCHANGE events.
+// Needs its own mutex since it's read cross-thread outside a marshal.
 std::mutex g_resolvedHwndsMutex;
 std::unordered_set<HWND> g_resolvedHwnds;
 
-// Actually runs the resolution chain and updates the cache. Returns
-// whether the cached HWND changed - used by the caller to decide whether
-// a relayout is worth triggering.
-//
-// Deliberately ONLY ever called from the resolve timer, never from
-// GetButtonHwnd or an active Arrange pass: the click-sentinel technique
-// interacts with the taskbar's internal click-handling machinery, and
-// running it while a button is being structurally inserted/removed from
-// an ItemsRepeater's data source reaches STATUS_STOWED_EXCEPTION
-// (confirmed via crash-dump analysis) - which happens whenever Windows'
-// "show taskbar apps on" setting isn't "All taskbars" and a window moves
-// across monitors.
+// Runs the resolution chain and updates the cache. Deliberately ONLY ever
+// called from the resolve timer, never from GetButtonHwnd or an active
+// Arrange pass - running the click-sentinel technique while a button is
+// mid-insertion/removal in an ItemsRepeater crashes explorer.exe (see
+// RATIONALE.md).
 bool ResolveAndCacheButtonHwnd(FrameworkElement element,
                                const std::wstring& identity) {
     void* key = winrt::get_abi(element);
@@ -1315,13 +1099,10 @@ bool ResolveAndCacheButtonHwnd(FrameworkElement element,
     return hwnd != previous;
 }
 
-// Read-only: never triggers resolution itself, only ever reads whatever
-// ResolveAndCacheButtonHwnd (via the timer) has already cached. A button
-// with no cache entry yet, or one whose cached window has since closed,
-// reads as unresolved here and falls back to the default-side
-// classification until the next timer tick catches up - see
-// ResolveAndCacheButtonHwnd's comment for why this can never call the
-// resolution chain directly.
+// Read-only: never triggers resolution itself, only reads whatever the
+// timer has already cached (see ResolveAndCacheButtonHwnd for why). A
+// button with no entry yet, or a closed cached window, falls back to the
+// default-side classification until the next tick.
 HWND GetButtonHwnd(FrameworkElement element) {
     void* key = winrt::get_abi(element);
 
@@ -1360,11 +1141,9 @@ struct WindowClassification {
     double distanceFromCenter = std::numeric_limits<double>::infinity();
 };
 
-// A minimized window's GetWindowRect returns a nonsense off-screen position
-// (classically around (-32000,-32000)), which would otherwise always
-// classify it as "left". Instead, freeze at the last known classification
-// from before it was minimized. Not pruned on window close - see note at
-// GetButtonHwnd's cache for why that's an acceptable tradeoff here too.
+// A minimized window's GetWindowRect returns a nonsense off-screen
+// position, so this freezes at the last known classification from before
+// it was minimized instead.
 std::unordered_map<HWND, WindowClassification> g_lastKnownWindowClassification;
 
 WindowClassification ClassifyByWindowPositionCached(HWND hwnd) {
@@ -1378,15 +1157,10 @@ WindowClassification ClassifyByWindowPositionCached(HWND hwnd) {
             return it->second;
         }
 
-        // No prior classification to freeze at - this window has been
-        // minimized since before we ever saw it (e.g. an app that
-        // auto-launches straight to a minimized/tray state, common among
-        // startup apps right after login). GetWindowPlacement's
-        // rcNormalPosition still reports the window's restored position
-        // while minimized (unlike GetWindowRect, which is why the branch
-        // above exists at all - it returns nonsense off-screen
-        // coordinates for a minimized window), so this can classify it
-        // correctly on first sight instead of permanently defaulting.
+        // No prior classification - this window was minimized before we
+        // ever saw it. GetWindowPlacement's rcNormalPosition still
+        // reports the restored position while minimized (unlike
+        // GetWindowRect).
         WINDOWPLACEMENT wp{.length = sizeof(wp)};
         if (!hwnd || !GetWindowPlacement(hwnd, &wp) ||
             !GetMonitorInfo(mon, &mi)) {
@@ -1394,12 +1168,9 @@ WindowClassification ClassifyByWindowPositionCached(HWND hwnd) {
         }
         wr = wp.rcNormalPosition;
         // rcNormalPosition is in workspace coordinates (relative to
-        // rcWork, which excludes the taskbar/appbars), while screenCenterX
-        // below is computed from rcMonitor. Identical on a normal
-        // bottom-docked taskbar (rcWork.left == rcMonitor.left), but a
-        // left-docked appbar shifts rcWork.left right of rcMonitor.left -
-        // without this offset a window near the boundary could classify
-        // to the wrong side.
+        // rcWork), while screenCenterX below is computed from rcMonitor -
+        // a left-docked appbar shifts these apart, so this offset keeps a
+        // boundary window from classifying to the wrong side.
         LONG workOffsetX = mi.rcWork.left - mi.rcMonitor.left;
         wr.left += workOffsetX;
         wr.right += workOffsetX;
@@ -1457,12 +1228,9 @@ struct ButtonClassification {
 };
 
 // Classification priority: explicit user override by app name, then live
-// window position, then the configured default (mainly hit by pinned apps
-// that aren't running and weren't listed in leftApps/rightApps). Skips the
-// accessible-name lookup (an AutomationProperties::GetName call plus a
-// lowercasing string copy) entirely when there's nothing to match it
-// against - leftApps/rightApps are both empty by default, and this runs
-// for every task-list button on every single ArrangeOverride pass.
+// window position, then the configured default. Skips the accessible-name
+// lookup entirely when leftApps/rightApps are both empty (the default) -
+// this runs for every task-list button on every ArrangeOverride pass.
 ButtonClassification ClassifyTaskListButton(FrameworkElement element) {
     if (!g_settings.leftApps.empty() || !g_settings.rightApps.empty()) {
         std::wstring name = GetButtonAccessibleName(element);
@@ -1542,19 +1310,12 @@ double FullFootprintWidth(FrameworkElement element) {
     return m.Left + element.ActualWidth() + m.Right;
 }
 
-// Search, Task View and Widgets can each be individually hidden/shown
-// using a negative-margin collapse trick - ActualWidth() includes that
-// margin, so it never drops below the collapsed width and grows on every
-// layout pass once a transition starts. Reads the content child's
-// DesiredSize instead (matching taskbar-start-button-position.wh.cpp's
-// fix for the same button types), falling back to ActualWidth() if no
-// child is realized yet.
-//
-// Deliberately NOT used for Start or task list buttons: Start is never
-// hidden/shown, so it was never exposed to this bug (and swapping its
-// width source anyway understated it - see RecomputeLayoutPlan's
-// Start-width comment); task list buttons have no evidence of the same
-// mechanism and are this file's hottest path.
+// Search, Task View and Widgets use a negative-margin collapse trick when
+// hidden/shown - ActualWidth() includes that margin, so it never drops
+// below the collapsed width. Reads the content child's DesiredSize instead
+// (matching taskbar-start-button-position.wh.cpp), falling back to
+// ActualWidth() if no child is realized yet. NOT used for Start or task
+// list buttons - see RATIONALE.md.
 double SystemButtonContentWidth(FrameworkElement element) {
     if (Media::VisualTreeHelper::GetChildrenCount(element) > 0) {
         auto child = Media::VisualTreeHelper::GetChild(element, 0)
@@ -1566,11 +1327,8 @@ double SystemButtonContentWidth(FrameworkElement element) {
     return element.ActualWidth();
 }
 
-// Same margin-inclusive shape as FullFootprintWidth, for the three
-// system buttons (Search/Task View/Widgets) that need the
-// SystemButtonContentWidth fix above. Start doesn't use this - its own
-// width is read bare (no margin added), matching how it was already
-// read before this fix, just with ActualWidth() swapped out.
+// Same margin-inclusive shape as FullFootprintWidth, for Search/Task
+// View/Widgets. Start doesn't use this - its width is read bare.
 double SystemButtonFootprintWidth(FrameworkElement element) {
     Thickness m = element.Margin();
     return m.Left + SystemButtonContentWidth(element) + m.Right;
@@ -1641,31 +1399,23 @@ int SystemButtonRank(SystemButton b) {
 }
 
 // Total footprint of Search+TaskView+Widgets together, used both to lay
-// them out and to reserve room for them next to Start (in adjacent mode).
-// Computed unconditionally every RecomputeLayoutPlan pass so an empty
-// cluster (all three hidden) reads as genuinely 0 rather than keeping a
-// stale nonzero value that would permanently reserve dead space.
+// them out and to reserve room for them next to Start (adjacent mode).
+// Recomputed every pass so a hidden cluster reads as genuinely 0.
 double g_lastLeftSystemClusterWidth = 0;
 double g_lastRightSystemClusterWidth = 0;
 
 // A repeater child paired with its SystemButton classification, computed
-// once per child per RecomputeLayoutPlan pass and reused across the
-// Start-finding, cluster-width, and system-button-placement loops rather
-// than re-deriving IdentifySystemButton (a winrt::get_class_name call)
-// separately in each.
+// once per child per pass and reused across loops rather than
+// re-deriving IdentifySystemButton each time.
 struct ChildInfo {
     FrameworkElement element;
     SystemButton systemButton;
 };
 
-// Places Search/TaskView/Widgets either at the taskbar's far left edge, or
-// immediately adjacent to one side of the Start button, per
-// g_settings.systemButtonsPlacement. clusterWidth is the combined width of
-// all three, computed once by the caller (see g_lastLeftSystemClusterWidth's
-// comment for why it's no longer computed here as a side effect).
-// childInfos is the whole repeater's already-classified children (see
-// ChildInfo's comment) - avoids both re-walking the repeater and
-// re-deriving each child's SystemButton classification.
+// Places Search/TaskView/Widgets at the taskbar's far left edge or
+// adjacent to Start, per g_settings.systemButtonsPlacement. clusterWidth
+// is the combined width of all three; childInfos is the repeater's
+// already-classified children (avoids re-walking/re-classifying).
 double ComputeSystemButtonX(const std::vector<ChildInfo>& childInfos,
                             FrameworkElement targetElement,
                             SystemButton target,
@@ -1721,14 +1471,11 @@ struct LayoutPlanStats {
 // changed - same reasoning as g_passStats.
 thread_local LayoutPlanStats g_planStats;
 
-// Total realized repeater children (every kind - Start, system buttons,
-// task list buttons) as of the last successful RecomputeLayoutPlan pass -
-// used only by that function's own staleness-backstop check (see there)
-// to detect ANY child appearing/disappearing via a single cheap count
-// comparison, with no per-child class-name lookup needed. Deliberately
-// broader than g_planStats.taskListTotal: a Search/Task View/Widgets
-// visibility change also needs to invalidate the plan, not just a task
-// list button count change.
+// Total realized repeater children (every kind) as of the last successful
+// RecomputeLayoutPlan pass - used by its own staleness-backstop check to
+// detect any child appearing/disappearing without a per-child class-name
+// lookup. Broader than g_planStats.taskListTotal so a system-button
+// visibility change also invalidates the plan.
 thread_local int g_planChildCount;
 
 struct TaskListPlanEntry {
@@ -1738,22 +1485,18 @@ struct TaskListPlanEntry {
     int index;  // Position within `children`, i.e. taskbar order.
 };
 
-// Computes every task list button's target X in one O(n) pass, classifying
-// each button exactly once. Every entry is written into outPlan and stays
-// in this mod's own coordinate system - never falls through to native
-// Arrange, since Start is forced to true center regardless and mixing
-// forced- and native-position elements produces a visible overlap.
-// Instead, an overflowing side's inter-icon spacing compresses (icons
-// stay full width) to fit within leftBoundLocal/rightBoundLocal - the
-// taskbar's left edge past the system-button cluster, and the system
-// tray's left edge, respectively.
+// Computes every task list button's target X in one O(n) pass. Every
+// entry is written into outPlan and stays in this mod's own coordinate
+// system - an overflowing side compresses inter-icon spacing (icons stay
+// full width) to fit within leftBoundLocal/rightBoundLocal instead of
+// falling through to native Arrange, since Start is forced to true center
+// regardless.
 //
 // Each side is walked innermost-first from Start's own edge outward,
 // using each icon's *unscaled* width for its own placement (only the
-// running reference point advances by the scaled amount) - this is what
+// running reference point advances by the scaled amount) - this
 // guarantees the innermost icon's edge never drifts into Start under
-// compression. Scaling the placement itself looks equivalent at scale=1
-// but breaks that guarantee - do not reintroduce it.
+// compression. Do not scale the placement itself instead.
 void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
                          double startCenterX,
                          double leftBoundLocal,
@@ -1795,10 +1538,8 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
                              ? (g_lastRightSystemClusterWidth + gap)
                              : 0;
 
-    // Innermost reference point for each side - Start's own edge, minus
-    // the gap. Every side's innermost icon is placed exactly here,
-    // regardless of compression (see the function comment for why that's
-    // the Start-overlap safety guarantee).
+    // Innermost reference point for each side - every side's innermost
+    // icon is placed exactly here, regardless of compression.
     double leftInnerX = startCenterX - startWidth / 2.0 - gap - leftExtra;
     double rightInnerX = startCenterX + startWidth / 2.0 + gap + rightExtra;
 
@@ -1808,12 +1549,8 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
     }
 
     if (g_settings.taskListOrder == TaskListOrder::DistanceFromCenter) {
-        // Sort each side closest-to-center-first, i.e. innermost-first -
-        // exactly the walk order used below. Ties - e.g. multiple
-        // pinned/overridden buttons, which all share the same
-        // +/-infinity orderKey - break on taskbar index instead of an
-        // ABI-pointer value: equally stable frame to frame, but a
-        // predictable order instead of an arbitrary one.
+        // Sort each side closest-to-center-first (innermost-first). Ties
+        // break on taskbar index for a stable, predictable order.
         auto byOrderKey = [](const TaskListPlanEntry* a,
                              const TaskListPlanEntry* b) {
             if (a->info.orderKey != b->info.orderKey) {
@@ -1824,21 +1561,11 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
         std::sort(left.begin(), left.end(), byOrderKey);
         std::sort(right.begin(), right.end(), byOrderKey);
     } else {
-        // Preserve taskbar order, read left-to-right across the whole
-        // split layout the way native taskbar order reads: on the left
-        // side, the earliest entry sits at the outer (leftmost) edge and
-        // later entries sit progressively closer to Start; on the right
-        // side it's the opposite - the earliest entry sits innermost
-        // (right next to Start) and later entries sit progressively
-        // farther out. Together these reproduce native left-to-right
-        // order across the whole taskbar once Start is inserted in the
-        // middle. `left`/`right` are already in taskbar order (entries
-        // was built that way); the right side's walk below (accumulating
-        // outward from Start) already puts its earliest entry innermost,
-        // but the left side needs reversing first - walking it in
-        // original taskbar order would put the *earliest* entry innermost
-        // instead, backwards from what preserves reading order there
-        // (earliest belongs at the outer edge on the left side).
+        // Preserve taskbar order, reading left-to-right across the split
+        // layout: left side's earliest entry at the outer edge, right
+        // side's earliest entry innermost. `left` needs reversing first
+        // to get that (it's built in taskbar order, which would otherwise
+        // put the earliest entry innermost instead).
         std::reverse(left.begin(), left.end());
     }
 
@@ -1851,19 +1578,12 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
         rightTotal += entry->width;
     }
 
-    // Scale <1 compresses inter-icon spacing (not each icon's own
-    // rendered width) so the outermost icon's own edge never passes
-    // leftBoundLocal/rightBoundLocal, at the cost of icons overlapping
-    // each other once a side is too full for natural spacing. A side
-    // with plenty of room keeps scale at 1.
-    //
-    // The outermost icon's own width (left.back()/right.back() - the
-    // walk loop below always processes them last) is excluded from both
-    // the total and the available space fed into the ratio: that icon is
-    // placed at full, unscaled width with nothing beyond it to compress
-    // against, so folding its width into the compressible pool would
-    // double-count it and let its own edge overshoot the bound by
-    // width*(1-scale).
+    // Scale <1 compresses inter-icon spacing (not each icon's rendered
+    // width) so the outermost icon's edge never passes
+    // leftBoundLocal/rightBoundLocal. The outermost icon's own width
+    // (left.back()/right.back()) is excluded from the compressible pool -
+    // it has nothing beyond it to compress against, so including it would
+    // let its edge overshoot the bound.
     double leftAvailable = leftInnerX - leftBoundLocal;
     double leftScale = 1.0;
     if (!left.empty() && leftTotal > leftAvailable) {
@@ -1885,35 +1605,23 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
                          : 1.0;
     }
 
-    // Each icon's own placement uses its unscaled width (x - entry->width,
-    // not x - entry->width * leftScale), so the innermost icon's edge
-    // lands exactly at leftInnerX/rightInnerX regardless of scale - only
-    // x itself (the reference point carried to the next icon) advances by
-    // the scaled amount. Scaling the placement itself instead would drift
-    // the innermost icon into Start as compression increases.
-    // A just-realized button reports ActualWidth()==0 for one pass (only
-    // the *previous* arrange pass ever sets it), so entry->width can be 0
-    // here for a genuinely brand-new button. Giving it a plan entry in
-    // that state would place it exactly on top of its neighbor for one
-    // frame. Leaving it out of outPlan entirely instead falls through to
-    // native positioning for that one pass (same fallback every element
-    // this mod doesn't plan gets) - and since it's then also missing from
-    // g_lastArrangedX, RecomputeLayoutPlan's own staleness check (the
-    // hash-lookup miss, not even the child-count backstop) forces a real
-    // recompute on the very next pass once its real width is available,
-    // so this is a one-frame artifact, not a persistent one. Doesn't
-    // affect `x`'s advance either way - a zero-width entry doesn't move
-    // the reference point regardless of whether it gets a plan entry.
+    // Each icon's own placement uses its unscaled width, so the innermost
+    // icon's edge lands exactly at leftInnerX/rightInnerX regardless of
+    // scale - only `x` itself advances by the scaled amount. A
+    // just-realized button's ActualWidth() is 0 for one pass (Margin
+    // isn't, so entry->width alone isn't a reliable zero-width signal -
+    // see RATIONALE.md); skipping its outPlan entry then avoids
+    // stacking it on its neighbor for that one frame.
     double x = leftInnerX;
     for (auto* entry : left) {
-        if (entry->width > 0) {
+        if (entry->element.ActualWidth() > 0) {
             outPlan[winrt::get_abi(entry->element)] = x - entry->width;
         }
         x -= entry->width * leftScale;
     }
     x = rightInnerX;
     for (auto* entry : right) {
-        if (entry->width > 0) {
+        if (entry->element.ActualWidth() > 0) {
             outPlan[winrt::get_abi(entry->element)] = x;
         }
         x += entry->width * rightScale;
@@ -1925,137 +1633,83 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
 // ============================================================================
 
 // Defined later (Live drag-follow section). Only ever marks the taskbar's
-// layout dirty (InvalidateArrange/InvalidateMeasure) - never forces a
-// synchronous UpdateLayout() call, which reenters WinUI layout while
-// already nested inside it and fails fast with STATUS_STOWED_EXCEPTION.
+// layout dirty - never forces a synchronous UpdateLayout() (see
+// RATIONALE.md).
 void InvalidateTaskbarLayout();
 
-// Idle re-check cadence once every cached button is already resolved - an
-// ItemsRepeater rebind (e.g. a drag-reorder) can change which item an
-// already-resolved element represents without changing the button count,
-// so this keeps identity re-checked periodically even at steady state.
-// Also used by ResolvePendingButtonHwnds as a fallback delay for passes
-// that bail out before confirming the live button set.
+// Idle re-check cadence once every cached button is resolved - keeps
+// identity re-checked periodically (an ItemsRepeater rebind can change
+// which item an element represents without changing the button count).
 constexpr DWORD kIdleResolveTickMs = 30000;
 
 // Defined later (Mod lifecycle section).
 void StartWinEventHook();
 
 // Defined later (Mod lifecycle section); lets the ArrangeOverride hook
-// request an immediate HWND-resolve attempt (delayMs = 0) as soon as it
-// notices the task list button count changed, rather than waiting for the
-// timer's own backoff schedule to catch up.
+// request an immediate HWND-resolve attempt.
 void ArmButtonHwndResolveTimer(DWORD delayMs);
 
 // Defined later (Mod lifecycle section).
 DWORD NextResolveDelayMs();
 
-// Defined later (Live drag-follow section). WindhawkUtils::
-// SetWindowSubclassFromAnyThread/RemoveWindowSubclassFromAnyThread key the
-// subclass by this proc's own address, not by dwRefData (unused, passed
-// as 0) - there's no separate id parameter the way raw SetWindowSubclass/
-// RemoveWindowSubclass have.
+// Defined later (Live drag-follow section).
 LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
                                         UINT uMsg,
                                         WPARAM wParam,
                                         LPARAM lParam,
                                         DWORD_PTR dwRefData);
 
-// g_hTaskbarWnd is normally resolved once, in Wh_ModAfterInit. But if
-// Windhawk injects into explorer.exe before Shell_TrayWnd has been created
-// yet - observed after a fresh boot, never after a manual mod disable/
-// re-enable since the taskbar is already fully up by then - that one-shot
-// lookup fails and g_hTaskbarWnd stays null forever, which silently
-// disables all positioning (IUIElement_Arrange_Hook and the position math
-// below both require it). Retried once per ArrangeOverride pass instead
-// (see call site) so the mod self-heals as soon as the taskbar exists,
-// rather than needing a manual toggle to re-run Wh_ModAfterInit.
+// Resolves g_hTaskbarWnd and installs the taskbar-window subclass,
+// self-healing on every ArrangeOverride pass rather than a one-shot
+// Wh_ModAfterInit lookup - see RATIONALE.md for why both parts need to
+// keep retrying rather than running once.
 HWND EnsureTaskbarWnd() {
     // Shell_TrayWnd can in principle be recreated without explorer.exe
-    // itself restarting (not something this mod's own code causes, but
-    // not something it can rule out either) - without this check, a
-    // stale g_hTaskbarWnd would silently stop all positioning forever
-    // (every position-math function requires it) with no self-healing
-    // path, since the early return below would never let a fresh
-    // FindCurrentProcessTaskbarWnd() attempt happen again. Cheap enough
-    // to check unconditionally every pass.
+    // restarting. Cheap enough to check unconditionally every pass.
     if (g_hTaskbarWnd && !IsWindow(g_hTaskbarWnd)) {
         g_hTaskbarWnd = nullptr;
-        // The old window's subclass chain goes with it (comctl32 tears it
-        // down via WM_NCDESTROY, which TaskbarWndSubclassProc already
-        // forwards to DefSubclassProc for every message it doesn't
-        // otherwise handle) - this just keeps the flag in step so a fresh
-        // resolve below knows to install a subclass on the new window
-        // rather than assuming the old one still covers it.
+        // comctl32 tears the old subclass down on WM_NCDESTROY already -
+        // this just keeps the flag in step so a fresh install is attempted
+        // on the new window.
         g_taskbarWndSubclassed = false;
     }
 
-    if (g_hTaskbarWnd) {
-        return g_hTaskbarWnd;
-    }
-    if (g_unloading) {
-        // Guards against Wh_ModBeforeUninit's own InvalidateTaskbarLayout
-        // call (or a naturally-timed pass) landing while the mod's hooks
-        // are still installed but g_hTaskbarWnd was somehow never set -
-        // without this, resolving it here would call StartWinEventHook()
-        // and create a thread with no later teardown call left to stop it
-        // (Wh_ModBeforeUninit already ran).
-        return nullptr;
-    }
-
-    g_hTaskbarWnd = FindCurrentProcessTaskbarWnd();
-    if (g_hTaskbarWnd) {
+    if (!g_hTaskbarWnd) {
+        if (g_unloading) {
+            // Guards against a pass landing here after Wh_ModBeforeUninit
+            // already ran, with no teardown left to stop a newly-created
+            // WinEventHook thread.
+            return nullptr;
+        }
+        g_hTaskbarWnd = FindCurrentProcessTaskbarWnd();
+        if (!g_hTaskbarWnd) {
+            return nullptr;
+        }
         Wh_Log(L"Resolved taskbar window: %p", (HWND)g_hTaskbarWnd);
         StartWinEventHook();
+    }
 
-        // Lets InvalidateTaskbarLayout/ButtonHwndResolveTimerProc/
-        // ApplyLoadedSettings notify this window with a non-blocking
-        // PostMessage - see g_taskbarWndSubclassed's own comment for why
-        // there's no fallback if this fails. A one-time blocking install
-        // here (via SetWindowSubclassFromAnyThread's own marshal, if this
-        // isn't already running on the taskbar thread) is fine; it's the
-        // per-event cost on the hot invalidate path this is meant to
-        // avoid, not one-shot setup.
-        if (WindhawkUtils::SetWindowSubclassFromAnyThread(
-                g_hTaskbarWnd, TaskbarWndSubclassProc, 0)) {
-            g_taskbarWndSubclassed = true;
+    // Retried on every call until it succeeds, not just the pass that
+    // first resolves g_hTaskbarWnd above - see RATIONALE.md for why that
+    // matters. Cheap: this runs on the taskbar's own thread, so
+    // SetWindowSubclassFromAnyThread takes its same-thread fast path.
+    if (!g_taskbarWndSubclassed && !g_unloading &&
+        WindhawkUtils::SetWindowSubclassFromAnyThread(
+            g_hTaskbarWnd, TaskbarWndSubclassProc, 0)) {
+        g_taskbarWndSubclassed = true;
 
-            // Wh_ModBeforeUninit's own removal pass only runs once, gated
-            // by this same g_taskbarWndSubclassed.exchange(false) latch -
-            // if it already ran with g_hTaskbarWnd still null (reachable:
-            // right after a Shell_TrayWnd recreate, or a fresh-boot
-            // startup where the one-shot Wh_ModAfterInit lookup failed,
-            // is exactly when EnsureTaskbarWnd can still be resolving
-            // this for the first time as unload begins), it can never run
-            // again - a subclass installed here after that point would
-            // stay wired into Shell_TrayWnd with no later removal call,
-            // and Windhawk unmaps this module's code shortly after
-            // Wh_ModUninit returns. Re-checking g_unloading immediately
-            // after install and undoing it right here closes that window;
-            // StartWinEventHook above needs no equivalent recheck since
-            // its own start/stop pair is already serialized by
-            // g_winEventThreadMutex/g_winEventThreadStopped.
-            if (g_unloading && g_taskbarWndSubclassed.exchange(false)) {
-                WindhawkUtils::RemoveWindowSubclassFromAnyThread(
-                    g_hTaskbarWnd, TaskbarWndSubclassProc);
-            } else {
-                // With no fallback marshal, a subclass that installs
-                // successfully on a LATER call (e.g. after an earlier
-                // attempt failed and the taskbar has since recreated)
-                // needs an explicit kick - ButtonHwndResolveTimerProc's
-                // own self-rearming stopped entirely while unsubclassed
-                // (see its comment), so nothing else would restart it.
-                // Harmless to call unconditionally on the very first
-                // successful resolve too, alongside Wh_ModAfterInit's own
-                // InvalidateTaskbarLayout() call right after this returns.
-                ArmButtonHwndResolveTimer(0);
-                InvalidateTaskbarLayout();
-            }
+        // Undo immediately if Wh_ModBeforeUninit's removal pass already
+        // ran with the subclass not yet installed - see RATIONALE.md for
+        // the crash this closes.
+        if (g_unloading && g_taskbarWndSubclassed.exchange(false)) {
+            WindhawkUtils::RemoveWindowSubclassFromAnyThread(
+                g_hTaskbarWnd, TaskbarWndSubclassProc);
         } else {
-            Wh_Log(L"EnsureTaskbarWnd: SetWindowSubclassFromAnyThread "
-                   L"failed - live drag-follow, HWND resolution, and live "
-                   L"settings updates will be unavailable until the "
-                   L"taskbar recreates and a fresh attempt succeeds");
+            // Kicks the resolve timer and a relayout awake - needed since
+            // nothing else restarts them once a subclass install has
+            // failed for a while (see ButtonHwndResolveTimerProc).
+            ArmButtonHwndResolveTimer(0);
+            InvalidateTaskbarLayout();
         }
     }
 
@@ -2072,24 +1726,13 @@ FrameworkElement FindTaskbarFrameRepeater(FrameworkElement anyDescendant) {
     return nullptr;
 }
 
-// Caches the resolved repeater across calls instead of every caller
-// redoing GetTaskbarXamlRoot's resolution chain (taskband HWND -> vtable
-// scan -> TaskbarHost::FrameHeight prologue parse -> QueryInterface) plus
-// FindTaskbarFrameRepeater's three-level tree walk from scratch - this used
-// to run independently in RecomputeLayoutPlan, InvalidateTaskbarLayout, and
-// ResolvePendingButtonHwnds on every single call.
-//
-// A weak_ref alone isn't a reliable "still live" signal: the repeater's
-// own layout, ItemsSourceView and the animation machinery can each hold a
-// reference of their own, so if any of those outlives the taskbar's tree
-// even briefly (a taskbar recreate, a DPI/monitor change), the weak_ref
-// still resolves to a now-detached element - one with a null XamlRoot,
-// since that's only ever non-null while actually attached to a tree.
-// GetCachedTaskbarRepeater checks that explicitly below rather than
-// trusting the weak_ref by itself.
-//
-// MUST only run when confirmed to be on g_hTaskbarWnd's own thread - same
-// constraint as GetTaskbarXamlRoot itself, which this wraps.
+// Caches the resolved repeater across calls instead of redoing
+// GetTaskbarXamlRoot's resolution chain plus FindTaskbarFrameRepeater's
+// tree walk from scratch every time. A weak_ref alone isn't a reliable
+// "still live" signal (a taskbar recreate or DPI change can leave it
+// resolving to a now-detached element), so this also checks XamlRoot().
+// MUST only run on g_hTaskbarWnd's own thread - same constraint as
+// GetTaskbarXamlRoot, which this wraps.
 winrt::weak_ref<FrameworkElement> g_cachedTaskbarRepeaterWeak;
 
 FrameworkElement GetCachedTaskbarRepeater() {
@@ -2097,11 +1740,7 @@ FrameworkElement GetCachedTaskbarRepeater() {
         if (cached.XamlRoot()) {
             return cached;
         }
-        // Detached - see g_cachedTaskbarRepeaterWeak's comment. Every
-        // caller of this function eventually dereferences XamlRoot() (or
-        // relies on the repeater actually being the live one), so
-        // returning it anyway would be a null deref down the line rather
-        // than here. Clear it and fall through to a fresh resolution.
+        // Detached - clear and fall through to a fresh resolution.
         g_cachedTaskbarRepeaterWeak = nullptr;
     }
 
@@ -2119,34 +1758,18 @@ FrameworkElement GetCachedTaskbarRepeater() {
 }
 
 // Walks the primary taskbar's current TaskListButtons and (re)resolves any
-// whose cache entry is missing, stale (window closed), or past the
-// negative-cache TTL - see ResolveAndCacheButtonHwnd's comment for the
-// full story on why this runs on a timer instead of inline during Arrange.
+// whose cache entry is missing, stale, or past the negative-cache TTL -
+// see ResolveAndCacheButtonHwnd for why this runs on a timer instead of
+// inline during Arrange.
 //
-// g_unloading gates this before anything else: the click-sentinel probe
-// only stays safe while CTaskListWnd_HandleClick_Hook is installed to
-// intercept it, and that hook (like all of this mod's hooks) can be gone
-// before Wh_ModUninit actually stops the timer that calls this - without
-// this gate, a probe landing in that window reaches the taskbar's real
-// HandleClick with a garbage LauncherOptions pointer (the sentinel
-// string reinterpreted as a vtable), an access violation plus a
-// genuinely dispatched click. g_unloading is set at the top of
-// Wh_ModBeforeUninit, before the hooks are removed, so this closes the
-// window regardless of exactly when the timer's next tick lands.
+// g_unloading gates this first - once the mod's hooks are gone, a click-
+// sentinel probe here reaches the taskbar's real HandleClick with a
+// garbage pointer instead of being intercepted (see RATIONALE.md).
 //
-// Also guarded against running while nested inside an active Arrange
-// pass on this thread - defense in depth, not the primary protection.
-// Reentrancy guard: this function runs dispatched from the posted
-// ResolveButtonHwndsMsg via TaskbarWndSubclassProc, and it mutates
-// g_buttonHwndCache/g_lastKnownWindowClassification with
-// erase-while-iterating prune loops. It calls into taskbar.dll and WinRT,
-// either of which could pump messages - if another posted
-// ResolveButtonHwndsMsg gets dispatched reentrantly while a call is
-// already in progress here, a nested call's inserts would invalidate the
-// outer loop's iterator - undefined behavior, not just wasted work. RAII rather than a
-// plain set/clear, same reasoning as ScopedArrangeOverrideFlag: this
-// function has several early returns a plain clear at the end would never
-// reach.
+// Reentrancy guard (RAII, since this has several early returns): calling
+// into taskbar.dll/WinRT here can pump messages, letting a second posted
+// ResolveButtonHwndsMsg reenter this same function and corrupt the
+// erase-while-iterating prune loops below.
 thread_local bool g_inResolvePendingButtonHwnds;
 struct ScopedResolvePendingButtonHwndsFlag {
     ScopedResolvePendingButtonHwndsFlag() {
@@ -2164,21 +1787,12 @@ void ResolvePendingButtonHwnds() {
     ScopedResolvePendingButtonHwndsFlag scopedReentrancyFlag;
 
     // Computes and arms this function's own next tick on destruction, on
-    // every return path, always on this thread right after this pass's
-    // own cache reads/writes are done - computing it from
-    // ButtonHwndResolveTimerProc instead would read g_buttonHwndCache
-    // concurrently with this function's own insert/erase calls on the
-    // taskbar thread, a use-after-free.
-    //
-    // NextResolveDelayMs' INFINITE answer is only trustworthy once a pass
-    // has actually confirmed the live button set - an empty
-    // g_buttonHwndCache from a pass that bailed out before enumerating
-    // anything (every early-return guard below, or no repeater yet) looks
-    // identical to a genuinely empty taskbar otherwise, and the timer
-    // would then never be armed again except by incidental luck.
-    // `enumerated` tracks whether the walk below actually ran to
-    // completion; the destructor falls back to kIdleResolveTickMs instead
-    // of trusting INFINITE when it didn't.
+    // every return path, right after this pass's own cache reads/writes
+    // are done (doing it from ButtonHwndResolveTimerProc instead would
+    // race g_buttonHwndCache). `enumerated` tracks whether the walk below
+    // actually completed, since NextResolveDelayMs' INFINITE answer is
+    // only trustworthy then - the destructor falls back to
+    // kIdleResolveTickMs otherwise.
     bool enumerated = false;
     struct ScheduleNextResolveTick {
         bool* enumerated;
@@ -2186,9 +1800,6 @@ void ResolvePendingButtonHwnds() {
             DWORD delay =
                 *enumerated ? NextResolveDelayMs() : kIdleResolveTickMs;
             if (delay != INFINITE) {
-                // Posts to the WinEventHook thread's own queue - safe to
-                // call unconditionally, including during unload
-                // (ArmButtonHwndResolveTimer itself no-ops on g_unloading).
                 ArmButtonHwndResolveTimer(delay);
             }
         }
@@ -2198,14 +1809,8 @@ void ResolvePendingButtonHwnds() {
         return;
     }
 
-    // Runs dispatched via TaskbarWndSubclassProc, a raw Win32 callback
-    // boundary with no C++/WinRT exception translation on the other side,
-    // same as IUIElement_Arrange_Hook/RecomputeLayoutPlan/
-    // PerformTaskbarLayoutInvalidate. Every WinRT property access below
-    // (Content(), ItemsSourceView(), get_class_name, GetName, XamlRoot())
-    // can throw winrt::hresult_error, most likely exactly when the taskbar
-    // tree is being recreated - an uncaught throw here crosses the boundary
-    // and fail-fasts explorer.exe.
+    // Raw Win32 callback boundary (dispatched via TaskbarWndSubclassProc) -
+    // an uncaught WinRT exception here fail-fasts explorer.exe.
     try {
         FrameworkElement repeater = GetCachedTaskbarRepeater();
         if (!repeater) {
@@ -2230,40 +1835,24 @@ void ResolvePendingButtonHwnds() {
             auto it = g_buttonHwndCache.find(key);
             bool needsResolve = it == g_buttonHwndCache.end();
             if (needsResolve) {
-                // A brand-new button in the live set - even if it fails to
-                // resolve an HWND right away (e.g. a just-pinned app with no
-                // window yet), its mere appearance means g_lastArrangedX has
-                // no entry for it and the plan needs rebuilding regardless of
-                // whether ResolveAndCacheButtonHwnd's own HWND-changed check
-                // fires below.
+                // A brand-new button - its mere appearance means
+                // g_lastArrangedX has no entry for it yet.
                 anyChanged = true;
             }
             if (!needsResolve) {
                 // Identity mismatch means ItemsRepeater rebound this element
-                // to a different item since we last resolved it - see
-                // ButtonHwndCacheEntry's comment. Checked on both branches
-                // below, not just the resolved one: a rebind onto a
-                // negatively-cached element (e.g. drag-reordering a pinned-
-                // not-running app past a running one) is just as real a
-                // rebind, and without this check here it would inherit the
-                // old entry's accumulated backoff instead of resolving.
+                // to a different item since we last resolved it - checked
+                // on both branches, since a rebind onto a negatively-cached
+                // element is just as real.
                 if (it->second.hwnd) {
-                    // The old HWND is still a perfectly valid window, just
-                    // no longer this element's, so IsWindow() alone can't
-                    // catch a rebind.
+                    // The old HWND is still valid, just no longer this
+                    // element's, so IsWindow() alone can't catch a rebind.
                     needsResolve = !IsWindow(it->second.hwnd) ||
                                    identity != it->second.identity;
                 } else {
-                    // forceResolve: a negatively-cached element's own
-                    // consecutiveFailures keeps accumulating for as long as
-                    // its button exists (which, for a pinned-but-not-running
-                    // app, is the entire session) - by the time it's
-                    // actually launched, the backoff could be minutes away,
-                    // silently defeating EVENT_OBJECT_SHOW's whole purpose
-                    // of triggering an immediate resolve. Bounded to
+                    // forceResolve: bounded to
                     // consecutiveFailures < kMaxForcedRetryFailures - see
-                    // its own comment for why an unconditional force here
-                    // was a real bug, not just belt-and-suspenders.
+                    // its own comment.
                     bool backoffElapsed =
                         now - it->second.lastAttempt >=
                         ResolveBackoffMs(it->second.consecutiveFailures);
@@ -2280,22 +1869,13 @@ void ResolvePendingButtonHwnds() {
         }
         enumerated = true;
 
-        // Prune g_buttonHwndCache entries for buttons that no longer exist.
-        // XAML routinely destroys and recreates TaskListButtons (unpin, app
-        // close, virtualization), and the allocator can reuse a destroyed
-        // element's address for a later, unrelated one - without this, that
-        // new element would silently inherit the destroyed one's cached HWND
-        // (the cache is keyed by raw ABI pointer with no reference held, so
-        // there's no way to detect this other than checking against a fresh
-        // enumeration like this one). g_lastArrangedX doesn't need the same
-        // treatment - RecomputeLayoutPlan already rebuilds it from scratch
-        // every ArrangeOverride pass, so a stale entry there can never
-        // outlive one pass regardless.
+        // Prune g_buttonHwndCache entries for buttons that no longer exist -
+        // XAML recreates TaskListButtons and the allocator can reuse a
+        // destroyed element's address, so a fresh enumeration is the only
+        // way to detect that. g_lastArrangedX isn't pruned here - it's
+        // rebuilt separately by RecomputeLayoutPlan (see g_planDirty).
         for (auto it = g_buttonHwndCache.begin(); it != g_buttonHwndCache.end();) {
             if (liveTaskListButtons.find(it->first) == liveTaskListButtons.end()) {
-                // A button disappeared (unpin, app close) - its old absolute X
-                // in g_lastArrangedX would otherwise sit stale (nothing else
-                // occupies that slot), leaving a hole where it used to be.
                 it = g_buttonHwndCache.erase(it);
                 anyChanged = true;
             } else {
@@ -2303,22 +1883,17 @@ void ResolvePendingButtonHwnds() {
             }
         }
 
-        // Same idea one level up: g_lastKnownWindowClassification is keyed by
-        // HWND, which Windows also recycles, and it's only ever consulted for
-        // a minimized window's frozen side (ClassifyByWindowPositionCached) -
-        // so a brand-new window could otherwise inherit a closed window's
-        // stale classification.
+        // Same idea for g_lastKnownWindowClassification, keyed by HWND
+        // (which Windows also recycles).
         for (auto it = g_lastKnownWindowClassification.begin();
              it != g_lastKnownWindowClassification.end();) {
             it = IsWindow(it->first) ? std::next(it)
                                       : g_lastKnownWindowClassification.erase(it);
         }
 
-        // Rebuild the published resolved-HWND set from g_buttonHwndCache's
-        // just-finished state, for WinEventProc's drag-follow filter (see
-        // g_resolvedHwnds' own comment) - unconditionally, not just when
-        // anyChanged, since it's cheap and needs to reflect this pass's
-        // pruning even when nothing else about the plan changed.
+        // Rebuild the published resolved-HWND set for WinEventProc's
+        // drag-follow filter - unconditionally, since it's cheap and needs
+        // to reflect this pass's pruning either way.
         {
             std::unordered_set<HWND> resolvedNow;
             for (auto& kv : g_buttonHwndCache) {
@@ -2343,47 +1918,24 @@ using IUIElement_Arrange_t =
 IUIElement_Arrange_t IUIElement_Arrange_Original;
 
 // Every Start/system-button/task-list-button's target X, keyed by the XAML
-// element's ABI pointer (same identity technique as g_buttonHwndCache).
-// Written only by RecomputeLayoutPlan, which rebuilds this map from
-// scratch whenever g_planDirty says something might have changed since
-// the last rebuild (see its own comment) - so IUIElement_Arrange_Hook
-// below never needs to compute anything itself, only look a value up. An
-// element with no entry (a secondary-monitor element, which
-// RecomputeLayoutPlan never walks; or a primary element so new it wasn't
-// realized yet when this pass's plan was built) falls through to
-// Windows' own native positioning for that one pass, same as any element
-// this mod doesn't touch at all.
+// element's ABI pointer. Written only by RecomputeLayoutPlan, so
+// IUIElement_Arrange_Hook below never computes anything, only looks a
+// value up. An element with no entry (secondary-monitor, or too new to be
+// in this pass's plan) falls through to native positioning.
 std::unordered_map<void*, double> g_lastArrangedX;
 
 // Set whenever something might have changed that g_lastArrangedX doesn't
-// reflect yet - a window moving, a button's HWND/side resolving, the
-// ArrangeOverride hook's button-count-change check, a settings change, or
-// mod startup, each setting it at the point that specific change actually
-// becomes visible on the taskbar thread (see InvalidateTaskbarLayout's own
-// comment for why it can't be set any earlier, at the calling thread's
-// call site). Starts true so the first ArrangeOverride pass always
-// computes a real plan. RecomputeLayoutPlan clears it only after a
-// genuinely successful recompute - left set on an exception so a later
-// pass retries rather than freezing on a broken plan. Every read and write
-// now happens on the taskbar thread only, so plain bool would be
-// sufficient - kept atomic as low-risk insurance rather than downgrading
-// it while touching this area for an unrelated fix.
-//
-// This flag skips RecomputeLayoutPlan's full traversal (a taskbar.dll
-// vtable scan, a VisualTreeHelper walk, a classification per child) on
-// the very common passes where nothing this mod cares about changed -
-// a pure short-circuit around already-correct plan-computation logic,
-// not a rewrite of it.
+// reflect yet, at the point that change becomes visible on the taskbar
+// thread. Starts true so the first pass always computes a real plan.
+// RecomputeLayoutPlan clears it only after a genuinely successful
+// recompute - left true on an exception so a later pass retries. Skips
+// RecomputeLayoutPlan's full traversal on passes where nothing changed.
 std::atomic<bool> g_planDirty{true};
 
-// Staleness backstop for g_planDirty: some real triggers for a layout
-// change (Search/Task View/Widgets visibility, taskbar geometry/DPI/
-// monitor changes, a button appearing/disappearing between two dirty
-// passes with nothing else invalidating in between) aren't guaranteed to
-// call InvalidateTaskbarLayout. Rather than track every such trigger
-// individually, RecomputeLayoutPlan forces a real recompute at least this
-// often regardless of g_planDirty, bounding how long the plan can disagree
-// with reality instead of only reacting to known triggers.
+// Staleness backstop for g_planDirty: some real triggers aren't
+// guaranteed to call InvalidateTaskbarLayout. RecomputeLayoutPlan forces
+// a real recompute at least this often regardless, bounding how long the
+// plan can disagree with reality.
 constexpr ULONGLONG kMaxPlanStalenessMs = 500;
 ULONGLONG g_lastPlanRecomputeTick;
 
@@ -2409,11 +1961,8 @@ HRESULT WINAPI IUIElement_Arrange_Hook(void* pThis,
         return original();
     }
 
-    // This hook replaces the process-wide IUIElement::Arrange vtable slot -
-    // a raw ABI boundary with no C++/WinRT exception translation, so an
-    // uncaught throw here fail-fasts the whole process. The QueryInterface
-    // below is the only WinRT call left in this function; everything else
-    // is a plain map lookup.
+    // Raw ABI boundary (process-wide vtable slot) - an uncaught throw
+    // here fail-fasts the whole process.
     try {
         g_passStats.totalArrangeCalls++;
 
@@ -2442,26 +1991,16 @@ HRESULT WINAPI IUIElement_Arrange_Hook(void* pThis,
 }
 
 // Builds the complete layout plan in a single top-down pass over the
-// PRIMARY taskbar's own repeater - every Start/system-button/task-list-
-// button's target X, written into g_lastArrangedX - called from
-// TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook BEFORE XAML's
-// own ArrangeOverride, i.e. before any nested Arrange calls (and so
-// IUIElement_Arrange_Hook) run at all this pass - see
-// g_inTaskbarArrangeOverride's comment for why that ordering matters.
+// PRIMARY taskbar's own repeater, written into g_lastArrangedX - called
+// BEFORE XAML's own ArrangeOverride so no nested Arrange call ever sees a
+// partial plan. Rebuilds from scratch on every genuine recompute (bounded
+// to kMaxPlanStalenessMs, not immediate - see g_planDirty).
 //
-// Rebuilds g_lastArrangedX from scratch every recompute, so a destroyed
-// element's stale entry can never outlive it - no pruning pass needed
-// here, unlike g_buttonHwndCache/g_lastKnownWindowClassification (see
-// ResolvePendingButtonHwnds for why those need it).
-//
-// MUST only run when confirmed to be on g_hTaskbarWnd's own thread:
-// GetTaskbarXamlRoot reaches the PRIMARY's XAML object specifically, an
-// unsafe unmarshaled cross-apartment call from any other thread.
-// Shell_TrayWnd and Shell_SecondaryTrayWnd share one Explorer UI thread,
-// so this check also passes for secondary-monitor passes - harmless,
-// since secondary-monitor elements never end up in g_lastArrangedX
-// regardless; the check is purely the apartment-safety guard, not a
-// monitor-scoping mechanism.
+// MUST only run confirmed on g_hTaskbarWnd's own thread - an unsafe
+// unmarshaled cross-apartment call otherwise. Shell_TrayWnd and
+// Shell_SecondaryTrayWnd share one thread, so this also passes for
+// secondary-monitor passes (harmless, since those elements never end up
+// in g_lastArrangedX anyway).
 void RecomputeLayoutPlan() {
     // Snapshot once - see g_hTaskbarWnd's own comment.
     HWND hTaskbarWnd = g_hTaskbarWnd;
@@ -2474,24 +2013,12 @@ void RecomputeLayoutPlan() {
     }
     if (!g_planDirty &&
         GetTickCount64() - g_lastPlanRecomputeTick < kMaxPlanStalenessMs) {
-        // This backstop only bounds staleness while ArrangeOverride keeps
-        // getting called at least this often - a change landing in a
-        // skipped pass on an otherwise-idle desktop (e.g. a pin/unpin)
-        // could sit stale indefinitely otherwise. GetCachedTaskbarRepeater
-        // makes checking the realized child set against what the plan
-        // actually covers affordable every time this branch is taken - if
-        // any live task list button isn't in g_lastArrangedX, or the live
-        // child count doesn't match the last recompute's, the plan is
-        // stale regardless of the dirty flag or the clock.
-        //
-        // Hash lookup first, IsTaskListButton (winrt::get_class_name - a
-        // GetRuntimeClassName round trip plus an HSTRING allocation)
-        // second, short-circuited via && - every element the plan covers
-        // (Start and the system buttons too, not just task list buttons)
-        // is already a key in g_lastArrangedX, so the common "nothing
-        // changed" case never pays for a single class-name lookup here.
-        // IsTaskListButton only runs at all on a hash-lookup miss, i.e.
-        // a genuinely new child.
+        // Cheap staleness check: if any live task list button isn't in
+        // g_lastArrangedX, or the live child count doesn't match the last
+        // recompute's, the plan is stale regardless of the dirty flag.
+        // Hash lookup first, IsTaskListButton (a real class-name lookup)
+        // second and short-circuited, so the common "nothing changed"
+        // case never pays for it.
         bool planIsCurrent = true;
         try {
             if (FrameworkElement repeater = GetCachedTaskbarRepeater()) {
@@ -2501,37 +2028,22 @@ void RecomputeLayoutPlan() {
                     if (!g_lastArrangedX.count(winrt::get_abi(child)) &&
                         IsTaskListButton(child)) {
                         // A live task list button the plan doesn't cover
-                        // yet (just realized after the last recompute).
-                        // Scoped to task list buttons specifically since
-                        // a brand-new system button reaching this branch
-                        // isn't otherwise possible - Search/Task View/
-                        // Widgets/Start don't get created or destroyed
-                        // the way task list buttons do - so there's
-                        // nothing to gain from paying for the class-name
-                        // check on a system-button miss too.
+                        // yet. Scoped to task list buttons since a
+                        // brand-new system button can't reach this branch.
                         planIsCurrent = false;
                         break;
                     }
                 }
-                // A child *disappearing* (unpin, app closed, or a system
-                // button's visibility changing) adds nothing new to
-                // g_lastArrangedX's coverage - every remaining live child
-                // is still a key in it - so the loop above alone can't
-                // catch it, and a removed task list button would
-                // otherwise sit at its old X (a visible hole) until the
-                // resolve timer's own prune eventually invalidates, up to
-                // kIdleResolveTickMs or the backoff schedule away. This
-                // count comparison against g_planChildCount (every child
-                // kind, not just task list buttons - see its own comment)
-                // catches that direction too, for free, off the same walk.
+                // A child *disappearing* adds nothing new to
+                // g_lastArrangedX's coverage, so the loop above alone
+                // can't catch it - this count comparison against
+                // g_planChildCount does, off the same walk.
                 if (planIsCurrent && liveChildCount != g_planChildCount) {
                     planIsCurrent = false;
                 }
             }
         } catch (...) {
-            // Conservative default: treat an exception here as "can't
-            // confirm the plan is current" and fall through to the real
-            // recompute below, which has its own exception handling.
+            // Conservative default: fall through to the real recompute.
             planIsCurrent = false;
         }
         if (planIsCurrent) {
@@ -2566,36 +2078,20 @@ void RecomputeLayoutPlan() {
         }
 
         // Start first: ComputeSystemButtonX/PlanTaskListButtons below
-        // both read g_lastStartWidth, so it needs to already reflect this
-        // pass by the time they run, not the previous one.
+        // both read g_lastStartWidth, so it must reflect this pass.
         for (auto& info : childInfos) {
             if (info.systemButton == SystemButton::Start) {
-                // Deliberately bare ActualWidth(), NOT
-                // SystemButtonContentWidth: Start is never hidden/shown
-                // the way Search/Task View/Widgets are, so it was never
-                // exposed to ActualWidth()'s collapse-margin growth
-                // problem (see SystemButtonContentWidth's comment) -
-                // swapping to the content child's DesiredSize() here
-                // instead understated Start's true width, since Start's
-                // own visual-tree shape doesn't match what that technique
-                // was validated against.
-                //
-                // ActualWidth() still reflects the previous arrange pass
-                // and is 0 for a just-realized element, so
-                // g_lastStartWidth only updates when it's actually
-                // positive - a freshly (re)created Start button keeps the
-                // last known-good width instead of collapsing the whole
-                // taskbar around a zero-width Start for one pass.
+                // Bare ActualWidth(), NOT SystemButtonContentWidth - see
+                // RATIONALE.md for why that fix doesn't apply to Start.
+                // Only updates g_lastStartWidth when positive, so a
+                // freshly (re)created Start keeps the last known-good
+                // width instead of collapsing around a zero-width Start.
                 double w = info.element.ActualWidth();
                 if (w > 0) {
                     g_lastStartWidth = w;
                 }
-                // The X handed to Arrange sets the layout slot's left
-                // edge; XAML then insets the rendered content by the
-                // element's own Margin.Left. Without subtracting it here,
-                // Start's rendered icon centers at startCenterX +
-                // Margin.Left instead of true screen-center - a no-op
-                // when the margin happens to be 0, but wrong otherwise.
+                // Subtract Margin.Left since XAML insets rendered content
+                // by it - otherwise Start centers off by that amount.
                 newPlan[winrt::get_abi(info.element)] =
                     startCenterX - info.element.Margin().Left -
                     g_lastStartWidth / 2.0;
@@ -2604,12 +2100,8 @@ void RecomputeLayoutPlan() {
         }
 
         // Search/TaskView/Widgets next: PlanTaskListButtons reads
-        // g_lastLeftSystemClusterWidth/g_lastRightSystemClusterWidth, so
-        // these need to be set - unconditionally, every pass, so a
-        // cluster that's empty this pass reads as genuinely 0 rather than
-        // keeping a stale value from an earlier one (see
-        // g_lastLeftSystemClusterWidth's comment) - before any task list
-        // button below runs for the same reason.
+        // g_last{Left,Right}SystemClusterWidth, set unconditionally here
+        // so an empty cluster reads as genuinely 0.
         double systemClusterWidth = 0;
         for (auto& info : childInfos) {
             if (SystemButtonRank(info.systemButton) >= 0) {
@@ -2639,22 +2131,16 @@ void RecomputeLayoutPlan() {
                 g_lastStartWidth, systemClusterWidth);
         }
 
-        // Bounds each task list group is compressed to fit within - see
-        // PlanTaskListButtons' own comment for what these mean and why.
+        // Bounds each task list group compresses to fit within.
         double leftBoundLocal =
             (g_settings.systemButtonsPlacement == SystemButtonsPlacement::FarLeft)
                 ? (kFarLeftSystemButtonMarginPx + systemClusterWidth)
                 : 0;
 
-        // The system tray/clock (SystemTray.SystemTrayFrame in this
-        // taskbar's own XAML tree, a sibling of Taskbar.TaskbarFrame
-        // under the same root content) is a real, measurable bound,
-        // unlike the taskbar's own outer edge - the tray only occupies
-        // the last portion of the taskbar's full width, so bounding
-        // against the whole taskbar barely constrains anything in
-        // practice (confirmed via live testing: icons still visibly ran
-        // under the tray with that bound). Falls back to the taskbar's
-        // own width only if the tray frame can't be resolved this pass.
+        // SystemTray.SystemTrayFrame's own left edge is a real bound,
+        // unlike the taskbar's outer edge (the tray only occupies the
+        // last portion of the taskbar's width). Falls back to the
+        // taskbar's own width if it can't be resolved this pass.
         FrameworkElement systemTrayFrame =
             FindChildByClassName(content, L"SystemTray.SystemTrayFrame");
         double rightBoundLocal =
@@ -2663,9 +2149,8 @@ void RecomputeLayoutPlan() {
                    kTrayMarginPx)
                 : GetTaskbarWidthLocal();
 
-        // Task list buttons last - see PlanTaskListButtons' own comment
-        // for why this is a single O(n) pass over `children` rather than
-        // calling a per-button compute function in a loop here.
+        // Task list buttons last - see PlanTaskListButtons for the
+        // single-O(n)-pass reasoning.
         PlanTaskListButtons(children, startCenterX, leftBoundLocal,
                             rightBoundLocal, newPlan);
 
@@ -2675,13 +2160,9 @@ void RecomputeLayoutPlan() {
     } catch (...) {
         g_planStats.exceptions++;
         // g_lastArrangedX is left as whatever the last successful pass
-        // produced - IUIElement_Arrange_Hook's lookup-or-fall-through
-        // handles a stale/incomplete plan exactly like it already handles
-        // a brand-new not-yet-planned element. g_planDirty deliberately
-        // stays true (not cleared) here, unlike the success path above -
-        // this pass didn't actually produce a plan reflecting current
-        // state, so a later pass should retry rather than treat this as
-        // "up to date" and skip forever.
+        // produced. g_planDirty deliberately stays true here (unlike the
+        // success path) so a later pass retries instead of treating this
+        // as up to date.
     }
 }
 
@@ -2720,19 +2201,12 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
 
     EnsureTaskbarWnd();
 
-    // Builds this pass's whole plan up front - see RecomputeLayoutPlan's
-    // comment for why this ordering (before the original ArrangeOverride,
-    // so before any nested Arrange calls) is what keeps this safe.
+    // Builds this pass's whole plan up front - see RecomputeLayoutPlan.
     RecomputeLayoutPlan();
 
-    // The button count can change without any window moving (new pin, app
-    // launched/closed). If RecomputeLayoutPlan's repeater walk ran before
-    // XAML had realized a just-inserted button yet, this pass's plan has
-    // no entry for it and it renders at its native position for one pass.
-    // Self-correct by invalidating whenever the observed count changes,
-    // and arm an immediate HWND-resolve attempt, since a newly-inserted
-    // button is exactly what ResolvePendingButtonHwnds' cache-only view
-    // (NextResolveDelayMs) can't see coming on its own.
+    // The button count can change without any window moving. Self-correct
+    // by invalidating whenever the observed count changes, and arm an
+    // immediate HWND-resolve attempt for a newly-inserted button.
     static thread_local int lastPlanTaskListCount = -1;
     int currentTaskListCount = g_planStats.taskListTotal;
     if (currentTaskListCount != lastPlanTaskListCount) {
@@ -2745,10 +2219,8 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
         }
     }
 
-    // RAII rather than a plain set/clear pair around the original call:
-    // if that call ever exited non-locally, a plain clear below it would
-    // never run, leaving this stuck true and routing every later Arrange
-    // on this thread through the plan lookup regardless of context.
+    // RAII: a non-local exit from the original call would otherwise leave
+    // this stuck true.
     struct ScopedArrangeOverrideFlag {
         ScopedArrangeOverrideFlag() { g_inTaskbarArrangeOverride = true; }
         ~ScopedArrangeOverrideFlag() { g_inTaskbarArrangeOverride = false; }
@@ -2790,24 +2262,12 @@ HRESULT WINAPI TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook(
 // Live drag-follow: force a taskbar relayout when a top-level window moves
 // ============================================================================
 
-// Guards against reentering the invalidate body itself on the taskbar's
-// own thread. WinEventProc can fire in rapid bursts (observed: thousands
-// of raw events within seconds while something on screen is spamming
-// EVENT_OBJECT_LOCATIONCHANGE), each one posting another
-// InvalidateTaskbarLayoutMsg dispatched via TaskbarWndSubclassProc - a
-// nested WinRT/taskbar.dll call inside this function's own body (GetCached
-// TaskbarRepeater, InvalidateArrange/InvalidateMeasure) could pump
-// messages and let a second posted message land reentrantly on this same
-// thread before the first call returns.
-//
-// This deliberately never calls UpdateLayout() - see the note on
-// InvalidateTaskbarLayout below for why forcing a synchronous layout pass
-// here is unsafe regardless of this guard.
+// Guards against reentering this body on the taskbar's own thread. See
+// RATIONALE.md for why it's needed and why this never calls UpdateLayout().
 thread_local bool g_inInvalidateTaskbarLayout;
 
-// The actual invalidate work, shared by both of InvalidateTaskbarLayout's
-// call paths below. MUST only run on g_hTaskbarWnd's own thread - same
-// constraint as GetCachedTaskbarRepeater, which this uses.
+// MUST only run on g_hTaskbarWnd's own thread - same constraint as
+// GetCachedTaskbarRepeater, which this uses.
 void PerformTaskbarLayoutInvalidate() {
     if (g_inInvalidateTaskbarLayout) {
         g_invalidateSkippedReentrant++;
@@ -2815,10 +2275,8 @@ void PerformTaskbarLayoutInvalidate() {
     }
     g_inInvalidateTaskbarLayout = true;
 
-    // Set here, not in InvalidateTaskbarLayout - see that function's own
-    // comment for why marking dirty has to happen at the point a change
-    // actually becomes visible on the taskbar thread, not at the calling
-    // thread's call site.
+    // Set here (not in InvalidateTaskbarLayout) - dirty has to be marked
+    // at the point the change becomes visible on the taskbar thread.
     g_planDirty = true;
 
     try {
@@ -2838,10 +2296,8 @@ void PerformTaskbarLayoutInvalidate() {
 
 // Private message InvalidateTaskbarLayout posts to run
 // PerformTaskbarLayoutInvalidate on the taskbar's own thread without
-// blocking the caller - see InvalidateTaskbarLayout's own comment for why
-// that matters on this specific call path. Function-local static rather
-// than a namespace-scope variable, so RegisterWindowMessage runs lazily on
-// first real use instead of from a dynamic initializer under DllMain's
+// blocking the caller. Function-local static so RegisterWindowMessage
+// runs lazily rather than from a dynamic initializer under DllMain's
 // loader lock.
 UINT InvalidateTaskbarLayoutMsg() {
     static const UINT msg =
@@ -2857,29 +2313,20 @@ UINT ResolveButtonHwndsMsg() {
     return msg;
 }
 
-// Same idea again, for a settings change. Unlike the two above this one
-// carries a payload: lParam is a heap-allocated ModSettings* that the
-// dispatch case below takes ownership of and deletes - PostMessage is
-// asynchronous, so the settings can't just live on the posting call's own
-// stack the way a plain signal can. See ApplyLoadedSettings.
+// Same idea again, for a settings change. Carries a payload: lParam is a
+// heap-allocated ModSettings* the dispatch case below owns and deletes.
+// See ApplyLoadedSettings.
 UINT SettingsChangedMsg() {
     static const UINT msg =
         RegisterWindowMessage(L"Windhawk_SettingsChanged_" WH_MOD_ID);
     return msg;
 }
 
-// Installed on g_hTaskbarWnd by EnsureTaskbarWnd via
-// SetWindowSubclassFromAnyThread. A subclass proc only ever runs on the
-// thread that owns the window, which is what lets these call paths use a
-// plain, non-blocking PostMessage - no per-call SetWindowsHookEx/
-// SendMessage/UnhookWindowsHookEx dance needed. This is also the SOLE way
-// any of these three messages reach the taskbar thread; if this subclass
-// never installs (see g_taskbarWndSubclassed's own comment), there is no
-// fallback. Everything other than these private messages is forwarded to
-// DefSubclassProc, which is also what lets comctl32 clean this subclass up
-// automatically via WM_NCDESTROY if the window is ever destroyed out from
-// under the mod without Wh_ModBeforeUninit's explicit removal call running
-// first.
+// Installed on g_hTaskbarWnd by EnsureTaskbarWnd. Handles the three private
+// messages above and forwards everything else to DefSubclassProc (which
+// also lets comctl32 clean this subclass up via WM_NCDESTROY if the window
+// is destroyed before Wh_ModBeforeUninit removes it). See RATIONALE.md for
+// why this is the sole path onto the taskbar thread, with no fallback.
 LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
                                         UINT uMsg,
                                         WPARAM wParam,
@@ -2897,48 +2344,27 @@ LRESULT CALLBACK TaskbarWndSubclassProc(HWND hWnd,
         std::unique_ptr<ModSettings> heapSettings(
             reinterpret_cast<ModSettings*>(lParam));
         g_settings = std::move(*heapSettings);
-        // The plan the previous recompute produced was built from the
-        // settings that just got replaced - see InvalidateTaskbarLayout's
-        // comment for why this needs to be set exactly here, not by the
-        // separate InvalidateTaskbarLayout() call Wh_ModSettingsChanged
-        // also makes.
+        // Marks the previous plan stale now that the settings it was built
+        // from just changed. See RATIONALE.md.
         g_planDirty = true;
         return 0;
     }
     return DefSubclassProc(hWnd, uMsg, wParam, lParam);
 }
 
-// Lets the XAML dispatcher pick up a relayout on its own next tick rather
-// than forcing a synchronous UpdateLayout() call: callers include a raw
-// OS callback (WinEventProc) that can fire while already nested inside
-// XAML-internal layout activity, and a forced UpdateLayout() there
-// reenters WinUI layout and fails fast with STATUS_STOWED_EXCEPTION - a
-// raw SEH RaiseException, not a C++ exception, so no try/catch anywhere
-// in this file can contain it. Don't reintroduce a forced call here
-// without a fundamentally different (genuinely async, post-unwind-only)
-// mechanism.
-//
-// Deliberately does NOT set g_planDirty itself: the marshal below is
-// usually asynchronous (PostMessage), so a natural ArrangeOverride pass
-// could land on the taskbar thread between this call setting the flag and
-// the posted message being processed, see it already true, recompute
-// with stale state, and clear the flag - leaving the posted invalidate
-// with nothing to do. Each real caller marks dirty itself instead, at the
-// point its own state change becomes visible on the taskbar thread:
-// PerformTaskbarLayoutInvalidate and the SettingsChangedMsg dispatch case
-// in TaskbarWndSubclassProc.
+// Schedules a relayout on the taskbar's own thread via PostMessage rather
+// than forcing a synchronous UpdateLayout() call. MUST stay async: a forced
+// UpdateLayout() from a nested callback (e.g. WinEventProc) reenters WinUI
+// layout and raises STATUS_STOWED_EXCEPTION, a raw SEH exception no
+// try/catch in this file can contain. Does not set g_planDirty itself -
+// see RATIONALE.md; each real caller marks dirty at its own point instead.
 void InvalidateTaskbarLayout() {
-    // Snapshot once so every read below agrees, even if EnsureTaskbarWnd
-    // writes a new value on another thread mid-function - see
-    // g_hTaskbarWnd's own comment for why that matters here specifically
-    // (a stale nullptr reaching PostMessage is not a no-op).
+    // Snapshot so a concurrent EnsureTaskbarWnd write can't change this
+    // mid-function.
     HWND hTaskbarWnd = g_hTaskbarWnd;
     // No fallback if the subclass never installed - see
-    // g_taskbarWndSubclassed's own comment for why. Called from
-    // WinEventProc's drag-follow throttle at up to ~7 times/sec while any
-    // window on the system is being dragged, plus every resolve tick, so
-    // this is a hot path - PostMessage doesn't block on Explorer's UI
-    // thread pumping it.
+    // g_taskbarWndSubclassed. Hot path (up to ~7/sec during a drag), so
+    // PostMessage's non-blocking behavior matters here.
     if (!hTaskbarWnd || !g_taskbarWndSubclassed) {
         return;
     }
@@ -2948,9 +2374,8 @@ void InvalidateTaskbarLayout() {
     }
 }
 
-// One-shot: fires once the throttle window below has gone quiet, applying
-// whatever position a drag/move most recently landed on. See its arm site
-// in WinEventProc for why this exists.
+// One-shot: fires once the throttle window in WinEventProc has gone quiet,
+// applying whatever position a drag/move most recently landed on.
 void CALLBACK DragFollowTrailingTimerProc(HWND hwnd,
                                           UINT uMsg,
                                           UINT_PTR idEvent,
@@ -2958,17 +2383,14 @@ void CALLBACK DragFollowTrailingTimerProc(HWND hwnd,
     KillTimer(nullptr, idEvent);
     g_dragFollowTrailingTimerId = 0;
 
-    // Same g_unloading check WinEventProc already has: on the fallback
-    // path (subclass never installed), InvalidateTaskbarLayout blocks in
-    // SendMessage until the taskbar thread pumps it, which
-    // StopWinEventHook's now-unconditional wait (see its own comment)
-    // would otherwise be stuck behind if this fired mid-teardown.
+    // Cheap early-exit during teardown; InvalidateTaskbarLayout would
+    // already no-op safely either way.
     if (g_unloading) {
         return;
     }
 
-    // This fire is itself an invalidate - see g_lastDragFollowInvalidate's
-    // comment for why WinEventProc's throttle needs to know about it too.
+    // This fire is itself an invalidate - WinEventProc's throttle needs to
+    // know about it too.
     g_lastDragFollowInvalidate = GetTickCount64();
 
     g_winEventInvalidateCount++;
@@ -2989,14 +2411,10 @@ void CALLBACK WinEventProc(HWINEVENTHOOK hook,
         return;
     }
 
-    // For LOCATIONCHANGE specifically, this is the cheapest and most
-    // selective filter available - only a window this mod has actually
-    // resolved to a taskbar button can change the layout, and checking a
-    // hashset first skips the three cross-process USER32 calls below for
-    // every other moving window on the system (there are a lot of them -
-    // see this function's own comment on raw event volume further down).
-    // Not applied to SHOW: a newly-shown window that's about to become a
-    // taskbar button's target is, by definition, not resolved yet.
+    // Only a window this mod has resolved to a taskbar button can affect
+    // the layout on a move, so filter LOCATIONCHANGE against that set
+    // before the cross-process USER32 calls below. Not applied to SHOW: a
+    // newly-shown window can't be resolved yet by definition.
     if (event == EVENT_OBJECT_LOCATIONCHANGE) {
         std::lock_guard<std::mutex> guard(g_resolvedHwndsMutex);
         if (!g_resolvedHwnds.count(hwnd)) {
@@ -3010,28 +2428,12 @@ void CALLBACK WinEventProc(HWINEVENTHOOK hook,
     }
 
     if (event == EVENT_OBJECT_SHOW) {
-        // A real top-level window (per the filtering above) becoming
-        // visible is what a pinned-but-not-running app launching looks
-        // like - nudge the resolve timer to run right away, and force it
-        // to ignore each negatively-cached entry's own backoff (see
-        // g_forceResolveUnresolved's comment for why arming the timer
-        // alone isn't enough), instead of leaving it to the backoff
-        // schedule. That schedule is kept as a fallback - this is a fast
-        // path on top of it, not a replacement for it, in case a launch
-        // is ever reached through a code path that legitimately doesn't
-        // produce this event.
-        //
-        // Leading-edge throttled the same way the location-change branch
-        // below is: this event fires for every top-level window becoming
-        // visible anywhere on the system, unthrottled, so an app that
-        // opens several windows at once (or a burst of unrelated launches)
-        // would otherwise schedule a full resolve pass - a blocking
-        // marshal onto Explorer's UI thread plus a repeater walk and an
-        // AutomationProperties::GetName per button - for every single one.
-        // No trailing timer is needed the way drag-follow has one: unlike
-        // a window's final drop position, arm(0) just needs to run once to
-        // pick up every currently-pending button, so missing the last
-        // event in a burst costs nothing.
+        // A newly-visible top-level window is what a pinned-but-not-running
+        // app launching looks like - nudge the resolve timer to run now,
+        // bypassing each entry's own backoff. Leading-edge throttled since
+        // this event is unthrottled and can arrive in bursts; no trailing
+        // timer needed since a single arm(0) picks up every pending button
+        // regardless of which SHOW event triggered it. See RATIONALE.md.
         ULONGLONG nowShow = GetTickCount64();
         if (nowShow - g_lastShowEventArm < 150) {
             return;
@@ -3043,21 +2445,11 @@ void CALLBACK WinEventProc(HWINEVENTHOOK hook,
     }
 
     // event == EVENT_OBJECT_LOCATIONCHANGE from here on - drag-follow.
-    // (Already filtered against g_resolvedHwnds above, before the
-    // top-level-window checks.)
     ULONGLONG now = GetTickCount64();
     if (now - g_lastDragFollowInvalidate < 150) {
-        // The throttle above is leading-edge only, so the final
-        // location-change event of a drag/move - the one carrying its
-        // actual release position - is routinely the one that lands
-        // inside this window and gets dropped, since a drag generates a
-        // continuous event stream right up to release. Without this, the
-        // icon can be left classified by a stale mid-drag position until
-        // some unrelated window happens to move. Re-arm a short one-shot
-        // timer on every throttled event so it always fires once the
-        // burst actually goes quiet, applying the final position. Runs on
-        // this same dedicated WinEventHook thread (see
-        // g_dragFollowTrailingTimerId's comment).
+        // Leading-edge throttle, so re-arm a trailing one-shot timer on
+        // every throttled event to catch the drag/move's final position
+        // once the burst goes quiet. See RATIONALE.md.
         if (g_dragFollowTrailingTimerId) {
             KillTimer(nullptr, g_dragFollowTrailingTimerId);
         }
@@ -3168,23 +2560,14 @@ bool HookTaskbarDllSymbols() {
 }
 
 bool HookTaskbarViewDllSymbols(HMODULE module) {
-    // All marked optional so HookSymbols doesn't abort the whole batch on
-    // the first miss - we want a per-symbol report while bringing this mod
-    // up on a new Windows build, not just a single opaque FAILED. Which of
-    // the two modules below is actually loaded depends on the Windows
-    // build - see GetTaskbarViewModuleHandle.
-    // Taskbar.View.dll, ExplorerExtensions.dll
+    // Hooks for Taskbar.View.dll / ExplorerExtensions.dll (see
+    // GetTaskbarViewModuleHandle). Most entries are optional so a single
+    // missing symbol doesn't abort the whole batch - see RATIONALE.md.
     WindhawkUtils::SYMBOL_HOOK hooks[] = {
         {
-            // Deliberately NOT optional, unlike every other entry below:
-            // this hook is the mod's entire function - if it can't be
-            // resolved, positioning silently does nothing. Every other
-            // symbol here is optional purely so HookSymbols doesn't abort
-            // the whole batch on the first miss (a per-symbol report is
-            // more useful than one opaque FAILED while bringing this mod
-            // up on a new Windows build), but a build where this one is
-            // missing should surface as a real failure in Windhawk, not a
-            // mod that "loads successfully" and does nothing.
+            // Not optional, unlike every entry below: this hook is the
+            // mod's entire function. A build where it's missing must
+            // surface as a real failure, not a silently-inert mod.
             {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarCollapsibleLayout,struct winrt::Microsoft::UI::Xaml::Controls::IVirtualizingLayoutOverrides>::ArrangeOverride(void *,struct winrt::Windows::Foundation::Size,struct winrt::Windows::Foundation::Size *))"},
             &TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original,
             TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Hook,
@@ -3258,14 +2641,8 @@ void HandleLoadedModuleIfTaskbarView(HMODULE module, LPCWSTR lpLibFileName) {
         Wh_Log(L"Loaded %s", lpLibFileName);
 
         // Applied unconditionally, not gated on HookTaskbarViewDllSymbols'
-        // own return value: that value reflects whether EVERY symbol in
-        // its table resolved, optional ones included, so a single missing
-        // optional HWND-resolution symbol - exactly the case that table's
-        // `optional = true` entries exist to tolerate - would otherwise
-        // skip applying hooks for every symbol that DID resolve, ArrangeOverride
-        // included. The per-symbol resolved/MISSING logging already
-        // reports what to investigate; there's nothing to gain from also
-        // discarding the hooks that succeeded.
+        // return value - see RATIONALE.md for why a missing optional
+        // symbol shouldn't discard hooks that did resolve.
         HookTaskbarViewDllSymbols(module);
         Wh_ApplyHookOperations();
     }
@@ -3288,29 +2665,16 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
 // Mod lifecycle
 // ============================================================================
 
-// EVENT_OBJECT_LOCATIONCHANGE fires for every window move on the entire
-// system - "thousands of raw events within seconds" has been observed -
-// and EVENT_OBJECT_SHOW (added for the resolve-timer fast path, see
-// WinEventProc) is nearly as frequent. WINEVENT_OUTOFCONTEXT delivers
-// callbacks on whichever thread called SetWinEventHook, and only if that
-// thread pumps messages; registering on g_hTaskbarWnd's own thread would
-// put all of that - plus WinEventProc's own filtering calls on each one -
-// in direct contention with the shell's own layout work. This dedicated
-// mod-owned thread (the pattern taskbar-background-helper.wh.cpp and
-// taskbar-auto-hide-when-maximized.wh.cpp both use) keeps it off the
-// shell's thread entirely.
+// WinEvent hooks run on a dedicated mod-owned thread rather than the
+// taskbar's own, to keep the high raw event volume off the shell's layout
+// thread. See RATIONALE.md.
 //
-// kArmResolveNowMsg (like WM_APP below) is a private signal on this
-// thread's own message queue: the resolve timer lives here too (see
-// g_buttonHwndResolveTimerId), but callers of ArmButtonHwndResolveTimer
-// run on the taskbar thread, and a per-thread SetTimer/KillTimer can only
-// be touched from the thread that owns it - PostThreadMessage is how a
-// different thread asks this one to do that on its behalf.
+// Private message this thread's own queue uses to let ArmButtonHwndResolveTimer
+// (called from the taskbar thread) re-arm the resolve timer, which lives
+// on this thread.
 constexpr UINT kArmResolveNowMsg = WM_APP + 1;
 
-// Defined later in this section, alongside NextResolveDelayMs -
-// forward-declared here so WinEventHookThreadProc (right below) can
-// start/re-arm it directly on its own thread.
+// Defined later in this section, alongside NextResolveDelayMs.
 void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
                                          UINT uMsg,
                                          UINT_PTR idEvent,
@@ -3319,15 +2683,14 @@ void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
 DWORD WINAPI WinEventHookThreadProc(LPVOID) {
     // Forces this thread's message queue into existence before
     // SetWinEventHook runs, so WINEVENT_OUTOFCONTEXT has somewhere to
-    // deliver callbacks to as soon as registration succeeds, rather than
-    // racing the GetMessage loop below into existence.
+    // deliver callbacks to immediately.
     MSG msg;
     PeekMessage(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
 
-    // Deliberately NOT using WINEVENT_SKIPOWNPROCESS: File Explorer
-    // windows often run inside explorer.exe's own process, and that flag
-    // would silently drop their location-change events too. The taskbar's
-    // own windows are already excluded explicitly in WinEventProc.
+    // Not WINEVENT_SKIPOWNPROCESS: File Explorer windows often run inside
+    // explorer.exe's own process, and that flag would drop their
+    // location-change events too. The taskbar's own windows are excluded
+    // explicitly in WinEventProc instead.
     g_locationChangeHook = SetWinEventHook(
         EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_LOCATIONCHANGE, nullptr,
         WinEventProc, 0, 0, WINEVENT_OUTOFCONTEXT);
@@ -3339,10 +2702,8 @@ DWORD WINAPI WinEventHookThreadProc(LPVOID) {
                L"will");
     }
 
-    // A second, separate hook rather than widening the range above: the
-    // two event IDs aren't adjacent, and a single range spanning both
-    // would also pick up several unrelated event types in between. See
-    // WinEventProc's own EVENT_OBJECT_SHOW branch for what this is for.
+    // Separate hook since the two event IDs aren't adjacent - a single
+    // range spanning both would also pick up unrelated event types.
     g_showEventHook = SetWinEventHook(EVENT_OBJECT_SHOW, EVENT_OBJECT_SHOW,
                                       nullptr, WinEventProc, 0, 0,
                                       WINEVENT_OUTOFCONTEXT);
@@ -3353,17 +2714,13 @@ DWORD WINAPI WinEventHookThreadProc(LPVOID) {
                L"than immediately");
     }
 
-    // Kicks off the first HWND-resolve attempt shortly after this thread
-    // (and so the taskbar window) is up, so buttons already present at
-    // mod startup get picked up - after that, NextResolveDelayMs and
-    // ArmButtonHwndResolveTimer keep it armed only for as long as
-    // there's actually something to do.
+    // Kicks off the first HWND-resolve attempt so buttons already present
+    // at mod startup get picked up; NextResolveDelayMs/
+    // ArmButtonHwndResolveTimer keep it armed afterward only as needed.
     g_buttonHwndResolveTimerId =
         SetTimer(nullptr, 0, 100, ButtonHwndResolveTimerProc);
 
-    // WM_APP (posted by StopWinEventHook) is this thread's shutdown
-    // signal - it has no window to route to, so it's read directly out of
-    // the queue rather than via a window procedure.
+    // WM_APP (posted by StopWinEventHook) is this thread's shutdown signal.
     while (GetMessage(&msg, nullptr, 0, 0) > 0) {
         if (msg.message == WM_APP) {
             break;
@@ -3399,24 +2756,12 @@ DWORD WINAPI WinEventHookThreadProc(LPVOID) {
 }
 
 HANDLE g_winEventThread;
-// Written under g_winEventThreadMutex (Start/StopWinEventHook), but read
-// without it in ArmButtonHwndResolveTimer from the taskbar thread -
-// atomic makes that well-defined, matching g_taskbarWndSubclassed's own
-// treatment elsewhere in this file.
+// Written under g_winEventThreadMutex, read without it (from the taskbar
+// thread) in ArmButtonHwndResolveTimer - atomic makes that well-defined.
 std::atomic<DWORD> g_winEventThreadId;
 
-// Serializes StartWinEventHook/StopWinEventHook against each other.
-// EnsureTaskbarWnd can call StartWinEventHook from either Wh_ModAfterInit's
-// own thread or Explorer's UI thread (via the ArrangeOverride hook) once
-// g_hTaskbarWnd first resolves, and that call can still be inside
-// CreateThread - before g_winEventThread is written - when Wh_ModUninit
-// calls StopWinEventHook concurrently: a plain check-then-act (even an
-// atomic one guarding just the CreateThread call) can't stop
-// StopWinEventHook from checking g_winEventThread before StartWinEventHook
-// has finished writing it, missing the very thread it was meant to tear
-// down and leaving it to crash the process when Windhawk unmaps the
-// module later. The mutex makes "is there a thread, and should one ever
-// be created again" one atomic question both functions agree on.
+// Serializes StartWinEventHook/StopWinEventHook against each other - see
+// RATIONALE.md for the race this prevents.
 std::mutex g_winEventThreadMutex;
 bool g_winEventThreadStopped;
 
@@ -3426,9 +2771,8 @@ void StartWinEventHook() {
         return;
     }
 
-    // CreateThread's out-parameter needs a plain DWORD*, not
-    // atomic<DWORD>* - written through the local and then published to
-    // the atomic once CreateThread returns.
+    // CreateThread needs a plain DWORD* out-param, published to the
+    // atomic once it returns.
     DWORD threadId = 0;
     g_winEventThread = CreateThread(nullptr, 0, WinEventHookThreadProc,
                                     nullptr, 0, &threadId);
@@ -3439,20 +2783,16 @@ void StartWinEventHook() {
     }
 }
 
-// This thread is entirely mod-owned: PostThreadMessage can't silently
-// fail the way a marshaled call onto someone else's thread can, and
-// waiting for the thread to actually exit guarantees UnhookWinEvent (and
-// the resolve timer's own KillTimer, now that it lives here too) has
-// already run before Windhawk unmaps this module's code.
+// Waits for the thread to fully exit, guaranteeing UnhookWinEvent and the
+// resolve timer's KillTimer have run before Windhawk unmaps this module.
 void StopWinEventHook() {
     HANDLE thread;
     DWORD threadId;
     {
         std::lock_guard<std::mutex> guard(g_winEventThreadMutex);
-        // Set before releasing the lock, not after the thread is confirmed
-        // gone below - this is what stops a StartWinEventHook call that
-        // arrives after this point (e.g. a late ArrangeOverride pass) from
-        // recreating a thread nobody would be left to tear down.
+        // Set before releasing the lock, so a StartWinEventHook call
+        // arriving after this point can't recreate a thread nobody would
+        // tear down.
         g_winEventThreadStopped = true;
         thread = g_winEventThread;
         threadId = g_winEventThreadId;
@@ -3463,43 +2803,33 @@ void StopWinEventHook() {
         return;
     }
 
-    // PostThreadMessage fails with ERROR_INVALID_THREAD_ID if the thread
-    // hasn't created its message queue yet (WinEventHookThreadProc does
-    // that as its first action) - retry rather than give up, but tie the
-    // retry to the thread's own liveness rather than a fixed attempt
-    // count: giving up after N tries and falling through to the
-    // unconditional wait below with the signal never delivered would hang
-    // Wh_ModUninit forever, since nothing else can wake that wait.
+    // Retry until the thread's message queue exists (or it exits on its
+    // own) rather than giving up after N tries - nothing else would wake
+    // the unconditional wait below if the signal were never delivered.
     while (!PostThreadMessage(threadId, WM_APP, 0, 0)) {
         if (WaitForSingleObject(thread, 10) == WAIT_OBJECT_0) {
             break;  // Thread exited on its own before ever seeing WM_APP.
         }
     }
 
-    // Unconditional wait, not a bounded timeout: giving up early would let
-    // Wh_ModUninit return and Windhawk unmap this module's code while the
-    // thread is still inside it - a deferred crash, not a mitigated one.
+    // Unconditional wait: returning early would let Windhawk unmap this
+    // module's code while the thread is still running inside it.
     WaitForSingleObject(thread, INFINITE);
     CloseHandle(thread);
 }
 
 // Capped exponential backoff for the click-sentinel probe, shared by
-// ResolvePendingButtonHwnds and NextResolveDelayMs: a fallback safety net
-// for a pinned-but-not-running app's button, in case its launch is ever
-// reached through a path that doesn't produce EVENT_OBJECT_SHOW
-// (WinEventProc's fast path normally re-resolves it immediately - see its
-// own comment). The 30-minute ceiling keeps this fallback from becoming a
-// source of frequent synthetic clicks itself.
+// ResolvePendingButtonHwnds and NextResolveDelayMs. Fallback safety net for
+// launches that don't produce EVENT_OBJECT_SHOW; see RATIONALE.md.
 constexpr ULONGLONG kResolveBackoffCeilingMs = 30ULL * 60 * 1000;
 ULONGLONG ResolveBackoffMs(int consecutiveFailures) {
     int shift = std::min(consecutiveFailures, 16);  // keep the shift itself from overflowing
     return std::min(2000ULL << shift, kResolveBackoffCeilingMs);
 }
 
-// How long until the next resolve attempt could possibly do anything
-// useful, based only on g_buttonHwndCache's already-recorded state - no
-// XAML/tree access, just a scan of an in-memory map, so this is cheap
-// enough to call after every timer tick.
+// How long until the next resolve attempt could do anything useful, based
+// only on g_buttonHwndCache's recorded state - cheap enough to call after
+// every timer tick.
 DWORD NextResolveDelayMs() {
     ULONGLONG now = GetTickCount64();
     bool anyPending = false;
@@ -3521,16 +2851,10 @@ DWORD NextResolveDelayMs() {
     }
 
     if (!anyPending) {
-        // Even once every cached button is resolved, ItemsRepeater can
-        // rebind an already-realized element to a different item (a
-        // drag-reorder) without changing the total count - the one other
-        // thing that re-arms this timer. Without a periodic re-check
-        // here, ResolvePendingButtonHwnds' identity comparison (see
-        // ButtonHwndCacheEntry) would never run again once everything
-        // first resolves. Only armed when something is actually resolved
-        // - an all-pinned taskbar already gets its own tick from the
-        // backoff loop above; this only truly goes idle (INFINITE) when
-        // the cache is empty.
+        // A periodic re-check even once everything resolves, so a
+        // drag-reorder rebind (see ButtonHwndCacheEntry) still gets
+        // picked up. Only armed when something is actually resolved; goes
+        // fully idle (INFINITE) only when the cache is empty.
         if (anyResolved) {
             return kIdleResolveTickMs;
         }
@@ -3539,14 +2863,9 @@ DWORD NextResolveDelayMs() {
 
     DWORD pendingDelay = earliestDue > now ? (DWORD)(earliestDue - now) : 0;
     if (anyResolved) {
-        // Mixed cache: some buttons resolved (need the same periodic
-        // rebind re-check as the anyPending==false branch above), others
-        // still pending on their own up-to-30-minute backoff schedule,
-        // which could otherwise silently starve rebind detection for
-        // everyone else. Capping at kIdleResolveTickMs here doesn't
-        // resolve the pending entry any earlier, it only ensures the
-        // already-resolved entries keep getting their identity re-checked
-        // on the normal idle cadence.
+        // Mixed cache: cap at kIdleResolveTickMs so already-resolved
+        // entries still get their rebind re-check on the normal cadence,
+        // without waiting on a pending entry's own long backoff.
         return std::min(pendingDelay, kIdleResolveTickMs);
     }
     return pendingDelay;
@@ -3556,13 +2875,8 @@ void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
                                          UINT uMsg,
                                          UINT_PTR idEvent,
                                          DWORD dwTime) {
-    // Self-managing one-shot rather than a recurring interval - stop
-    // first, kick off the resolve pass, and let that pass decide for
-    // itself whether (and when) to re-arm (see
-    // ResolvePendingButtonHwnds' ScheduleNextResolveTick), rather than
-    // running forever even once everything is resolved and nothing has
-    // changed. Runs on this thread directly (a per-thread SetTimer with
-    // hWnd=nullptr), so KillTimer here needs no cross-thread marshal.
+    // Self-managing one-shot: stop first, kick off the resolve pass, and
+    // let it decide whether/when to re-arm (see ScheduleNextResolveTick).
     KillTimer(nullptr, idEvent);
     g_buttonHwndResolveTimerId = 0;
 
@@ -3570,40 +2884,21 @@ void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
         return;
     }
 
-    // Snapshot once so both branches below (and the fallback log message)
-    // agree on one value - see g_hTaskbarWnd's own comment for why a
-    // stale nullptr reaching PostMessage isn't a no-op. Named distinctly
-    // from this callback's own `hwnd` parameter (the timer's owning
-    // window, always nullptr for this thread-owned timer, unrelated to
-    // the taskbar window).
+    // Snapshot so both branches below agree on one value.
     HWND hTaskbarWnd = g_hTaskbarWnd;
     if (!hTaskbarWnd) {
-        // The taskbar window went away (recreate) between this timer
-        // being armed and firing - EnsureTaskbarWnd will re-resolve it on
-        // its own next pass. Retry later rather than let a null reach
-        // PostMessage below.
+        // Taskbar window went away (recreate); EnsureTaskbarWnd will
+        // re-resolve it. Retry later instead of letting null reach
+        // PostMessage.
         ArmButtonHwndResolveTimer(kIdleResolveTickMs);
         return;
     }
 
     // No fallback if the subclass never installed - see
-    // g_taskbarWndSubclassed's own comment for why. In that case,
-    // ResolvePendingButtonHwnds simply never runs and this timer stops
-    // re-arming itself entirely; EnsureTaskbarWnd explicitly kicks both
-    // this timer and InvalidateTaskbarLayout the moment a subclass
-    // install eventually succeeds (its own comment explains why that
-    // kick is needed with no fallback marshal to have kept this ticking
-    // in the meantime).
-    //
-    // ResolvePendingButtonHwnds computes/arms the next delay itself, at
-    // the very end of whichever pass this triggers (see its own
-    // ScheduleNextResolveTick comment for why: computing it here, right
-    // after an async PostMessage, would read g_buttonHwndCache
-    // concurrently with that pass's own writes to it). The one case that
-    // still needs handling here is a PostMessage failure - nothing will
-    // ever call back to re-arm if the message never arrives, so retry
-    // after a fixed fallback delay rather than leaving the timer silently
-    // dead.
+    // g_taskbarWndSubclassed. ResolvePendingButtonHwnds arms the next
+    // delay itself once its pass completes; the only case needing
+    // handling here is a PostMessage failure, since nothing else would
+    // re-arm the timer if the message never arrives.
     if (g_taskbarWndSubclassed) {
         if (!PostMessage(hTaskbarWnd, ResolveButtonHwndsMsg(), 0, 0)) {
             Wh_Log(L"ButtonHwndResolveTimerProc: PostMessage failed, "
@@ -3613,13 +2908,9 @@ void CALLBACK ButtonHwndResolveTimerProc(HWND hwnd,
     }
 }
 
-// The resolve timer lives on the dedicated WinEventHook thread (see
-// g_buttonHwndResolveTimerId), not on a window this mod doesn't own, so
-// arming it from the taskbar thread (where every caller of this function
-// runs) needs to ask that thread to do it on its own message queue -
-// PostThreadMessage can't silently fail the way a window-based marshal
-// can, and there's nothing left to leak if it does (the thread just
-// doesn't get the nudge, and its own next scheduled tick catches up).
+// The resolve timer lives on the dedicated WinEventHook thread, so arming
+// it from the taskbar thread needs PostThreadMessage to ask that thread to
+// do it on its own queue.
 void ArmButtonHwndResolveTimer(DWORD delayMs) {
     if (!g_winEventThreadId || g_unloading) {
         return;
@@ -3639,19 +2930,10 @@ BOOL Wh_ModInit() {
     if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
         Wh_Log(L"Taskbar view module already loaded at init time");
         g_taskbarViewDllLoaded = true;
-        // Deliberately NOT checking HookTaskbarViewDllSymbols' own return
-        // value here: it reflects whether EVERY symbol in its table
-        // resolved, optional ones included, so a single missing optional
-        // HWND-resolution symbol would fail this ENTIRE mod's load -
-        // exactly the outcome `optional = true` on those entries exists
-        // to prevent (see that table's own comment, and
-        // HandleLoadedModuleIfTaskbarView's identical reasoning for why
-        // its hook-apply call isn't gated on this return value either).
-        // ArrangeOverride is the one truly required symbol in that table
-        // - the mod's entire function depends on it - so that's checked
-        // directly below instead, matching HookTaskbarDllSymbols' own
-        // check above (safe to trust as-is, since every symbol load-
-        // gating that check is genuinely required, not optional).
+        // Not gated on HookTaskbarViewDllSymbols' own return value (which
+        // reflects optional symbols too) - see RATIONALE.md. The one
+        // symbol that must load, ArrangeOverride, is checked directly
+        // below instead.
         HookTaskbarViewDllSymbols(taskbarViewModule);
         if (!TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride_Original) {
             return FALSE;
@@ -3683,9 +2965,8 @@ void Wh_ModAfterInit() {
     if (!g_taskbarViewDllLoaded) {
         if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
             if (!g_taskbarViewDllLoaded.exchange(true)) {
-                // See HandleLoadedModuleIfTaskbarView's identical comment -
-                // applied unconditionally so a missing optional symbol
-                // doesn't also discard the hooks that did resolve.
+                // See HandleLoadedModuleIfTaskbarView - unconditional so a
+                // missing optional symbol doesn't discard resolved hooks.
                 HookTaskbarViewDllSymbols(taskbarViewModule);
                 Wh_ApplyHookOperations();
             }
@@ -3704,26 +2985,17 @@ void Wh_ModBeforeUninit() {
 
     g_unloading = true;
 
-    // Deliberately NOT tearing down the WinEventHook thread here: this
-    // mod's hooks stay installed until this function returns, and
-    // ArrangeOverride isn't gated on g_unloading - a pass landing in that
-    // window could still call StartWinEventHook via EnsureTaskbarWnd,
-    // creating a thread nobody would tear down (Wh_ModUninit, which does
-    // the actual teardown, runs after this). g_unloading being set first
-    // is what keeps ResolvePendingButtonHwnds' click-sentinel probe from
-    // running once its hooks are gone, and makes IUIElement_Arrange_Hook
-    // fall through to native positioning immediately regardless of
-    // whether anything below forces a relayout.
+    // The WinEventHook thread is torn down later, in Wh_ModUninit - this
+    // mod's hooks (and so StartWinEventHook's own call paths) stay live
+    // until this function returns. Setting g_unloading first is what stops
+    // the click-sentinel probe and makes IUIElement_Arrange_Hook fall
+    // through to native positioning immediately.
 
-    // Comes off Shell_TrayWnd as early as it's safe to, rather than
-    // staying wired in for the rest of teardown. With no fallback marshal
-    // once this is gone (see g_taskbarWndSubclassed's own comment), there
-    // is no reliable way left to force an immediate visual snap-back to
-    // native positions on disable - g_unloading above already guarantees
-    // the mod stops overriding anything, so this is a cosmetic timing
-    // difference only: native positions apply as soon as anything next
-    // triggers XAML to re-run Arrange on its own (opening/closing an app,
-    // a resize, etc.), rather than instantly.
+    // Removes the subclass as early as it's safe to. This is the sole
+    // marshal onto the taskbar thread (see g_taskbarWndSubclassed), so
+    // once it's gone there's no way to force an immediate visual
+    // snap-back on disable - native positions apply cosmetically late
+    // instead, next time XAML re-runs Arrange on its own. See RATIONALE.md.
     HWND hTaskbarWnd = g_hTaskbarWnd;
     if (hTaskbarWnd && g_taskbarWndSubclassed.exchange(false)) {
         WindhawkUtils::RemoveWindowSubclassFromAnyThread(
@@ -3734,30 +3006,20 @@ void Wh_ModBeforeUninit() {
 void Wh_ModUninit() {
     Wh_Log(L">");
 
-    // See Wh_ModBeforeUninit's comment for why this doesn't run there -
-    // the mod's own hooks are gone by the time Wh_ModUninit runs, so
-    // nothing can reawaken the thread being torn down here. This one
-    // join now also covers the HWND-resolve timer, which lives on the
-    // same thread.
+    // Runs here rather than in Wh_ModBeforeUninit - the mod's own hooks
+    // are gone by this point, so nothing can reawaken the thread. Also
+    // covers the HWND-resolve timer, which lives on the same thread.
     StopWinEventHook();
 }
 
-// Applies a freshly-loaded settings struct on the taskbar's own thread -
-// needed since it reassigns leftApps/rightApps (std::vector<std::wstring>),
-// which a concurrent ContainsAnyFragment call during a layout pass on that
-// thread could otherwise read mid-reassignment. No fallback if the
-// subclass never installed or PostMessage itself fails - see
-// g_taskbarWndSubclassed's own comment for why. Unlike
-// InvalidateTaskbarLayout/the HWND-resolve tick, a dropped settings change
-// here is a real loss rather than a delayed retry (there's no periodic
-// mechanism that would naturally pick it up later), so it's logged loudly
-// rather than silently swallowed - the new settings just don't take effect
-// until the taskbar recreates and a fresh subclass attempt succeeds.
+// Applies a freshly-loaded settings struct on the taskbar's own thread,
+// since it reassigns leftApps/rightApps while a concurrent layout pass
+// could be reading them. No fallback if the subclass isn't installed or
+// PostMessage fails - logged loudly rather than silently dropped, since
+// unlike InvalidateTaskbarLayout there's no periodic retry for a missed
+// settings change. See RATIONALE.md.
 void ApplyLoadedSettings(ModSettings settings) {
-    // Snapshot once so every read below agrees - see g_hTaskbarWnd's own
-    // comment for why a stale nullptr reaching PostMessage isn't a no-op
-    // (here, it would mean the heap ModSettings gets release()d and
-    // leaked while the settings change is silently dropped).
+    // Snapshot so every read below agrees.
     HWND hTaskbarWnd = g_hTaskbarWnd;
     if (!hTaskbarWnd) {
         g_settings = std::move(settings);
@@ -3770,11 +3032,9 @@ void ApplyLoadedSettings(ModSettings settings) {
         return;
     }
 
-    // PostMessage is async, so the settings can't live on this function's
-    // own stack - ownership transfers to the heap allocation, released via
-    // .release() only once PostMessage has actually queued it, and
-    // reclaimed by TaskbarWndSubclassProc's SettingsChangedMsg case on the
-    // dispatch side.
+    // PostMessage is async, so ownership transfers to a heap allocation,
+    // released only once PostMessage has queued it, and reclaimed by
+    // TaskbarWndSubclassProc's SettingsChangedMsg case.
     auto heapSettings = std::make_unique<ModSettings>(std::move(settings));
     if (PostMessage(hTaskbarWnd, SettingsChangedMsg(), 0,
                     (LPARAM)heapSettings.get())) {
@@ -3788,9 +3048,8 @@ void ApplyLoadedSettings(ModSettings settings) {
 void Wh_ModSettingsChanged() {
     Wh_Log(L">");
 
-    // Read every setting on this calling thread - Wh_Get/FreeStringSetting
-    // don't touch XAML/COM, so they don't need to run on the taskbar
-    // thread at all, only the final assignment into g_settings does (see
+    // Reads every setting on this calling thread; only the final
+    // assignment into g_settings needs the taskbar thread (see
     // ApplyLoadedSettings).
     ApplyLoadedSettings(LoadSettingsFromStore());
 

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -92,6 +92,14 @@ right next to Start on whichever side you prefer.
   grouping is a native decision made before this mod's hooks ever see a
   button - but it's flagged here as a planned follow-up pending
   confirmation of whether it reproduces with the mod disabled.
+- **A grouped button (multiple windows combined under one icon) follows
+  only its first window.** With "Combine taskbar buttons" set to "Always",
+  a group's side and ordering are both decided by whichever of its windows
+  happens to be first in the taskbar's own internal list - not necessarily
+  the one you'd expect - so a group whose windows straddle the center line
+  won't visually reflect all of them. There's no exposed way to pick a
+  more meaningful "primary" window for a group, so this is a documented
+  tradeoff rather than a bug.
 - **Undocumented internals.** This mod hooks private, unversioned classes
   inside `taskbar.dll` and `Taskbar.View.dll` (via symbols resolved from
   Microsoft's public symbol server at runtime, not hardcoded offsets). A
@@ -864,6 +872,19 @@ thread_local void* g_clickSentinel_TaskGroup;
 // session, with only a log line as the symptom. kClickSentinelMissesBeforeBroken
 // requires a few misses (still a bounded cost if the mechanism really is
 // broken) before actually latching - see NoteUnconfirmedClickSentinelMiss.
+//
+// This bound only holds pre-confirmation: NoteUnconfirmedClickSentinelMiss
+// returns immediately once a path is confirmed, by design (a post-
+// confirmation miss is routinely innocent - see above - so counting it
+// would risk latching a working path dead over an unrelated timing
+// hiccup). So "at most kClickSentinelMissesBeforeBroken real clicks per
+// path, per session" is the guarantee before first confirmation, not a
+// session-wide cap. Also note ResolveHwndFromTaskListButton tries the
+// item path first and falls through to the group path on a miss, so one
+// unresolvable button can burn a probe on BOTH paths in a single attempt
+// - the worst case before both latches trip is
+// 2 * kClickSentinelMissesBeforeBroken (6, at the current constant)
+// dispatched clicks, not kClickSentinelMissesBeforeBroken.
 std::atomic<bool> g_clickSentinelItemConfirmed;
 std::atomic<bool> g_clickSentinelItemBroken;
 std::atomic<int> g_clickSentinelItemMisses;
@@ -1722,6 +1743,16 @@ struct LayoutPlanStats {
 // changed - same reasoning as g_passStats.
 thread_local LayoutPlanStats g_planStats;
 
+// Total realized repeater children (every kind - Start, system buttons,
+// task list buttons) as of the last successful RecomputeLayoutPlan pass -
+// used only by that function's own staleness-backstop check (see there)
+// to detect ANY child appearing/disappearing via a single cheap count
+// comparison, with no per-child class-name lookup needed. Deliberately
+// broader than g_planStats.taskListTotal: a Search/Task View/Widgets
+// visibility change also needs to invalidate the plan, not just a task
+// list button count change.
+thread_local int g_planChildCount;
+
 struct TaskListPlanEntry {
     FrameworkElement element;
     ButtonClassification info;
@@ -1882,14 +1913,31 @@ void PlanTaskListButtons(const std::vector<FrameworkElement>& children,
     // x itself (the reference point carried to the next icon) advances by
     // the scaled amount. Scaling the placement itself instead would drift
     // the innermost icon into Start as compression increases.
+    // A just-realized button reports ActualWidth()==0 for one pass (only
+    // the *previous* arrange pass ever sets it), so entry->width can be 0
+    // here for a genuinely brand-new button. Giving it a plan entry in
+    // that state would place it exactly on top of its neighbor for one
+    // frame. Leaving it out of outPlan entirely instead falls through to
+    // native positioning for that one pass (same fallback every element
+    // this mod doesn't plan gets) - and since it's then also missing from
+    // g_lastArrangedX, RecomputeLayoutPlan's own staleness check (the
+    // hash-lookup miss, not even the child-count backstop) forces a real
+    // recompute on the very next pass once its real width is available,
+    // so this is a one-frame artifact, not a persistent one. Doesn't
+    // affect `x`'s advance either way - a zero-width entry doesn't move
+    // the reference point regardless of whether it gets a plan entry.
     double x = leftInnerX;
     for (auto* entry : left) {
-        outPlan[winrt::get_abi(entry->element)] = x - entry->width;
+        if (entry->width > 0) {
+            outPlan[winrt::get_abi(entry->element)] = x - entry->width;
+        }
         x -= entry->width * leftScale;
     }
     x = rightInnerX;
     for (auto* entry : right) {
-        outPlan[winrt::get_abi(entry->element)] = x;
+        if (entry->width > 0) {
+            outPlan[winrt::get_abi(entry->element)] = x;
+        }
         x += entry->width * rightScale;
     }
 }
@@ -2415,54 +2463,63 @@ void RecomputeLayoutPlan() {
         // getting called at least this often - a change landing in a
         // skipped pass on an otherwise-idle desktop (e.g. a pin/unpin)
         // could sit stale indefinitely otherwise. GetCachedTaskbarRepeater
-        // makes checking the realized task-list-button set against what
-        // the plan actually covers affordable every time this branch is
-        // taken - if any live button isn't in g_lastArrangedX, the plan is
+        // makes checking the realized child set against what the plan
+        // actually covers affordable every time this branch is taken - if
+        // any live task list button isn't in g_lastArrangedX, or the live
+        // child count doesn't match the last recompute's, the plan is
         // stale regardless of the dirty flag or the clock.
-        bool planCoversLiveTaskListButtons = true;
+        //
+        // Hash lookup first, IsTaskListButton (winrt::get_class_name - a
+        // GetRuntimeClassName round trip plus an HSTRING allocation)
+        // second, short-circuited via && - every element the plan covers
+        // (Start and the system buttons too, not just task list buttons)
+        // is already a key in g_lastArrangedX, so the common "nothing
+        // changed" case never pays for a single class-name lookup here.
+        // IsTaskListButton only runs at all on a hash-lookup miss, i.e.
+        // a genuinely new child.
+        bool planIsCurrent = true;
         try {
             if (FrameworkElement repeater = GetCachedTaskbarRepeater()) {
-                int liveTaskListCount = 0;
+                int liveChildCount = 0;
                 for (auto& child : GetRepeaterChildElements(repeater)) {
-                    // Map lookup first: every element the plan covers is
-                    // already a key in g_lastArrangedX, so this is a plain
-                    // hash lookup for the common case. IsTaskListButton
-                    // (winrt::get_class_name - a GetRuntimeClassName round
-                    // trip plus an HSTRING allocation) only runs once per
-                    // child, hoisted into a local rather than called twice.
-                    bool isTaskListButton = IsTaskListButton(child);
-                    if (!isTaskListButton) {
-                        continue;
-                    }
-                    liveTaskListCount++;
-                    if (!g_lastArrangedX.count(winrt::get_abi(child))) {
-                        // A live button the plan doesn't cover yet (just
-                        // realized after the last recompute) - the case
-                        // this check was originally added for.
-                        planCoversLiveTaskListButtons = false;
+                    liveChildCount++;
+                    if (!g_lastArrangedX.count(winrt::get_abi(child)) &&
+                        IsTaskListButton(child)) {
+                        // A live task list button the plan doesn't cover
+                        // yet (just realized after the last recompute).
+                        // Scoped to task list buttons specifically since
+                        // a brand-new system button reaching this branch
+                        // isn't otherwise possible - Search/Task View/
+                        // Widgets/Start don't get created or destroyed
+                        // the way task list buttons do - so there's
+                        // nothing to gain from paying for the class-name
+                        // check on a system-button miss too.
+                        planIsCurrent = false;
                         break;
                     }
                 }
-                // A button *disappearing* (unpin, app closed) adds nothing
-                // new to g_lastArrangedX's coverage - every remaining live
-                // button is still a key in it - so the loop above alone
-                // can't catch it, and it would otherwise sit at its old X
-                // (a visible hole) until the resolve timer's own prune
-                // eventually invalidates, up to kIdleResolveTickMs or the
-                // backoff schedule away. This count comparison catches
-                // that direction too.
-                if (planCoversLiveTaskListButtons &&
-                    liveTaskListCount != g_planStats.taskListTotal) {
-                    planCoversLiveTaskListButtons = false;
+                // A child *disappearing* (unpin, app closed, or a system
+                // button's visibility changing) adds nothing new to
+                // g_lastArrangedX's coverage - every remaining live child
+                // is still a key in it - so the loop above alone can't
+                // catch it, and a removed task list button would
+                // otherwise sit at its old X (a visible hole) until the
+                // resolve timer's own prune eventually invalidates, up to
+                // kIdleResolveTickMs or the backoff schedule away. This
+                // count comparison against g_planChildCount (every child
+                // kind, not just task list buttons - see its own comment)
+                // catches that direction too, for free, off the same walk.
+                if (planIsCurrent && liveChildCount != g_planChildCount) {
+                    planIsCurrent = false;
                 }
             }
         } catch (...) {
             // Conservative default: treat an exception here as "can't
             // confirm the plan is current" and fall through to the real
             // recompute below, which has its own exception handling.
-            planCoversLiveTaskListButtons = false;
+            planIsCurrent = false;
         }
-        if (planCoversLiveTaskListButtons) {
+        if (planIsCurrent) {
             return;
         }
     }
@@ -2598,6 +2655,7 @@ void RecomputeLayoutPlan() {
                             rightBoundLocal, newPlan);
 
         g_lastArrangedX = std::move(newPlan);
+        g_planChildCount = (int)children.size();
         g_planDirty = false;
     } catch (...) {
         g_planStats.exceptions++;

--- a/mods/taskbar-centered-start-split-icons.wh.cpp
+++ b/mods/taskbar-centered-start-split-icons.wh.cpp
@@ -930,7 +930,14 @@ HWND GetWindowFromNativeTaskItem(void* nativeTaskItem) {
                : nullptr;
 }
 
-HWND ResolveHwndFromIndividualTaskItem(FrameworkElement element) {
+// outClickDispatched is set true iff this call actually reached
+// TaskItem_ReportClicked_Original - see g_realTaskbarClickObserved's
+// caller (ResolveAndCacheButtonHwnd) for why bail-outs before that point
+// must be distinguished from a genuinely dispatched-and-missed click.
+HWND ResolveHwndFromIndividualTaskItem(FrameworkElement element,
+                                       bool& outClickDispatched) {
+    outClickDispatched = false;
+
     // CTaskListWnd_HandleClick_Original proves the interception hook is
     // actually installed - it's optional (see HookTaskbarDllSymbols), so
     // on a build where it didn't resolve, the ReportClicked call below
@@ -970,6 +977,7 @@ HWND ResolveHwndFromIndividualTaskItem(FrameworkElement element) {
 
     g_clickSentinel_TaskItem = nullptr;
     g_clickSentinelProbingGroup = false;
+    outClickDispatched = true;
     TaskItem_ReportClicked_Original(windowsUdkTaskItem.get(),
                                      &g_clickSentinel);
 
@@ -987,8 +995,12 @@ HWND ResolveHwndFromIndividualTaskItem(FrameworkElement element) {
 
 // Grouped button (all windows of one app collapsed under a single icon,
 // e.g. "Combine taskbar buttons" set to Always) - see the resolution
-// overview comment above this section for the full chain.
-HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
+// overview comment above this section for the full chain. outClickDispatched
+// - see ResolveHwndFromIndividualTaskItem's own comment.
+HWND ResolveHwndFromTaskGroup(FrameworkElement element,
+                              bool& outClickDispatched) {
+    outClickDispatched = false;
+
     // Same interception hook as ResolveHwndFromIndividualTaskItem
     // (CTaskListWnd::HandleClick handles both item and group paths).
     if (!CTaskListWnd_HandleClick_Original ||
@@ -1057,6 +1069,7 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
 
     g_clickSentinel_TaskGroup = nullptr;
     g_clickSentinelProbingGroup = true;
+    outClickDispatched = true;
     TaskGroup_ReportClicked_Original(windowsUdkTaskGroup, &g_clickSentinel);
     void* nativeTaskGroup = g_clickSentinel_TaskGroup;
     g_clickSentinel_TaskGroup = nullptr;
@@ -1082,21 +1095,29 @@ HWND ResolveHwndFromTaskGroup(FrameworkElement element) {
     return hwnd;
 }
 
-HWND ResolveHwndFromTaskListButton(FrameworkElement element) {
+HWND ResolveHwndFromTaskListButton(FrameworkElement element,
+                                   bool& outClickDispatched) {
     // Each path bails out once its own sentinel is known broken, rather
     // than dispatching more genuine clicks - see g_clickSentinelItemBroken/
     // g_clickSentinelGroupBroken.
+    bool itemDispatched = false;
     HWND hwnd = g_clickSentinelItemBroken
                     ? nullptr
-                    : ResolveHwndFromIndividualTaskItem(element);
-    if (hwnd) {
+                    : ResolveHwndFromIndividualTaskItem(element, itemDispatched);
+    if (hwnd || itemDispatched) {
+        // A dispatched-and-missed item-path click already proves this
+        // button is bound to a TaskListWindowViewModel, not a group - the
+        // group path would just dispatch a second, wholly redundant click
+        // for the same button. See RATIONALE.md.
+        outClickDispatched = itemDispatched;
         return hwnd;
     }
 
     if (g_clickSentinelGroupBroken) {
+        outClickDispatched = false;
         return nullptr;
     }
-    return ResolveHwndFromTaskGroup(element);
+    return ResolveHwndFromTaskGroup(element, outClickDispatched);
 }
 
 // Per-button HWND cache, keyed by the XAML element's ABI pointer. Avoids
@@ -1130,7 +1151,12 @@ constexpr int kMaxForcedRetryFailures = 3;
 // trips) would keep dispatching a real ReportClicked on this entry every
 // ResolveBackoffMs interval, forever. A button whose identity changes, or
 // that gets pruned and recreated, still gets a fresh consecutiveFailures
-// count and resumes retrying normally.
+// count and resumes retrying normally. Only counts a genuinely dispatched-
+// and-missed click (see ResolveAndCacheButtonHwnd) - a bail-out before
+// ever dispatching one doesn't risk anything and must not count toward
+// this. NextResolveDelayMs must treat a terminal entry exactly like a
+// resolved one (idle cadence, not the backoff schedule) - see its own
+// comment for the busy-loop that requires. See RATIONALE.md.
 constexpr int kMaxResolveFailures = 8;
 
 // The HWNDs g_buttonHwndCache currently resolves to, rebuilt at the end of
@@ -1157,8 +1183,21 @@ bool ResolveAndCacheButtonHwnd(FrameworkElement element,
         failures = it->second.consecutiveFailures;
     }
 
-    HWND hwnd = ResolveHwndFromTaskListButton(element);
-    failures = hwnd ? 0 : failures + 1;
+    bool clickDispatched = false;
+    HWND hwnd = ResolveHwndFromTaskListButton(element, clickDispatched);
+    // Only a genuinely dispatched-and-missed click counts toward
+    // kMaxResolveFailures' terminal cap - a bail-out before ever
+    // dispatching one (not yet confirmed reachable, a view-model lookup
+    // miss, a not-currently-running group) isn't a click-safety risk and
+    // must not count against a button that may resolve fine later. See
+    // RATIONALE.md. lastAttempt still advances either way, so a
+    // persistently-bailing-out entry keeps retrying at ResolveBackoffMs(0)
+    // - a cheap, indefinite cadence - rather than escalating toward the cap.
+    if (hwnd) {
+        failures = 0;
+    } else if (clickDispatched) {
+        failures = failures + 1;
+    }
     g_buttonHwndCache[key] = {hwnd, identity, GetTickCount64(), failures};
     return hwnd != previous;
 }
@@ -2996,13 +3035,21 @@ ULONGLONG ResolveBackoffMs(int consecutiveFailures) {
 DWORD NextResolveDelayMs() {
     ULONGLONG now = GetTickCount64();
     bool anyPending = false;
-    bool anyResolved = false;
+    // True for a resolved entry OR a terminal one (consecutiveFailures at
+    // kMaxResolveFailures) - either way, only the slow idle-rebind cadence
+    // below still applies to it, never the backoff schedule. Must exactly
+    // match ResolvePendingButtonHwnds' own backoffElapsed check, which
+    // never retries a terminal entry - see RATIONALE.md for the busy-loop
+    // this closes: without this, a terminal entry's fixed, no-longer-
+    // advancing dueAt falls further into the past every tick, pinning
+    // pendingDelay at 0 (SetTimer's 10ms floor) forever.
+    bool anyIdleWorthy = false;
     ULONGLONG earliestDue = 0;
 
     for (auto& kv : g_buttonHwndCache) {
         const ButtonHwndCacheEntry& entry = kv.second;
-        if (entry.hwnd) {
-            anyResolved = true;
+        if (entry.hwnd || entry.consecutiveFailures >= kMaxResolveFailures) {
+            anyIdleWorthy = true;
             continue;
         }
         ULONGLONG dueAt =
@@ -3016,19 +3063,21 @@ DWORD NextResolveDelayMs() {
     if (!anyPending) {
         // A periodic re-check even once everything resolves, so a
         // drag-reorder rebind (see ButtonHwndCacheEntry) still gets
-        // picked up. Only armed when something is actually resolved; goes
-        // fully idle (INFINITE) only when the cache is empty.
-        if (anyResolved) {
+        // picked up. Only armed when something is actually resolved or
+        // terminal; goes fully idle (INFINITE) only when the cache is
+        // empty (or holds only genuinely-still-retryable entries, which
+        // can't happen here since anyPending would then be true).
+        if (anyIdleWorthy) {
             return kIdleResolveTickMs;
         }
         return INFINITE;
     }
 
     DWORD pendingDelay = earliestDue > now ? (DWORD)(earliestDue - now) : 0;
-    if (anyResolved) {
-        // Mixed cache: cap at kIdleResolveTickMs so already-resolved
-        // entries still get their rebind re-check on the normal cadence,
-        // without waiting on a pending entry's own long backoff.
+    if (anyIdleWorthy) {
+        // Mixed cache: cap at kIdleResolveTickMs so already-resolved/
+        // terminal entries still get their rebind re-check on the normal
+        // cadence, without waiting on a pending entry's own long backoff.
         return std::min(pendingDelay, kIdleResolveTickMs);
     }
     return pendingDelay;


### PR DESCRIPTION
## Summary
Adds a new mod: **Taskbar Start Button Centered Origin** (`taskbar-centered-start-split-icons`).

Pins the Windows 11 Start button to the true horizontal center of the primary monitor regardless of icon count, and splits running-app taskbar buttons into two groups flanking Start based on which side of the screen each window is currently on (with live drag-follow as windows move). Also supports positioning Search/Task View/Widgets, per-app left/right overrides, and configurable ordering within each side.

Full feature list, settings, known limitations, and development changelog are documented in the mod's own `WindhawkModReadme` block.

## Test plan
- [x] Built and run locally via Windhawk on Windows 11 over multiple days of iteration, including fixes for explorer.exe crashes on cross-monitor window moves (root-caused via WinDbg) and settling-window cosmetic polish
- [x] Verified stable across repeated cross-monitor moves, new app launches, and pin/unpin changes with no crashes

## Design note: unattended click-sentinel probing

The HWND-resolution step (mapping a taskbar button back to its window, needed to classify which side of the screen it's on) reuses the "sentinel click" technique already used elsewhere in this repo (`taskbar-numberer`, `taskbar-reorder-right-drag`) - dispatching a real click through the taskbar's internal click handler and intercepting it before it reaches the real handler. Those mods only fire it in response to an actual user gesture; this mod fires it unattended, from a background timer and from a fast-path nudge on `TaskListButton::UpdateVisualStates` (a taskbar button's own visual-state transitions, including a pinned app's running/not-running change), against every not-yet-resolved button.

Mitigations in place: an `ITaskGroup::IsRunning` bail-out before ever probing a group with no running windows (a pinned-but-not-running app therefore never gets probed at all), a per-path confirmed/broken latch that disables further probing after three unconfirmed misses, and capped exponential backoff between retries. Before a path's first confirmation, up to three probes on that path can miss - and a miss there is a real click reaching the taskbar's actual handler with the sentinel value in place of its real argument, so the realistic worst case is a stray window activate/minimize or an access violation in explorer.exe - before the latch trips and further probing on that path stops. (The threshold is three rather than one because a probe only ever runs after a real click has already been seen passing through the same interception point, so an early miss is far more likely a startup transient than evidence the hook is broken; a successful capture resets the count.) That bound is pre-confirmation only: once a path is confirmed working, a later miss no longer counts toward the latch (a post-confirmation miss is usually innocent - the window closed mid-probe, or a taskbar rebuild caught the item mid-teardown - so counting it risked latching a working path dead over an unrelated timing hiccup). For that case, retry frequency (not total count) is bounded instead by the same capped exponential backoff (2s up to 30min) the resolution cache uses everywhere else, so a persistently-broken-but-still-confirmed path can't dispatch clicks faster than that schedule allows.

I believe this is an acceptable risk given the mitigations, but I'm flagging it explicitly per review feedback since it's a stability/blast-radius judgment call rather than something provably safe from the code alone.

## Mod authorship

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Written by Claude Code (Anthropic's CLI) under my direction across multiple sessions - I described the desired behavior, reported bugs/crashes as they came up during real-world testing, and made the design decisions, while Claude wrote and iterated on the actual code. See the mod's own "Disclosures" section for the same note.

