### PR TITLE
[Disable Windows Shortcuts] New shortcut additions with a few bug fixes and settings refactor

### DIFF
--- a/mods/disable-windows-shortcuts.wh.cpp
+++ b/mods/disable-windows-shortcuts.wh.cpp
@@ -241,6 +241,9 @@ If you use the **"Block hotkey"** option, or if you disable window snapping (Win
   - DisableWinSpace: false
     $name: Win+Space
     $description: Switch keyboard layout
+  - DisableWinShiftR: false
+    $name: Win+Shift+R
+    $description: Snipping Tool record
   - DisableWinShiftS: false
     $name: Win+Shift+S
     $description: Snipping Tool screenshot
@@ -379,6 +382,7 @@ struct
     bool DisableWinCtrlO;
     bool DisableWinCtrlS;
     bool DisableWinSpace;
+    bool DisableWinShiftR;
     bool DisableWinShiftS;
     bool DisableWinAltK;
     bool DisableWinPeriod;
@@ -473,6 +477,7 @@ void LoadSettings()
     g_settings.DisableWinCtrlO = Wh_GetIntSetting(L"StandardShortcuts.DisableWinCtrlO");
     g_settings.DisableWinCtrlS = Wh_GetIntSetting(L"StandardShortcuts.DisableWinCtrlS");
     g_settings.DisableWinSpace = Wh_GetIntSetting(L"StandardShortcuts.DisableWinSpace");
+    g_settings.DisableWinShiftR = Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftR");
     g_settings.DisableWinShiftS = Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftS");
     g_settings.DisableWinAltK = Wh_GetIntSetting(L"StandardShortcuts.DisableWinAltK");
     g_settings.DisableWinPeriod = Wh_GetIntSetting(L"StandardShortcuts.DisableWinPeriod");
@@ -547,6 +552,7 @@ bool ShouldBlockHotkey(UINT fsModifiers, UINT vk)
             {
                 case 'C': block = g_settings.DisableWinShiftC; break;
                 case 'M': block = g_settings.DisableWinShiftM; break;
+                case 'R': block = g_settings.DisableWinShiftR; break;
                 case 'S': block = g_settings.DisableWinShiftS; break;
                 case VK_LEFT: block = g_settings.DisableWinShiftLeft; break;
                 case VK_RIGHT: block = g_settings.DisableWinShiftRight; break;

--- a/mods/disable-windows-shortcuts.wh.cpp
+++ b/mods/disable-windows-shortcuts.wh.cpp
@@ -33,7 +33,7 @@ If you use the **"Block hotkey"** option, or if you disable window snapping (Win
 3. Under **Process inclusion list**, ensure `dwm.exe` is added (or `*` is used to include all processes)
 4. Click **Save**. Windhawk will automatically restart to apply the new settings.
 
-*Note: Changes to standard shortcuts (like Win+E) require an Explorer restart to take effect. You will be prompted automatically. If you completely disable or remove this mod from Windhawk, you must manually restart Explorer to restore those standard shortcuts.*
+*Note: Changes to standard shortcuts (like Win+E) require an Explorer restart to completely release the hotkeys for other applications (such as PowerToys or GlazeWM). You will be prompted automatically. If you completely disable or remove this mod from Windhawk, you must manually restart Explorer to restore those standard shortcuts.*
 
 ## Notes
 - Win key (Start Menu) is handled by the "Block Start Menu and Hosts" mod
@@ -322,7 +322,7 @@ bool g_isExplorer = false;
 bool g_isDWM = false;
 
 // Settings structure
-struct
+struct Settings
 {
     int DisableWinA;
     bool DisableWinB;
@@ -402,6 +402,98 @@ struct
     bool DisableWinKey;
     bool DisableCtrlEsc;
 } g_settings;
+
+bool StandardShortcutsEqual(const Settings& a, const Settings& b)
+{
+    return a.DisableWinB == b.DisableWinB &&
+           a.DisableWinD == b.DisableWinD &&
+           a.DisableWinE == b.DisableWinE &&
+           a.DisableWinF == b.DisableWinF &&
+           a.DisableWinF1 == b.DisableWinF1 &&
+           a.DisableWinG == b.DisableWinG &&
+           a.DisableWinH == b.DisableWinH &&
+           a.DisableWinI == b.DisableWinI &&
+           a.DisableWinJ == b.DisableWinJ &&
+           a.DisableWinM == b.DisableWinM &&
+           a.DisableWinO == b.DisableWinO &&
+           a.DisableWinQ == b.DisableWinQ &&
+           a.DisableWinR == b.DisableWinR &&
+           a.DisableWinS == b.DisableWinS &&
+           a.DisableWinT == b.DisableWinT &&
+           a.DisableWinV == b.DisableWinV &&
+           a.DisableWinW == b.DisableWinW &&
+           a.DisableWinX == b.DisableWinX &&
+           a.DisableWinY == b.DisableWinY &&
+           a.DisableWinZ == b.DisableWinZ &&
+           a.DisableWinTab == b.DisableWinTab &&
+           a.DisableWinUp == b.DisableWinUp &&
+           a.DisableWinDown == b.DisableWinDown &&
+           a.DisableWinLeft == b.DisableWinLeft &&
+           a.DisableWinRight == b.DisableWinRight &&
+           a.DisableWinHome == b.DisableWinHome &&
+           a.DisableWinShiftC == b.DisableWinShiftC &&
+           a.DisableWinShiftM == b.DisableWinShiftM &&
+           a.DisableWinComma == b.DisableWinComma &&
+           a.DisableWinPause == b.DisableWinPause &&
+           a.DisableWinCtrlD == b.DisableWinCtrlD &&
+           a.DisableWinCtrlF == b.DisableWinCtrlF &&
+           a.DisableWinCtrlF4 == b.DisableWinCtrlF4 &&
+           a.DisableWinCtrlLeft == b.DisableWinCtrlLeft &&
+           a.DisableWinCtrlRight == b.DisableWinCtrlRight &&
+           a.DisableWinNumbers == b.DisableWinNumbers &&
+           a.DisableWinShiftNumbers == b.DisableWinShiftNumbers &&
+           a.DisableWinCtrlNumbers == b.DisableWinCtrlNumbers &&
+           a.DisableWinAltNumbers == b.DisableWinAltNumbers &&
+           a.DisableWinPlus == b.DisableWinPlus &&
+           a.DisableWinMinus == b.DisableWinMinus &&
+           a.DisableWinEsc == b.DisableWinEsc &&
+           a.DisableWinCtrlEnter == b.DisableWinCtrlEnter &&
+           a.DisableWinCtrlC == b.DisableWinCtrlC &&
+           a.DisableWinCtrlN == b.DisableWinCtrlN &&
+           a.DisableWinCtrlO == b.DisableWinCtrlO &&
+           a.DisableWinCtrlS == b.DisableWinCtrlS &&
+           a.DisableWinSpace == b.DisableWinSpace &&
+           a.DisableWinShiftS == b.DisableWinShiftS &&
+           a.DisableWinAltK == b.DisableWinAltK &&
+           a.DisableWinPeriod == b.DisableWinPeriod &&
+           a.DisableWinSemicolon == b.DisableWinSemicolon &&
+           a.DisableWinPrtSc == b.DisableWinPrtSc &&
+           a.DisableWinShiftLeft == b.DisableWinShiftLeft &&
+           a.DisableWinShiftRight == b.DisableWinShiftRight &&
+           a.DisableWinShiftUp == b.DisableWinShiftUp &&
+           a.DisableWinShiftDown == b.DisableWinShiftDown &&
+           a.DisableOfficeHotkeys == b.DisableOfficeHotkeys &&
+           a.DisableWinAltD == b.DisableWinAltD &&
+           a.DisableWinAltB == b.DisableWinAltB &&
+           a.DisableWinAltR == b.DisableWinAltR &&
+           a.DisableWinAltG == b.DisableWinAltG &&
+           a.DisableWinAltPrtSc == b.DisableWinAltPrtSc &&
+           a.DisableWinAltT == b.DisableWinAltT &&
+           a.DisableWinAltM == b.DisableWinAltM &&
+           a.DisableWinCtrlShiftB == b.DisableWinCtrlShiftB &&
+           a.DisableWinCtrlQ == b.DisableWinCtrlQ &&
+           a.DisableAltShift == b.DisableAltShift &&
+           a.DisableWinKey == b.DisableWinKey &&
+           a.DisableCtrlEsc == b.DisableCtrlEsc;
+}
+
+bool HasAnyStandardShortcutsDisabled()
+{
+    Settings emptySettings{};
+    return !StandardShortcutsEqual(g_settings, emptySettings);
+}
+
+bool SettingsEqual(const Settings& a, const Settings& b)
+{
+    return a.DisableWinA == b.DisableWinA &&
+           a.DisableWinC == b.DisableWinC &&
+           a.DisableWinK == b.DisableWinK &&
+           a.DisableWinN == b.DisableWinN &&
+           a.DisableWinP == b.DisableWinP &&
+           a.DisableWinU == b.DisableWinU &&
+           a.DisableWinSlash == b.DisableWinSlash &&
+           StandardShortcutsEqual(a, b);
+}
 
 
 int GetSettingIntSafe(PCWSTR settingName) {
@@ -666,13 +758,13 @@ bool IsKnownHardcodedHotkey(UINT fsModifiers, UINT vk)
             // Hardcoded keys that bypass RegisterHotKey
             if (vk == VK_TAB || vk == VK_UP || vk == VK_DOWN || vk == VK_LEFT || vk == VK_RIGHT || vk == VK_SPACE)
                 return true;
-            if (vk == 'A' && g_settings.DisableWinA == 2) return true;
-            if (vk == 'C' && g_settings.DisableWinC == 2) return true;
-            if (vk == 'K' && g_settings.DisableWinK == 2) return true;
-            if (vk == 'N' && g_settings.DisableWinN == 2) return true;
-            if (vk == 'P' && g_settings.DisableWinP == 2) return true;
-            if (vk == 'U' && g_settings.DisableWinU == 2) return true;
-            if (vk == VK_OEM_2 && g_settings.DisableWinSlash == 2) return true;
+            if (vk == 'A' && g_settings.DisableWinA > 0) return true;
+            if (vk == 'C' && g_settings.DisableWinC > 0) return true;
+            if (vk == 'K' && g_settings.DisableWinK > 0) return true;
+            if (vk == 'N' && g_settings.DisableWinN > 0) return true;
+            if (vk == 'P' && g_settings.DisableWinP > 0) return true;
+            if (vk == 'U' && g_settings.DisableWinU > 0) return true;
+            if (vk == VK_OEM_2 && g_settings.DisableWinSlash > 0) return true;
         } else {
             // Win+Shift+Arrows
             if (vk == VK_UP || vk == VK_DOWN || vk == VK_LEFT || vk == VK_RIGHT)
@@ -716,22 +808,11 @@ BOOL WINAPI RegisterHotKey_Hook(HWND hWnd, int id, UINT fsModifiers, UINT vk)
 // Explorer restart prompt
 // ============================================================================
 
-bool IsFirstTimeInit()
-{
-    int initialized = Wh_GetIntValue(L"Initialized", 0);
-    if (initialized == 0)
-    {
-        Wh_SetIntValue(L"Initialized", 1);
-        return true; // First time
-    }
-    return false;
-}
-
 HANDLE g_restartExplorerPromptThread = NULL;
 std::atomic<HWND> g_restartExplorerPromptWindow = NULL;
 
 constexpr WCHAR kRestartExplorerPromptTitle[] = L"Disable Windows Shortcuts - Windhawk";
-constexpr WCHAR kRestartExplorerPromptText[] = L"Explorer needs to be restarted to apply the changes to standard shortcuts. Restart now?";
+constexpr WCHAR kRestartExplorerPromptText[] = L"Explorer needs to be restarted to apply changes and release standard shortcuts for other applications. Restart now?";
 
 void PromptForExplorerRestart()
 {
@@ -740,6 +821,7 @@ void PromptForExplorerRestart()
         if (WaitForSingleObject(g_restartExplorerPromptThread, 0) != WAIT_OBJECT_0)
             return;
         CloseHandle(g_restartExplorerPromptThread);
+        g_restartExplorerPromptThread = NULL;
     }
 
     g_restartExplorerPromptThread = CreateThread(nullptr, 0, [](LPVOID) WINAPI -> DWORD {
@@ -765,16 +847,19 @@ void PromptForExplorerRestart()
             },
         };
 
-        int button;
-        if (SUCCEEDED(TaskDialogIndirect(&taskDialogConfig, &button, nullptr, nullptr)) && button == IDYES)
+        static decltype(&TaskDialogIndirect) pTaskDialogIndirect = []() {
+            HMODULE hComctl32 = LoadLibraryExW(L"comctl32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+            if (!hComctl32) return (decltype(&TaskDialogIndirect))nullptr;
+            return (decltype(&TaskDialogIndirect))GetProcAddress(hComctl32, "TaskDialogIndirect");
+        }();
+
+        int button = 0;
+        if (pTaskDialogIndirect && SUCCEEDED(pTaskDialogIndirect(&taskDialogConfig, &button, nullptr, nullptr)) && button == IDYES)
         {
-            // By adding a slight timeout, we give Wh_ModUninit the exact chance to return gracefully to Windhawk
-            // *before* explorer.exe violently closes. This prevents Windhawk from registering an uninit crash,
-            // which avoids the backoff/slow re-init protection delays. We also use 'start' to detach the shell gracefully.
             WCHAR commandLine[] = L"cmd.exe /c \"timeout /t 1 /nobreak >nul & taskkill /F /IM explorer.exe & start explorer.exe\"";
-            STARTUPINFO si = { .cb = sizeof(si) };
+            STARTUPINFOW si = { .cb = sizeof(si) };
             PROCESS_INFORMATION pi{};
-            if (CreateProcess(nullptr, commandLine, nullptr, nullptr, FALSE, CREATE_NO_WINDOW, nullptr, nullptr, &si, &pi))
+            if (CreateProcessW(nullptr, commandLine, nullptr, nullptr, FALSE, CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP, nullptr, nullptr, &si, &pi))
             {
                 CloseHandle(pi.hThread);
                 CloseHandle(pi.hProcess);
@@ -817,21 +902,23 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
             return CallNextHookEx(g_hHook, nCode, wParam, lParam);
         }
 
-        // Fast path for dummy key (used to mask Start Menu)
-        if (vkCode == 0xFF)
+        // Fast path for dummy keys (used to mask Start Menu or language switch)
+        if (vkCode == 0xFF || vkCode == 0xE8)
             return CallNextHookEx(g_hHook, nCode, wParam, lParam);
 
+        bool isInitialDown = false;
         if (vkCode < 256)
         {
             if (isDown)
             {
                 if (!g_keyState[vkCode])
                 {
+                    isInitialDown = true;
                     if (vkCode == VK_LWIN || vkCode == VK_RWIN)
                     {
                         g_winKeyUsed = false;
                     }
-                    else if (vkCode != 0xFF)
+                    else
                     {
                         g_winKeyUsed = true;
                     }
@@ -954,8 +1041,8 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
                 if (vkCode < 256)
                     g_suppressedKeys[vkCode] = true;
 
-                if (hasWin) {
-                    // AHK Start Menu Masking Trick
+                if (hasWin && isInitialDown) {
+                    // AHK Start Menu Masking Trick (sent once per modifier-key sequence)
                     // Forces the OS to see an unassigned keystroke, cancelling the Start Menu pop-up
                     INPUT inputs[2] = {};
                     inputs[0].type = INPUT_KEYBOARD;
@@ -989,7 +1076,11 @@ DWORD WINAPI HookThread(LPVOID lpParam)
 
     g_hHook = SetWindowsHookExW(WH_KEYBOARD_LL, LowLevelKeyboardProc, hMod, 0);
     if (!g_hHook)
+    {
+        Wh_Log(L"SetWindowsHookExW failed: %u", GetLastError());
+        g_hookThreadRunning = false;
         return 1;
+    }
 
     // Dedicated message pump to keep the hook alive and responsive
     while (GetMessage(&msg, NULL, 0, 0) > 0)
@@ -999,6 +1090,7 @@ DWORD WINAPI HookThread(LPVOID lpParam)
     }
 
     UnhookWindowsHookEx(g_hHook);
+    g_hHook = NULL;
     return 0;
 }
 
@@ -1007,14 +1099,28 @@ void StartHookThread()
     if (g_hookThreadRunning) return;
     
     g_hookThreadRunning = true;
-    g_hookThread = CreateThread(NULL, 0, HookThread, NULL, 0, (LPDWORD)&g_hookThreadId);
+    DWORD threadId = 0;
+    g_hookThread = CreateThread(NULL, 0, HookThread, NULL, 0, &threadId);
+    if (g_hookThread)
+    {
+        g_hookThreadId = threadId;
+    }
+    else
+    {
+        Wh_Log(L"CreateThread failed: %u", GetLastError());
+        g_hookThreadRunning = false;
+    }
 }
 
 void StopHookThread()
 {
     if (g_hookThreadRunning)
     {
-        PostThreadMessage(g_hookThreadId, WM_QUIT, 0, 0);
+        while (!PostThreadMessage(g_hookThreadId, WM_QUIT, 0, 0))
+        {
+            if (WaitForSingleObject(g_hookThread, 10) == WAIT_OBJECT_0)
+                break; // thread already exited
+        }
         g_hookThreadRunning = false;
     }
 
@@ -1028,10 +1134,10 @@ void StopHookThread()
 
 bool NeedsDwmHook()
 {
-    return (g_settings.DisableWinA == 2) || (g_settings.DisableWinC == 2) || 
-           (g_settings.DisableWinK == 2) || (g_settings.DisableWinN == 2) || 
-           (g_settings.DisableWinP == 2) || (g_settings.DisableWinU == 2) || 
-           (g_settings.DisableWinSlash == 2) || 
+    return (g_settings.DisableWinA > 0) || (g_settings.DisableWinC > 0) || 
+           (g_settings.DisableWinK > 0) || (g_settings.DisableWinN > 0) || 
+           (g_settings.DisableWinP > 0) || (g_settings.DisableWinU > 0) || 
+           (g_settings.DisableWinSlash > 0) || 
            g_settings.DisableWinTab ||
            g_settings.DisableWinUp || g_settings.DisableWinDown || 
            g_settings.DisableWinLeft || g_settings.DisableWinRight ||
@@ -1072,8 +1178,8 @@ bool IsExplorerUptimeLarge()
         current.LowPart = systemTime.dwLowDateTime;
         current.HighPart = systemTime.dwHighDateTime;
         
-        // 30 seconds = 300,000,000 intervals of 100ns
-        if (current.QuadPart > creation.QuadPart && (current.QuadPart - creation.QuadPart) > 300000000ULL)
+        // 5 seconds = 50,000,000 intervals of 100ns (distinguishes fresh boot from mid-session re-enable)
+        if (current.QuadPart > creation.QuadPart && (current.QuadPart - creation.QuadPart) > 50000000ULL)
             return true;
     }
     return false;
@@ -1111,20 +1217,10 @@ BOOL Wh_ModInit()
                 Wh_SetFunctionHook(pRegisterHotKey, (void*)RegisterHotKey_Hook, (void**)&RegisterHotKey_Original);
         }
 
-        // Check if Explorer has already registered standard hotkeys.
-        // We use Win+R as a probe. If it fails, Explorer is mid-session and already owns it.
-        // We only do this for the main Explorer process, and only if it's been running for a while (>30s),
-        // to avoid false prompts on system startup or when secondary Explorers are launched.
-        if (IsMainExplorer() && IsExplorerUptimeLarge() && !IsFirstTimeInit())
+        // Prompt ONLY if Explorer is running mid-session (>5s) AND at least one standard shortcut is disabled
+        if (IsMainExplorer() && !GetSystemMetrics(SM_SHUTTINGDOWN) && IsExplorerUptimeLarge() && HasAnyStandardShortcutsDisabled())
         {
-            if (!RegisterHotKey(NULL, 0x1337, MOD_WIN | MOD_NOREPEAT, 'R'))
-            {
-                PromptForExplorerRestart();
-            }
-            else
-            {
-                UnregisterHotKey(NULL, 0x1337);
-            }
+            PromptForExplorerRestart();
         }
     }
 
@@ -1137,25 +1233,55 @@ BOOL Wh_ModInit()
 void Wh_ModUninit()
 {
     if (g_isDWM)
-        StopHookThread();
-
-    if (g_isExplorer && IsMainExplorer())
     {
-        // Use the native prompt instead of PowerShell. 
-        // We call the existing prompt function and wait for it to complete.
-        PromptForExplorerRestart();
+        StopHookThread();
     }
 
-    if (g_restartExplorerPromptThread)
+    if (g_isExplorer)
     {
-        WaitForSingleObject(g_restartExplorerPromptThread, INFINITE);
-        CloseHandle(g_restartExplorerPromptThread);
-        g_restartExplorerPromptThread = nullptr;
+        // 1. Close any pending prompt from a previous settings change
+        if (HWND promptWindow = g_restartExplorerPromptWindow)
+        {
+            PostMessage(promptWindow, WM_CLOSE, 0, 0);
+        }
+
+        if (g_restartExplorerPromptThread)
+        {
+            WaitForSingleObject(g_restartExplorerPromptThread, INFINITE);
+            CloseHandle(g_restartExplorerPromptThread);
+            g_restartExplorerPromptThread = nullptr;
+        }
+
+        // 2. If standard shortcuts were disabled, prompt the user on mod unload/disable
+        if (IsMainExplorer() && !GetSystemMetrics(SM_SHUTTINGDOWN))
+        {
+            if (HasAnyStandardShortcutsDisabled())
+            {
+                PromptForExplorerRestart();
+            }
+        }
+
+        // 3. Bounded wait for the unload prompt to guarantee safety without hanging
+        if (g_restartExplorerPromptThread)
+        {
+            if (WaitForSingleObject(g_restartExplorerPromptThread, 30000) == WAIT_TIMEOUT)
+            {
+                // User did not respond within 30 seconds: close dialog
+                if (HWND promptWindow = g_restartExplorerPromptWindow)
+                {
+                    PostMessage(promptWindow, WM_CLOSE, 0, 0);
+                }
+                WaitForSingleObject(g_restartExplorerPromptThread, INFINITE);
+            }
+            CloseHandle(g_restartExplorerPromptThread);
+            g_restartExplorerPromptThread = nullptr;
+        }
     }
 }
 
 void Wh_ModSettingsChanged()
 {
+    Settings oldSettings = g_settings;
     LoadSettings();
     
     if (g_isDWM)
@@ -1166,6 +1292,8 @@ void Wh_ModSettingsChanged()
             StopHookThread();
     }
     
-    if (g_isExplorer && IsMainExplorer())
+    if (g_isExplorer && IsMainExplorer() && !GetSystemMetrics(SM_SHUTTINGDOWN) && !StandardShortcutsEqual(oldSettings, g_settings))
+    {
         PromptForExplorerRestart();
+    }
 }

--- a/mods/disable-windows-shortcuts.wh.cpp
+++ b/mods/disable-windows-shortcuts.wh.cpp
@@ -1221,12 +1221,15 @@ void Wh_ModUninit()
         StopHookThread();
     }
 
-    if (g_isExplorer && IsMainExplorer())
+    if (g_isExplorer)
     {
-        // 1. Signal any pending prompt dialog from a prior settings change to close
+        // 1. Signal any pending prompt dialog from a prior settings change to close.
+        // Thread join must not depend on IsMainExplorer() — handle existence is the
+        // correct gate. Loop is bounded to 5 s to prevent an infinite hang if the
+        // dialog never opens (e.g. TaskDialogIndirect fails).
         if (g_restartExplorerPromptThread)
         {
-            while (WaitForSingleObject(g_restartExplorerPromptThread, 100) == WAIT_TIMEOUT)
+            for (int i = 0; i < 50 && WaitForSingleObject(g_restartExplorerPromptThread, 100) == WAIT_TIMEOUT; i++)
             {
                 if (HWND promptWindow = g_restartExplorerPromptWindow.load())
                 {
@@ -1237,25 +1240,28 @@ void Wh_ModUninit()
             g_restartExplorerPromptThread = nullptr;
         }
 
-        // 2. If standard shortcuts were disabled, prompt user on unload to restore them
-        if (!GetSystemMetrics(SM_SHUTTINGDOWN) && HasAnyStandardShortcutsDisabled())
+        if (IsMainExplorer())
         {
-            PromptForExplorerRestart();
-        }
-
-        // 3. Safe bounded wait (30s) matching official simple-window-switcher pattern
-        if (g_restartExplorerPromptThread)
-        {
-            if (WaitForSingleObject(g_restartExplorerPromptThread, 30000) == WAIT_TIMEOUT)
+            // 2. If standard shortcuts were disabled, prompt user on unload to restore them
+            if (!GetSystemMetrics(SM_SHUTTINGDOWN) && HasAnyStandardShortcutsDisabled())
             {
-                if (HWND promptWindow = g_restartExplorerPromptWindow.load())
-                {
-                    PostMessage(promptWindow, WM_CLOSE, 0, 0);
-                }
-                WaitForSingleObject(g_restartExplorerPromptThread, INFINITE);
+                PromptForExplorerRestart();
             }
-            CloseHandle(g_restartExplorerPromptThread);
-            g_restartExplorerPromptThread = nullptr;
+
+            // 3. Safe bounded wait (30s) matching official simple-window-switcher pattern
+            if (g_restartExplorerPromptThread)
+            {
+                if (WaitForSingleObject(g_restartExplorerPromptThread, 30000) == WAIT_TIMEOUT)
+                {
+                    if (HWND promptWindow = g_restartExplorerPromptWindow.load())
+                    {
+                        PostMessage(promptWindow, WM_CLOSE, 0, 0);
+                    }
+                    WaitForSingleObject(g_restartExplorerPromptThread, INFINITE);
+                }
+                CloseHandle(g_restartExplorerPromptThread);
+                g_restartExplorerPromptThread = nullptr;
+            }
         }
     }
 }

--- a/mods/disable-windows-shortcuts.wh.cpp
+++ b/mods/disable-windows-shortcuts.wh.cpp
@@ -407,9 +407,16 @@ struct Settings
     bool DisableCtrlEsc;
 } g_settings;
 
-bool StandardShortcutsEqual(const Settings& a, const Settings& b)
+bool ExplorerShortcutsEqual(const Settings& a, const Settings& b)
 {
-    return a.DisableWinB == b.DisableWinB &&
+    return (a.DisableWinA == 1) == (b.DisableWinA == 1) &&
+           (a.DisableWinC == 1) == (b.DisableWinC == 1) &&
+           (a.DisableWinK == 1) == (b.DisableWinK == 1) &&
+           (a.DisableWinN == 1) == (b.DisableWinN == 1) &&
+           (a.DisableWinP == 1) == (b.DisableWinP == 1) &&
+           (a.DisableWinU == 1) == (b.DisableWinU == 1) &&
+           (a.DisableWinSlash == 1) == (b.DisableWinSlash == 1) &&
+           a.DisableWinB == b.DisableWinB &&
            a.DisableWinD == b.DisableWinD &&
            a.DisableWinE == b.DisableWinE &&
            a.DisableWinF == b.DisableWinF &&
@@ -429,14 +436,11 @@ bool StandardShortcutsEqual(const Settings& a, const Settings& b)
            a.DisableWinX == b.DisableWinX &&
            a.DisableWinY == b.DisableWinY &&
            a.DisableWinZ == b.DisableWinZ &&
-           a.DisableWinTab == b.DisableWinTab &&
-           a.DisableWinUp == b.DisableWinUp &&
-           a.DisableWinDown == b.DisableWinDown &&
-           a.DisableWinLeft == b.DisableWinLeft &&
-           a.DisableWinRight == b.DisableWinRight &&
            a.DisableWinHome == b.DisableWinHome &&
            a.DisableWinShiftC == b.DisableWinShiftC &&
            a.DisableWinShiftM == b.DisableWinShiftM &&
+           a.DisableWinShiftR == b.DisableWinShiftR &&
+           a.DisableWinShiftS == b.DisableWinShiftS &&
            a.DisableWinComma == b.DisableWinComma &&
            a.DisableWinPause == b.DisableWinPause &&
            a.DisableWinCtrlD == b.DisableWinCtrlD &&
@@ -456,18 +460,10 @@ bool StandardShortcutsEqual(const Settings& a, const Settings& b)
            a.DisableWinCtrlN == b.DisableWinCtrlN &&
            a.DisableWinCtrlO == b.DisableWinCtrlO &&
            a.DisableWinCtrlS == b.DisableWinCtrlS &&
-           a.DisableWinSpace == b.DisableWinSpace &&
-           a.DisableWinShiftR == b.DisableWinShiftR &&
-           a.DisableWinShiftS == b.DisableWinShiftS &&
            a.DisableWinAltK == b.DisableWinAltK &&
            a.DisableWinPeriod == b.DisableWinPeriod &&
            a.DisableWinSemicolon == b.DisableWinSemicolon &&
            a.DisableWinPrtSc == b.DisableWinPrtSc &&
-           a.DisableWinShiftLeft == b.DisableWinShiftLeft &&
-           a.DisableWinShiftRight == b.DisableWinShiftRight &&
-           a.DisableWinShiftUp == b.DisableWinShiftUp &&
-           a.DisableWinShiftDown == b.DisableWinShiftDown &&
-           a.DisableOfficeHotkeys == b.DisableOfficeHotkeys &&
            a.DisableWinAltD == b.DisableWinAltD &&
            a.DisableWinAltB == b.DisableWinAltB &&
            a.DisableWinAltR == b.DisableWinAltR &&
@@ -475,29 +471,13 @@ bool StandardShortcutsEqual(const Settings& a, const Settings& b)
            a.DisableWinAltPrtSc == b.DisableWinAltPrtSc &&
            a.DisableWinAltT == b.DisableWinAltT &&
            a.DisableWinAltM == b.DisableWinAltM &&
-           a.DisableWinCtrlShiftB == b.DisableWinCtrlShiftB &&
-           a.DisableWinCtrlQ == b.DisableWinCtrlQ &&
-           a.DisableAltShift == b.DisableAltShift &&
-           a.DisableWinKey == b.DisableWinKey &&
-           a.DisableCtrlEsc == b.DisableCtrlEsc;
+           a.DisableWinCtrlQ == b.DisableWinCtrlQ;
 }
 
-bool HasAnyStandardShortcutsDisabled()
+bool HasAnyExplorerShortcutsDisabled()
 {
     Settings emptySettings{};
-    return !StandardShortcutsEqual(g_settings, emptySettings);
-}
-
-bool SettingsEqual(const Settings& a, const Settings& b)
-{
-    return a.DisableWinA == b.DisableWinA &&
-           a.DisableWinC == b.DisableWinC &&
-           a.DisableWinK == b.DisableWinK &&
-           a.DisableWinN == b.DisableWinN &&
-           a.DisableWinP == b.DisableWinP &&
-           a.DisableWinU == b.DisableWinU &&
-           a.DisableWinSlash == b.DisableWinSlash &&
-           StandardShortcutsEqual(a, b);
+    return !ExplorerShortcutsEqual(g_settings, emptySettings);
 }
 
 
@@ -765,13 +745,13 @@ bool IsKnownHardcodedHotkey(UINT fsModifiers, UINT vk)
             // Hardcoded keys that bypass RegisterHotKey
             if (vk == VK_TAB || vk == VK_UP || vk == VK_DOWN || vk == VK_LEFT || vk == VK_RIGHT || vk == VK_SPACE)
                 return true;
-            if (vk == 'A' && g_settings.DisableWinA > 0) return true;
-            if (vk == 'C' && g_settings.DisableWinC > 0) return true;
-            if (vk == 'K' && g_settings.DisableWinK > 0) return true;
-            if (vk == 'N' && g_settings.DisableWinN > 0) return true;
-            if (vk == 'P' && g_settings.DisableWinP > 0) return true;
-            if (vk == 'U' && g_settings.DisableWinU > 0) return true;
-            if (vk == VK_OEM_2 && g_settings.DisableWinSlash > 0) return true;
+            if (vk == 'A' && g_settings.DisableWinA == 2) return true;
+            if (vk == 'C' && g_settings.DisableWinC == 2) return true;
+            if (vk == 'K' && g_settings.DisableWinK == 2) return true;
+            if (vk == 'N' && g_settings.DisableWinN == 2) return true;
+            if (vk == 'P' && g_settings.DisableWinP == 2) return true;
+            if (vk == 'U' && g_settings.DisableWinU == 2) return true;
+            if (vk == VK_OEM_2 && g_settings.DisableWinSlash == 2) return true;
         } else {
             // Win+Shift+Arrows
             if (vk == VK_UP || vk == VK_DOWN || vk == VK_LEFT || vk == VK_RIGHT)
@@ -932,10 +912,6 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
         {
             return CallNextHookEx(g_hHook, nCode, wParam, lParam);
         }
-
-        // Fast path for dummy keys (used to mask Start Menu or language switch)
-        if (vkCode == 0xFF || vkCode == 0xE8)
-            return CallNextHookEx(g_hHook, nCode, wParam, lParam);
 
         bool isInitialDown = false;
         if (vkCode < 256)
@@ -1184,10 +1160,10 @@ void StopHookThread()
 
 bool NeedsDwmHook()
 {
-    return (g_settings.DisableWinA > 0) || (g_settings.DisableWinC > 0) || 
-           (g_settings.DisableWinK > 0) || (g_settings.DisableWinN > 0) || 
-           (g_settings.DisableWinP > 0) || (g_settings.DisableWinU > 0) || 
-           (g_settings.DisableWinSlash > 0) || 
+    return (g_settings.DisableWinA == 2) || (g_settings.DisableWinC == 2) || 
+           (g_settings.DisableWinK == 2) || (g_settings.DisableWinN == 2) || 
+           (g_settings.DisableWinP == 2) || (g_settings.DisableWinU == 2) || 
+           (g_settings.DisableWinSlash == 2) || 
            g_settings.DisableWinTab ||
            g_settings.DisableWinUp || g_settings.DisableWinDown || 
            g_settings.DisableWinLeft || g_settings.DisableWinRight ||
@@ -1228,10 +1204,59 @@ bool IsExplorerUptimeLarge()
         current.LowPart = systemTime.dwLowDateTime;
         current.HighPart = systemTime.dwHighDateTime;
         
-        // 5 seconds = 50,000,000 intervals of 100ns (distinguishes fresh boot from mid-session re-enable)
-        if (current.QuadPart > creation.QuadPart && (current.QuadPart - creation.QuadPart) > 50000000ULL)
+        // 15 seconds = 150,000,000 intervals of 100ns (distinguishes fresh boot from mid-session re-enable)
+        if (current.QuadPart > creation.QuadPart && (current.QuadPart - creation.QuadPart) > 150000000ULL)
             return true;
     }
+    return false;
+}
+
+bool ProbeIsHotkeyRegistered(UINT fsModifiers, UINT vk)
+{
+    const int kProbeHotkeyId = 0xBEEF;
+    if (RegisterHotKey(NULL, kProbeHotkeyId, fsModifiers, vk))
+    {
+        UnregisterHotKey(NULL, kProbeHotkeyId);
+        return false; // Hotkey is free: Explorer does not hold it
+    }
+    return true; // Hotkey is registered by Explorer or another process
+}
+
+bool AreAnyDisabledExplorerHotkeysRegistered()
+{
+    if (g_settings.DisableWinE && ProbeIsHotkeyRegistered(MOD_WIN, 'E')) return true;
+    if (g_settings.DisableWinR && ProbeIsHotkeyRegistered(MOD_WIN, 'R')) return true;
+    if (g_settings.DisableWinD && ProbeIsHotkeyRegistered(MOD_WIN, 'D')) return true;
+    if (g_settings.DisableWinI && ProbeIsHotkeyRegistered(MOD_WIN, 'I')) return true;
+    if (g_settings.DisableWinS && ProbeIsHotkeyRegistered(MOD_WIN, 'S')) return true;
+    if (g_settings.DisableWinV && ProbeIsHotkeyRegistered(MOD_WIN, 'V')) return true;
+    if (g_settings.DisableWinX && ProbeIsHotkeyRegistered(MOD_WIN, 'X')) return true;
+    if (g_settings.DisableWinB && ProbeIsHotkeyRegistered(MOD_WIN, 'B')) return true;
+    if (g_settings.DisableWinG && ProbeIsHotkeyRegistered(MOD_WIN, 'G')) return true;
+    if (g_settings.DisableWinH && ProbeIsHotkeyRegistered(MOD_WIN, 'H')) return true;
+    if (g_settings.DisableWinM && ProbeIsHotkeyRegistered(MOD_WIN, 'M')) return true;
+    if (g_settings.DisableWinZ && ProbeIsHotkeyRegistered(MOD_WIN, 'Z')) return true;
+    if ((g_settings.DisableWinA == 1) && ProbeIsHotkeyRegistered(MOD_WIN, 'A')) return true;
+    if ((g_settings.DisableWinC == 1) && ProbeIsHotkeyRegistered(MOD_WIN, 'C')) return true;
+    if ((g_settings.DisableWinK == 1) && ProbeIsHotkeyRegistered(MOD_WIN, 'K')) return true;
+    if ((g_settings.DisableWinN == 1) && ProbeIsHotkeyRegistered(MOD_WIN, 'N')) return true;
+    if ((g_settings.DisableWinP == 1) && ProbeIsHotkeyRegistered(MOD_WIN, 'P')) return true;
+    if ((g_settings.DisableWinU == 1) && ProbeIsHotkeyRegistered(MOD_WIN, 'U')) return true;
+    if ((g_settings.DisableWinSlash == 1) && ProbeIsHotkeyRegistered(MOD_WIN, VK_OEM_2)) return true;
+    if (g_settings.DisableWinShiftS && ProbeIsHotkeyRegistered(MOD_WIN | MOD_SHIFT, 'S')) return true;
+    if (g_settings.DisableWinShiftR && ProbeIsHotkeyRegistered(MOD_WIN | MOD_SHIFT, 'R')) return true;
+    if (g_settings.DisableWinShiftC && ProbeIsHotkeyRegistered(MOD_WIN | MOD_SHIFT, 'C')) return true;
+    if (g_settings.DisableWinCtrlD && ProbeIsHotkeyRegistered(MOD_WIN | MOD_CONTROL, 'D')) return true;
+    if (g_settings.DisableWinCtrlQ && ProbeIsHotkeyRegistered(MOD_WIN | MOD_CONTROL, 'Q')) return true;
+    if (g_settings.DisableWinAltD && ProbeIsHotkeyRegistered(MOD_WIN | MOD_ALT, 'D')) return true;
+    if (g_settings.DisableWinAltG && ProbeIsHotkeyRegistered(MOD_WIN | MOD_ALT, 'G')) return true;
+    if (g_settings.DisableWinAltR && ProbeIsHotkeyRegistered(MOD_WIN | MOD_ALT, 'R')) return true;
+    if (g_settings.DisableWinAltB && ProbeIsHotkeyRegistered(MOD_WIN | MOD_ALT, 'B')) return true;
+
+    // Fallback probe for general Explorer registration state
+    if (ProbeIsHotkeyRegistered(MOD_WIN, 'R') || ProbeIsHotkeyRegistered(MOD_WIN, 'E'))
+        return true;
+
     return false;
 }
 
@@ -1267,8 +1292,8 @@ BOOL Wh_ModInit()
                 Wh_SetFunctionHook(pRegisterHotKey, (void*)RegisterHotKey_Hook, (void**)&RegisterHotKey_Original);
         }
 
-        // Prompt ONLY if Explorer is running mid-session (>5s) AND at least one standard shortcut is disabled
-        if (IsMainExplorer() && !GetSystemMetrics(SM_SHUTTINGDOWN) && IsExplorerUptimeLarge() && HasAnyStandardShortcutsDisabled())
+        // Prompt ONLY if Explorer is running mid-session (>15s) AND at least one Explorer shortcut is disabled AND Explorer holds it
+        if (IsMainExplorer() && !GetSystemMetrics(SM_SHUTTINGDOWN) && IsExplorerUptimeLarge() && HasAnyExplorerShortcutsDisabled() && AreAnyDisabledExplorerHotkeysRegistered())
         {
             PromptForExplorerRestart();
         }
@@ -1289,40 +1314,16 @@ void Wh_ModUninit()
 
     if (g_isExplorer)
     {
-        // 1. Close any pending prompt from a previous settings change
-        if (HWND promptWindow = g_restartExplorerPromptWindow)
+        // 1. Signal any pending prompt dialog from a prior settings change to close
+        if (HWND promptWindow = g_restartExplorerPromptWindow.load())
         {
             PostMessage(promptWindow, WM_CLOSE, 0, 0);
         }
 
+        // 2. Safe bounded wait to let the prompt thread exit cleanly
         if (g_restartExplorerPromptThread)
         {
-            WaitForSingleObject(g_restartExplorerPromptThread, INFINITE);
-            CloseHandle(g_restartExplorerPromptThread);
-            g_restartExplorerPromptThread = nullptr;
-        }
-
-        // 2. If standard shortcuts were disabled, prompt the user on mod unload/disable
-        if (IsMainExplorer() && !GetSystemMetrics(SM_SHUTTINGDOWN))
-        {
-            if (HasAnyStandardShortcutsDisabled())
-            {
-                PromptForExplorerRestart();
-            }
-        }
-
-        // 3. Bounded wait for the unload prompt to guarantee safety without hanging
-        if (g_restartExplorerPromptThread)
-        {
-            if (WaitForSingleObject(g_restartExplorerPromptThread, 30000) == WAIT_TIMEOUT)
-            {
-                // User did not respond within 30 seconds: close dialog
-                if (HWND promptWindow = g_restartExplorerPromptWindow)
-                {
-                    PostMessage(promptWindow, WM_CLOSE, 0, 0);
-                }
-                WaitForSingleObject(g_restartExplorerPromptThread, INFINITE);
-            }
+            WaitForSingleObject(g_restartExplorerPromptThread, 1000);
             CloseHandle(g_restartExplorerPromptThread);
             g_restartExplorerPromptThread = nullptr;
         }
@@ -1342,7 +1343,7 @@ void Wh_ModSettingsChanged()
             StopHookThread();
     }
     
-    if (g_isExplorer && IsMainExplorer() && !GetSystemMetrics(SM_SHUTTINGDOWN) && !StandardShortcutsEqual(oldSettings, g_settings))
+    if (g_isExplorer && IsMainExplorer() && !GetSystemMetrics(SM_SHUTTINGDOWN) && !ExplorerShortcutsEqual(oldSettings, g_settings))
     {
         PromptForExplorerRestart();
     }

--- a/mods/disable-windows-shortcuts.wh.cpp
+++ b/mods/disable-windows-shortcuts.wh.cpp
@@ -2,7 +2,7 @@
 // @id              disable-windows-shortcuts
 // @name            Disable Windows Shortcuts
 // @description     Selectively disable Windows keyboard shortcuts with individual toggles
-// @version         1.2.2
+// @version         1.3.0
 // @author          Lone
 // @github          https://github.com/Louis047
 // @include         explorer.exe
@@ -19,82 +19,100 @@ Selectively disable Windows keyboard shortcuts with individual toggles for each 
 - Individual toggle for each shortcut
 - Uses a lightweight background hook thread ensuring third-party modifiers (like AltSnap, GlazeWM) are completely unaffected.
 
-## Special Shortcuts
-A small number of system shortcuts (Win+A, Win+C, Win+K, Win+N, Win+P, Win+U) and hardcoded keys (Win+Tab, Win+Arrows) operate at a lower OS level.
-To handle these properly, this mod provides **three options** for them in a dedicated section at the top of the settings:
-- **0 - Off:** The shortcut is completely unaffected.
-- **1 - Disable hotkey:** Disables the shortcut natively. Lightweight, but third-party apps that simulate these keys (like custom taskbars) will also be blocked.
-- **2 - Block hotkey:** Blocks the physical keystroke but tricks Windows into thinking it was registered. This allows simulating apps to work while physically blocking the key, but **requires injecting into `dwm.exe`**.
+## How Shortcuts Are Handled
+This mod provides three organized categories of shortcuts:
+1. **Special Shortcuts (Flyouts):** Windows processes system flyouts (`Win+A`, `Win+N`, `Win+C`, `Win+K`, `Win+P`, `Win+U`, `Win+/`) at a lower compositor level. The mod physically suppresses keypresses via a low-level keyboard hook running in `dwm.exe`. Injected/simulated keystrokes (e.g. custom taskbars like YASB or macros) and native taskbar tray mouse clicks continue to work seamlessly.
+2. **Direct Shortcuts (No Restart Required):** Handled immediately via low-level keyboard hook in `dwm.exe`. Disabling shortcuts like `Win` or `Alt+Shift` allows third-party apps (such as Flow Launcher's Windows key launcher or custom `Alt+Shift` keybinds) to be used without Windows opening the Start Menu or switching keyboard layouts. Hardcoded shortcuts (`Ctrl+Esc`, `Win+Tab`, `Win+Arrows`, `Win+Space`, `Win+Ctrl+Shift+Alt`, `Win+Ctrl+Shift+B`) are blocked immediately without requiring an Explorer restart.
+3. **Standard Shortcuts (Requires Explorer Restart):** Handled via Explorer's `RegisterHotKey` API. When disabled, Explorer is prevented from claiming the key, freeing it in the OS kernel so other applications (such as PowerToys, GlazeWM, or Flow Launcher) can bind to it. Changes require an Explorer restart to release the key (a restart dialog will prompt you automatically).
 
 ## ⚠️ Important `dwm.exe` Installation Step ⚠️
-If you use the **"Block hotkey"** option, or if you disable window snapping (Win+Arrows), Task View (Win+Tab), Switch keyboard layout (Win+Space, Alt+Shift), or Start Menu (Win, Ctrl+Esc), you **must** allow Windhawk to inject into the Desktop Window Manager (`dwm.exe`):
+For **Special Shortcuts** and **Direct Shortcuts** to be blocked, you **must** allow Windhawk to inject into the Desktop Window Manager (`dwm.exe`):
 1. Open Windhawk and go to **Settings**
 2. Click on **Advanced settings** at the bottom
 3. Under **Process inclusion list**, ensure `dwm.exe` is added (or `*` is used to include all processes)
 4. Click **Save**. Windhawk will automatically restart to apply the new settings.
 
-*Note: Changes to standard shortcuts (like Win+E) require an Explorer restart to completely release the hotkeys for other applications (such as PowerToys or GlazeWM). You will be prompted automatically. If you completely disable or remove this mod from Windhawk, you must manually restart Explorer to restore those standard shortcuts.*
+*Note: Changes to standard shortcuts (like Win+E) require an Explorer restart to completely release the hotkeys for other applications. You will be prompted automatically. If you completely disable or remove this mod from Windhawk, you must restart Explorer to restore those standard shortcuts.*
 
 ## Notes
-- Win key (Start Menu) is handled by the "Block Start Menu and Hosts" mod
 - Win+L (Lock PC) cannot be blocked through standard hooks
-- Win+Q is redundant with Win+S (both open Search)
 */
 // ==/WindhawkModReadme==
 // ==WindhawkModSettings==
 /*
 - SpecialShortcuts:
-  - DisableWinA: "off"
+  - DisableWinA: false
     $name: Win+A
     $description: Action Center / Quick Settings
-    $options:
-    - "off": Off
-    - disable: Disable hotkey (Simulating apps affected)
-    - block: Block hotkey (Requires dwm.exe, simulating apps work)
-  - DisableWinC: "off"
+  - DisableWinC: false
     $name: Win+C
-    $description: Cortana / Copilot (May require 'Block hotkey' on Win 11)
-    $options:
-    - "off": Off
-    - disable: Disable hotkey (Simulating apps affected)
-    - block: Block hotkey (Requires dwm.exe, simulating apps work)
-  - DisableWinK: "off"
+    $description: Cortana / Copilot
+  - DisableWinK: false
     $name: Win+K
-    $description: Connect (Cast)
-    $options:
-    - "off": Off
-    - disable: Disable hotkey (Simulating apps affected)
-    - block: Block hotkey (Requires dwm.exe, simulating apps work)
-  - DisableWinN: "off"
+    $description: Connect / Cast
+  - DisableWinN: false
     $name: Win+N
     $description: Notification Center
-    $options:
-    - "off": Off
-    - disable: Disable hotkey (Simulating apps affected)
-    - block: Block hotkey (Requires dwm.exe, simulating apps work)
-  - DisableWinP: "off"
+  - DisableWinP: false
     $name: Win+P
     $description: Project / Display mode
-    $options:
-    - "off": Off
-    - disable: Disable hotkey (Simulating apps affected)
-    - block: Block hotkey (Requires dwm.exe, simulating apps work)
-  - DisableWinU: "off"
+  - DisableWinU: false
     $name: Win+U
     $description: Accessibility Settings
-    $options:
-    - "off": Off
-    - disable: Disable hotkey (Simulating apps affected)
-    - block: Block hotkey (Requires dwm.exe, simulating apps work)
-  - DisableWinSlash: "off"
+  - DisableWinSlash: false
     $name: Win+/
     $description: IME reconversion
-    $options:
-    - "off": Off
-    - disable: Disable hotkey (Simulating apps affected)
-    - block: Block hotkey (Requires dwm.exe, simulating apps work)
-  $name: Special Shortcuts (3-Tier Options)
-  $description: See 'Special Shortcuts' in Details
+  $name: Special Shortcuts
+  $description: System flyouts handled via DWM low-level hook. Requires dwm.exe in Process inclusion list.
+
+- DirectShortcuts:
+  - DisableWinKey: false
+    $name: Win
+    $description: Open Start Menu
+  - DisableCtrlEsc: false
+    $name: Ctrl+Esc
+    $description: Open Start Menu
+  - DisableAltShift: false
+    $name: Alt+Shift
+    $description: Switch keyboard layout
+  - DisableWinSpace: false
+    $name: Win+Space
+    $description: Switch keyboard layout
+  - DisableOfficeHotkeys: false
+    $name: Win+Ctrl+Shift+Alt
+    $description: Office Hub / Microsoft 365 app combinations
+  - DisableWinTab: false
+    $name: Win+Tab
+    $description: Task View
+  - DisableWinUp: false
+    $name: Win+Up
+    $description: Maximize window
+  - DisableWinDown: false
+    $name: Win+Down
+    $description: Restore/Minimize window
+  - DisableWinLeft: false
+    $name: Win+Left
+    $description: Snap window left
+  - DisableWinRight: false
+    $name: Win+Right
+    $description: Snap window right
+  - DisableWinShiftUp: false
+    $name: Win+Shift+Up
+    $description: Stretch window vertically
+  - DisableWinShiftDown: false
+    $name: Win+Shift+Down
+    $description: Restore/minimize height
+  - DisableWinShiftLeft: false
+    $name: Win+Shift+Left
+    $description: Move window to left monitor
+  - DisableWinShiftRight: false
+    $name: Win+Shift+Right
+    $description: Move window to right monitor
+  - DisableWinCtrlShiftB: false
+    $name: Win+Ctrl+Shift+B
+    $description: Restart graphics driver
+  $name: Direct Shortcuts
+  $description: Shortcuts handled immediately via low-level hook without requiring an Explorer restart. Requires dwm.exe in Process inclusion list.
 
 - StandardShortcuts:
   - DisableWinB: false
@@ -157,21 +175,6 @@ If you use the **"Block hotkey"** option, or if you disable window snapping (Win
   - DisableWinZ: false
     $name: Win+Z
     $description: Snap Layouts
-  - DisableWinTab: false
-    $name: Win+Tab
-    $description: Task View
-  - DisableWinUp: false
-    $name: Win+Up
-    $description: Maximize window
-  - DisableWinDown: false
-    $name: Win+Down
-    $description: Restore/Minimize window
-  - DisableWinLeft: false
-    $name: Win+Left
-    $description: Snap window left
-  - DisableWinRight: false
-    $name: Win+Right
-    $description: Snap window right
   - DisableWinHome: false
     $name: Win+Home
     $description: Minimize inactive windows
@@ -238,9 +241,6 @@ If you use the **"Block hotkey"** option, or if you disable window snapping (Win
   - DisableWinCtrlS: false
     $name: Win+Ctrl+S
     $description: Speech Recognition
-  - DisableWinSpace: false
-    $name: Win+Space
-    $description: Switch keyboard layout
   - DisableWinShiftR: false
     $name: Win+Shift+R
     $description: Snipping Tool record
@@ -259,21 +259,6 @@ If you use the **"Block hotkey"** option, or if you disable window snapping (Win
   - DisableWinPrtSc: false
     $name: Win+PrtSc
     $description: Screenshot to file
-  - DisableWinShiftLeft: false
-    $name: Win+Shift+Left
-    $description: Move window to left monitor
-  - DisableWinShiftRight: false
-    $name: Win+Shift+Right
-    $description: Move window to right monitor
-  - DisableWinShiftUp: false
-    $name: Win+Shift+Up
-    $description: Stretch window vertically
-  - DisableWinShiftDown: false
-    $name: Win+Shift+Down
-    $description: Restore/minimize height
-  - DisableOfficeHotkeys: false
-    $name: Office Hotkeys
-    $description: Ctrl+Shift+Alt+Win combinations
   - DisableWinAltD: false
     $name: Win+Alt+D
     $description: Show date/time
@@ -295,23 +280,11 @@ If you use the **"Block hotkey"** option, or if you disable window snapping (Win
   - DisableWinAltM: false
     $name: Win+Alt+M
     $description: Toggle microphone (Game Bar)
-  - DisableWinCtrlShiftB: false
-    $name: Win+Ctrl+Shift+B
-    $description: Restart graphics driver
   - DisableWinCtrlQ: false
     $name: Win+Ctrl+Q
     $description: Quick Assist
-  - DisableAltShift: false
-    $name: Alt+Shift
-    $description: Switch keyboard layout
-  - DisableWinKey: false
-    $name: Win
-    $description: Open Start Menu
-  - DisableCtrlEsc: false
-    $name: Ctrl+Esc
-    $description: Open Start Menu
-  $name: Standard Shortcuts (On/Off)
-  $description: Regular shortcuts that only require Explorer
+  $name: Standard Shortcuts
+  $description: Regular shortcuts registered by Explorer. Requires restarting Explorer to apply changes and release hotkeys for third-party apps.
 */
 // ==/WindhawkModSettings==
 
@@ -327,9 +300,9 @@ bool g_isDWM = false;
 // Settings structure
 struct Settings
 {
-    int DisableWinA;
+    bool DisableWinA;
     bool DisableWinB;
-    int DisableWinC;
+    bool DisableWinC;
     bool DisableWinD;
     bool DisableWinE;
     bool DisableWinF;
@@ -338,22 +311,22 @@ struct Settings
     bool DisableWinH;
     bool DisableWinI;
     bool DisableWinJ;
-    int DisableWinK;
+    bool DisableWinK;
     bool DisableWinM;
-    int DisableWinN;
+    bool DisableWinN;
     bool DisableWinO;
-    int DisableWinP;
+    bool DisableWinP;
     bool DisableWinQ;
     bool DisableWinR;
     bool DisableWinS;
     bool DisableWinT;
-    int DisableWinU;
+    bool DisableWinU;
     bool DisableWinV;
     bool DisableWinW;
     bool DisableWinX;
     bool DisableWinY;
     bool DisableWinZ;
-    int DisableWinSlash;
+    bool DisableWinSlash;
     bool DisableWinTab;
     bool DisableWinUp;
     bool DisableWinDown;
@@ -407,16 +380,9 @@ struct Settings
     bool DisableCtrlEsc;
 } g_settings;
 
-bool ExplorerShortcutsEqual(const Settings& a, const Settings& b)
+bool StandardShortcutsEqual(const Settings& a, const Settings& b)
 {
-    return (a.DisableWinA == 1) == (b.DisableWinA == 1) &&
-           (a.DisableWinC == 1) == (b.DisableWinC == 1) &&
-           (a.DisableWinK == 1) == (b.DisableWinK == 1) &&
-           (a.DisableWinN == 1) == (b.DisableWinN == 1) &&
-           (a.DisableWinP == 1) == (b.DisableWinP == 1) &&
-           (a.DisableWinU == 1) == (b.DisableWinU == 1) &&
-           (a.DisableWinSlash == 1) == (b.DisableWinSlash == 1) &&
-           a.DisableWinB == b.DisableWinB &&
+    return a.DisableWinB == b.DisableWinB &&
            a.DisableWinD == b.DisableWinD &&
            a.DisableWinE == b.DisableWinE &&
            a.DisableWinF == b.DisableWinF &&
@@ -474,30 +440,42 @@ bool ExplorerShortcutsEqual(const Settings& a, const Settings& b)
            a.DisableWinCtrlQ == b.DisableWinCtrlQ;
 }
 
-bool HasAnyExplorerShortcutsDisabled()
+bool HasAnyStandardShortcutsDisabled()
 {
     Settings emptySettings{};
-    return !ExplorerShortcutsEqual(g_settings, emptySettings);
-}
-
-
-int GetSettingIntSafe(PCWSTR settingName) {
-    PCWSTR val = Wh_GetStringSetting(settingName);
-    if (!val) return 0;
-    int res = 0;
-    if (wcscmp(val, L"true") == 0 || wcscmp(val, L"disable") == 0) res = 1;
-    else if (wcscmp(val, L"false") == 0 || wcscmp(val, L"off") == 0) res = 0;
-    else if (wcscmp(val, L"block") == 0) res = 2;
-    else res = _wtoi(val); // fallback for legacy numbers
-    Wh_FreeStringSetting(val);
-    return res;
+    return !StandardShortcutsEqual(g_settings, emptySettings);
 }
 
 void LoadSettings()
 {
-    g_settings.DisableWinA = GetSettingIntSafe(L"SpecialShortcuts.DisableWinA");
+    // Special Shortcuts (Flyouts handled via DWM)
+    g_settings.DisableWinA = Wh_GetIntSetting(L"SpecialShortcuts.DisableWinA");
+    g_settings.DisableWinC = Wh_GetIntSetting(L"SpecialShortcuts.DisableWinC");
+    g_settings.DisableWinK = Wh_GetIntSetting(L"SpecialShortcuts.DisableWinK");
+    g_settings.DisableWinN = Wh_GetIntSetting(L"SpecialShortcuts.DisableWinN");
+    g_settings.DisableWinP = Wh_GetIntSetting(L"SpecialShortcuts.DisableWinP");
+    g_settings.DisableWinU = Wh_GetIntSetting(L"SpecialShortcuts.DisableWinU");
+    g_settings.DisableWinSlash = Wh_GetIntSetting(L"SpecialShortcuts.DisableWinSlash");
+
+    // Direct Shortcuts (No Explorer Restart Required - with backward-compatible fallback)
+    g_settings.DisableWinKey = Wh_GetIntSetting(L"DirectShortcuts.DisableWinKey") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinKey");
+    g_settings.DisableCtrlEsc = Wh_GetIntSetting(L"DirectShortcuts.DisableCtrlEsc") || Wh_GetIntSetting(L"StandardShortcuts.DisableCtrlEsc");
+    g_settings.DisableAltShift = Wh_GetIntSetting(L"DirectShortcuts.DisableAltShift") || Wh_GetIntSetting(L"StandardShortcuts.DisableAltShift");
+    g_settings.DisableWinSpace = Wh_GetIntSetting(L"DirectShortcuts.DisableWinSpace") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinSpace");
+    g_settings.DisableOfficeHotkeys = Wh_GetIntSetting(L"DirectShortcuts.DisableOfficeHotkeys") || Wh_GetIntSetting(L"StandardShortcuts.DisableOfficeHotkeys");
+    g_settings.DisableWinTab = Wh_GetIntSetting(L"DirectShortcuts.DisableWinTab") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinTab");
+    g_settings.DisableWinUp = Wh_GetIntSetting(L"DirectShortcuts.DisableWinUp") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinUp");
+    g_settings.DisableWinDown = Wh_GetIntSetting(L"DirectShortcuts.DisableWinDown") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinDown");
+    g_settings.DisableWinLeft = Wh_GetIntSetting(L"DirectShortcuts.DisableWinLeft") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinLeft");
+    g_settings.DisableWinRight = Wh_GetIntSetting(L"DirectShortcuts.DisableWinRight") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinRight");
+    g_settings.DisableWinShiftUp = Wh_GetIntSetting(L"DirectShortcuts.DisableWinShiftUp") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftUp");
+    g_settings.DisableWinShiftDown = Wh_GetIntSetting(L"DirectShortcuts.DisableWinShiftDown") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftDown");
+    g_settings.DisableWinShiftLeft = Wh_GetIntSetting(L"DirectShortcuts.DisableWinShiftLeft") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftLeft");
+    g_settings.DisableWinShiftRight = Wh_GetIntSetting(L"DirectShortcuts.DisableWinShiftRight") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftRight");
+    g_settings.DisableWinCtrlShiftB = Wh_GetIntSetting(L"DirectShortcuts.DisableWinCtrlShiftB") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinCtrlShiftB");
+
+    // Standard Shortcuts (Requires Explorer Restart)
     g_settings.DisableWinB = Wh_GetIntSetting(L"StandardShortcuts.DisableWinB");
-    g_settings.DisableWinC = GetSettingIntSafe(L"SpecialShortcuts.DisableWinC");
     g_settings.DisableWinD = Wh_GetIntSetting(L"StandardShortcuts.DisableWinD");
     g_settings.DisableWinE = Wh_GetIntSetting(L"StandardShortcuts.DisableWinE");
     g_settings.DisableWinF = Wh_GetIntSetting(L"StandardShortcuts.DisableWinF");
@@ -506,27 +484,17 @@ void LoadSettings()
     g_settings.DisableWinH = Wh_GetIntSetting(L"StandardShortcuts.DisableWinH");
     g_settings.DisableWinI = Wh_GetIntSetting(L"StandardShortcuts.DisableWinI");
     g_settings.DisableWinJ = Wh_GetIntSetting(L"StandardShortcuts.DisableWinJ");
-    g_settings.DisableWinK = GetSettingIntSafe(L"SpecialShortcuts.DisableWinK");
     g_settings.DisableWinM = Wh_GetIntSetting(L"StandardShortcuts.DisableWinM");
-    g_settings.DisableWinN = GetSettingIntSafe(L"SpecialShortcuts.DisableWinN");
     g_settings.DisableWinO = Wh_GetIntSetting(L"StandardShortcuts.DisableWinO");
-    g_settings.DisableWinP = GetSettingIntSafe(L"SpecialShortcuts.DisableWinP");
     g_settings.DisableWinQ = Wh_GetIntSetting(L"StandardShortcuts.DisableWinQ");
     g_settings.DisableWinR = Wh_GetIntSetting(L"StandardShortcuts.DisableWinR");
     g_settings.DisableWinS = Wh_GetIntSetting(L"StandardShortcuts.DisableWinS");
     g_settings.DisableWinT = Wh_GetIntSetting(L"StandardShortcuts.DisableWinT");
-    g_settings.DisableWinU = GetSettingIntSafe(L"SpecialShortcuts.DisableWinU");
     g_settings.DisableWinV = Wh_GetIntSetting(L"StandardShortcuts.DisableWinV");
     g_settings.DisableWinW = Wh_GetIntSetting(L"StandardShortcuts.DisableWinW");
     g_settings.DisableWinX = Wh_GetIntSetting(L"StandardShortcuts.DisableWinX");
     g_settings.DisableWinY = Wh_GetIntSetting(L"StandardShortcuts.DisableWinY");
     g_settings.DisableWinZ = Wh_GetIntSetting(L"StandardShortcuts.DisableWinZ");
-    g_settings.DisableWinSlash = GetSettingIntSafe(L"SpecialShortcuts.DisableWinSlash");
-    g_settings.DisableWinTab = Wh_GetIntSetting(L"StandardShortcuts.DisableWinTab");
-    g_settings.DisableWinUp = Wh_GetIntSetting(L"StandardShortcuts.DisableWinUp");
-    g_settings.DisableWinDown = Wh_GetIntSetting(L"StandardShortcuts.DisableWinDown");
-    g_settings.DisableWinLeft = Wh_GetIntSetting(L"StandardShortcuts.DisableWinLeft");
-    g_settings.DisableWinRight = Wh_GetIntSetting(L"StandardShortcuts.DisableWinRight");
     g_settings.DisableWinHome = Wh_GetIntSetting(L"StandardShortcuts.DisableWinHome");
     g_settings.DisableWinShiftC = Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftC");
     g_settings.DisableWinShiftM = Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftM");
@@ -549,18 +517,12 @@ void LoadSettings()
     g_settings.DisableWinCtrlN = Wh_GetIntSetting(L"StandardShortcuts.DisableWinCtrlN");
     g_settings.DisableWinCtrlO = Wh_GetIntSetting(L"StandardShortcuts.DisableWinCtrlO");
     g_settings.DisableWinCtrlS = Wh_GetIntSetting(L"StandardShortcuts.DisableWinCtrlS");
-    g_settings.DisableWinSpace = Wh_GetIntSetting(L"StandardShortcuts.DisableWinSpace");
     g_settings.DisableWinShiftR = Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftR");
     g_settings.DisableWinShiftS = Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftS");
     g_settings.DisableWinAltK = Wh_GetIntSetting(L"StandardShortcuts.DisableWinAltK");
     g_settings.DisableWinPeriod = Wh_GetIntSetting(L"StandardShortcuts.DisableWinPeriod");
     g_settings.DisableWinSemicolon = Wh_GetIntSetting(L"StandardShortcuts.DisableWinSemicolon");
     g_settings.DisableWinPrtSc = Wh_GetIntSetting(L"StandardShortcuts.DisableWinPrtSc");
-    g_settings.DisableWinShiftLeft = Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftLeft");
-    g_settings.DisableWinShiftRight = Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftRight");
-    g_settings.DisableWinShiftUp = Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftUp");
-    g_settings.DisableWinShiftDown = Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftDown");
-    g_settings.DisableOfficeHotkeys = Wh_GetIntSetting(L"StandardShortcuts.DisableOfficeHotkeys");
     g_settings.DisableWinAltD = Wh_GetIntSetting(L"StandardShortcuts.DisableWinAltD");
     g_settings.DisableWinAltB = Wh_GetIntSetting(L"StandardShortcuts.DisableWinAltB");
     g_settings.DisableWinAltR = Wh_GetIntSetting(L"StandardShortcuts.DisableWinAltR");
@@ -568,11 +530,7 @@ void LoadSettings()
     g_settings.DisableWinAltPrtSc = Wh_GetIntSetting(L"StandardShortcuts.DisableWinAltPrtSc");
     g_settings.DisableWinAltT = Wh_GetIntSetting(L"StandardShortcuts.DisableWinAltT");
     g_settings.DisableWinAltM = Wh_GetIntSetting(L"StandardShortcuts.DisableWinAltM");
-    g_settings.DisableWinCtrlShiftB = Wh_GetIntSetting(L"StandardShortcuts.DisableWinCtrlShiftB");
     g_settings.DisableWinCtrlQ = Wh_GetIntSetting(L"StandardShortcuts.DisableWinCtrlQ");
-    g_settings.DisableAltShift = Wh_GetIntSetting(L"StandardShortcuts.DisableAltShift");
-    g_settings.DisableWinKey = Wh_GetIntSetting(L"StandardShortcuts.DisableWinKey");
-    g_settings.DisableCtrlEsc = Wh_GetIntSetting(L"StandardShortcuts.DisableCtrlEsc");
 }
 
 bool IsNumberKey(DWORD vkCode)
@@ -674,9 +632,9 @@ bool ShouldBlockHotkey(UINT fsModifiers, UINT vk)
         {
             switch (vk)
             {
-                case 'A': block = (g_settings.DisableWinA > 0); break;
+                case 'A': block = g_settings.DisableWinA; break;
                 case 'B': block = g_settings.DisableWinB; break;
-                case 'C': block = (g_settings.DisableWinC > 0); break;
+                case 'C': block = g_settings.DisableWinC; break;
                 case 'D': block = g_settings.DisableWinD; break;
                 case 'E': block = g_settings.DisableWinE; break;
                 case 'F': block = g_settings.DisableWinF; break;
@@ -685,16 +643,16 @@ bool ShouldBlockHotkey(UINT fsModifiers, UINT vk)
                 case 'H': block = g_settings.DisableWinH; break;
                 case 'I': block = g_settings.DisableWinI; break;
                 case 'J': block = g_settings.DisableWinJ; break;
-                case 'K': block = (g_settings.DisableWinK > 0); break;
+                case 'K': block = g_settings.DisableWinK; break;
                 case 'M': block = g_settings.DisableWinM; break;
-                case 'N': block = (g_settings.DisableWinN > 0); break;
+                case 'N': block = g_settings.DisableWinN; break;
                 case 'O': block = g_settings.DisableWinO; break;
-                case 'P': block = (g_settings.DisableWinP > 0); break;
+                case 'P': block = g_settings.DisableWinP; break;
                 case 'Q': block = g_settings.DisableWinQ; break;
                 case 'R': block = g_settings.DisableWinR; break;
                 case 'S': block = g_settings.DisableWinS; break;
                 case 'T': block = g_settings.DisableWinT; break;
-                case 'U': block = (g_settings.DisableWinU > 0); break;
+                case 'U': block = g_settings.DisableWinU; break;
                 case 'V': block = g_settings.DisableWinV; break;
                 case 'W': block = g_settings.DisableWinW; break;
                 case 'X': block = g_settings.DisableWinX; break;
@@ -713,7 +671,7 @@ bool ShouldBlockHotkey(UINT fsModifiers, UINT vk)
                 case VK_ESCAPE: block = g_settings.DisableWinEsc; break;
                 case VK_SPACE: block = g_settings.DisableWinSpace; break;
                 case VK_OEM_PERIOD: block = g_settings.DisableWinPeriod; break;
-                case VK_OEM_2: block = (g_settings.DisableWinSlash > 0); break;
+                case VK_OEM_2: block = g_settings.DisableWinSlash; break;
                 case VK_OEM_1: block = g_settings.DisableWinSemicolon; break;
                 case VK_SNAPSHOT: block = g_settings.DisableWinPrtSc; break;
             }
@@ -745,13 +703,13 @@ bool IsKnownHardcodedHotkey(UINT fsModifiers, UINT vk)
             // Hardcoded keys that bypass RegisterHotKey
             if (vk == VK_TAB || vk == VK_UP || vk == VK_DOWN || vk == VK_LEFT || vk == VK_RIGHT || vk == VK_SPACE)
                 return true;
-            if (vk == 'A' && g_settings.DisableWinA == 2) return true;
-            if (vk == 'C' && g_settings.DisableWinC == 2) return true;
-            if (vk == 'K' && g_settings.DisableWinK == 2) return true;
-            if (vk == 'N' && g_settings.DisableWinN == 2) return true;
-            if (vk == 'P' && g_settings.DisableWinP == 2) return true;
-            if (vk == 'U' && g_settings.DisableWinU == 2) return true;
-            if (vk == VK_OEM_2 && g_settings.DisableWinSlash == 2) return true;
+            if (vk == 'A' && g_settings.DisableWinA) return true;
+            if (vk == 'C' && g_settings.DisableWinC) return true;
+            if (vk == 'K' && g_settings.DisableWinK) return true;
+            if (vk == 'N' && g_settings.DisableWinN) return true;
+            if (vk == 'P' && g_settings.DisableWinP) return true;
+            if (vk == 'U' && g_settings.DisableWinU) return true;
+            if (vk == VK_OEM_2 && g_settings.DisableWinSlash) return true;
         } else {
             // Win+Shift+Arrows
             if (vk == VK_UP || vk == VK_DOWN || vk == VK_LEFT || vk == VK_RIGHT)
@@ -775,11 +733,12 @@ BOOL WINAPI RegisterHotKey_Hook(HWND hWnd, int id, UINT fsModifiers, UINT vk)
 {
     if (ShouldBlockHotkey(fsModifiers, vk))
     {
-        // If the hotkey is a known hardcoded shell key (like Win+A for Action Center),
-        // we MUST let Explorer successfully register it. If we fake a failure here, 
-        // Explorer components fail to initialize and the user can't even open them 
-        // with a manual mouse click on the taskbar tray icons!
-        // The physical keyboard shortcut will still be blocked safely by our DWM LL hook.
+        // For Special Shortcuts & hardcoded keys, IsKnownHardcodedHotkey returns true:
+        // Explorer registers the hotkey so internal shell flyouts initialize properly 
+        // and taskbar tray mouse clicks or simulating apps continue to work, 
+        // while the physical keystroke is blocked in DWM.
+        // For Standard shortcuts (like Win+E, Win+R, Win+D), IsKnownHardcodedHotkey returns false:
+        // Explorer is prevented from claiming the hotkey, freeing it at OS level for other apps.
         if (IsKnownHardcodedHotkey(fsModifiers, vk))
         {
             return RegisterHotKey_Original(hWnd, id, fsModifiers, vk);
@@ -902,17 +861,9 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
         DWORD vkCode = pKeyBoard->vkCode;
         bool isDown = (wParam == WM_KEYDOWN || wParam == WM_SYSKEYDOWN);
         bool isUp = (wParam == WM_KEYUP || wParam == WM_SYSKEYUP);
+        bool isInjected = (pKeyBoard->flags & LLKHF_INJECTED) != 0;
 
-        // Ignore programmatically injected keystrokes. 
-        // This is extremely important because when a user manually clicks on a taskbar
-        // tray icon (like Network/Volume to open Quick Settings), Explorer actually 
-        // synthesizes a fake Win+A keystroke to trigger the flyout. If we block 
-        // injected keys, clicking the tray icon with the mouse will fail!
-        if (pKeyBoard->flags & LLKHF_INJECTED)
-        {
-            return CallNextHookEx(g_hHook, nCode, wParam, lParam);
-        }
-
+        // --- STEP 1: Unconditionally update software key state FIRST ---
         bool isInitialDown = false;
         if (vkCode < 256)
         {
@@ -932,10 +883,32 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
                 }
                 g_keyState[vkCode] = true;
             }
-            if (isUp) g_keyState[vkCode] = false;
+            else if (isUp)
+            {
+                g_keyState[vkCode] = false;
+            }
         }
 
-        // --- 1. Pass Modifiers Through ---
+        // --- STEP 2: Evaluate 100% accurate modifier states ---
+        bool hasWin = g_keyState[VK_LWIN] || g_keyState[VK_RWIN] || (GetAsyncKeyState(VK_LWIN) & 0x8000) || (GetAsyncKeyState(VK_RWIN) & 0x8000);
+        bool hasCtrl = g_keyState[VK_CONTROL] || g_keyState[VK_LCONTROL] || g_keyState[VK_RCONTROL] || (GetAsyncKeyState(VK_CONTROL) & 0x8000) || (GetAsyncKeyState(VK_LCONTROL) & 0x8000) || (GetAsyncKeyState(VK_RCONTROL) & 0x8000);
+        bool hasShift = g_keyState[VK_SHIFT] || g_keyState[VK_LSHIFT] || g_keyState[VK_RSHIFT] || (GetAsyncKeyState(VK_SHIFT) & 0x8000) || (GetAsyncKeyState(VK_LSHIFT) & 0x8000) || (GetAsyncKeyState(VK_RSHIFT) & 0x8000);
+        bool hasAlt = g_keyState[VK_MENU] || g_keyState[VK_LMENU] || g_keyState[VK_RMENU] || (GetAsyncKeyState(VK_MENU) & 0x8000) || (GetAsyncKeyState(VK_LMENU) & 0x8000) || (GetAsyncKeyState(VK_RMENU) & 0x8000);
+
+        UINT fsModifiers = 0;
+        if (hasWin) fsModifiers |= MOD_WIN;
+        if (hasCtrl) fsModifiers |= MOD_CONTROL;
+        if (hasShift) fsModifiers |= MOD_SHIFT;
+        if (hasAlt) fsModifiers |= MOD_ALT;
+
+        // --- STEP 3: Handle Injected Keystrokes ---
+        // Allow injected/simulated keystrokes (e.g. from third-party tools, tray clicks, or macros)
+        if (isInjected)
+        {
+            return CallNextHookEx(g_hHook, nCode, wParam, lParam);
+        }
+
+        // --- STEP 4: Pass Modifiers Through (Physical) ---
         // Never block modifiers themselves to preserve third-party app compatibility
         if ((vkCode >= VK_SHIFT && vkCode <= VK_MENU) ||
             vkCode == VK_LWIN || vkCode == VK_RWIN ||
@@ -952,11 +925,10 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
                 // to disrupt the layout switcher's sequence detection.
                 if (isUp && (isShift || isAlt))
                 {
-                    bool hasWinState = g_keyState[VK_LWIN] || g_keyState[VK_RWIN] || (GetAsyncKeyState(VK_LWIN) & 0x8000) || (GetAsyncKeyState(VK_RWIN) & 0x8000);
-                    bool hasCtrlState = g_keyState[VK_CONTROL] || g_keyState[VK_LCONTROL] || g_keyState[VK_RCONTROL] || (GetAsyncKeyState(VK_CONTROL) & 0x8000);
-                    
-                    bool hasShiftState = g_keyState[VK_SHIFT] || g_keyState[VK_LSHIFT] || g_keyState[VK_RSHIFT] || (GetAsyncKeyState(VK_SHIFT) & 0x8000) || isShift;
-                    bool hasAltState = g_keyState[VK_MENU] || g_keyState[VK_LMENU] || g_keyState[VK_RMENU] || (GetAsyncKeyState(VK_MENU) & 0x8000) || isAlt;
+                    bool hasWinState = g_keyState[VK_LWIN] || g_keyState[VK_RWIN];
+                    bool hasCtrlState = g_keyState[VK_CONTROL] || g_keyState[VK_LCONTROL] || g_keyState[VK_RCONTROL];
+                    bool hasShiftState = g_keyState[VK_SHIFT] || g_keyState[VK_LSHIFT] || g_keyState[VK_RSHIFT] || isShift;
+                    bool hasAltState = g_keyState[VK_MENU] || g_keyState[VK_LMENU] || g_keyState[VK_RMENU] || isAlt;
 
                     if (hasAltState && hasShiftState && !hasWinState && !hasCtrlState)
                     {
@@ -982,12 +954,12 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
                 bool isShift = (vkCode == VK_LSHIFT || vkCode == VK_RSHIFT || vkCode == VK_SHIFT);
                 bool isAlt = (vkCode == VK_LMENU || vkCode == VK_RMENU || vkCode == VK_MENU);
 
-                bool hasWin = g_keyState[VK_LWIN] || g_keyState[VK_RWIN] || (GetAsyncKeyState(VK_LWIN) & 0x8000) || (GetAsyncKeyState(VK_RWIN) & 0x8000) || isWin;
-                bool hasCtrl = g_keyState[VK_CONTROL] || g_keyState[VK_LCONTROL] || g_keyState[VK_RCONTROL] || (GetAsyncKeyState(VK_CONTROL) & 0x8000) || (GetAsyncKeyState(VK_LCONTROL) & 0x8000) || (GetAsyncKeyState(VK_RCONTROL) & 0x8000) || isCtrl;
-                bool hasShift = g_keyState[VK_SHIFT] || g_keyState[VK_LSHIFT] || g_keyState[VK_RSHIFT] || (GetAsyncKeyState(VK_SHIFT) & 0x8000) || (GetAsyncKeyState(VK_LSHIFT) & 0x8000) || (GetAsyncKeyState(VK_RSHIFT) & 0x8000) || isShift;
-                bool hasAlt = g_keyState[VK_MENU] || g_keyState[VK_LMENU] || g_keyState[VK_RMENU] || (GetAsyncKeyState(VK_MENU) & 0x8000) || (GetAsyncKeyState(VK_LMENU) & 0x8000) || (GetAsyncKeyState(VK_RMENU) & 0x8000) || isAlt;
+                bool hasWinState = hasWin || isWin;
+                bool hasCtrlState = hasCtrl || isCtrl;
+                bool hasShiftState = hasShift || isShift;
+                bool hasAltState = hasAlt || isAlt;
                 
-                if (hasWin && hasCtrl && hasShift && hasAlt)
+                if (hasWinState && hasCtrlState && hasShiftState && hasAltState)
                 {
                     if (isDown)
                     {
@@ -1014,7 +986,7 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
             return CallNextHookEx(g_hHook, nCode, wParam, lParam);
         }
 
-        // --- 3. Handle UP Events ---
+        // --- STEP 5: Handle UP Events (Physical) ---
         if (isUp)
         {
             if (vkCode < 256 && g_suppressedKeys[vkCode])
@@ -1025,23 +997,9 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
             return CallNextHookEx(g_hHook, nCode, wParam, lParam);
         }
 
-        // --- 4. Handle DOWN Events ---
+        // --- STEP 6: Handle DOWN Events (Physical) ---
         if (isDown)
         {
-            // Use our own state tracking to ensure we don't miss modifiers 
-            // Fallback to GetAsyncKeyState in case hook missed the down event (e.g. started while key held)
-            bool hasWin = g_keyState[VK_LWIN] || g_keyState[VK_RWIN] || (GetAsyncKeyState(VK_LWIN) & 0x8000) || (GetAsyncKeyState(VK_RWIN) & 0x8000);
-            bool hasCtrl = g_keyState[VK_CONTROL] || g_keyState[VK_LCONTROL] || g_keyState[VK_RCONTROL] || (GetAsyncKeyState(VK_CONTROL) & 0x8000) || (GetAsyncKeyState(VK_LCONTROL) & 0x8000) || (GetAsyncKeyState(VK_RCONTROL) & 0x8000);
-            bool hasShift = g_keyState[VK_SHIFT] || g_keyState[VK_LSHIFT] || g_keyState[VK_RSHIFT] || (GetAsyncKeyState(VK_SHIFT) & 0x8000) || (GetAsyncKeyState(VK_LSHIFT) & 0x8000) || (GetAsyncKeyState(VK_RSHIFT) & 0x8000);
-            bool hasAlt = g_keyState[VK_MENU] || g_keyState[VK_LMENU] || g_keyState[VK_RMENU] || (GetAsyncKeyState(VK_MENU) & 0x8000) || (GetAsyncKeyState(VK_LMENU) & 0x8000) || (GetAsyncKeyState(VK_RMENU) & 0x8000);
-
-            // Convert to MOD_* flags for evaluating
-            UINT fsModifiers = 0;
-            if (hasWin) fsModifiers |= MOD_WIN;
-            if (hasCtrl) fsModifiers |= MOD_CONTROL;
-            if (hasShift) fsModifiers |= MOD_SHIFT;
-            if (hasAlt) fsModifiers |= MOD_ALT;
-
             // Check if this hotkey is disabled in settings AND is hardcoded
             if (ShouldBlockHotkey(fsModifiers, vkCode) && IsKnownHardcodedHotkey(fsModifiers, vkCode))
             {
@@ -1160,10 +1118,10 @@ void StopHookThread()
 
 bool NeedsDwmHook()
 {
-    return (g_settings.DisableWinA == 2) || (g_settings.DisableWinC == 2) || 
-           (g_settings.DisableWinK == 2) || (g_settings.DisableWinN == 2) || 
-           (g_settings.DisableWinP == 2) || (g_settings.DisableWinU == 2) || 
-           (g_settings.DisableWinSlash == 2) || 
+    return g_settings.DisableWinA || g_settings.DisableWinC || 
+           g_settings.DisableWinK || g_settings.DisableWinN || 
+           g_settings.DisableWinP || g_settings.DisableWinU || 
+           g_settings.DisableWinSlash || 
            g_settings.DisableWinTab ||
            g_settings.DisableWinUp || g_settings.DisableWinDown || 
            g_settings.DisableWinLeft || g_settings.DisableWinRight ||
@@ -1236,13 +1194,6 @@ bool AreAnyDisabledExplorerHotkeysRegistered()
     if (g_settings.DisableWinH && ProbeIsHotkeyRegistered(MOD_WIN, 'H')) return true;
     if (g_settings.DisableWinM && ProbeIsHotkeyRegistered(MOD_WIN, 'M')) return true;
     if (g_settings.DisableWinZ && ProbeIsHotkeyRegistered(MOD_WIN, 'Z')) return true;
-    if ((g_settings.DisableWinA == 1) && ProbeIsHotkeyRegistered(MOD_WIN, 'A')) return true;
-    if ((g_settings.DisableWinC == 1) && ProbeIsHotkeyRegistered(MOD_WIN, 'C')) return true;
-    if ((g_settings.DisableWinK == 1) && ProbeIsHotkeyRegistered(MOD_WIN, 'K')) return true;
-    if ((g_settings.DisableWinN == 1) && ProbeIsHotkeyRegistered(MOD_WIN, 'N')) return true;
-    if ((g_settings.DisableWinP == 1) && ProbeIsHotkeyRegistered(MOD_WIN, 'P')) return true;
-    if ((g_settings.DisableWinU == 1) && ProbeIsHotkeyRegistered(MOD_WIN, 'U')) return true;
-    if ((g_settings.DisableWinSlash == 1) && ProbeIsHotkeyRegistered(MOD_WIN, VK_OEM_2)) return true;
     if (g_settings.DisableWinShiftS && ProbeIsHotkeyRegistered(MOD_WIN | MOD_SHIFT, 'S')) return true;
     if (g_settings.DisableWinShiftR && ProbeIsHotkeyRegistered(MOD_WIN | MOD_SHIFT, 'R')) return true;
     if (g_settings.DisableWinShiftC && ProbeIsHotkeyRegistered(MOD_WIN | MOD_SHIFT, 'C')) return true;
@@ -1278,7 +1229,7 @@ BOOL Wh_ModInit()
 
     if (g_isDWM && !NeedsDwmHook())
     {
-        return FALSE; // Unload from DWM if no hardcoded keys are disabled
+        return FALSE; // Unload from DWM if no hardcoded/special keys are disabled
     }
 
     // Hook RegisterHotKey in explorer (we don't need it in DWM)
@@ -1292,8 +1243,8 @@ BOOL Wh_ModInit()
                 Wh_SetFunctionHook(pRegisterHotKey, (void*)RegisterHotKey_Hook, (void**)&RegisterHotKey_Original);
         }
 
-        // Prompt ONLY if Explorer is running mid-session (>15s) AND at least one Explorer shortcut is disabled AND Explorer holds it
-        if (IsMainExplorer() && !GetSystemMetrics(SM_SHUTTINGDOWN) && IsExplorerUptimeLarge() && HasAnyExplorerShortcutsDisabled() && AreAnyDisabledExplorerHotkeysRegistered())
+        // Prompt ONLY if Explorer is running mid-session (>15s) AND standard shortcuts are disabled AND Explorer holds them
+        if (IsMainExplorer() && !GetSystemMetrics(SM_SHUTTINGDOWN) && IsExplorerUptimeLarge() && HasAnyStandardShortcutsDisabled() && AreAnyDisabledExplorerHotkeysRegistered())
         {
             PromptForExplorerRestart();
         }
@@ -1312,7 +1263,7 @@ void Wh_ModUninit()
         StopHookThread();
     }
 
-    if (g_isExplorer)
+    if (g_isExplorer && IsMainExplorer())
     {
         // 1. Signal any pending prompt dialog from a prior settings change to close
         if (HWND promptWindow = g_restartExplorerPromptWindow.load())
@@ -1320,10 +1271,30 @@ void Wh_ModUninit()
             PostMessage(promptWindow, WM_CLOSE, 0, 0);
         }
 
-        // 2. Safe bounded wait to let the prompt thread exit cleanly
         if (g_restartExplorerPromptThread)
         {
-            WaitForSingleObject(g_restartExplorerPromptThread, 1000);
+            WaitForSingleObject(g_restartExplorerPromptThread, INFINITE);
+            CloseHandle(g_restartExplorerPromptThread);
+            g_restartExplorerPromptThread = nullptr;
+        }
+
+        // 2. If standard shortcuts were disabled, prompt user on unload to restore them
+        if (!GetSystemMetrics(SM_SHUTTINGDOWN) && HasAnyStandardShortcutsDisabled())
+        {
+            PromptForExplorerRestart();
+        }
+
+        // 3. Safe bounded wait (30s) matching official simple-window-switcher pattern
+        if (g_restartExplorerPromptThread)
+        {
+            if (WaitForSingleObject(g_restartExplorerPromptThread, 30000) == WAIT_TIMEOUT)
+            {
+                if (HWND promptWindow = g_restartExplorerPromptWindow.load())
+                {
+                    PostMessage(promptWindow, WM_CLOSE, 0, 0);
+                }
+                WaitForSingleObject(g_restartExplorerPromptThread, INFINITE);
+            }
             CloseHandle(g_restartExplorerPromptThread);
             g_restartExplorerPromptThread = nullptr;
         }
@@ -1343,7 +1314,7 @@ void Wh_ModSettingsChanged()
             StopHookThread();
     }
     
-    if (g_isExplorer && IsMainExplorer() && !GetSystemMetrics(SM_SHUTTINGDOWN) && !ExplorerShortcutsEqual(oldSettings, g_settings))
+    if (g_isExplorer && IsMainExplorer() && !GetSystemMetrics(SM_SHUTTINGDOWN) && !StandardShortcutsEqual(oldSettings, g_settings))
     {
         PromptForExplorerRestart();
     }

--- a/mods/disable-windows-shortcuts.wh.cpp
+++ b/mods/disable-windows-shortcuts.wh.cpp
@@ -795,6 +795,7 @@ void PromptForExplorerRestart()
 // ============================================================================
 
 HHOOK g_hHook = NULL;
+HWINEVENTHOOK g_desktopSwitchHook = NULL;
 HANDLE g_hookThread = NULL;
 std::atomic<bool> g_hookThreadRunning{false};
 std::atomic<DWORD> g_hookThreadId{0};
@@ -802,6 +803,29 @@ bool g_suppressedKeys[256] = {false};
 bool g_keyState[256] = {false}; // Track our own key states reliably
 
 bool g_winKeyUsed = false;
+
+void RefreshKeyboardState()
+{
+    for (int vkCode = 0; vkCode < 256; vkCode++)
+    {
+        g_keyState[vkCode] = !!(GetAsyncKeyState(vkCode) & 0x8000);
+        g_suppressedKeys[vkCode] = false;
+    }
+
+    g_winKeyUsed = false;
+}
+
+void CALLBACK DesktopSwitchProc(
+    HWINEVENTHOOK hWinEventHook,
+    DWORD event,
+    HWND hwnd,
+    LONG idObject,
+    LONG idChild,
+    DWORD idEventThread,
+    DWORD dwmsEventTime)
+{
+    RefreshKeyboardState();
+}
 
 LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
 {
@@ -997,6 +1021,22 @@ DWORD WINAPI HookThread(LPVOID lpParam)
     if (!g_hHook)
         return 1;
 
+    g_desktopSwitchHook = SetWinEventHook(
+        EVENT_SYSTEM_DESKTOPSWITCH,
+        EVENT_SYSTEM_DESKTOPSWITCH,
+        NULL,
+        DesktopSwitchProc,
+        0,
+        0,
+        WINEVENT_OUTOFCONTEXT
+    );
+    if (!g_desktopSwitchHook)
+    {
+        UnhookWindowsHookEx(g_hHook);
+        g_hHook = NULL;
+        return 1;
+    }
+
     // Dedicated message pump to keep the hook alive and responsive
     while (GetMessage(&msg, NULL, 0, 0) > 0)
     {
@@ -1004,7 +1044,10 @@ DWORD WINAPI HookThread(LPVOID lpParam)
         DispatchMessage(&msg);
     }
 
+    UnhookWinEvent(g_desktopSwitchHook);
+    g_desktopSwitchHook = NULL;
     UnhookWindowsHookEx(g_hHook);
+    g_hHook = NULL;
     return 0;
 }
 

--- a/mods/disable-windows-shortcuts.wh.cpp
+++ b/mods/disable-windows-shortcuts.wh.cpp
@@ -2,7 +2,7 @@
 // @id              disable-windows-shortcuts
 // @name            Disable Windows Shortcuts
 // @description     Selectively disable Windows keyboard shortcuts with individual toggles
-// @version         1.2.1
+// @version         1.2.2
 // @author          Lone
 // @github          https://github.com/Louis047
 // @include         explorer.exe
@@ -175,6 +175,9 @@ If you use the **"Block hotkey"** option, or if you disable window snapping (Win
   - DisableWinHome: false
     $name: Win+Home
     $description: Minimize inactive windows
+  - DisableWinShiftC: false
+    $name: Win+Shift+C
+    $description: Charms Menu (Windows 10)
   - DisableWinShiftM: false
     $name: Win+Shift+M
     $description: Restore minimized windows
@@ -354,6 +357,7 @@ struct
     bool DisableWinLeft;
     bool DisableWinRight;
     bool DisableWinHome;
+    bool DisableWinShiftC;
     bool DisableWinShiftM;
     bool DisableWinComma;
     bool DisableWinPause;
@@ -447,6 +451,7 @@ void LoadSettings()
     g_settings.DisableWinLeft = Wh_GetIntSetting(L"StandardShortcuts.DisableWinLeft");
     g_settings.DisableWinRight = Wh_GetIntSetting(L"StandardShortcuts.DisableWinRight");
     g_settings.DisableWinHome = Wh_GetIntSetting(L"StandardShortcuts.DisableWinHome");
+    g_settings.DisableWinShiftC = Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftC");
     g_settings.DisableWinShiftM = Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftM");
     g_settings.DisableWinComma = Wh_GetIntSetting(L"StandardShortcuts.DisableWinComma");
     g_settings.DisableWinPause = Wh_GetIntSetting(L"StandardShortcuts.DisableWinPause");
@@ -540,6 +545,7 @@ bool ShouldBlockHotkey(UINT fsModifiers, UINT vk)
         {
             switch (vk)
             {
+                case 'C': block = g_settings.DisableWinShiftC; break;
                 case 'M': block = g_settings.DisableWinShiftM; break;
                 case 'S': block = g_settings.DisableWinShiftS; break;
                 case VK_LEFT: block = g_settings.DisableWinShiftLeft; break;

--- a/mods/disable-windows-shortcuts.wh.cpp
+++ b/mods/disable-windows-shortcuts.wh.cpp
@@ -457,6 +457,7 @@ bool StandardShortcutsEqual(const Settings& a, const Settings& b)
            a.DisableWinCtrlO == b.DisableWinCtrlO &&
            a.DisableWinCtrlS == b.DisableWinCtrlS &&
            a.DisableWinSpace == b.DisableWinSpace &&
+           a.DisableWinShiftR == b.DisableWinShiftR &&
            a.DisableWinShiftS == b.DisableWinShiftS &&
            a.DisableWinAltK == b.DisableWinAltK &&
            a.DisableWinPeriod == b.DisableWinPeriod &&
@@ -1123,9 +1124,7 @@ DWORD WINAPI HookThread(LPVOID lpParam)
     );
     if (!g_desktopSwitchHook)
     {
-        UnhookWindowsHookEx(g_hHook);
-        g_hHook = NULL;
-        return 1;
+        Wh_Log(L"SetWinEventHook failed: %u (non-fatal, continuing keyboard hook)", GetLastError());
     }
 
     // Dedicated message pump to keep the hook alive and responsive
@@ -1135,8 +1134,11 @@ DWORD WINAPI HookThread(LPVOID lpParam)
         DispatchMessage(&msg);
     }
 
-    UnhookWinEvent(g_desktopSwitchHook);
-    g_desktopSwitchHook = NULL;
+    if (g_desktopSwitchHook)
+    {
+        UnhookWinEvent(g_desktopSwitchHook);
+        g_desktopSwitchHook = NULL;
+    }
     UnhookWindowsHookEx(g_hHook);
     g_hHook = NULL;
     return 0;

--- a/mods/disable-windows-shortcuts.wh.cpp
+++ b/mods/disable-windows-shortcuts.wh.cpp
@@ -667,8 +667,10 @@ bool ShouldBlockHotkey(UINT fsModifiers, UINT vk)
                 case VK_HOME: block = g_settings.DisableWinHome; break;
                 case VK_OEM_COMMA: block = g_settings.DisableWinComma; break;
                 case VK_PAUSE: block = g_settings.DisableWinPause; break;
-                case VK_OEM_PLUS: block = g_settings.DisableWinPlus; break;
-                case VK_OEM_MINUS: block = g_settings.DisableWinMinus; break;
+                case VK_OEM_PLUS:
+                case VK_ADD: block = g_settings.DisableWinPlus; break;
+                case VK_OEM_MINUS:
+                case VK_SUBTRACT: block = g_settings.DisableWinMinus; break;
                 case VK_ESCAPE: block = g_settings.DisableWinEsc; break;
                 case VK_SPACE: block = g_settings.DisableWinSpace; break;
                 case VK_OEM_PERIOD: block = g_settings.DisableWinPeriod; break;
@@ -877,7 +879,7 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
                     {
                         g_winKeyUsed = false;
                     }
-                    else
+                    else if (!isInjected)
                     {
                         g_winKeyUsed = true;
                     }
@@ -1231,11 +1233,11 @@ void Wh_ModUninit()
     {
         // 1. Signal any pending prompt dialog from a prior settings change to close.
         // Thread join must not depend on IsMainExplorer() — handle existence is the
-        // correct gate. Loop is bounded to 5 s to prevent an infinite hang if the
-        // dialog never opens (e.g. TaskDialogIndirect fails).
+        // correct gate. Re-post WM_CLOSE until the thread exits; TDF_ALLOW_DIALOG_CANCELLATION
+        // ensures the dialog always closes.
         if (g_restartExplorerPromptThread)
         {
-            for (int i = 0; i < 50 && WaitForSingleObject(g_restartExplorerPromptThread, 100) == WAIT_TIMEOUT; i++)
+            while (WaitForSingleObject(g_restartExplorerPromptThread, 100) == WAIT_TIMEOUT)
             {
                 if (HWND promptWindow = g_restartExplorerPromptWindow.load())
                 {

--- a/mods/disable-windows-shortcuts.wh.cpp
+++ b/mods/disable-windows-shortcuts.wh.cpp
@@ -291,8 +291,6 @@ For **Special Shortcuts** and **Direct Shortcuts** to be blocked, you **must** a
 #include <windows.h>
 #include <atomic>
 #include <commctrl.h>
-#include <algorithm>
-#include <string>
 
 bool g_isExplorer = false;
 bool g_isDWM = false;
@@ -457,22 +455,22 @@ void LoadSettings()
     g_settings.DisableWinU = Wh_GetIntSetting(L"SpecialShortcuts.DisableWinU");
     g_settings.DisableWinSlash = Wh_GetIntSetting(L"SpecialShortcuts.DisableWinSlash");
 
-    // Direct Shortcuts (No Explorer Restart Required - with backward-compatible fallback)
-    g_settings.DisableWinKey = Wh_GetIntSetting(L"DirectShortcuts.DisableWinKey") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinKey");
-    g_settings.DisableCtrlEsc = Wh_GetIntSetting(L"DirectShortcuts.DisableCtrlEsc") || Wh_GetIntSetting(L"StandardShortcuts.DisableCtrlEsc");
-    g_settings.DisableAltShift = Wh_GetIntSetting(L"DirectShortcuts.DisableAltShift") || Wh_GetIntSetting(L"StandardShortcuts.DisableAltShift");
-    g_settings.DisableWinSpace = Wh_GetIntSetting(L"DirectShortcuts.DisableWinSpace") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinSpace");
-    g_settings.DisableOfficeHotkeys = Wh_GetIntSetting(L"DirectShortcuts.DisableOfficeHotkeys") || Wh_GetIntSetting(L"StandardShortcuts.DisableOfficeHotkeys");
-    g_settings.DisableWinTab = Wh_GetIntSetting(L"DirectShortcuts.DisableWinTab") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinTab");
-    g_settings.DisableWinUp = Wh_GetIntSetting(L"DirectShortcuts.DisableWinUp") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinUp");
-    g_settings.DisableWinDown = Wh_GetIntSetting(L"DirectShortcuts.DisableWinDown") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinDown");
-    g_settings.DisableWinLeft = Wh_GetIntSetting(L"DirectShortcuts.DisableWinLeft") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinLeft");
-    g_settings.DisableWinRight = Wh_GetIntSetting(L"DirectShortcuts.DisableWinRight") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinRight");
-    g_settings.DisableWinShiftUp = Wh_GetIntSetting(L"DirectShortcuts.DisableWinShiftUp") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftUp");
-    g_settings.DisableWinShiftDown = Wh_GetIntSetting(L"DirectShortcuts.DisableWinShiftDown") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftDown");
-    g_settings.DisableWinShiftLeft = Wh_GetIntSetting(L"DirectShortcuts.DisableWinShiftLeft") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftLeft");
-    g_settings.DisableWinShiftRight = Wh_GetIntSetting(L"DirectShortcuts.DisableWinShiftRight") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftRight");
-    g_settings.DisableWinCtrlShiftB = Wh_GetIntSetting(L"DirectShortcuts.DisableWinCtrlShiftB") || Wh_GetIntSetting(L"StandardShortcuts.DisableWinCtrlShiftB");
+    // Direct Shortcuts (No Explorer Restart Required)
+    g_settings.DisableWinKey = Wh_GetIntSetting(L"DirectShortcuts.DisableWinKey");
+    g_settings.DisableCtrlEsc = Wh_GetIntSetting(L"DirectShortcuts.DisableCtrlEsc");
+    g_settings.DisableAltShift = Wh_GetIntSetting(L"DirectShortcuts.DisableAltShift");
+    g_settings.DisableWinSpace = Wh_GetIntSetting(L"DirectShortcuts.DisableWinSpace");
+    g_settings.DisableOfficeHotkeys = Wh_GetIntSetting(L"DirectShortcuts.DisableOfficeHotkeys");
+    g_settings.DisableWinTab = Wh_GetIntSetting(L"DirectShortcuts.DisableWinTab");
+    g_settings.DisableWinUp = Wh_GetIntSetting(L"DirectShortcuts.DisableWinUp");
+    g_settings.DisableWinDown = Wh_GetIntSetting(L"DirectShortcuts.DisableWinDown");
+    g_settings.DisableWinLeft = Wh_GetIntSetting(L"DirectShortcuts.DisableWinLeft");
+    g_settings.DisableWinRight = Wh_GetIntSetting(L"DirectShortcuts.DisableWinRight");
+    g_settings.DisableWinShiftUp = Wh_GetIntSetting(L"DirectShortcuts.DisableWinShiftUp");
+    g_settings.DisableWinShiftDown = Wh_GetIntSetting(L"DirectShortcuts.DisableWinShiftDown");
+    g_settings.DisableWinShiftLeft = Wh_GetIntSetting(L"DirectShortcuts.DisableWinShiftLeft");
+    g_settings.DisableWinShiftRight = Wh_GetIntSetting(L"DirectShortcuts.DisableWinShiftRight");
+    g_settings.DisableWinCtrlShiftB = Wh_GetIntSetting(L"DirectShortcuts.DisableWinCtrlShiftB");
 
     // Standard Shortcuts (Requires Explorer Restart)
     g_settings.DisableWinB = Wh_GetIntSetting(L"StandardShortcuts.DisableWinB");
@@ -983,6 +981,12 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
                 }
             }
 
+            if (isUp && vkCode < 256 && g_suppressedKeys[vkCode])
+            {
+                g_suppressedKeys[vkCode] = false;
+                return 1; // Suppress the matching modifier UP event
+            }
+
             return CallNextHookEx(g_hHook, nCode, wParam, lParam);
         }
 
@@ -1082,6 +1086,12 @@ void StartHookThread()
 {
     if (g_hookThreadRunning) return;
     
+    if (g_hookThread)
+    {
+        CloseHandle(g_hookThread);
+        g_hookThread = NULL;
+    }
+
     g_hookThreadRunning = true;
     DWORD threadId = 0;
     g_hookThread = CreateThread(NULL, 0, HookThread, NULL, 0, &threadId);
@@ -1147,67 +1157,15 @@ bool IsMainExplorer()
     return true;
 }
 
-bool IsExplorerUptimeLarge()
+bool IsExplorerMidSession()
 {
-    FILETIME creationTime, exitTime, kernelTime, userTime;
-    if (GetProcessTimes(GetCurrentProcess(), &creationTime, &exitTime, &kernelTime, &userTime))
+    HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", NULL);
+    if (hTaskbar)
     {
-        ULARGE_INTEGER creation;
-        creation.LowPart = creationTime.dwLowDateTime;
-        creation.HighPart = creationTime.dwHighDateTime;
-        
-        FILETIME systemTime;
-        GetSystemTimeAsFileTime(&systemTime);
-        ULARGE_INTEGER current;
-        current.LowPart = systemTime.dwLowDateTime;
-        current.HighPart = systemTime.dwHighDateTime;
-        
-        // 15 seconds = 150,000,000 intervals of 100ns (distinguishes fresh boot from mid-session re-enable)
-        if (current.QuadPart > creation.QuadPart && (current.QuadPart - creation.QuadPart) > 150000000ULL)
-            return true;
+        DWORD trayPid = 0;
+        GetWindowThreadProcessId(hTaskbar, &trayPid);
+        return (trayPid == GetCurrentProcessId());
     }
-    return false;
-}
-
-bool ProbeIsHotkeyRegistered(UINT fsModifiers, UINT vk)
-{
-    const int kProbeHotkeyId = 0xBEEF;
-    if (RegisterHotKey(NULL, kProbeHotkeyId, fsModifiers, vk))
-    {
-        UnregisterHotKey(NULL, kProbeHotkeyId);
-        return false; // Hotkey is free: Explorer does not hold it
-    }
-    return true; // Hotkey is registered by Explorer or another process
-}
-
-bool AreAnyDisabledExplorerHotkeysRegistered()
-{
-    if (g_settings.DisableWinE && ProbeIsHotkeyRegistered(MOD_WIN, 'E')) return true;
-    if (g_settings.DisableWinR && ProbeIsHotkeyRegistered(MOD_WIN, 'R')) return true;
-    if (g_settings.DisableWinD && ProbeIsHotkeyRegistered(MOD_WIN, 'D')) return true;
-    if (g_settings.DisableWinI && ProbeIsHotkeyRegistered(MOD_WIN, 'I')) return true;
-    if (g_settings.DisableWinS && ProbeIsHotkeyRegistered(MOD_WIN, 'S')) return true;
-    if (g_settings.DisableWinV && ProbeIsHotkeyRegistered(MOD_WIN, 'V')) return true;
-    if (g_settings.DisableWinX && ProbeIsHotkeyRegistered(MOD_WIN, 'X')) return true;
-    if (g_settings.DisableWinB && ProbeIsHotkeyRegistered(MOD_WIN, 'B')) return true;
-    if (g_settings.DisableWinG && ProbeIsHotkeyRegistered(MOD_WIN, 'G')) return true;
-    if (g_settings.DisableWinH && ProbeIsHotkeyRegistered(MOD_WIN, 'H')) return true;
-    if (g_settings.DisableWinM && ProbeIsHotkeyRegistered(MOD_WIN, 'M')) return true;
-    if (g_settings.DisableWinZ && ProbeIsHotkeyRegistered(MOD_WIN, 'Z')) return true;
-    if (g_settings.DisableWinShiftS && ProbeIsHotkeyRegistered(MOD_WIN | MOD_SHIFT, 'S')) return true;
-    if (g_settings.DisableWinShiftR && ProbeIsHotkeyRegistered(MOD_WIN | MOD_SHIFT, 'R')) return true;
-    if (g_settings.DisableWinShiftC && ProbeIsHotkeyRegistered(MOD_WIN | MOD_SHIFT, 'C')) return true;
-    if (g_settings.DisableWinCtrlD && ProbeIsHotkeyRegistered(MOD_WIN | MOD_CONTROL, 'D')) return true;
-    if (g_settings.DisableWinCtrlQ && ProbeIsHotkeyRegistered(MOD_WIN | MOD_CONTROL, 'Q')) return true;
-    if (g_settings.DisableWinAltD && ProbeIsHotkeyRegistered(MOD_WIN | MOD_ALT, 'D')) return true;
-    if (g_settings.DisableWinAltG && ProbeIsHotkeyRegistered(MOD_WIN | MOD_ALT, 'G')) return true;
-    if (g_settings.DisableWinAltR && ProbeIsHotkeyRegistered(MOD_WIN | MOD_ALT, 'R')) return true;
-    if (g_settings.DisableWinAltB && ProbeIsHotkeyRegistered(MOD_WIN | MOD_ALT, 'B')) return true;
-
-    // Fallback probe for general Explorer registration state
-    if (ProbeIsHotkeyRegistered(MOD_WIN, 'R') || ProbeIsHotkeyRegistered(MOD_WIN, 'E'))
-        return true;
-
     return false;
 }
 
@@ -1217,13 +1175,13 @@ bool AreAnyDisabledExplorerHotkeysRegistered()
 
 BOOL Wh_ModInit()
 {
-    WCHAR exeName[MAX_PATH];
-    GetModuleFileNameW(NULL, exeName, MAX_PATH);
-    std::wstring exeStr(exeName);
-    std::transform(exeStr.begin(), exeStr.end(), exeStr.begin(), ::towlower);
+    WCHAR exePath[MAX_PATH];
+    GetModuleFileNameW(NULL, exePath, ARRAYSIZE(exePath));
+    PCWSTR exeName = wcsrchr(exePath, L'\\');
+    exeName = exeName ? exeName + 1 : exePath;
 
-    g_isExplorer = (exeStr.find(L"explorer.exe") != std::wstring::npos);
-    g_isDWM = (exeStr.find(L"dwm.exe") != std::wstring::npos);
+    g_isExplorer = (_wcsicmp(exeName, L"explorer.exe") == 0);
+    g_isDWM = (_wcsicmp(exeName, L"dwm.exe") == 0);
 
     LoadSettings();
 
@@ -1243,8 +1201,8 @@ BOOL Wh_ModInit()
                 Wh_SetFunctionHook(pRegisterHotKey, (void*)RegisterHotKey_Hook, (void**)&RegisterHotKey_Original);
         }
 
-        // Prompt ONLY if Explorer is running mid-session (>15s) AND standard shortcuts are disabled AND Explorer holds them
-        if (IsMainExplorer() && !GetSystemMetrics(SM_SHUTTINGDOWN) && IsExplorerUptimeLarge() && HasAnyStandardShortcutsDisabled() && AreAnyDisabledExplorerHotkeysRegistered())
+        // Prompt if Explorer is running mid-session and standard shortcuts are disabled
+        if (IsExplorerMidSession() && !GetSystemMetrics(SM_SHUTTINGDOWN) && HasAnyStandardShortcutsDisabled())
         {
             PromptForExplorerRestart();
         }
@@ -1266,14 +1224,15 @@ void Wh_ModUninit()
     if (g_isExplorer && IsMainExplorer())
     {
         // 1. Signal any pending prompt dialog from a prior settings change to close
-        if (HWND promptWindow = g_restartExplorerPromptWindow.load())
-        {
-            PostMessage(promptWindow, WM_CLOSE, 0, 0);
-        }
-
         if (g_restartExplorerPromptThread)
         {
-            WaitForSingleObject(g_restartExplorerPromptThread, INFINITE);
+            while (WaitForSingleObject(g_restartExplorerPromptThread, 100) == WAIT_TIMEOUT)
+            {
+                if (HWND promptWindow = g_restartExplorerPromptWindow.load())
+                {
+                    PostMessage(promptWindow, WM_CLOSE, 0, 0);
+                }
+            }
             CloseHandle(g_restartExplorerPromptThread);
             g_restartExplorerPromptThread = nullptr;
         }

--- a/mods/disable-windows-shortcuts.wh.cpp
+++ b/mods/disable-windows-shortcuts.wh.cpp
@@ -7,7 +7,6 @@
 // @github          https://github.com/Louis047
 // @include         explorer.exe
 // @include         dwm.exe
-// @compilerOptions -lcomctl32
 // ==/WindhawkMod==
 // ==WindhawkModReadme==
 /*
@@ -33,6 +32,10 @@ For **Special Shortcuts** and **Direct Shortcuts** to be blocked, you **must** a
 4. Click **Save**. Windhawk will automatically restart to apply the new settings.
 
 *Note: Changes to standard shortcuts (like Win+E) require an Explorer restart to completely release the hotkeys for other applications. You will be prompted automatically. If you completely disable or remove this mod from Windhawk, you must restart Explorer to restore those standard shortcuts.*
+
+## Changes in 1.3.0
+- Reorganized shortcuts into three distinct sections: **Special Shortcuts**, **Direct Shortcuts**, and **Standard Shortcuts**.
+- If upgrading from version 1.2.1 or earlier, please review and re-apply your settings as configuration keys were restructured.
 
 ## Notes
 - Win+L (Lock PC) cannot be blocked through standard hooks
@@ -800,7 +803,7 @@ void PromptForExplorerRestart()
         int button = 0;
         if (pTaskDialogIndirect && SUCCEEDED(pTaskDialogIndirect(&taskDialogConfig, &button, nullptr, nullptr)) && button == IDYES)
         {
-            WCHAR commandLine[] = L"cmd.exe /c \"timeout /t 1 /nobreak >nul & taskkill /F /IM explorer.exe & start explorer.exe\"";
+            WCHAR commandLine[] = L"cmd.exe /d /c \"timeout /t 1 /nobreak >nul & taskkill /F /IM explorer.exe & start explorer.exe\"";
             STARTUPINFOW si = { .cb = sizeof(si) };
             PROCESS_INFORMATION pi{};
             if (CreateProcessW(nullptr, commandLine, nullptr, nullptr, FALSE, CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP, nullptr, nullptr, &si, &pi))
@@ -1035,6 +1038,9 @@ DWORD WINAPI HookThread(LPVOID lpParam)
     // Force OS to create a message queue for this thread
     MSG msg;
     PeekMessage(&msg, NULL, WM_USER, WM_USER, PM_NOREMOVE);
+
+    // Initialize/seed keyboard state cleanly before installing the hook
+    RefreshKeyboardState();
 
     HMODULE hMod = NULL;
     GetModuleHandleExW(

--- a/mods/disable-windows-shortcuts.wh.cpp
+++ b/mods/disable-windows-shortcuts.wh.cpp
@@ -731,6 +731,7 @@ bool IsKnownHardcodedHotkey(UINT fsModifiers, UINT vk)
 
 typedef BOOL(WINAPI *RegisterHotKey_t)(HWND hWnd, int id, UINT fsModifiers, UINT vk);
 RegisterHotKey_t RegisterHotKey_Original;
+std::atomic<bool> g_blockedAnyRegistration{false};
 
 BOOL WINAPI RegisterHotKey_Hook(HWND hWnd, int id, UINT fsModifiers, UINT vk)
 {
@@ -747,6 +748,7 @@ BOOL WINAPI RegisterHotKey_Hook(HWND hWnd, int id, UINT fsModifiers, UINT vk)
             return RegisterHotKey_Original(hWnd, id, fsModifiers, vk);
         }
 
+        g_blockedAnyRegistration = true;
         SetLastError(ERROR_HOTKEY_ALREADY_REGISTERED);
         return FALSE;
     }
@@ -1250,8 +1252,12 @@ void Wh_ModUninit()
 
         if (IsMainExplorer())
         {
-            // 2. If standard shortcuts were disabled, prompt user on unload to restore them
-            if (!GetSystemMetrics(SM_SHUTTINGDOWN) && HasAnyStandardShortcutsDisabled())
+            // 2. If we actually blocked Explorer from registering standard shortcuts
+            // in this session, prompt user on unload so Explorer can reclaim them.
+            // If no registrations were blocked (e.g. mod loaded mid-session after
+            // Explorer already registered, or no standard shortcuts toggled), skip
+            // the prompt since Explorer already owns the hotkeys.
+            if (!GetSystemMetrics(SM_SHUTTINGDOWN) && g_blockedAnyRegistration)
             {
                 PromptForExplorerRestart();
             }

--- a/mods/disable-windows-shortcuts.wh.cpp
+++ b/mods/disable-windows-shortcuts.wh.cpp
@@ -731,7 +731,6 @@ bool IsKnownHardcodedHotkey(UINT fsModifiers, UINT vk)
 
 typedef BOOL(WINAPI *RegisterHotKey_t)(HWND hWnd, int id, UINT fsModifiers, UINT vk);
 RegisterHotKey_t RegisterHotKey_Original;
-std::atomic<bool> g_blockedAnyRegistration{false};
 
 BOOL WINAPI RegisterHotKey_Hook(HWND hWnd, int id, UINT fsModifiers, UINT vk)
 {
@@ -748,7 +747,7 @@ BOOL WINAPI RegisterHotKey_Hook(HWND hWnd, int id, UINT fsModifiers, UINT vk)
             return RegisterHotKey_Original(hWnd, id, fsModifiers, vk);
         }
 
-        g_blockedAnyRegistration = true;
+        SetEnvironmentVariableW(L"WINDHAWK_DWS_BLOCKED", L"1");
         SetLastError(ERROR_HOTKEY_ALREADY_REGISTERED);
         return FALSE;
     }
@@ -1211,8 +1210,13 @@ BOOL Wh_ModInit()
                 Wh_SetFunctionHook(pRegisterHotKey, (void*)RegisterHotKey_Hook, (void**)&RegisterHotKey_Original);
         }
 
-        // Prompt if Explorer is running mid-session and standard shortcuts are disabled
-        if (IsExplorerMidSession() && !GetSystemMetrics(SM_SHUTTINGDOWN) && HasAnyStandardShortcutsDisabled())
+        // Prompt if Explorer is running mid-session, standard shortcuts are disabled,
+        // and this Explorer process hasn't already had them blocked at startup.
+        WCHAR envBuf[4] = {0};
+        bool alreadyBlockedInThisProcess = (GetEnvironmentVariableW(L"WINDHAWK_DWS_BLOCKED", envBuf, ARRAYSIZE(envBuf)) > 0);
+
+        if (IsExplorerMidSession() && !GetSystemMetrics(SM_SHUTTINGDOWN) && 
+            HasAnyStandardShortcutsDisabled() && !alreadyBlockedInThisProcess)
         {
             PromptForExplorerRestart();
         }
@@ -1252,26 +1256,24 @@ void Wh_ModUninit()
 
         if (IsMainExplorer())
         {
-            // 2. If we actually blocked Explorer from registering standard shortcuts
-            // in this session, prompt user on unload so Explorer can reclaim them.
-            // If no registrations were blocked (e.g. mod loaded mid-session after
-            // Explorer already registered, or no standard shortcuts toggled), skip
-            // the prompt since Explorer already owns the hotkeys.
-            if (!GetSystemMetrics(SM_SHUTTINGDOWN) && g_blockedAnyRegistration)
+            // 2. If standard shortcuts were disabled, prompt user on unload to restore them
+            if (!GetSystemMetrics(SM_SHUTTINGDOWN) && HasAnyStandardShortcutsDisabled())
             {
                 PromptForExplorerRestart();
             }
 
-            // 3. Safe bounded wait (30s) matching official simple-window-switcher pattern
+            // 3. Safe bounded wait (30s) matching step 1 re-posting pattern
             if (g_restartExplorerPromptThread)
             {
                 if (WaitForSingleObject(g_restartExplorerPromptThread, 30000) == WAIT_TIMEOUT)
                 {
-                    if (HWND promptWindow = g_restartExplorerPromptWindow.load())
+                    while (WaitForSingleObject(g_restartExplorerPromptThread, 100) == WAIT_TIMEOUT)
                     {
-                        PostMessage(promptWindow, WM_CLOSE, 0, 0);
+                        if (HWND promptWindow = g_restartExplorerPromptWindow.load())
+                        {
+                            PostMessage(promptWindow, WM_CLOSE, 0, 0);
+                        }
                     }
-                    WaitForSingleObject(g_restartExplorerPromptThread, INFINITE);
                 }
                 CloseHandle(g_restartExplorerPromptThread);
                 g_restartExplorerPromptThread = nullptr;
@@ -1295,6 +1297,10 @@ void Wh_ModSettingsChanged()
     
     if (g_isExplorer && IsMainExplorer() && !GetSystemMetrics(SM_SHUTTINGDOWN) && !StandardShortcutsEqual(oldSettings, g_settings))
     {
+        if (!HasAnyStandardShortcutsDisabled())
+        {
+            SetEnvironmentVariableW(L"WINDHAWK_DWS_BLOCKED", nullptr);
+        }
         PromptForExplorerRestart();
     }
 }

--- a/mods/disable-windows-shortcuts.wh.cpp
+++ b/mods/disable-windows-shortcuts.wh.cpp
@@ -731,6 +731,8 @@ bool IsKnownHardcodedHotkey(UINT fsModifiers, UINT vk)
 
 typedef BOOL(WINAPI *RegisterHotKey_t)(HWND hWnd, int id, UINT fsModifiers, UINT vk);
 RegisterHotKey_t RegisterHotKey_Original;
+// One-shot in-memory gate: prevents multiple Wh_SetIntValue writes per session.
+std::atomic<bool> g_recordedBlock{false};
 
 BOOL WINAPI RegisterHotKey_Hook(HWND hWnd, int id, UINT fsModifiers, UINT vk)
 {
@@ -747,7 +749,12 @@ BOOL WINAPI RegisterHotKey_Hook(HWND hWnd, int id, UINT fsModifiers, UINT vk)
             return RegisterHotKey_Original(hWnd, id, fsModifiers, vk);
         }
 
-        SetEnvironmentVariableW(L"WINDHAWK_DWS_BLOCKED", L"1");
+        // Record that this Explorer process had a standard registration blocked.
+        // Stored in Windhawk's own storage (invisible to child processes, survives mod reloads).
+        if (!g_recordedBlock.exchange(true))
+        {
+            Wh_SetIntValue(L"blockedInPid", (int)GetCurrentProcessId());
+        }
         SetLastError(ERROR_HOTKEY_ALREADY_REGISTERED);
         return FALSE;
     }
@@ -1212,8 +1219,9 @@ BOOL Wh_ModInit()
 
         // Prompt if Explorer is running mid-session, standard shortcuts are disabled,
         // and this Explorer process hasn't already had them blocked at startup.
-        WCHAR envBuf[4] = {0};
-        bool alreadyBlockedInThisProcess = (GetEnvironmentVariableW(L"WINDHAWK_DWS_BLOCKED", envBuf, ARRAYSIZE(envBuf)) > 0);
+        // Wh_GetIntValue persists across mod reloads; PID mismatch means a new Explorer
+        // process started and genuinely needs a restart to claim the blocked shortcuts.
+        bool alreadyBlockedInThisProcess = (Wh_GetIntValue(L"blockedInPid", 0) == (int)GetCurrentProcessId());
 
         if (IsExplorerMidSession() && !GetSystemMetrics(SM_SHUTTINGDOWN) && 
             HasAnyStandardShortcutsDisabled() && !alreadyBlockedInThisProcess)
@@ -1256,8 +1264,11 @@ void Wh_ModUninit()
 
         if (IsMainExplorer())
         {
-            // 2. If standard shortcuts were disabled, prompt user on unload to restore them
-            if (!GetSystemMetrics(SM_SHUTTINGDOWN) && HasAnyStandardShortcutsDisabled())
+            // 2. Prompt to restore standard shortcuts only if this Explorer process actually
+            // had registrations blocked by the hook. Gated on PID so the prompt is skipped
+            // on reloads where no blocking occurred (e.g. mid-session enable + "No" path).
+            if (!GetSystemMetrics(SM_SHUTTINGDOWN) &&
+                Wh_GetIntValue(L"blockedInPid", 0) == (int)GetCurrentProcessId())
             {
                 PromptForExplorerRestart();
             }
@@ -1299,7 +1310,10 @@ void Wh_ModSettingsChanged()
     {
         if (!HasAnyStandardShortcutsDisabled())
         {
-            SetEnvironmentVariableW(L"WINDHAWK_DWS_BLOCKED", nullptr);
+            // All standard shortcuts turned off — clear the block record so uninit/init
+            // no longer treat this process as having blocked registrations.
+            Wh_SetIntValue(L"blockedInPid", 0);
+            g_recordedBlock = false;
         }
         PromptForExplorerRestart();
     }

--- a/mods/disable-windows-shortcuts.wh.cpp
+++ b/mods/disable-windows-shortcuts.wh.cpp
@@ -18,14 +18,15 @@ Selectively disable Windows keyboard shortcuts with individual toggles for each 
 - Individual toggle for each shortcut
 - Uses a lightweight background hook thread ensuring third-party modifiers (like AltSnap, GlazeWM) are completely unaffected.
 
-## How Shortcuts Are Handled
-This mod provides three organized categories of shortcuts:
-1. **Special Shortcuts (Flyouts):** Windows processes system flyouts (`Win+A`, `Win+N`, `Win+C`, `Win+K`, `Win+P`, `Win+U`, `Win+/`) at a lower compositor level. The mod physically suppresses keypresses via a low-level keyboard hook running in `dwm.exe`. Injected/simulated keystrokes (e.g. custom taskbars like YASB or macros) and native taskbar tray mouse clicks continue to work seamlessly.
-2. **Direct Shortcuts (No Restart Required):** Handled immediately via low-level keyboard hook in `dwm.exe`. Disabling shortcuts like `Win` or `Alt+Shift` allows third-party apps (such as Flow Launcher's Windows key launcher or custom `Alt+Shift` keybinds) to be used without Windows opening the Start Menu or switching keyboard layouts. Hardcoded shortcuts (`Ctrl+Esc`, `Win+Tab`, `Win+Arrows`, `Win+Space`, `Win+Ctrl+Shift+Alt`, `Win+Ctrl+Shift+B`) are blocked immediately without requiring an Explorer restart.
-3. **Standard Shortcuts (Requires Explorer Restart):** Handled via Explorer's `RegisterHotKey` API. When disabled, Explorer is prevented from claiming the key, freeing it in the OS kernel so other applications (such as PowerToys, GlazeWM, or Flow Launcher) can bind to it. Changes require an Explorer restart to release the key (a restart dialog will prompt you automatically).
+## Special Shortcuts
+A small number of system shortcuts (`Win+A`, `Win+C`, `Win+K`, `Win+N`, `Win+P`, `Win+U`, `Win+/`) open flyout panels and are not registered via the standard `RegisterHotKey` API.
+The mod provides **three options** for each of these:
+- **Off:** The shortcut is completely unaffected.
+- **Disable hotkey:** Blocks the shortcut natively by intercepting it in Explorer. Lightweight and does **not** require `dwm.exe`. Note: third-party apps that simulate these keys (e.g. some custom taskbars) will also be blocked.
+- **Block hotkey:** Physically suppresses the keystroke via a low-level hook running in `dwm.exe`, while letting Windows believe the key was registered. Third-party tools that simulate the shortcut continue to work. Requires `dwm.exe` in the inclusion list.
 
 ## ⚠️ Important `dwm.exe` Installation Step ⚠️
-For **Special Shortcuts** and **Direct Shortcuts** to be blocked, you **must** allow Windhawk to inject into the Desktop Window Manager (`dwm.exe`):
+Required only if you use the **"Block hotkey"** option on Special Shortcuts, or if you disable `Win+Tab`, window snapping (`Win+Arrows`), `Win+Space`, `Alt+Shift`, `Win` (Start Menu), or `Ctrl+Esc`:
 1. Open Windhawk and go to **Settings**
 2. Click on **Advanced settings** at the bottom
 3. Under **Process inclusion list**, ensure `dwm.exe` is added (or `*` is used to include all processes)
@@ -34,8 +35,8 @@ For **Special Shortcuts** and **Direct Shortcuts** to be blocked, you **must** a
 *Note: Changes to standard shortcuts (like Win+E) require an Explorer restart to completely release the hotkeys for other applications. You will be prompted automatically. If you completely disable or remove this mod from Windhawk, you must restart Explorer to restore those standard shortcuts.*
 
 ## Changes in 1.3.0
-- Reorganized shortcuts into three distinct sections: **Special Shortcuts**, **Direct Shortcuts**, and **Standard Shortcuts**.
-- If upgrading from version 1.2.1 or earlier, please review and re-apply your settings as configuration keys were restructured.
+- Added new shortcuts: `Win+Shift+C`, `Win+Shift+R`, `Win+Shift+Up/Down/Left/Right`, `Win+Ctrl+Shift+B`, Office hotkeys (`Win+Ctrl+Shift+Alt`), and more.
+- If upgrading from version 1.2.1 or earlier, your existing Special Shortcuts settings are preserved. Other settings remain unchanged.
 
 ## Notes
 - Win+L (Lock PC) cannot be blocked through standard hooks
@@ -44,80 +45,104 @@ For **Special Shortcuts** and **Direct Shortcuts** to be blocked, you **must** a
 // ==WindhawkModSettings==
 /*
 - SpecialShortcuts:
-  - DisableWinA: false
+  - DisableWinA: "off"
     $name: Win+A
     $description: Action Center / Quick Settings
-  - DisableWinC: false
+    $options:
+    - "off": Off
+    - disable: Disable hotkey (lightweight, simulating apps affected)
+    - block: Block hotkey (requires dwm.exe, simulating apps work)
+  - DisableWinC: "off"
     $name: Win+C
     $description: Cortana / Copilot
-  - DisableWinK: false
+    $options:
+    - "off": Off
+    - disable: Disable hotkey (lightweight, simulating apps affected)
+    - block: Block hotkey (requires dwm.exe, simulating apps work)
+  - DisableWinK: "off"
     $name: Win+K
     $description: Connect / Cast
-  - DisableWinN: false
+    $options:
+    - "off": Off
+    - disable: Disable hotkey (lightweight, simulating apps affected)
+    - block: Block hotkey (requires dwm.exe, simulating apps work)
+  - DisableWinN: "off"
     $name: Win+N
     $description: Notification Center
-  - DisableWinP: false
+    $options:
+    - "off": Off
+    - disable: Disable hotkey (lightweight, simulating apps affected)
+    - block: Block hotkey (requires dwm.exe, simulating apps work)
+  - DisableWinP: "off"
     $name: Win+P
     $description: Project / Display mode
-  - DisableWinU: false
+    $options:
+    - "off": Off
+    - disable: Disable hotkey (lightweight, simulating apps affected)
+    - block: Block hotkey (requires dwm.exe, simulating apps work)
+  - DisableWinU: "off"
     $name: Win+U
     $description: Accessibility Settings
-  - DisableWinSlash: false
+    $options:
+    - "off": Off
+    - disable: Disable hotkey (lightweight, simulating apps affected)
+    - block: Block hotkey (requires dwm.exe, simulating apps work)
+  - DisableWinSlash: "off"
     $name: Win+/
     $description: IME reconversion
+    $options:
+    - "off": Off
+    - disable: Disable hotkey (lightweight, simulating apps affected)
+    - block: Block hotkey (requires dwm.exe, simulating apps work)
   $name: Special Shortcuts
-  $description: System flyouts handled via DWM low-level hook. Requires dwm.exe in Process inclusion list.
-
-- DirectShortcuts:
-  - DisableWinKey: false
-    $name: Win
-    $description: Open Start Menu
-  - DisableCtrlEsc: false
-    $name: Ctrl+Esc
-    $description: Open Start Menu
-  - DisableAltShift: false
-    $name: Alt+Shift
-    $description: Switch keyboard layout
-  - DisableWinSpace: false
-    $name: Win+Space
-    $description: Switch keyboard layout
-  - DisableOfficeHotkeys: false
-    $name: Win+Ctrl+Shift+Alt
-    $description: Office Hub / Microsoft 365 app combinations
-  - DisableWinTab: false
-    $name: Win+Tab
-    $description: Task View
-  - DisableWinUp: false
-    $name: Win+Up
-    $description: Maximize window
-  - DisableWinDown: false
-    $name: Win+Down
-    $description: Restore/Minimize window
-  - DisableWinLeft: false
-    $name: Win+Left
-    $description: Snap window left
-  - DisableWinRight: false
-    $name: Win+Right
-    $description: Snap window right
-  - DisableWinShiftUp: false
-    $name: Win+Shift+Up
-    $description: Stretch window vertically
-  - DisableWinShiftDown: false
-    $name: Win+Shift+Down
-    $description: Restore/minimize height
-  - DisableWinShiftLeft: false
-    $name: Win+Shift+Left
-    $description: Move window to left monitor
-  - DisableWinShiftRight: false
-    $name: Win+Shift+Right
-    $description: Move window to right monitor
-  - DisableWinCtrlShiftB: false
-    $name: Win+Ctrl+Shift+B
-    $description: Restart graphics driver
-  $name: Direct Shortcuts
-  $description: Shortcuts handled immediately via low-level hook without requiring an Explorer restart. Requires dwm.exe in Process inclusion list.
+  $description: "Flyout shortcuts. 'Disable hotkey' is lightweight and works without dwm.exe. 'Block hotkey' requires dwm.exe but keeps simulating apps (e.g. custom taskbars) working."
 
 - StandardShortcuts:
+  - DisableWinKey: false
+    $name: Win
+    $description: Open Start Menu (requires dwm.exe)
+  - DisableCtrlEsc: false
+    $name: Ctrl+Esc
+    $description: Open Start Menu (requires dwm.exe)
+  - DisableAltShift: false
+    $name: Alt+Shift
+    $description: Switch keyboard layout (requires dwm.exe)
+  - DisableWinSpace: false
+    $name: Win+Space
+    $description: Switch keyboard layout (requires dwm.exe)
+  - DisableOfficeHotkeys: false
+    $name: Win+Ctrl+Shift+Alt
+    $description: Office Hub / Microsoft 365 app combinations (requires dwm.exe)
+  - DisableWinTab: false
+    $name: Win+Tab
+    $description: Task View (requires dwm.exe)
+  - DisableWinUp: false
+    $name: Win+Up
+    $description: Maximize window (requires dwm.exe)
+  - DisableWinDown: false
+    $name: Win+Down
+    $description: Restore/Minimize window (requires dwm.exe)
+  - DisableWinLeft: false
+    $name: Win+Left
+    $description: Snap window left (requires dwm.exe)
+  - DisableWinRight: false
+    $name: Win+Right
+    $description: Snap window right (requires dwm.exe)
+  - DisableWinShiftUp: false
+    $name: Win+Shift+Up
+    $description: Stretch window vertically (requires dwm.exe)
+  - DisableWinShiftDown: false
+    $name: Win+Shift+Down
+    $description: Restore/minimize height (requires dwm.exe)
+  - DisableWinShiftLeft: false
+    $name: Win+Shift+Left
+    $description: Move window to left monitor (requires dwm.exe)
+  - DisableWinShiftRight: false
+    $name: Win+Shift+Right
+    $description: Move window to right monitor (requires dwm.exe)
+  - DisableWinCtrlShiftB: false
+    $name: Win+Ctrl+Shift+B
+    $description: Restart graphics driver (requires dwm.exe)
   - DisableWinB: false
     $name: Win+B
     $description: Focus system tray
@@ -287,7 +312,7 @@ For **Special Shortcuts** and **Direct Shortcuts** to be blocked, you **must** a
     $name: Win+Ctrl+Q
     $description: Quick Assist
   $name: Standard Shortcuts
-  $description: Regular shortcuts registered by Explorer. Requires restarting Explorer to apply changes and release hotkeys for third-party apps.
+  $description: Regular shortcuts registered by Explorer or handled via low-level hook. Explorer-registered shortcuts require restarting Explorer to release for third-party apps. Shortcuts marked "(requires dwm.exe)" are handled via low-level hook.
 */
 // ==/WindhawkModSettings==
 
@@ -301,9 +326,16 @@ bool g_isDWM = false;
 // Settings structure
 struct Settings
 {
-    bool DisableWinA;
+    // Special Shortcuts (0=off, 1=disable via RegisterHotKey block, 2=block via DWM hook)
+    int DisableWinA;
+    int DisableWinC;
+    int DisableWinK;
+    int DisableWinN;
+    int DisableWinP;
+    int DisableWinU;
+    int DisableWinSlash;
+    // Standard/DWM-hook shortcuts (bool)
     bool DisableWinB;
-    bool DisableWinC;
     bool DisableWinD;
     bool DisableWinE;
     bool DisableWinF;
@@ -312,22 +344,17 @@ struct Settings
     bool DisableWinH;
     bool DisableWinI;
     bool DisableWinJ;
-    bool DisableWinK;
     bool DisableWinM;
-    bool DisableWinN;
     bool DisableWinO;
-    bool DisableWinP;
     bool DisableWinQ;
     bool DisableWinR;
     bool DisableWinS;
     bool DisableWinT;
-    bool DisableWinU;
     bool DisableWinV;
     bool DisableWinW;
     bool DisableWinX;
     bool DisableWinY;
     bool DisableWinZ;
-    bool DisableWinSlash;
     bool DisableWinTab;
     bool DisableWinUp;
     bool DisableWinDown;
@@ -381,9 +408,38 @@ struct Settings
     bool DisableCtrlEsc;
 } g_settings;
 
+// Reads a string setting that can be "off"/"false" (0), "disable"/"true" (1), or "block" (2).
+// Falls back to numeric parse for legacy stored integers.
+int GetSettingIntSafe(PCWSTR settingName)
+{
+    PCWSTR val = Wh_GetStringSetting(settingName);
+    if (!val) return 0;
+    int res = 0;
+    if (wcscmp(val, L"true") == 0 || wcscmp(val, L"disable") == 0) res = 1;
+    else if (wcscmp(val, L"false") == 0 || wcscmp(val, L"off") == 0) res = 0;
+    else if (wcscmp(val, L"block") == 0) res = 2;
+    else res = _wtoi(val); // fallback for legacy stored numbers
+    Wh_FreeStringSetting(val);
+    return res;
+}
+
+// Returns true if the settings differ in ways that require an Explorer restart.
+// Includes: Standard Shortcuts (RegisterHotKey-based) AND Special Shortcuts at tier 1
+// (which also block via RegisterHotKey, so Explorer must restart to release them).
+// Does NOT include DWM-hook-only shortcuts (Win+Tab, arrows, Win key, etc.) because
+// those are handled purely in dwm.exe and do not affect Explorer's registered hotkeys.
 bool StandardShortcutsEqual(const Settings& a, const Settings& b)
 {
-    return a.DisableWinB == b.DisableWinB &&
+    // Special shortcuts at tier 1 also block via RegisterHotKey — count as "standard" for restart purposes
+    auto specialTier1Equal = [](int x, int y) { return (x == 1) == (y == 1); };
+    return specialTier1Equal(a.DisableWinA, b.DisableWinA) &&
+           specialTier1Equal(a.DisableWinC, b.DisableWinC) &&
+           specialTier1Equal(a.DisableWinK, b.DisableWinK) &&
+           specialTier1Equal(a.DisableWinN, b.DisableWinN) &&
+           specialTier1Equal(a.DisableWinP, b.DisableWinP) &&
+           specialTier1Equal(a.DisableWinU, b.DisableWinU) &&
+           specialTier1Equal(a.DisableWinSlash, b.DisableWinSlash) &&
+           a.DisableWinB == b.DisableWinB &&
            a.DisableWinD == b.DisableWinD &&
            a.DisableWinE == b.DisableWinE &&
            a.DisableWinF == b.DisableWinF &&
@@ -449,33 +505,33 @@ bool HasAnyStandardShortcutsDisabled()
 
 void LoadSettings()
 {
-    // Special Shortcuts (Flyouts handled via DWM)
-    g_settings.DisableWinA = Wh_GetIntSetting(L"SpecialShortcuts.DisableWinA");
-    g_settings.DisableWinC = Wh_GetIntSetting(L"SpecialShortcuts.DisableWinC");
-    g_settings.DisableWinK = Wh_GetIntSetting(L"SpecialShortcuts.DisableWinK");
-    g_settings.DisableWinN = Wh_GetIntSetting(L"SpecialShortcuts.DisableWinN");
-    g_settings.DisableWinP = Wh_GetIntSetting(L"SpecialShortcuts.DisableWinP");
-    g_settings.DisableWinU = Wh_GetIntSetting(L"SpecialShortcuts.DisableWinU");
-    g_settings.DisableWinSlash = Wh_GetIntSetting(L"SpecialShortcuts.DisableWinSlash");
+    // Special Shortcuts: 3-tier string option ("off"=0, "disable"=1, "block"=2)
+    g_settings.DisableWinA = GetSettingIntSafe(L"SpecialShortcuts.DisableWinA");
+    g_settings.DisableWinC = GetSettingIntSafe(L"SpecialShortcuts.DisableWinC");
+    g_settings.DisableWinK = GetSettingIntSafe(L"SpecialShortcuts.DisableWinK");
+    g_settings.DisableWinN = GetSettingIntSafe(L"SpecialShortcuts.DisableWinN");
+    g_settings.DisableWinP = GetSettingIntSafe(L"SpecialShortcuts.DisableWinP");
+    g_settings.DisableWinU = GetSettingIntSafe(L"SpecialShortcuts.DisableWinU");
+    g_settings.DisableWinSlash = GetSettingIntSafe(L"SpecialShortcuts.DisableWinSlash");
 
-    // Direct Shortcuts (No Explorer Restart Required)
-    g_settings.DisableWinKey = Wh_GetIntSetting(L"DirectShortcuts.DisableWinKey");
-    g_settings.DisableCtrlEsc = Wh_GetIntSetting(L"DirectShortcuts.DisableCtrlEsc");
-    g_settings.DisableAltShift = Wh_GetIntSetting(L"DirectShortcuts.DisableAltShift");
-    g_settings.DisableWinSpace = Wh_GetIntSetting(L"DirectShortcuts.DisableWinSpace");
-    g_settings.DisableOfficeHotkeys = Wh_GetIntSetting(L"DirectShortcuts.DisableOfficeHotkeys");
-    g_settings.DisableWinTab = Wh_GetIntSetting(L"DirectShortcuts.DisableWinTab");
-    g_settings.DisableWinUp = Wh_GetIntSetting(L"DirectShortcuts.DisableWinUp");
-    g_settings.DisableWinDown = Wh_GetIntSetting(L"DirectShortcuts.DisableWinDown");
-    g_settings.DisableWinLeft = Wh_GetIntSetting(L"DirectShortcuts.DisableWinLeft");
-    g_settings.DisableWinRight = Wh_GetIntSetting(L"DirectShortcuts.DisableWinRight");
-    g_settings.DisableWinShiftUp = Wh_GetIntSetting(L"DirectShortcuts.DisableWinShiftUp");
-    g_settings.DisableWinShiftDown = Wh_GetIntSetting(L"DirectShortcuts.DisableWinShiftDown");
-    g_settings.DisableWinShiftLeft = Wh_GetIntSetting(L"DirectShortcuts.DisableWinShiftLeft");
-    g_settings.DisableWinShiftRight = Wh_GetIntSetting(L"DirectShortcuts.DisableWinShiftRight");
-    g_settings.DisableWinCtrlShiftB = Wh_GetIntSetting(L"DirectShortcuts.DisableWinCtrlShiftB");
+    // DWM-hook-only shortcuts (booleans, no Explorer restart needed)
+    g_settings.DisableWinKey = Wh_GetIntSetting(L"StandardShortcuts.DisableWinKey");
+    g_settings.DisableCtrlEsc = Wh_GetIntSetting(L"StandardShortcuts.DisableCtrlEsc");
+    g_settings.DisableAltShift = Wh_GetIntSetting(L"StandardShortcuts.DisableAltShift");
+    g_settings.DisableWinSpace = Wh_GetIntSetting(L"StandardShortcuts.DisableWinSpace");
+    g_settings.DisableOfficeHotkeys = Wh_GetIntSetting(L"StandardShortcuts.DisableOfficeHotkeys");
+    g_settings.DisableWinTab = Wh_GetIntSetting(L"StandardShortcuts.DisableWinTab");
+    g_settings.DisableWinUp = Wh_GetIntSetting(L"StandardShortcuts.DisableWinUp");
+    g_settings.DisableWinDown = Wh_GetIntSetting(L"StandardShortcuts.DisableWinDown");
+    g_settings.DisableWinLeft = Wh_GetIntSetting(L"StandardShortcuts.DisableWinLeft");
+    g_settings.DisableWinRight = Wh_GetIntSetting(L"StandardShortcuts.DisableWinRight");
+    g_settings.DisableWinShiftUp = Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftUp");
+    g_settings.DisableWinShiftDown = Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftDown");
+    g_settings.DisableWinShiftLeft = Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftLeft");
+    g_settings.DisableWinShiftRight = Wh_GetIntSetting(L"StandardShortcuts.DisableWinShiftRight");
+    g_settings.DisableWinCtrlShiftB = Wh_GetIntSetting(L"StandardShortcuts.DisableWinCtrlShiftB");
 
-    // Standard Shortcuts (Requires Explorer Restart)
+    // Standard Shortcuts (Explorer RegisterHotKey — require Explorer restart)
     g_settings.DisableWinB = Wh_GetIntSetting(L"StandardShortcuts.DisableWinB");
     g_settings.DisableWinD = Wh_GetIntSetting(L"StandardShortcuts.DisableWinD");
     g_settings.DisableWinE = Wh_GetIntSetting(L"StandardShortcuts.DisableWinE");
@@ -633,9 +689,9 @@ bool ShouldBlockHotkey(UINT fsModifiers, UINT vk)
         {
             switch (vk)
             {
-                case 'A': block = g_settings.DisableWinA; break;
+                case 'A': block = (g_settings.DisableWinA > 0); break;
                 case 'B': block = g_settings.DisableWinB; break;
-                case 'C': block = g_settings.DisableWinC; break;
+                case 'C': block = (g_settings.DisableWinC > 0); break;
                 case 'D': block = g_settings.DisableWinD; break;
                 case 'E': block = g_settings.DisableWinE; break;
                 case 'F': block = g_settings.DisableWinF; break;
@@ -644,16 +700,16 @@ bool ShouldBlockHotkey(UINT fsModifiers, UINT vk)
                 case 'H': block = g_settings.DisableWinH; break;
                 case 'I': block = g_settings.DisableWinI; break;
                 case 'J': block = g_settings.DisableWinJ; break;
-                case 'K': block = g_settings.DisableWinK; break;
+                case 'K': block = (g_settings.DisableWinK > 0); break;
                 case 'M': block = g_settings.DisableWinM; break;
-                case 'N': block = g_settings.DisableWinN; break;
+                case 'N': block = (g_settings.DisableWinN > 0); break;
                 case 'O': block = g_settings.DisableWinO; break;
-                case 'P': block = g_settings.DisableWinP; break;
+                case 'P': block = (g_settings.DisableWinP > 0); break;
                 case 'Q': block = g_settings.DisableWinQ; break;
                 case 'R': block = g_settings.DisableWinR; break;
                 case 'S': block = g_settings.DisableWinS; break;
                 case 'T': block = g_settings.DisableWinT; break;
-                case 'U': block = g_settings.DisableWinU; break;
+                case 'U': block = (g_settings.DisableWinU > 0); break;
                 case 'V': block = g_settings.DisableWinV; break;
                 case 'W': block = g_settings.DisableWinW; break;
                 case 'X': block = g_settings.DisableWinX; break;
@@ -674,7 +730,7 @@ bool ShouldBlockHotkey(UINT fsModifiers, UINT vk)
                 case VK_ESCAPE: block = g_settings.DisableWinEsc; break;
                 case VK_SPACE: block = g_settings.DisableWinSpace; break;
                 case VK_OEM_PERIOD: block = g_settings.DisableWinPeriod; break;
-                case VK_OEM_2: block = g_settings.DisableWinSlash; break;
+                case VK_OEM_2: block = (g_settings.DisableWinSlash > 0); break;
                 case VK_OEM_1: block = g_settings.DisableWinSemicolon; break;
                 case VK_SNAPSHOT: block = g_settings.DisableWinPrtSc; break;
             }
@@ -703,16 +759,19 @@ bool IsKnownHardcodedHotkey(UINT fsModifiers, UINT vk)
     if (hasWin && !hasCtrl && !hasAlt)
     {
         if (!hasShift) {
-            // Hardcoded keys that bypass RegisterHotKey
+            // DWM-hook-only hardcoded keys: always pass through RegisterHotKey
             if (vk == VK_TAB || vk == VK_UP || vk == VK_DOWN || vk == VK_LEFT || vk == VK_RIGHT || vk == VK_SPACE)
                 return true;
-            if (vk == 'A' && g_settings.DisableWinA) return true;
-            if (vk == 'C' && g_settings.DisableWinC) return true;
-            if (vk == 'K' && g_settings.DisableWinK) return true;
-            if (vk == 'N' && g_settings.DisableWinN) return true;
-            if (vk == 'P' && g_settings.DisableWinP) return true;
-            if (vk == 'U' && g_settings.DisableWinU) return true;
-            if (vk == VK_OEM_2 && g_settings.DisableWinSlash) return true;
+            // Special shortcuts at tier 2 ("block"): let Explorer register so flyouts initialize,
+            // physical key is suppressed in DWM hook. At tier 1 ("disable"), return false so
+            // Explorer is blocked from registering — freeing the key at OS level.
+            if (vk == 'A' && g_settings.DisableWinA == 2) return true;
+            if (vk == 'C' && g_settings.DisableWinC == 2) return true;
+            if (vk == 'K' && g_settings.DisableWinK == 2) return true;
+            if (vk == 'N' && g_settings.DisableWinN == 2) return true;
+            if (vk == 'P' && g_settings.DisableWinP == 2) return true;
+            if (vk == 'U' && g_settings.DisableWinU == 2) return true;
+            if (vk == VK_OEM_2 && g_settings.DisableWinSlash == 2) return true;
         } else {
             // Win+Shift+Arrows
             if (vk == VK_UP || vk == VK_DOWN || vk == VK_LEFT || vk == VK_RIGHT)
@@ -1144,17 +1203,19 @@ void StopHookThread()
 
 bool NeedsDwmHook()
 {
-    return g_settings.DisableWinA || g_settings.DisableWinC || 
-           g_settings.DisableWinK || g_settings.DisableWinN || 
-           g_settings.DisableWinP || g_settings.DisableWinU || 
-           g_settings.DisableWinSlash || 
+    // Special shortcuts need the DWM hook only at tier 2 ("block").
+    // At tier 1 ("disable"), they are handled entirely via RegisterHotKey_Hook (no DWM required).
+    return (g_settings.DisableWinA == 2) || (g_settings.DisableWinC == 2) ||
+           (g_settings.DisableWinK == 2) || (g_settings.DisableWinN == 2) ||
+           (g_settings.DisableWinP == 2) || (g_settings.DisableWinU == 2) ||
+           (g_settings.DisableWinSlash == 2) ||
            g_settings.DisableWinTab ||
-           g_settings.DisableWinUp || g_settings.DisableWinDown || 
+           g_settings.DisableWinUp || g_settings.DisableWinDown ||
            g_settings.DisableWinLeft || g_settings.DisableWinRight ||
-           g_settings.DisableWinShiftUp || g_settings.DisableWinShiftDown || 
+           g_settings.DisableWinShiftUp || g_settings.DisableWinShiftDown ||
            g_settings.DisableWinShiftLeft || g_settings.DisableWinShiftRight ||
            g_settings.DisableWinCtrlShiftB || g_settings.DisableOfficeHotkeys ||
-           g_settings.DisableWinSpace || g_settings.DisableAltShift || 
+           g_settings.DisableWinSpace || g_settings.DisableAltShift ||
            g_settings.DisableWinKey || g_settings.DisableCtrlEsc;
 }
 


### PR DESCRIPTION
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

### Additions

- Added new shortcuts
  - `Win+Shift+C` - Charms Menu in Windows 10 (Removed in later releases but windows still controls the shortcut)
  - `Win+Shift+R` - Snipping Tool Recorder (Credits to @SteffanDonal)

### Fixes
- Fixed key states being stuck when related keys held after locking the system (Credits to @SteffanDonal)

### Updates
- Refactored the Settings Structure into three sections
  - Special Shortcuts
  - Direct Shortcuts
  - Standard Shortcuts
- Removed the 3-tier dropdown settings for Special Shortcuts and change it into a single boolean toggle
- Refined the README to match the latest architectural standards
  
## Issue References

- #5158 
