### PR TITLE
Update Taskbar Icon Separators to v1.0.13

### DIFF
--- a/mods/taskbar-icon-separators.wh.cpp
+++ b/mods/taskbar-icon-separators.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-icon-separators
 // @name            Taskbar Icon Separators
 // @description     Create tracked icon separators with configurable padding on the taskbar.
-// @version         0.5.42-p43
+// @version         1.0.0
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @license         GPL-3.0
@@ -17,24 +17,22 @@
 
 Create tracked icon separators with configurable padding on the taskbar.
 
-![Screenshot](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/taskbar-icon-separators/SEP.png)
+![Screenshot](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/taskbar-icon-separators/SEP2.png)
 _Example for creating separators on the taskbar_
 
-Another mod offers similar functionality, but this implementation takes a different approach.
+Another mod offers similar functionality; this implementation takes on a more native-first spin.
 
-This mod uses private COM APIs to insert a genuine taskbar button, styles its width and centering, and keeps activation/tooltip behavior inert. Separators remain genuine pinned slots, can be reordered with the native taskbar drag behavior, and can also be created from the empty-taskbar context menu.
+This mod uses private COM APIs to insert a genuine taskbar button, styles its width and centering, and keeps activation/tooltip behavior inert. 
+Separators remain genuine, can be manually reordered, and can also be created from the taskbar context menu.
 
 
-Note: The mod creates pinned shortcuts targeting the Windows `systray.exe` stub (with a hidden, immediately exiting `cmd.exe` fallback) and reorders the persisted taskbar pin list. Cleanup is best-effort; in the worst failure case, separators may require manual unpinning.
+Note: The mod creates pinned shortcuts targeting Windows `systray.exe` (with fallback) and reorders the persisted taskbar pin list. 
+Cleanup is best-effort; in the worst failure case, manual taskbar unpinning and reordering may be required.
 
-Separator instances and their taskbar positions are stored by the mod itself
+Separator properties are stored by the mod itself
 inside its Windhawk mod-storage directory. Windhawk settings expose only the
 global separator width. Native Add, drag/reorder, and Unpin operations update
-that mod-owned state directly.
-
-Separator right-click is handled entirely inside explorer.exe with a small
-WinRT XAML MenuFlyout containing the mod-owned Unpin command. No companion
-ShellExperienceHost injection or cross-process coordination is required.
+ are persisted directly.
 
 Windows 11 only.
 */

--- a/mods/taskbar-icon-separators.wh.cpp
+++ b/mods/taskbar-icon-separators.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-icon-separators
 // @name            Taskbar Icon Separators
 // @description     Create tracked icon separators with configurable padding on the taskbar.
-// @version         0.5.39
+// @version         0.5.42-p43
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @license         GPL-3.0
@@ -22,10 +22,19 @@ _Example for creating separators on the taskbar_
 
 Another mod offers similar functionality, but this implementation takes a different approach.
 
-This mod uses private COM APIs to insert a genuine taskbar button, styles its width and centering, and disables all interaction events. Because each separator occupies a real pinned slot, it stays anchored between the same pinned items as running apps change.
+This mod uses private COM APIs to insert a genuine taskbar button, styles its width and centering, and keeps activation/tooltip behavior inert. Separators remain genuine pinned slots, can be reordered with the native taskbar drag behavior, and can also be created from the empty-taskbar context menu.
 
 
 Note: The mod creates pinned shortcuts targeting the Windows `systray.exe` stub (with a hidden, immediately exiting `cmd.exe` fallback) and reorders the persisted taskbar pin list. Cleanup is best-effort; in the worst failure case, separators may require manual unpinning.
+
+Separator instances and their taskbar positions are stored by the mod itself
+inside its Windhawk mod-storage directory. Windhawk settings expose only the
+global separator width. Native Add, drag/reorder, and Unpin operations update
+that mod-owned state directly.
+
+Separator right-click is handled entirely inside explorer.exe with a small
+WinRT XAML MenuFlyout containing the mod-owned Unpin command. No companion
+ShellExperienceHost injection or cross-process coordination is required.
 
 Windows 11 only.
 */
@@ -33,21 +42,9 @@ Windows 11 only.
 
 // ==WindhawkModSettings==
 /*
-- identifierPrefix: WindhawkSeparator
-  $name: Separator Identifier Prefix
-  $description: >-
-    Customizable part of separator identities. A fixed unique suffix is always appended.
-    
-    Change this only if a naming collision occurs (very rare).
-- separators:
-    - - index: 1
-        $name: Final Position
-        $description: 1 = first pinned taskbar position. Right after Search / Taskview. 
-      - width: 20
-        $name: Width
-        $description: Width of the separator slot. 
-  $name: Separators
-  $description: Each new entry corresponds to a new separator being created.
+- width: 20
+  $name: Separator Width
+  $description: Width of every separator slot.
 */
 // ==/WindhawkModSettings==
 
@@ -57,11 +54,13 @@ Windows 11 only.
 
 #include <windows.h>
 #include <shlobj.h>
+#include <shellapi.h>
 #include <shobjidl.h>
 #include <propkey.h>
 #include <propvarutil.h>
 
 #include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.UI.Xaml.h>
 #include <winrt/Windows.UI.Xaml.Automation.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
@@ -72,9 +71,14 @@ Windows 11 only.
 #include <algorithm>
 #include <atomic>
 #include <cwctype>
+#include <cwchar>
+#include <climits>
 #include <iterator>
 #include <list>
 #include <mutex>
+#include <shared_mutex>
+#include <new>
+#include <cstdlib>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -153,38 +157,65 @@ struct IPinManagerInterop3 : IPinManagerInterop2 {
 // -----------------------------------------------------------------------------
 
 struct SeparatorSetting {
-    int ordinal;       // Stable within this loaded settings snapshot: 1, 2, ...
+    int ordinal;       // Current mod-state row, 1-based (logging only).
+    int sourceIndex;   // Current mod-state vector index, 0-based.
     int targetIndex;   // Zero-based value passed to MoveTaskbarPin.
     double width;      // FrameworkElement::MaxWidth for the separator slot.
-    std::wstring identity;
+    std::wstring stableId; // Persistent internal identity, independent of array order.
+    std::wstring identity; // AppUserModelID / shortcut stem derived from stableId.
 };
 
 struct Settings {
     std::wstring identifierPrefix;
+    double width = 20.0;
     std::vector<SeparatorSetting> separators;
 };
 
 static Settings g_settings;
+static Settings g_appliedSettings;
 static SeparatorSetting g_refreshPulseSetting;
 static std::vector<SeparatorSetting> g_storedSeparatorSettings;
+static std::shared_mutex g_settingsMutex;
+// Serializes native Add/drag/Unpin mutations with state-file writes and the
+// global Windhawk width-setting callback.
+static std::mutex g_settingsMutationMutex;
 static std::wstring g_storagePath;
 static std::wstring g_iconPath;
+static std::wstring g_separatorStatePath;
+
+// True after native reordering changes the in-memory taskbar layout and until
+// the drag-completion boundary persists the current separator state.
+static bool g_separatorStateDirty = false;  // guarded by g_settingsMutationMutex
 
 static std::atomic<bool> g_taskbarViewDllHooked = false;
 static std::atomic<bool> g_taskbarLifecycleHookInstalled = false;
 static std::atomic<bool> g_taskbarInteractionHooksInstalled = false;
 static std::atomic<bool> g_loadLibraryWatcherInstalled = false;
 static std::atomic<bool> g_unloading = false;
+// True only while this mod intentionally tears down its own pins. User-facing
+// Add/Unpin callbacks must not mutate desired state during that window.
+static std::atomic<bool> g_internalCleanupInProgress = false;
 static std::mutex g_lifecycleMutex;
 static bool g_taskbarViewHookInstallationAttempted = false;
 static bool g_taskbarLifecycleHookInstallationAttempted = false;
 static bool g_taskbarInteractionHookInstallationAttempted = false;
 static bool g_backendStopped = false;
+static std::atomic<bool> g_backendHasConverged = false;
 static HANDLE g_backendThread = nullptr;
 static HANDLE g_backendStopEvent = nullptr;
+static HANDLE g_backendWakeEvent = nullptr;
 static thread_local HANDLE g_currentBackendStopEvent = nullptr;
+static thread_local HANDLE g_currentBackendWakeEvent = nullptr;
 
 static constexpr wchar_t kSeparatorIdentitySuffix[] = L"8F31A7D2";
+static constexpr wchar_t kSeparatorIdentifierPrefix[] = L"WindhawkSeparator";
+static constexpr wchar_t kSeparatorStateFileName[] = L"separator-state-v1.txt";
+
+// Read-only compatibility key used only for the one-time migration from the
+// pre-p42 builds. New builds never write separator configuration to Windhawk
+// values/settings; the authoritative separator list lives in mod storage.
+static constexpr wchar_t kLegacyIdentityManifestValueName[] =
+    L"separatorIdentityManifestV1";
 
 // Reserved outside the supported separator range. The helper is briefly
 // pinned and unpinned after positioning to make Explorer process a concrete
@@ -353,38 +384,14 @@ static std::wstring JoinPath(
     return directory + L"\\" + fileName;
 }
 
