### PR TITLE
Never Auto-Expand Explorer Tree Items v1.1.1

### DIFF
--- a/mods/never-auto-expand-explorer-tree-items.wh.cpp
+++ b/mods/never-auto-expand-explorer-tree-items.wh.cpp
@@ -2,7 +2,7 @@
 // @id              never-auto-expand-explorer-tree-items
 // @name            Never Auto-Expand Explorer Tree Items
 // @description     Stops the unwanted auto-expansion of navigation pane items even if the "Expand to current folder" option is off
-// @version         1.1
+// @version         1.1.1
 // @author          Kitsune
 // @github          https://github.com/AromaKitsune
 // @include         *
@@ -76,12 +76,9 @@ bool IsExplorerNavigationPane(HWND hTreeView)
             return false;
         }
 
-        if (GetClassNameW(hRootWnd, szClassName, ARRAYSIZE(szClassName)) &&
+        return (GetClassNameW(hRootWnd, szClassName, ARRAYSIZE(szClassName)) &&
             (_wcsicmp(szClassName, L"CabinetWClass") == 0 ||
-                _wcsicmp(szClassName, L"#32770") == 0))
-        {
-            return true;
-        }
+                _wcsicmp(szClassName, L"#32770") == 0));
     }
 
     return false;
@@ -93,7 +90,10 @@ bool IsUserInteractingWithTreeView(HWND hTreeView)
 {
     // Verify keyboard interactions
     HWND hFocusWnd = GetFocus();
-    if (hFocusWnd == hTreeView || IsChild(hTreeView, hFocusWnd))
+    if ((hFocusWnd == hTreeView || IsChild(hTreeView, hFocusWnd)) &&
+        ((GetAsyncKeyState(VK_RIGHT) & 0x8000) ||
+            (GetAsyncKeyState(VK_ADD) & 0x8000) ||
+            (GetAsyncKeyState(VK_MULTIPLY) & 0x8000)))
     {
         return true;
     }
@@ -107,10 +107,7 @@ bool IsUserInteractingWithTreeView(HWND hTreeView)
         if (GetCursorPos(&cursorPos))
         {
             HWND hHoverWnd = WindowFromPoint(cursorPos);
-            if (hHoverWnd == hTreeView || IsChild(hTreeView, hHoverWnd))
-            {
-                return true;
-            }
+            return (hHoverWnd == hTreeView || IsChild(hTreeView, hHoverWnd));
         }
     }
 