-static std::wstring SanitizeIdentifierPrefix(std::wstring value) {
-    for (wchar_t& ch : value) {
-        const bool allowed =
-            (ch >= L'a' && ch <= L'z') ||
-            (ch >= L'A' && ch <= L'Z') ||
-            (ch >= L'0' && ch <= L'9') ||
-            ch == L'-' || ch == L'_';
-        if (!allowed) {
-            ch = L'_';
-        }
-    }
-
-    if (value.empty()) {
-        value = L"WindhawkSeparator";
-    }
-
-    constexpr size_t kMaxPrefixLength = 48;
-    if (value.size() > kMaxPrefixLength) {
-        value.resize(kMaxPrefixLength);
-    }
-
-    return value;
-}
-
 static std::wstring BuildSeparatorIdentity(
     std::wstring_view prefix,
-    int ordinal) {
+    std::wstring_view stableId) {
     return std::wstring(prefix) +
            L"." +
            kSeparatorIdentitySuffix +
            L"." +
-           std::to_wstring(ordinal);
+           std::wstring(stableId);
 }
 
 static std::wstring GetSeparatorShortcutPath(
@@ -457,36 +464,936 @@ static std::wstring GetShortcutIdentity(const std::wstring& path) {
     return path.substr(fileNameStart, extension - fileNameStart);
 }
 
-static bool IsCurrentSeparatorIdentity(std::wstring_view identity) {
+static bool IsIdentityInSettings(
+    const Settings& settings,
+    std::wstring_view identity) {
     return std::any_of(
-        g_settings.separators.begin(),
-        g_settings.separators.end(),
+        settings.separators.begin(),
+        settings.separators.end(),
         [identity](const SeparatorSetting& separator) {
             return identity == std::wstring_view(separator.identity);
         });
 }
 
-static void LoadStoredSeparatorSettings() {
-    g_storedSeparatorSettings.clear();
 
-    const double width = g_settings.separators.empty()
-                             ? 20.0
-                             : g_settings.separators.front().width;
+struct LegacySeparatorIdentitySeed {
+    std::wstring stableId;
+    int sourceIndex;
+    int targetIndex;
+};
+
+static bool IsValidStableId(std::wstring_view value) {
+    if (value.empty() || value.size() > 64) {
+        return false;
+    }
+
+    return std::all_of(
+        value.begin(),
+        value.end(),
+        [](wchar_t ch) {
+            return std::iswalnum(ch) ||
+                   ch == L'-' || ch == L'_';
+        });
+}
+
+static bool ParseWideInt(
+    std::wstring_view text,
+    int* valueOut) {
+    if (!valueOut || text.empty()) {
+        return false;
+    }
+
+    std::wstring copy(text);
+    wchar_t* end = nullptr;
+    long value = std::wcstol(
+        copy.c_str(),
+        &end,
+        10);
+
+    if (!end || *end != L'\0' ||
+        value < INT_MIN || value > INT_MAX) {
+        return false;
+    }
+
+    *valueOut = static_cast<int>(value);
+    return true;
+}
+
+static std::vector<LegacySeparatorIdentitySeed>
+LoadLegacyIdentityManifest() {
+    std::vector<wchar_t> buffer(65536);
+    size_t length = Wh_GetStringValue(
+        kLegacyIdentityManifestValueName,
+        buffer.data(),
+        buffer.size());
+
+    if (!length) {
+        return {};
+    }
+
+    std::vector<LegacySeparatorIdentitySeed> result;
+    std::wstring_view data(buffer.data(), length);
+    size_t lineStart = 0;
+
+    while (lineStart < data.size()) {
+        size_t lineEnd = data.find(L'\n', lineStart);
+        if (lineEnd == std::wstring_view::npos) {
+            lineEnd = data.size();
+        }
+
+        std::wstring_view line =
+            data.substr(lineStart, lineEnd - lineStart);
+        if (!line.empty() && line.back() == L'\r') {
+            line.remove_suffix(1);
+        }
+
+        // Legacy format:
+        // stableId<TAB>sourceIndex<TAB>targetIndex<TAB>width
+        std::wstring_view fields[4];
+        size_t fieldStart = 0;
+        bool valid = true;
+
+        for (int field = 0; field < 4; field++) {
+            size_t fieldEnd =
+                field == 3
+                    ? line.size()
+                    : line.find(L'\t', fieldStart);
+
+            if (fieldEnd == std::wstring_view::npos ||
+                fieldStart > line.size()) {
+                valid = false;
+                break;
+            }
+
+            fields[field] =
+                line.substr(fieldStart, fieldEnd - fieldStart);
+            fieldStart = fieldEnd + 1;
+        }
+
+        if (valid && IsValidStableId(fields[0])) {
+            int sourceIndex = 0;
+            int targetIndex = 0;
+            int ignoredWidth = 0;
+
+            if (ParseWideInt(fields[1], &sourceIndex) &&
+                ParseWideInt(fields[2], &targetIndex) &&
+                ParseWideInt(fields[3], &ignoredWidth) &&
+                sourceIndex >= -1 &&
+                targetIndex >= -1) {
+                result.push_back({
+                    .stableId = std::wstring(fields[0]),
+                    .sourceIndex = sourceIndex,
+                    .targetIndex = targetIndex,
+                });
+            }
+        }
+
+        lineStart = lineEnd + 1;
+    }
+
+    return result;
+}
+
+static void AppendHex(
+    std::wstring& output,
+    unsigned long long value,
+    int digits) {
+    static constexpr wchar_t kHexDigits[] =
+        L"0123456789abcdef";
+
+    for (int digit = digits - 1; digit >= 0; digit--) {
+        output.push_back(
+            kHexDigits[
+                (value >> (digit * 4)) & 0xF]);
+    }
+}
+
+static bool GenerateRandomBytes(
+    BYTE* buffer,
+    ULONG size) {
+    using BCryptGenRandom_t =
+        LONG(WINAPI*)(
+            void* algorithm,
+            BYTE* buffer,
+            ULONG size,
+            ULONG flags);
+
+    static BCryptGenRandom_t bcryptGenRandom = [] {
+        HMODULE bcrypt =
+            GetModuleHandleW(L"bcrypt.dll");
+        if (!bcrypt) {
+            bcrypt = LoadLibraryW(L"bcrypt.dll");
+        }
+
+        return bcrypt
+                   ? reinterpret_cast<BCryptGenRandom_t>(
+                         GetProcAddress(
+                             bcrypt,
+                             "BCryptGenRandom"))
+                   : nullptr;
+    }();
+
+    // BCRYPT_USE_SYSTEM_PREFERRED_RNG.
+    constexpr ULONG kUseSystemPreferredRng = 0x00000002;
+
+    return bcryptGenRandom &&
+        bcryptGenRandom(
+            nullptr,
+            buffer,
+            size,
+            kUseSystemPreferredRng) >= 0;
+}
+
+static std::wstring GenerateStableId() {
+    BYTE randomBytes[16] = {};
+
+    if (GenerateRandomBytes(
+            randomBytes,
+            ARRAYSIZE(randomBytes))) {
+        std::wstring result = L"g";
+        result.reserve(33);
+
+        for (BYTE byte : randomBytes) {
+            AppendHex(result, byte, 2);
+        }
+
+        return result;
+    }
+
+    // BCryptGenRandom should always be available on supported Windows
+    // versions. Retain a process-local fallback so a native Add action doesn't
+    // fail merely because random generation unexpectedly did.
+    static std::atomic<unsigned long long> counter{0};
+    LARGE_INTEGER performanceCounter = {};
+    QueryPerformanceCounter(&performanceCounter);
+
+    unsigned long long seed =
+        static_cast<unsigned long long>(
+            performanceCounter.QuadPart) ^
+        (GetTickCount64() << 17) ^
+        (static_cast<unsigned long long>(
+             GetCurrentProcessId()) << 32) ^
+        GetCurrentThreadId();
+
+    std::wstring result = L"g";
+    AppendHex(result, seed, 16);
+    AppendHex(
+        result,
+        counter.fetch_add(
+            1,
+            std::memory_order_relaxed),
+        16);
+    return result;
+}
+
+
+static bool ParseStateInt(
+    std::string_view text,
+    int* valueOut) {
+    if (!valueOut || text.empty()) {
+        return false;
+    }
+
+    std::string copy(text);
+    char* end = nullptr;
+    long value = std::strtol(
+        copy.c_str(),
+        &end,
+        10);
+
+    if (!end || *end != '\0' ||
+        value < INT_MIN || value > INT_MAX) {
+        return false;
+    }
+
+    *valueOut = static_cast<int>(value);
+    return true;
+}
+
+static bool ReadSeparatorStateFile(
+    double width,
+    Settings* settingsOut,
+    bool* existsOut) {
+    if (!settingsOut || !existsOut) {
+        return false;
+    }
+
+    *existsOut = false;
+    settingsOut->identifierPrefix = kSeparatorIdentifierPrefix;
+    settingsOut->width = width;
+    settingsOut->separators.clear();
+
+    DWORD attrs =
+        GetFileAttributesW(g_separatorStatePath.c_str());
+    if (attrs == INVALID_FILE_ATTRIBUTES) {
+        if (GetLastError() == ERROR_FILE_NOT_FOUND ||
+            GetLastError() == ERROR_PATH_NOT_FOUND) {
+            return true;
+        }
+
+        Wh_Log(
+            L"[STATE] GetFileAttributesW('%s') failed error=%u",
+            g_separatorStatePath.c_str(),
+            GetLastError());
+        return false;
+    }
+
+    if (attrs & FILE_ATTRIBUTE_DIRECTORY) {
+        Wh_Log(
+            L"[STATE] State path is unexpectedly a directory: '%s'",
+            g_separatorStatePath.c_str());
+        return false;
+    }
+
+    *existsOut = true;
+
+    HANDLE file =
+        CreateFileW(
+            g_separatorStatePath.c_str(),
+            GENERIC_READ,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            nullptr,
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            nullptr);
+
+    if (file == INVALID_HANDLE_VALUE) {
+        Wh_Log(
+            L"[STATE] CreateFileW('%s') for read failed error=%u",
+            g_separatorStatePath.c_str(),
+            GetLastError());
+        return false;
+    }
+
+    LARGE_INTEGER size = {};
+    if (!GetFileSizeEx(file, &size) ||
+        size.QuadPart < 0 ||
+        size.QuadPart > 1024 * 1024) {
+        DWORD error = GetLastError();
+        CloseHandle(file);
+        Wh_Log(
+            L"[STATE] Invalid state-file size error=%u size=%lld",
+            error,
+            static_cast<long long>(size.QuadPart));
+        return false;
+    }
+
+    std::string data(
+        static_cast<size_t>(size.QuadPart),
+        '\0');
+
+    DWORD bytesRead = 0;
+    BOOL readOk =
+        data.empty() ||
+        ReadFile(
+            file,
+            data.data(),
+            static_cast<DWORD>(data.size()),
+            &bytesRead,
+            nullptr);
+    DWORD readError = readOk ? ERROR_SUCCESS : GetLastError();
+    CloseHandle(file);
+
+    if (!readOk || bytesRead != data.size()) {
+        Wh_Log(
+            L"[STATE] ReadFile failed/incomplete error=%u read=%u expected=%zu",
+            readError,
+            bytesRead,
+            data.size());
+        return false;
+    }
+
+    size_t lineStart = 0;
+    bool headerSeen = false;
+    constexpr size_t kMaxSeparators = 256;
+
+    while (lineStart <= data.size()) {
+        size_t lineEnd = data.find('\n', lineStart);
+        if (lineEnd == std::string::npos) {
+            lineEnd = data.size();
+        }
+
+        std::string_view line(
+            data.data() + lineStart,
+            lineEnd - lineStart);
+        if (!line.empty() && line.back() == '\r') {
+            line.remove_suffix(1);
+        }
+
+        if (!headerSeen) {
+            if (line != "v1") {
+                Wh_Log(L"[STATE] Unsupported/corrupt separator state header");
+                return false;
+            }
+            headerSeen = true;
+        } else if (!line.empty()) {
+            size_t tab = line.find('\t');
+            if (tab == std::string_view::npos ||
+                tab == 0 ||
+                tab + 1 >= line.size()) {
+                Wh_Log(L"[STATE] Malformed separator state row");
+                return false;
+            }
+
+            std::string_view stableIdAscii =
+                line.substr(0, tab);
+            std::wstring stableId;
+            stableId.reserve(stableIdAscii.size());
+
+            bool asciiOnly = true;
+            for (unsigned char ch : stableIdAscii) {
+                if (ch >= 0x80) {
+                    asciiOnly = false;
+                    break;
+                }
+                stableId.push_back(
+                    static_cast<wchar_t>(ch));
+            }
+
+            int targetIndex = 0;
+            if (!asciiOnly ||
+                !IsValidStableId(stableId) ||
+                !ParseStateInt(
+                    line.substr(tab + 1),
+                    &targetIndex) ||
+                targetIndex < -1) {
+                Wh_Log(L"[STATE] Invalid separator state row");
+                return false;
+            }
+
+            if (settingsOut->separators.size() >=
+                kMaxSeparators) {
+                Wh_Log(
+                    L"[STATE] Too many separators in state file");
+                return false;
+            }
+
+            if (std::any_of(
+                    settingsOut->separators.begin(),
+                    settingsOut->separators.end(),
+                    [&stableId](const SeparatorSetting& existing) {
+                        return existing.stableId == stableId;
+                    })) {
+                Wh_Log(
+                    L"[STATE] Duplicate stable ID in state file: '%s'",
+                    stableId.c_str());
+                return false;
+            }
+
+            int sourceIndex =
+                static_cast<int>(
+                    settingsOut->separators.size());
+
+            settingsOut->separators.push_back({
+                .ordinal = sourceIndex + 1,
+                .sourceIndex = sourceIndex,
+                .targetIndex = targetIndex,
+                .width = width,
+                .stableId = stableId,
+                .identity = BuildSeparatorIdentity(
+                    settingsOut->identifierPrefix,
+                    stableId),
+            });
+        }
+
+        if (lineEnd == data.size()) {
+            break;
+        }
+        lineStart = lineEnd + 1;
+    }
+
+    if (!headerSeen) {
+        Wh_Log(L"[STATE] Empty/corrupt separator state file");
+        return false;
+    }
+
+    return true;
+}
+
+static bool SaveSeparatorStateFile(
+    const Settings& settings) {
+    std::string serialized = "v1\n";
+
+    for (const auto& separator : settings.separators) {
+        if (!IsValidStableId(separator.stableId) ||
+            separator.targetIndex < -1) {
+            Wh_Log(
+                L"[STATE] Refusing to persist invalid separator state");
+            return false;
+        }
+
+        for (wchar_t ch : separator.stableId) {
+            if (ch > 0x7F) {
+                Wh_Log(
+                    L"[STATE] Refusing to persist non-ASCII stable ID");
+                return false;
+            }
+            serialized.push_back(
+                static_cast<char>(ch));
+        }
+
+        serialized.push_back('\t');
+        serialized +=
+            std::to_string(separator.targetIndex);
+        serialized.push_back('\n');
+    }
+
+    std::wstring temporaryPath =
+        g_separatorStatePath + L".tmp";
+
+    HANDLE file =
+        CreateFileW(
+            temporaryPath.c_str(),
+            GENERIC_WRITE,
+            0,
+            nullptr,
+            CREATE_ALWAYS,
+            FILE_ATTRIBUTE_NORMAL,
+            nullptr);
+
+    if (file == INVALID_HANDLE_VALUE) {
+        Wh_Log(
+            L"[STATE] CreateFileW('%s') for write failed error=%u",
+            temporaryPath.c_str(),
+            GetLastError());
+        return false;
+    }
+
+    DWORD written = 0;
+    BOOL writeOk =
+        serialized.empty() ||
+        WriteFile(
+            file,
+            serialized.data(),
+            static_cast<DWORD>(serialized.size()),
+            &written,
+            nullptr);
+    DWORD writeError =
+        writeOk ? ERROR_SUCCESS : GetLastError();
+
+    BOOL flushOk =
+        writeOk && FlushFileBuffers(file);
+    DWORD flushError =
+        flushOk ? ERROR_SUCCESS : GetLastError();
+
+    CloseHandle(file);
+
+    if (!writeOk ||
+        written != serialized.size() ||
+        !flushOk) {
+        Wh_Log(
+            L"[STATE] State write failed error=%u flushError=%u written=%u expected=%zu",
+            writeError,
+            flushError,
+            written,
+            serialized.size());
+        DeleteFileW(temporaryPath.c_str());
+        return false;
+    }
+
+    if (!MoveFileExW(
+            temporaryPath.c_str(),
+            g_separatorStatePath.c_str(),
+            MOVEFILE_REPLACE_EXISTING |
+                MOVEFILE_WRITE_THROUGH)) {
+        Wh_Log(
+            L"[STATE] Atomic state replace failed error=%u",
+            GetLastError());
+        DeleteFileW(temporaryPath.c_str());
+        return false;
+    }
+
+    return true;
+}
+
+static double LoadSeparatorWidthSetting() {
+    constexpr int kDefaultWidth = 20;
+    constexpr int kMinWidth = 1;
+    constexpr int kMaxWidth = 1000;
+
+    int configuredWidth =
+        Wh_GetIntSetting(L"width");
+
+    if (configuredWidth == 0) {
+        configuredWidth = kDefaultWidth;
+    }
+
+    int width =
+        std::clamp(
+            configuredWidth,
+            kMinWidth,
+            kMaxWidth);
+
+    if (width != configuredWidth) {
+        Wh_Log(
+            L"[SETTINGS] Clamped separator width from %d to %d",
+            configuredWidth,
+            width);
+    }
+
+    return static_cast<double>(width);
+}
+
+static bool MigrateLegacySeparatorState(
+    double width,
+    Settings* settingsOut) {
+    if (!settingsOut) {
+        return false;
+    }
+
+    Settings migrated;
+    migrated.identifierPrefix =
+        kSeparatorIdentifierPrefix;
+    migrated.width = width;
+
+    auto legacySeeds =
+        LoadLegacyIdentityManifest();
+
+    if (!legacySeeds.empty()) {
+        // The old manifest was already ordered in the mod's logical separator
+        // order. Keep every stable ID and target position, but ignore its old
+        // per-row width: p42 has one global width setting.
+        for (const auto& seed : legacySeeds) {
+            if (!IsValidStableId(seed.stableId) ||
+                seed.targetIndex < -1) {
+                continue;
+            }
+
+            if (std::any_of(
+                    migrated.separators.begin(),
+                    migrated.separators.end(),
+                    [&seed](const SeparatorSetting& existing) {
+                        return existing.stableId == seed.stableId;
+                    })) {
+                continue;
+            }
+
+            int sourceIndex =
+                static_cast<int>(
+                    migrated.separators.size());
+
+            migrated.separators.push_back({
+                .ordinal = sourceIndex + 1,
+                .sourceIndex = sourceIndex,
+                .targetIndex = seed.targetIndex,
+                .width = width,
+                .stableId = seed.stableId,
+                .identity = BuildSeparatorIdentity(
+                    migrated.identifierPrefix,
+                    seed.stableId),
+            });
+        }
+    } else {
+        // Older builds without an identity manifest: import the old visible
+        // separator rows once. Numeric IDs preserve the pre-stable-ID shortcut
+        // names for the ordinary migration case.
+        constexpr int kMaxSeparators = 256;
+
+        for (int i = 0; i < kMaxSeparators; i++) {
+            int position =
+                Wh_GetIntSetting(
+                    L"separators[%d].index",
+                    i);
+
+            if (position == 0) {
+                break;
+            }
+
+            int targetIndex = -1;
+            if (position == -1) {
+                targetIndex = -1;
+            } else if (position >= 1) {
+                targetIndex = position - 1;
+            } else {
+                continue;
+            }
+
+            std::wstring stableId =
+                std::to_wstring(i + 1);
+
+            migrated.separators.push_back({
+                .ordinal = i + 1,
+                .sourceIndex = i,
+                .targetIndex = targetIndex,
+                .width = width,
+                .stableId = stableId,
+                .identity = BuildSeparatorIdentity(
+                    migrated.identifierPrefix,
+                    stableId),
+            });
+        }
+    }
+
+    if (!SaveSeparatorStateFile(migrated)) {
+        Wh_Log(
+            L"[STATE] Failed to create p42 separator state during migration");
+        return false;
+    }
+
+    Wh_Log(
+        L"[STATE] Migrated %zu separator(s) into '%s'",
+        migrated.separators.size(),
+        g_separatorStatePath.c_str());
+
+    *settingsOut = std::move(migrated);
+    return true;
+}
+
+static bool LoadSettingsFromStorage(
+    Settings* settingsOut,
+    SeparatorSetting* refreshPulseOut) {
+    if (!settingsOut || !refreshPulseOut) {
+        return false;
+    }
+
+    double width =
+        LoadSeparatorWidthSetting();
+
+    bool stateExists = false;
+    Settings settings;
+
+    if (!ReadSeparatorStateFile(
+            width,
+            &settings,
+            &stateExists)) {
+        return false;
+    }
+
+    if (!stateExists &&
+        !MigrateLegacySeparatorState(
+            width,
+            &settings)) {
+        return false;
+    }
+
+    *refreshPulseOut = {
+        .ordinal = kRefreshPulseOrdinal,
+        .sourceIndex = -1,
+        .targetIndex = 0,
+        .width = width,
+        .stableId = std::to_wstring(
+            kRefreshPulseOrdinal),
+        .identity = BuildSeparatorIdentity(
+            settings.identifierPrefix,
+            std::to_wstring(
+                kRefreshPulseOrdinal)),
+    };
+
+    Wh_Log(
+        L"[STATE] Loaded %zu separator(s) from mod storage; width=%d",
+        settings.separators.size(),
+        static_cast<int>(width));
+
+    *settingsOut = std::move(settings);
+    return true;
+}
+
+static const SeparatorSetting* FindSeparatorByIdentity(
+    const Settings& settings,
+    std::wstring_view identity) {
+    auto it = std::find_if(
+        settings.separators.begin(),
+        settings.separators.end(),
+        [identity](const SeparatorSetting& separator) {
+            return separator.identity ==
+                std::wstring(identity);
+        });
+
+    return it == settings.separators.end()
+               ? nullptr
+               : &*it;
+}
+
+static void AppendStoredSeparatorCandidate(
+    std::vector<SeparatorSetting>& stored,
+    const SeparatorSetting& candidate,
+    const Settings& desiredSettings,
+    const SeparatorSetting& refreshPulse) {
+    if (candidate.identity.empty() ||
+        IsIdentityInSettings(
+            desiredSettings,
+            candidate.identity) ||
+        candidate.identity == refreshPulse.identity) {
+        return;
+    }
+
+    if (std::any_of(
+            stored.begin(),
+            stored.end(),
+            [&candidate](const SeparatorSetting& existing) {
+                return existing.identity == candidate.identity;
+            })) {
+        return;
+    }
+
+    SeparatorSetting copy = candidate;
+    copy.ordinal = 0;
+    stored.push_back(std::move(copy));
+}
+
+static std::vector<SeparatorSetting>
+BuildStoredSeparatorSettings(
+    const Settings& desiredSettings,
+    const SeparatorSetting& refreshPulse,
+    const Settings& appliedSettings,
+    const Settings* previousDesiredSettings = nullptr,
+    const SeparatorSetting* previousRefreshPulse = nullptr,
+    const std::vector<SeparatorSetting>* retainedStoredSettings = nullptr) {
+    std::vector<SeparatorSetting> stored;
+
+    // Keep identities from earlier transitions until a successful backend
+    // pass proves that their backing shortcuts are gone. This also covers a
+    // previous backend snapshot that was superseded before it created/pinned
+    // all of its files: if one such item appears late, it is still styled and
+    // inert rather than briefly becoming an ordinary taskbar button.
+    if (retainedStoredSettings) {
+        for (const auto& separator : *retainedStoredSettings) {
+            AppendStoredSeparatorCandidate(
+                stored,
+                separator,
+                desiredSettings,
+                refreshPulse);
+        }
+    }
+
+    if (previousDesiredSettings) {
+        for (const auto& separator :
+             previousDesiredSettings->separators) {
+            AppendStoredSeparatorCandidate(
+                stored,
+                separator,
+                desiredSettings,
+                refreshPulse);
+        }
+    }
+
+    if (previousRefreshPulse) {
+        AppendStoredSeparatorCandidate(
+            stored,
+            *previousRefreshPulse,
+            desiredSettings,
+            refreshPulse);
+    }
+
+    const double defaultWidth =
+        !appliedSettings.separators.empty()
+            ? appliedSettings.separators.front().width
+            : (!desiredSettings.separators.empty()
+                   ? desiredSettings.separators.front().width
+                   : 20.0);
 
     for (const auto& path : EnumerateSeparatorShortcuts()) {
-        std::wstring identity = GetShortcutIdentity(path);
+        std::wstring identity =
+            GetShortcutIdentity(path);
+
         if (identity.empty() ||
-            IsCurrentSeparatorIdentity(identity) ||
-            identity == g_refreshPulseSetting.identity) {
+            IsIdentityInSettings(
+                desiredSettings,
+                identity) ||
+            identity == refreshPulse.identity) {
             continue;
         }
 
-        g_storedSeparatorSettings.push_back({
-            .ordinal = 0,
-            .targetIndex = 0,
-            .width = width,
-            .identity = std::move(identity),
-        });
+        if (std::any_of(
+                stored.begin(),
+                stored.end(),
+                [&identity](const SeparatorSetting& existing) {
+                    return existing.identity == identity;
+                })) {
+            continue;
+        }
+
+        const SeparatorSetting* known =
+            FindSeparatorByIdentity(
+                appliedSettings,
+                identity);
+
+        if (!known && previousDesiredSettings) {
+            known = FindSeparatorByIdentity(
+                *previousDesiredSettings,
+                identity);
+        }
+
+        if (known) {
+            AppendStoredSeparatorCandidate(
+                stored,
+                *known,
+                desiredSettings,
+                refreshPulse);
+        } else {
+            stored.push_back({
+                .ordinal = 0,
+                .sourceIndex = -1,
+                .targetIndex = 0,
+                .width = defaultWidth,
+                .stableId = {},
+                .identity = std::move(identity),
+            });
+        }
+    }
+
+    return stored;
+}
+
+static bool SettingsRequireBackendReconcile(
+    const Settings& oldSettings,
+    const Settings& newSettings);
+
+static bool SettingsSnapshotsEqual(
+    const Settings& a,
+    const Settings& b) {
+    if (a.identifierPrefix != b.identifierPrefix ||
+        a.separators.size() != b.separators.size()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < a.separators.size(); i++) {
+        const auto& left = a.separators[i];
+        const auto& right = b.separators[i];
+
+        if (left.ordinal != right.ordinal ||
+            left.sourceIndex != right.sourceIndex ||
+            left.targetIndex != right.targetIndex ||
+            left.width != right.width ||
+            left.stableId != right.stableId ||
+            left.identity != right.identity) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static void RefreshStoredSeparatorSettings() {
+    Settings desired;
+    Settings applied;
+    SeparatorSetting refreshPulse;
+
+    {
+        std::shared_lock lock(g_settingsMutex);
+        desired = g_settings;
+        applied = g_appliedSettings;
+        refreshPulse = g_refreshPulseSetting;
+    }
+
+    auto stored =
+        BuildStoredSeparatorSettings(
+            desired,
+            refreshPulse,
+            applied);
+
+    {
+        std::unique_lock lock(g_settingsMutex);
+
+        // The desired settings might have changed while the filesystem was
+        // enumerated. In that case the settings-change path will rebuild this
+        // snapshot again.
+        if (SettingsSnapshotsEqual(
+                desired,
+                g_settings)) {
+            g_storedSeparatorSettings =
+                std::move(stored);
+        }
     }
 }
 
@@ -536,74 +1443,71 @@ static bool WriteBinaryFile(
     return true;
 }
 
-static void LoadSettings() {
-    g_settings = {};
+static bool LoadSettings() {
+    Settings settings;
+    SeparatorSetting refreshPulse;
 
-    g_settings.identifierPrefix = SanitizeIdentifierPrefix(
-        WindhawkUtils::StringSetting::make(
-            L"identifierPrefix").get());
-
-    // Wh_GetIntSetting returns 0 for a missing setting.
-    // Positions are therefore deliberately user-facing 1-based values.
-    constexpr int kMaxSeparators = 256;
-    constexpr int kMinWidth = 1;
-    constexpr int kMaxWidth = 1000;
-
-    for (int i = 0; i < kMaxSeparators; i++) {
-        int position =
-            Wh_GetIntSetting(L"separators[%d].index", i);
-
-        if (position == 0) {
-            break;
-        }
-
-        if (position < 1) {
-            Wh_Log(
-                L"[SETTINGS] Ignoring separator %d: invalid position=%d",
-                i + 1,
-                position);
-            continue;
-        }
-
-        int configuredWidth =
-            Wh_GetIntSetting(L"separators[%d].width", i);
-        int width = std::clamp(
-            configuredWidth,
-            kMinWidth,
-            kMaxWidth);
-
-        if (width != configuredWidth) {
-            Wh_Log(
-                L"[SETTINGS] Clamped separator %d width from %d to %d",
-                i + 1,
-                configuredWidth,
-                width);
-        }
-        g_settings.separators.push_back({
-            .ordinal = i + 1,
-            .targetIndex = position - 1,
-            .width = static_cast<double>(width),
-            .identity = BuildSeparatorIdentity(
-                g_settings.identifierPrefix,
-                i + 1),
-        });
+    if (!LoadSettingsFromStorage(
+            &settings,
+            &refreshPulse)) {
+        Wh_Log(L"[STATE] Failed to load separator state");
+        return false;
     }
 
-    g_refreshPulseSetting = {
-        .ordinal = kRefreshPulseOrdinal,
-        .targetIndex = 0,
-        .width = g_settings.separators.empty()
-                     ? 20.0
-                     : g_settings.separators.front().width,
-        .identity = BuildSeparatorIdentity(
-            g_settings.identifierPrefix,
-            kRefreshPulseOrdinal),
-    };
+    std::unique_lock lock(g_settingsMutex);
+    g_settings = std::move(settings);
+    g_appliedSettings = {};
+    g_refreshPulseSetting =
+        std::move(refreshPulse);
+    g_storedSeparatorSettings.clear();
+    g_separatorStateDirty = false;
+    return true;
+}
 
-    Wh_Log(
-        L"[SETTINGS] prefix='%s' separators=%zu",
-        g_settings.identifierPrefix.c_str(),
-        g_settings.separators.size());
+static const SeparatorSetting* FindSeparatorByStableId(
+    const Settings& settings,
+    std::wstring_view stableId) {
+    auto it = std::find_if(
+        settings.separators.begin(),
+        settings.separators.end(),
+        [stableId](const SeparatorSetting& separator) {
+            return separator.stableId ==
+                std::wstring(stableId);
+        });
+
+    return it == settings.separators.end()
+               ? nullptr
+               : &*it;
+}
+
+static bool SettingsRequireBackendReconcile(
+    const Settings& oldSettings,
+    const Settings& newSettings) {
+    if (oldSettings.identifierPrefix !=
+        newSettings.identifierPrefix) {
+        return true;
+    }
+
+    if (oldSettings.separators.size() !=
+        newSettings.separators.size()) {
+        return true;
+    }
+
+    for (const auto& oldSeparator :
+         oldSettings.separators) {
+        const SeparatorSetting* newSeparator =
+            FindSeparatorByStableId(
+                newSettings,
+                oldSeparator.stableId);
+
+        if (!newSeparator ||
+            oldSeparator.identity != newSeparator->identity ||
+            oldSeparator.targetIndex != newSeparator->targetIndex) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 static bool InitializeStoragePath() {
@@ -636,8 +1540,10 @@ static bool InitializeStoragePath() {
         JoinPath(
             g_storagePath,
             L"separator.ico");
-
-    LoadStoredSeparatorSettings();
+    g_separatorStatePath =
+        JoinPath(
+            g_storagePath,
+            kSeparatorStateFileName);
 
     return true;
 }
@@ -651,30 +1557,26 @@ static bool InitializeStoragePath() {
 // entry points are modified.
 // -----------------------------------------------------------------------------
 
-// Native TaskListButton IsDraggable XAML binding helpers, resolved from
-// Taskbar.View.dll. The isolated runtime probe verified that setting this
-// property to false prevents drag initiation without touching pointer input,
-// drag gesture handlers, or the taskbar model's reorder path.
-using TaskListButton_GetIsDraggable_t =
-    winrt::Windows::Foundation::IInspectable(*)(
-        winrt::Windows::Foundation::IInspectable const& target);
-
-static TaskListButton_GetIsDraggable_t
-    g_taskListButtonGetIsDraggable;
-
-using TaskListButton_SetIsDraggable_t =
-    void(*)(
-        winrt::Windows::Foundation::IInspectable const& target,
-        winrt::Windows::Foundation::IInspectable const& value);
-
-static TaskListButton_SetIsDraggable_t
-    g_taskListButtonSetIsDraggable;
-
-static thread_local bool g_settingSeparatorIsDraggable;
-
 using TaskListButton_UpdateVisualStates_t = void(WINAPI*)(void* pThis);
 static TaskListButton_UpdateVisualStates_t
     g_taskListButtonUpdateVisualStatesOriginal;
+
+static void PersistPendingSeparatorState();
+
+using TaskListButton_OnDragCompletedGesture_t =
+    void(WINAPI*)(void* pThis);
+static TaskListButton_OnDragCompletedGesture_t
+    g_taskListButtonOnDragCompletedGestureOriginal;
+
+static void WINAPI TaskListButton_OnDragCompletedGesture_Hook(
+    void* pThis) {
+    g_taskListButtonOnDragCompletedGestureOriginal(
+        pThis);
+
+    if (!g_unloading) {
+        PersistPendingSeparatorState();
+    }
+}
 
 static FrameworkElement GetTaskListButtonElement(void* pThis) {
     FrameworkElement element = nullptr;
@@ -769,10 +1671,11 @@ static bool ContainsIdentityToken(
     return false;
 }
 
-static const SeparatorSetting* FindSeparatorByAutomationName(
-    std::wstring_view name) {
+static bool FindSeparatorByAutomationName(
+    std::wstring_view name,
+    SeparatorSetting* separatorOut = nullptr) {
     if (name.empty()) {
-        return nullptr;
+        return false;
     }
 
     // Almost every TaskListButton is unrelated to this mod. Reject it with a
@@ -781,32 +1684,45 @@ static const SeparatorSetting* FindSeparatorByAutomationName(
     static const std::wstring identityMarker =
         std::wstring(L".") + kSeparatorIdentitySuffix + L".";
     if (name.find(identityMarker) == std::wstring_view::npos) {
-        return nullptr;
+        return false;
     }
+
+    std::shared_lock lock(g_settingsMutex);
+
+    const auto copyMatch =
+        [separatorOut](const SeparatorSetting& separator) {
+            if (separatorOut) {
+                *separatorOut = separator;
+            }
+            return true;
+        };
 
     for (const auto& separator : g_settings.separators) {
         if (ContainsIdentityToken(name, separator.identity)) {
-            return &separator;
+            return copyMatch(separator);
         }
     }
 
     for (const auto& separator : g_storedSeparatorSettings) {
         if (ContainsIdentityToken(name, separator.identity)) {
-            return &separator;
+            return copyMatch(separator);
         }
     }
 
-    return ContainsIdentityToken(
-               name,
-               g_refreshPulseSetting.identity)
-               ? &g_refreshPulseSetting
-               : nullptr;
+    if (ContainsIdentityToken(
+            name,
+            g_refreshPulseSetting.identity)) {
+        return copyMatch(g_refreshPulseSetting);
+    }
+
+    return false;
 }
 
-static const SeparatorSetting* GetSeparatorForElement(
-    const FrameworkElement& element) {
+static bool GetSeparatorForElement(
+    const FrameworkElement& element,
+    SeparatorSetting* separatorOut = nullptr) {
     if (!element) {
-        return nullptr;
+        return false;
     }
 
     winrt::hstring automationName;
@@ -816,7 +1732,7 @@ static const SeparatorSetting* GetSeparatorForElement(
             winrt::Windows::UI::Xaml::Automation::
                 AutomationProperties::GetName(element);
     } catch (...) {
-        return nullptr;
+        return false;
     }
 
     std::wstring_view name{
@@ -824,23 +1740,29 @@ static const SeparatorSetting* GetSeparatorForElement(
         automationName.size()
     };
 
-    return FindSeparatorByAutomationName(name);
+    return FindSeparatorByAutomationName(
+        name,
+        separatorOut);
 }
 
-static const SeparatorSetting* GetSeparatorForTaskListButton(
+static bool GetSeparatorForTaskListButton(
     void* pThis,
-    FrameworkElement* elementOut = nullptr) {
+    FrameworkElement* elementOut = nullptr,
+    SeparatorSetting* separatorOut = nullptr) {
     FrameworkElement element =
         GetTaskListButtonElement(pThis);
 
-    const SeparatorSetting* separator =
-        GetSeparatorForElement(element);
+    if (!GetSeparatorForElement(
+            element,
+            separatorOut)) {
+        return false;
+    }
 
-    if (separator && elementOut) {
+    if (elementOut) {
         *elementOut = element;
     }
 
-    return separator;
+    return true;
 }
 
 struct SeparatorVisualState {
@@ -873,8 +1795,6 @@ struct SeparatorVisualState {
     winrt::Windows::Foundation::IInspectable
         originalTaskListButtonToolTipLocalValue{nullptr};
 
-    bool isDraggableCaptured = false;
-    bool originalIsDraggable = false;
 };
 
 static thread_local std::list<SeparatorVisualState>
@@ -1041,50 +1961,7 @@ static void SuppressSeparatorHoverChrome(
     }
 }
 
-static void DisableSeparatorDragging(
-    SeparatorVisualState& state,
-    const FrameworkElement& taskListButton) {
-    if (!taskListButton ||
-        g_settingSeparatorIsDraggable ||
-        !g_taskListButtonGetIsDraggable ||
-        !g_taskListButtonSetIsDraggable) {
-        return;
-    }
 
-    g_settingSeparatorIsDraggable = true;
-
-    try {
-        auto target =
-            taskListButton.as<
-                winrt::Windows::Foundation::IInspectable>();
-
-        auto beforeBox =
-            g_taskListButtonGetIsDraggable(target);
-
-        bool isDraggable =
-            winrt::unbox_value<bool>(beforeBox);
-
-        if (!state.isDraggableCaptured) {
-            state.originalIsDraggable = isDraggable;
-            state.isDraggableCaptured = true;
-        }
-
-        if (isDraggable) {
-            auto falseBox =
-                winrt::box_value(false);
-
-            g_taskListButtonSetIsDraggable(
-                target,
-                falseBox);
-        }
-    } catch (...) {
-        // Input hardening only. If a future Taskbar.View build changes the
-        // binding helper ABI, leave stock drag behavior rather than affecting
-        // unrelated taskbar buttons.
-    }
-
-    g_settingSeparatorIsDraggable = false;
-}
 
 static void RestoreDependencyPropertyLocalValue(
     const DependencyObject& object,
@@ -1129,22 +2006,6 @@ static void RestoreSeparatorVisualState(
                 state.originalTaskListButtonToolTipLocalValue);
         }
     } catch (...) {
-    }
-
-    try {
-        if (state.isDraggableCaptured &&
-            g_taskListButtonSetIsDraggable &&
-            !g_settingSeparatorIsDraggable) {
-            g_settingSeparatorIsDraggable = true;
-            auto target = element.as<
-                winrt::Windows::Foundation::IInspectable>();
-            g_taskListButtonSetIsDraggable(
-                target,
-                winrt::box_value(state.originalIsDraggable));
-            g_settingSeparatorIsDraggable = false;
-        }
-    } catch (...) {
-        g_settingSeparatorIsDraggable = false;
     }
 
     if (auto iconPanel = state.iconPanel.get()) {
@@ -1327,10 +2188,243 @@ static void RestoreTrackedSeparatorVisualStates() {
         reinterpret_cast<LPARAM>(&context));
 }
 
-// Modern WinUI taskbar context-menu paths.
+static void WINAPI RefreshSeparatorVisualStatesOnCurrentThread(void*) {
+    g_updatingSeparatorVisualStates = true;
+    SeparatorVisualStateUpdateGuard updateGuard;
+    PruneExpiredSeparatorVisualStates();
+
+    for (auto it = g_separatorVisualStates.begin();
+         it != g_separatorVisualStates.end();) {
+        auto current = it++;
+
+        SeparatorVisualState& state = *current;
+        auto element = state.element.get();
+
+        SeparatorSetting separator;
+        if (!element ||
+            g_unloading ||
+            !GetSeparatorForElement(
+                element,
+                &separator)) {
+            RestoreSeparatorVisualState(current);
+            continue;
+        }
+
+        ApplySeparatorMaxWidthOverride(
+            state,
+            element,
+            separator);
+
+        FrameworkElement iconPanel =
+            FindChildByName(element, L"IconPanel");
+        CenterSeparatorIcon(state, iconPanel);
+        SuppressSeparatorHoverChrome(
+            state,
+            element,
+            iconPanel);
+        }
+}
+
+static void RefreshTrackedSeparatorVisualStates() {
+    struct EnumContext {
+        std::vector<DWORD> processedThreadIds;
+    } context;
+
+    EnumWindows(
+        [](HWND window, LPARAM lParam) -> BOOL {
+            DWORD processId = 0;
+            DWORD threadId =
+                GetWindowThreadProcessId(window, &processId);
+            if (!threadId || processId != GetCurrentProcessId()) {
+                return TRUE;
+            }
+
+            wchar_t className[64] = {};
+            if (!GetClassNameW(
+                    window,
+                    className,
+                    ARRAYSIZE(className)) ||
+                (_wcsicmp(className, L"Shell_TrayWnd") != 0 &&
+                 _wcsicmp(className, L"Shell_SecondaryTrayWnd") != 0)) {
+                return TRUE;
+            }
+
+            auto* context =
+                reinterpret_cast<EnumContext*>(lParam);
+            if (std::find(
+                    context->processedThreadIds.begin(),
+                    context->processedThreadIds.end(),
+                    threadId) !=
+                context->processedThreadIds.end()) {
+                return TRUE;
+            }
+
+            context->processedThreadIds.push_back(threadId);
+
+            if (!RunFromWindowThread(
+                    window,
+                    RefreshSeparatorVisualStatesOnCurrentThread,
+                    nullptr)) {
+                Wh_Log(
+                    L"[SETTINGS] Failed to refresh taskbar visuals on thread %u",
+                    threadId);
+            }
+
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&context));
+}
+
+// Native empty-taskbar context menu frontend.
 //
-// These hooks cover the context-request routes seen across Taskbar.View builds.
-// They are filtered independently and don't touch generic pointer input.
+// This follows the same Taskbar.View menu construction path used by
+// Taskbar Restart Explorer: mark
+// the ShowTaskbarSettingsContextMenu build scope, intercept the first
+// IVector<MenuFlyoutItemBase>::Append, and add one native MenuFlyoutItem.
+static void RequestBackendReconcile();
+static void AddSeparatorFromTaskbarMenu();
+
+static constexpr wchar_t kAddSeparatorMenuText[] = L"Add separator";
+static constexpr wchar_t kAddSeparatorMenuName[] = L"WindhawkAddSeparatorItem";
+static constexpr wchar_t kAddSeparatorMenuDividerName[] =
+    L"WindhawkAddSeparatorDivider";
+
+static thread_local int g_taskbarSettingsMenuDepth = 0;
+static thread_local bool g_taskbarSettingsMenuInjected = false;
+
+static bool IsNamedMenuItem(
+    winrt::Windows::UI::Xaml::Controls::MenuFlyoutItemBase const& item,
+    const wchar_t* name) {
+    try {
+        if (auto element = item.try_as<FrameworkElement>()) {
+            return std::wstring_view(element.Name().c_str()) == name;
+        }
+    } catch (...) {
+    }
+    return false;
+}
+
+static bool IsMenuSeparator(
+    winrt::Windows::UI::Xaml::Controls::MenuFlyoutItemBase const& item) {
+    try {
+        return !!item.try_as<
+            winrt::Windows::UI::Xaml::Controls::MenuFlyoutSeparator>();
+    } catch (...) {
+        return false;
+    }
+}
+
+static void OnAddSeparatorMenuClick(
+    winrt::Windows::Foundation::IInspectable const&,
+    RoutedEventArgs const&) {
+    AddSeparatorFromTaskbarMenu();
+}
+
+using MenuFlyoutItemBaseVector_Append_t =
+    void(__cdecl*)(
+        void* pThis,
+        winrt::Windows::UI::Xaml::Controls::MenuFlyoutItemBase const& item);
+static MenuFlyoutItemBaseVector_Append_t
+    g_menuFlyoutItemBaseVectorAppendOriginal;
+
+static void AppendAddSeparatorMenuItems(void* vectorThis) {
+    using namespace winrt::Windows::UI::Xaml::Controls;
+
+    MenuFlyoutItem item;
+    item.Name(kAddSeparatorMenuName);
+    item.Tag(winrt::box_value(winrt::hstring{kAddSeparatorMenuName}));
+    item.Text(kAddSeparatorMenuText);
+
+    FontIcon icon;
+    icon.FontFamily(
+        winrt::Windows::UI::Xaml::Media::FontFamily(
+            L"Segoe Fluent Icons"));
+    icon.Glyph(L"\xE710");
+    icon.FontSize(16);
+    item.Icon(icon);
+    item.Click(RoutedEventHandler{&OnAddSeparatorMenuClick});
+
+    MenuFlyoutSeparator divider;
+    divider.Name(kAddSeparatorMenuDividerName);
+    divider.Tag(
+        winrt::box_value(
+            winrt::hstring{kAddSeparatorMenuDividerName}));
+
+    g_menuFlyoutItemBaseVectorAppendOriginal(vectorThis, item);
+    g_menuFlyoutItemBaseVectorAppendOriginal(vectorThis, divider);
+
+    g_taskbarSettingsMenuInjected = true;
+    Wh_Log(L"[NATIVE-ADD] Injected Add separator into taskbar context menu");
+}
+
+static void __cdecl MenuFlyoutItemBaseVector_Append_Hook(
+    void* pThis,
+    winrt::Windows::UI::Xaml::Controls::MenuFlyoutItemBase const& item) {
+    if (!g_unloading &&
+        g_taskbarSettingsMenuDepth > 0 &&
+        !g_taskbarSettingsMenuInjected) {
+        try {
+            if (!IsMenuSeparator(item) &&
+                !IsNamedMenuItem(item, kAddSeparatorMenuName) &&
+                !IsNamedMenuItem(item, kAddSeparatorMenuDividerName)) {
+                AppendAddSeparatorMenuItems(pThis);
+            }
+        } catch (...) {
+            Wh_Log(L"[NATIVE-ADD] Menu append inspection failed; skipping injection");
+        }
+    }
+
+    g_menuFlyoutItemBaseVectorAppendOriginal(pThis, item);
+}
+
+struct ScopedTaskbarSettingsMenuBuild {
+    bool outer = false;
+
+    ScopedTaskbarSettingsMenuBuild() {
+        outer = g_taskbarSettingsMenuDepth++ == 0;
+        if (outer) {
+            g_taskbarSettingsMenuInjected = false;
+        }
+    }
+
+    ~ScopedTaskbarSettingsMenuBuild() {
+        if (outer && !g_taskbarSettingsMenuInjected && !g_unloading) {
+            Wh_Log(L"[NATIVE-ADD] No taskbar menu append observed; injection skipped");
+        }
+        g_taskbarSettingsMenuDepth--;
+    }
+};
+
+using ContextMenus_ShowTaskbarSettingsContextMenu_t =
+    void(__cdecl*)(
+        FrameworkElement const& target,
+        void* taskbarSettings,
+        winrt::Windows::UI::Xaml::Input::ContextRequestedEventArgs const& args,
+        unsigned long long options);
+static ContextMenus_ShowTaskbarSettingsContextMenu_t
+    g_contextMenusShowTaskbarSettingsContextMenuOriginal;
+
+static void __cdecl ContextMenus_ShowTaskbarSettingsContextMenu_Hook(
+    FrameworkElement const& target,
+    void* taskbarSettings,
+    winrt::Windows::UI::Xaml::Input::ContextRequestedEventArgs const& args,
+    unsigned long long options) {
+    ScopedTaskbarSettingsMenuBuild scopedBuild;
+    g_contextMenusShowTaskbarSettingsContextMenuOriginal(
+        target,
+        taskbarSettings,
+        args,
+        options);
+}
+
+// Modern per-item taskbar context-menu paths.
+//
+// Different Windows 11 builds route the request through slightly different
+// Taskbar.View entry points, so retain all three proven hooks. Every route feeds
+// the same tiny handler: identify our separator, suppress the stock JumpView,
+// and show a one-item explorer-hosted XAML MenuFlyout. The first route that
+// reaches the handler opens the flyout; the remaining callbacks for the same
+// request only suppress their native path.
 using TaskListButton_OnContextRequested_t =
     void(WINAPI*)(
         void* pThis,
@@ -1340,21 +2434,6 @@ using TaskListButton_OnContextRequested_t =
 static TaskListButton_OnContextRequested_t
     g_taskListButtonOnContextRequestedOriginal;
 
-static void WINAPI TaskListButton_OnContextRequested_Hook(
-    void* pThis,
-    winrt::Windows::UI::Xaml::UIElement const& sender,
-    winrt::Windows::UI::Xaml::Input::ContextRequestedEventArgs const& args) {
-    if (!g_unloading &&
-        GetSeparatorForTaskListButton(pThis)) {
-        return;
-    }
-
-    g_taskListButtonOnContextRequestedOriginal(
-        pThis,
-        sender,
-        args);
-}
-
 using TaskListButtonHandlers_HandleContextRequested_t =
     void(WINAPI*)(
         winrt::Windows::UI::Xaml::UIElement const& sender,
@@ -1362,24 +2441,6 @@ using TaskListButtonHandlers_HandleContextRequested_t =
 
 static TaskListButtonHandlers_HandleContextRequested_t
     g_taskListButtonHandlersHandleContextRequestedOriginal;
-
-static void WINAPI TaskListButtonHandlers_HandleContextRequested_Hook(
-    winrt::Windows::UI::Xaml::UIElement const& sender,
-    winrt::Windows::UI::Xaml::Input::ContextRequestedEventArgs const& args) {
-    if (!g_unloading) {
-        auto element =
-            sender.try_as<FrameworkElement>();
-
-        if (element &&
-            GetSeparatorForElement(element)) {
-            return;
-        }
-    }
-
-    g_taskListButtonHandlersHandleContextRequestedOriginal(
-        sender,
-        args);
-}
 
 using TaskbarResources_OnTaskListButtonContextRequested_t =
     void(WINAPI*)(
@@ -1390,20 +2451,178 @@ using TaskbarResources_OnTaskListButtonContextRequested_t =
 static TaskbarResources_OnTaskListButtonContextRequested_t
     g_taskbarResourcesOnTaskListButtonContextRequestedOriginal;
 
+static std::atomic<bool> g_separatorContextMenuOpen = false;
+
+static void RemoveSeparatorFromContextMenu(
+    std::wstring identity);
+
+static void OnSeparatorContextMenuClosed(
+    winrt::Windows::Foundation::IInspectable const&,
+    winrt::Windows::Foundation::IInspectable const&) {
+    g_separatorContextMenuOpen = false;
+}
+
+static void OnSeparatorUnpinMenuClick(
+    winrt::Windows::Foundation::IInspectable const& sender,
+    RoutedEventArgs const&) {
+    // The target TaskListButton may disappear before FlyoutBase::Closed is
+    // delivered. Release the de-duplication gate at command dispatch too.
+    g_separatorContextMenuOpen = false;
+
+    if (g_unloading ||
+        g_internalCleanupInProgress.load()) {
+        return;
+    }
+
+    try {
+        auto item =
+            sender.try_as<
+                winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem>();
+        if (!item) {
+            return;
+        }
+
+        auto tag = item.Tag();
+        if (!tag) {
+            return;
+        }
+
+        winrt::hstring identity =
+            winrt::unbox_value<winrt::hstring>(tag);
+        if (identity.empty()) {
+            return;
+        }
+
+        RemoveSeparatorFromContextMenu(
+            std::wstring(identity.c_str(), identity.size()));
+    } catch (...) {
+        Wh_Log(L"[CTX] Separator Unpin callback failed");
+    }
+}
+
+static void ShowSeparatorContextMenu(
+    const FrameworkElement& target,
+    const SeparatorSetting& separator) {
+    if (!target ||
+        separator.identity.empty() ||
+        g_unloading) {
+        return;
+    }
+
+    bool expected = false;
+    if (!g_separatorContextMenuOpen.compare_exchange_strong(
+            expected,
+            true)) {
+        return;
+    }
+
+    try {
+        using namespace winrt::Windows::UI::Xaml::Controls;
+        using namespace winrt::Windows::UI::Xaml::Controls::Primitives;
+
+        MenuFlyout menu;
+        menu.Placement(FlyoutPlacementMode::Top);
+
+        MenuFlyoutItem unpin;
+        unpin.Text(L"Unpin from taskbar");
+        unpin.Tag(
+            winrt::box_value(
+                winrt::hstring{separator.identity}));
+
+        FontIcon icon;
+        icon.FontFamily(
+            winrt::Windows::UI::Xaml::Media::FontFamily(
+                L"Segoe Fluent Icons"));
+        // Segoe Fluent Icons: Remove (minus sign).
+        icon.Glyph(L"\xE738");
+        icon.FontSize(16);
+        unpin.Icon(icon);
+        unpin.Click(
+            RoutedEventHandler{
+                &OnSeparatorUnpinMenuClick});
+
+        menu.Items().Append(unpin);
+        menu.Closed(
+            winrt::Windows::Foundation::
+                EventHandler<winrt::Windows::Foundation::IInspectable>{
+                    &OnSeparatorContextMenuClosed});
+
+        menu.ShowAt(target);
+        Wh_Log(
+            L"[CTX] Opened separator context menu identity='%s'",
+            separator.identity.c_str());
+    } catch (...) {
+        g_separatorContextMenuOpen = false;
+        Wh_Log(L"[CTX] Failed to show separator context menu");
+    }
+}
+
+static bool TryHandleSeparatorContextRequest(
+    const FrameworkElement& element,
+    const SeparatorSetting* knownSeparator = nullptr) {
+    if (g_unloading || !element) {
+        return false;
+    }
+
+    SeparatorSetting separator;
+    if (knownSeparator) {
+        separator = *knownSeparator;
+    } else if (!GetSeparatorForElement(
+                   element,
+                   &separator)) {
+        return false;
+    }
+
+    ShowSeparatorContextMenu(
+        element,
+        separator);
+    return true;
+}
+
+static void WINAPI TaskListButton_OnContextRequested_Hook(
+    void* pThis,
+    winrt::Windows::UI::Xaml::UIElement const& sender,
+    winrt::Windows::UI::Xaml::Input::ContextRequestedEventArgs const& args) {
+    FrameworkElement element = nullptr;
+    SeparatorSetting separator;
+
+    if (!g_unloading &&
+        GetSeparatorForTaskListButton(
+            pThis,
+            &element,
+            &separator)) {
+        TryHandleSeparatorContextRequest(
+            element,
+            &separator);
+        return;
+    }
+
+    g_taskListButtonOnContextRequestedOriginal(
+        pThis,
+        sender,
+        args);
+}
+
+static void WINAPI TaskListButtonHandlers_HandleContextRequested_Hook(
+    winrt::Windows::UI::Xaml::UIElement const& sender,
+    winrt::Windows::UI::Xaml::Input::ContextRequestedEventArgs const& args) {
+    auto element = sender.try_as<FrameworkElement>();
+    if (TryHandleSeparatorContextRequest(element)) {
+        return;
+    }
+
+    g_taskListButtonHandlersHandleContextRequestedOriginal(
+        sender,
+        args);
+}
+
 static void WINAPI TaskbarResources_OnTaskListButtonContextRequested_Hook(
     void* pThis,
     winrt::Windows::UI::Xaml::UIElement const& sender,
     winrt::Windows::UI::Xaml::Input::ContextRequestedEventArgs const& args) {
-    if (!g_unloading) {
-        auto element =
-            sender.try_as<FrameworkElement>();
-
-        if (element &&
-            GetSeparatorForElement(element)) {
-            // Don't set args.Handled here. That path is crash-prone on some
-            // Taskbar.View builds; skipping the handler is sufficient.
-            return;
-        }
+    auto element = sender.try_as<FrameworkElement>();
+    if (TryHandleSeparatorContextRequest(element)) {
+        return;
     }
 
     g_taskbarResourcesOnTaskListButtonContextRequestedOriginal(
@@ -1429,15 +2648,18 @@ static void WINAPI TaskListButton_UpdateVisualStates_Hook(
 
     FrameworkElement element =
         GetTaskListButtonElement(pThis);
-    const SeparatorSetting* separator =
-        GetSeparatorForElement(element);
+    SeparatorSetting separator;
+    bool isSeparator =
+        GetSeparatorForElement(
+            element,
+            &separator);
 
     PruneExpiredSeparatorVisualStates();
     auto stateIt = FindSeparatorVisualState(pThis);
 
     // ItemsRepeater recycles TaskListButton containers. Undo every property
     // owned by this mod as soon as a container stops representing a separator.
-    if (!separator || !element || g_unloading) {
+    if (!isSeparator || !element || g_unloading) {
         if (stateIt != g_separatorVisualStates.end()) {
             RestoreSeparatorVisualState(stateIt);
         }
@@ -1457,7 +2679,7 @@ static void WINAPI TaskListButton_UpdateVisualStates_Hook(
     ApplySeparatorMaxWidthOverride(
         state,
         element,
-        *separator);
+        separator);
 
     // If unload began while width was being applied, undo this button instead
     // of applying the remaining separator-only properties.
@@ -1470,7 +2692,6 @@ static void WINAPI TaskListButton_UpdateVisualStates_Hook(
         FindChildByName(element, L"IconPanel");
     CenterSeparatorIcon(state, iconPanel);
     SuppressSeparatorHoverChrome(state, element, iconPanel);
-    DisableSeparatorDragging(state, element);
 }
 
 static HMODULE GetTaskbarViewModuleHandle() {
@@ -1488,6 +2709,22 @@ static bool HookTaskbarViewDllSymbols(HMODULE module) {
     WindhawkUtils::SYMBOL_HOOK taskbarViewHooks[] = {
         {
             {
+                LR"(void __cdecl winrt::Taskbar::implementation::ContextMenus::ShowTaskbarSettingsContextMenu(struct winrt::Windows::UI::Xaml::FrameworkElement const &,struct winrt::WindowsUdk::UI::Shell::TaskbarSettings const &,struct winrt::Windows::UI::Xaml::Input::ContextRequestedEventArgs const &,unsigned __int64))"
+            },
+            &g_contextMenusShowTaskbarSettingsContextMenuOriginal,
+            ContextMenus_ShowTaskbarSettingsContextMenu_Hook,
+            true,
+        },
+        {
+            {
+                LR"(public: __cdecl winrt::impl::consume_Windows_Foundation_Collections_IVector<struct winrt::Windows::Foundation::Collections::IVector<struct winrt::Windows::UI::Xaml::Controls::MenuFlyoutItemBase>,struct winrt::Windows::UI::Xaml::Controls::MenuFlyoutItemBase>::Append(struct winrt::Windows::UI::Xaml::Controls::MenuFlyoutItemBase const &)const )"
+            },
+            &g_menuFlyoutItemBaseVectorAppendOriginal,
+            MenuFlyoutItemBaseVector_Append_Hook,
+            true,
+        },
+        {
+            {
                 LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateVisualStates(void))"
             },
             &g_taskListButtonUpdateVisualStatesOriginal,
@@ -1495,17 +2732,11 @@ static bool HookTaskbarViewDllSymbols(HMODULE module) {
         },
         {
             {
-                LR"(struct winrt::Windows::Foundation::IInspectable __cdecl winrt::Taskbar::implementation::GetValueTypeMember_IsDraggable<struct winrt::Taskbar::TaskListButton,bool>(struct winrt::Windows::Foundation::IInspectable const &))"
+                LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::OnDragCompletedGesture(void))"
             },
-            &g_taskListButtonGetIsDraggable,
-            nullptr,
-        },
-        {
-            {
-                LR"(void __cdecl winrt::Taskbar::implementation::SetValueTypeMember_IsDraggable<struct winrt::Taskbar::TaskListButton,bool>(struct winrt::Windows::Foundation::IInspectable const &,struct winrt::Windows::Foundation::IInspectable const &))"
-            },
-            &g_taskListButtonSetIsDraggable,
-            nullptr,
+            &g_taskListButtonOnDragCompletedGestureOriginal,
+            TaskListButton_OnDragCompletedGesture_Hook,
+            true,
         },
         {
             {
@@ -1734,21 +2965,22 @@ static bool InitializeTaskbarStylingHooks() {
 // -----------------------------------------------------------------------------
 // Separator interaction suppression.
 //
-// Taskbar.View owns modern context requests and the native IsDraggable property;
+// Taskbar.View owns modern context requests and the drag-completion boundary;
 // those are handled above. taskbar.dll is used only for model-level semantic
 // actions that already expose the exact ITaskGroup:
 //
 // - CTaskListWnd::HandleClick:
 //     swallow activation for our separator groups.
 // - CTaskListWnd::OnContextMenu:
-//     swallow the legacy context-menu route.
+//     suppress the legacy separator context-menu route.
 // - CTaskBtnGroup::ShouldShowToolTip:
 //     legacy tooltip gate fallback.
 // - CTaskGroup::GetToolTipText:
 //     directly report no tooltip text for separator groups.
 //
-// No pointer press/move hooks, drag gesture hooks, TryMoveGroup hooks, or
-// jumplist-hover hooks are needed.
+// CTaskListWnd::TryMoveGroup is observed (never blocked) so successful native
+// pinned-item drags can be mirrored into the mod-owned state file. Separator
+// Unpin is a direct command from our Explorer-hosted MenuFlyout to desired state.
 // -----------------------------------------------------------------------------
 
 static void* g_taskGroupGetAppIdAddress;
@@ -1813,20 +3045,25 @@ static bool IsSeparatorTaskGroup(void* taskGroup) {
     }
 
     std::wstring_view appIdView(appId);
+    std::shared_lock lock(g_settingsMutex);
+
     for (const auto& separator : g_settings.separators) {
-        if (appIdView == std::wstring_view(separator.identity)) {
+        if (appIdView ==
+            std::wstring_view(separator.identity)) {
             return true;
         }
     }
 
     for (const auto& separator : g_storedSeparatorSettings) {
-        if (appIdView == std::wstring_view(separator.identity)) {
+        if (appIdView ==
+            std::wstring_view(separator.identity)) {
             return true;
         }
     }
 
     return appIdView ==
-        std::wstring_view(g_refreshPulseSetting.identity);
+        std::wstring_view(
+            g_refreshPulseSetting.identity);
 }
 
 static HRESULT WINAPI TaskListWnd_HandleClick_Hook(
@@ -1855,6 +3092,7 @@ static void WINAPI TaskListWnd_OnContextMenu_Hook(
     void* taskItem) {
     if (!g_unloading &&
         IsSeparatorTaskGroup(taskGroup)) {
+        Wh_Log(L"[CTX] Suppressed legacy separator context menu");
         return;
     }
 
@@ -1915,6 +3153,408 @@ static HRESULT WINAPI TaskGroup_GetToolTipText_Hook(
         cchText);
 }
 
+using TaskListWnd_IsPinned_t =
+    bool(WINAPI*)(void* pThis, void* taskGroup);
+static TaskListWnd_IsPinned_t
+    g_taskListWndIsPinned;
+
+using TaskListWnd_GetRelativeTaskOrder_t =
+    int(WINAPI*)(void* pThis, void* taskGroup);
+static TaskListWnd_GetRelativeTaskOrder_t
+    g_taskListWndGetRelativeTaskOrder;
+static TaskListWnd_GetRelativeTaskOrder_t
+    g_taskListWndMultiGetRelativeTaskOrder;
+
+using TaskListWnd_TryMoveGroup_t =
+    bool(WINAPI*)(void* pThis, void* taskGroup, unsigned int index);
+static TaskListWnd_TryMoveGroup_t
+    g_taskListWndTryMoveGroupOriginal;
+
+using TaskListWndMulti_IsPinned_t =
+    bool(WINAPI*)(void* pThis, void* taskGroup);
+static TaskListWndMulti_IsPinned_t
+    g_taskListWndMultiIsPinned;
+
+using TaskListWndMulti_TryMoveGroup_t =
+    bool(WINAPI*)(void* pThis, void* taskGroup, unsigned int index);
+static TaskListWndMulti_TryMoveGroup_t
+    g_taskListWndMultiTryMoveGroupOriginal;
+
+static thread_local int g_tryMoveGroupHookDepth = 0;
+
+static std::wstring CopyTaskGroupAppId(void* taskGroup) {
+    if (!taskGroup || !g_taskGroupGetAppIdAddress) {
+        return {};
+    }
+
+    using CTaskGroup_GetAppID_t =
+        const wchar_t*(WINAPI*)(void* pThis);
+    auto getAppId =
+        reinterpret_cast<CTaskGroup_GetAppID_t>(
+            g_taskGroupGetAppIdAddress);
+
+    const wchar_t* appId = getAppId(taskGroup);
+    return appId ? std::wstring(appId) : std::wstring();
+}
+
+static void ApplyPinnedMoveToSnapshot(
+    Settings& settings,
+    std::wstring_view movedAppId,
+    int oldIndex,
+    int newIndex) {
+    if (oldIndex == newIndex) {
+        return;
+    }
+
+    SeparatorSetting* movedSeparator = nullptr;
+    for (auto& separator : settings.separators) {
+        if (separator.identity == movedAppId) {
+            movedSeparator = &separator;
+            break;
+        }
+    }
+
+    for (auto& separator : settings.separators) {
+        if (&separator == movedSeparator || separator.targetIndex < 0) {
+            continue;
+        }
+
+        if (oldIndex < newIndex) {
+            if (separator.targetIndex > oldIndex &&
+                separator.targetIndex <= newIndex) {
+                separator.targetIndex--;
+            }
+        } else {
+            if (separator.targetIndex >= newIndex &&
+                separator.targetIndex < oldIndex) {
+                separator.targetIndex++;
+            }
+        }
+    }
+
+    if (movedSeparator) {
+        movedSeparator->targetIndex = newIndex;
+    }
+}
+
+
+// -----------------------------------------------------------------------------
+// Native taskbar mutation persistence.
+//
+// Windhawk no longer owns separator position/list configuration. TryMoveGroup
+// mirrors native reorder operations into the in-memory separator state. The
+// Taskbar.View drag-completion hook persists that state exactly once when the
+// drag ends. Add and Unpin have their own discrete commit points and save the
+// same state file directly.
+// -----------------------------------------------------------------------------
+
+static void PersistPendingSeparatorState() {
+    std::lock_guard<std::mutex> mutationLock(
+        g_settingsMutationMutex);
+
+    if (!g_separatorStateDirty ||
+        g_unloading) {
+        return;
+    }
+
+    Settings snapshot;
+    {
+        std::shared_lock lock(g_settingsMutex);
+        snapshot = g_settings;
+    }
+
+    if (SaveSeparatorStateFile(snapshot)) {
+        g_separatorStateDirty = false;
+        Wh_Log(
+            L"[STATE] Persisted native taskbar reorder");
+    } else {
+        Wh_Log(
+            L"[STATE] Failed to persist native taskbar reorder; "
+            L"will retry on the next commit/unload");
+    }
+}
+
+static void RecordNativePinnedMove(
+    std::wstring_view movedAppId,
+    int oldIndex,
+    int newIndex) {
+    if (oldIndex < 0 ||
+        newIndex < 0 ||
+        oldIndex == newIndex) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> mutationLock(
+        g_settingsMutationMutex);
+
+    bool touchesSeparator = false;
+
+    {
+        std::unique_lock lock(g_settingsMutex);
+
+        Settings before = g_settings;
+
+        ApplyPinnedMoveToSnapshot(
+            g_settings,
+            movedAppId,
+            oldIndex,
+            newIndex);
+
+        touchesSeparator =
+            !SettingsSnapshotsEqual(
+                before,
+                g_settings);
+
+        if (!touchesSeparator) {
+            return;
+        }
+
+        // Windows already performed this move. Mirror it into the applied and
+        // stale-artifact snapshots immediately so the backend never "corrects"
+        // the user's native taskbar order while the drag is still in progress.
+        ApplyPinnedMoveToSnapshot(
+            g_appliedSettings,
+            movedAppId,
+            oldIndex,
+            newIndex);
+
+        for (auto& stored :
+             g_storedSeparatorSettings) {
+            if (stored.identity == movedAppId) {
+                stored.targetIndex = newIndex;
+                continue;
+            }
+
+            if (stored.targetIndex < 0) {
+                continue;
+            }
+
+            if (oldIndex < newIndex) {
+                if (stored.targetIndex > oldIndex &&
+                    stored.targetIndex <= newIndex) {
+                    stored.targetIndex--;
+                }
+            } else if (
+                stored.targetIndex >= newIndex &&
+                stored.targetIndex < oldIndex) {
+                stored.targetIndex++;
+            }
+        }
+
+        g_separatorStateDirty = true;
+    }
+
+    Wh_Log(
+        L"[NATIVE-MOVE] staged native pinned move appId='%s' %d -> %d",
+        std::wstring(movedAppId).c_str(),
+        oldIndex,
+        newIndex);
+}
+
+static bool RunTryMoveGroupObserver(
+    TaskListWnd_TryMoveGroup_t original,
+    TaskListWnd_IsPinned_t isPinnedFunction,
+    TaskListWnd_GetRelativeTaskOrder_t getRelativeTaskOrder,
+    const wchar_t* route,
+    void* pThis,
+    void* taskGroup,
+    unsigned int index) {
+    const bool outer =
+        g_tryMoveGroupHookDepth++ == 0;
+
+    int oldIndex = -1;
+    int newIndex = -1;
+    bool pinned = false;
+    std::wstring appId;
+
+    if (!g_unloading &&
+        outer &&
+        taskGroup &&
+        getRelativeTaskOrder &&
+        isPinnedFunction) {
+        oldIndex =
+            getRelativeTaskOrder(
+                pThis,
+                taskGroup);
+        pinned =
+            isPinnedFunction(
+                pThis,
+                taskGroup);
+        appId =
+            CopyTaskGroupAppId(taskGroup);
+    }
+
+    bool result =
+        original(
+            pThis,
+            taskGroup,
+            index);
+
+    if (!g_unloading &&
+        outer &&
+        taskGroup &&
+        getRelativeTaskOrder) {
+        newIndex =
+            getRelativeTaskOrder(
+                pThis,
+                taskGroup);
+    }
+
+    --g_tryMoveGroupHookDepth;
+
+    if (!g_unloading &&
+        outer &&
+        result &&
+        pinned &&
+        oldIndex >= 0 &&
+        newIndex >= 0 &&
+        oldIndex != newIndex) {
+        Wh_Log(
+            L"[NATIVE-MOVE] %s appId='%s' relative=%d -> %d argTarget=%u",
+            route,
+            appId.c_str(),
+            oldIndex,
+            newIndex,
+            index);
+
+        RecordNativePinnedMove(
+            appId,
+            oldIndex,
+            newIndex);
+    }
+
+    return result;
+}
+
+static bool WINAPI TaskListWnd_TryMoveGroup_Hook(
+    void* pThis,
+    void* taskGroup,
+    unsigned int index) {
+    return RunTryMoveGroupObserver(
+        g_taskListWndTryMoveGroupOriginal,
+        g_taskListWndIsPinned,
+        g_taskListWndGetRelativeTaskOrder,
+        L"CTaskListWnd::TryMoveGroup",
+        pThis,
+        taskGroup,
+        index);
+}
+
+static bool WINAPI TaskListWndMulti_TryMoveGroup_Hook(
+    void* pThis,
+    void* taskGroup,
+    unsigned int index) {
+    return RunTryMoveGroupObserver(
+        reinterpret_cast<TaskListWnd_TryMoveGroup_t>(
+            g_taskListWndMultiTryMoveGroupOriginal),
+        reinterpret_cast<TaskListWnd_IsPinned_t>(
+            g_taskListWndMultiIsPinned),
+        g_taskListWndMultiGetRelativeTaskOrder,
+        L"CTaskListWndMulti::TryMoveGroup",
+        pThis,
+        taskGroup,
+        index);
+}
+
+static void ShiftSeparatorTargetsAfterRemoval(
+    Settings& settings,
+    std::wstring_view removedIdentity,
+    int removedIndex) {
+    settings.separators.erase(
+        std::remove_if(
+            settings.separators.begin(),
+            settings.separators.end(),
+            [removedIdentity](const SeparatorSetting& separator) {
+                return separator.identity ==
+                    removedIdentity;
+            }),
+        settings.separators.end());
+
+    if (removedIndex >= 0) {
+        for (auto& separator :
+             settings.separators) {
+            if (separator.targetIndex >
+                removedIndex) {
+                separator.targetIndex--;
+            }
+        }
+    }
+
+    for (size_t i = 0;
+         i < settings.separators.size();
+         i++) {
+        settings.separators[i].sourceIndex =
+            static_cast<int>(i);
+        settings.separators[i].ordinal =
+            static_cast<int>(i) + 1;
+    }
+}
+
+
+static void RemoveSeparatorFromContextMenu(
+    std::wstring identity) {
+    if (identity.empty() ||
+        g_unloading ||
+        g_internalCleanupInProgress.load()) {
+        return;
+    }
+
+    Settings updated;
+    int removedIndex = -1;
+
+    {
+        std::lock_guard<std::mutex> mutationLock(
+            g_settingsMutationMutex);
+
+        {
+            std::shared_lock lock(g_settingsMutex);
+            updated = g_settings;
+
+            const SeparatorSetting* existing =
+                FindSeparatorByIdentity(
+                    g_settings,
+                    identity);
+            if (!existing) {
+                return;
+            }
+
+            removedIndex = existing->targetIndex;
+        }
+
+        ShiftSeparatorTargetsAfterRemoval(
+            updated,
+            identity,
+            removedIndex);
+
+        // State is authoritative. Persist the user's intent before touching the
+        // live pin list; a failed write leaves both desired and actual state
+        // unchanged.
+        if (!SaveSeparatorStateFile(updated)) {
+            Wh_Log(
+                L"[NATIVE-UNPIN] State write failed; separator kept identity='%s'",
+                identity.c_str());
+            return;
+        }
+
+        {
+            std::unique_lock lock(g_settingsMutex);
+            g_settings = updated;
+            g_backendHasConverged = false;
+            g_separatorStateDirty = false;
+        }
+    }
+
+    Wh_Log(
+        L"[NATIVE-UNPIN] Removed separator from desired state identity='%s' index=%d",
+        identity.c_str(),
+        removedIndex);
+
+    // Keep the old applied/stored snapshots until the backend has actually
+    // unpinned the shortcut. That keeps the still-visible button recognized,
+    // styled, and inert during the short convergence window.
+    RequestBackendReconcile();
+}
+
 using TrayUI_StartTaskbar_t =
     void(WINAPI*)(void* pThis);
 
@@ -1963,6 +3603,51 @@ static bool HookTaskbarInteractionSymbols(HMODULE taskbarDll) {
             },
             &g_taskGroupGetAppIdAddress,
             nullptr,
+        },
+        {
+            {
+                LR"(public: virtual bool __cdecl CTaskListWnd::IsPinned(struct ITaskGroup *))"
+            },
+            &g_taskListWndIsPinned,
+            nullptr,
+        },
+        {
+            {
+                LR"(public: virtual int __cdecl CTaskListWnd::GetRelativeTaskOrder(struct ITaskGroup *))"
+            },
+            &g_taskListWndGetRelativeTaskOrder,
+            nullptr,
+        },
+        {
+            {
+                LR"(public: virtual bool __cdecl CTaskListWnd::TryMoveGroup(struct ITaskGroup *,unsigned int))"
+            },
+            &g_taskListWndTryMoveGroupOriginal,
+            TaskListWnd_TryMoveGroup_Hook,
+        },
+        {
+            {
+                LR"(public: virtual bool __cdecl CTaskListWndMulti::IsPinned(struct ITaskGroup *))"
+            },
+            &g_taskListWndMultiIsPinned,
+            nullptr,
+            true,
+        },
+        {
+            {
+                LR"(public: virtual int __cdecl CTaskListWndMulti::GetRelativeTaskOrder(struct ITaskGroup *))"
+            },
+            &g_taskListWndMultiGetRelativeTaskOrder,
+            nullptr,
+            true,
+        },
+        {
+            {
+                LR"(public: virtual bool __cdecl CTaskListWndMulti::TryMoveGroup(struct ITaskGroup *,unsigned int))"
+            },
+            &g_taskListWndMultiTryMoveGroupOriginal,
+            TaskListWndMulti_TryMoveGroup_Hook,
+            true,
         },
         {
             {
@@ -2211,6 +3896,7 @@ static HRESULT CreatePinManager(
 }
 
 static bool IsBackendStopRequested();
+static bool IsBackendPassSuperseded();
 
 static bool UnpinAndDeleteShortcut(
     IPinManagerInterop3* pinManager,
@@ -2276,11 +3962,13 @@ static bool UnpinAndDeleteShortcut(
 }
 
 static bool CleanupStaleSeparatorShortcuts(
-    IPinManagerInterop3* pinManager) {
+    IPinManagerInterop3* pinManager,
+    const Settings& settings) {
     std::vector<std::wstring> stalePaths;
 
     for (const auto& path : EnumerateSeparatorShortcuts()) {
-        if (!IsCurrentSeparatorIdentity(
+        if (!IsIdentityInSettings(
+                settings,
                 GetShortcutIdentity(path))) {
             stalePaths.push_back(path);
         }
@@ -2291,21 +3979,21 @@ static bool CleanupStaleSeparatorShortcuts(
     }
 
     Wh_Log(
-        L"[CLEANUP] Removing %zu shortcut(s) from an older settings snapshot",
+        L"[SYNC] Removing %zu shortcut(s) not present in desired settings",
         stalePaths.size());
 
     bool success = true;
     for (auto it = stalePaths.rbegin();
          it != stalePaths.rend();
          ++it) {
-        if (IsBackendStopRequested()) {
+        if (IsBackendPassSuperseded()) {
             return false;
         }
 
         if (!UnpinAndDeleteShortcut(
                 pinManager,
                 *it,
-                L"CLEANUP")) {
+                L"SYNC")) {
             success = false;
         }
     }
@@ -2317,43 +4005,90 @@ static bool CleanupStaleSeparatorShortcuts(
 // Creation / positioning.
 // -----------------------------------------------------------------------------
 
-static bool PrepareSeparatorFiles() {
-    if (g_settings.separators.empty()) {
+static bool PrepareSeparatorFiles(
+    const Settings& settings,
+    const Settings& appliedSettings,
+    const SeparatorSetting& refreshPulse,
+    std::vector<std::wstring>* identitiesToPin) {
+    if (IsBackendPassSuperseded()) {
+        return false;
+    }
+
+    identitiesToPin->clear();
+
+    if (settings.separators.empty()) {
         Wh_Log(L"[PIN] No separators configured");
         return true;
     }
 
-    if (!WriteBinaryFile(
+    // The icon file is shared by every separator shortcut. Rewriting it during
+    // a live settings change needlessly invalidates Explorer's icon-cache
+    // assumptions, so leave an existing file untouched.
+    if (!FileExists(g_iconPath) &&
+        !WriteBinaryFile(
             g_iconPath,
             kSeparatorIcon,
             static_cast<DWORD>(sizeof(kSeparatorIcon)))) {
         return false;
     }
 
-    // First create every backing shortcut, before mutating the taskbar.
-    for (const auto& separator : g_settings.separators) {
+    // Stable separator shortcuts are immutable while their identity survives.
+    // Overwriting a pinned .lnk in place can make Explorer keep the taskbar
+    // button while losing its cached glyph. Create only genuinely new/missing
+    // backing files; survivors keep the exact file Windows already knows.
+    for (const auto& separator : settings.separators) {
+        if (IsBackendPassSuperseded()) {
+            return false;
+        }
+
         std::wstring shortcutPath =
             GetSeparatorShortcutPath(separator);
+        bool shortcutCreated = false;
 
-        HRESULT hr =
-            CreateSeparatorShortcut(
-                separator,
-                shortcutPath);
+        if (!FileExists(shortcutPath)) {
+            HRESULT hr =
+                CreateSeparatorShortcut(
+                    separator,
+                    shortcutPath);
 
-        if (FAILED(hr)) {
-            Wh_Log(
-                L"[PIN] Failed to create separator #%d hr=0x%08X",
-                separator.ordinal,
-                static_cast<unsigned int>(hr));
-            return false;
+            if (FAILED(hr)) {
+                Wh_Log(
+                    L"[PIN] Failed to create separator #%d hr=0x%08X",
+                    separator.ordinal,
+                    static_cast<unsigned int>(hr));
+                return false;
+            }
+
+            shortcutCreated = true;
+        }
+
+        // Pin only identities that aren't part of the last converged snapshot,
+        // plus a survivor whose backing file had to be recovered. This keeps
+        // ordinary add/remove/reorder operations from re-asserting every
+        // already-correct pinned item.
+        const SeparatorSetting* appliedSeparator =
+            FindSeparatorByStableId(
+                appliedSettings,
+                separator.stableId);
+
+        if (shortcutCreated ||
+            !appliedSeparator ||
+            appliedSeparator->identity != separator.identity) {
+            identitiesToPin->push_back(
+                separator.identity);
         }
     }
 
+    if (IsBackendPassSuperseded()) {
+        return false;
+    }
+
+    // The refresh helper is intentionally transient, so recreating it is safe.
     std::wstring refreshShortcutPath =
-        GetSeparatorShortcutPath(g_refreshPulseSetting);
+        GetSeparatorShortcutPath(refreshPulse);
     HRESULT refreshHr =
         CreateSeparatorShortcut(
-            g_refreshPulseSetting,
+            refreshPulse,
             refreshShortcutPath);
 
     if (FAILED(refreshHr)) {
@@ -2395,20 +4130,71 @@ static bool IsBackendStopRequested() {
             0) == WAIT_OBJECT_0;
 }
 
-static bool WaitForBackendStop(DWORD timeout) {
-    return g_currentBackendStopEvent &&
+static bool IsBackendReconcileRequested() {
+    return g_currentBackendWakeEvent &&
         WaitForSingleObject(
-            g_currentBackendStopEvent,
-            timeout) == WAIT_OBJECT_0;
+            g_currentBackendWakeEvent,
+            0) == WAIT_OBJECT_0;
 }
 
-static bool PinSeparators(IPinManagerInterop3* pinManager) {
+static bool IsBackendPassSuperseded() {
+    return IsBackendStopRequested() ||
+        IsBackendReconcileRequested();
+}
+
+enum class BackendWaitResult {
+    Timeout,
+    Stop,
+    Reconcile,
+    Failed,
+};
+
+static BackendWaitResult WaitForBackendStopOrReconcile(
+    DWORD timeout) {
+    HANDLE events[] = {
+        g_currentBackendStopEvent,
+        g_currentBackendWakeEvent,
+    };
+
+    if (!events[0] || !events[1]) {
+        return BackendWaitResult::Failed;
+    }
+
+    DWORD result = WaitForMultipleObjects(
+        ARRAYSIZE(events),
+        events,
+        FALSE,
+        timeout);
+
+    switch (result) {
+        case WAIT_TIMEOUT:
+            return BackendWaitResult::Timeout;
+        case WAIT_OBJECT_0:
+            return BackendWaitResult::Stop;
+        case WAIT_OBJECT_0 + 1:
+            return BackendWaitResult::Reconcile;
+        default:
+            return BackendWaitResult::Failed;
+    }
+}
+
+static bool PinSeparators(
+    IPinManagerInterop3* pinManager,
+    const Settings& settings,
+    const std::vector<std::wstring>& identitiesToPin) {
     bool success = true;
 
-    // Complete the entire pin phase before positioning anything. Retrying this
-    // operation is safe because each shortcut has a stable path and AppUserModelID.
-    for (const auto& separator : g_settings.separators) {
-        if (IsBackendStopRequested()) {
+    // Only new/recovered identities need a pin mutation. Existing stable pins
+    // are left untouched and are handled solely by the positioning pass.
+    for (const auto& separator : settings.separators) {
+        if (std::find(
+                identitiesToPin.begin(),
+                identitiesToPin.end(),
+                separator.identity) == identitiesToPin.end()) {
+            continue;
+        }
+
+        if (IsBackendPassSuperseded()) {
             return false;
         }
 
@@ -2449,14 +4235,16 @@ static bool PinSeparators(IPinManagerInterop3* pinManager) {
     return success;
 }
 
-static bool PositionSeparators(IPinManagerInterop3* pinManager) {
+static bool PositionSeparators(
+    IPinManagerInterop3* pinManager,
+    const Settings& settings) {
     bool success = true;
 
     // Moving in ascending destination order makes multiple requested positions
     // deterministic as items are pulled forward from their initial appended
     // locations.
     std::vector<SeparatorSetting> moveOrder =
-        g_settings.separators;
+        settings.separators;
 
     std::stable_sort(
         moveOrder.begin(),
@@ -2466,8 +4254,18 @@ static bool PositionSeparators(IPinManagerInterop3* pinManager) {
         });
 
     for (const auto& separator : moveOrder) {
-        if (IsBackendStopRequested()) {
+        if (IsBackendPassSuperseded()) {
             return false;
+        }
+
+        // targetIndex=-1 is used by the native Add separator command. The
+        // PinManager append is already the desired final placement, so don't
+        // issue a MoveTaskbarPin until/unless the user later drags it.
+        if (separator.targetIndex < 0) {
+            Wh_Log(
+                L"[MOVE] Separator #%d left at native appended position",
+                separator.ordinal);
+            continue;
         }
 
         std::wstring shortcutPath =
@@ -2510,13 +4308,15 @@ static bool PositionSeparators(IPinManagerInterop3* pinManager) {
     return success;
 }
 
-static bool PulseTaskbarPinList(IPinManagerInterop3* pinManager) {
-    if (IsBackendStopRequested()) {
+static bool PulseTaskbarPinList(
+    IPinManagerInterop3* pinManager,
+    const SeparatorSetting& refreshPulse) {
+    if (IsBackendPassSuperseded()) {
         return false;
     }
 
     std::wstring shortcutPath =
-        GetSeparatorShortcutPath(g_refreshPulseSetting);
+        GetSeparatorShortcutPath(refreshPulse);
 
     PIDLIST_ABSOLUTE pidl = nullptr;
     HRESULT hr = GetPidlForPath(shortcutPath, &pidl);
@@ -2564,32 +4364,41 @@ static bool PulseTaskbarPinList(IPinManagerInterop3* pinManager) {
     return false;
 }
 
-static bool CreateAndPinSeparators() {
-    if (g_settings.separators.empty() &&
+static bool ConvergeSeparatorPins(
+    const Settings& settings,
+    const Settings& appliedSettings,
+    const SeparatorSetting& refreshPulse) {
+    if (settings.separators.empty() &&
         EnumerateSeparatorShortcuts().empty()) {
         DeleteFileIfPresent(g_iconPath);
         return true;
     }
 
-    constexpr int kStartupAttempts = 5;
-    constexpr DWORD kInitialStartupRetryDelay = 250;
-    constexpr DWORD kStartupRetryBackoff = 2;
-    DWORD retryDelay = kInitialStartupRetryDelay;
+    constexpr int kConvergeAttempts = 5;
+    constexpr DWORD kInitialRetryDelay = 250;
+    constexpr DWORD kRetryBackoff = 2;
+    DWORD retryDelay = kInitialRetryDelay;
     bool staleCleanupComplete = false;
     bool filesPrepared = false;
+    std::vector<std::wstring> identitiesToPin;
 
     for (int attempt = 1;
-         attempt <= kStartupAttempts;
+         attempt <= kConvergeAttempts;
          ++attempt) {
         if (IsBackendStopRequested()) {
-            Wh_Log(L"[INIT] Separator startup cancelled");
+            Wh_Log(L"[SYNC] Separator reconciliation cancelled");
+            return false;
+        }
+
+        if (IsBackendReconcileRequested()) {
+            Wh_Log(L"[SYNC] Reconciliation superseded by newer settings");
             return false;
         }
 
         Wh_Log(
-            L"[INIT] Separator startup attempt %d/%d",
+            L"[SYNC] Separator reconciliation attempt %d/%d",
             attempt,
-            kStartupAttempts);
+            kConvergeAttempts);
 
         IPinManagerInterop3* pinManager = nullptr;
         HRESULT hr = CreatePinManager(&pinManager);
@@ -2601,38 +4410,55 @@ static bool CreateAndPinSeparators() {
         bool refreshed = false;
 
         if (SUCCEEDED(hr) && pinManager) {
-            // Storage, rather than the current settings snapshot, is the
-            // durable list of shortcuts this mod owns. Remove old identities
-            // before creating any paths for the new snapshot.
+            // Storage is the durable list of shortcut artifacts this mod owns.
+            // Remove only identities not present in the desired snapshot;
+            // unchanged separators are never unpinned during live refresh.
             if (!staleCleanupComplete) {
                 staleCleanupComplete =
-                    CleanupStaleSeparatorShortcuts(pinManager);
+                    CleanupStaleSeparatorShortcuts(
+                        pinManager,
+                        settings);
                 staleShortcutsRemoved = staleCleanupComplete;
             }
 
             if (staleShortcutsRemoved && !filesPrepared) {
-                filesPrepared = PrepareSeparatorFiles();
+                filesPrepared =
+                    PrepareSeparatorFiles(
+                        settings,
+                        appliedSettings,
+                        refreshPulse,
+                        &identitiesToPin);
                 filesReady = filesPrepared;
             }
 
             if (staleShortcutsRemoved && filesReady &&
-                g_settings.separators.empty()) {
+                settings.separators.empty()) {
                 DeleteFileIfPresent(g_iconPath);
                 pinsReady = true;
                 positioned = true;
                 refreshed = true;
             } else if (staleShortcutsRemoved && filesReady) {
-                pinsReady = PinSeparators(pinManager);
+                pinsReady =
+                    PinSeparators(
+                        pinManager,
+                        settings,
+                        identitiesToPin);
 
                 if (pinsReady) {
-                    positioned = PositionSeparators(pinManager);
+                    positioned =
+                        PositionSeparators(
+                            pinManager,
+                            settings);
 
                     if (positioned) {
-                        refreshed = PulseTaskbarPinList(pinManager);
+                        refreshed =
+                            PulseTaskbarPinList(
+                                pinManager,
+                                refreshPulse);
                     }
                 } else {
                     Wh_Log(
-                        L"[INIT] Pin pass incomplete; skipping move pass");
+                        L"[SYNC] Pin pass incomplete; skipping move pass");
                 }
             }
 
@@ -2642,34 +4468,49 @@ static bool CreateAndPinSeparators() {
         if (staleShortcutsRemoved && filesReady &&
             pinsReady && positioned && refreshed) {
             Wh_Log(
-                L"[INIT] Separator startup converged on attempt %d",
+                L"[SYNC] Separator state converged on attempt %d",
                 attempt);
             return true;
         }
 
         if (IsBackendStopRequested()) {
-            Wh_Log(L"[INIT] Separator startup cancelled");
+            Wh_Log(L"[SYNC] Separator reconciliation cancelled");
             return false;
         }
 
-        if (attempt < kStartupAttempts) {
+        if (attempt < kConvergeAttempts) {
             Wh_Log(
-                L"[INIT] Separator startup attempt failed; "
+                L"[SYNC] Reconciliation attempt failed; "
                 L"retrying in %u ms",
                 retryDelay);
 
-            if (WaitForBackendStop(retryDelay)) {
-                Wh_Log(L"[INIT] Separator startup cancelled");
+            BackendWaitResult waitResult =
+                WaitForBackendStopOrReconcile(retryDelay);
+
+            if (waitResult == BackendWaitResult::Stop) {
+                Wh_Log(L"[SYNC] Separator reconciliation cancelled");
                 return false;
             }
 
-            retryDelay *= kStartupRetryBackoff;
+            if (waitResult == BackendWaitResult::Reconcile) {
+                Wh_Log(L"[SYNC] Reconciliation superseded by newer settings");
+                return false;
+            }
+
+            if (waitResult == BackendWaitResult::Failed) {
+                Wh_Log(
+                    L"[SYNC] Reconciliation retry wait failed error=%u",
+                    GetLastError());
+                return false;
+            }
+
+            retryDelay *= kRetryBackoff;
         }
     }
 
     Wh_Log(
-        L"[INIT] Separator startup did not converge after %d attempts",
-        kStartupAttempts);
+        L"[SYNC] Separator state did not converge after %d attempts",
+        kConvergeAttempts);
     return false;
 }
 
@@ -2737,9 +4578,20 @@ static bool UnpinAndDeleteSeparators(bool recoverMissingPins) {
 
 static HWND FindCurrentProcessTaskbarWnd();
 
+struct BackendThreadParameters {
+    HANDLE stopEvent;
+    HANDLE wakeEvent;
+};
+
 static DWORD WINAPI BackendThreadProc(void* parameter) {
-    g_currentBackendStopEvent =
-        static_cast<HANDLE>(parameter);
+    auto* parameters =
+        static_cast<BackendThreadParameters*>(parameter);
+    HANDLE stopEvent = parameters->stopEvent;
+    HANDLE wakeEvent = parameters->wakeEvent;
+    delete parameters;
+
+    g_currentBackendStopEvent = stopEvent;
+    g_currentBackendWakeEvent = wakeEvent;
 
     Wh_Log(L"[INIT] Separator backend worker starting");
 
@@ -2752,18 +4604,96 @@ static DWORD WINAPI BackendThreadProc(void* parameter) {
         Wh_Log(
             L"[INIT] Backend worker CoInitializeEx failed hr=0x%08X",
             static_cast<unsigned int>(hrInit));
+        g_currentBackendStopEvent = nullptr;
+        g_currentBackendWakeEvent = nullptr;
         return 0;
     }
 
-    bool success = CreateAndPinSeparators();
+    for (;;) {
+        // A settings notification that arrived before this iteration is
+        // already represented by the snapshot we are about to take.
+        ResetEvent(wakeEvent);
+
+        Settings settings;
+        Settings appliedSettings;
+        SeparatorSetting refreshPulse;
+
+        {
+            std::shared_lock lock(g_settingsMutex);
+            settings = g_settings;
+            appliedSettings = g_appliedSettings;
+            refreshPulse = g_refreshPulseSetting;
+        }
+
+        bool success =
+            ConvergeSeparatorPins(
+                settings,
+                appliedSettings,
+                refreshPulse);
+
+        if (success) {
+            {
+                std::unique_lock lock(g_settingsMutex);
+
+                // Record what the pin backend actually converged to. If only
+                // presentation/logging metadata changed while the backend was
+                // working, adopt the newer snapshot too because no additional
+                // PinManager work is required.
+                g_appliedSettings = settings;
+
+                if (!SettingsRequireBackendReconcile(
+                        settings,
+                        g_settings)) {
+                    g_appliedSettings = g_settings;
+                    g_backendHasConverged = true;
+                } else {
+                    g_backendHasConverged = false;
+                }
+            }
+
+            RefreshStoredSeparatorSettings();
+        } else if (!IsBackendStopRequested()) {
+            g_backendHasConverged = false;
+
+            if (!IsBackendReconcileRequested()) {
+                Wh_Log(
+                    L"[SYNC] One or more separator operations failed; "
+                    L"waiting for another settings/retry request");
+            }
+        }
+
+        if (IsBackendStopRequested()) {
+            break;
+        }
+
+        HANDLE events[] = {
+            stopEvent,
+            wakeEvent,
+        };
+
+        DWORD waitResult =
+            WaitForMultipleObjects(
+                ARRAYSIZE(events),
+                events,
+                FALSE,
+                INFINITE);
+
+        if (waitResult == WAIT_OBJECT_0) {
+            break;
+        }
+
+        if (waitResult != WAIT_OBJECT_0 + 1) {
+            Wh_Log(
+                L"[SYNC] Backend wait failed result=0x%08X error=%u",
+                waitResult,
+                GetLastError());
+            break;
+        }
+    }
 
     CoUninitialize();
-
-    if (!success && !IsBackendStopRequested()) {
-        Wh_Log(
-            L"[INIT] One or more separator operations failed; "
-            L"mod remains loaded so unload can still clean up");
-    }
+    g_currentBackendStopEvent = nullptr;
+    g_currentBackendWakeEvent = nullptr;
 
     Wh_Log(L"[INIT] Separator backend worker finished");
     return 0;
@@ -2828,8 +4758,42 @@ static bool CleanupSeparatorArtifacts(bool recoverMissingPins) {
 }
 
 static bool StartBackendWorkerLocked() {
-    if (g_backendStopped || g_backendThread) {
+    if (g_backendStopped) {
         return true;
+    }
+
+    if (g_backendThread) {
+        DWORD threadState =
+            WaitForSingleObject(
+                g_backendThread,
+                0);
+
+        if (threadState == WAIT_TIMEOUT) {
+            return true;
+        }
+
+        if (threadState == WAIT_FAILED) {
+            Wh_Log(
+                L"[INIT] Backend worker handle wait failed error=%u; "
+                L"recreating worker",
+                GetLastError());
+        }
+
+        // The long-lived worker should normally only exit during shutdown.
+        // If initialization/waiting failed, allow a later readiness/settings
+        // event to create a fresh worker.
+        CloseHandle(g_backendThread);
+        g_backendThread = nullptr;
+
+        if (g_backendWakeEvent) {
+            CloseHandle(g_backendWakeEvent);
+            g_backendWakeEvent = nullptr;
+        }
+
+        if (g_backendStopEvent) {
+            CloseHandle(g_backendStopEvent);
+            g_backendStopEvent = nullptr;
+        }
     }
 
     g_backendStopEvent =
@@ -2841,8 +4805,39 @@ static bool StartBackendWorkerLocked() {
 
     if (!g_backendStopEvent) {
         Wh_Log(
-            L"[INIT] CreateEvent for backend worker failed error=%u",
+            L"[INIT] CreateEvent for backend stop failed error=%u",
             GetLastError());
+        return false;
+    }
+
+    g_backendWakeEvent =
+        CreateEventW(
+            nullptr,
+            TRUE,
+            FALSE,
+            nullptr);
+
+    if (!g_backendWakeEvent) {
+        Wh_Log(
+            L"[INIT] CreateEvent for backend wake failed error=%u",
+            GetLastError());
+        CloseHandle(g_backendStopEvent);
+        g_backendStopEvent = nullptr;
+        return false;
+    }
+
+    auto* parameters =
+        new (std::nothrow) BackendThreadParameters{
+            .stopEvent = g_backendStopEvent,
+            .wakeEvent = g_backendWakeEvent,
+        };
+
+    if (!parameters) {
+        Wh_Log(L"[INIT] Failed to allocate backend worker parameters");
+        CloseHandle(g_backendWakeEvent);
+        CloseHandle(g_backendStopEvent);
+        g_backendWakeEvent = nullptr;
+        g_backendStopEvent = nullptr;
         return false;
     }
 
@@ -2851,7 +4846,7 @@ static bool StartBackendWorkerLocked() {
             nullptr,
             0,
             BackendThreadProc,
-            g_backendStopEvent,
+            parameters,
             0,
             nullptr);
 
@@ -2859,7 +4854,10 @@ static bool StartBackendWorkerLocked() {
         Wh_Log(
             L"[INIT] CreateThread for backend worker failed error=%u",
             GetLastError());
+        delete parameters;
+        CloseHandle(g_backendWakeEvent);
         CloseHandle(g_backendStopEvent);
+        g_backendWakeEvent = nullptr;
         g_backendStopEvent = nullptr;
         return false;
     }
@@ -2874,26 +4872,156 @@ static void StartBackendWorker() {
         return;
     }
 
+    bool workerWasRunning =
+        g_backendThread &&
+        WaitForSingleObject(
+            g_backendThread,
+            0) == WAIT_TIMEOUT;
+
     if (!StartBackendWorkerLocked()) {
         Wh_Log(L"[INIT] Failed to start separator backend worker");
+        return;
     }
+
+    // TrayUI::StartTaskbar can run again if Explorer reconstructs the taskbar
+    // in-process. A persistent worker already exists in that case, so wake it
+    // to re-assert the pin order and refresh pulse for the new presentation.
+    if (workerWasRunning && g_backendWakeEvent) {
+        SetEvent(g_backendWakeEvent);
+    }
+}
+
+static void RequestBackendReconcile() {
+    std::lock_guard<std::mutex> lock(g_lifecycleMutex);
+
+    if (g_unloading || g_backendStopped) {
+        return;
+    }
+
+    // Preserve the Stage A readiness policy: if the taskbar hasn't been
+    // created yet, TrayUI::StartTaskbar will start the worker later and it
+    // will consume the newest desired settings snapshot.
+    if (!g_backendThread &&
+        !FindCurrentProcessTaskbarWnd()) {
+        return;
+    }
+
+    // Always go through StartBackendWorkerLocked. Besides creating a missing
+    // worker, it notices a worker that exited unexpectedly and recreates it.
+    if (!StartBackendWorkerLocked()) {
+        Wh_Log(
+            L"[SYNC] Failed to start separator backend worker");
+        return;
+    }
+
+    if (g_backendWakeEvent) {
+        SetEvent(g_backendWakeEvent);
+    }
+}
+
+
+static void AddSeparatorFromTaskbarMenu() {
+    if (g_unloading ||
+        g_internalCleanupInProgress.load()) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> mutationLock(
+        g_settingsMutationMutex);
+
+    Settings updated;
+    {
+        std::shared_lock lock(g_settingsMutex);
+        updated = g_settings;
+    }
+
+    std::wstring stableId;
+    const auto alreadyUsed =
+        [&updated](std::wstring_view candidate) {
+            return std::any_of(
+                updated.separators.begin(),
+                updated.separators.end(),
+                [candidate](const SeparatorSetting& separator) {
+                    return separator.stableId ==
+                        candidate;
+                });
+        };
+
+    do {
+        stableId = GenerateStableId();
+    } while (alreadyUsed(stableId));
+
+    int sourceIndex =
+        static_cast<int>(
+            updated.separators.size());
+
+    updated.separators.push_back({
+        .ordinal = sourceIndex + 1,
+        .sourceIndex = sourceIndex,
+        // Let Windows keep the freshly pinned item at its native appended
+        // position. The first native drag gives it an explicit index.
+        .targetIndex = -1,
+        .width = updated.width,
+        .stableId = stableId,
+        .identity = BuildSeparatorIdentity(
+            updated.identifierPrefix,
+            stableId),
+    });
+
+    // Persist before publishing the desired state. If storage fails, no pin is
+    // created and the taskbar remains unchanged.
+    if (!SaveSeparatorStateFile(updated)) {
+        Wh_Log(
+            L"[NATIVE-ADD] State write failed; separator not added");
+        return;
+    }
+
+    {
+        std::unique_lock lock(g_settingsMutex);
+        g_settings = updated;
+        g_backendHasConverged = false;
+        g_separatorStateDirty = false;
+    }
+
+    Wh_Log(
+        L"[NATIVE-ADD] Added separator identity='%s' at native end",
+        updated.separators.back().identity.c_str());
+
+    RefreshStoredSeparatorSettings();
+    RequestBackendReconcile();
 }
 
 static void StopBackendWorker() {
     HANDLE thread = nullptr;
     HANDLE stopEvent = nullptr;
+    HANDLE wakeEvent = nullptr;
 
     {
         std::lock_guard<std::mutex> lock(g_lifecycleMutex);
 
-        // Permanent latch: no loader-hook callback can create a worker after
-        // shutdown begins.
+        // Permanent latch: no loader-hook callback or settings callback can
+        // create/wake a worker after shutdown begins.
         g_backendStopped = true;
-        stopEvent = std::exchange(g_backendStopEvent, nullptr);
-        thread = std::exchange(g_backendThread, nullptr);
+        g_backendHasConverged = false;
+
+        stopEvent =
+            std::exchange(
+                g_backendStopEvent,
+                nullptr);
+        wakeEvent =
+            std::exchange(
+                g_backendWakeEvent,
+                nullptr);
+        thread =
+            std::exchange(
+                g_backendThread,
+                nullptr);
 
         if (stopEvent) {
             SetEvent(stopEvent);
+        }
+        if (wakeEvent) {
+            SetEvent(wakeEvent);
         }
     }
 
@@ -2905,6 +5033,10 @@ static void StopBackendWorker() {
 
         WaitForSingleObject(thread, INFINITE);
         CloseHandle(thread);
+    }
+
+    if (wakeEvent) {
+        CloseHandle(wakeEvent);
     }
 
     if (stopEvent) {
@@ -2939,18 +5071,22 @@ static bool IsMainExplorerProcess() {
            commandLine.find(L" -embedding") == std::wstring::npos;
 }
 
-BOOL Wh_ModInit() {
+BOOL ExplorerModInit() {
     if (!IsMainExplorerProcess()) {
         return FALSE;
     }
 
     Wh_Log(L"[INIT] Taskbar Icon Separators loading");
 
-    LoadSettings();
-
     if (!InitializeStoragePath()) {
         return FALSE;
     }
+
+    if (!LoadSettings()) {
+        return FALSE;
+    }
+
+    RefreshStoredSeparatorSettings();
 
     if (!InitializeTaskbarStylingHooks()) {
         Wh_Log(
@@ -2973,7 +5109,7 @@ BOOL Wh_ModInit() {
     return TRUE;
 }
 
-void Wh_ModAfterInit() {
+void ExplorerModAfterInit() {
     // Close the small race where the module wasn't present in Wh_ModInit but
     // appeared before/around Wh_ModAfterInit.
     if (!g_taskbarViewDllHooked) {
@@ -3004,22 +5140,32 @@ void Wh_ModAfterInit() {
     }
 }
 
-void Wh_ModBeforeUninit() {
+void ExplorerModBeforeUninit() {
+    // A completed native reorder should already have been persisted by
+    // OnDragCompletedGesture. This is a final no-timer fallback for a missed
+    // completion callback or a shutdown that lands mid-drag.
+    PersistPendingSeparatorState();
+
     // Join the worker first, then remove pins while the styling and input
     // hooks can still keep a transient recovery pin styled and inert.
     StopBackendWorker();
+    g_internalCleanupInProgress = true;
     CleanupSeparatorArtifacts(true);
 
-    // Stop applying separator state, then restore every tracked container on
-    // its owning taskbar UI thread before Windhawk removes the hooks.
+    // Stop applying separator state before releasing the cleanup guard.
     g_unloading = true;
+    g_internalCleanupInProgress = false;
+
+    // Restore every tracked container on its owning taskbar UI thread before
+    // Windhawk removes the hooks.
     RestoreTrackedSeparatorVisualStates();
 }
 
-void Wh_ModUninit() {
+void ExplorerModUninit() {
     Wh_Log(L"[UNINIT] Taskbar Icon Separators unloading");
 
     // Defensive in case an older Windhawk build skips Wh_ModBeforeUninit.
+    PersistPendingSeparatorState();
     g_unloading = true;
     StopBackendWorker();
 
@@ -3032,10 +5178,71 @@ void Wh_ModUninit() {
     Wh_Log(L"[UNINIT] Taskbar Icon Separators unloaded");
 }
 
-BOOL Wh_ModSettingsChanged(BOOL* bReload) {
-    // Phase A keeps the reviewed full-reload settings behavior. Live
-    // reconciliation is a separate follow-up once persistent identities are
-    // available.
-    *bReload = TRUE;
+BOOL ExplorerModSettingsChanged(BOOL* bReload) {
+    if (bReload) {
+        *bReload = FALSE;
+    }
+
+    double newWidth =
+        LoadSeparatorWidthSetting();
+
+    {
+        std::lock_guard<std::mutex> mutationLock(
+            g_settingsMutationMutex);
+        std::unique_lock lock(g_settingsMutex);
+
+        g_settings.width = newWidth;
+        g_appliedSettings.width = newWidth;
+
+        for (auto& separator :
+             g_settings.separators) {
+            separator.width = newWidth;
+        }
+        for (auto& separator :
+             g_appliedSettings.separators) {
+            separator.width = newWidth;
+        }
+        for (auto& separator :
+             g_storedSeparatorSettings) {
+            separator.width = newWidth;
+        }
+
+        g_refreshPulseSetting.width =
+            newWidth;
+    }
+
+    Wh_Log(
+        L"[SETTINGS] Applied global separator width=%d",
+        static_cast<int>(newWidth));
+
+    // Width is presentation-only. Native separator positions and identities
+    // live in the mod-storage state file and never require PinManager work.
+    RefreshTrackedSeparatorVisualStates();
+
     return TRUE;
+}
+
+
+// -----------------------------------------------------------------------------
+// Windhawk entry points.
+// -----------------------------------------------------------------------------
+
+BOOL Wh_ModInit() {
+    return ExplorerModInit();
+}
+
+void Wh_ModAfterInit() {
+    ExplorerModAfterInit();
+}
+
+void Wh_ModBeforeUninit() {
+    ExplorerModBeforeUninit();
+}
+
+void Wh_ModUninit() {
+    ExplorerModUninit();
+}
+
+BOOL Wh_ModSettingsChanged(BOOL* bReload) {
+    return ExplorerModSettingsChanged(bReload);
 }

--- a/mods/taskbar-icon-separators.wh.cpp
+++ b/mods/taskbar-icon-separators.wh.cpp
@@ -745,12 +745,14 @@ static bool ParseStateInt(
 static bool ReadSeparatorStateFile(
     double width,
     Settings* settingsOut,
-    bool* existsOut) {
-    if (!settingsOut || !existsOut) {
+    bool* existsOut,
+    bool* contentInvalidOut) {
+    if (!settingsOut || !existsOut || !contentInvalidOut) {
         return false;
     }
 
     *existsOut = false;
+    *contentInvalidOut = false;
     settingsOut->identifierPrefix = kSeparatorIdentifierPrefix;
     settingsOut->width = width;
     settingsOut->separators.clear();
@@ -798,15 +800,22 @@ static bool ReadSeparatorStateFile(
     }
 
     LARGE_INTEGER size = {};
-    if (!GetFileSizeEx(file, &size) ||
-        size.QuadPart < 0 ||
-        size.QuadPart > 1024 * 1024) {
+    if (!GetFileSizeEx(file, &size)) {
         DWORD error = GetLastError();
         CloseHandle(file);
         Wh_Log(
-            L"[STATE] Invalid state-file size error=%u size=%lld",
-            error,
+            L"[STATE] GetFileSizeEx failed error=%u",
+            error);
+        return false;
+    }
+
+    if (size.QuadPart < 0 ||
+        size.QuadPart > 1024 * 1024) {
+        CloseHandle(file);
+        Wh_Log(
+            L"[STATE] Invalid state-file size=%lld",
             static_cast<long long>(size.QuadPart));
+        *contentInvalidOut = true;
         return false;
     }
 
@@ -855,6 +864,7 @@ static bool ReadSeparatorStateFile(
         if (!headerSeen) {
             if (line != "v1") {
                 Wh_Log(L"[STATE] Unsupported/corrupt separator state header");
+                *contentInvalidOut = true;
                 return false;
             }
             headerSeen = true;
@@ -864,6 +874,7 @@ static bool ReadSeparatorStateFile(
                 tab == 0 ||
                 tab + 1 >= line.size()) {
                 Wh_Log(L"[STATE] Malformed separator state row");
+                *contentInvalidOut = true;
                 return false;
             }
 
@@ -890,6 +901,7 @@ static bool ReadSeparatorStateFile(
                     &targetIndex) ||
                 targetIndex < -1) {
                 Wh_Log(L"[STATE] Invalid separator state row");
+                *contentInvalidOut = true;
                 return false;
             }
 
@@ -897,6 +909,7 @@ static bool ReadSeparatorStateFile(
                 kMaxSeparators) {
                 Wh_Log(
                     L"[STATE] Too many separators in state file");
+                *contentInvalidOut = true;
                 return false;
             }
 
@@ -909,6 +922,7 @@ static bool ReadSeparatorStateFile(
                 Wh_Log(
                     L"[STATE] Duplicate stable ID in state file: '%s'",
                     stableId.c_str());
+                *contentInvalidOut = true;
                 return false;
             }
 
@@ -936,6 +950,7 @@ static bool ReadSeparatorStateFile(
 
     if (!headerSeen) {
         Wh_Log(L"[STATE] Empty/corrupt separator state file");
+        *contentInvalidOut = true;
         return false;
     }
 
@@ -1285,12 +1300,18 @@ static bool LoadSettingsFromStorage(
         LoadSeparatorWidthSetting();
 
     bool stateExists = false;
+    bool contentInvalid = false;
     Settings settings;
 
     if (!ReadSeparatorStateFile(
             width,
             &settings,
-            &stateExists)) {
+            &stateExists,
+            &contentInvalid)) {
+        if (!contentInvalid) {
+            return false;
+        }
+
         Settings recovered;
         recovered.identifierPrefix =
             kSeparatorIdentifierPrefix;
@@ -1316,11 +1337,11 @@ static bool LoadSettingsFromStorage(
                     backupPath.c_str(),
                     MOVEFILE_WRITE_THROUGH)) {
                 Wh_Log(
-                    L"[STATE] Moved unreadable state file aside as '%s'",
+                    L"[STATE] Moved invalid state file aside as '%s'",
                     backupPath.c_str());
             } else {
                 Wh_Log(
-                    L"[STATE] Couldn't move unreadable state file aside "
+                    L"[STATE] Couldn't move invalid state file aside "
                     L"error=%u; recovery will retry persistence in place",
                     GetLastError());
             }
@@ -4118,6 +4139,7 @@ static bool RunTryMoveGroupObserver(
         outer &&
         result &&
         pinned &&
+        !appId.empty() &&
         oldIndex >= 0 &&
         newIndex >= 0 &&
         oldIndex != newIndex) {
@@ -4293,7 +4315,6 @@ static bool HookTaskbarDllSymbols(HMODULE taskbarDll) {
             },
             &g_taskGroupGetAppIdAddress,
             nullptr,
-            true,
         },
         {
             {
@@ -4301,7 +4322,6 @@ static bool HookTaskbarDllSymbols(HMODULE taskbarDll) {
             },
             &g_taskListWndIsPinned,
             nullptr,
-            true,
         },
         {
             {
@@ -4309,7 +4329,6 @@ static bool HookTaskbarDllSymbols(HMODULE taskbarDll) {
             },
             &g_taskListWndGetRelativeTaskOrder,
             nullptr,
-            true,
         },
         {
             {
@@ -4325,7 +4344,6 @@ static bool HookTaskbarDllSymbols(HMODULE taskbarDll) {
             },
             &g_taskListWndTryMoveGroupOriginal,
             TaskListWnd_TryMoveGroup_Hook,
-            true,
         },
         {
             {

--- a/mods/taskbar-icon-separators.wh.cpp
+++ b/mods/taskbar-icon-separators.wh.cpp
@@ -3594,6 +3594,7 @@ static void WINAPI TrayUI_StartTaskbar_Hook(void* pThis) {
 }
 
 static bool HookTaskbarLifecycleSymbols(HMODULE taskbarDll) {
+    // taskbar.dll
     WindhawkUtils::SYMBOL_HOOK taskbarLifecycleHooks[] = {
         {
             {

--- a/mods/taskbar-icon-separators.wh.cpp
+++ b/mods/taskbar-icon-separators.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-icon-separators
 // @name            Taskbar Icon Separators
 // @description     Create tracked icon separators with configurable padding on the taskbar.
-// @version         1.0.0
+// @version         1.0.1
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @license         GPL-3.0
@@ -181,26 +181,26 @@ static std::wstring g_storagePath;
 static std::wstring g_iconPath;
 static std::wstring g_separatorStatePath;
 
-// True after native reordering changes the in-memory taskbar layout and until
-// the drag-completion boundary persists the current separator state.
+// True after native state changes in memory and until the backend worker has
+// durably written the matching separator-state snapshot.
 static bool g_separatorStateDirty = false;  // guarded by g_settingsMutationMutex
 
 static std::atomic<bool> g_taskbarViewDllHooked = false;
-static std::atomic<bool> g_taskbarLifecycleHookInstalled = false;
-static std::atomic<bool> g_taskbarInteractionHooksInstalled = false;
+static std::atomic<bool> g_taskbarDllHooked = false;
+static std::atomic<bool> g_taskbarViewHookInstallationClaimed = false;
+static std::atomic<bool> g_taskbarDllHookInstallationClaimed = false;
+static std::atomic<unsigned int> g_hookInstallersInFlight = 0;
 static std::atomic<bool> g_loadLibraryWatcherInstalled = false;
 static std::atomic<bool> g_unloading = false;
 // Closed at the start of Wh_ModBeforeUninit, before the broader unloading flag
-// is set. This prevents late module-load callbacks from installing hooks while
-// separator cleanup still deliberately keeps styling hooks operational.
+// is set. This prevents late module-load callbacks from claiming new hook work.
 static std::atomic<bool> g_hookInstallationClosed = false;
 // True only while this mod intentionally tears down its own pins. User-facing
 // Add/Unpin callbacks must not mutate desired state during that window.
 static std::atomic<bool> g_internalCleanupInProgress = false;
+// This mutex protects only backend worker handles/lifetime. Hook installation
+// deliberately never takes it, especially from LoadLibraryExW_Hook.
 static std::mutex g_lifecycleMutex;
-static bool g_taskbarViewHookInstallationAttempted = false;
-static bool g_taskbarLifecycleHookInstallationAttempted = false;
-static bool g_taskbarInteractionHookInstallationAttempted = false;
 static bool g_backendStopped = false;
 static std::atomic<bool> g_backendHasConverged = false;
 static HANDLE g_backendThread = nullptr;
@@ -1563,7 +1563,8 @@ using TaskListButton_UpdateVisualStates_t = void(WINAPI*)(void* pThis);
 static TaskListButton_UpdateVisualStates_t
     g_taskListButtonUpdateVisualStatesOriginal;
 
-static void PersistPendingSeparatorState();
+static void QueueBackendWork();
+static void FlushPendingSeparatorStateSynchronously();
 
 using TaskListButton_OnDragCompletedGesture_t =
     void(WINAPI*)(void* pThis);
@@ -1576,7 +1577,18 @@ static void WINAPI TaskListButton_OnDragCompletedGesture_Hook(
         pThis);
 
     if (!g_unloading) {
-        PersistPendingSeparatorState();
+        bool stateDirty = false;
+        {
+            std::lock_guard<std::mutex> mutationLock(
+                g_settingsMutationMutex);
+            stateDirty = g_separatorStateDirty;
+        }
+
+        if (stateDirty) {
+            // The taskbar UI thread only signals work. The backend worker owns
+            // the durable write so drag completion never blocks on disk I/O.
+            QueueBackendWork();
+        }
     }
 }
 
@@ -2780,36 +2792,77 @@ static bool HookTaskbarViewDllSymbols(HMODULE module) {
 using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 static LoadLibraryExW_t g_loadLibraryExWOriginal;
 
-static bool HookTaskbarLifecycleSymbols(HMODULE taskbarDll);
-static bool HookTaskbarInteractionSymbols(HMODULE taskbarDll);
+static bool HookTaskbarDllSymbols(HMODULE taskbarDll);
 static HWND FindCurrentProcessTaskbarWnd();
 static void StartBackendWorker();
+
+class HookInstallerScope {
+public:
+    HookInstallerScope() {
+        if (g_hookInstallationClosed.load(std::memory_order_acquire)) {
+            return;
+        }
+
+        g_hookInstallersInFlight.fetch_add(
+            1,
+            std::memory_order_acq_rel);
+
+        // Close the race where unload begins between the first closed check and
+        // publishing this installer as in-flight.
+        if (g_hookInstallationClosed.load(std::memory_order_acquire)) {
+            g_hookInstallersInFlight.fetch_sub(
+                1,
+                std::memory_order_acq_rel);
+            return;
+        }
+
+        active_ = true;
+    }
+
+    ~HookInstallerScope() {
+        if (active_) {
+            g_hookInstallersInFlight.fetch_sub(
+                1,
+                std::memory_order_acq_rel);
+        }
+    }
+
+    explicit operator bool() const {
+        return active_;
+    }
+
+private:
+    bool active_ = false;
+};
+
+static void DrainHookInstallers() {
+    while (g_hookInstallersInFlight.load(
+               std::memory_order_acquire) != 0) {
+        SwitchToThread();
+    }
+}
 
 static bool InstallTaskbarViewHooks(
     HMODULE module,
     bool applyOperations) {
-    if (g_hookInstallationClosed.load(std::memory_order_acquire)) {
+    HookInstallerScope installer;
+    if (!installer || g_unloading) {
         return false;
     }
 
-    std::lock_guard<std::mutex> lock(g_lifecycleMutex);
-
-    // Re-check after taking the installation mutex. An unload can close the
-    // latch while this caller is waiting behind another installer.
-    if (g_hookInstallationClosed.load(std::memory_order_acquire) ||
-        g_unloading) {
-        return false;
-    }
-
-    if (g_taskbarViewDllHooked) {
+    if (g_taskbarViewDllHooked.load(std::memory_order_acquire)) {
         return true;
     }
 
-    if (g_taskbarViewHookInstallationAttempted) {
-        return false;
+    bool expected = false;
+    if (!g_taskbarViewHookInstallationClaimed.compare_exchange_strong(
+            expected,
+            true,
+            std::memory_order_acq_rel)) {
+        return g_taskbarViewDllHooked.load(std::memory_order_acquire);
     }
 
-    g_taskbarViewHookInstallationAttempted = true;
+    // No mod mutex is held while entering the Windhawk symbol/hook engine.
     if (!HookTaskbarViewDllSymbols(module)) {
         return false;
     }
@@ -2819,79 +2872,42 @@ static bool InstallTaskbarViewHooks(
         return false;
     }
 
-    g_taskbarViewDllHooked = true;
+    g_taskbarViewDllHooked.store(true, std::memory_order_release);
     return true;
 }
 
-static bool InstallTaskbarLifecycleHook(
+static bool InstallTaskbarDllHooks(
     HMODULE module,
     bool applyOperations) {
-    if (g_hookInstallationClosed.load(std::memory_order_acquire)) {
+    HookInstallerScope installer;
+    if (!installer || g_unloading) {
         return false;
     }
 
-    std::lock_guard<std::mutex> lock(g_lifecycleMutex);
-
-    if (g_hookInstallationClosed.load(std::memory_order_acquire) ||
-        g_unloading) {
-        return false;
-    }
-
-    if (g_taskbarLifecycleHookInstalled) {
+    if (g_taskbarDllHooked.load(std::memory_order_acquire)) {
         return true;
     }
 
-    if (g_taskbarLifecycleHookInstallationAttempted) {
-        return false;
+    bool expected = false;
+    if (!g_taskbarDllHookInstallationClaimed.compare_exchange_strong(
+            expected,
+            true,
+            std::memory_order_acq_rel)) {
+        return g_taskbarDllHooked.load(std::memory_order_acquire);
     }
 
-    g_taskbarLifecycleHookInstallationAttempted = true;
-    if (!HookTaskbarLifecycleSymbols(module)) {
+    // Resolve every taskbar.dll symbol in one HookSymbols call. Besides being
+    // faster, this avoids invalidating WindhawkUtils' per-module symbol cache.
+    if (!HookTaskbarDllSymbols(module)) {
         return false;
     }
 
     if (applyOperations && !Wh_ApplyHookOperations()) {
-        Wh_Log(L"[LIFECYCLE] Wh_ApplyHookOperations failed");
+        Wh_Log(L"[TASKBAR] Wh_ApplyHookOperations failed");
         return false;
     }
 
-    g_taskbarLifecycleHookInstalled = true;
-    return true;
-}
-
-static bool InstallTaskbarInteractionHooks(
-    HMODULE module,
-    bool applyOperations) {
-    if (g_hookInstallationClosed.load(std::memory_order_acquire)) {
-        return false;
-    }
-
-    std::lock_guard<std::mutex> lock(g_lifecycleMutex);
-
-    if (g_hookInstallationClosed.load(std::memory_order_acquire) ||
-        g_unloading) {
-        return false;
-    }
-
-    if (g_taskbarInteractionHooksInstalled) {
-        return true;
-    }
-
-    if (g_taskbarInteractionHookInstallationAttempted) {
-        return false;
-    }
-
-    g_taskbarInteractionHookInstallationAttempted = true;
-    if (!HookTaskbarInteractionSymbols(module)) {
-        return false;
-    }
-
-    if (applyOperations && !Wh_ApplyHookOperations()) {
-        Wh_Log(L"[INPUT] Wh_ApplyHookOperations failed");
-        return false;
-    }
-
-    g_taskbarInteractionHooksInstalled = true;
+    g_taskbarDllHooked.store(true, std::memory_order_release);
     return true;
 }
 
@@ -2920,23 +2936,15 @@ static HMODULE WINAPI LoadLibraryExW_Hook(
         InstallTaskbarViewHooks(module, true);
     }
 
-    if (GetModuleHandleW(L"taskbar.dll") == module) {
-        if (!g_taskbarLifecycleHookInstalled) {
-            Wh_Log(
-                L"[LIFECYCLE] taskbar.dll loaded; installing startup hook");
-            InstallTaskbarLifecycleHook(module, true);
-        }
+    if (!g_taskbarDllHooked.load(std::memory_order_acquire) &&
+        GetModuleHandleW(L"taskbar.dll") == module) {
+        Wh_Log(
+            L"[TASKBAR] taskbar.dll loaded; installing taskbar hooks");
+        InstallTaskbarDllHooks(module, true);
 
-        if (!g_taskbarInteractionHooksInstalled) {
-            Wh_Log(L"[INPUT] taskbar.dll loaded; installing interaction hooks");
-            InstallTaskbarInteractionHooks(module, true);
-        }
-
-        // Close the late-load race if the taskbar was created before the
-        // TrayUI::StartTaskbar hook became active.
-        if (FindCurrentProcessTaskbarWnd()) {
-            StartBackendWorker();
-        }
+        // Do not scan windows or create the backend worker from inside a
+        // LoadLibraryExW hook. TrayUI::StartTaskbar and Wh_ModAfterInit own
+        // backend readiness/startup outside the loader-lock-sensitive path.
     }
 
     return module;
@@ -3269,29 +3277,29 @@ static void ApplyPinnedMoveToSnapshot(
 // same state file directly.
 // -----------------------------------------------------------------------------
 
-static void PersistPendingSeparatorState() {
-    std::lock_guard<std::mutex> mutationLock(
-        g_settingsMutationMutex);
-
-    if (!g_separatorStateDirty ||
-        g_unloading) {
-        return;
-    }
-
+static void FlushPendingSeparatorStateSynchronously() {
     Settings snapshot;
-    {
-        std::shared_lock lock(g_settingsMutex);
-        snapshot = g_settings;
-    }
 
-    if (SaveSeparatorStateFile(snapshot)) {
-        g_separatorStateDirty = false;
-        Wh_Log(
-            L"[STATE] Persisted native taskbar reorder");
-    } else {
-        Wh_Log(
-            L"[STATE] Failed to persist native taskbar reorder; "
-            L"will retry on the next commit/unload");
+    {
+        std::lock_guard<std::mutex> mutationLock(
+            g_settingsMutationMutex);
+
+        if (!g_separatorStateDirty) {
+            return;
+        }
+
+        {
+            std::shared_lock lock(g_settingsMutex);
+            snapshot = g_settings;
+        }
+
+        // Teardown-only fallback. Live taskbar paths never call this function.
+        if (SaveSeparatorStateFile(snapshot)) {
+            g_separatorStateDirty = false;
+            Wh_Log(L"[STATE] Persisted pending separator state during teardown");
+        } else {
+            Wh_Log(L"[STATE] Failed to persist pending separator state during teardown");
+        }
     }
 }
 
@@ -3547,22 +3555,16 @@ static void RemoveSeparatorFromContextMenu(
             identity,
             removedIndex);
 
-        // State is authoritative. Persist the user's intent before touching the
-        // live pin list; a failed write leaves both desired and actual state
-        // unchanged.
-        if (!SaveSeparatorStateFile(updated)) {
-            Wh_Log(
-                L"[NATIVE-UNPIN] State write failed; separator kept identity='%s'",
-                identity.c_str());
-            return;
-        }
-
         {
             std::unique_lock lock(g_settingsMutex);
             g_settings = updated;
             g_backendHasConverged = false;
-            g_separatorStateDirty = false;
         }
+
+        // The backend worker persists this snapshot before it is allowed to
+        // unpin anything, preserving persist-before-mutate without blocking
+        // the taskbar UI thread on FlushFileBuffers/MoveFileEx.
+        g_separatorStateDirty = true;
     }
 
     Wh_Log(
@@ -3573,7 +3575,7 @@ static void RemoveSeparatorFromContextMenu(
     // Keep the old applied/stored snapshots until the backend has actually
     // unpinned the shortcut. That keeps the still-visible button recognized,
     // styled, and inert during the short convergence window.
-    RequestBackendReconcile();
+    QueueBackendWork();
 }
 
 using TrayUI_StartTaskbar_t =
@@ -3593,9 +3595,8 @@ static void WINAPI TrayUI_StartTaskbar_Hook(void* pThis) {
     StartBackendWorker();
 }
 
-static bool HookTaskbarLifecycleSymbols(HMODULE taskbarDll) {
-    // taskbar.dll
-    WindhawkUtils::SYMBOL_HOOK taskbarLifecycleHooks[] = {
+static bool HookTaskbarDllSymbols(HMODULE taskbarDll) {
+    WindhawkUtils::SYMBOL_HOOK taskbarDllHooks[] = {
         {
             {
                 LR"(public: virtual void __cdecl TrayUI::StartTaskbar(void))"
@@ -3603,28 +3604,13 @@ static bool HookTaskbarLifecycleSymbols(HMODULE taskbarDll) {
             &g_trayUIStartTaskbarOriginal,
             TrayUI_StartTaskbar_Hook,
         },
-    };
-
-    if (!WindhawkUtils::HookSymbols(
-            taskbarDll,
-            taskbarLifecycleHooks,
-            ARRAYSIZE(taskbarLifecycleHooks))) {
-        Wh_Log(L"[LIFECYCLE] HookSymbols(TrayUI::StartTaskbar) failed");
-        return false;
-    }
-
-    Wh_Log(L"[LIFECYCLE] Taskbar startup hook installed");
-    return true;
-}
-
-static bool HookTaskbarInteractionSymbols(HMODULE taskbarDll) {
-    WindhawkUtils::SYMBOL_HOOK taskbarDllHooks[] = {
         {
             {
                 LR"(public: virtual unsigned short const * __cdecl CTaskGroup::GetAppID(void))"
             },
             &g_taskGroupGetAppIdAddress,
             nullptr,
+            true,
         },
         {
             {
@@ -3632,6 +3618,7 @@ static bool HookTaskbarInteractionSymbols(HMODULE taskbarDll) {
             },
             &g_taskListWndIsPinned,
             nullptr,
+            true,
         },
         {
             {
@@ -3639,6 +3626,7 @@ static bool HookTaskbarInteractionSymbols(HMODULE taskbarDll) {
             },
             &g_taskListWndGetRelativeTaskOrder,
             nullptr,
+            true,
         },
         {
             {
@@ -3646,6 +3634,7 @@ static bool HookTaskbarInteractionSymbols(HMODULE taskbarDll) {
             },
             &g_taskListWndTryMoveGroupOriginal,
             TaskListWnd_TryMoveGroup_Hook,
+            true,
         },
         {
             {
@@ -3693,6 +3682,7 @@ static bool HookTaskbarInteractionSymbols(HMODULE taskbarDll) {
             },
             &g_taskListWndHandleClickOriginal,
             TaskListWnd_HandleClick_Hook,
+            true,
         },
         {
             {
@@ -3700,6 +3690,7 @@ static bool HookTaskbarInteractionSymbols(HMODULE taskbarDll) {
             },
             &g_taskListWndOnContextMenuOriginal,
             TaskListWnd_OnContextMenu_Hook,
+            true,
         },
         {
             {
@@ -3715,13 +3706,11 @@ static bool HookTaskbarInteractionSymbols(HMODULE taskbarDll) {
             taskbarDll,
             taskbarDllHooks,
             ARRAYSIZE(taskbarDllHooks))) {
-        Wh_Log(
-            L"[INPUT] HookSymbols(taskbar.dll) failed");
+        Wh_Log(L"[TASKBAR] HookSymbols(taskbar.dll) failed");
         return false;
     }
 
-    Wh_Log(L"[INPUT] Taskbar interaction hooks installed");
-
+    Wh_Log(L"[TASKBAR] taskbar.dll hooks installed in one symbol pass");
     return true;
 }
 
@@ -4123,24 +4112,13 @@ static bool PrepareSeparatorFiles(
     return true;
 }
 
-static bool InitializeTaskbarLifecycleHook() {
+static bool InitializeTaskbarDllHooks() {
     if (HMODULE taskbarDll = GetModuleHandleW(L"taskbar.dll")) {
-        return InstallTaskbarLifecycleHook(taskbarDll, false);
+        return InstallTaskbarDllHooks(taskbarDll, false);
     }
 
     Wh_Log(
-        L"[LIFECYCLE] taskbar.dll isn't loaded yet; "
-        L"installing LoadLibraryExW watcher");
-    return InstallLoadLibraryWatcher();
-}
-
-static bool InitializeTaskbarInteractionHooks() {
-    if (HMODULE taskbarDll = GetModuleHandleW(L"taskbar.dll")) {
-        return InstallTaskbarInteractionHooks(taskbarDll, false);
-    }
-
-    Wh_Log(
-        L"[INPUT] taskbar.dll isn't loaded yet; "
+        L"[TASKBAR] taskbar.dll isn't loaded yet; "
         L"installing LoadLibraryExW watcher");
     return InstallLoadLibraryWatcher();
 }
@@ -4632,55 +4610,124 @@ static DWORD WINAPI BackendThreadProc(void* parameter) {
     }
 
     for (;;) {
-        // A settings notification that arrived before this iteration is
-        // already represented by the snapshot we are about to take.
+        // A request that arrived before this iteration is represented by the
+        // snapshot we are about to take. A newer request arriving afterwards
+        // re-signals the manual-reset event and supersedes this pass.
         ResetEvent(wakeEvent);
 
         Settings settings;
         Settings appliedSettings;
         SeparatorSetting refreshPulse;
+        bool stateDirty = false;
 
         {
+            // Keep the established mutation->settings lock order, but only for
+            // the cheap in-memory snapshot. Disk I/O happens after both locks
+            // have been released.
+            std::lock_guard<std::mutex> mutationLock(
+                g_settingsMutationMutex);
             std::shared_lock lock(g_settingsMutex);
             settings = g_settings;
             appliedSettings = g_appliedSettings;
             refreshPulse = g_refreshPulseSetting;
+            stateDirty = g_separatorStateDirty;
         }
 
-        bool success =
-            ConvergeSeparatorPins(
-                settings,
-                appliedSettings,
-                refreshPulse);
+        bool stateReady = true;
+        if (stateDirty) {
+            stateReady = SaveSeparatorStateFile(settings);
 
-        if (success) {
-            {
-                std::unique_lock lock(g_settingsMutex);
-
-                // Record what the pin backend actually converged to. If only
-                // presentation/logging metadata changed while the backend was
-                // working, adopt the newer snapshot too because no additional
-                // PinManager work is required.
-                g_appliedSettings = settings;
-
-                if (!SettingsRequireBackendReconcile(
-                        settings,
-                        g_settings)) {
-                    g_appliedSettings = g_settings;
-                    g_backendHasConverged = true;
-                } else {
-                    g_backendHasConverged = false;
+            if (stateReady) {
+                bool snapshotStillCurrent = false;
+                {
+                    std::lock_guard<std::mutex> mutationLock(
+                        g_settingsMutationMutex);
+                    std::shared_lock lock(g_settingsMutex);
+                    snapshotStillCurrent =
+                        SettingsSnapshotsEqual(
+                            settings,
+                            g_settings);
+                    if (snapshotStillCurrent) {
+                        g_separatorStateDirty = false;
+                    }
                 }
-            }
 
-            RefreshStoredSeparatorSettings();
-        } else if (!IsBackendStopRequested()) {
-            g_backendHasConverged = false;
+                if (!snapshotStillCurrent) {
+                    Wh_Log(
+                        L"[STATE] Persisted snapshot was superseded; "
+                        L"writing the newer state next");
+                    continue;
+                }
+
+                Wh_Log(L"[STATE] Persisted separator state on backend worker");
+            } else if (!IsBackendStopRequested()) {
+                Wh_Log(
+                    L"[STATE] Failed to persist separator state; "
+                    L"PinManager convergence deferred");
+            }
+        }
+
+        if (IsBackendStopRequested()) {
+            break;
+        }
+
+        bool needsReconcile =
+            !g_backendHasConverged.load(std::memory_order_acquire) ||
+            SettingsRequireBackendReconcile(
+                appliedSettings,
+                settings);
+
+        bool success = stateReady;
+        if (stateReady && needsReconcile) {
+            success =
+                ConvergeSeparatorPins(
+                    settings,
+                    appliedSettings,
+                    refreshPulse);
+
+            if (success) {
+                {
+                    std::unique_lock lock(g_settingsMutex);
+
+                    // Record what the pin backend actually converged to. If
+                    // only presentation/logging metadata changed while it was
+                    // working, adopt the newer snapshot too because no further
+                    // PinManager work is required.
+                    g_appliedSettings = settings;
+
+                    if (!SettingsRequireBackendReconcile(
+                            settings,
+                            g_settings)) {
+                        g_appliedSettings = g_settings;
+                        g_backendHasConverged.store(
+                            true,
+                            std::memory_order_release);
+                    } else {
+                        g_backendHasConverged.store(
+                            false,
+                            std::memory_order_release);
+                    }
+                }
+
+                // Directory enumeration belongs to the worker as well. No
+                // taskbar UI callback scans mod storage anymore.
+                RefreshStoredSeparatorSettings();
+            }
+        }
+
+        if (!success && !IsBackendStopRequested()) {
+            g_backendHasConverged.store(
+                false,
+                std::memory_order_release);
 
             if (!IsBackendReconcileRequested()) {
-                Wh_Log(
-                    L"[SYNC] One or more separator operations failed; "
-                    L"waiting for another settings/retry request");
+                if (stateReady) {
+                    Wh_Log(L"[SYNC] One or more separator operations failed; "
+                          L"waiting for another settings/retry request");
+                } else {
+                    Wh_Log(L"[STATE] Waiting 1 second before retrying state persistence");
+                }
+            
             }
         }
 
@@ -4693,15 +4740,22 @@ static DWORD WINAPI BackendThreadProc(void* parameter) {
             wakeEvent,
         };
 
+        // Persistence failures get a bounded retry without spinning. Normal
+        // converged operation stays asleep until explicitly woken.
+        DWORD timeout = stateReady ? INFINITE : 1000;
         DWORD waitResult =
             WaitForMultipleObjects(
                 ARRAYSIZE(events),
                 events,
                 FALSE,
-                INFINITE);
+                timeout);
 
         if (waitResult == WAIT_OBJECT_0) {
             break;
+        }
+
+        if (waitResult == WAIT_TIMEOUT && !stateReady) {
+            continue;
         }
 
         if (waitResult != WAIT_OBJECT_0 + 1) {
@@ -4942,6 +4996,32 @@ static void RequestBackendReconcile() {
 }
 
 
+static bool SignalBackendWorker() {
+    std::lock_guard<std::mutex> lock(g_lifecycleMutex);
+
+    if (g_unloading || g_backendStopped ||
+        !g_backendThread || !g_backendWakeEvent) {
+        return false;
+    }
+
+    if (WaitForSingleObject(
+            g_backendThread,
+            0) != WAIT_TIMEOUT) {
+        return false;
+    }
+
+    return SetEvent(g_backendWakeEvent) != FALSE;
+}
+
+static void QueueBackendWork() {
+    // Native taskbar callbacks normally arrive after TrayUI::StartTaskbar, so
+    // the hot path is a single SetEvent. Fall back to the existing worker
+    // readiness logic only if the worker is unexpectedly absent.
+    if (!SignalBackendWorker()) {
+        RequestBackendReconcile();
+    }
+}
+
 static void AddSeparatorFromTaskbarMenu() {
     if (g_unloading ||
         g_internalCleanupInProgress.load()) {
@@ -4990,27 +5070,21 @@ static void AddSeparatorFromTaskbarMenu() {
             stableId),
     });
 
-    // Persist before publishing the desired state. If storage fails, no pin is
-    // created and the taskbar remains unchanged.
-    if (!SaveSeparatorStateFile(updated)) {
-        Wh_Log(
-            L"[NATIVE-ADD] State write failed; separator not added");
-        return;
-    }
-
     {
         std::unique_lock lock(g_settingsMutex);
         g_settings = updated;
         g_backendHasConverged = false;
-        g_separatorStateDirty = false;
     }
+
+    // Publish the desired state immediately, but let the backend worker make
+    // it durable before PinManager is allowed to create the new pin.
+    g_separatorStateDirty = true;
 
     Wh_Log(
         L"[NATIVE-ADD] Added separator identity='%s' at native end",
         updated.separators.back().identity.c_str());
 
-    RefreshStoredSeparatorSettings();
-    RequestBackendReconcile();
+    QueueBackendWork();
 }
 
 static void StopBackendWorker() {
@@ -5108,21 +5182,14 @@ BOOL ExplorerModInit() {
         return FALSE;
     }
 
-    RefreshStoredSeparatorSettings();
-
     if (!InitializeTaskbarStylingHooks()) {
         Wh_Log(
             L"[INIT] TaskListButton styling hooks unavailable");
     }
 
-    if (!InitializeTaskbarLifecycleHook()) {
+    if (!InitializeTaskbarDllHooks()) {
         Wh_Log(
-            L"[INIT] Taskbar startup hook unavailable");
-    }
-
-    if (!InitializeTaskbarInteractionHooks()) {
-        Wh_Log(
-            L"[INIT] Taskbar interaction hooks unavailable");
+            L"[INIT] taskbar.dll hooks unavailable");
     }
 
     // Hook operations installed during Wh_ModInit are applied automatically
@@ -5140,15 +5207,9 @@ void ExplorerModAfterInit() {
         }
     }
 
-    // Lifecycle and interaction hooks are independent. A symbol change in one
-    // family must not gate the other or the PinManager backend.
-    if (HMODULE module = GetModuleHandleW(L"taskbar.dll")) {
-        if (!g_taskbarLifecycleHookInstalled) {
-            InstallTaskbarLifecycleHook(module, true);
-        }
-
-        if (!g_taskbarInteractionHooksInstalled) {
-            InstallTaskbarInteractionHooks(module, true);
+    if (!g_taskbarDllHooked.load(std::memory_order_acquire)) {
+        if (HMODULE module = GetModuleHandleW(L"taskbar.dll")) {
+            InstallTaskbarDllHooks(module, true);
         }
     }
 
@@ -5164,22 +5225,19 @@ void ExplorerModAfterInit() {
 
 void ExplorerModBeforeUninit() {
     // Hook APIs are legal only until this callback returns. Close every late
-    // installation path first, then use the same mutex as the installers as a
-    // drain barrier. Once the lock is acquired, any installer that entered
-    // before the latch closed has finished; later callers fail both checks.
+    // installation path first, then wait only for installers that had already
+    // entered the Windhawk hook engine. No mod mutex participates in that path.
     g_hookInstallationClosed.store(true, std::memory_order_release);
-    {
-        std::lock_guard<std::mutex> lock(g_lifecycleMutex);
-    }
+    DrainHookInstallers();
 
-    // A completed native reorder should already have been persisted by
-    // OnDragCompletedGesture. This is a final no-timer fallback for a missed
-    // completion callback or a shutdown that lands mid-drag.
-    PersistPendingSeparatorState();
-
-    // Join the worker first, then remove pins while the styling and input
-    // hooks can still keep a transient recovery pin styled and inert.
+    // Join the worker first so there can be no concurrent state-file writer.
+    // Then perform one teardown-only synchronous durability fallback for a
+    // missed drag-completion signal or an in-flight native mutation.
     StopBackendWorker();
+    FlushPendingSeparatorStateSynchronously();
+
+    // Remove pins while the styling and input hooks can still keep a transient
+    // recovery pin styled and inert.
     g_internalCleanupInProgress = true;
     CleanupSeparatorArtifacts(true);
 
@@ -5196,9 +5254,9 @@ void ExplorerModUninit() {
     Wh_Log(L"[UNINIT] Taskbar Icon Separators unloading");
 
     // Defensive in case an older Windhawk build skips Wh_ModBeforeUninit.
-    PersistPendingSeparatorState();
     g_unloading = true;
     StopBackendWorker();
+    FlushPendingSeparatorStateSynchronously();
 
     // Defensive fallback for Windhawk builds that skip Wh_ModBeforeUninit.
     // Hooks may already be gone here, so never recover an absent pin by

--- a/mods/taskbar-icon-separators.wh.cpp
+++ b/mods/taskbar-icon-separators.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-icon-separators
 // @name            Taskbar Icon Separators
 // @description     Create tracked icon separators with configurable padding on the taskbar.
-// @version         1.0.1
+// @version         1.0.2
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @license         GPL-3.0
@@ -2758,6 +2758,7 @@ static bool HookTaskbarViewDllSymbols(HMODULE module) {
             },
             &g_taskListButtonOnContextRequestedOriginal,
             TaskListButton_OnContextRequested_Hook,
+            true,
         },
         {
             {
@@ -2765,6 +2766,7 @@ static bool HookTaskbarViewDllSymbols(HMODULE module) {
             },
             &g_taskListButtonHandlersHandleContextRequestedOriginal,
             TaskListButtonHandlers_HandleContextRequested_Hook,
+            true,
         },
         {
             {
@@ -2781,6 +2783,22 @@ static bool HookTaskbarViewDllSymbols(HMODULE module) {
             taskbarViewHooks,
             ARRAYSIZE(taskbarViewHooks))) {
         Wh_Log(L"[STYLE] HookSymbols(Taskbar view) failed");
+        return false;
+    }
+
+    const bool hasContextRequestRoute =
+        g_taskListButtonOnContextRequestedOriginal ||
+        g_taskListButtonHandlersHandleContextRequestedOriginal ||
+        g_taskbarResourcesOnTaskListButtonContextRequestedOriginal;
+
+    Wh_Log(
+        L"[STYLE] Context routes: button=%d handlers=%d resources=%d",
+        g_taskListButtonOnContextRequestedOriginal ? 1 : 0,
+        g_taskListButtonHandlersHandleContextRequestedOriginal ? 1 : 0,
+        g_taskbarResourcesOnTaskListButtonContextRequestedOriginal ? 1 : 0);
+
+    if (!hasContextRequestRoute) {
+        Wh_Log(L"[STYLE] No supported Taskbar.View context-request route resolved");
         return false;
     }
 
@@ -2836,9 +2854,22 @@ private:
 };
 
 static void DrainHookInstallers() {
+    constexpr ULONGLONG kDrainTimeoutMs = 2000;
+    constexpr DWORD kDrainSleepMs = 5;
+
+    const ULONGLONG started = GetTickCount64();
     while (g_hookInstallersInFlight.load(
-               std::memory_order_acquire) != 0) {
-        SwitchToThread();
+               std::memory_order_acquire) != 0 &&
+           GetTickCount64() - started < kDrainTimeoutMs) {
+        Sleep(kDrainSleepMs);
+    }
+
+    const unsigned int remaining =
+        g_hookInstallersInFlight.load(std::memory_order_acquire);
+    if (remaining != 0) {
+        Wh_Log(
+            L"[HOOK] Timed out draining %u in-flight hook installer(s); proceeding with unload",
+            remaining);
     }
 }
 
@@ -2864,6 +2895,13 @@ static bool InstallTaskbarViewHooks(
 
     // No mod mutex is held while entering the Windhawk symbol/hook engine.
     if (!HookTaskbarViewDllSymbols(module)) {
+        return false;
+    }
+
+    // If unload started while symbol resolution was in progress, don't enter
+    // another engine operation from this late installer.
+    if (g_hookInstallationClosed.load(std::memory_order_acquire) ||
+        g_unloading) {
         return false;
     }
 
@@ -2899,6 +2937,11 @@ static bool InstallTaskbarDllHooks(
     // Resolve every taskbar.dll symbol in one HookSymbols call. Besides being
     // faster, this avoids invalidating WindhawkUtils' per-module symbol cache.
     if (!HookTaskbarDllSymbols(module)) {
+        return false;
+    }
+
+    if (g_hookInstallationClosed.load(std::memory_order_acquire) ||
+        g_unloading) {
         return false;
     }
 
@@ -3272,9 +3315,9 @@ static void ApplyPinnedMoveToSnapshot(
 //
 // Windhawk no longer owns separator position/list configuration. TryMoveGroup
 // mirrors native reorder operations into the in-memory separator state. The
-// Taskbar.View drag-completion hook persists that state exactly once when the
-// drag ends. Add and Unpin have their own discrete commit points and save the
-// same state file directly.
+// Taskbar.View drag-completion hook queues one backend persistence pass when
+// the drag ends. Add and Unpin have their own discrete commit points and queue
+// the same worker; live taskbar UI callbacks never perform synchronous disk I/O.
 // -----------------------------------------------------------------------------
 
 static void FlushPendingSeparatorStateSynchronously() {
@@ -4609,6 +4652,18 @@ static DWORD WINAPI BackendThreadProc(void* parameter) {
         return 0;
     }
 
+    // A failed state write is retried with bounded exponential backoff. After
+    // the final retry, stay asleep until a fresh explicit wake (Add/Remove/
+    // drag/settings/lifecycle) rather than hammering the storage path forever.
+    static constexpr DWORD kStateWriteRetryDelaysMs[] = {
+        250,
+        500,
+        1000,
+        2000,
+        4000,
+    };
+    size_t stateWriteFailureCount = 0;
+
     for (;;) {
         // A request that arrived before this iteration is represented by the
         // snapshot we are about to take. A newer request arriving afterwards
@@ -4638,6 +4693,8 @@ static DWORD WINAPI BackendThreadProc(void* parameter) {
             stateReady = SaveSeparatorStateFile(settings);
 
             if (stateReady) {
+                stateWriteFailureCount = 0;
+
                 bool snapshotStillCurrent = false;
                 {
                     std::lock_guard<std::mutex> mutationLock(
@@ -4661,10 +4718,14 @@ static DWORD WINAPI BackendThreadProc(void* parameter) {
 
                 Wh_Log(L"[STATE] Persisted separator state on backend worker");
             } else if (!IsBackendStopRequested()) {
+                stateWriteFailureCount++;
                 Wh_Log(
-                    L"[STATE] Failed to persist separator state; "
-                    L"PinManager convergence deferred");
+                    L"[STATE] Failed to persist separator state (failure %zu); "
+                    L"PinManager convergence deferred",
+                    stateWriteFailureCount);
             }
+        } else {
+            stateWriteFailureCount = 0;
         }
 
         if (IsBackendStopRequested()) {
@@ -4722,12 +4783,21 @@ static DWORD WINAPI BackendThreadProc(void* parameter) {
 
             if (!IsBackendReconcileRequested()) {
                 if (stateReady) {
-                    Wh_Log(L"[SYNC] One or more separator operations failed; "
-                          L"waiting for another settings/retry request");
+                    Wh_Log(
+                        L"[SYNC] One or more separator operations failed; "
+                        L"waiting for another settings/retry request");
+                } else if (
+                    stateWriteFailureCount <=
+                    ARRAYSIZE(kStateWriteRetryDelaysMs)) {
+                    Wh_Log(
+                        L"[STATE] Retrying state persistence in %u ms",
+                        kStateWriteRetryDelaysMs[
+                            stateWriteFailureCount - 1]);
                 } else {
-                    Wh_Log(L"[STATE] Waiting 1 second before retrying state persistence");
+                    Wh_Log(
+                        L"[STATE] State persistence retry limit reached; "
+                        L"waiting for the next explicit wake");
                 }
-            
             }
         }
 
@@ -4740,9 +4810,16 @@ static DWORD WINAPI BackendThreadProc(void* parameter) {
             wakeEvent,
         };
 
-        // Persistence failures get a bounded retry without spinning. Normal
-        // converged operation stays asleep until explicitly woken.
-        DWORD timeout = stateReady ? INFINITE : 1000;
+        DWORD timeout = INFINITE;
+        if (!stateReady &&
+            stateWriteFailureCount > 0 &&
+            stateWriteFailureCount <=
+                ARRAYSIZE(kStateWriteRetryDelaysMs)) {
+            timeout =
+                kStateWriteRetryDelaysMs[
+                    stateWriteFailureCount - 1];
+        }
+
         DWORD waitResult =
             WaitForMultipleObjects(
                 ARRAYSIZE(events),
@@ -4758,13 +4835,17 @@ static DWORD WINAPI BackendThreadProc(void* parameter) {
             continue;
         }
 
-        if (waitResult != WAIT_OBJECT_0 + 1) {
-            Wh_Log(
-                L"[SYNC] Backend wait failed result=0x%08X error=%u",
-                waitResult,
-                GetLastError());
-            break;
+        if (waitResult == WAIT_OBJECT_0 + 1) {
+            // A real user/settings/lifecycle request gets a fresh retry budget.
+            stateWriteFailureCount = 0;
+            continue;
         }
+
+        Wh_Log(
+            L"[SYNC] Backend wait failed result=0x%08X error=%u",
+            waitResult,
+            GetLastError());
+        break;
     }
 
     CoUninitialize();
@@ -5225,8 +5306,9 @@ void ExplorerModAfterInit() {
 
 void ExplorerModBeforeUninit() {
     // Hook APIs are legal only until this callback returns. Close every late
-    // installation path first, then wait only for installers that had already
-    // entered the Windhawk hook engine. No mod mutex participates in that path.
+    // installation path first, then give already-entered installers a short,
+    // bounded chance to leave the Windhawk hook engine. Never block unload
+    // indefinitely waiting on engine work from another thread.
     g_hookInstallationClosed.store(true, std::memory_order_release);
     DrainHookInstallers();
 

--- a/mods/taskbar-icon-separators.wh.cpp
+++ b/mods/taskbar-icon-separators.wh.cpp
@@ -1273,10 +1273,13 @@ static bool MigrateLegacySeparatorState(
 
 static bool LoadSettingsFromStorage(
     Settings* settingsOut,
-    SeparatorSetting* refreshPulseOut) {
-    if (!settingsOut || !refreshPulseOut) {
+    SeparatorSetting* refreshPulseOut,
+    bool* stateNeedsSaveOut) {
+    if (!settingsOut || !refreshPulseOut || !stateNeedsSaveOut) {
         return false;
     }
+
+    *stateNeedsSaveOut = false;
 
     double width =
         LoadSeparatorWidthSetting();
@@ -1288,7 +1291,48 @@ static bool LoadSettingsFromStorage(
             width,
             &settings,
             &stateExists)) {
-        return false;
+        Settings recovered;
+        recovered.identifierPrefix =
+            kSeparatorIdentifierPrefix;
+        recovered.width = width;
+
+        if (!AdoptLegacySeparatorShortcuts(&recovered)) {
+            Wh_Log(
+                L"[STATE] State recovery couldn't adopt every owned shortcut");
+            return false;
+        }
+
+        DWORD attributes =
+            GetFileAttributesW(g_separatorStatePath.c_str());
+        if (attributes != INVALID_FILE_ATTRIBUTES &&
+            !(attributes & FILE_ATTRIBUTE_DIRECTORY)) {
+            std::wstring backupPath =
+                g_separatorStatePath +
+                L".invalid-" +
+                std::to_wstring(GetTickCount64());
+
+            if (MoveFileExW(
+                    g_separatorStatePath.c_str(),
+                    backupPath.c_str(),
+                    MOVEFILE_WRITE_THROUGH)) {
+                Wh_Log(
+                    L"[STATE] Moved unreadable state file aside as '%s'",
+                    backupPath.c_str());
+            } else {
+                Wh_Log(
+                    L"[STATE] Couldn't move unreadable state file aside "
+                    L"error=%u; recovery will retry persistence in place",
+                    GetLastError());
+            }
+        }
+
+        settings = std::move(recovered);
+        stateExists = true;
+        *stateNeedsSaveOut = true;
+
+        Wh_Log(
+            L"[STATE] Recovered %zu separator(s) from owned shortcuts",
+            settings.separators.size());
     }
 
     if (!stateExists &&
@@ -1578,10 +1622,12 @@ static bool WriteBinaryFile(
 static bool LoadSettings() {
     Settings settings;
     SeparatorSetting refreshPulse;
+    bool stateNeedsSave = false;
 
     if (!LoadSettingsFromStorage(
             &settings,
-            &refreshPulse)) {
+            &refreshPulse,
+            &stateNeedsSave)) {
         Wh_Log(L"[STATE] Failed to load separator state");
         return false;
     }
@@ -1592,7 +1638,7 @@ static bool LoadSettings() {
     g_refreshPulseSetting =
         std::move(refreshPulse);
     g_storedSeparatorSettings.clear();
-    g_separatorStateDirty = false;
+    g_separatorStateDirty = stateNeedsSave;
     return true;
 }
 
@@ -1715,14 +1761,11 @@ static void WINAPI TaskListButton_OnDragCompletedGesture_Hook(
         }
 
         if (stateDirty) {
-            // Refresh presentation only after the native drag has completely
-            // unwound. This closes an unanchored separator's persistent guide
-            // as soon as TryMoveGroup has assigned its first concrete index.
+            // Persistence was already queued by TryMoveGroup. This optional
+            // completion callback only refreshes presentation after the native
+            // drag has completely unwound, closing an unanchored separator's
+            // guide once it has its first concrete index.
             RefreshTrackedSeparatorVisualStates();
-
-            // The taskbar UI thread only signals work. The backend worker owns
-            // the durable write so drag completion never blocks on disk I/O.
-            QueueBackendWork();
         }
 
     }
@@ -2537,7 +2580,75 @@ static bool RunFromWindowThread(
     return parameters.executed;
 }
 
+// XAML owns menu items and their delegates beyond the hook invocation that
+// creates them. Retain the exact objects/tokens on their taskbar UI thread so
+// teardown can unregister every mod-owned delegate before the DLL is unmapped.
+static thread_local winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem
+    g_injectedAddSeparatorMenuItem{nullptr};
+static thread_local winrt::event_token
+    g_injectedAddSeparatorClickToken{};
+static thread_local winrt::Windows::UI::Xaml::Controls::MenuFlyout
+    g_openSeparatorContextMenu{nullptr};
+static thread_local winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem
+    g_openSeparatorContextMenuItem{nullptr};
+static thread_local winrt::event_token
+    g_openSeparatorContextMenuClickToken{};
+static thread_local winrt::event_token
+    g_openSeparatorContextMenuClosedToken{};
+static std::atomic<bool> g_separatorContextMenuOpen = false;
+
+static void DetachInjectedAddSeparatorMenuHandler() {
+    try {
+        if (g_injectedAddSeparatorMenuItem) {
+            g_injectedAddSeparatorMenuItem.Click(
+                g_injectedAddSeparatorClickToken);
+        }
+    } catch (...) {
+        Wh_Log(L"[CTX] Failed to detach Add separator menu handler");
+    }
+    g_injectedAddSeparatorMenuItem = nullptr;
+    g_injectedAddSeparatorClickToken = {};
+}
+
+static void CloseSeparatorContextMenuOnCurrentThread(bool hide) {
+    try {
+        if (g_openSeparatorContextMenuItem) {
+            g_openSeparatorContextMenuItem.Click(
+                g_openSeparatorContextMenuClickToken);
+        }
+    } catch (...) {
+        Wh_Log(L"[CTX] Failed to detach separator menu command");
+    }
+
+    try {
+        if (g_openSeparatorContextMenu) {
+            g_openSeparatorContextMenu.Closed(
+                g_openSeparatorContextMenuClosedToken);
+        }
+    } catch (...) {
+        Wh_Log(L"[CTX] Failed to detach separator menu close handler");
+    }
+
+    if (hide) {
+        try {
+            if (g_openSeparatorContextMenu) {
+                g_openSeparatorContextMenu.Hide();
+            }
+        } catch (...) {
+            Wh_Log(L"[CTX] Failed to hide separator context menu");
+        }
+    }
+    g_openSeparatorContextMenuItem = nullptr;
+    g_openSeparatorContextMenu = nullptr;
+    g_openSeparatorContextMenuClickToken = {};
+    g_openSeparatorContextMenuClosedToken = {};
+}
+
 static void WINAPI RestoreSeparatorVisualStatesOnCurrentThread(void*) {
+    DetachInjectedAddSeparatorMenuHandler();
+    CloseSeparatorContextMenuOnCurrentThread(true);
+    g_separatorContextMenuOpen = false;
+
     g_updatingSeparatorVisualStates = true;
     SeparatorVisualStateUpdateGuard updateGuard;
     PruneExpiredSeparatorVisualStates();
@@ -2740,6 +2851,10 @@ static MenuFlyoutItemBaseVector_Append_t
 static void AppendAddSeparatorMenuItems(void* vectorThis) {
     using namespace winrt::Windows::UI::Xaml::Controls;
 
+    // A newer taskbar-menu build supersedes the previous injected item on this
+    // UI thread. Detach its callback before replacing our retained reference.
+    DetachInjectedAddSeparatorMenuHandler();
+
     MenuFlyoutItem item;
     item.Name(kAddSeparatorMenuName);
     item.Tag(winrt::box_value(winrt::hstring{kAddSeparatorMenuName}));
@@ -2752,7 +2867,9 @@ static void AppendAddSeparatorMenuItems(void* vectorThis) {
     icon.Glyph(L"\xE710");
     icon.FontSize(16);
     item.Icon(icon);
-    item.Click(RoutedEventHandler{&OnAddSeparatorMenuClick});
+    winrt::event_token clickToken =
+        item.Click(
+            RoutedEventHandler{&OnAddSeparatorMenuClick});
 
     MenuFlyoutSeparator divider;
     divider.Name(kAddSeparatorMenuDividerName);
@@ -2761,6 +2878,8 @@ static void AppendAddSeparatorMenuItems(void* vectorThis) {
             winrt::hstring{kAddSeparatorMenuDividerName}));
 
     g_menuFlyoutItemBaseVectorAppendOriginal(vectorThis, item);
+    g_injectedAddSeparatorMenuItem = item;
+    g_injectedAddSeparatorClickToken = clickToken;
     g_menuFlyoutItemBaseVectorAppendOriginal(vectorThis, divider);
 
     g_taskbarSettingsMenuInjected = true;
@@ -2861,14 +2980,13 @@ using TaskbarResources_OnTaskListButtonContextRequested_t =
 static TaskbarResources_OnTaskListButtonContextRequested_t
     g_taskbarResourcesOnTaskListButtonContextRequestedOriginal;
 
-static std::atomic<bool> g_separatorContextMenuOpen = false;
-
 static void RemoveSeparatorFromContextMenu(
     std::wstring identity);
 
 static void OnSeparatorContextMenuClosed(
     winrt::Windows::Foundation::IInspectable const&,
     winrt::Windows::Foundation::IInspectable const&) {
+    CloseSeparatorContextMenuOnCurrentThread(false);
     g_separatorContextMenuOpen = false;
 }
 
@@ -2926,6 +3044,11 @@ static void ShowSeparatorContextMenu(
         return;
     }
 
+    // The click callback releases the process-wide gate before XAML always
+    // delivers Closed. If this UI thread still owns that older menu, retire it
+    // before publishing a replacement.
+    CloseSeparatorContextMenuOnCurrentThread(true);
+
     try {
         using namespace winrt::Windows::UI::Xaml::Controls;
         using namespace winrt::Windows::UI::Xaml::Controls::Primitives;
@@ -2947,21 +3070,31 @@ static void ShowSeparatorContextMenu(
         icon.Glyph(L"\xE738");
         icon.FontSize(16);
         unpin.Icon(icon);
-        unpin.Click(
-            RoutedEventHandler{
-                &OnSeparatorUnpinMenuClick});
+        winrt::event_token clickToken =
+            unpin.Click(
+                RoutedEventHandler{
+                    &OnSeparatorUnpinMenuClick});
 
         menu.Items().Append(unpin);
-        menu.Closed(
-            winrt::Windows::Foundation::
-                EventHandler<winrt::Windows::Foundation::IInspectable>{
-                    &OnSeparatorContextMenuClosed});
+        winrt::event_token closedToken =
+            menu.Closed(
+                winrt::Windows::Foundation::
+                    EventHandler<winrt::Windows::Foundation::IInspectable>{
+                        &OnSeparatorContextMenuClosed});
+
+        // Publish ownership before ShowAt: if XAML partially opens the flyout
+        // and then throws, the catch path can still detach both delegates.
+        g_openSeparatorContextMenu = menu;
+        g_openSeparatorContextMenuItem = unpin;
+        g_openSeparatorContextMenuClickToken = clickToken;
+        g_openSeparatorContextMenuClosedToken = closedToken;
 
         menu.ShowAt(target);
         Wh_Log(
             L"[CTX] Opened separator context menu identity='%s'",
             separator.identity.c_str());
     } catch (...) {
+        CloseSeparatorContextMenuOnCurrentThread(true);
         g_separatorContextMenuOpen = false;
         Wh_Log(L"[CTX] Failed to show separator context menu");
     }
@@ -3124,7 +3257,6 @@ static bool HookTaskbarViewDllSymbols(HMODULE module) {
             },
             &g_contextMenusShowTaskbarSettingsContextMenuOriginal,
             ContextMenus_ShowTaskbarSettingsContextMenu_Hook,
-            true,
         },
         {
             {
@@ -3132,7 +3264,6 @@ static bool HookTaskbarViewDllSymbols(HMODULE module) {
             },
             &g_menuFlyoutItemBaseVectorAppendOriginal,
             MenuFlyoutItemBaseVector_Append_Hook,
-            true,
         },
         {
             {
@@ -3180,6 +3311,13 @@ static bool HookTaskbarViewDllSymbols(HMODULE module) {
             taskbarViewHooks,
             ARRAYSIZE(taskbarViewHooks))) {
         Wh_Log(L"[STYLE] HookSymbols(Taskbar view) failed");
+        return false;
+    }
+
+    if (!g_contextMenusShowTaskbarSettingsContextMenuOriginal ||
+        !g_menuFlyoutItemBaseVectorAppendOriginal) {
+        Wh_Log(
+            L"[STYLE] Add-separator taskbar menu route unavailable");
         return false;
     }
 
@@ -3812,10 +3950,11 @@ static HRESULT WINAPI TaskListWnd_HandleWinNumHotKey_Hook(
 // Native taskbar mutation persistence.
 //
 // Windhawk no longer owns separator position/list configuration. TryMoveGroup
-// mirrors native reorder operations into the in-memory separator state. The
-// Taskbar.View drag-completion hook queues one backend persistence pass when
-// the drag ends. Add and Unpin have their own discrete commit points and queue
-// the same worker; live taskbar UI callbacks never perform synchronous disk I/O.
+// mirrors native reorder operations into the in-memory separator state and
+// immediately queues the backend persistence pass. The optional Taskbar.View
+// drag-completion hook only refreshes presentation. Add and Remove have their
+// own discrete commit points and queue the same worker; live taskbar UI
+// callbacks never perform synchronous disk I/O.
 // -----------------------------------------------------------------------------
 
 static void FlushPendingSeparatorStateSynchronously() {
@@ -3854,13 +3993,12 @@ static void RecordNativePinnedMove(
         return;
     }
 
-    std::lock_guard<std::mutex> mutationLock(
-        g_settingsMutationMutex);
-
     bool touchesSeparator = false;
 
     {
-        std::unique_lock lock(g_settingsMutex);
+        std::lock_guard<std::mutex> mutationLock(
+            g_settingsMutationMutex);
+        std::unique_lock settingsLock(g_settingsMutex);
 
         Settings before = g_settings;
 
@@ -3919,6 +4057,10 @@ static void RecordNativePinnedMove(
         std::wstring(movedAppId).c_str(),
         oldIndex,
         newIndex);
+
+    // Persist through the long-lived worker even if the optional
+    // OnDragCompletedGesture presentation callback isn't available.
+    QueueBackendWork();
 }
 
 static bool RunTryMoveGroupObserver(

--- a/mods/taskbar-icon-separators.wh.cpp
+++ b/mods/taskbar-icon-separators.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-icon-separators
 // @name            Taskbar Icon Separators
 // @description     Create tracked icon separators with configurable padding on the taskbar.
-// @version         1.0.2
+// @version         1.0.13
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @license         GPL-3.0
@@ -29,10 +29,12 @@ Separators remain genuine, can be manually reordered, and can also be created fr
 Note: The mod creates pinned shortcuts targeting Windows `systray.exe` (with fallback) and reorders the persisted taskbar pin list. 
 Cleanup is best-effort; in the worst failure case, manual taskbar unpinning and reordering may be required.
 
-Separator properties are stored by the mod itself
-inside its Windhawk mod-storage directory. Windhawk settings expose only the
-global separator width. Native Add, drag/reorder, and Unpin operations update
- are persisted directly.
+Add separators from the taskbar context menu and drag them into place; positions
+are saved automatically. A newly added, unanchored separator keeps a small
+"Drag to anchor this separator" guide attached above it until it is moved once; the guide is attached directly to the live TaskListButton with Popup.PlacementTarget, so Windows keeps it aligned through dragging and taskbar relayouts.
+Right-click a separator to remove it. Windhawk settings expose only the global separator width.
+Win+1 through Win+0 taskbar shortcuts automatically skip anchored separator slots
+when selecting their numbered app.
 
 Windows 11 only.
 */
@@ -59,6 +61,8 @@ Windows 11 only.
 
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.UI.h>
+#include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Xaml.h>
 #include <winrt/Windows.UI.Xaml.Automation.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
@@ -76,6 +80,7 @@ Windows 11 only.
 #include <mutex>
 #include <shared_mutex>
 #include <new>
+#include <optional>
 #include <cstdlib>
 #include <string>
 #include <string_view>
@@ -497,6 +502,31 @@ static bool IsValidStableId(std::wstring_view value) {
                    ch == L'-' || ch == L'_';
         });
 }
+
+static std::optional<std::wstring> ExtractStableIdFromSeparatorIdentity(
+    std::wstring_view identity) {
+    static const std::wstring marker =
+        std::wstring(L".") +
+        kSeparatorIdentitySuffix +
+        L".";
+
+    size_t markerPosition =
+        identity.rfind(marker);
+    if (markerPosition == std::wstring_view::npos) {
+        return std::nullopt;
+    }
+
+    std::wstring_view stableId =
+        identity.substr(
+            markerPosition + marker.size());
+
+    if (!IsValidStableId(stableId)) {
+        return std::nullopt;
+    }
+
+    return std::wstring(stableId);
+}
+
 
 static bool ParseWideInt(
     std::wstring_view text,
@@ -1036,6 +1066,96 @@ static double LoadSeparatorWidthSetting() {
     return static_cast<double>(width);
 }
 
+static bool AdoptLegacySeparatorShortcuts(
+    Settings* settings) {
+    if (!settings) {
+        return false;
+    }
+
+    const auto shortcutPaths =
+        EnumerateSeparatorShortcuts();
+
+    if (shortcutPaths.empty()) {
+        return true;
+    }
+
+    const std::wstring refreshPulseStableId =
+        std::to_wstring(kRefreshPulseOrdinal);
+
+    bool sawUnrecognizedShortcut = false;
+    size_t adoptedCount = 0;
+
+    for (const auto& path : shortcutPaths) {
+        std::wstring identity =
+            GetShortcutIdentity(path);
+
+        auto stableId =
+            ExtractStableIdFromSeparatorIdentity(
+                identity);
+        if (!stableId) {
+            sawUnrecognizedShortcut = true;
+            Wh_Log(
+                L"[STATE] Legacy shortcut identity couldn't be parsed: '%s'",
+                identity.c_str());
+            continue;
+        }
+
+        // A refresh helper can survive an interrupted old backend pass. It is
+        // not a user separator and may be cleaned as stale after migration.
+        if (*stableId == refreshPulseStableId) {
+            continue;
+        }
+
+        if (std::any_of(
+                settings->separators.begin(),
+                settings->separators.end(),
+                [&stableId](const SeparatorSetting& separator) {
+                    return separator.stableId == *stableId;
+                })) {
+            continue;
+        }
+
+        const int sourceIndex =
+            static_cast<int>(
+                settings->separators.size());
+
+        settings->separators.push_back({
+            .ordinal = sourceIndex + 1,
+            .sourceIndex = sourceIndex,
+            // The old shortcut proves ownership but not its pin-list index.
+            // Keep it unanchored at Windows' native end until the user drags it;
+            // the ordinary TryMoveGroup path then records a durable position.
+            .targetIndex = -1,
+            .width = settings->width,
+            .stableId = *stableId,
+            // Preserve the exact old shortcut identity for this migration
+            // session. The new state format stores only stable IDs/positions.
+            .identity = std::move(identity),
+        });
+
+        adoptedCount++;
+    }
+
+    if (sawUnrecognizedShortcut) {
+        // No authoritative state file exists yet. Even a partially successful
+        // adoption must not authorize stale cleanup to delete an owned artifact
+        // that this migration couldn't identify.
+        Wh_Log(
+            L"[STATE] Refusing migration while unrecognized legacy "
+            L"shortcut artifacts exist");
+        return false;
+    }
+
+    if (adoptedCount > 0) {
+        Wh_Log(
+            L"[STATE] Adopted %zu legacy separator shortcut(s) from mod storage",
+            adoptedCount);
+    }
+
+    return true;
+}
+
+
 static bool MigrateLegacySeparatorState(
     double width,
     Settings* settingsOut) {
@@ -1124,6 +1244,16 @@ static bool MigrateLegacySeparatorState(
                     stableId),
             });
         }
+    }
+
+    // Published v0.5.38 could have live separator shortcuts even when its
+    // default settings row was never explicitly persisted. If the legacy
+    // settings sources found nothing, recover those owned shortcuts before
+    // creating the new authoritative state file.
+    if (migrated.separators.empty() &&
+        !AdoptLegacySeparatorShortcuts(
+            &migrated)) {
+        return false;
     }
 
     if (!SaveSeparatorStateFile(migrated)) {
@@ -1565,7 +1695,7 @@ static TaskListButton_UpdateVisualStates_t
 
 static void QueueBackendWork();
 static void FlushPendingSeparatorStateSynchronously();
-
+static void RefreshTrackedSeparatorVisualStates();
 using TaskListButton_OnDragCompletedGesture_t =
     void(WINAPI*)(void* pThis);
 static TaskListButton_OnDragCompletedGesture_t
@@ -1585,10 +1715,16 @@ static void WINAPI TaskListButton_OnDragCompletedGesture_Hook(
         }
 
         if (stateDirty) {
+            // Refresh presentation only after the native drag has completely
+            // unwound. This closes an unanchored separator's persistent guide
+            // as soon as TryMoveGroup has assigned its first concrete index.
+            RefreshTrackedSeparatorVisualStates();
+
             // The taskbar UI thread only signals work. The backend worker owns
             // the durable write so drag completion never blocks on disk I/O.
             QueueBackendWork();
         }
+
     }
 }
 
@@ -1809,6 +1945,15 @@ struct SeparatorVisualState {
     winrt::Windows::Foundation::IInspectable
         originalTaskListButtonToolTipLocalValue{nullptr};
 
+    // targetIndex == -1 presentation. The Popup is created asynchronously after
+    // TaskListButton::UpdateVisualStates has unwound, and is kept open until the
+    // first successful native drag assigns a concrete targetIndex.
+    winrt::Windows::UI::Xaml::Controls::Primitives::Popup
+        anchorHintPopup{nullptr};
+    winrt::Windows::Foundation::IAsyncAction
+        anchorHintAction{nullptr};
+    std::wstring anchorHintIdentity;
+    bool anchorHintQueued = false;
 };
 
 static thread_local std::list<SeparatorVisualState>
@@ -1821,11 +1966,43 @@ struct SeparatorVisualStateUpdateGuard {
     }
 };
 
+static void CloseSeparatorAnchorHint(
+    SeparatorVisualState& state) {
+    state.anchorHintQueued = false;
+    state.anchorHintIdentity.clear();
+
+    // RunAsync work is cancellable. This matters on mod unload: no queued
+    // dispatcher delegate may retain a callback into code after the mod is gone.
+    if (state.anchorHintAction) {
+        try {
+            state.anchorHintAction.Cancel();
+        } catch (...) {
+        }
+        state.anchorHintAction = nullptr;
+    }
+
+    if (!state.anchorHintPopup) {
+        return;
+    }
+
+    try {
+        state.anchorHintPopup.IsOpen(false);
+    } catch (...) {
+    }
+
+    state.anchorHintPopup = nullptr;
+}
+
 static void PruneExpiredSeparatorVisualStates() {
-    g_separatorVisualStates.remove_if(
-        [](const SeparatorVisualState& state) {
-            return !state.element.get();
-        });
+    for (auto it = g_separatorVisualStates.begin();
+         it != g_separatorVisualStates.end();) {
+        if (!it->element.get()) {
+            CloseSeparatorAnchorHint(*it);
+            it = g_separatorVisualStates.erase(it);
+        } else {
+            ++it;
+        }
+    }
 }
 
 static auto FindSeparatorVisualState(void* taskListButton) {
@@ -1835,6 +2012,220 @@ static auto FindSeparatorVisualState(void* taskListButton) {
         [taskListButton](const SeparatorVisualState& state) {
             return state.taskListButton == taskListButton;
         });
+}
+
+static void ShowQueuedSeparatorAnchorHint(
+    void* taskListButton,
+    winrt::weak_ref<FrameworkElement> weakElement,
+    std::wstring identity) {
+    auto stateIt =
+        FindSeparatorVisualState(taskListButton);
+    if (stateIt == g_separatorVisualStates.end()) {
+        return;
+    }
+
+    SeparatorVisualState& state = *stateIt;
+
+    // A recycled TaskListButton can queue a second request before an older one
+    // runs. Only the request for the currently tracked identity owns this state.
+    if (state.anchorHintIdentity != identity) {
+        return;
+    }
+
+    state.anchorHintQueued = false;
+    state.anchorHintAction = nullptr;
+
+    if (g_unloading) {
+        CloseSeparatorAnchorHint(state);
+        return;
+    }
+
+    FrameworkElement element = weakElement.get();
+    FrameworkElement trackedElement = state.element.get();
+    if (!element ||
+        !trackedElement ||
+        winrt::get_abi(element) != winrt::get_abi(trackedElement)) {
+        CloseSeparatorAnchorHint(state);
+        return;
+    }
+
+    SeparatorSetting separator;
+    if (!GetSeparatorForElement(
+            element,
+            &separator) ||
+        separator.identity != identity ||
+        separator.targetIndex >= 0) {
+        CloseSeparatorAnchorHint(state);
+        return;
+    }
+
+    try {
+        using namespace winrt::Windows::UI;
+        using namespace winrt::Windows::UI::Xaml::Controls;
+        using namespace winrt::Windows::UI::Xaml::Controls::Primitives;
+        using namespace winrt::Windows::UI::Xaml::Media;
+
+        XamlRoot xamlRoot = element.XamlRoot();
+        if (!xamlRoot) {
+            return;
+        }
+
+        Popup popup;
+        popup.XamlRoot(xamlRoot);
+        popup.IsLightDismissEnabled(false);
+        popup.ShouldConstrainToRootBounds(false);
+        popup.IsHitTestVisible(false);
+
+        // A tiny self-contained callout rather than another taskbar tooltip.
+        // It deliberately owns no input and remains visible until we close it.
+        StackPanel callout;
+        callout.HorizontalAlignment(HorizontalAlignment::Center);
+        callout.IsHitTestVisible(false);
+
+        bool lightTheme =
+            element.ActualTheme() == ElementTheme::Light;
+
+        Color backgroundColor =
+            lightTheme
+                ? Color{0xF7, 0xF9, 0xF9, 0xF9}
+                : Color{0xF7, 0x2B, 0x2B, 0x2B};
+        Color foregroundColor =
+            lightTheme
+                ? Color{0xFF, 0x1B, 0x1B, 0x1B}
+                : Color{0xFF, 0xFF, 0xFF, 0xFF};
+        Color borderColor =
+            lightTheme
+                ? Color{0x24, 0x00, 0x00, 0x00}
+                : Color{0x28, 0xFF, 0xFF, 0xFF};
+
+        SolidColorBrush backgroundBrush{backgroundColor};
+        SolidColorBrush foregroundBrush{foregroundColor};
+        SolidColorBrush borderBrush{borderColor};
+
+        Border card;
+        card.Background(backgroundBrush);
+        card.BorderBrush(borderBrush);
+        card.BorderThickness(Thickness{1, 1, 1, 1});
+        card.CornerRadius(CornerRadius{8, 8, 8, 8});
+        card.Padding(Thickness{12, 7, 12, 7});
+        card.IsHitTestVisible(false);
+
+        TextBlock label;
+        label.Text(L"Drag to anchor this separator");
+        label.FontSize(12);
+        label.Foreground(foregroundBrush);
+        label.TextWrapping(TextWrapping::NoWrap);
+        label.IsHitTestVisible(false);
+        card.Child(label);
+
+        // A short stem visually ties the callout to the narrow separator slot.
+        Border stem;
+        stem.Width(2);
+        stem.Height(6);
+        stem.Background(backgroundBrush);
+        stem.HorizontalAlignment(HorizontalAlignment::Center);
+        stem.IsHitTestVisible(false);
+
+        callout.Children().Append(card);
+        callout.Children().Append(stem);
+        popup.Child(callout);
+
+        // Windows 11 Popup has a real PlacementTarget. Let XAML own the
+        // relationship instead of copying target coordinates into detached
+        // HorizontalOffset/VerticalOffset values. This makes the guide follow
+        // native drag transforms, virtual-desktop relayouts, animations and
+        // container movement automatically.
+        popup.PlacementTarget(element);
+        popup.DesiredPlacement(PopupPlacementMode::Top);
+
+        state.anchorHintPopup = popup;
+        state.anchorHintIdentity = identity;
+
+        popup.IsOpen(true);
+
+        Wh_Log(
+            L"[NATIVE-ADD] Showing persistent anchor guide identity='%s'",
+            identity.c_str());
+    } catch (...) {
+        state.anchorHintPopup = nullptr;
+        Wh_Log(
+            L"[NATIVE-ADD] Failed to show persistent anchor guide identity='%s'",
+            identity.c_str());
+    }
+}
+
+static void UpdateSeparatorAnchorHint(
+    SeparatorVisualState& state,
+    const FrameworkElement& element,
+    const SeparatorSetting& separator) {
+    if (!element ||
+        g_unloading ||
+        separator.targetIndex >= 0) {
+        CloseSeparatorAnchorHint(state);
+        return;
+    }
+
+    if ((state.anchorHintPopup || state.anchorHintQueued) &&
+        state.anchorHintIdentity != separator.identity) {
+        CloseSeparatorAnchorHint(state);
+    }
+
+    if (state.anchorHintPopup &&
+        state.anchorHintIdentity == separator.identity) {
+        try {
+            if (state.anchorHintPopup.IsOpen()) {
+                // PlacementTarget keeps the Popup attached to the live
+                // TaskListButton; no manual coordinate refresh is needed.
+                return;
+            }
+        } catch (...) {
+        }
+
+        CloseSeparatorAnchorHint(state);
+    }
+
+    if (state.anchorHintQueued &&
+        state.anchorHintIdentity == separator.identity) {
+        return;
+    }
+
+    // Never create/open the Popup from inside UpdateVisualStates itself.
+    // Constructing popup presentation while TaskListButton is still
+    // materializing can re-enter XAML/layout at a fragile point. Queue one
+    // low-priority dispatcher callback and revalidate identity/state there.
+    try {
+        auto dispatcher = element.Dispatcher();
+        if (!dispatcher) {
+            return;
+        }
+
+        state.anchorHintIdentity = separator.identity;
+        state.anchorHintQueued = true;
+
+        auto weakElement =
+            winrt::make_weak(element);
+        void* taskListButton =
+            state.taskListButton;
+        std::wstring identity =
+            separator.identity;
+
+        state.anchorHintAction =
+            dispatcher.RunAsync(
+                winrt::Windows::UI::Core::
+                    CoreDispatcherPriority::Low,
+                winrt::Windows::UI::Core::DispatchedHandler{
+                    [taskListButton,
+                     weakElement,
+                     identity = std::move(identity)]() mutable {
+                        ShowQueuedSeparatorAnchorHint(
+                            taskListButton,
+                            weakElement,
+                            std::move(identity));
+                    }});
+    } catch (...) {
+        state.anchorHintQueued = false;
+        state.anchorHintIdentity.clear();
+    }
 }
 
 static void ApplySeparatorMaxWidthOverride(
@@ -1947,7 +2338,8 @@ static void SuppressSeparatorHoverChrome(
             }
         }
 
-        // Clear XAML-attached tooltip content as a presentation-layer fallback.
+        // The persistent anchor guide is a separate Popup. Keep every ordinary
+        // taskbar tooltip silent so it never competes with that presentation.
         if (!state.taskListButtonToolTipCaptured) {
             state.originalTaskListButtonToolTipLocalValue =
                 taskListButton.ReadLocalValue(
@@ -1957,7 +2349,6 @@ static void SuppressSeparatorHoverChrome(
         }
 
         winrt::Windows::Foundation::IInspectable noToolTip{nullptr};
-
         winrt::Windows::UI::Xaml::Controls::ToolTipService::
             SetToolTip(
                 taskListButton,
@@ -1976,7 +2367,6 @@ static void SuppressSeparatorHoverChrome(
 }
 
 
-
 static void RestoreDependencyPropertyLocalValue(
     const DependencyObject& object,
     const DependencyProperty& property,
@@ -1991,6 +2381,8 @@ static void RestoreDependencyPropertyLocalValue(
 static void RestoreSeparatorVisualState(
     std::list<SeparatorVisualState>::iterator stateIt) {
     SeparatorVisualState& state = *stateIt;
+
+    CloseSeparatorAnchorHint(state);
 
     auto element = state.element.get();
 
@@ -2236,6 +2628,10 @@ static void WINAPI RefreshSeparatorVisualStatesOnCurrentThread(void*) {
             state,
             element,
             iconPanel);
+        UpdateSeparatorAnchorHint(
+            state,
+            element,
+            separator);
         }
 }
 
@@ -2706,6 +3102,7 @@ static void WINAPI TaskListButton_UpdateVisualStates_Hook(
         FindChildByName(element, L"IconPanel");
     CenterSeparatorIcon(state, iconPanel);
     SuppressSeparatorHoverChrome(state, element, iconPanel);
+    UpdateSeparatorAnchorHint(state, element, separator);
 }
 
 static HMODULE GetTaskbarViewModuleHandle() {
@@ -3225,6 +3622,7 @@ static HRESULT WINAPI TaskGroup_GetToolTipText_Hook(
         cchText);
 }
 
+
 using TaskListWnd_IsPinned_t =
     bool(WINAPI*)(void* pThis, void* taskGroup);
 static TaskListWnd_IsPinned_t
@@ -3241,6 +3639,11 @@ using TaskListWnd_TryMoveGroup_t =
     bool(WINAPI*)(void* pThis, void* taskGroup, unsigned int index);
 static TaskListWnd_TryMoveGroup_t
     g_taskListWndTryMoveGroupOriginal;
+
+using TaskListWnd_HandleWinNumHotKey_t =
+    HRESULT(WINAPI*)(void* pThis, short index, unsigned short flags);
+static TaskListWnd_HandleWinNumHotKey_t
+    g_taskListWndHandleWinNumHotKeyOriginal;
 
 using TaskListWndMulti_IsPinned_t =
     bool(WINAPI*)(void* pThis, void* taskGroup);
@@ -3307,6 +3710,101 @@ static void ApplyPinnedMoveToSnapshot(
     if (movedSeparator) {
         movedSeparator->targetIndex = newIndex;
     }
+}
+
+
+// -----------------------------------------------------------------------------
+// Win+number compensation.
+//
+// CTaskListWnd::HandleWinNumHotKey uses a zero-based taskbar-group index. The
+// stock implementation counts our genuine pinned separator groups, which makes
+// every app to the right of a separator shift by one Win+number slot. Translate
+// the requested logical app index to the corresponding physical taskbar-group
+// index by skipping every resolved separator position.
+//
+// targetIndex == -1 is intentionally ignored. It means the separator is
+// unanchored: PinManager leaves it at the native right edge until the user drags
+// it once. Since no existing taskbar app lies to the right of a freshly appended
+// unanchored slot, it must not shift any existing Win+number target. The first
+// native separator drag records a concrete targetIndex, after which normal
+// compensation applies automatically.
+// -----------------------------------------------------------------------------
+
+static short CompensateWinNumHotKeyIndex(short logicalIndex) {
+    // Win+1..Win+0 reaches this layer as zero-based 0..9. Leave any unexpected
+    // internal/special value alone rather than changing undocumented behavior.
+    if (logicalIndex < 0 || logicalIndex > 9 ||
+        g_unloading ||
+        g_internalCleanupInProgress.load(std::memory_order_acquire)) {
+        return logicalIndex;
+    }
+
+    // While the backend is creating/removing/recovering pins, desired state can
+    // briefly differ from the visible taskbar. Stock behavior is safer for that
+    // very short transition. Native user drags don't clear this latch: their
+    // new positions are mirrored synchronously by TryMoveGroup below, so Win+N
+    // compensation follows a completed drag immediately.
+    if (!g_backendHasConverged.load(std::memory_order_acquire)) {
+        return logicalIndex;
+    }
+
+    std::vector<int> separatorPositions;
+    {
+        std::shared_lock lock(g_settingsMutex);
+        separatorPositions.reserve(g_settings.separators.size());
+
+        for (const auto& separator : g_settings.separators) {
+            if (separator.targetIndex >= 0) {
+                separatorPositions.push_back(separator.targetIndex);
+            }
+        }
+    }
+
+    if (separatorPositions.empty()) {
+        return logicalIndex;
+    }
+
+    std::sort(
+        separatorPositions.begin(),
+        separatorPositions.end());
+
+    int physicalIndex = logicalIndex;
+    for (int separatorIndex : separatorPositions) {
+        if (separatorIndex <= physicalIndex) {
+            ++physicalIndex;
+        } else {
+            // Positions are sorted, so no later separator can affect this
+            // target unless an earlier one has already shifted it into range.
+            break;
+        }
+    }
+
+    if (physicalIndex > SHRT_MAX) {
+        return logicalIndex;
+    }
+
+    return static_cast<short>(physicalIndex);
+}
+
+static HRESULT WINAPI TaskListWnd_HandleWinNumHotKey_Hook(
+    void* pThis,
+    short index,
+    unsigned short flags) {
+    short compensatedIndex =
+        CompensateWinNumHotKeyIndex(index);
+
+    if (compensatedIndex != index) {
+        Wh_Log(
+            L"[WINNUM] logical=%d physical=%d flags=0x%04X",
+            static_cast<int>(index),
+            static_cast<int>(compensatedIndex),
+            static_cast<unsigned int>(flags));
+    }
+
+    return g_taskListWndHandleWinNumHotKeyOriginal(
+        pThis,
+        compensatedIndex,
+        flags);
 }
 
 
@@ -3669,6 +4167,14 @@ static bool HookTaskbarDllSymbols(HMODULE taskbarDll) {
             },
             &g_taskListWndGetRelativeTaskOrder,
             nullptr,
+            true,
+        },
+        {
+            {
+                LR"(public: virtual long __cdecl CTaskListWnd::HandleWinNumHotKey(short,unsigned short))"
+            },
+            &g_taskListWndHandleWinNumHotKeyOriginal,
+            TaskListWnd_HandleWinNumHotKey_Hook,
             true,
         },
         {
@@ -4301,9 +4807,8 @@ static bool PositionSeparators(
             return false;
         }
 
-        // targetIndex=-1 is used by the native Add separator command. The
-        // PinManager append is already the desired final placement, so don't
-        // issue a MoveTaskbarPin until/unless the user later drags it.
+        // targetIndex=-1 is an intentional unanchored state. Leave the
+        // separator where Windows appended it until the user drags it once.
         if (separator.targetIndex < 0) {
             Wh_Log(
                 L"[MOVE] Separator #%d left at native appended position",
@@ -5141,8 +5646,8 @@ static void AddSeparatorFromTaskbarMenu() {
     updated.separators.push_back({
         .ordinal = sourceIndex + 1,
         .sourceIndex = sourceIndex,
-        // Let Windows keep the freshly pinned item at its native appended
-        // position. The first native drag gives it an explicit index.
+        // Explicitly unanchored. Windows appends it at the native end; the
+        // first user drag records the concrete position through TryMoveGroup.
         .targetIndex = -1,
         .width = updated.width,
         .stableId = stableId,

--- a/mods/taskbar-icon-separators.wh.cpp
+++ b/mods/taskbar-icon-separators.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-icon-separators
 // @name            Taskbar Icon Separators
 // @description     Create tracked icon separators with configurable padding on the taskbar.
-// @version         0.5.38
+// @version         0.5.39
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @license         GPL-3.0
@@ -24,7 +24,6 @@ Another mod offers similar functionality, but this implementation takes a differ
 
 This mod uses private COM APIs to insert a genuine taskbar button, styles its width and centering, and disables all interaction events. Because each separator occupies a real pinned slot, it stays anchored between the same pinned items as running apps change.
 
-Native taskbar extent-offset resolution is derived from m417z's [Taskbar height and icon size](https://windhawk.net/mods/taskbar-icon-size), published under GPLv3.
 
 Note: The mod creates pinned shortcuts targeting the Windows `systray.exe` stub (with a hidden, immediately exiting `cmd.exe` fallback) and reorders the persisted taskbar pin list. Cleanup is best-effort; in the worst failure case, separators may require manual unpinning.
 
@@ -40,25 +39,13 @@ Windows 11 only.
     Customizable part of separator identities. A fixed unique suffix is always appended.
     
     Change this only if a naming collision occurs (very rare).
-- maxWidthCompatibilityMode: false
-  $name: Taskbar Icon Size Compatibility Mode
-  $description: >-
-    Only normal icon sizes take effect with this option enabled. 
-
-    Compatibility mode for Taskbar height and icon size. 
-    Sets MaxWidth property while keeping native taskbar icon sizes untouched to avoid collision. 
-    
-    Enable this if you observe crashes when used with that mod. 
 - separators:
     - - index: 1
         $name: Final Position
         $description: 1 = first pinned taskbar position. Right after Search / Taskview. 
       - width: 20
-        $name: Normal Width
-        $description: Width for normal taskbar icon mode. 
-      - widthSmall: 10
-        $name: Small Width
-        $description: Width for small taskbar icon mode. 
+        $name: Width
+        $description: Width of the separator slot. 
   $name: Separators
   $description: Each new entry corresponds to a new separator being created.
 */
@@ -88,8 +75,6 @@ Windows 11 only.
 #include <iterator>
 #include <list>
 #include <mutex>
-#include <optional>
-#include <regex>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -170,14 +155,12 @@ struct IPinManagerInterop3 : IPinManagerInterop2 {
 struct SeparatorSetting {
     int ordinal;       // Stable within this loaded settings snapshot: 1, 2, ...
     int targetIndex;   // Zero-based value passed to MoveTaskbarPin.
-    double width;      // Normal width; also used as MaxWidth in compatibility mode.
-    double widthSmall; // Small icon mode width in native-extent mode.
+    double width;      // FrameworkElement::MaxWidth for the separator slot.
     std::wstring identity;
 };
 
 struct Settings {
     std::wstring identifierPrefix;
-    bool maxWidthCompatibilityMode;
     std::vector<SeparatorSetting> separators;
 };
 
@@ -188,12 +171,13 @@ static std::wstring g_storagePath;
 static std::wstring g_iconPath;
 
 static std::atomic<bool> g_taskbarViewDllHooked = false;
+static std::atomic<bool> g_taskbarLifecycleHookInstalled = false;
 static std::atomic<bool> g_taskbarInteractionHooksInstalled = false;
 static std::atomic<bool> g_loadLibraryWatcherInstalled = false;
 static std::atomic<bool> g_unloading = false;
-static std::atomic<bool> g_afterInit = false;
 static std::mutex g_lifecycleMutex;
 static bool g_taskbarViewHookInstallationAttempted = false;
+static bool g_taskbarLifecycleHookInstallationAttempted = false;
 static bool g_taskbarInteractionHookInstallationAttempted = false;
 static bool g_backendStopped = false;
 static HANDLE g_backendThread = nullptr;
@@ -488,9 +472,6 @@ static void LoadStoredSeparatorSettings() {
     const double width = g_settings.separators.empty()
                              ? 20.0
                              : g_settings.separators.front().width;
-    const double widthSmall = g_settings.separators.empty()
-                                  ? 10.0
-                                  : g_settings.separators.front().widthSmall;
 
     for (const auto& path : EnumerateSeparatorShortcuts()) {
         std::wstring identity = GetShortcutIdentity(path);
@@ -504,7 +485,6 @@ static void LoadStoredSeparatorSettings() {
             .ordinal = 0,
             .targetIndex = 0,
             .width = width,
-            .widthSmall = widthSmall,
             .identity = std::move(identity),
         });
     }
@@ -563,9 +543,6 @@ static void LoadSettings() {
         WindhawkUtils::StringSetting::make(
             L"identifierPrefix").get());
 
-    g_settings.maxWidthCompatibilityMode =
-        Wh_GetIntSetting(L"maxWidthCompatibilityMode") != 0;
-
     // Wh_GetIntSetting returns 0 for a missing setting.
     // Positions are therefore deliberately user-facing 1-based values.
     constexpr int kMaxSeparators = 256;
@@ -590,14 +567,8 @@ static void LoadSettings() {
 
         int configuredWidth =
             Wh_GetIntSetting(L"separators[%d].width", i);
-        int configuredWidthSmall =
-            Wh_GetIntSetting(L"separators[%d].widthSmall", i);
         int width = std::clamp(
             configuredWidth,
-            kMinWidth,
-            kMaxWidth);
-        int widthSmall = std::clamp(
-            configuredWidthSmall,
             kMinWidth,
             kMaxWidth);
 
@@ -608,19 +579,10 @@ static void LoadSettings() {
                 configuredWidth,
                 width);
         }
-        if (widthSmall != configuredWidthSmall) {
-            Wh_Log(
-                L"[SETTINGS] Clamped separator %d small width from %d to %d",
-                i + 1,
-                configuredWidthSmall,
-                widthSmall);
-        }
-
         g_settings.separators.push_back({
             .ordinal = i + 1,
             .targetIndex = position - 1,
             .width = static_cast<double>(width),
-            .widthSmall = static_cast<double>(widthSmall),
             .identity = BuildSeparatorIdentity(
                 g_settings.identifierPrefix,
                 i + 1),
@@ -633,21 +595,15 @@ static void LoadSettings() {
         .width = g_settings.separators.empty()
                      ? 20.0
                      : g_settings.separators.front().width,
-        .widthSmall = g_settings.separators.empty()
-                          ? 10.0
-                          : g_settings.separators.front().widthSmall,
         .identity = BuildSeparatorIdentity(
             g_settings.identifierPrefix,
             kRefreshPulseOrdinal),
     };
 
     Wh_Log(
-        L"[SETTINGS] prefix='%s' separators=%zu widthMode=%s",
+        L"[SETTINGS] prefix='%s' separators=%zu",
         g_settings.identifierPrefix.c_str(),
-        g_settings.separators.size(),
-        g_settings.maxWidthCompatibilityMode
-            ? L"MaxWidthCompatibility"
-            : L"NativeExtent");
+        g_settings.separators.size());
 }
 
 static bool InitializeStoragePath() {
@@ -690,29 +646,10 @@ static bool InitializeStoragePath() {
 // -----------------------------------------------------------------------------
 // TaskListButton separator width styling.
 //
-// Native-extent mode (default):
-// - restore the original separator width mechanism;
-// - let Windows and all downstream UpdateVisualStates hooks finish first;
-// - then write only this separator instance's medium/small taskbar extents;
-// - re-run the real padding/column entry points so other installed hooks can
-//   still participate.
-//
-// MaxWidth compatibility mode:
-// - never writes the private medium/small taskbar extent fields;
-// - after UpdateVisualStates finishes, constrains only FrameworkElement::MaxWidth;
-// - intended as a fallback if Taskbar height and icon size / TaskbarIconSize
-//   compatibility causes Explorer/taskbar crashes;
-// - deliberately uses 'width' in both icon modes, so widthSmall is unavailable.
-//
-// Settings changes always request a full mod reload, so changing width mode
-// destroys/recreates the separator buttons instead of hot-swapping ownership on
-// live TaskListButtons.
+// Separator width is owned through the XAML FrameworkElement::MaxWidth
+// property only. No private TaskListButton extent fields or private layout
+// entry points are modified.
 // -----------------------------------------------------------------------------
-
-static void* g_taskListButtonUpdateButtonPaddingAddress;
-static void* g_taskListButtonUpdateIconColumnDefinitionAddress;
-static void* g_taskbarConfigurationGetIconHeightInViewPixelsAddress;
-static bool g_hasDynamicIconScaling;
 
 // Native TaskListButton IsDraggable XAML binding helpers, resolved from
 // Taskbar.View.dll. The isolated runtime probe verified that setting this
@@ -734,65 +671,6 @@ static TaskListButton_SetIsDraggable_t
     g_taskListButtonSetIsDraggable;
 
 static thread_local bool g_settingSeparatorIsDraggable;
-
-static std::optional<bool> IsOsFeatureEnabled(UINT32 featureId) {
-    enum FEATURE_ENABLED_STATE {
-        FEATURE_ENABLED_STATE_DEFAULT = 0,
-        FEATURE_ENABLED_STATE_DISABLED = 1,
-        FEATURE_ENABLED_STATE_ENABLED = 2,
-    };
-
-#pragma pack(push, 1)
-    struct RTL_FEATURE_CONFIGURATION {
-        unsigned int featureId;
-        unsigned __int32 group : 4;
-        FEATURE_ENABLED_STATE enabledState : 2;
-        unsigned __int32 enabledStateOptions : 1;
-        unsigned __int32 unused1 : 1;
-        unsigned __int32 variant : 6;
-        unsigned __int32 variantPayloadKind : 2;
-        unsigned __int32 unused2 : 16;
-        unsigned int payload;
-    };
-#pragma pack(pop)
-
-    using RtlQueryFeatureConfiguration_t =
-        int(NTAPI*)(UINT32, int, INT64*, RTL_FEATURE_CONFIGURATION*);
-
-    static RtlQueryFeatureConfiguration_t queryFeatureConfiguration = [] {
-        HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-        return ntdll
-                   ? reinterpret_cast<RtlQueryFeatureConfiguration_t>(
-                         GetProcAddress(ntdll, "RtlQueryFeatureConfiguration"))
-                   : nullptr;
-    }();
-
-    if (!queryFeatureConfiguration) {
-        return std::nullopt;
-    }
-
-    RTL_FEATURE_CONFIGURATION feature = {};
-    INT64 changeStamp = 0;
-
-    HRESULT hr = queryFeatureConfiguration(
-        featureId,
-        1,
-        &changeStamp,
-        &feature);
-
-    if (FAILED(hr)) {
-        return std::nullopt;
-    }
-
-    switch (feature.enabledState) {
-        case FEATURE_ENABLED_STATE_DISABLED:
-            return false;
-        case FEATURE_ENABLED_STATE_ENABLED:
-            return true;
-        default:
-            return std::nullopt;
-    }
-}
 
 using TaskListButton_UpdateVisualStates_t = void(WINAPI*)(void* pThis);
 static TaskListButton_UpdateVisualStates_t
@@ -965,206 +843,9 @@ static const SeparatorSetting* GetSeparatorForTaskListButton(
     return separator;
 }
 
-static LONG GetMediumTaskbarButtonExtentOffset() {
-    static LONG offset = []() -> LONG {
-        if (!g_taskListButtonUpdateIconColumnDefinitionAddress) {
-            Wh_Log(
-                L"[STYLE] UpdateIconColumnDefinition address unavailable");
-            return 0;
-        }
-
-#if defined(_M_X64)
-        // x64 logic from the upstream Taskbar height and icon size mod.
-        // Search for a movsd that loads the per-instance medium extent,
-        // followed by a subsd using the loaded value.
-        const BYTE* start =
-            reinterpret_cast<const BYTE*>(
-                g_taskListButtonUpdateIconColumnDefinitionAddress);
-        const BYTE* end = start + 0x200;
-
-        LONG offsetCandidate = 0;
-        LONG foundOffset = 0;
-
-        for (const BYTE* p = start; p != end; p++) {
-            if (p[0] == 0xF2 && p[1] == 0x0F && p[2] == 0x10 &&
-                (p[3] & 0xC0) == 0x80) {
-                offsetCandidate =
-                    *reinterpret_cast<const LONG*>(p + 4);
-            }
-
-            if (p[0] == 0xF2 && p[1] == 0x44 &&
-                p[2] == 0x0F && p[3] == 0x10 &&
-                (p[4] & 0xC0) == 0x80) {
-                offsetCandidate =
-                    *reinterpret_cast<const LONG*>(p + 5);
-            }
-
-            if (p[0] == 0xF2 && p[1] == 0x0F && p[2] == 0x5C &&
-                (p[3] & 0xC0) == 0x80) {
-                foundOffset = offsetCandidate;
-                break;
-            }
-
-            if (p[0] == 0xF2 && p[1] == 0x44 &&
-                p[2] == 0x0F && p[3] == 0x5C &&
-                (p[4] & 0xC0) == 0x80) {
-                foundOffset = offsetCandidate;
-                break;
-            }
-        }
-
-        return (foundOffset < 0 || foundOffset > 0xFFFF)
-                   ? 0
-                   : foundOffset;
-#elif defined(_M_ARM64)
-        // ARM64 logic from the upstream Taskbar height and icon size mod.
-        // Find two double loads from the same object which feed an fsub; the
-        // first load is the per-instance medium extent.
-        const DWORD* start =
-            reinterpret_cast<const DWORD*>(
-                g_taskListButtonUpdateIconColumnDefinitionAddress);
-        const DWORD* end = start + 0x80;
-
-        std::regex loadWithOffset(
-            R"(ldr\s+(d\d+), \[(x\d+), #0x([0-9a-f]+)\])");
-        std::regex otherLoad(R"(ldr\s+(d\d+),.*)");
-        std::regex subtract(
-            R"(fsub\s+d\d+, (d\d+), (d\d+))");
-
-        struct LoadInstruction {
-            std::string destinationRegister;
-            std::string sourceRegister;
-            LONG offset;
-        } loads[32];
-        size_t loadCount = 0;
-
-        for (const DWORD* instruction = start;
-             instruction != end;
-             instruction++) {
-            WH_DISASM_RESULT result;
-            if (!Wh_Disasm(
-                    const_cast<DWORD*>(instruction),
-                    &result)) {
-                break;
-            }
-
-            std::string_view text = result.text;
-            if (text == "ret") {
-                break;
-            }
-
-            if (loadCount == ARRAYSIZE(loads)) {
-                break;
-            }
-
-            std::match_results<std::string_view::const_iterator> match;
-            if (std::regex_match(
-                    text.begin(),
-                    text.end(),
-                    match,
-                    loadWithOffset)) {
-                loads[loadCount++] = {
-                    .destinationRegister = match[1].str(),
-                    .sourceRegister = match[2].str(),
-                    .offset = static_cast<LONG>(
-                        std::stoul(match[3].str(), nullptr, 16)),
-                };
-                continue;
-            }
-
-            if (std::regex_match(
-                    text.begin(),
-                    text.end(),
-                    match,
-                    otherLoad)) {
-                loads[loadCount++] = {
-                    .destinationRegister = match[1].str(),
-                    .sourceRegister = {},
-                    .offset = 0,
-                };
-                continue;
-            }
-
-            if (!std::regex_match(
-                    text.begin(),
-                    text.end(),
-                    match,
-                    subtract)) {
-                continue;
-            }
-
-            const std::string firstInput = match[1].str();
-            const std::string secondInput = match[2].str();
-            const LoadInstruction* firstLoad = nullptr;
-            const LoadInstruction* secondLoad = nullptr;
-
-            for (size_t i = loadCount; i > 0; i--) {
-                const LoadInstruction& load = loads[i - 1];
-                if (!firstLoad &&
-                    load.destinationRegister == firstInput) {
-                    firstLoad = &load;
-                }
-                if (!secondLoad &&
-                    load.destinationRegister == secondInput) {
-                    secondLoad = &load;
-                }
-            }
-
-            if (firstLoad && secondLoad &&
-                !firstLoad->sourceRegister.empty() &&
-                firstLoad->sourceRegister == secondLoad->sourceRegister) {
-                LONG foundOffset = firstLoad->offset;
-                return (foundOffset < 0 || foundOffset > 0xFFFF)
-                           ? 0
-                           : foundOffset;
-            }
-        }
-
-        return 0;
-#else
-#error "Unsupported architecture"
-#endif
-    }();
-
-    return offset;
-}
-
-static void RefreshTaskListButtonLayout(void* pThis) {
-    // Call real function entry points, not our own trampolines.
-    //
-    // UpdateButtonPadding is intentionally invoked through its target address:
-    // if Taskbar height and icon size hooks it, that hook participates.
-    if (g_taskListButtonUpdateButtonPaddingAddress) {
-        auto updateButtonPadding =
-            reinterpret_cast<void(WINAPI*)(void*)>(
-                g_taskListButtonUpdateButtonPaddingAddress);
-
-        updateButtonPadding(pThis);
-    }
-
-    // Our width write occurs after UpdateVisualStates has already returned.
-    // Re-run the column update explicitly so XAML consumes the new extent.
-    if (g_taskListButtonUpdateIconColumnDefinitionAddress) {
-        auto updateIconColumnDefinition =
-            reinterpret_cast<void(WINAPI*)(void*)>(
-                g_taskListButtonUpdateIconColumnDefinitionAddress);
-
-        updateIconColumnDefinition(pThis);
-    }
-}
-
 struct SeparatorVisualState {
     winrt::weak_ref<FrameworkElement> element;
     void* taskListButton;
-
-    bool mediumExtentCaptured = false;
-    double originalMediumExtent = 0;
-    bool mediumExtentApplied = false;
-    double lastAppliedMediumExtent = 0;
-    bool smallExtentCaptured = false;
-    double originalSmallExtent = 0;
-    bool smallExtentApplied = false;
-    double lastAppliedSmallExtent = 0;
 
     bool maxWidthCaptured = false;
     winrt::Windows::Foundation::IInspectable originalMaxWidthLocalValue{
@@ -1220,73 +901,6 @@ static auto FindSeparatorVisualState(void* taskListButton) {
         [taskListButton](const SeparatorVisualState& state) {
             return state.taskListButton == taskListButton;
         });
-}
-
-static bool ApplySeparatorWidthOverride(
-    SeparatorVisualState& state,
-    const SeparatorSetting& separator) {
-    if (!g_taskListButtonUpdateIconColumnDefinitionAddress) {
-        return false;
-    }
-
-    LONG mediumOffset = GetMediumTaskbarButtonExtentOffset();
-    if (!mediumOffset) {
-        return false;
-    }
-
-    auto* mediumExtent =
-        reinterpret_cast<double*>(
-            reinterpret_cast<BYTE*>(state.taskListButton) + mediumOffset);
-    bool changed = false;
-
-    if (*mediumExtent < 1 || *mediumExtent >= 10000) {
-        return false;
-    }
-
-    // UpdateVisualStates runs after Windows and downstream hooks. If their
-    // latest extent differs from the value this mod previously enforced,
-    // treat it as the new stock value to restore later.
-    if (!state.mediumExtentCaptured ||
-        !state.mediumExtentApplied ||
-        *mediumExtent != state.lastAppliedMediumExtent) {
-        state.originalMediumExtent = *mediumExtent;
-        state.mediumExtentCaptured = true;
-    }
-
-    if (*mediumExtent != separator.width) {
-        *mediumExtent = separator.width;
-        changed = true;
-    }
-    state.lastAppliedMediumExtent = separator.width;
-    state.mediumExtentApplied = true;
-
-    // On DynamicIconScaling builds the small extent immediately precedes
-    // the medium extent. Don't assume that layout on older taskbars.
-    if (g_hasDynamicIconScaling) {
-        double* smallExtent = mediumExtent - 1;
-
-        if (*smallExtent >= 1 && *smallExtent < 10000) {
-            if (!state.smallExtentCaptured ||
-                !state.smallExtentApplied ||
-                *smallExtent != state.lastAppliedSmallExtent) {
-                state.originalSmallExtent = *smallExtent;
-                state.smallExtentCaptured = true;
-            }
-
-            if (*smallExtent != separator.widthSmall) {
-                *smallExtent = separator.widthSmall;
-                changed = true;
-            }
-            state.lastAppliedSmallExtent = separator.widthSmall;
-            state.smallExtentApplied = true;
-        }
-    }
-
-    if (changed) {
-        RefreshTaskListButtonLayout(state.taskListButton);
-    }
-
-    return true;
 }
 
 static void ApplySeparatorMaxWidthOverride(
@@ -1496,33 +1110,6 @@ static void RestoreSeparatorVisualState(
         return;
     }
 
-    bool extentChanged = false;
-
-    LONG mediumOffset =
-        (state.taskListButton &&
-         (state.mediumExtentCaptured || state.smallExtentCaptured))
-            ? GetMediumTaskbarButtonExtentOffset()
-            : 0;
-    if (mediumOffset) {
-        auto* mediumExtent =
-            reinterpret_cast<double*>(
-                reinterpret_cast<BYTE*>(state.taskListButton) + mediumOffset);
-
-        if (state.mediumExtentCaptured &&
-            *mediumExtent != state.originalMediumExtent) {
-            *mediumExtent = state.originalMediumExtent;
-            extentChanged = true;
-        }
-
-        if (state.smallExtentCaptured) {
-            double* smallExtent = mediumExtent - 1;
-            if (*smallExtent != state.originalSmallExtent) {
-                *smallExtent = state.originalSmallExtent;
-                extentChanged = true;
-            }
-        }
-    }
-
     try {
         if (state.maxWidthCaptured) {
             RestoreDependencyPropertyLocalValue(
@@ -1601,10 +1188,6 @@ static void RestoreSeparatorVisualState(
             }
         } catch (...) {
         }
-    }
-
-    if (extentChanged) {
-        RefreshTaskListButtonLayout(state.taskListButton);
     }
 
     g_separatorVisualStates.erase(stateIt);
@@ -1871,25 +1454,10 @@ static void WINAPI TaskListButton_UpdateVisualStates_Hook(
 
     SeparatorVisualState& state = *stateIt;
 
-    if (g_settings.maxWidthCompatibilityMode) {
-        // Compatibility path: native/TIS extents remain untouched.
-        ApplySeparatorMaxWidthOverride(
-            state,
-            element,
-            *separator);
-    } else {
-        // Default path: original per-instance medium/small extent override.
-        if (!ApplySeparatorWidthOverride(
-                state,
-                *separator)) {
-            // A future build can retain the symbol while changing the object
-            // layout. Keep the separator usable with the public XAML fallback.
-            ApplySeparatorMaxWidthOverride(
-                state,
-                element,
-                *separator);
-        }
-    }
+    ApplySeparatorMaxWidthOverride(
+        state,
+        element,
+        *separator);
 
     // If unload began while width was being applied, undo this button instead
     // of applying the remaining separator-only properties.
@@ -1918,22 +1486,6 @@ static HMODULE GetTaskbarViewModuleHandle() {
 static bool HookTaskbarViewDllSymbols(HMODULE module) {
     // Taskbar.View.dll, ExplorerExtensions.dll
     WindhawkUtils::SYMBOL_HOOK taskbarViewHooks[] = {
-        {
-            {
-                LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateButtonPadding(void))"
-            },
-            &g_taskListButtonUpdateButtonPaddingAddress,
-            nullptr,
-            true, // Used only by native-extent mode.
-        },
-        {
-            {
-                LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateIconColumnDefinition(void))"
-            },
-            &g_taskListButtonUpdateIconColumnDefinitionAddress,
-            nullptr,
-            true, // Used only by native-extent mode.
-        },
         {
             {
                 LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateVisualStates(void))"
@@ -1977,14 +1529,6 @@ static bool HookTaskbarViewDllSymbols(HMODULE module) {
             TaskbarResources_OnTaskListButtonContextRequested_Hook,
             true,
         },
-        {
-            {
-                LR"(public: double __cdecl winrt::Taskbar::implementation::TaskbarConfiguration::GetIconHeightInViewPixels(void))"
-            },
-            &g_taskbarConfigurationGetIconHeightInViewPixelsAddress,
-            nullptr,
-            true, // DynamicIconScaling-era builds; native-extent mode only.
-        },
     };
 
     if (!WindhawkUtils::HookSymbols(
@@ -1995,31 +1539,7 @@ static bool HookTaskbarViewDllSymbols(HMODULE module) {
         return false;
     }
 
-    constexpr UINT kDynamicIconScaling = 29785184;
-
-    g_hasDynamicIconScaling =
-        g_taskbarConfigurationGetIconHeightInViewPixelsAddress &&
-        IsOsFeatureEnabled(kDynamicIconScaling).value_or(true);
-
-    if (!g_settings.maxWidthCompatibilityMode) {
-        // Native object layout is private and can change independently of the
-        // symbols. Fall back to MaxWidth instead of aborting or pinning an
-        // unstyled full-width button.
-        if (!g_taskListButtonUpdateButtonPaddingAddress ||
-            !g_taskListButtonUpdateIconColumnDefinitionAddress ||
-            !GetMediumTaskbarButtonExtentOffset()) {
-            Wh_Log(
-                L"[STYLE] Native-extent resolution unavailable; "
-                L"using MaxWidth fallback");
-            g_settings.maxWidthCompatibilityMode = true;
-        }
-    }
-
-    Wh_Log(
-        L"[STYLE] Taskbar view hooks installed; widthMode=%s",
-        g_settings.maxWidthCompatibilityMode
-            ? L"MaxWidthCompatibility"
-            : L"NativeExtent");
+    Wh_Log(L"[STYLE] Taskbar view hooks installed; widthMode=MaxWidth");
 
     return true;
 }
@@ -2027,8 +1547,10 @@ static bool HookTaskbarViewDllSymbols(HMODULE module) {
 using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 static LoadLibraryExW_t g_loadLibraryExWOriginal;
 
+static bool HookTaskbarLifecycleSymbols(HMODULE taskbarDll);
 static bool HookTaskbarInteractionSymbols(HMODULE taskbarDll);
-static void TryStartBackendWorker();
+static HWND FindCurrentProcessTaskbarWnd();
+static void StartBackendWorker();
 
 static bool InstallTaskbarViewHooks(
     HMODULE module,
@@ -2058,6 +1580,37 @@ static bool InstallTaskbarViewHooks(
     }
 
     g_taskbarViewDllHooked = true;
+    return true;
+}
+
+static bool InstallTaskbarLifecycleHook(
+    HMODULE module,
+    bool applyOperations) {
+    std::lock_guard<std::mutex> lock(g_lifecycleMutex);
+
+    if (g_unloading) {
+        return false;
+    }
+
+    if (g_taskbarLifecycleHookInstalled) {
+        return true;
+    }
+
+    if (g_taskbarLifecycleHookInstallationAttempted) {
+        return false;
+    }
+
+    g_taskbarLifecycleHookInstallationAttempted = true;
+    if (!HookTaskbarLifecycleSymbols(module)) {
+        return false;
+    }
+
+    if (applyOperations && !Wh_ApplyHookOperations()) {
+        Wh_Log(L"[LIFECYCLE] Wh_ApplyHookOperations failed");
+        return false;
+    }
+
+    g_taskbarLifecycleHookInstalled = true;
     return true;
 }
 
@@ -2112,17 +1665,25 @@ static HMODULE WINAPI LoadLibraryExW_Hook(
             L"[STYLE] Taskbar view module loaded: %s",
             lpLibFileName ? lpLibFileName : L"<unknown>");
 
-        if (InstallTaskbarViewHooks(module, true)) {
-            TryStartBackendWorker();
-        }
+        InstallTaskbarViewHooks(module, true);
     }
 
-    if (!g_taskbarInteractionHooksInstalled &&
-        GetModuleHandleW(L"taskbar.dll") == module) {
-        Wh_Log(L"[INPUT] taskbar.dll loaded; installing interaction hooks");
+    if (GetModuleHandleW(L"taskbar.dll") == module) {
+        if (!g_taskbarLifecycleHookInstalled) {
+            Wh_Log(
+                L"[LIFECYCLE] taskbar.dll loaded; installing startup hook");
+            InstallTaskbarLifecycleHook(module, true);
+        }
 
-        if (InstallTaskbarInteractionHooks(module, true)) {
-            TryStartBackendWorker();
+        if (!g_taskbarInteractionHooksInstalled) {
+            Wh_Log(L"[INPUT] taskbar.dll loaded; installing interaction hooks");
+            InstallTaskbarInteractionHooks(module, true);
+        }
+
+        // Close the late-load race if the taskbar was created before the
+        // TrayUI::StartTaskbar hook became active.
+        if (FindCurrentProcessTaskbarWnd()) {
+            StartBackendWorker();
         }
     }
 
@@ -2352,6 +1913,46 @@ static HRESULT WINAPI TaskGroup_GetToolTipText_Hook(
         taskItem,
         text,
         cchText);
+}
+
+using TrayUI_StartTaskbar_t =
+    void(WINAPI*)(void* pThis);
+
+static TrayUI_StartTaskbar_t
+    g_trayUIStartTaskbarOriginal;
+
+static void WINAPI TrayUI_StartTaskbar_Hook(void* pThis) {
+    g_trayUIStartTaskbarOriginal(pThis);
+
+    if (g_unloading) {
+        return;
+    }
+
+    Wh_Log(L"[LIFECYCLE] TrayUI::StartTaskbar completed");
+    StartBackendWorker();
+}
+
+static bool HookTaskbarLifecycleSymbols(HMODULE taskbarDll) {
+    WindhawkUtils::SYMBOL_HOOK taskbarLifecycleHooks[] = {
+        {
+            {
+                LR"(public: virtual void __cdecl TrayUI::StartTaskbar(void))"
+            },
+            &g_trayUIStartTaskbarOriginal,
+            TrayUI_StartTaskbar_Hook,
+        },
+    };
+
+    if (!WindhawkUtils::HookSymbols(
+            taskbarDll,
+            taskbarLifecycleHooks,
+            ARRAYSIZE(taskbarLifecycleHooks))) {
+        Wh_Log(L"[LIFECYCLE] HookSymbols(TrayUI::StartTaskbar) failed");
+        return false;
+    }
+
+    Wh_Log(L"[LIFECYCLE] Taskbar startup hook installed");
+    return true;
 }
 
 static bool HookTaskbarInteractionSymbols(HMODULE taskbarDll) {
@@ -2765,6 +2366,17 @@ static bool PrepareSeparatorFiles() {
     return true;
 }
 
+static bool InitializeTaskbarLifecycleHook() {
+    if (HMODULE taskbarDll = GetModuleHandleW(L"taskbar.dll")) {
+        return InstallTaskbarLifecycleHook(taskbarDll, false);
+    }
+
+    Wh_Log(
+        L"[LIFECYCLE] taskbar.dll isn't loaded yet; "
+        L"installing LoadLibraryExW watcher");
+    return InstallLoadLibraryWatcher();
+}
+
 static bool InitializeTaskbarInteractionHooks() {
     if (HMODULE taskbarDll = GetModuleHandleW(L"taskbar.dll")) {
         return InstallTaskbarInteractionHooks(taskbarDll, false);
@@ -3131,33 +2743,6 @@ static DWORD WINAPI BackendThreadProc(void* parameter) {
 
     Wh_Log(L"[INIT] Separator backend worker starting");
 
-    if (!FindCurrentProcessTaskbarWnd()) {
-        Wh_Log(L"[INIT] Waiting for the taskbar window");
-
-        constexpr int kTaskbarWaitPolls = 240;
-        constexpr DWORD kTaskbarWaitInterval = 250;
-        bool taskbarFound = false;
-
-        for (int poll = 0; poll < kTaskbarWaitPolls; ++poll) {
-            if (WaitForBackendStop(kTaskbarWaitInterval)) {
-                Wh_Log(L"[INIT] Separator startup cancelled");
-                return 0;
-            }
-
-            if (FindCurrentProcessTaskbarWnd()) {
-                taskbarFound = true;
-                break;
-            }
-        }
-
-        if (!taskbarFound) {
-            Wh_Log(
-                L"[INIT] Taskbar window did not appear within 60 seconds; "
-                L"backend worker stopping");
-            return 0;
-        }
-    }
-
     HRESULT hrInit =
         CoInitializeEx(
             nullptr,
@@ -3282,18 +2867,10 @@ static bool StartBackendWorkerLocked() {
     return true;
 }
 
-static void TryStartBackendWorker() {
+static void StartBackendWorker() {
     std::lock_guard<std::mutex> lock(g_lifecycleMutex);
 
-    if (!g_afterInit || g_unloading || g_backendStopped) {
-        return;
-    }
-
-    // The backend creates real pinned taskbar items. Don't create them until
-    // the core styling hook can guarantee separator sizing and presentation.
-    // Interaction and tooltip hooks remain optional backend-independent
-    // hardening.
-    if (!g_taskbarViewDllHooked) {
+    if (g_unloading || g_backendStopped) {
         return;
     }
 
@@ -3380,6 +2957,11 @@ BOOL Wh_ModInit() {
             L"[INIT] TaskListButton styling hooks unavailable");
     }
 
+    if (!InitializeTaskbarLifecycleHook()) {
+        Wh_Log(
+            L"[INIT] Taskbar startup hook unavailable");
+    }
+
     if (!InitializeTaskbarInteractionHooks()) {
         Wh_Log(
             L"[INIT] Taskbar interaction hooks unavailable");
@@ -3392,8 +2974,6 @@ BOOL Wh_ModInit() {
 }
 
 void Wh_ModAfterInit() {
-    g_afterInit = true;
-
     // Close the small race where the module wasn't present in Wh_ModInit but
     // appeared before/around Wh_ModAfterInit.
     if (!g_taskbarViewDllHooked) {
@@ -3402,16 +2982,26 @@ void Wh_ModAfterInit() {
         }
     }
 
-    // Do the equivalent late-attach check for taskbar.dll. It might have
-    // loaded between Wh_ModInit and hook activation, before the watcher could
-    // observe its LoadLibraryExW call.
-    if (!g_taskbarInteractionHooksInstalled) {
-        if (HMODULE module = GetModuleHandleW(L"taskbar.dll")) {
+    // Lifecycle and interaction hooks are independent. A symbol change in one
+    // family must not gate the other or the PinManager backend.
+    if (HMODULE module = GetModuleHandleW(L"taskbar.dll")) {
+        if (!g_taskbarLifecycleHookInstalled) {
+            InstallTaskbarLifecycleHook(module, true);
+        }
+
+        if (!g_taskbarInteractionHooksInstalled) {
             InstallTaskbarInteractionHooks(module, true);
         }
     }
 
-    TryStartBackendWorker();
+    // If the mod is enabled after Explorer already created the taskbar,
+    // TrayUI::StartTaskbar has already returned and won't fire for us.
+    if (FindCurrentProcessTaskbarWnd()) {
+        Wh_Log(L"[LIFECYCLE] Existing taskbar window found; starting backend");
+        StartBackendWorker();
+    } else {
+        Wh_Log(L"[LIFECYCLE] Waiting for TrayUI::StartTaskbar");
+    }
 }
 
 void Wh_ModBeforeUninit() {
@@ -3443,11 +3033,9 @@ void Wh_ModUninit() {
 }
 
 BOOL Wh_ModSettingsChanged(BOOL* bReload) {
-    // Keep the old loaded settings intact. The old instance must unpin/delete
-    // exactly the separator identities it created; the reloaded instance then
-    // reads the new settings and recreates fresh buttons. This is also how the
-    // native-extent <-> MaxWidth compatibility mode switch stays clean: width
-    // ownership is never hot-swapped on an existing TaskListButton.
+    // Phase A keeps the reviewed full-reload settings behavior. Live
+    // reconciliation is a separate follow-up once persistent identities are
+    // available.
     *bReload = TRUE;
     return TRUE;
 }

--- a/mods/taskbar-icon-separators.wh.cpp
+++ b/mods/taskbar-icon-separators.wh.cpp
@@ -2524,7 +2524,7 @@ static void ShowSeparatorContextMenu(
         menu.Placement(FlyoutPlacementMode::Top);
 
         MenuFlyoutItem unpin;
-        unpin.Text(L"Unpin from taskbar");
+        unpin.Text(L"Remove separator");
         unpin.Tag(
             winrt::box_value(
                 winrt::hstring{separator.identity}));

--- a/mods/taskbar-icon-separators.wh.cpp
+++ b/mods/taskbar-icon-separators.wh.cpp
@@ -192,6 +192,10 @@ static std::atomic<bool> g_taskbarLifecycleHookInstalled = false;
 static std::atomic<bool> g_taskbarInteractionHooksInstalled = false;
 static std::atomic<bool> g_loadLibraryWatcherInstalled = false;
 static std::atomic<bool> g_unloading = false;
+// Closed at the start of Wh_ModBeforeUninit, before the broader unloading flag
+// is set. This prevents late module-load callbacks from installing hooks while
+// separator cleanup still deliberately keeps styling hooks operational.
+static std::atomic<bool> g_hookInstallationClosed = false;
 // True only while this mod intentionally tears down its own pins. User-facing
 // Add/Unpin callbacks must not mutate desired state during that window.
 static std::atomic<bool> g_internalCleanupInProgress = false;
@@ -2786,9 +2790,16 @@ static void StartBackendWorker();
 static bool InstallTaskbarViewHooks(
     HMODULE module,
     bool applyOperations) {
+    if (g_hookInstallationClosed.load(std::memory_order_acquire)) {
+        return false;
+    }
+
     std::lock_guard<std::mutex> lock(g_lifecycleMutex);
 
-    if (g_unloading) {
+    // Re-check after taking the installation mutex. An unload can close the
+    // latch while this caller is waiting behind another installer.
+    if (g_hookInstallationClosed.load(std::memory_order_acquire) ||
+        g_unloading) {
         return false;
     }
 
@@ -2817,9 +2828,14 @@ static bool InstallTaskbarViewHooks(
 static bool InstallTaskbarLifecycleHook(
     HMODULE module,
     bool applyOperations) {
+    if (g_hookInstallationClosed.load(std::memory_order_acquire)) {
+        return false;
+    }
+
     std::lock_guard<std::mutex> lock(g_lifecycleMutex);
 
-    if (g_unloading) {
+    if (g_hookInstallationClosed.load(std::memory_order_acquire) ||
+        g_unloading) {
         return false;
     }
 
@@ -2848,9 +2864,14 @@ static bool InstallTaskbarLifecycleHook(
 static bool InstallTaskbarInteractionHooks(
     HMODULE module,
     bool applyOperations) {
+    if (g_hookInstallationClosed.load(std::memory_order_acquire)) {
+        return false;
+    }
+
     std::lock_guard<std::mutex> lock(g_lifecycleMutex);
 
-    if (g_unloading) {
+    if (g_hookInstallationClosed.load(std::memory_order_acquire) ||
+        g_unloading) {
         return false;
     }
 
@@ -2886,7 +2907,9 @@ static HMODULE WINAPI LoadLibraryExW_Hook(
             hFile,
             dwFlags);
 
-    if (!module || g_unloading) {
+    if (!module ||
+        g_hookInstallationClosed.load(std::memory_order_acquire) ||
+        g_unloading) {
         return module;
     }
 
@@ -5141,6 +5164,15 @@ void ExplorerModAfterInit() {
 }
 
 void ExplorerModBeforeUninit() {
+    // Hook APIs are legal only until this callback returns. Close every late
+    // installation path first, then use the same mutex as the installers as a
+    // drain barrier. Once the lock is acquired, any installer that entered
+    // before the latch closed has finished; later callers fail both checks.
+    g_hookInstallationClosed.store(true, std::memory_order_release);
+    {
+        std::lock_guard<std::mutex> lock(g_lifecycleMutex);
+    }
+
     // A completed native reorder should already have been persisted by
     // OnDragCompletedGesture. This is a final no-timer fallback for a missed
     // completion callback or a shutdown that lands mid-drag.


### PR DESCRIPTION
## Changelog

- Added dynamic taskbar management: add separators from the taskbar menu, drag to reorder, and right-click to remove.
  ![Screenshot](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/taskbar-icon-separators/SEP2.png)

- Moved separator identities and positions to persistent mod storage, with automatic migration from previous settings.

- Moved to MaxWidth-only styling for better compatibility and maintainability. 
- Expanded the original worker backend for reliable persistence and genuine hot-reload.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