@@ -169,10 +166,12 @@ LRESULT WINAPI SendMessageW_Hook(HWND hWnd, UINT uMsg, WPARAM wParam,
     {
         auto* pNotifyHeader = reinterpret_cast<LPNMHDR>(lParam);
         if (pNotifyHeader != nullptr &&
+            !IsBadReadPtr(pNotifyHeader, sizeof(NMHDR)) &&
             pNotifyHeader->code == TVN_ITEMEXPANDINGW)
         {
             auto* pTreeViewNotify = reinterpret_cast<LPNMTREEVIEWW>(lParam);
-            if (pTreeViewNotify->action == TVE_EXPAND)
+            if (!IsBadReadPtr(pTreeViewNotify, sizeof(NMTREEVIEWW)) &&
+                pTreeViewNotify->action == TVE_EXPAND)
             {
                 auto hTreeView = pNotifyHeader->hwndFrom;
                 auto hTreeItem = pTreeViewNotify->itemNew.hItem;

--- a/mods/never-auto-expand-explorer-tree-items.wh.cpp
+++ b/mods/never-auto-expand-explorer-tree-items.wh.cpp
@@ -6,7 +6,7 @@
 // @author          Kitsune
 // @github          https://github.com/AromaKitsune
 // @include         *
-// @compilerOptions -lcomctl32 -luser32
+// @compilerOptions -luser32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -91,7 +91,8 @@ bool IsUserInteractingWithTreeView(HWND hTreeView)
     // Verify keyboard interactions
     HWND hFocusWnd = GetFocus();
     if ((hFocusWnd == hTreeView || IsChild(hTreeView, hFocusWnd)) &&
-        ((GetAsyncKeyState(VK_RIGHT) & 0x8000) ||
+        ((GetAsyncKeyState(VK_LEFT) & 0x8000) ||
+            (GetAsyncKeyState(VK_RIGHT) & 0x8000) ||
             (GetAsyncKeyState(VK_ADD) & 0x8000) ||
             (GetAsyncKeyState(VK_MULTIPLY) & 0x8000)))
     {

--- a/mods/never-auto-expand-explorer-tree-items.wh.cpp
+++ b/mods/never-auto-expand-explorer-tree-items.wh.cpp
@@ -6,7 +6,6 @@
 // @author          Kitsune
 // @github          https://github.com/AromaKitsune
 // @include         *
-// @compilerOptions -luser32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -65,23 +64,17 @@ bool IsExplorerNavigationPane(HWND hTreeView)
     }
 
     WCHAR szClassName[32];
-    if (GetClassNameW(hParentWnd, szClassName, ARRAYSIZE(szClassName)) &&
-        _wcsicmp(szClassName, L"NamespaceTreeControl") == 0)
-    {
-        // Retrieve the root window to confirm it's a File Explorer window or
-        // file picker dialog
-        HWND hRootWnd = GetAncestor(hTreeView, GA_ROOT);
-        if (!hRootWnd)
-        {
-            return false;
-        }
 
-        return (GetClassNameW(hRootWnd, szClassName, ARRAYSIZE(szClassName)) &&
-            (_wcsicmp(szClassName, L"CabinetWClass") == 0 ||
-                _wcsicmp(szClassName, L"#32770") == 0));
-    }
+    // Retrieve the root window to confirm it's a File Explorer window or
+    // file picker dialog
+    HWND hRootWnd = GetAncestor(hTreeView, GA_ROOT);
 
-    return false;
+    return (hRootWnd &&
+        GetClassNameW(hParentWnd, szClassName, ARRAYSIZE(szClassName)) &&
+        _wcsicmp(szClassName, L"NamespaceTreeControl") == 0 &&
+        GetClassNameW(hRootWnd, szClassName, ARRAYSIZE(szClassName)) &&
+        (_wcsicmp(szClassName, L"CabinetWClass") == 0 ||
+            _wcsicmp(szClassName, L"#32770") == 0));
 }
 
 // Helper: Verify if the tree view is receiving keyboard or mouse input
@@ -100,16 +93,14 @@ bool IsUserInteractingWithTreeView(HWND hTreeView)
     }
 
     // Verify mouse interactions
-    if ((GetAsyncKeyState(VK_LBUTTON) & 0x8000) ||
-        (GetAsyncKeyState(VK_RBUTTON) & 0x8000) ||
-        (GetAsyncKeyState(VK_MBUTTON) & 0x8000))
+    POINT cursorPos;
+    if (((GetAsyncKeyState(VK_LBUTTON) & 0x8000) ||
+            (GetAsyncKeyState(VK_RBUTTON) & 0x8000) ||
+            (GetAsyncKeyState(VK_MBUTTON) & 0x8000)) &&
+        GetCursorPos(&cursorPos))
     {
-        POINT cursorPos;
-        if (GetCursorPos(&cursorPos))
-        {
-            HWND hHoverWnd = WindowFromPoint(cursorPos);
-            return (hHoverWnd == hTreeView || IsChild(hTreeView, hHoverWnd));
-        }
+        HWND hHoverWnd = WindowFromPoint(cursorPos);
+        return (hHoverWnd == hTreeView || IsChild(hTreeView, hHoverWnd));
     }
 
     return false;
@@ -146,44 +137,39 @@ LRESULT WINAPI SendMessageW_Hook(HWND hWnd, UINT uMsg, WPARAM wParam,
         return SendMessageW_Original(hWnd, uMsg, wParam, lParam);
     }
 
-    if (uMsg == TVM_EXPAND && (wParam & TVE_EXPAND))
+    if (uMsg == TVM_EXPAND && (wParam & 0x0003) == TVE_EXPAND)
     {
         WCHAR szClassName[16];
+        auto hTreeItem = reinterpret_cast<HTREEITEM>(lParam);
         if (GetClassNameW(hWnd, szClassName, ARRAYSIZE(szClassName)) &&
-            _wcsicmp(szClassName, L"SysTreeView32") == 0)
+            _wcsicmp(szClassName, L"SysTreeView32") == 0 &&
+            IsExplorerNavigationPane(hWnd) &&
+            !IsUserInteractingWithTreeView(hWnd) &&
+            !IsSingleRootItem(hWnd, hTreeItem) &&
+            !(settings.allowTopLevelItemAutoExpansion &&
+                IsTopLevelItem(hWnd, hTreeItem)))
         {
-            auto hTreeItem = reinterpret_cast<HTREEITEM>(lParam);
-            if (IsExplorerNavigationPane(hWnd) &&
-                !IsUserInteractingWithTreeView(hWnd) &&
-                !IsSingleRootItem(hWnd, hTreeItem) &&
-                !(settings.allowTopLevelItemAutoExpansion &&
-                    IsTopLevelItem(hWnd, hTreeItem)))
-            {
-                return 0;
-            }
+            return 0;
         }
     }
     else if (uMsg == WM_NOTIFY)
     {
-        auto* pNotifyHeader = reinterpret_cast<LPNMHDR>(lParam);
-        if (pNotifyHeader != nullptr &&
-            !IsBadReadPtr(pNotifyHeader, sizeof(NMHDR)) &&
-            pNotifyHeader->code == TVN_ITEMEXPANDINGW)
+        WCHAR szClassName[32];
+        auto* pTreeViewNotify = reinterpret_cast<LPNMTREEVIEWW>(lParam);
+        if (GetClassNameW(hWnd, szClassName, ARRAYSIZE(szClassName)) &&
+            _wcsicmp(szClassName, L"NamespaceTreeControl") == 0 &&
+            pTreeViewNotify->hdr.code == TVN_ITEMEXPANDINGW &&
+            pTreeViewNotify->action == TVE_EXPAND)
         {
-            auto* pTreeViewNotify = reinterpret_cast<LPNMTREEVIEWW>(lParam);
-            if (!IsBadReadPtr(pTreeViewNotify, sizeof(NMTREEVIEWW)) &&
-                pTreeViewNotify->action == TVE_EXPAND)
+            auto hTreeView = pTreeViewNotify->hdr.hwndFrom;
+            auto hTreeItem = pTreeViewNotify->itemNew.hItem;
+            if (IsExplorerNavigationPane(hTreeView) &&
+                !IsUserInteractingWithTreeView(hTreeView) &&
+                !IsSingleRootItem(hTreeView, hTreeItem) &&
+                !(settings.allowTopLevelItemAutoExpansion &&
+                    IsTopLevelItem(hTreeView, hTreeItem)))
             {
-                auto hTreeView = pNotifyHeader->hwndFrom;
-                auto hTreeItem = pTreeViewNotify->itemNew.hItem;
-                if (IsExplorerNavigationPane(hTreeView) &&
-                    !IsUserInteractingWithTreeView(hTreeView) &&
-                    !IsSingleRootItem(hTreeView, hTreeItem) &&
-                    !(settings.allowTopLevelItemAutoExpansion &&
-                        IsTopLevelItem(hTreeView, hTreeItem)))
-                {
-                    return TRUE;
-                }
+                return TRUE;
             }
         }
     }

--- a/mods/never-auto-expand-explorer-tree-items.wh.cpp
+++ b/mods/never-auto-expand-explorer-tree-items.wh.cpp
@@ -158,19 +158,18 @@ LRESULT WINAPI SendMessageW_Hook(HWND hWnd, UINT uMsg, WPARAM wParam,
         auto* pTreeViewNotify = reinterpret_cast<LPNMTREEVIEWW>(lParam);
         if (GetClassNameW(hWnd, szClassName, ARRAYSIZE(szClassName)) &&
             _wcsicmp(szClassName, L"NamespaceTreeControl") == 0 &&
+            pTreeViewNotify &&
             pTreeViewNotify->hdr.code == TVN_ITEMEXPANDINGW &&
-            pTreeViewNotify->action == TVE_EXPAND)
+            pTreeViewNotify->action == TVE_EXPAND &&
+            IsExplorerNavigationPane(pTreeViewNotify->hdr.hwndFrom) &&
+            !IsUserInteractingWithTreeView(pTreeViewNotify->hdr.hwndFrom) &&
+            !IsSingleRootItem(pTreeViewNotify->hdr.hwndFrom,
+                pTreeViewNotify->itemNew.hItem) &&
+            !(settings.allowTopLevelItemAutoExpansion &&
+                IsTopLevelItem(pTreeViewNotify->hdr.hwndFrom,
+                    pTreeViewNotify->itemNew.hItem)))
         {
-            auto hTreeView = pTreeViewNotify->hdr.hwndFrom;
-            auto hTreeItem = pTreeViewNotify->itemNew.hItem;
-            if (IsExplorerNavigationPane(hTreeView) &&
-                !IsUserInteractingWithTreeView(hTreeView) &&
-                !IsSingleRootItem(hTreeView, hTreeItem) &&
-                !(settings.allowTopLevelItemAutoExpansion &&
-                    IsTopLevelItem(hTreeView, hTreeItem)))
-            {
-                return TRUE;
-            }
+            return TRUE;
         }
     }
 


### PR DESCRIPTION
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Resolved an issue where navigating back to an external drive from a pinned folder unexpectedly auto-expands the "This PC" item.
* Fixed a bug that caused OneDrive to crash during the sign-in process.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
