### PR TITLE
Make the "Redirect Settings to Control Panel" mod more stable

### DIFF
--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -12,8 +12,11 @@
 // ==WindhawkModReadme==
 /*
 # Redirect Settings → Control Panel
+
 ## Screenshot
+
 ![Image](https://raw.githubusercontent.com/babamohammed2022/babamohammed2022/main/Senza%20nome.png)
+
 ---
 ## About
 This mod intercepts modern `ms-settings:` links (the ones that open the
@@ -210,7 +213,8 @@ static std::atomic_bool g_unloading{false};
 // watchdog thread, tray recreation, or a settings change) needs an explicit
 // Wh_ApplyHookOperations() call, which this flag lets us gate on.
 static std::atomic_bool g_modInitComplete{false};
-static std::atomic<long> g_activeHookCalls{0};
+// static std::atomic<int> g_activeHookCalls{0};  
+
 
 class ScopedHandle {
 public:
@@ -335,38 +339,6 @@ public:
 
 private:
     T* value_ = nullptr;
-};
-
-// Keeps an unload from racing a hook that is already executing mod code.
-// The caller still invokes the original trampoline when this guard is inactive.
-class HookInvocationGuard {
-public:
-    HookInvocationGuard() noexcept {
-        if (g_unloading.load(std::memory_order_acquire)) {
-            return;
-        }
-
-        g_activeHookCalls.fetch_add(1, std::memory_order_acq_rel);
-        if (!g_unloading.load(std::memory_order_acquire)) {
-            active_ = true;
-        } else {
-            g_activeHookCalls.fetch_sub(1, std::memory_order_acq_rel);
-        }
-    }
-
-    ~HookInvocationGuard() {
-        if (active_) {
-            g_activeHookCalls.fetch_sub(1, std::memory_order_acq_rel);
-        }
-    }
-
-    bool AllowCustomBehavior() const noexcept { return active_; }
-
-    HookInvocationGuard(const HookInvocationGuard&) = delete;
-    HookInvocationGuard& operator=(const HookInvocationGuard&) = delete;
-
-private:
-    bool active_ = false;
 };
 
 static BOOL CallOriginalShellExecuteExW(SHELLEXECUTEINFOW* pei) {
@@ -665,24 +637,21 @@ static void LoadSettings() {
 }
 
 static bool ICMH_CALL ICMH_hook_SndVolSSO(HMENU m, HWND w) {
-    HookInvocationGuard invocation;
-    if (!invocation.AllowCustomBehavior() || !RedirectsEnabled() || !RedirectSystemTrayEnabled())
+    if (g_unloading.load(std::memory_order_acquire) || !RedirectsEnabled() || !RedirectSystemTrayEnabled())
         return CallOriginalSndVolSSO(m, w);
     // Nothing here can throw, so there's no exception to guard against.
     return false;
 }
 
 static bool ICMH_CALL ICMH_hook_pnidui(HMENU m, HWND w) {
-    HookInvocationGuard invocation;
-    if (!invocation.AllowCustomBehavior() || !RedirectsEnabled() || !RedirectSystemTrayEnabled())
+    if (g_unloading.load(std::memory_order_acquire) || !RedirectsEnabled() || !RedirectSystemTrayEnabled())
         return CallOriginalPnidui(m, w);
     // Nothing here can throw, so there's no exception to guard against.
     return false;
 }
 
 static bool ICMH_CALL ICMH_hook_Shell32Devices(void* pThis, HMENU m, UINT u) {
-    HookInvocationGuard invocation;
-    if (!invocation.AllowCustomBehavior() || !RedirectsEnabled() || !RedirectSystemTrayEnabled())
+    if (g_unloading.load(std::memory_order_acquire) || !RedirectsEnabled() || !RedirectSystemTrayEnabled())
         return CallOriginalShell32Devices(pThis, m, u);
     // Nothing here can throw, so there's no exception to guard against.
     return false;
@@ -991,32 +960,25 @@ static void OpenClassicDevicesAndPrinters() {
 static LRESULT CALLBACK TrayToolbarSubclassProc(
     HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData)
 {
-    HookInvocationGuard invocation;
-    try {
-        if (invocation.AllowCustomBehavior() && msg == WM_RBUTTONUP) {
-            POINT pt;
-            pt.x = (int)(short)LOWORD(lParam);
-            pt.y = (int)(short)HIWORD(lParam);
-            int hitIndex = (int)SendMessageW(hwnd, TB_HITTEST, 0, (LPARAM)&pt);
+    if (!g_unloading.load(std::memory_order_acquire) && msg == WM_RBUTTONUP) {
+        POINT pt;
+        pt.x = (int)(short)LOWORD(lParam);
+        pt.y = (int)(short)HIWORD(lParam);
+        int hitIndex = (int)SendMessageW(hwnd, TB_HITTEST, 0, (LPARAM)&pt);
 
-            if (hitIndex >= 0) {
-                int buttonType = GetTrayButtonType(hwnd, hitIndex);
-                if (buttonType == 1) {
-                    std::lock_guard<std::mutex> lk(g_trayContextMutex);
-                    g_trayContextType = 1;
-                    g_trayContextTick = GetTickCount();
-                }
-                else if (buttonType == 2) {
-                    std::lock_guard<std::mutex> lk(g_trayContextMutex);
-                    g_trayContextType = 2;
-                    g_trayContextTick = GetTickCount();
-                }
+        if (hitIndex >= 0) {
+            int buttonType = GetTrayButtonType(hwnd, hitIndex);
+            if (buttonType == 1) {
+                std::lock_guard<std::mutex> lk(g_trayContextMutex);
+                g_trayContextType = 1;
+                g_trayContextTick = GetTickCount();
+            }
+            else if (buttonType == 2) {
+                std::lock_guard<std::mutex> lk(g_trayContextMutex);
+                g_trayContextType = 2;
+                g_trayContextTick = GetTickCount();
             }
         }
-    } catch (const std::exception&) {
-        Wh_Log(L"[STABILITY] Tray toolbar subclass caught std::exception");
-    } catch (...) {
-        Wh_Log(L"[STABILITY] Tray toolbar subclass caught an unknown exception");
     }
     return DefSubclassProc(hwnd, msg, wParam, lParam);
 }
@@ -1105,8 +1067,7 @@ static BOOL WINAPI CommonTrackPopupMenuEx_Hook(
     BOOL (WINAPI* pOrig)(HMENU, UINT, int, int, HWND, const TPMPARAMS*),
     const wchar_t* logPrefix)
 {
-    HookInvocationGuard invocation;
-    if (!invocation.AllowCustomBehavior() || !pOrig ||
+    if (g_unloading.load(std::memory_order_acquire) || !pOrig ||
         !RedirectSystemTrayEnabled() || !RedirectsEnabled()) {
         return CallOriginalTrackPopupMenuEx(pOrig, hMenu, uFlags, x, y, hWnd, lptpm);
     }
@@ -1114,8 +1075,6 @@ static BOOL WINAPI CommonTrackPopupMenuEx_Hook(
     HookGuard guard;
     if (guard.IsReentrant())
         return CallOriginalTrackPopupMenuEx(pOrig, hMenu, uFlags, x, y, hWnd, lptpm);
-
-    try {
 
     // --- Primary: subclass flag set on WM_RBUTTONUP ---
     int contextType = 0;
@@ -1217,12 +1176,6 @@ static BOOL WINAPI CommonTrackPopupMenuEx_Hook(
     }
 
     return result;
-    } catch (const std::exception&) {
-        Wh_Log(L"[%s] Stability fallback after std::exception", logPrefix ? logPrefix : L"TRAY-HOOK");
-    } catch (...) {
-        Wh_Log(L"[%s] Stability fallback after unknown exception", logPrefix ? logPrefix : L"TRAY-HOOK");
-    }
-    return CallOriginalTrackPopupMenuEx(pOrig, hMenu, uFlags, x, y, hWnd, lptpm);
 }
 
 BOOL WINAPI TrackPopupMenuEx_Hook(HMENU hMenu, UINT uFlags, int x, int y, HWND hWnd, const TPMPARAMS* lptpm) {
@@ -1622,13 +1575,16 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
 
     std::wstring mappedTarget;
     bool mappingFound = false;
-    if (!IsDisplayGroupUri(uri) || RedirectDisplayPagesEnabled()) {
-        std::lock_guard<std::mutex> lk(g_mappingsMutex);
-        auto it = g_mappings.find(uri);
-        if (it != g_mappings.end()) {
-            mappedTarget = it->second;
-            mappingFound = true;
-        }
+    if (IsDisplayGroupUri(uri) && !RedirectDisplayPagesEnabled()) {
+    return {L"", false};
+}
+if (true) {
+    std::lock_guard<std::mutex> lk(g_mappingsMutex);
+    auto it = g_mappings.find(uri);
+    if (it != g_mappings.end()) {
+        mappedTarget = it->second;
+        mappingFound = true;
+    }
     }
 
     if (mappingFound) {
@@ -1714,48 +1670,41 @@ HRESULT STDMETHODCALLTYPE AAM_ActivateApplication_hook(
     DWORD options,
     DWORD* processId)
 {
-    HookInvocationGuard invocation;
-    if (!invocation.AllowCustomBehavior() || !RedirectsEnabled() ||
+    if (g_unloading.load(std::memory_order_acquire) || !RedirectsEnabled() ||
         !ComActivationRedirectEnabled()) {
         return CallOriginalActivateApplication(pThis, appUserModelId, arguments, options, processId);
     }
 
-    try {
-        Wh_Log(L"[AAM-HOOK] ActivateApplication: appId=%s, args=%s",
-               appUserModelId ? appUserModelId : L"(null)",
-               arguments ? arguments : L"(null)");
+    Wh_Log(L"[AAM-HOOK] ActivateApplication: appId=%s, args=%s",
+           appUserModelId ? appUserModelId : L"(null)",
+           arguments ? arguments : L"(null)");
 
-        // Is this the Settings app being activated?
-        if (appUserModelId && arguments &&
-            _wcsnicmp(appUserModelId, L"windows.immersivecontrolpanel", 29) == 0)
-        {
-            std::wstring uri = NormalizeUri(arguments);
-            Wh_Log(L"[AAM-HOOK] Settings activation intercepted: %s", uri.c_str());
+    // Is this the Settings app being activated?
+    if (appUserModelId && arguments &&
+        _wcsnicmp(appUserModelId, L"windows.immersivecontrolpanel", 29) == 0)
+    {
+        std::wstring uri = NormalizeUri(arguments);
+        Wh_Log(L"[AAM-HOOK] Settings activation intercepted: %s", uri.c_str());
 
-            auto result = ResolveUri(uri, nullptr);
-            if (result.intercept) {
-                if (!result.target.empty()) {
-                    LaunchTarget(result.target);
-                    Wh_Log(L"[AAM-HOOK] Redirected to: %s", result.target.c_str());
-                } else {
-                    Wh_Log(L"[AAM-HOOK] Activation handled by fallback mode");
-                }
-                if (processId) *processId = GetCurrentProcessId();
-                return S_OK;
+        auto result = ResolveUri(uri, nullptr);
+        if (result.intercept) {
+            if (!result.target.empty()) {
+                LaunchTarget(result.target);
+                Wh_Log(L"[AAM-HOOK] Redirected to: %s", result.target.c_str());
+            } else {
+                Wh_Log(L"[AAM-HOOK] Activation handled by fallback mode");
             }
-            Wh_Log(L"[AAM-HOOK] No mapping found, falling back to original");
+            if (processId) *processId = GetCurrentProcessId();
+            return S_OK;
         }
-    } catch (const std::exception&) {
-        Wh_Log(L"[AAM-HOOK] std::exception; passing activation through");
-    } catch (...) {
-        Wh_Log(L"[AAM-HOOK] Unknown exception; passing activation through");
+        Wh_Log(L"[AAM-HOOK] No mapping found, falling back to original");
     }
 
     return CallOriginalActivateApplication(pThis, appUserModelId, arguments, options, processId);
 }
 
 static void InstallAAMHook() {
-    if (g_unloading.load(std::memory_order_acquire)) return;
+    if (g_unloading.load(std::memory_order_acquire) || !ComActivationRedirectEnabled()) return;
     try {
         std::lock_guard<std::mutex> lk(g_aamHookMutex);
         if (g_aamHookInstalled || g_unloading.load(std::memory_order_acquire)) return;
@@ -1857,30 +1806,22 @@ bool COpenControlPanel__MapLegacyName_hook(
     UINT     uLen,
     bool    *nameChanged)
 {
-    HookInvocationGuard invocation;
-    if (!invocation.AllowCustomBehavior() || !LegacyNameMappingFixEnabled()) {
+    if (g_unloading.load(std::memory_order_acquire) || !LegacyNameMappingFixEnabled()) {
         return CallOriginalMapLegacyName(pThis, pszLegacyName, pszNewName, uLen, nameChanged);
     }
 
-    try {
-        if (!ShouldSuppressLegacyNameMapping(pszLegacyName)) {
-            return CallOriginalMapLegacyName(pThis, pszLegacyName, pszNewName, uLen, nameChanged);
-        }
-
-        // Tell the caller the name was NOT changed — this forces Explorer to use
-        // the original legacy Control Panel path, but only for the whitelisted
-        // legacy names above.
-        if (nameChanged) *nameChanged = false;
-        if (pszNewName && uLen > 0) *pszNewName = L'\0';
-        Wh_Log(L"[MAP-LEGACY] Suppressed mapping for: %s",
-               pszLegacyName ? pszLegacyName : L"(null)");
-        return false;
-    } catch (const std::exception&) {
-        Wh_Log(L"[MAP-LEGACY] std::exception; using original mapping");
-    } catch (...) {
-        Wh_Log(L"[MAP-LEGACY] Unknown exception; using original mapping");
+    if (!ShouldSuppressLegacyNameMapping(pszLegacyName)) {
+        return CallOriginalMapLegacyName(pThis, pszLegacyName, pszNewName, uLen, nameChanged);
     }
-    return CallOriginalMapLegacyName(pThis, pszLegacyName, pszNewName, uLen, nameChanged);
+
+    // Tell the caller the name was NOT changed — this forces Explorer to use
+    // the original legacy Control Panel path, but only for the whitelisted
+    // legacy names above.
+    if (nameChanged) *nameChanged = false;
+    if (pszNewName && uLen > 0) *pszNewName = L'\0';
+    Wh_Log(L"[MAP-LEGACY] Suppressed mapping for: %s",
+           pszLegacyName ? pszLegacyName : L"(null)");
+    return false;
 }
 static std::wstring BaseNameLower(const std::wstring& path) {
     size_t pos = path.rfind(L'\\');
@@ -1945,83 +1886,69 @@ static std::wstring ExtractExplorerLaunchUri(const std::wstring& cmdLine) {
 }
 
 BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
-    HookInvocationGuard invocation;
-    try {
-        if (!invocation.AllowCustomBehavior() || IsChildProcess() || !RedirectsEnabled() || !pei) {
-            return CallOriginalShellExecuteExW(pei);
-        }
+    if (g_unloading.load(std::memory_order_acquire) || IsChildProcess() || !RedirectsEnabled() || !pei) {
+        return CallOriginalShellExecuteExW(pei);
+    }
 
-        HookGuard guard;
-        if (guard.IsReentrant()) return CallOriginalShellExecuteExW(pei);
+    HookGuard guard;
+    if (guard.IsReentrant()) return CallOriginalShellExecuteExW(pei);
 
-        if (IsControlSystemParams(pei->lpFile, pei->lpParameters)) {
-            LaunchTarget(g_isWin11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID);
+    if (IsControlSystemParams(pei->lpFile, pei->lpParameters)) {
+        LaunchTarget(g_isWin11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID);
+        if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
+        return TRUE;
+    }
+
+    std::wstring uri;
+    const wchar_t* f = pei->lpFile;
+    const wchar_t* p = pei->lpParameters;
+
+    if (f && ToLower(f).find(L"ms-settings:") != std::wstring::npos) uri = NormalizeUri(f);
+    else if (p && ToLower(p).find(L"ms-settings:") != std::wstring::npos) uri = NormalizeUri(p);
+    else if (f && ToLower(f).find(L"shell:::") != std::wstring::npos) uri = ToLower(f);
+    else if (p && ToLower(p).find(L"shell:::") != std::wstring::npos) uri = ToLower(p);
+
+    if (uri == L"ms-settings:taskbar")
+        return CallOriginalShellExecuteExW(pei);
+
+    if (!uri.empty()) {
+        auto result = ResolveUri(uri, pei->hwnd);
+        if (result.intercept) {
+            if (!result.target.empty()) LaunchTarget(result.target);
             if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
             return TRUE;
         }
-
-        std::wstring uri;
-        const wchar_t* f = pei->lpFile;
-        const wchar_t* p = pei->lpParameters;
-
-        if (f && ToLower(f).find(L"ms-settings:") != std::wstring::npos) uri = NormalizeUri(f);
-        else if (p && ToLower(p).find(L"ms-settings:") != std::wstring::npos) uri = NormalizeUri(p);
-        else if (f && ToLower(f).find(L"shell:::") != std::wstring::npos) uri = ToLower(f);
-        else if (p && ToLower(p).find(L"shell:::") != std::wstring::npos) uri = ToLower(p);
-
-        if (uri == L"ms-settings:taskbar")
-            return CallOriginalShellExecuteExW(pei);
-
-        if (!uri.empty()) {
-            auto result = ResolveUri(uri, pei->hwnd);
-            if (result.intercept) {
-                if (!result.target.empty()) LaunchTarget(result.target);
-                if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
-                return TRUE;
-            }
-        }
-    } catch (const std::exception&) {
-        Wh_Log(L"[STABILITY] ShellExecuteExW hook caught std::exception; passing through");
-    } catch (...) {
-        Wh_Log(L"[STABILITY] ShellExecuteExW hook caught an unknown exception; passing through");
     }
     return CallOriginalShellExecuteExW(pei);
 }
 HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file, LPCWSTR params, LPCWSTR dir, INT show) {
-    HookInvocationGuard invocation;
-    try {
-        if (!invocation.AllowCustomBehavior() || IsChildProcess() || !RedirectsEnabled()) {
-            return CallOriginalShellExecuteW(hwnd, op, file, params, dir, show);
-        }
+    if (g_unloading.load(std::memory_order_acquire) || IsChildProcess() || !RedirectsEnabled()) {
+        return CallOriginalShellExecuteW(hwnd, op, file, params, dir, show);
+    }
 
-        HookGuard guard;
-        if (guard.IsReentrant()) return CallOriginalShellExecuteW(hwnd, op, file, params, dir, show);
+    HookGuard guard;
+    if (guard.IsReentrant()) return CallOriginalShellExecuteW(hwnd, op, file, params, dir, show);
 
-        if (IsControlSystemParams(file, params)) {
-            LaunchTarget(g_isWin11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID);
+    if (IsControlSystemParams(file, params)) {
+        LaunchTarget(g_isWin11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID);
+        return (HINSTANCE)33;
+    }
+
+    std::wstring uri;
+    if (file && ToLower(file).find(L"ms-settings:") != std::wstring::npos) uri = NormalizeUri(file);
+    else if (params && ToLower(params).find(L"ms-settings:") != std::wstring::npos) uri = NormalizeUri(params);
+    else if (file && ToLower(file).find(L"shell:::") != std::wstring::npos) uri = ToLower(file);
+    else if (params && ToLower(params).find(L"shell:::") != std::wstring::npos) uri = ToLower(params);
+
+    if (uri == L"ms-settings:taskbar")
+        return CallOriginalShellExecuteW(hwnd, op, file, params, dir, show);
+
+    if (!uri.empty()) {
+        auto result = ResolveUri(uri, hwnd);
+        if (result.intercept) {
+            if (!result.target.empty()) LaunchTarget(result.target);
             return (HINSTANCE)33;
         }
-
-        std::wstring uri;
-        if (file && ToLower(file).find(L"ms-settings:") != std::wstring::npos) uri = NormalizeUri(file);
-        else if (params && ToLower(params).find(L"ms-settings:") != std::wstring::npos) uri = NormalizeUri(params);
-        else if (file && ToLower(file).find(L"shell:::") != std::wstring::npos) uri = ToLower(file);
-        else if (params && ToLower(params).find(L"shell:::") != std::wstring::npos) uri = ToLower(params);
-
-        if (uri == L"ms-settings:taskbar")
-            return CallOriginalShellExecuteW(hwnd, op, file, params, dir, show);
-
-        if (!uri.empty()) {
-            auto result = ResolveUri(uri, hwnd);
-            if (result.intercept) {
-                if (!result.target.empty()) LaunchTarget(result.target);
-                return (HINSTANCE)33;
-            }
-        }
-    } catch (const std::exception&) {
-        Wh_Log(L"[STABILITY] ShellExecuteW hook caught std::exception; passing through");
-    } catch (...) {
-        Wh_Log(L"[STABILITY] ShellExecuteW hook caught an unknown exception; passing through");
     }
     return CallOriginalShellExecuteW(hwnd, op, file, params, dir, show);
 }
@@ -2030,46 +1957,39 @@ BOOL WINAPI CreateProcessW_hook(LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
                                  BOOL bInheritHandles, DWORD dwCreationFlags, LPVOID lpEnvironment,
                                  LPCWSTR lpCurrentDirectory, LPSTARTUPINFOW lpStartupInfo,
                                  LPPROCESS_INFORMATION lpProcessInformation) {
-    HookInvocationGuard invocation;
-    try {
-        if (!invocation.AllowCustomBehavior() || IsChildProcess() || !RedirectsEnabled() ||
-            UiOnlyRedirectsEnabled()) {
-            return CallOriginalCreateProcessW(lpApplicationName, lpCommandLine,
-                lpProcessAttributes, lpThreadAttributes, bInheritHandles, dwCreationFlags,
-                lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInformation);
+    if (g_unloading.load(std::memory_order_acquire) || IsChildProcess() || !RedirectsEnabled() ||
+        UiOnlyRedirectsEnabled()) {
+        return CallOriginalCreateProcessW(lpApplicationName, lpCommandLine,
+            lpProcessAttributes, lpThreadAttributes, bInheritHandles, dwCreationFlags,
+            lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInformation);
+    }
+
+    HookGuard guard;
+    if (guard.IsReentrant()) {
+        return CallOriginalCreateProcessW(lpApplicationName, lpCommandLine,
+            lpProcessAttributes, lpThreadAttributes, bInheritHandles, dwCreationFlags,
+            lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInformation);
+    }
+
+    if (lpCommandLine) {
+        std::wstring cmdLine(lpCommandLine);
+        if (IsControlSystemCommand(cmdLine)) {
+            LaunchTarget(g_isWin11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID);
+            if (lpProcessInformation) ZeroMemory(lpProcessInformation, sizeof(PROCESS_INFORMATION));
+            SetLastError(ERROR_SUCCESS);
+            return TRUE;
         }
 
-        HookGuard guard;
-        if (guard.IsReentrant()) {
-            return CallOriginalCreateProcessW(lpApplicationName, lpCommandLine,
-                lpProcessAttributes, lpThreadAttributes, bInheritHandles, dwCreationFlags,
-                lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInformation);
-        }
-
-        if (lpCommandLine) {
-            std::wstring cmdLine(lpCommandLine);
-            if (IsControlSystemCommand(cmdLine)) {
-                LaunchTarget(g_isWin11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID);
+        std::wstring uri = ExtractExplorerLaunchUri(cmdLine);
+        if (!uri.empty()) {
+            auto result = ResolveUri(uri, nullptr);
+            if (result.intercept) {
+                if (!result.target.empty()) LaunchTarget(result.target);
                 if (lpProcessInformation) ZeroMemory(lpProcessInformation, sizeof(PROCESS_INFORMATION));
                 SetLastError(ERROR_SUCCESS);
                 return TRUE;
             }
-
-            std::wstring uri = ExtractExplorerLaunchUri(cmdLine);
-            if (!uri.empty()) {
-                auto result = ResolveUri(uri, nullptr);
-                if (result.intercept) {
-                    if (!result.target.empty()) LaunchTarget(result.target);
-                    if (lpProcessInformation) ZeroMemory(lpProcessInformation, sizeof(PROCESS_INFORMATION));
-                    SetLastError(ERROR_SUCCESS);
-                    return TRUE;
-                }
-            }
         }
-    } catch (const std::exception&) {
-        Wh_Log(L"[STABILITY] CreateProcessW hook caught std::exception; passing through");
-    } catch (...) {
-        Wh_Log(L"[STABILITY] CreateProcessW hook caught an unknown exception; passing through");
     }
     return CallOriginalCreateProcessW(lpApplicationName, lpCommandLine,
         lpProcessAttributes, lpThreadAttributes, bInheritHandles, dwCreationFlags,
@@ -2291,8 +2211,9 @@ static void ReinitializeTrayRedirect() {
             SetupTraySubclass();
         }
 
-        InstallImmersiveMenuHooks();
-        InstallShell32Hooks();
+if (RedirectSystemTrayEnabled()) {
+    InstallImmersiveMenuHooks();
+}        InstallShell32Hooks();
     } catch (const std::exception&) {
         Wh_Log(L"[STABILITY] ReinitializeTrayRedirect caught std::exception");
     } catch (...) {
@@ -2310,13 +2231,14 @@ static void PerformBackgroundInit(bool skipSleep = false) {
     }
 
     if (g_unloading.load(std::memory_order_acquire)) return;
+if (RedirectSystemTrayEnabled()) {
     InstallImmersiveMenuHooks();
-    if (g_unloading.load(std::memory_order_acquire)) return;
+}    if (g_unloading.load(std::memory_order_acquire)) return;
     InstallShell32Hooks();
 
-    if (!g_unloading.load(std::memory_order_acquire) && g_isWin11) {
-        InstallAAMHook();
-    }
+if (!g_unloading.load(std::memory_order_acquire) && g_isWin11 && ComActivationRedirectEnabled()) {
+    InstallAAMHook();
+}
 }
 
 static DWORD WINAPI TraySubclassWatchdogThread(LPVOID) {
@@ -2377,47 +2299,38 @@ HWND WINAPI CreateWindowExW_Hook(
     DWORD dwStyle, int X, int Y, int nWidth, int nHeight,
     HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
 {
-    HWND hwnd = nullptr;
-    try {
-        if (!CreateWindowExW_Original) {
-            SetLastError(ERROR_PROC_NOT_FOUND);
-            return nullptr;
-        }
+    if (!CreateWindowExW_Original) {
+        SetLastError(ERROR_PROC_NOT_FOUND);
+        return nullptr;
+    }
 
-        hwnd = CreateWindowExW_Original(
-            dwExStyle, lpClassName, lpWindowName, dwStyle,
-            X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+    HWND hwnd = CreateWindowExW_Original(
+        dwExStyle, lpClassName, lpWindowName, dwStyle,
+        X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
 
-        HookInvocationGuard invocation;
-        if (!invocation.AllowCustomBehavior() || !RedirectSystemTrayEnabled() || !hwnd ||
-            !lpClassName || IS_INTRESOURCE(lpClassName) || lpClassName[0] != L'T') {
-            return hwnd;
-        }
+    if (g_unloading.load(std::memory_order_acquire) || !RedirectSystemTrayEnabled() || !hwnd ||
+        !lpClassName || IS_INTRESOURCE(lpClassName) || lpClassName[0] != L'T') {
+        return hwnd;
+    }
 
-        HookGuard guard;
-        if (guard.IsReentrant() || wcscmp(lpClassName, L"ToolbarWindow32") != 0) {
-            return hwnd;
-        }
+    HookGuard guard;
+    if (guard.IsReentrant() || wcscmp(lpClassName, L"ToolbarWindow32") != 0) {
+        return hwnd;
+    }
 
-        bool trayToolbarMissing = false;
-        {
-            std::lock_guard<std::mutex> lk(g_traySubclassMutex);
-            trayToolbarMissing = (g_hTrayToolbar == nullptr);
-        }
-        if (trayToolbarMissing) {
-            SetupTraySubclass();
-        }
-    } catch (const std::exception&) {
-        Wh_Log(L"[STABILITY] CreateWindowExW hook caught std::exception; returning original window");
-    } catch (...) {
-        Wh_Log(L"[STABILITY] CreateWindowExW hook caught an unknown exception; returning original window");
+    bool trayToolbarMissing = false;
+    {
+        std::lock_guard<std::mutex> lk(g_traySubclassMutex);
+        trayToolbarMissing = (g_hTrayToolbar == nullptr);
+    }
+    if (trayToolbarMissing) {
+        SetupTraySubclass();
     }
     return hwnd;
 }
 BOOL Wh_ModInit() {
     try {
         g_unloading.store(false, std::memory_order_release);
-        g_activeHookCalls.store(0, std::memory_order_release);
         g_shellExecuteExHookRegistered.store(false, std::memory_order_release);
         g_shellExecuteHookRegistered.store(false, std::memory_order_release);
         g_createProcessHookRegistered.store(false, std::memory_order_release);
@@ -2568,20 +2481,7 @@ void Wh_ModBeforeUninit() {
     }
 }
 
-static bool WaitForActiveHooksToDrain() noexcept {
-    constexpr DWORD kMaxWaitMs = 5000;
-    constexpr DWORD kSleepMs = 10;
-    DWORD waited = 0;
-    while (g_activeHookCalls.load(std::memory_order_acquire) > 0 && waited < kMaxWaitMs) {
-        Sleep(kSleepMs);
-        waited += kSleepMs;
-    }
-    const bool drained = g_activeHookCalls.load(std::memory_order_acquire) == 0;
-    if (!drained) {
-        Wh_Log(L"[STABILITY] Hook calls remained active after %lu ms; shared state will be retained for the engine unload guard", kMaxWaitMs);
-    }
-    return drained;
-}
+
 
 void Wh_ModUninit() {
     try {
@@ -2600,33 +2500,26 @@ void Wh_ModUninit() {
             CloseHandle(g_traySubclassWatchdogThread);
             g_traySubclassWatchdogThread = nullptr;
         }
+RemoveTraySubclass();
 
-        const bool hooksDrained = WaitForActiveHooksToDrain();
-        RemoveTraySubclass();
+if (g_stopEvent) {
+    CloseHandle(g_stopEvent);
+    g_stopEvent = nullptr;
+}
 
-        if (g_stopEvent) {
-            CloseHandle(g_stopEvent);
-            g_stopEvent = nullptr;
-        }
-
-        // Do not free state underneath a hook that did not finish within the
-        // diagnostic wait. Normal module destruction releases it after the
-        // engine completes its own in-flight hook synchronization.
-        if (hooksDrained) {
-            {
-                std::lock_guard<std::mutex> lk(g_bounceGuardMtx);
-                g_bounceGuard.clear();
-            }
-            {
-                std::lock_guard<std::mutex> lk(g_loopGuardMtx);
-                g_loopGuard.clear();
-            }
-            {
-                std::lock_guard<std::mutex> lk(g_mappingsMutex);
-                g_mappings.clear();
-            }
-            g_childEnvBlock.clear();
-        }
+{
+    std::lock_guard<std::mutex> lk(g_bounceGuardMtx);
+    g_bounceGuard.clear();
+}
+{
+    std::lock_guard<std::mutex> lk(g_loopGuardMtx);
+    g_loopGuard.clear();
+}
+{
+    std::lock_guard<std::mutex> lk(g_mappingsMutex);
+    g_mappings.clear();
+}
+g_childEnvBlock.clear();
     } catch (const std::exception&) {
         Wh_Log(L"[STABILITY] Wh_ModUninit caught std::exception");
     } catch (...) {

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -37,7 +37,7 @@ Panel pages, using only native Windows components.
 - The mod includes an anti-loop protection (stops windows from reopening endlessly)
 - The mod includes a configurable fallback behavior for unmapped links
 - The mod includes an experimental tray menu detection (which works on some builds)
-- The mod includes a defensive handling: guarded hooks, RAII cleanup for handles/COM/environment blocks, and safe fallbacks when an optional hook or launch fails
+- The mod includes defensive handling around its own logic: guarded hook installers, RAII cleanup for handles/COM/environment blocks, and safe fallbacks when an optional hook or launch fails. This guards against failed initialization and allocation failures inside the mod's own code, not against Explorer crashes in general (an access violation elsewhere in the process is not something a C++ `try`/`catch` can intercept)
 
 
 **Note**: This mod is a best-effort implementation. It aims to intercept and redirect as many `ms-settings:` links as possible, but due to differences between Windows 10 and Windows 11, as well as changes introduced by Microsoft in each build, some redirects may not work perfectly in all environments.
@@ -49,6 +49,7 @@ Panel pages, using only native Windows components.
 - The system tray context menu redirect only supports the Win32 taskbar (the one from Windows 10). However, in some Windows 11 configurations if explorer is restarted the network system tray redirect might not work.
 - The device & printers system tray redirect may not work on some Windows 11 configurations, as Microsoft hardcoded the redirect to the Settings app in certain shell code paths. This could change in future if correct documentation is found.
 - The mod is not compatible with 32 bit based operating systems. It requires a 64-bit version of Windows (x64 or ARM64).
+- The `ms-settings:display` group (Display, display-advanced, display-advanced-graphics, display-adapter-properties, display-resolution, screenrotation) all map to the same classic Display/Screen Resolution applet that the **Classic Display Control Panel Restorer** mod also restores. If you use that mod, turn off the "Redirect Display Pages" setting here to avoid the two mods fighting over the same pages.
 
 ---
 
@@ -108,6 +109,9 @@ All of these mods are **reversible** and help make Windows 10 and 11 look more l
 - LegacyNameMappingFix: true
   $name: Fix Legacy Name Mapping
   $description: "This option fixes a shell issue where certain classic Control Panel pages show up blank or silently redirect to the modern Settings app. Recommended on both Windows 10 and 11."
+- RedirectDisplayPages: true
+  $name: Redirect Display Pages
+  $description: "Controls the ms-settings:display group (Display, display-advanced, display-advanced-graphics, display-adapter-properties, display-resolution, screenrotation). Turn this off if you also use the Classic Display Control Panel Restorer mod, since both mods target the same classic Display/Screen Resolution pages."
 */
 // ==/WindhawkModSettings==
 
@@ -168,6 +172,9 @@ static HANDLE g_stopEvent = nullptr;
 static bool ICMH_CALL ICMH_hook_SndVolSSO(HMENU m, HWND w);
 static bool ICMH_CALL ICMH_hook_pnidui(HMENU m, HWND w);
 static bool ICMH_CALL ICMH_hook_Shell32Devices(void* pThis, HMENU m, UINT u);
+// Applies a hook operation queued after Wh_ModInit already returned; see the
+// definition further down for details.
+static bool ApplyLateHookIfNeeded();
 
 // Constants
 #define PERS_ROOT       L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"
@@ -197,6 +204,12 @@ static std::atomic_bool g_createProcessHookRegistered{false};
 // infrastructure: a failed optional path must not leave a live handle, a thread, or
 // an exception crossing an Explorer/COM/Win32 boundary.
 static std::atomic_bool g_unloading{false};
+// Set once after the initial in-Wh_ModInit hook batch has been queued.
+// Windhawk applies hook operations registered during Wh_ModInit
+// automatically once it returns; anything registered afterwards (from the
+// watchdog thread, tray recreation, or a settings change) needs an explicit
+// Wh_ApplyHookOperations() call, which this flag lets us gate on.
+static std::atomic_bool g_modInitComplete{false};
 static std::atomic<long> g_activeHookCalls{0};
 
 class ScopedHandle {
@@ -566,6 +579,7 @@ struct ModSettings {
     std::atomic_int maxLaunchesPerUri{3};
     std::atomic_bool comActivationRedirect{false};
     std::atomic_bool legacyNameMappingFix{true};
+    std::atomic_bool redirectDisplayPages{true};
 };
 
 static ModSettings g_settings;
@@ -594,6 +608,9 @@ static bool ComActivationRedirectEnabled() noexcept {
 static bool LegacyNameMappingFixEnabled() noexcept {
     return g_settings.legacyNameMappingFix.load(std::memory_order_acquire);
 }
+static bool RedirectDisplayPagesEnabled() noexcept {
+    return g_settings.redirectDisplayPages.load(std::memory_order_acquire);
+}
 
 static void DisableRedirectsAfterSettingsFailure() noexcept {
     g_settings.enableRedirects.store(false, std::memory_order_release);
@@ -604,6 +621,7 @@ static void DisableRedirectsAfterSettingsFailure() noexcept {
     g_settings.maxLaunchesPerUri.store(3, std::memory_order_release);
     g_settings.comActivationRedirect.store(false, std::memory_order_release);
     g_settings.legacyNameMappingFix.store(true, std::memory_order_release);
+    g_settings.redirectDisplayPages.store(true, std::memory_order_release);
 }
 
 static void LoadSettings() {
@@ -626,6 +644,7 @@ static void LoadSettings() {
             ? configuredMaxLaunches : 3;
         const bool comActivationRedirect = Wh_GetIntSetting(L"ComActivationRedirect") != 0;
         const bool legacyNameMappingFix = Wh_GetIntSetting(L"LegacyNameMappingFix") != 0;
+        const bool redirectDisplayPages = Wh_GetIntSetting(L"RedirectDisplayPages") != 0;
 
         g_settings.enableRedirects.store(enableRedirects, std::memory_order_release);
         g_settings.redirectSystemTray.store(redirectSystemTray, std::memory_order_release);
@@ -635,6 +654,7 @@ static void LoadSettings() {
         g_settings.maxLaunchesPerUri.store(maxLaunchesPerUri, std::memory_order_release);
         g_settings.comActivationRedirect.store(comActivationRedirect, std::memory_order_release);
         g_settings.legacyNameMappingFix.store(legacyNameMappingFix, std::memory_order_release);
+        g_settings.redirectDisplayPages.store(redirectDisplayPages, std::memory_order_release);
     } catch (const std::exception&) {
         DisableRedirectsAfterSettingsFailure();
         Wh_Log(L"[STABILITY] LoadSettings caught std::exception; redirects are disabled for safety");
@@ -648,42 +668,24 @@ static bool ICMH_CALL ICMH_hook_SndVolSSO(HMENU m, HWND w) {
     HookInvocationGuard invocation;
     if (!invocation.AllowCustomBehavior() || !RedirectsEnabled() || !RedirectSystemTrayEnabled())
         return CallOriginalSndVolSSO(m, w);
-    try {
-        return false;
-    } catch (const std::exception&) {
-        Wh_Log(L"[STABILITY] SndVolSSO context hook caught std::exception");
-    } catch (...) {
-        Wh_Log(L"[STABILITY] SndVolSSO context hook caught an unknown exception");
-    }
-    return CallOriginalSndVolSSO(m, w);
+    // Nothing here can throw, so there's no exception to guard against.
+    return false;
 }
 
 static bool ICMH_CALL ICMH_hook_pnidui(HMENU m, HWND w) {
     HookInvocationGuard invocation;
     if (!invocation.AllowCustomBehavior() || !RedirectsEnabled() || !RedirectSystemTrayEnabled())
         return CallOriginalPnidui(m, w);
-    try {
-        return false;
-    } catch (const std::exception&) {
-        Wh_Log(L"[STABILITY] pnidui context hook caught std::exception");
-    } catch (...) {
-        Wh_Log(L"[STABILITY] pnidui context hook caught an unknown exception");
-    }
-    return CallOriginalPnidui(m, w);
+    // Nothing here can throw, so there's no exception to guard against.
+    return false;
 }
 
 static bool ICMH_CALL ICMH_hook_Shell32Devices(void* pThis, HMENU m, UINT u) {
     HookInvocationGuard invocation;
     if (!invocation.AllowCustomBehavior() || !RedirectsEnabled() || !RedirectSystemTrayEnabled())
         return CallOriginalShell32Devices(pThis, m, u);
-    try {
-        return false;
-    } catch (const std::exception&) {
-        Wh_Log(L"[STABILITY] shell32 devices context hook caught std::exception");
-    } catch (...) {
-        Wh_Log(L"[STABILITY] shell32 devices context hook caught an unknown exception");
-    }
-    return CallOriginalShell32Devices(pThis, m, u);
+    // Nothing here can throw, so there's no exception to guard against.
+    return false;
 }
 
 static bool g_isWin11 = false;
@@ -1251,7 +1253,7 @@ static bool InitMappings() {
         {L"ms-settings:fonts", L"shell:::{BD84B380-8CA2-1069-AB1D-08000948F534}"},
         {L"ms-settings:display-advanced-color", L"colorcpl.exe"},
         {L"ms-settings:colorcpl", L"colorcpl.exe"},
-        // {L"ms-settings:display", L"rundll32.exe display.dll,ShowAdapterSettings 0"}, <- This has been removed because a restoration mod for the legacy page has been created
+        {L"ms-settings:display", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
         {L"ms-settings:display-advanced", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
         {L"ms-settings:display-advanced-graphics", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
         {L"ms-settings:display-adapter-properties", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
@@ -1591,6 +1593,25 @@ static bool ShouldApplyBounceGuard(const std::wstring& uri) {
     return uri.find(L"personalization") != std::wstring::npos;
 }
 
+// The classic Display / Screen Resolution pages this group maps to are also
+// what the companion "Classic Display Control Panel Restorer" mod restores.
+// Gated behind RedirectDisplayPages so the two mods can coexist: when off,
+// these URIs fall through to HandleFallback instead of being redirected here.
+static bool IsDisplayGroupUri(const std::wstring& uri) {
+    static const std::wstring_view kDisplayGroupUris[] = {
+        L"ms-settings:display",
+        L"ms-settings:display-advanced",
+        L"ms-settings:display-advanced-graphics",
+        L"ms-settings:display-adapter-properties",
+        L"ms-settings:display-resolution",
+        L"ms-settings:screenrotation",
+    };
+    for (const auto& candidate : kDisplayGroupUris) {
+        if (uri == candidate) return true;
+    }
+    return false;
+}
+
 static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
     if (uri == L"ms-settings:personalization-background") {
         if (BounceGuardIsBounce(uri)) return {L"", true};
@@ -1601,7 +1622,7 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
 
     std::wstring mappedTarget;
     bool mappingFound = false;
-    {
+    if (!IsDisplayGroupUri(uri) || RedirectDisplayPagesEnabled()) {
         std::lock_guard<std::mutex> lk(g_mappingsMutex);
         auto it = g_mappings.find(uri);
         if (it != g_mappings.end()) {
@@ -1777,8 +1798,12 @@ static void InstallAAMHook() {
 
         if (WindhawkUtils::SetFunctionHook(target, AAM_ActivateApplication_hook,
                                             &g_origActivateApplication)) {
-            g_aamHookInstalled = true;
-            Wh_Log(L"[AAM-HOOK] Successfully installed");
+            if (ApplyLateHookIfNeeded()) {
+                g_aamHookInstalled = true;
+                Wh_Log(L"[AAM-HOOK] Successfully installed");
+            } else {
+                Wh_Log(L"[AAM-HOOK] Registered but Wh_ApplyHookOperations failed; will retry later");
+            }
         } else {
             Wh_Log(L"[AAM-HOOK] SetFunctionHook failed; COM redirect remains disabled");
         }
@@ -2050,6 +2075,25 @@ BOOL WINAPI CreateProcessW_hook(LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
         lpProcessAttributes, lpThreadAttributes, bInheritHandles, dwCreationFlags,
         lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInformation);
 }
+// If a late (post-Wh_ModInit) registration succeeds, the operation still
+// needs to be applied explicitly - Windhawk only auto-applies the batch that
+// was queued while Wh_ModInit was running. Returns whether the hook is
+// actually active and safe to mark "installed".
+static bool ApplyLateHookIfNeeded() {
+    if (!g_modInitComplete.load(std::memory_order_acquire)) {
+        // Still inside the initial Wh_ModInit batch; Windhawk will apply it
+        // automatically once Wh_ModInit returns.
+        return true;
+    }
+    if (!Wh_ApplyHookOperations()) {
+        Wh_Log(L"[STABILITY] Wh_ApplyHookOperations failed for a late hook batch");
+        return false;
+    }
+    return true;
+}
+
+static std::atomic_bool g_pniduiHookFailed{false};
+
 static bool TryInstallPniduiHook() {
     if (g_unloading.load(std::memory_order_acquire)) return false;
     try {
@@ -2058,6 +2102,12 @@ static bool TryInstallPniduiHook() {
 
         if (g_pniduiHookInstalled.load(std::memory_order_acquire)) {
             return true;
+        }
+        // Only retry module/symbol resolution if we haven't already tried
+        // and failed - repeated HookSymbols calls against the same module
+        // invalidate its symbol cache and force a slow re-resolution.
+        if (g_pniduiHookFailed.load(std::memory_order_acquire)) {
+            return false;
         }
 
         HMODULE hMod = GetModuleHandleW(L"pnidui.dll");
@@ -2079,6 +2129,11 @@ static bool TryInstallPniduiHook() {
         }};
 
         bool result = WindhawkUtils::HookSymbols(hMod, pnidui_dll_hooks, 1);
+        if (!result) {
+            g_pniduiHookFailed.store(true, std::memory_order_release);
+            return false;
+        }
+        result = ApplyLateHookIfNeeded();
         if (result) {
             g_pniduiHookInstalled.store(true, std::memory_order_release);
         }
@@ -2092,7 +2147,9 @@ static bool TryInstallPniduiHook() {
 }
 
 static std::atomic_bool g_sndVolSSOHookInstalled{false};
+static std::atomic_bool g_sndVolSSOHookFailed{false};
 static std::atomic_bool g_shell32HooksInstalled{false};
+static std::atomic_bool g_shell32HooksFailed{false};
 static std::mutex g_immersiveMenuHookMutex;
 static std::mutex g_shell32HookMutex;
 
@@ -2101,7 +2158,8 @@ static void InstallImmersiveMenuHooks() {
     try {
         std::lock_guard<std::mutex> installLock(g_immersiveMenuHookMutex);
         if (g_unloading.load(std::memory_order_acquire)) return;
-        if (!g_sndVolSSOHookInstalled.load(std::memory_order_acquire)) {
+        if (!g_sndVolSSOHookInstalled.load(std::memory_order_acquire) &&
+            !g_sndVolSSOHookFailed.load(std::memory_order_acquire)) {
             HMODULE hMod = GetModuleHandleW(L"SndVolSSO.dll");
             if (!hMod) hMod = LoadLibraryExW(L"SndVolSSO.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
 
@@ -2117,7 +2175,11 @@ static void InstallImmersiveMenuHooks() {
                 }};
 
                 if (WindhawkUtils::HookSymbols(hMod, sndVolSSO_dll_hooks, 1)) {
-                    g_sndVolSSOHookInstalled.store(true, std::memory_order_release);
+                    if (ApplyLateHookIfNeeded()) {
+                        g_sndVolSSOHookInstalled.store(true, std::memory_order_release);
+                    }
+                } else {
+                    g_sndVolSSOHookFailed.store(true, std::memory_order_release);
                 }
             }
         }
@@ -2141,6 +2203,9 @@ static void InstallShell32Hooks() {
     std::lock_guard<std::mutex> lk(g_shell32HookMutex);
     if (g_unloading.load(std::memory_order_acquire)) return;
     if (g_shell32HooksInstalled.load(std::memory_order_acquire)) return;
+    // Already tried and the symbols weren't hookable - don't keep re-resolving
+    // the module on every settings change / tray recreation.
+    if (g_shell32HooksFailed.load(std::memory_order_acquire)) return;
 
     HMODULE hShell32 = GetModuleHandleW(L"shell32.dll");
     if (!hShell32) return;
@@ -2175,8 +2240,12 @@ static void InstallShell32Hooks() {
             shell32_dll_hooks,
             ARRAYSIZE(shell32_dll_hooks)))
     {
-        g_shell32HooksInstalled.store(true, std::memory_order_release);
-        Wh_Log(L"[SHELL32-HOOKS] Installed shell32 hook set");
+        if (ApplyLateHookIfNeeded()) {
+            g_shell32HooksInstalled.store(true, std::memory_order_release);
+            Wh_Log(L"[SHELL32-HOOKS] Installed shell32 hook set");
+        }
+    } else {
+        g_shell32HooksFailed.store(true, std::memory_order_release);
     }
     } catch (const std::exception&) {
         Wh_Log(L"[STABILITY] shell32 hook setup caught std::exception");
@@ -2437,6 +2506,10 @@ BOOL Wh_ModInit() {
             // returns, so Windhawk can apply them as part of normal initialization
             // without explicit Wh_ApplyHookOperations calls later.
             PerformBackgroundInit(true);
+            // Everything queued above rides along with Windhawk's automatic
+            // post-Wh_ModInit apply. Anything installed after this point is a
+            // late registration and must call Wh_ApplyHookOperations() itself.
+            g_modInitComplete.store(true, std::memory_order_release);
 
             {
                 std::lock_guard<std::mutex> lk(g_shellTrayWndMutex);

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id             settings-to-control-panel
 // @name           Redirect Settings to Control Panel
-// @description    This mod forces the classic Control Panel to open instead of Windows 10/11 Settings app using native components.
-// @version        10.0.35
+// @description    This mod forces the classic Control Panel to open instead of Windows 10/11 Settings app using native components
+// @version        10.0.36
 // @author         babamohammed
 // @github         https://github.com/babamohammed2022
 // @include        explorer.exe
@@ -27,16 +27,18 @@ Panel pages, using only native Windows components.
 - **Windows 10** – Mostly complete support
 - **Windows 11** – Partial support
 
-**Note**: The mod has been tested on Windows 10 1809, Windows 10 21H2, Windows 11 23H2 and Windows 11 24H2 and the tests confirm that the mod is more functional on Windows 10 but both should not cause issues.
+**Note**: The mod has been tested on Windows 10 1809, Windows 10 21H2, Windows 11 23H2, Windows 11 24H2 and Windows 11 25H2 and the tests confirm that the mod is more functional on Windows 10 but both should not cause issues.
 
 ---
 
 ## Features
 
-- Redirects many `ms-settings:` links to the classic Control Panel
-- Anti-loop protection (stops windows from reopening endlessly)
-- Configurable fallback behavior for unmapped links
-- Tray menu detection (experimental)
+- The mod redirects many `ms-settings:` links to the classic Control Panel
+- The mod includes an anti-loop protection (stops windows from reopening endlessly)
+- The mod includes a configurable fallback behavior for unmapped links
+- The mod includes an experimental tray menu detection (which works on some builds)
+- The mod includes a defensive handling: guarded hooks, RAII cleanup for handles/COM/environment blocks, and safe fallbacks when an optional hook or launch fails
+
 
 **Note**: This mod is a best-effort implementation. It aims to intercept and redirect as many `ms-settings:` links as possible, but due to differences between Windows 10 and Windows 11, as well as changes introduced by Microsoft in each build, some redirects may not work perfectly in all environments.
 
@@ -50,11 +52,17 @@ Panel pages, using only native Windows components.
 
 ---
 
-**Recommendation**: For a better experience on Windows 11 (and Windows 10 if necessary), it is recommended to pair this mod with Anixx's **[Restore the classic Personalization and other CPLs](https://windhawk.net/mods/restore-classic-cpls)** that re-enables some of the classic applets from older Windows versions. Some other suggested mods are:
+**Recommendation**: For a better experience on Windows 11 (and Windows 10 if necessary), it is recommended to pair this mod with some of the hereby suggested implementations:
 
 - **[Windows 7/8.1 Action Center Recreation](https://windhawk.net/mods/win7-action-center-recreation)** – recreates the classic Windows 7/8.1 Action Center tray icon and flyout with real-time security status monitoring along with a partial restore of a link inside the Action Center Control Panel page.
 - **[Classic Taskbar and Start Menu Properties](https://windhawk.net/mods/classic-taskbar-properties)** – recreates the classic Windows 7 "Taskbar and Start Menu Properties" dialog for Windows 10 and 11.
 - **[Windows 7 Network Flyout Recreation](https://windhawk.net/mods/win7-network-flyout-recreation)** – recreates the classic Windows 7 network flyout with Wi-Fi list, signal strength, and connection support and, if enabled, partial restore of some links inside the classic "Network and Sharing Center" Control Panel page.
+- **[Windows 7 "Open With" Dialog](https://windhawk.net/mods/win7-open-with-dialog)** – recreates the classic Windows 7 "Open With" dialog for Windows 10 and 11.
+- **[Classic Display Control Panel Restorer](https://windhawk.net/mods/win7-display-control-panel-restorer)** – restores the classic Display and Screen Resolution Control Panel pages.
+- **[Windows 11 HomeGroup Restorer](https://windhawk.net/mods/win11-home-group-restorer)** – restores the classic HomeGroup applet on Windows 11.
+- **[Windows Update Control Panel Restorer](https://windhawk.net/mods/windows-update-control-panel-restorer)** – restores the classic Windows Update Control Panel page on Windows 10/11.
+- **[Performance Information and Tools Restorer](https://windhawk.net/mods/performance-info-tools-restorer)** – restores the classic "Performance Information and Tools" applet.
+- **[Windows 7 Legacy Applet Restorer](https://windhawk.net/mods/win7-legacy-applet-restorer)** – restores various legacy Windows 7 Control Panel applets (Credits to Anixx for the original mod).
 
 All of these mods are **reversible** and help make Windows 10 and 11 look more like Windows 7 and classic versions of Windows without replacing system files.
 
@@ -62,9 +70,11 @@ All of these mods are **reversible** and help make Windows 10 and 11 look more l
 
 ## Credits
 
+
 - m417z – Code reviews and feedback
 - Anixx – Testing on Windows 11 23H2 and the original toolbar subclassing approach
 - sebastian08dm08-cpu - Testing on Windows 10 1809
+- Cips_35 - Testing on Windows 11 25H2
 - dbilanoski – CLSID documentation
 */
 // ==/WindhawkModReadme==
@@ -113,6 +123,13 @@ All of these mods are **reversible** and help make Windows 10 and 11 look more l
 #include <unordered_set>
 #include <vector>
 #include <mutex>
+#include <atomic>
+#include <exception>
+#include <cwctype>
+#include <cstddef>
+// ## Stability hardening (10.0.36)
+
+// This maintenance update does not change the redirect map or the settings behavior. It hardens the existing implementation with scoped resource cleanup, exception boundaries around hooks and worker code, synchronized settings/map access, bounded guard caches, safer tray data reads, and unload-aware cleanup. When an optional path cannot be completed, it falls back to the original Windows behavior rather than risking Explorer stability.
 
 // Manually defined GUIDs to avoid requiring -luuid / static ole32 linkage.
 // {45BA127D-10A8-46EA-8AB7-56EA9078943C} = CLSID_ApplicationActivationManager
@@ -142,7 +159,7 @@ using ICMH_HCM_t = bool(ICMH_CALL*)(void* /*pThis*/, HMENU, UINT);
 static ICMH_CAODTM_t g_icmhOrig_SndVolSSO = nullptr;
 static ICMH_CAODTM_t g_icmhOrig_pnidui    = nullptr;
 static ICMH_HCM_t g_icmhOrig_Shell32Devices = nullptr;
-static bool g_pniduiHookInstalled = false;
+static std::atomic_bool g_pniduiHookInstalled{false};
 static std::mutex g_pniduiHookMutex;
 static HANDLE g_traySubclassWatchdogThread = nullptr;
 static HWND g_lastShellTrayWnd = nullptr;
@@ -169,6 +186,268 @@ using ShellExecuteW_t = HINSTANCE(WINAPI*)(HWND, LPCWSTR, LPCWSTR, LPCWSTR, LPCW
 using ShellExecuteExW_t = BOOL(WINAPI*)(SHELLEXECUTEINFOW*);
 static ShellExecuteExW_t ShellExecuteExW_orig = nullptr;
 static ShellExecuteW_t ShellExecuteW_orig = nullptr;
+// A failed registration means the public export remains unhooked and is a
+// valid last-resort launcher. If registration succeeded but the trampoline is
+// not available yet, do not call the public export (that would recurse).
+static std::atomic_bool g_shellExecuteExHookRegistered{false};
+static std::atomic_bool g_shellExecuteHookRegistered{false};
+static std::atomic_bool g_createProcessHookRegistered{false};
+
+// The mod runs inside Explorer. Treat every resource and callback as host-process
+// infrastructure: a failed optional path must not leave a live handle, a thread, or
+// an exception crossing an Explorer/COM/Win32 boundary.
+static std::atomic_bool g_unloading{false};
+static std::atomic<long> g_activeHookCalls{0};
+
+class ScopedHandle {
+public:
+    ScopedHandle() noexcept = default;
+    explicit ScopedHandle(HANDLE value) noexcept : value_(value) {}
+    ~ScopedHandle() { reset(); }
+
+    ScopedHandle(const ScopedHandle&) = delete;
+    ScopedHandle& operator=(const ScopedHandle&) = delete;
+
+    ScopedHandle(ScopedHandle&& other) noexcept : value_(other.release()) {}
+    ScopedHandle& operator=(ScopedHandle&& other) noexcept {
+        if (this != &other) {
+            reset(other.release());
+        }
+        return *this;
+    }
+
+    HANDLE get() const noexcept { return value_; }
+    explicit operator bool() const noexcept {
+        return value_ != nullptr && value_ != INVALID_HANDLE_VALUE;
+    }
+
+    HANDLE release() noexcept {
+        HANDLE value = value_;
+        value_ = nullptr;
+        return value;
+    }
+
+    void reset(HANDLE value = nullptr) noexcept {
+        if (*this) {
+            CloseHandle(value_);
+        }
+        value_ = value;
+    }
+
+private:
+    HANDLE value_ = nullptr;
+};
+
+class ScopedProcessInformation {
+public:
+    PROCESS_INFORMATION* get() noexcept { return &value_; }
+    const PROCESS_INFORMATION& value() const noexcept { return value_; }
+
+    ScopedProcessInformation(const ScopedProcessInformation&) = delete;
+    ScopedProcessInformation& operator=(const ScopedProcessInformation&) = delete;
+    ScopedProcessInformation() = default;
+
+    ~ScopedProcessInformation() {
+        if (value_.hThread) {
+            CloseHandle(value_.hThread);
+        }
+        if (value_.hProcess) {
+            CloseHandle(value_.hProcess);
+        }
+    }
+
+private:
+    PROCESS_INFORMATION value_{};
+};
+
+class ScopedEnvironmentStrings {
+public:
+    explicit ScopedEnvironmentStrings(LPWCH value = nullptr) noexcept : value_(value) {}
+    ~ScopedEnvironmentStrings() {
+        if (value_) {
+            FreeEnvironmentStringsW(value_);
+        }
+    }
+
+    ScopedEnvironmentStrings(const ScopedEnvironmentStrings&) = delete;
+    ScopedEnvironmentStrings& operator=(const ScopedEnvironmentStrings&) = delete;
+
+    LPWCH get() const noexcept { return value_; }
+
+private:
+    LPWCH value_ = nullptr;
+};
+
+class ScopedCoInitialize {
+public:
+    explicit ScopedCoInitialize(DWORD flags) noexcept : result_(CoInitializeEx(nullptr, flags)) {}
+    ~ScopedCoInitialize() {
+        if (SUCCEEDED(result_)) {
+            CoUninitialize();
+        }
+    }
+
+    HRESULT result() const noexcept { return result_; }
+    bool initialized() const noexcept { return SUCCEEDED(result_); }
+
+    ScopedCoInitialize(const ScopedCoInitialize&) = delete;
+    ScopedCoInitialize& operator=(const ScopedCoInitialize&) = delete;
+
+private:
+    HRESULT result_ = E_FAIL;
+};
+
+template <typename T>
+class ScopedComPtr {
+public:
+    ScopedComPtr() = default;
+    ~ScopedComPtr() { reset(); }
+
+    ScopedComPtr(const ScopedComPtr&) = delete;
+    ScopedComPtr& operator=(const ScopedComPtr&) = delete;
+
+    T* get() const noexcept { return value_; }
+    T** put() noexcept {
+        reset();
+        return &value_;
+    }
+    explicit operator bool() const noexcept { return value_ != nullptr; }
+
+    void reset(T* value = nullptr) noexcept {
+        if (value_) {
+            value_->Release();
+        }
+        value_ = value;
+    }
+
+private:
+    T* value_ = nullptr;
+};
+
+// Keeps an unload from racing a hook that is already executing mod code.
+// The caller still invokes the original trampoline when this guard is inactive.
+class HookInvocationGuard {
+public:
+    HookInvocationGuard() noexcept {
+        if (g_unloading.load(std::memory_order_acquire)) {
+            return;
+        }
+
+        g_activeHookCalls.fetch_add(1, std::memory_order_acq_rel);
+        if (!g_unloading.load(std::memory_order_acquire)) {
+            active_ = true;
+        } else {
+            g_activeHookCalls.fetch_sub(1, std::memory_order_acq_rel);
+        }
+    }
+
+    ~HookInvocationGuard() {
+        if (active_) {
+            g_activeHookCalls.fetch_sub(1, std::memory_order_acq_rel);
+        }
+    }
+
+    bool AllowCustomBehavior() const noexcept { return active_; }
+
+    HookInvocationGuard(const HookInvocationGuard&) = delete;
+    HookInvocationGuard& operator=(const HookInvocationGuard&) = delete;
+
+private:
+    bool active_ = false;
+};
+
+static BOOL CallOriginalShellExecuteExW(SHELLEXECUTEINFOW* pei) {
+    if (ShellExecuteExW_orig) {
+        return ShellExecuteExW_orig(pei);
+    }
+    if (!g_shellExecuteExHookRegistered.load(std::memory_order_acquire)) {
+        // No detour was installed, so calling the export cannot re-enter us.
+        return ShellExecuteExW(pei);
+    }
+    SetLastError(ERROR_PROC_NOT_FOUND);
+    return FALSE;
+}
+
+static HINSTANCE CallOriginalShellExecuteW(HWND hwnd, LPCWSTR op, LPCWSTR file,
+                                            LPCWSTR params, LPCWSTR dir, INT show) {
+    if (ShellExecuteW_orig) {
+        return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
+    }
+    if (!g_shellExecuteHookRegistered.load(std::memory_order_acquire)) {
+        return ShellExecuteW(hwnd, op, file, params, dir, show);
+    }
+    SetLastError(ERROR_PROC_NOT_FOUND);
+    return (HINSTANCE)(INT_PTR)SE_ERR_FNF;
+}
+
+static BOOL CallOriginalCreateProcessW(
+    LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
+    LPSECURITY_ATTRIBUTES lpProcessAttributes, LPSECURITY_ATTRIBUTES lpThreadAttributes,
+    BOOL bInheritHandles, DWORD dwCreationFlags, LPVOID lpEnvironment,
+    LPCWSTR lpCurrentDirectory, LPSTARTUPINFOW lpStartupInfo,
+    LPPROCESS_INFORMATION lpProcessInformation) {
+    if (CreateProcessW_orig) {
+        return CreateProcessW_orig(lpApplicationName, lpCommandLine,
+            lpProcessAttributes, lpThreadAttributes, bInheritHandles,
+            dwCreationFlags, lpEnvironment, lpCurrentDirectory,
+            lpStartupInfo, lpProcessInformation);
+    }
+    if (!g_createProcessHookRegistered.load(std::memory_order_acquire)) {
+        return CreateProcessW(lpApplicationName, lpCommandLine,
+            lpProcessAttributes, lpThreadAttributes, bInheritHandles,
+            dwCreationFlags, lpEnvironment, lpCurrentDirectory,
+            lpStartupInfo, lpProcessInformation);
+    }
+    SetLastError(ERROR_PROC_NOT_FOUND);
+    return FALSE;
+}
+
+static BOOL CallOriginalTrackPopupMenuEx(
+    BOOL (WINAPI* original)(HMENU, UINT, int, int, HWND, const TPMPARAMS*),
+    HMENU hMenu, UINT uFlags, int x, int y, HWND hWnd, const TPMPARAMS* lptpm) {
+    return original ? original(hMenu, uFlags, x, y, hWnd, lptpm) : FALSE;
+}
+
+static bool CallOriginalSndVolSSO(HMENU menu, HWND window) {
+    return g_icmhOrig_SndVolSSO ? g_icmhOrig_SndVolSSO(menu, window) : true;
+}
+
+static bool CallOriginalPnidui(HMENU menu, HWND window) {
+    return g_icmhOrig_pnidui ? g_icmhOrig_pnidui(menu, window) : true;
+}
+
+static bool CallOriginalShell32Devices(void* self, HMENU menu, UINT value) {
+    return g_icmhOrig_Shell32Devices ? g_icmhOrig_Shell32Devices(self, menu, value) : true;
+}
+
+// Read shell-owned, undocumented pointer data through the kernel instead of
+// dereferencing a possibly stale toolbar payload directly. This is best-effort:
+// a failed read only disables icon recognition for that click.
+// The mod targets x86-64 only. Use the integer-sized alias for pointer-sized
+// reads so clang-tidy does not mistake an intentional pointer-width copy for
+// a stale `sizeof(pointer)`/array-length bug.
+static constexpr SIZE_T NATIVE_POINTER_BYTES = sizeof(ULONG_PTR);
+
+static bool TryReadProcessMemory(const void* address, void* output, SIZE_T size) noexcept {
+    if (!address || !output || size == 0) {
+        return false;
+    }
+    SIZE_T read = 0;
+    return ReadProcessMemory(GetCurrentProcess(), address, output, size, &read) && read == size;
+}
+
+static bool IsExecutableAddress(const void* address) noexcept {
+    if (!address) {
+        return false;
+    }
+    MEMORY_BASIC_INFORMATION mbi{};
+    if (!VirtualQuery(address, &mbi, sizeof(mbi)) || mbi.State != MEM_COMMIT) {
+        return false;
+    }
+    DWORD protect = mbi.Protect & 0xFF;
+    return protect == PAGE_EXECUTE || protect == PAGE_EXECUTE_READ ||
+           protect == PAGE_EXECUTE_READWRITE || protect == PAGE_EXECUTE_WRITECOPY;
+}
 
 struct ResolveResult {
     std::wstring target;
@@ -178,9 +457,13 @@ struct ResolveResult {
 static thread_local int g_hookDepth = 0;
 
 struct HookGuard {
-    HookGuard() { ++g_hookDepth; }
-    ~HookGuard() { --g_hookDepth; }
-    bool IsReentrant() const { return g_hookDepth > 1; }
+    HookGuard() noexcept { ++g_hookDepth; }
+    ~HookGuard() noexcept {
+        if (g_hookDepth > 0) {
+            --g_hookDepth;
+        }
+    }
+    bool IsReentrant() const noexcept { return g_hookDepth > 1; }
 };
 
 static std::wstring ToLower(std::wstring s) {
@@ -214,19 +497,56 @@ static bool IsShellProcess() {
 static std::wstring g_childEnvBlock;
 
 static void BuildChildEnvironment() {
-    LPWCH curEnv = GetEnvironmentStringsW();
-    if (curEnv) {
-        LPWCH p = curEnv;
-        while (*p) {
+    // Use a local block and publish it only after it is complete. If allocation
+    // fails or the inherited block is unexpectedly huge, passing nullptr later
+    // intentionally preserves the parent environment instead of launching a
+    // child with a truncated environment.
+    try {
+        std::wstring environmentBlock;
+        ScopedEnvironmentStrings currentEnvironment(GetEnvironmentStringsW());
+
+        for (LPWCH p = currentEnvironment.get(); p && *p; ) {
             std::wstring entry(p);
-            if (entry.find(L"WH_STC_NOREDIRECT=") != 0) {
-                g_childEnvBlock += entry + L'\0';
+            constexpr size_t kMaxEnvironmentChars = 32767;
+            if (environmentBlock.size() + entry.size() + 2 > kMaxEnvironmentChars) {
+                Wh_Log(L"[STABILITY] Child environment is too large; inheriting it unchanged");
+                g_childEnvBlock.clear();
+                return;
+            }
+
+            // Environment names are case-insensitive on Windows. Do not pass
+            // an inherited copy of our recursion-suppression marker onward.
+            if (_wcsnicmp(entry.c_str(), L"WH_STC_NOREDIRECT=", 18) != 0) {
+                environmentBlock.append(entry);
+                environmentBlock.push_back(L'\0');
             }
             p += entry.length() + 1;
         }
-        FreeEnvironmentStringsW(curEnv);
+
+        constexpr wchar_t kNoRedirectVariable[] = L"WH_STC_NOREDIRECT=1";
+        if (environmentBlock.size() + wcslen(kNoRedirectVariable) + 2 > 32767) {
+            Wh_Log(L"[STABILITY] Child environment marker does not fit; inheriting environment");
+            g_childEnvBlock.clear();
+            return;
+        }
+
+        environmentBlock.append(kNoRedirectVariable);
+        environmentBlock.push_back(L'\0');
+        environmentBlock.push_back(L'\0');
+        g_childEnvBlock.swap(environmentBlock);
+    } catch (const std::exception&) {
+        g_childEnvBlock.clear();
+        Wh_Log(L"[STABILITY] BuildChildEnvironment caught std::exception; using inherited environment");
+    } catch (...) {
+        g_childEnvBlock.clear();
+        Wh_Log(L"[STABILITY] BuildChildEnvironment caught an unknown exception; using inherited environment");
     }
-    g_childEnvBlock += L"WH_STC_NOREDIRECT=1\0\0";
+}
+
+static LPVOID ChildEnvironmentBlock() noexcept {
+    return g_childEnvBlock.empty()
+        ? nullptr
+        : const_cast<wchar_t*>(g_childEnvBlock.c_str());
 }
 
 static bool IsChildProcess() {
@@ -238,57 +558,132 @@ static bool IsChildProcess() {
 }
 
 struct ModSettings {
-    bool enableRedirects = true;
-    bool redirectSystemTray = false;
-    bool uiOnlyRedirects = false;
-    int fallbackMode = 2;
-    bool win11CompatibilityMode = false;
-    int maxLaunchesPerUri = 3;
-    bool comActivationRedirect = false;
-    bool legacyNameMappingFix = true;
+    std::atomic_bool enableRedirects{true};
+    std::atomic_bool redirectSystemTray{false};
+    std::atomic_bool uiOnlyRedirects{false};
+    std::atomic_int fallbackMode{2};
+    std::atomic_bool win11CompatibilityMode{false};
+    std::atomic_int maxLaunchesPerUri{3};
+    std::atomic_bool comActivationRedirect{false};
+    std::atomic_bool legacyNameMappingFix{true};
 };
 
 static ModSettings g_settings;
 
-static bool ICMH_CALL ICMH_hook_SndVolSSO(HMENU m, HWND w) {
-    if (!g_settings.enableRedirects || !g_settings.redirectSystemTray)
-        return g_icmhOrig_SndVolSSO ? g_icmhOrig_SndVolSSO(m, w) : true;
-    return false;
+static bool RedirectsEnabled() noexcept {
+    return g_settings.enableRedirects.load(std::memory_order_acquire);
+}
+static bool RedirectSystemTrayEnabled() noexcept {
+    return g_settings.redirectSystemTray.load(std::memory_order_acquire);
+}
+static bool UiOnlyRedirectsEnabled() noexcept {
+    return g_settings.uiOnlyRedirects.load(std::memory_order_acquire);
+}
+static int FallbackMode() noexcept {
+    return g_settings.fallbackMode.load(std::memory_order_acquire);
+}
+static bool Win11CompatibilityModeEnabled() noexcept {
+    return g_settings.win11CompatibilityMode.load(std::memory_order_acquire);
+}
+static int MaxLaunchesPerUri() noexcept {
+    return g_settings.maxLaunchesPerUri.load(std::memory_order_acquire);
+}
+static bool ComActivationRedirectEnabled() noexcept {
+    return g_settings.comActivationRedirect.load(std::memory_order_acquire);
+}
+static bool LegacyNameMappingFixEnabled() noexcept {
+    return g_settings.legacyNameMappingFix.load(std::memory_order_acquire);
 }
 
-static bool ICMH_CALL ICMH_hook_pnidui(HMENU m, HWND w) {
-    if (!g_settings.enableRedirects || !g_settings.redirectSystemTray)
-        return g_icmhOrig_pnidui ? g_icmhOrig_pnidui(m, w) : true;
-    return false;
-}
-
-static bool ICMH_CALL ICMH_hook_Shell32Devices(void* pThis, HMENU m, UINT u) {
-    if (!g_settings.enableRedirects || !g_settings.redirectSystemTray)
-        return g_icmhOrig_Shell32Devices ? g_icmhOrig_Shell32Devices(pThis, m, u) : true;
-    return false;
+static void DisableRedirectsAfterSettingsFailure() noexcept {
+    g_settings.enableRedirects.store(false, std::memory_order_release);
+    g_settings.redirectSystemTray.store(false, std::memory_order_release);
+    g_settings.uiOnlyRedirects.store(false, std::memory_order_release);
+    g_settings.fallbackMode.store(2, std::memory_order_release);
+    g_settings.win11CompatibilityMode.store(false, std::memory_order_release);
+    g_settings.maxLaunchesPerUri.store(3, std::memory_order_release);
+    g_settings.comActivationRedirect.store(false, std::memory_order_release);
+    g_settings.legacyNameMappingFix.store(true, std::memory_order_release);
 }
 
 static void LoadSettings() {
-    g_settings.enableRedirects = Wh_GetIntSetting(L"EnableRedirects") != 0;
-    g_settings.redirectSystemTray = Wh_GetIntSetting(L"RedirectSystemTray") != 0;
-    g_settings.uiOnlyRedirects = Wh_GetIntSetting(L"UIOnlyRedirects") != 0;
+    try {
+        const bool enableRedirects = Wh_GetIntSetting(L"EnableRedirects") != 0;
+        const bool redirectSystemTray = Wh_GetIntSetting(L"RedirectSystemTray") != 0;
+        const bool uiOnlyRedirects = Wh_GetIntSetting(L"UIOnlyRedirects") != 0;
 
-    WindhawkUtils::StringSetting fallbackSetting(Wh_GetStringSetting(L"FallbackMode"));
-    PCWSTR fallbackStr = fallbackSetting;
-    if (fallbackStr[0] != L'\0') {
-        int mode = _wtoi(fallbackStr);
-        g_settings.fallbackMode = (mode >= 0 && mode <= 2) ? mode : 2;
-    } else {
-        g_settings.fallbackMode = 2;
+        int fallbackMode = 2;
+        WindhawkUtils::StringSetting fallbackSetting(Wh_GetStringSetting(L"FallbackMode"));
+        PCWSTR fallbackStr = fallbackSetting;
+        if (fallbackStr && fallbackStr[0] != L'\0') {
+            int mode = _wtoi(fallbackStr);
+            fallbackMode = (mode >= 0 && mode <= 2) ? mode : 2;
+        }
+
+        const bool win11CompatibilityMode = Wh_GetIntSetting(L"Win11CompatibilityMode") != 0;
+        const int configuredMaxLaunches = Wh_GetIntSetting(L"MaxLaunchesPerUri");
+        const int maxLaunchesPerUri = (configuredMaxLaunches >= 0 && configuredMaxLaunches <= 20)
+            ? configuredMaxLaunches : 3;
+        const bool comActivationRedirect = Wh_GetIntSetting(L"ComActivationRedirect") != 0;
+        const bool legacyNameMappingFix = Wh_GetIntSetting(L"LegacyNameMappingFix") != 0;
+
+        g_settings.enableRedirects.store(enableRedirects, std::memory_order_release);
+        g_settings.redirectSystemTray.store(redirectSystemTray, std::memory_order_release);
+        g_settings.uiOnlyRedirects.store(uiOnlyRedirects, std::memory_order_release);
+        g_settings.fallbackMode.store(fallbackMode, std::memory_order_release);
+        g_settings.win11CompatibilityMode.store(win11CompatibilityMode, std::memory_order_release);
+        g_settings.maxLaunchesPerUri.store(maxLaunchesPerUri, std::memory_order_release);
+        g_settings.comActivationRedirect.store(comActivationRedirect, std::memory_order_release);
+        g_settings.legacyNameMappingFix.store(legacyNameMappingFix, std::memory_order_release);
+    } catch (const std::exception&) {
+        DisableRedirectsAfterSettingsFailure();
+        Wh_Log(L"[STABILITY] LoadSettings caught std::exception; redirects are disabled for safety");
+    } catch (...) {
+        DisableRedirectsAfterSettingsFailure();
+        Wh_Log(L"[STABILITY] LoadSettings caught an unknown exception; redirects are disabled for safety");
     }
+}
 
-    g_settings.win11CompatibilityMode = Wh_GetIntSetting(L"Win11CompatibilityMode") != 0;
+static bool ICMH_CALL ICMH_hook_SndVolSSO(HMENU m, HWND w) {
+    HookInvocationGuard invocation;
+    if (!invocation.AllowCustomBehavior() || !RedirectsEnabled() || !RedirectSystemTrayEnabled())
+        return CallOriginalSndVolSSO(m, w);
+    try {
+        return false;
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] SndVolSSO context hook caught std::exception");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] SndVolSSO context hook caught an unknown exception");
+    }
+    return CallOriginalSndVolSSO(m, w);
+}
 
-    int ml = Wh_GetIntSetting(L"MaxLaunchesPerUri");
-    g_settings.maxLaunchesPerUri = (ml >= 0 && ml <= 20) ? ml : 3;
+static bool ICMH_CALL ICMH_hook_pnidui(HMENU m, HWND w) {
+    HookInvocationGuard invocation;
+    if (!invocation.AllowCustomBehavior() || !RedirectsEnabled() || !RedirectSystemTrayEnabled())
+        return CallOriginalPnidui(m, w);
+    try {
+        return false;
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] pnidui context hook caught std::exception");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] pnidui context hook caught an unknown exception");
+    }
+    return CallOriginalPnidui(m, w);
+}
 
-    g_settings.comActivationRedirect = Wh_GetIntSetting(L"ComActivationRedirect") != 0;
-    g_settings.legacyNameMappingFix = Wh_GetIntSetting(L"LegacyNameMappingFix") != 0;
+static bool ICMH_CALL ICMH_hook_Shell32Devices(void* pThis, HMENU m, UINT u) {
+    HookInvocationGuard invocation;
+    if (!invocation.AllowCustomBehavior() || !RedirectsEnabled() || !RedirectSystemTrayEnabled())
+        return CallOriginalShell32Devices(pThis, m, u);
+    try {
+        return false;
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] shell32 devices context hook caught std::exception");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] shell32 devices context hook caught an unknown exception");
+    }
+    return CallOriginalShell32Devices(pThis, m, u);
 }
 
 static bool g_isWin11 = false;
@@ -313,22 +708,54 @@ static std::mutex g_bounceGuardMtx;
 static std::unordered_map<std::wstring, BounceRecord> g_bounceGuard;
 
 static constexpr DWORD BOUNCE_WINDOW_MS = 3000;
+static constexpr size_t MAX_GUARD_RECORDS = 512;
+
+static void PruneBounceGuardLocked(DWORD now) {
+    if (g_bounceGuard.size() < MAX_GUARD_RECORDS) {
+        return;
+    }
+    for (auto it = g_bounceGuard.begin(); it != g_bounceGuard.end(); ) {
+        if (now - it->second.lastRedirectTick >= BOUNCE_WINDOW_MS) {
+            it = g_bounceGuard.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    if (g_bounceGuard.size() >= MAX_GUARD_RECORDS) {
+        // A hostile/very unusual stream of unique URIs must never turn into a
+        // permanent Explorer allocation. Clearing only sacrifices temporary
+        // bounce suppression for the oldest busy window.
+        g_bounceGuard.clear();
+    }
+}
 
 static void BounceGuardRecord(const std::wstring& uri) {
-    std::lock_guard<std::mutex> lk(g_bounceGuardMtx);
-    g_bounceGuard[uri].lastRedirectTick = GetTickCount();
+    try {
+        std::lock_guard<std::mutex> lk(g_bounceGuardMtx);
+        DWORD now = GetTickCount();
+        PruneBounceGuardLocked(now);
+        g_bounceGuard[uri].lastRedirectTick = now;
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] Bounce guard allocation failed; skipping this record");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] Bounce guard failed unexpectedly; skipping this record");
+    }
 }
 
 static bool BounceGuardIsBounce(const std::wstring& uri) {
-    std::lock_guard<std::mutex> lk(g_bounceGuardMtx);
-    auto it = g_bounceGuard.find(uri);
-    if (it == g_bounceGuard.end()) return false;
-    DWORD elapsed = GetTickCount() - it->second.lastRedirectTick;
-    if (elapsed < BOUNCE_WINDOW_MS) {
-        it->second.lastRedirectTick = 0;
-        return true;
+    try {
+        std::lock_guard<std::mutex> lk(g_bounceGuardMtx);
+        auto it = g_bounceGuard.find(uri);
+        if (it == g_bounceGuard.end()) return false;
+        DWORD elapsed = GetTickCount() - it->second.lastRedirectTick;
+        if (elapsed < BOUNCE_WINDOW_MS) {
+            it->second.lastRedirectTick = 0;
+            return true;
+        }
+        return false;
+    } catch (...) {
+        return false;
     }
-    return false;
 }
 
 struct LaunchRecord {
@@ -342,24 +769,48 @@ static std::unordered_map<std::wstring, LaunchRecord> g_loopGuard;
 static constexpr DWORD LOOP_WINDOW_MS = 5000;
 
 static bool LoopGuardAllow(const std::wstring& target) {
-    if (g_settings.maxLaunchesPerUri <= 0) return true;
+    const int maxLaunches = MaxLaunchesPerUri();
+    if (maxLaunches <= 0) return true;
 
-    std::lock_guard<std::mutex> lk(g_loopGuardMtx);
-    DWORD now = GetTickCount();
-    auto& rec = g_loopGuard[target];
+    try {
+        std::lock_guard<std::mutex> lk(g_loopGuardMtx);
+        DWORD now = GetTickCount();
+        if (g_loopGuard.size() >= MAX_GUARD_RECORDS) {
+            for (auto it = g_loopGuard.begin(); it != g_loopGuard.end(); ) {
+                if (now - it->second.firstTick >= LOOP_WINDOW_MS) {
+                    it = g_loopGuard.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+            if (g_loopGuard.size() >= MAX_GUARD_RECORDS) {
+                g_loopGuard.clear();
+            }
+        }
 
-    if (rec.count == 0 || (now - rec.firstTick) >= LOOP_WINDOW_MS) {
-        rec.count = 1;
-        rec.firstTick = now;
+        auto& rec = g_loopGuard[target];
+        if (rec.count == 0 || (now - rec.firstTick) >= LOOP_WINDOW_MS) {
+            rec.count = 1;
+            rec.firstTick = now;
+            return true;
+        }
+
+        if (rec.count < maxLaunches) {
+            rec.count++;
+            return true;
+        }
+
+        return false;
+    } catch (const std::exception&) {
+        // Prefer a one-off pass-through launch over an exception escaping a
+        // shell hook. The normal anti-loop limit remains active when memory is
+        // available again.
+        Wh_Log(L"[STABILITY] Loop guard allocation failed; allowing one launch");
+        return true;
+    } catch (...) {
+        Wh_Log(L"[STABILITY] Loop guard failed unexpectedly; allowing one launch");
         return true;
     }
-
-    if (rec.count < g_settings.maxLaunchesPerUri) {
-        rec.count++;
-        return true;
-    }
-
-    return false;
 }
 
 static const std::unordered_set<std::wstring> g_win11SafeClsids = {
@@ -456,8 +907,12 @@ static int GetTrayButtonType(HWND hToolbar, int buttonIndex) {
     if (!SendMessageW(hToolbar, TB_GETBUTTON, buttonIndex, (LPARAM)&tb)) return 0;
     if (!tb.dwData) return 0;
 
-    HWND hIconWnd = *(HWND*)tb.dwData;
-    if (!hIconWnd || !IsWindow(hIconWnd)) return 0;
+    HWND hIconWnd = nullptr;
+    if (!TryReadProcessMemory(reinterpret_cast<const void*>(tb.dwData),
+                              &hIconWnd, NATIVE_POINTER_BYTES) ||
+        !hIconWnd || !IsWindow(hIconWnd)) {
+        return 0;
+    }
 
     wchar_t className[256]{};
     if (!GetClassNameW(hIconWnd, className, 256)) return 0;
@@ -506,7 +961,7 @@ static void OpenClassicSoundPanel() {
     sei.lpFile = L"control.exe";
     sei.lpParameters = L"mmsys.cpl,,0";
     sei.nShow = SW_SHOWNORMAL;
-    ShellExecuteExW_orig(&sei);
+    CallOriginalShellExecuteExW(&sei);
 }
 
 static void OpenClassicNetworkConnections() {
@@ -517,7 +972,7 @@ static void OpenClassicNetworkConnections() {
     sei.lpFile = L"explorer.exe";
     sei.lpParameters = L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}";
     sei.nShow = SW_SHOWNORMAL;
-    ShellExecuteExW_orig(&sei);
+    CallOriginalShellExecuteExW(&sei);
 }
 
 static void OpenClassicDevicesAndPrinters() {
@@ -528,31 +983,38 @@ static void OpenClassicDevicesAndPrinters() {
     sei.lpFile = L"explorer.exe";
     sei.lpParameters = L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}";
     sei.nShow = SW_SHOWNORMAL;
-    ShellExecuteExW_orig(&sei);
+    CallOriginalShellExecuteExW(&sei);
 }
 
 static LRESULT CALLBACK TrayToolbarSubclassProc(
     HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData)
 {
-    if (msg == WM_RBUTTONUP) {
-        POINT pt;
-        pt.x = (int)(short)LOWORD(lParam);
-        pt.y = (int)(short)HIWORD(lParam);
-        int hitIndex = (int)SendMessageW(hwnd, TB_HITTEST, 0, (LPARAM)&pt);
+    HookInvocationGuard invocation;
+    try {
+        if (invocation.AllowCustomBehavior() && msg == WM_RBUTTONUP) {
+            POINT pt;
+            pt.x = (int)(short)LOWORD(lParam);
+            pt.y = (int)(short)HIWORD(lParam);
+            int hitIndex = (int)SendMessageW(hwnd, TB_HITTEST, 0, (LPARAM)&pt);
 
-        if (hitIndex >= 0) {
-            int buttonType = GetTrayButtonType(hwnd, hitIndex);
-            if (buttonType == 1) {
-                std::lock_guard<std::mutex> lk(g_trayContextMutex);
-                g_trayContextType = 1;
-                g_trayContextTick = GetTickCount();
-            }
-            else if (buttonType == 2) {
-                std::lock_guard<std::mutex> lk(g_trayContextMutex);
-                g_trayContextType = 2;
-                g_trayContextTick = GetTickCount();
+            if (hitIndex >= 0) {
+                int buttonType = GetTrayButtonType(hwnd, hitIndex);
+                if (buttonType == 1) {
+                    std::lock_guard<std::mutex> lk(g_trayContextMutex);
+                    g_trayContextType = 1;
+                    g_trayContextTick = GetTickCount();
+                }
+                else if (buttonType == 2) {
+                    std::lock_guard<std::mutex> lk(g_trayContextMutex);
+                    g_trayContextType = 2;
+                    g_trayContextTick = GetTickCount();
+                }
             }
         }
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] Tray toolbar subclass caught std::exception");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] Tray toolbar subclass caught an unknown exception");
     }
     return DefSubclassProc(hwnd, msg, wParam, lParam);
 }
@@ -574,29 +1036,57 @@ static HWND FindTrayToolbar() {
 }
 
 static void SetupTraySubclass() {
-    HWND hToolbar;
-    {
-        std::lock_guard<std::mutex> lk(g_traySubclassMutex);
-        if (g_hTrayToolbar && IsWindow(g_hTrayToolbar)) return;
-        g_hTrayToolbar = nullptr;
-        hToolbar = FindTrayToolbar();
-    }
-    if (!hToolbar || !InitTrayDllInfo()) return;
-    BOOL ok = WindhawkUtils::SetWindowSubclassFromAnyThread(hToolbar, TrayToolbarSubclassProc, 0);
-    if (ok) {
-        std::lock_guard<std::mutex> lk(g_traySubclassMutex);
-        g_hTrayToolbar = hToolbar;
+    if (g_unloading.load(std::memory_order_acquire)) return;
+    try {
+        HWND hToolbar;
+        {
+            std::lock_guard<std::mutex> lk(g_traySubclassMutex);
+            if (g_hTrayToolbar && IsWindow(g_hTrayToolbar)) return;
+            g_hTrayToolbar = nullptr;
+            hToolbar = FindTrayToolbar();
+        }
+        if (!hToolbar || !IsWindow(hToolbar) || !InitTrayDllInfo() ||
+            g_unloading.load(std::memory_order_acquire)) {
+            return;
+        }
+        BOOL ok = WindhawkUtils::SetWindowSubclassFromAnyThread(hToolbar, TrayToolbarSubclassProc, 0);
+        bool removeImmediately = false;
+        if (ok) {
+            // Re-check while holding the same mutex used by teardown, so an
+            // unload cannot slip between the check and publishing the HWND.
+            std::lock_guard<std::mutex> lk(g_traySubclassMutex);
+            if (!g_unloading.load(std::memory_order_acquire)) {
+                g_hTrayToolbar = hToolbar;
+            } else {
+                removeImmediately = true;
+            }
+        }
+        if (removeImmediately) {
+            WindhawkUtils::RemoveWindowSubclassFromAnyThread(hToolbar, TrayToolbarSubclassProc);
+        }
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] SetupTraySubclass caught std::exception");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] SetupTraySubclass caught an unknown exception");
     }
 }
 
 static void RemoveTraySubclass() {
-    HWND h;
-    {
-        std::lock_guard<std::mutex> lk(g_traySubclassMutex);
-        h = g_hTrayToolbar;
-        g_hTrayToolbar = nullptr;
+    try {
+        HWND h;
+        {
+            std::lock_guard<std::mutex> lk(g_traySubclassMutex);
+            h = g_hTrayToolbar;
+            g_hTrayToolbar = nullptr;
+        }
+        if (h && IsWindow(h)) {
+            WindhawkUtils::RemoveWindowSubclassFromAnyThread(h, TrayToolbarSubclassProc);
+        }
+    } catch (...) {
+        // Teardown is best-effort. The system subclass helper owns any remaining
+        // bookkeeping if the shell window disappeared concurrently.
+        Wh_Log(L"[STABILITY] RemoveTraySubclass caught an exception");
     }
-    if (h) WindhawkUtils::RemoveWindowSubclassFromAnyThread(h, TrayToolbarSubclassProc);
 }
 static bool IsAddressInModule(void* address, const wchar_t* moduleName) {
     HMODULE hModule = nullptr;
@@ -613,14 +1103,17 @@ static BOOL WINAPI CommonTrackPopupMenuEx_Hook(
     BOOL (WINAPI* pOrig)(HMENU, UINT, int, int, HWND, const TPMPARAMS*),
     const wchar_t* logPrefix)
 {
-    if (!pOrig) return FALSE;
-
-    if (!g_settings.redirectSystemTray || !g_settings.enableRedirects)
-        return pOrig(hMenu, uFlags, x, y, hWnd, lptpm);
+    HookInvocationGuard invocation;
+    if (!invocation.AllowCustomBehavior() || !pOrig ||
+        !RedirectSystemTrayEnabled() || !RedirectsEnabled()) {
+        return CallOriginalTrackPopupMenuEx(pOrig, hMenu, uFlags, x, y, hWnd, lptpm);
+    }
 
     HookGuard guard;
     if (guard.IsReentrant())
-        return pOrig(hMenu, uFlags, x, y, hWnd, lptpm);
+        return CallOriginalTrackPopupMenuEx(pOrig, hMenu, uFlags, x, y, hWnd, lptpm);
+
+    try {
 
     // --- Primary: subclass flag set on WM_RBUTTONUP ---
     int contextType = 0;
@@ -668,7 +1161,7 @@ static BOOL WINAPI CommonTrackPopupMenuEx_Hook(
     }
 
     if (!isAudioMenu && !isNetworkMenu && !isDeviceMenu)
-        return pOrig(hMenu, uFlags, x, y, hWnd, lptpm);
+        return CallOriginalTrackPopupMenuEx(pOrig, hMenu, uFlags, x, y, hWnd, lptpm);
 
     int itemCount = GetMenuItemCount(hMenu);
     int targetIndex = -1;
@@ -698,14 +1191,14 @@ static BOOL WINAPI CommonTrackPopupMenuEx_Hook(
     }
     
     if (targetIndex == -1) {
-        return pOrig(hMenu, uFlags, x, y, hWnd, lptpm);
+        return CallOriginalTrackPopupMenuEx(pOrig, hMenu, uFlags, x, y, hWnd, lptpm);
     }
 
     UINT originalId = GetMenuItemID(hMenu, targetIndex);
     bool callerWantedReturnCmd = (uFlags & TPM_RETURNCMD) != 0;
     uFlags |= TPM_RETURNCMD;
     
-    BOOL result     = pOrig(hMenu, uFlags, x, y, hWnd, lptpm);
+    BOOL result = CallOriginalTrackPopupMenuEx(pOrig, hMenu, uFlags, x, y, hWnd, lptpm);
     int selectedId  = (int)result;
 
     if (originalId != 0 && selectedId == (int)originalId) {
@@ -722,6 +1215,12 @@ static BOOL WINAPI CommonTrackPopupMenuEx_Hook(
     }
 
     return result;
+    } catch (const std::exception&) {
+        Wh_Log(L"[%s] Stability fallback after std::exception", logPrefix ? logPrefix : L"TRAY-HOOK");
+    } catch (...) {
+        Wh_Log(L"[%s] Stability fallback after unknown exception", logPrefix ? logPrefix : L"TRAY-HOOK");
+    }
+    return CallOriginalTrackPopupMenuEx(pOrig, hMenu, uFlags, x, y, hWnd, lptpm);
 }
 
 BOOL WINAPI TrackPopupMenuEx_Hook(HMENU hMenu, UINT uFlags, int x, int y, HWND hWnd, const TPMPARAMS* lptpm) {
@@ -732,11 +1231,13 @@ BOOL WINAPI TrackPopupMenuEx_Hook(HMENU hMenu, UINT uFlags, int x, int y, HWND h
 }
 
 static std::unordered_map<std::wstring, std::wstring> g_mappings;
+static std::mutex g_mappingsMutex;
 
-static void InitMappings() {
+static bool InitMappings() {
+    try {
     const bool w11 = g_isWin11;
 
-    g_mappings = {
+    std::unordered_map<std::wstring, std::wstring> mappings = {
         {L"ms-settings:personalization", PERS_ROOT},
         {L"ms-settings:personalization-colors", PERS_COLORS},
         {L"ms-settings:colors", PERS_COLORS},
@@ -750,7 +1251,7 @@ static void InitMappings() {
         {L"ms-settings:fonts", L"shell:::{BD84B380-8CA2-1069-AB1D-08000948F534}"},
         {L"ms-settings:display-advanced-color", L"colorcpl.exe"},
         {L"ms-settings:colorcpl", L"colorcpl.exe"},
-        {L"ms-settings:display", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
+        // {L"ms-settings:display", L"rundll32.exe display.dll,ShowAdapterSettings 0"}, <- This has been removed because a restoration mod for the legacy page has been created
         {L"ms-settings:display-advanced", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
         {L"ms-settings:display-advanced-graphics", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
         {L"ms-settings:display-adapter-properties", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
@@ -880,12 +1381,24 @@ static void InitMappings() {
         {L"ms-settings:storagesense", L"control.exe"},
     };
 
-    g_mappings[L"ms-settings:backup"] = L"control.exe /name Microsoft.BackupAndRestore";
-    g_mappings[L"ms-settings:network-advancedsettings"] = L"control.exe /name Microsoft.NetworkAndSharingCenter";
+    mappings[L"ms-settings:backup"] = L"control.exe /name Microsoft.BackupAndRestore";
+    mappings[L"ms-settings:network-advancedsettings"] = L"control.exe /name Microsoft.NetworkAndSharingCenter";
 
     if (g_isWin11) {
-        g_mappings[L"ms-settings:recovery"] = L"shell:::{26EE0668-A00A-44D7-9371-BEB064C98683}\\0\\::{9FE63AFD-59CF-4419-9775-ABCC3849F861}";
+        mappings[L"ms-settings:recovery"] = L"shell:::{26EE0668-A00A-44D7-9371-BEB064C98683}\\0\\::{9FE63AFD-59CF-4419-9775-ABCC3849F861}";
     }
+
+    {
+        std::lock_guard<std::mutex> lk(g_mappingsMutex);
+        g_mappings.swap(mappings);
+    }
+    return true;
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] InitMappings caught std::exception; keeping the previous map");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] InitMappings caught an unknown exception; keeping the previous map");
+    }
+    return false;
 }
 
 static std::wstring NormalizeUri(const std::wstring& uri) {
@@ -923,14 +1436,14 @@ static std::wstring ApplyWin11Filter(const std::wstring& target) {
         if (lower.find(L"bb06c0e4") != std::wstring::npos) return L"sysdm.cpl";
         return L"control.exe";
     }
-    if (g_settings.win11CompatibilityMode && !IsClsidSafeOnWin11(clsPart)) {
+    if (Win11CompatibilityModeEnabled() && !IsClsidSafeOnWin11(clsPart)) {
         return L"control.exe";
     }
     return target;
 }
 
 static bool HandleFallback(const std::wstring& uri) {
-    switch (g_settings.fallbackMode) {
+    switch (FallbackMode()) {
         case 0: return true;
         case 1: {
             std::wstring cmd = L"control.exe";
@@ -938,10 +1451,10 @@ static bool HandleFallback(const std::wstring& uri) {
             si.cb = sizeof(si);
             si.dwFlags = STARTF_USESHOWWINDOW;
             si.wShowWindow = SW_SHOWNORMAL;
-            PROCESS_INFORMATION pi = {};
-            if (CreateProcessW_orig(nullptr, cmd.data(), nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi)) {
-                CloseHandle(pi.hProcess);
-                CloseHandle(pi.hThread);
+            ScopedProcessInformation pi;
+            if (!CallOriginalCreateProcessW(nullptr, cmd.data(), nullptr, nullptr,
+                                            FALSE, 0, nullptr, nullptr, &si, pi.get())) {
+                Wh_Log(L"[STABILITY] Fallback control.exe launch failed (%lu)", GetLastError());
             }
             return true;
         }
@@ -952,105 +1465,106 @@ static bool HandleFallback(const std::wstring& uri) {
 static void LaunchTarget(const std::wstring& command) {
     if (!LoopGuardAllow(command)) return;
 
-    std::wstring lower = ToLower(command);
-    
-    if (lower.find(L"explorer shell:::") != std::wstring::npos) {
-        SHELLEXECUTEINFOW sei = {};
-        sei.cbSize = sizeof(sei);
-        sei.fMask = SEE_MASK_FLAG_NO_UI;
-        sei.lpVerb = L"open";
-        sei.lpFile = L"explorer.exe";
-        sei.lpParameters = command.c_str() + 9;
-        sei.nShow = SW_SHOWNORMAL;
-        ShellExecuteExW_orig(&sei);
-        return;
-    }
-    
-    if (lower.find(L"rundll32.exe ") == 0) {
-        wchar_t rundll32Path[MAX_PATH];
-        if (GetSystemDirectoryW(rundll32Path, MAX_PATH)) {
-            wcscat_s(rundll32Path, MAX_PATH, L"\\rundll32.exe");
-        } else {
-            wcscpy_s(rundll32Path, MAX_PATH, L"rundll32.exe");
+    try {
+        std::wstring lower = ToLower(command);
+
+        if (lower.find(L"explorer shell:::") != std::wstring::npos) {
+            SHELLEXECUTEINFOW sei = {};
+            sei.cbSize = sizeof(sei);
+            sei.fMask = SEE_MASK_FLAG_NO_UI;
+            sei.lpVerb = L"open";
+            sei.lpFile = L"explorer.exe";
+            sei.lpParameters = command.c_str() + 9;
+            sei.nShow = SW_SHOWNORMAL;
+            CallOriginalShellExecuteExW(&sei);
+            return;
         }
-        SHELLEXECUTEINFOW sei = {};
-        sei.cbSize = sizeof(sei);
-        sei.fMask = SEE_MASK_FLAG_NO_UI;
-        sei.lpVerb = L"open";
-        sei.lpFile = rundll32Path;
-        sei.lpParameters = command.c_str() + 13;
-        sei.nShow = SW_SHOWNORMAL;
-        ShellExecuteExW_orig(&sei);
-        return;
-    }
-    
-    bool isFullCmdLine = (lower.find(L"explorer.exe ") != std::wstring::npos) ||
-                         (lower.find(L"control.exe /") != std::wstring::npos);
-    if (isFullCmdLine) {
+
+        if (lower.find(L"rundll32.exe ") == 0) {
+            wchar_t rundll32Path[MAX_PATH]{};
+            if (GetSystemDirectoryW(rundll32Path, ARRAYSIZE(rundll32Path))) {
+                wcscat_s(rundll32Path, ARRAYSIZE(rundll32Path), L"\\rundll32.exe");
+            } else {
+                wcscpy_s(rundll32Path, ARRAYSIZE(rundll32Path), L"rundll32.exe");
+            }
+            SHELLEXECUTEINFOW sei = {};
+            sei.cbSize = sizeof(sei);
+            sei.fMask = SEE_MASK_FLAG_NO_UI;
+            sei.lpVerb = L"open";
+            sei.lpFile = rundll32Path;
+            sei.lpParameters = command.c_str() + 13;
+            sei.nShow = SW_SHOWNORMAL;
+            CallOriginalShellExecuteExW(&sei);
+            return;
+        }
+
+        bool isFullCmdLine = (lower.find(L"explorer.exe ") != std::wstring::npos) ||
+                             (lower.find(L"control.exe /") != std::wstring::npos);
+        if (isFullCmdLine) {
+            STARTUPINFOW si = {};
+            si.cb = sizeof(si);
+            si.dwFlags = STARTF_USESHOWWINDOW;
+            si.wShowWindow = SW_SHOWNORMAL;
+            ScopedProcessInformation pi;
+            std::wstring mutableCmd = command;
+            if (!CallOriginalCreateProcessW(nullptr, mutableCmd.data(), nullptr, nullptr,
+                                            FALSE, CREATE_UNICODE_ENVIRONMENT,
+                                            ChildEnvironmentBlock(), nullptr, &si, pi.get())) {
+                Wh_Log(L"[STABILITY] Full command redirect launch failed (%lu)", GetLastError());
+            }
+            return;
+        }
+
+        if (command == L"devmgmt.msc" || command == L"compmgmt.msc" ||
+            command == L"slui.exe" || command == L"OptionalFeatures.exe") {
+            CallOriginalShellExecuteW(nullptr, L"open", command.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+            return;
+        }
+
         STARTUPINFOW si = {};
         si.cb = sizeof(si);
         si.dwFlags = STARTF_USESHOWWINDOW;
         si.wShowWindow = SW_SHOWNORMAL;
-        PROCESS_INFORMATION pi = {};
-        std::wstring mutable_cmd = command;
-        if (!CreateProcessW_orig(nullptr, mutable_cmd.data(), nullptr, nullptr,
-                                 FALSE, CREATE_UNICODE_ENVIRONMENT,
-                                 (LPVOID)g_childEnvBlock.c_str(), nullptr, &si, &pi)) {
-        } else {
-            CloseHandle(pi.hProcess);
-            CloseHandle(pi.hThread);
-        }
-        return;
-    }
+        std::wstring cmdLine;
 
-    if (command == L"devmgmt.msc" || command == L"compmgmt.msc" ||
-        command == L"slui.exe" || command == L"OptionalFeatures.exe") {
-        ShellExecuteW_orig(nullptr, L"open", command.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
-        return;
-    }
-
-    STARTUPINFOW si = {};
-    si.cb = sizeof(si);
-    si.dwFlags = STARTF_USESHOWWINDOW;
-    si.wShowWindow = SW_SHOWNORMAL;
-    PROCESS_INFORMATION pi = {};
-    std::wstring cmdLine;
-
-    if (command.find(L".msc") != std::wstring::npos) {
-        cmdLine = L"mmc.exe \"" + command + L"\"";
-    } else if (command.find(L".cpl") != std::wstring::npos) {
-        ShellExecuteW_orig(nullptr, L"open", L"control.exe", command.c_str(), nullptr, SW_SHOWNORMAL);
-        return;
-    } else if (command.find(L".exe") != std::wstring::npos) {
-        cmdLine = command;
-    } else if (command.find(L"shell:::") == 0) {
-        SHELLEXECUTEINFOW sei = {};
-        sei.cbSize = sizeof(sei);
-        sei.fMask = SEE_MASK_FLAG_NO_UI | SEE_MASK_INVOKEIDLIST;
-        sei.lpVerb = L"open";
-        sei.lpFile = L"explorer.exe";
-        sei.lpParameters = command.c_str();
-        sei.nShow = SW_SHOWNORMAL;
-        ShellExecuteExW_orig(&sei);
-        return;
-    } else if (command.empty()) {
-        cmdLine = L"control.exe";
-    } else {
-        cmdLine = L"control.exe " + command;
-    }
-
-    if (!cmdLine.empty()) {
-        std::wstring mutableCmd = cmdLine;
-        if (!CreateProcessW_orig(nullptr, mutableCmd.data(), nullptr, nullptr,
-                                 FALSE, CREATE_UNICODE_ENVIRONMENT,
-                                 (LPVOID)g_childEnvBlock.c_str(), nullptr, &si, &pi)) {
+        if (command.find(L".msc") != std::wstring::npos) {
+            cmdLine = L"mmc.exe \"" + command + L"\"";
+        } else if (command.find(L".cpl") != std::wstring::npos) {
+            CallOriginalShellExecuteW(nullptr, L"open", L"control.exe", command.c_str(), nullptr, SW_SHOWNORMAL);
             return;
+        } else if (command.find(L".exe") != std::wstring::npos) {
+            cmdLine = command;
+        } else if (command.find(L"shell:::") == 0) {
+            SHELLEXECUTEINFOW sei = {};
+            sei.cbSize = sizeof(sei);
+            sei.fMask = SEE_MASK_FLAG_NO_UI | SEE_MASK_INVOKEIDLIST;
+            sei.lpVerb = L"open";
+            sei.lpFile = L"explorer.exe";
+            sei.lpParameters = command.c_str();
+            sei.nShow = SW_SHOWNORMAL;
+            CallOriginalShellExecuteExW(&sei);
+            return;
+        } else if (command.empty()) {
+            cmdLine = L"control.exe";
+        } else {
+            cmdLine = L"control.exe " + command;
         }
-        CloseHandle(pi.hProcess);
-        CloseHandle(pi.hThread);
+
+        if (!cmdLine.empty()) {
+            std::wstring mutableCmd = cmdLine;
+            ScopedProcessInformation pi;
+            if (!CallOriginalCreateProcessW(nullptr, mutableCmd.data(), nullptr, nullptr,
+                                            FALSE, CREATE_UNICODE_ENVIRONMENT,
+                                            ChildEnvironmentBlock(), nullptr, &si, pi.get())) {
+                Wh_Log(L"[STABILITY] Redirect target launch failed (%lu)", GetLastError());
+            }
+        }
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] LaunchTarget caught std::exception; target was skipped");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] LaunchTarget caught an unknown exception; target was skipped");
     }
 }
-
 static bool IsPersonalizationWindow(HWND hwnd) {
     if (!hwnd) return false;
     HWND h = hwnd;
@@ -1084,14 +1598,25 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
         BounceGuardRecord(uri);
         return {t, true};
     }
-    auto it = g_mappings.find(uri);
-    if (it != g_mappings.end()) {
+
+    std::wstring mappedTarget;
+    bool mappingFound = false;
+    {
+        std::lock_guard<std::mutex> lk(g_mappingsMutex);
+        auto it = g_mappings.find(uri);
+        if (it != g_mappings.end()) {
+            mappedTarget = it->second;
+            mappingFound = true;
+        }
+    }
+
+    if (mappingFound) {
         bool useBounceGuard = ShouldApplyBounceGuard(uri);
         if (useBounceGuard && BounceGuardIsBounce(uri)) {
             bool handled = HandleFallback(uri);
             return {L"", handled};
         }
-        std::wstring t = ApplyWin11Filter(it->second);
+        std::wstring t = ApplyWin11Filter(mappedTarget);
         if (t == WIN11_PASSTHROUGH) {
             bool handled = HandleFallback(uri);
             return {L"", handled};
@@ -1153,6 +1678,14 @@ static ActivateApplication_t g_origActivateApplication = nullptr;
 static bool g_aamHookInstalled = false;
 static std::mutex g_aamHookMutex;
 
+static HRESULT CallOriginalActivateApplication(IUnknown* pThis, LPCWSTR appUserModelId,
+                                                LPCWSTR arguments, DWORD options,
+                                                DWORD* processId) noexcept {
+    return g_origActivateApplication
+        ? g_origActivateApplication(pThis, appUserModelId, arguments, options, processId)
+        : E_FAIL;
+}
+
 HRESULT STDMETHODCALLTYPE AAM_ActivateApplication_hook(
     IUnknown* pThis,
     LPCWSTR appUserModelId,
@@ -1160,73 +1693,100 @@ HRESULT STDMETHODCALLTYPE AAM_ActivateApplication_hook(
     DWORD options,
     DWORD* processId)
 {
-    if (!g_settings.enableRedirects || !g_settings.comActivationRedirect) {
-        if (g_origActivateApplication) {
-            return g_origActivateApplication(pThis, appUserModelId, arguments, options, processId);
-        }
-        return E_FAIL;
+    HookInvocationGuard invocation;
+    if (!invocation.AllowCustomBehavior() || !RedirectsEnabled() ||
+        !ComActivationRedirectEnabled()) {
+        return CallOriginalActivateApplication(pThis, appUserModelId, arguments, options, processId);
     }
 
-    Wh_Log(L"[AAM-HOOK] ActivateApplication: appId=%s, args=%s",
-           appUserModelId ? appUserModelId : L"(null)",
-           arguments ? arguments : L"(null)");
+    try {
+        Wh_Log(L"[AAM-HOOK] ActivateApplication: appId=%s, args=%s",
+               appUserModelId ? appUserModelId : L"(null)",
+               arguments ? arguments : L"(null)");
 
-    // Is this the Settings app being activated?
-    if (appUserModelId && arguments &&
-        _wcsnicmp(appUserModelId, L"windows.immersivecontrolpanel", 29) == 0)
-    {
-        std::wstring uri = NormalizeUri(arguments);
-        Wh_Log(L"[AAM-HOOK] Settings activation intercepted: %s", uri.c_str());
+        // Is this the Settings app being activated?
+        if (appUserModelId && arguments &&
+            _wcsnicmp(appUserModelId, L"windows.immersivecontrolpanel", 29) == 0)
+        {
+            std::wstring uri = NormalizeUri(arguments);
+            Wh_Log(L"[AAM-HOOK] Settings activation intercepted: %s", uri.c_str());
 
-        auto result = ResolveUri(uri, nullptr);
-        if (result.intercept) {
-            if (!result.target.empty()) {
-                LaunchTarget(result.target);
-                Wh_Log(L"[AAM-HOOK] Redirected to: %s", result.target.c_str());
-            } else {
-                Wh_Log(L"[AAM-HOOK] Activation handled by fallback mode");
+            auto result = ResolveUri(uri, nullptr);
+            if (result.intercept) {
+                if (!result.target.empty()) {
+                    LaunchTarget(result.target);
+                    Wh_Log(L"[AAM-HOOK] Redirected to: %s", result.target.c_str());
+                } else {
+                    Wh_Log(L"[AAM-HOOK] Activation handled by fallback mode");
+                }
+                if (processId) *processId = GetCurrentProcessId();
+                return S_OK;
             }
-            if (processId) *processId = GetCurrentProcessId();
-            return S_OK;
+            Wh_Log(L"[AAM-HOOK] No mapping found, falling back to original");
         }
-        Wh_Log(L"[AAM-HOOK] No mapping found, falling back to original");
+    } catch (const std::exception&) {
+        Wh_Log(L"[AAM-HOOK] std::exception; passing activation through");
+    } catch (...) {
+        Wh_Log(L"[AAM-HOOK] Unknown exception; passing activation through");
     }
 
-    // Not a Settings activation we can handle — call original
-    if (g_origActivateApplication) {
-        return g_origActivateApplication(pThis, appUserModelId, arguments, options, processId);
-    }
-    return E_FAIL;
+    return CallOriginalActivateApplication(pThis, appUserModelId, arguments, options, processId);
 }
 
 static void InstallAAMHook() {
-    std::lock_guard<std::mutex> lk(g_aamHookMutex);
-    if (g_aamHookInstalled) return;
+    if (g_unloading.load(std::memory_order_acquire)) return;
+    try {
+        std::lock_guard<std::mutex> lk(g_aamHookMutex);
+        if (g_aamHookInstalled || g_unloading.load(std::memory_order_acquire)) return;
 
-    HRESULT hrCo = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
-
-    IUnknown* pAAM = nullptr;
-    HRESULT hr = CoCreateInstance(
-        CLSID_ApplicationActivationManager_STC,
-        nullptr,
-        CLSCTX_INPROC_SERVER,
-        IID_IApplicationActivationManager_STC,
-        (void**)&pAAM);
-
-    if (SUCCEEDED(hr) && pAAM) {
-        IApplicationActivationManagerVtbl* vtbl = *(IApplicationActivationManagerVtbl**)pAAM;
-        if (vtbl) {
-            if (WindhawkUtils::SetFunctionHook((ActivateApplication_t)vtbl->ActivateApplication, AAM_ActivateApplication_hook, &g_origActivateApplication)) {
-                g_aamHookInstalled = true;
-                Wh_Log(L"[AAM-HOOK] Successfully installed");
-            }
+        ScopedCoInitialize com(COINIT_APARTMENTTHREADED);
+        if (!com.initialized() && com.result() != RPC_E_CHANGED_MODE) {
+            Wh_Log(L"[AAM-HOOK] CoInitializeEx failed: 0x%08X", com.result());
+            return;
         }
-        pAAM->Release();
-    } else {
-        Wh_Log(L"[AAM-HOOK] CoCreateInstance failed: 0x%08X", hr);
+
+        ScopedComPtr<IUnknown> aam;
+        HRESULT hr = CoCreateInstance(
+            CLSID_ApplicationActivationManager_STC,
+            nullptr,
+            CLSCTX_INPROC_SERVER,
+            IID_IApplicationActivationManager_STC,
+            reinterpret_cast<void**>(aam.put()));
+
+        if (FAILED(hr) || !aam) {
+            Wh_Log(L"[AAM-HOOK] CoCreateInstance failed: 0x%08X", hr);
+            return;
+        }
+
+        IApplicationActivationManagerVtbl* vtbl = nullptr;
+        ActivateApplication_t target = nullptr;
+        const void* activateApplicationSlot = nullptr;
+        if (TryReadProcessMemory(aam.get(), &vtbl, NATIVE_POINTER_BYTES) && vtbl) {
+            // Calculate the slot address without dereferencing the private
+            // vtable pointer. The following ReadProcessMemory performs the
+            // only read and fails safely if the object changed underneath us.
+            activateApplicationSlot = reinterpret_cast<const BYTE*>(vtbl) +
+                offsetof(IApplicationActivationManagerVtbl, ActivateApplication);
+        }
+        if (!activateApplicationSlot ||
+            !TryReadProcessMemory(activateApplicationSlot, &target, NATIVE_POINTER_BYTES) ||
+            !IsExecutableAddress(reinterpret_cast<const void*>(target))) { 
+            Wh_Log(L"[AAM-HOOK] Invalid IApplicationActivationManager vtable; hook skipped");
+            return;
+        }
+
+        if (WindhawkUtils::SetFunctionHook(target, AAM_ActivateApplication_hook,
+                                            &g_origActivateApplication)) {
+            g_aamHookInstalled = true;
+            Wh_Log(L"[AAM-HOOK] Successfully installed");
+        } else {
+            Wh_Log(L"[AAM-HOOK] SetFunctionHook failed; COM redirect remains disabled");
+        }
+    } catch (const std::exception&) {
+        Wh_Log(L"[AAM-HOOK] Install caught std::exception; feature skipped");
+    } catch (...) {
+        Wh_Log(L"[AAM-HOOK] Install caught an unknown exception; feature skipped");
     }
-    
-    if (SUCCEEDED(hrCo)) CoUninitialize();
 }
 
 bool (*COpenControlPanel__MapLegacyName_orig)(void*, LPCWSTR, LPWSTR, UINT, bool*);
@@ -1257,6 +1817,14 @@ static bool ShouldSuppressLegacyNameMapping(LPCWSTR pszLegacyName) {
     return kNames.count(name) != 0;
 }
 
+static bool CallOriginalMapLegacyName(void* pThis, LPCWSTR pszLegacyName,
+                                      LPWSTR pszNewName, UINT uLen,
+                                      bool* nameChanged) noexcept {
+    return COpenControlPanel__MapLegacyName_orig
+        ? COpenControlPanel__MapLegacyName_orig(pThis, pszLegacyName, pszNewName, uLen, nameChanged)
+        : false;
+}
+
 bool COpenControlPanel__MapLegacyName_hook(
     void    *pThis,
     LPCWSTR  pszLegacyName,
@@ -1264,24 +1832,30 @@ bool COpenControlPanel__MapLegacyName_hook(
     UINT     uLen,
     bool    *nameChanged)
 {
-    if (!g_settings.legacyNameMappingFix ||
-        !ShouldSuppressLegacyNameMapping(pszLegacyName))
-    {
-        if (COpenControlPanel__MapLegacyName_orig) {
-            return COpenControlPanel__MapLegacyName_orig(
-                pThis, pszLegacyName, pszNewName, uLen, nameChanged);
-        }
-        return false;
+    HookInvocationGuard invocation;
+    if (!invocation.AllowCustomBehavior() || !LegacyNameMappingFixEnabled()) {
+        return CallOriginalMapLegacyName(pThis, pszLegacyName, pszNewName, uLen, nameChanged);
     }
 
-    // Tell the caller the name was NOT changed — this forces Explorer to use
-    // the original legacy Control Panel path, but only for the whitelisted
-    // legacy names above.
-    if (nameChanged) *nameChanged = false;
-    if (pszNewName && uLen > 0) *pszNewName = L'\0';
-    Wh_Log(L"[MAP-LEGACY] Suppressed mapping for: %s",
-           pszLegacyName ? pszLegacyName : L"(null)");
-    return false;
+    try {
+        if (!ShouldSuppressLegacyNameMapping(pszLegacyName)) {
+            return CallOriginalMapLegacyName(pThis, pszLegacyName, pszNewName, uLen, nameChanged);
+        }
+
+        // Tell the caller the name was NOT changed — this forces Explorer to use
+        // the original legacy Control Panel path, but only for the whitelisted
+        // legacy names above.
+        if (nameChanged) *nameChanged = false;
+        if (pszNewName && uLen > 0) *pszNewName = L'\0';
+        Wh_Log(L"[MAP-LEGACY] Suppressed mapping for: %s",
+               pszLegacyName ? pszLegacyName : L"(null)");
+        return false;
+    } catch (const std::exception&) {
+        Wh_Log(L"[MAP-LEGACY] std::exception; using original mapping");
+    } catch (...) {
+        Wh_Log(L"[MAP-LEGACY] Unknown exception; using original mapping");
+    }
+    return CallOriginalMapLegacyName(pThis, pszLegacyName, pszNewName, uLen, nameChanged);
 }
 static std::wstring BaseNameLower(const std::wstring& path) {
     size_t pos = path.rfind(L'\\');
@@ -1346,170 +1920,215 @@ static std::wstring ExtractExplorerLaunchUri(const std::wstring& cmdLine) {
 }
 
 BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
-    if (IsChildProcess()) return ShellExecuteExW_orig(pei);
-    HookGuard guard;
-    if (guard.IsReentrant()) return ShellExecuteExW_orig(pei);
-    if (!g_settings.enableRedirects || !pei) return ShellExecuteExW_orig(pei);
+    HookInvocationGuard invocation;
+    try {
+        if (!invocation.AllowCustomBehavior() || IsChildProcess() || !RedirectsEnabled() || !pei) {
+            return CallOriginalShellExecuteExW(pei);
+        }
 
-    if (IsControlSystemParams(pei->lpFile, pei->lpParameters)) {
-        LaunchTarget(g_isWin11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID);
-        if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
-        return TRUE;
-    }
-    
-    std::wstring uri;
-    const wchar_t* f = pei->lpFile;
-    const wchar_t* p = pei->lpParameters;
+        HookGuard guard;
+        if (guard.IsReentrant()) return CallOriginalShellExecuteExW(pei);
 
-    if (f && ToLower(f).find(L"ms-settings:") != std::wstring::npos) uri = NormalizeUri(f);
-    else if (p && ToLower(p).find(L"ms-settings:") != std::wstring::npos) uri = NormalizeUri(p);
-    else if (f && ToLower(f).find(L"shell:::") != std::wstring::npos) uri = ToLower(f);
-    else if (p && ToLower(p).find(L"shell:::") != std::wstring::npos) uri = ToLower(p);
-
-    if (uri == L"ms-settings:taskbar")
-        return ShellExecuteExW_orig(pei);
-
-    if (!uri.empty()) {
-        auto result = ResolveUri(uri, pei->hwnd);
-        if (result.intercept) {
-            if (!result.target.empty()) LaunchTarget(result.target);
+        if (IsControlSystemParams(pei->lpFile, pei->lpParameters)) {
+            LaunchTarget(g_isWin11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID);
             if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
             return TRUE;
         }
+
+        std::wstring uri;
+        const wchar_t* f = pei->lpFile;
+        const wchar_t* p = pei->lpParameters;
+
+        if (f && ToLower(f).find(L"ms-settings:") != std::wstring::npos) uri = NormalizeUri(f);
+        else if (p && ToLower(p).find(L"ms-settings:") != std::wstring::npos) uri = NormalizeUri(p);
+        else if (f && ToLower(f).find(L"shell:::") != std::wstring::npos) uri = ToLower(f);
+        else if (p && ToLower(p).find(L"shell:::") != std::wstring::npos) uri = ToLower(p);
+
+        if (uri == L"ms-settings:taskbar")
+            return CallOriginalShellExecuteExW(pei);
+
+        if (!uri.empty()) {
+            auto result = ResolveUri(uri, pei->hwnd);
+            if (result.intercept) {
+                if (!result.target.empty()) LaunchTarget(result.target);
+                if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
+                return TRUE;
+            }
+        }
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] ShellExecuteExW hook caught std::exception; passing through");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] ShellExecuteExW hook caught an unknown exception; passing through");
     }
-    return ShellExecuteExW_orig(pei);
+    return CallOriginalShellExecuteExW(pei);
 }
-
 HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file, LPCWSTR params, LPCWSTR dir, INT show) {
-    if (IsChildProcess()) return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
-    HookGuard guard;
-    if (guard.IsReentrant()) return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
-    if (!g_settings.enableRedirects) return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
+    HookInvocationGuard invocation;
+    try {
+        if (!invocation.AllowCustomBehavior() || IsChildProcess() || !RedirectsEnabled()) {
+            return CallOriginalShellExecuteW(hwnd, op, file, params, dir, show);
+        }
 
-    if (IsControlSystemParams(file, params)) {
-        LaunchTarget(g_isWin11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID);
-        return (HINSTANCE)33;
-    }
-    
-    std::wstring uri;
-    if (file && ToLower(file).find(L"ms-settings:") != std::wstring::npos) uri = NormalizeUri(file);
-    else if (params && ToLower(params).find(L"ms-settings:") != std::wstring::npos) uri = NormalizeUri(params);
-    else if (file && ToLower(file).find(L"shell:::") != std::wstring::npos) uri = ToLower(file);
-    else if (params && ToLower(params).find(L"shell:::") != std::wstring::npos) uri = ToLower(params);
+        HookGuard guard;
+        if (guard.IsReentrant()) return CallOriginalShellExecuteW(hwnd, op, file, params, dir, show);
 
-    if (uri == L"ms-settings:taskbar")
-        return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
-
-    if (!uri.empty()) {
-        auto result = ResolveUri(uri, hwnd);
-        if (result.intercept) {
-            if (!result.target.empty()) LaunchTarget(result.target);
+        if (IsControlSystemParams(file, params)) {
+            LaunchTarget(g_isWin11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID);
             return (HINSTANCE)33;
         }
-    }
-    return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
-}
 
+        std::wstring uri;
+        if (file && ToLower(file).find(L"ms-settings:") != std::wstring::npos) uri = NormalizeUri(file);
+        else if (params && ToLower(params).find(L"ms-settings:") != std::wstring::npos) uri = NormalizeUri(params);
+        else if (file && ToLower(file).find(L"shell:::") != std::wstring::npos) uri = ToLower(file);
+        else if (params && ToLower(params).find(L"shell:::") != std::wstring::npos) uri = ToLower(params);
+
+        if (uri == L"ms-settings:taskbar")
+            return CallOriginalShellExecuteW(hwnd, op, file, params, dir, show);
+
+        if (!uri.empty()) {
+            auto result = ResolveUri(uri, hwnd);
+            if (result.intercept) {
+                if (!result.target.empty()) LaunchTarget(result.target);
+                return (HINSTANCE)33;
+            }
+        }
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] ShellExecuteW hook caught std::exception; passing through");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] ShellExecuteW hook caught an unknown exception; passing through");
+    }
+    return CallOriginalShellExecuteW(hwnd, op, file, params, dir, show);
+}
 BOOL WINAPI CreateProcessW_hook(LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
                                  LPSECURITY_ATTRIBUTES lpProcessAttributes, LPSECURITY_ATTRIBUTES lpThreadAttributes,
                                  BOOL bInheritHandles, DWORD dwCreationFlags, LPVOID lpEnvironment,
                                  LPCWSTR lpCurrentDirectory, LPSTARTUPINFOW lpStartupInfo,
                                  LPPROCESS_INFORMATION lpProcessInformation) {
-    if (IsChildProcess()) return CreateProcessW_orig(lpApplicationName, lpCommandLine, lpProcessAttributes, 
-        lpThreadAttributes, bInheritHandles, dwCreationFlags, lpEnvironment, lpCurrentDirectory, 
-        lpStartupInfo, lpProcessInformation);
-    HookGuard guard;
-    if (guard.IsReentrant()) return CreateProcessW_orig(lpApplicationName, lpCommandLine, lpProcessAttributes, 
-        lpThreadAttributes, bInheritHandles, dwCreationFlags, lpEnvironment, lpCurrentDirectory, 
-        lpStartupInfo, lpProcessInformation);
-    if (!g_settings.enableRedirects || g_settings.uiOnlyRedirects) return CreateProcessW_orig(lpApplicationName, 
-        lpCommandLine, lpProcessAttributes, lpThreadAttributes, bInheritHandles, dwCreationFlags, lpEnvironment, 
-        lpCurrentDirectory, lpStartupInfo, lpProcessInformation);
-
-    if (lpCommandLine) {
-        std::wstring cmdLine(lpCommandLine);
-        if (IsControlSystemCommand(cmdLine)) {
-            LaunchTarget(g_isWin11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID);
-            if (lpProcessInformation) ZeroMemory(lpProcessInformation, sizeof(PROCESS_INFORMATION));
-            SetLastError(ERROR_SUCCESS);
-            return TRUE;
+    HookInvocationGuard invocation;
+    try {
+        if (!invocation.AllowCustomBehavior() || IsChildProcess() || !RedirectsEnabled() ||
+            UiOnlyRedirectsEnabled()) {
+            return CallOriginalCreateProcessW(lpApplicationName, lpCommandLine,
+                lpProcessAttributes, lpThreadAttributes, bInheritHandles, dwCreationFlags,
+                lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInformation);
         }
 
-        std::wstring uri = ExtractExplorerLaunchUri(cmdLine);
-        if (!uri.empty()) {
-            auto result = ResolveUri(uri, nullptr);
-            if (result.intercept) {
-                if (!result.target.empty()) LaunchTarget(result.target);
+        HookGuard guard;
+        if (guard.IsReentrant()) {
+            return CallOriginalCreateProcessW(lpApplicationName, lpCommandLine,
+                lpProcessAttributes, lpThreadAttributes, bInheritHandles, dwCreationFlags,
+                lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInformation);
+        }
+
+        if (lpCommandLine) {
+            std::wstring cmdLine(lpCommandLine);
+            if (IsControlSystemCommand(cmdLine)) {
+                LaunchTarget(g_isWin11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID);
                 if (lpProcessInformation) ZeroMemory(lpProcessInformation, sizeof(PROCESS_INFORMATION));
                 SetLastError(ERROR_SUCCESS);
                 return TRUE;
             }
-        }
-    }
-    return CreateProcessW_orig(lpApplicationName, lpCommandLine, lpProcessAttributes, lpThreadAttributes, 
-        bInheritHandles, dwCreationFlags, lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInformation);
-}
 
+            std::wstring uri = ExtractExplorerLaunchUri(cmdLine);
+            if (!uri.empty()) {
+                auto result = ResolveUri(uri, nullptr);
+                if (result.intercept) {
+                    if (!result.target.empty()) LaunchTarget(result.target);
+                    if (lpProcessInformation) ZeroMemory(lpProcessInformation, sizeof(PROCESS_INFORMATION));
+                    SetLastError(ERROR_SUCCESS);
+                    return TRUE;
+                }
+            }
+        }
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] CreateProcessW hook caught std::exception; passing through");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] CreateProcessW hook caught an unknown exception; passing through");
+    }
+    return CallOriginalCreateProcessW(lpApplicationName, lpCommandLine,
+        lpProcessAttributes, lpThreadAttributes, bInheritHandles, dwCreationFlags,
+        lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInformation);
+}
 static bool TryInstallPniduiHook() {
-    std::lock_guard<std::mutex> lk(g_pniduiHookMutex);
-    
-    if (g_pniduiHookInstalled) {
-        return true;
-    }
-    
-    HMODULE hMod = GetModuleHandleW(L"pnidui.dll");
-    if (!hMod) {
-        hMod = LoadLibraryExW(L"pnidui.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-        if (!hMod) {
-            return false;
-        }
-    }
-    
-    WindhawkUtils::SYMBOL_HOOK pnidui_dll_hooks[] = {{
-        {
-            L"bool __cdecl ImmersiveContextMenuHelper::CanApplyOwnerDrawToMenu"
-            L"(struct HMENU__ *,struct HWND__ *)"
-        },
-        (void**)&g_icmhOrig_pnidui,
-        (void*)(ICMH_CAODTM_t)ICMH_hook_pnidui,
-        false
-    }};
+    if (g_unloading.load(std::memory_order_acquire)) return false;
+    try {
+        std::lock_guard<std::mutex> lk(g_pniduiHookMutex);
+        if (g_unloading.load(std::memory_order_acquire)) return false;
 
-    bool result = WindhawkUtils::HookSymbols(hMod, pnidui_dll_hooks, 1);
-    if (result) {
-        g_pniduiHookInstalled = true;
+        if (g_pniduiHookInstalled.load(std::memory_order_acquire)) {
+            return true;
+        }
+
+        HMODULE hMod = GetModuleHandleW(L"pnidui.dll");
+        if (!hMod) {
+            hMod = LoadLibraryExW(L"pnidui.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+            if (!hMod) {
+                return false;
+            }
+        }
+
+        WindhawkUtils::SYMBOL_HOOK pnidui_dll_hooks[] = {{
+            {
+                L"bool __cdecl ImmersiveContextMenuHelper::CanApplyOwnerDrawToMenu"
+                L"(struct HMENU__ *,struct HWND__ *)"
+            },
+            (void**)&g_icmhOrig_pnidui,
+            (void*)(ICMH_CAODTM_t)ICMH_hook_pnidui,
+            false
+        }};
+
+        bool result = WindhawkUtils::HookSymbols(hMod, pnidui_dll_hooks, 1);
+        if (result) {
+            g_pniduiHookInstalled.store(true, std::memory_order_release);
+        }
+        return result;
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] pnidui symbol hook setup caught std::exception");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] pnidui symbol hook setup caught an unknown exception");
     }
-    return result;
+    return false;
 }
 
-static bool g_sndVolSSOHookInstalled = false;
-static bool g_shell32HooksInstalled = false;
+static std::atomic_bool g_sndVolSSOHookInstalled{false};
+static std::atomic_bool g_shell32HooksInstalled{false};
+static std::mutex g_immersiveMenuHookMutex;
 static std::mutex g_shell32HookMutex;
 
 static void InstallImmersiveMenuHooks() {
-    if (!g_sndVolSSOHookInstalled) {
-        HMODULE hMod = GetModuleHandleW(L"SndVolSSO.dll");
-        if (!hMod) hMod = LoadLibraryExW(L"SndVolSSO.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-        
-        if (hMod) {
-            WindhawkUtils::SYMBOL_HOOK sndVolSSO_dll_hooks[] = {{
-                {
-                    L"bool __cdecl ImmersiveContextMenuHelper::CanApplyOwnerDrawToMenu"
-                    L"(struct HMENU__ *,struct HWND__ *)"
-                },
-                (void**)&g_icmhOrig_SndVolSSO,
-                (void*)(ICMH_CAODTM_t)ICMH_hook_SndVolSSO,
-                false
-            }};
+    if (g_unloading.load(std::memory_order_acquire)) return;
+    try {
+        std::lock_guard<std::mutex> installLock(g_immersiveMenuHookMutex);
+        if (g_unloading.load(std::memory_order_acquire)) return;
+        if (!g_sndVolSSOHookInstalled.load(std::memory_order_acquire)) {
+            HMODULE hMod = GetModuleHandleW(L"SndVolSSO.dll");
+            if (!hMod) hMod = LoadLibraryExW(L"SndVolSSO.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
 
-            if (WindhawkUtils::HookSymbols(hMod, sndVolSSO_dll_hooks, 1)) {
-                g_sndVolSSOHookInstalled = true;
+            if (hMod) {
+                WindhawkUtils::SYMBOL_HOOK sndVolSSO_dll_hooks[] = {{
+                    {
+                        L"bool __cdecl ImmersiveContextMenuHelper::CanApplyOwnerDrawToMenu"
+                        L"(struct HMENU__ *,struct HWND__ *)"
+                    },
+                    (void**)&g_icmhOrig_SndVolSSO,
+                    (void*)(ICMH_CAODTM_t)ICMH_hook_SndVolSSO,
+                    false
+                }};
+
+                if (WindhawkUtils::HookSymbols(hMod, sndVolSSO_dll_hooks, 1)) {
+                    g_sndVolSSOHookInstalled.store(true, std::memory_order_release);
+                }
             }
         }
-    }
 
-    if (!g_pniduiHookInstalled) {
-        TryInstallPniduiHook();
+        if (!g_pniduiHookInstalled.load(std::memory_order_acquire)) {
+            TryInstallPniduiHook();
+        }
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] Immersive menu hook setup caught std::exception");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] Immersive menu hook setup caught an unknown exception");
     }
 }
 
@@ -1517,8 +2136,11 @@ static void InstallImmersiveMenuHooks() {
 // Windhawk API best practice. The hook list is intentionally not conditional
 // on settings or OS version, to keep Windhawk symbol caching valid.
 static void InstallShell32Hooks() {
+    if (g_unloading.load(std::memory_order_acquire)) return;
+    try {
     std::lock_guard<std::mutex> lk(g_shell32HookMutex);
-    if (g_shell32HooksInstalled) return;
+    if (g_unloading.load(std::memory_order_acquire)) return;
+    if (g_shell32HooksInstalled.load(std::memory_order_acquire)) return;
 
     HMODULE hShell32 = GetModuleHandleW(L"shell32.dll");
     if (!hShell32) return;
@@ -1553,8 +2175,13 @@ static void InstallShell32Hooks() {
             shell32_dll_hooks,
             ARRAYSIZE(shell32_dll_hooks)))
     {
-        g_shell32HooksInstalled = true;
+        g_shell32HooksInstalled.store(true, std::memory_order_release);
         Wh_Log(L"[SHELL32-HOOKS] Installed shell32 hook set");
+    }
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] shell32 hook setup caught std::exception");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] shell32 hook setup caught an unknown exception");
     }
 }
 static bool HasTrayBeenRecreated() {
@@ -1579,71 +2206,96 @@ static bool HasTrayBeenRecreated() {
     return false;
 }
 static void ReinitializeTrayRedirect() {
-    RemoveTraySubclass();
+    if (g_unloading.load(std::memory_order_acquire)) return;
+    try {
+        RemoveTraySubclass();
 
-    {
-        std::lock_guard<std::mutex> lk(g_trayDllInfoMutex);
-        g_sndVolSSOBase = nullptr;
-        g_sndVolSSOEnd  = nullptr;
-        g_pniduiBase    = nullptr;
-        g_pniduiEnd     = nullptr;
+        {
+            std::lock_guard<std::mutex> lk(g_trayDllInfoMutex);
+            g_sndVolSSOBase = nullptr;
+            g_sndVolSSOEnd  = nullptr;
+            g_pniduiBase    = nullptr;
+            g_pniduiEnd     = nullptr;
+        }
+
+        if (RedirectSystemTrayEnabled()) {
+            SetupTraySubclass();
+        }
+
+        InstallImmersiveMenuHooks();
+        InstallShell32Hooks();
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] ReinitializeTrayRedirect caught std::exception");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] ReinitializeTrayRedirect caught an unknown exception");
     }
-
-    if (g_settings.redirectSystemTray) {
-        SetupTraySubclass();
-    }
-
-    InstallImmersiveMenuHooks();
-    InstallShell32Hooks();
 }
 
 static void PerformBackgroundInit(bool skipSleep = false) {
+    if (g_unloading.load(std::memory_order_acquire)) return;
     if (!skipSleep) {
-        Sleep(200);
+        HANDLE stopEvent = g_stopEvent;
+        if (stopEvent && WaitForSingleObject(stopEvent, 200) == WAIT_OBJECT_0) {
+            return;
+        }
     }
 
+    if (g_unloading.load(std::memory_order_acquire)) return;
     InstallImmersiveMenuHooks();
+    if (g_unloading.load(std::memory_order_acquire)) return;
     InstallShell32Hooks();
 
-    if (g_isWin11) {
+    if (!g_unloading.load(std::memory_order_acquire) && g_isWin11) {
         InstallAAMHook();
     }
-
 }
 
 static DWORD WINAPI TraySubclassWatchdogThread(LPVOID) {
-    PerformBackgroundInit();
+    try {
+        PerformBackgroundInit();
 
-    const int   FAST_PHASE_CHECKS   = 60;
-    const DWORD FAST_INTERVAL_MS    = 500;
-    const DWORD SLOW_INTERVAL_MS    = 3000;
+        const int   FAST_PHASE_CHECKS   = 60;
+        const DWORD FAST_INTERVAL_MS    = 500;
+        const DWORD SLOW_INTERVAL_MS    = 3000;
 
-    int tick = 0;
-    while (true) {
-        DWORD interval = tick < FAST_PHASE_CHECKS ? FAST_INTERVAL_MS : SLOW_INTERVAL_MS;
-        if (WaitForSingleObject(g_stopEvent, interval) == WAIT_OBJECT_0) break;
-
-        tick++;
-
-        if (HasTrayBeenRecreated()) {
-            ReinitializeTrayRedirect();
-            continue;
-        }
-
-        if (!g_settings.redirectSystemTray) continue;
-
-        bool needSetup = false;
-        {
-            std::lock_guard<std::mutex> lk(g_traySubclassMutex);
-            if (g_hTrayToolbar && !IsWindow(g_hTrayToolbar)) {
-                g_hTrayToolbar = nullptr;
+        int tick = 0;
+        while (!g_unloading.load(std::memory_order_acquire)) {
+            DWORD interval = tick < FAST_PHASE_CHECKS ? FAST_INTERVAL_MS : SLOW_INTERVAL_MS;
+            HANDLE stopEvent = g_stopEvent;
+            if (!stopEvent) break;
+            DWORD wait = WaitForSingleObject(stopEvent, interval);
+            if (wait == WAIT_OBJECT_0) break;
+            if (wait == WAIT_FAILED) {
+                Wh_Log(L"[STABILITY] Tray watchdog wait failed (%lu)", GetLastError());
+                break;
             }
-            needSetup = (g_hTrayToolbar == nullptr);
-        }
 
-        if (needSetup) {
-            SetupTraySubclass();
+            tick++;
+
+            if (HasTrayBeenRecreated()) {
+                ReinitializeTrayRedirect();
+                continue;
+            }
+
+            if (!RedirectSystemTrayEnabled()) continue;
+
+            bool needSetup = false;
+            {
+                std::lock_guard<std::mutex> lk(g_traySubclassMutex);
+                if (g_hTrayToolbar && !IsWindow(g_hTrayToolbar)) {
+                    g_hTrayToolbar = nullptr;
+                }
+                needSetup = (g_hTrayToolbar == nullptr);
+            }
+
+            if (needSetup) {
+                SetupTraySubclass();
+            }
         }
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] Tray watchdog caught std::exception and is stopping");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] Tray watchdog caught an unknown exception and is stopping");
     }
     return 0;
 }
@@ -1656,113 +2308,275 @@ HWND WINAPI CreateWindowExW_Hook(
     DWORD dwStyle, int X, int Y, int nWidth, int nHeight,
     HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
 {
-    HWND hwnd = CreateWindowExW_Original(
-        dwExStyle, lpClassName, lpWindowName, dwStyle,
-        X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
-    
-    bool trayToolbarMissing = false;
-    {
-        std::lock_guard<std::mutex> lk(g_traySubclassMutex);
-        trayToolbarMissing = (g_hTrayToolbar == nullptr);
-    }
+    HWND hwnd = nullptr;
+    try {
+        if (!CreateWindowExW_Original) {
+            SetLastError(ERROR_PROC_NOT_FOUND);
+            return nullptr;
+        }
 
-    if (g_settings.redirectSystemTray && hwnd && trayToolbarMissing && 
-        lpClassName && !IS_INTRESOURCE(lpClassName) && 
-        lpClassName[0] == L'T')
-    {
-        if (wcscmp(lpClassName, L"ToolbarWindow32") == 0) {
+        hwnd = CreateWindowExW_Original(
+            dwExStyle, lpClassName, lpWindowName, dwStyle,
+            X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+
+        HookInvocationGuard invocation;
+        if (!invocation.AllowCustomBehavior() || !RedirectSystemTrayEnabled() || !hwnd ||
+            !lpClassName || IS_INTRESOURCE(lpClassName) || lpClassName[0] != L'T') {
+            return hwnd;
+        }
+
+        HookGuard guard;
+        if (guard.IsReentrant() || wcscmp(lpClassName, L"ToolbarWindow32") != 0) {
+            return hwnd;
+        }
+
+        bool trayToolbarMissing = false;
+        {
+            std::lock_guard<std::mutex> lk(g_traySubclassMutex);
+            trayToolbarMissing = (g_hTrayToolbar == nullptr);
+        }
+        if (trayToolbarMissing) {
             SetupTraySubclass();
         }
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] CreateWindowExW hook caught std::exception; returning original window");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] CreateWindowExW hook caught an unknown exception; returning original window");
     }
-    
     return hwnd;
 }
-
 BOOL Wh_ModInit() {
-    DetectWindowsVersion();
-    LoadSettings();
-    BuildChildEnvironment();
-    InitMappings();
-
-    g_stopEvent = CreateEvent(nullptr, TRUE, FALSE, nullptr);
-
-    HMODULE hShell32 = GetModuleHandleW(L"shell32.dll");
-    if (!hShell32) hShell32 = LoadLibraryExW(L"shell32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-    if (!hShell32) return FALSE;
-
-    FARPROC pExW = GetProcAddress(hShell32, "ShellExecuteExW");
-    FARPROC pW = GetProcAddress(hShell32, "ShellExecuteW");
-    if (!pExW || !pW) return FALSE;
-
-    WindhawkUtils::SetFunctionHook((ShellExecuteExW_t)pExW, ShellExecuteExW_hook, &ShellExecuteExW_orig);
-    WindhawkUtils::SetFunctionHook((ShellExecuteW_t)pW, ShellExecuteW_hook, &ShellExecuteW_orig);
-
-    HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
-    if (!hKernel32) hKernel32 = LoadLibraryExW(L"kernel32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-    if (hKernel32) {
-        void* pCPW = (void*)GetProcAddress(hKernel32, "CreateProcessW");
-        if (pCPW) WindhawkUtils::SetFunctionHook((CreateProcessW_t)pCPW, CreateProcessW_hook, &CreateProcessW_orig);
-    }
-
-    if (IsShellProcess()) {
-        WindhawkUtils::SetFunctionHook(CreateWindowExW, CreateWindowExW_Hook, &CreateWindowExW_Original);
-        if (g_settings.redirectSystemTray) {
-            SetupTraySubclass();
+    try {
+        g_unloading.store(false, std::memory_order_release);
+        g_activeHookCalls.store(0, std::memory_order_release);
+        g_shellExecuteExHookRegistered.store(false, std::memory_order_release);
+        g_shellExecuteHookRegistered.store(false, std::memory_order_release);
+        g_createProcessHookRegistered.store(false, std::memory_order_release);
+        DetectWindowsVersion();
+        LoadSettings();
+        BuildChildEnvironment();
+        if (!InitMappings()) {
+            Wh_Log(L"[STABILITY] Initial URI map construction failed");
+            return FALSE;
         }
 
-        HMODULE hUser32 = GetModuleHandleW(L"user32.dll");
-        if (!hUser32) hUser32 = LoadLibraryExW(L"user32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-        if (hUser32) {
-            FARPROC pTrackPopupMenuEx = GetProcAddress(hUser32, "TrackPopupMenuEx");
-            if (pTrackPopupMenuEx) {
-                WindhawkUtils::SetFunctionHook((TrackPopupMenuEx_t)pTrackPopupMenuEx, TrackPopupMenuEx_Hook, &g_origTrackPopupMenuEx);
+        ScopedHandle stopEvent(CreateEventW(nullptr, TRUE, FALSE, nullptr));
+        if (!stopEvent) {
+            Wh_Log(L"[STABILITY] CreateEventW failed (%lu)", GetLastError());
+            return FALSE;
+        }
+
+        HMODULE hShell32 = GetModuleHandleW(L"shell32.dll");
+        if (!hShell32) hShell32 = LoadLibraryExW(L"shell32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+        if (!hShell32) {
+            Wh_Log(L"[STABILITY] shell32.dll is unavailable");
+            return FALSE;
+        }
+
+        FARPROC pExW = GetProcAddress(hShell32, "ShellExecuteExW");
+        FARPROC pW = GetProcAddress(hShell32, "ShellExecuteW");
+        if (!pExW || !pW) {
+            Wh_Log(L"[STABILITY] Required ShellExecute exports are unavailable");
+            return FALSE;
+        }
+
+        // From here hooks can be queued, so do not return FALSE: optional
+        // failures are logged and their hook bodies remain pass-through.
+        g_stopEvent = stopEvent.release();
+
+        const bool shellExecuteExHookInstalled = WindhawkUtils::SetFunctionHook(
+            (ShellExecuteExW_t)pExW, ShellExecuteExW_hook, &ShellExecuteExW_orig);
+        g_shellExecuteExHookRegistered.store(shellExecuteExHookInstalled, std::memory_order_release);
+        if (!shellExecuteExHookInstalled) {
+            Wh_Log(L"[STABILITY] ShellExecuteExW hook could not be installed");
+        }
+        const bool shellExecuteHookInstalled = WindhawkUtils::SetFunctionHook(
+            (ShellExecuteW_t)pW, ShellExecuteW_hook, &ShellExecuteW_orig);
+        g_shellExecuteHookRegistered.store(shellExecuteHookInstalled, std::memory_order_release);
+        if (!shellExecuteHookInstalled) {
+            Wh_Log(L"[STABILITY] ShellExecuteW hook could not be installed");
+        }
+
+        HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
+        if (!hKernel32) hKernel32 = LoadLibraryExW(L"kernel32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+        if (hKernel32) {
+            void* pCPW = (void*)GetProcAddress(hKernel32, "CreateProcessW");
+            if (pCPW) {
+                const bool createProcessHookInstalled = WindhawkUtils::SetFunctionHook(
+                    (CreateProcessW_t)pCPW, CreateProcessW_hook, &CreateProcessW_orig);
+                g_createProcessHookRegistered.store(createProcessHookInstalled, std::memory_order_release);
+                if (!createProcessHookInstalled) {
+                    Wh_Log(L"[STABILITY] CreateProcessW hook could not be installed");
+                }
+            }
+        } else {
+            Wh_Log(L"[STABILITY] kernel32.dll unavailable; process interception skipped");
+        }
+
+        if (IsShellProcess()) {
+            if (!WindhawkUtils::SetFunctionHook(CreateWindowExW, CreateWindowExW_Hook,
+                                                 &CreateWindowExW_Original)) {
+                Wh_Log(L"[STABILITY] CreateWindowExW hook could not be installed");
+            }
+            if (RedirectSystemTrayEnabled()) {
+                SetupTraySubclass();
+            }
+
+            HMODULE hUser32 = GetModuleHandleW(L"user32.dll");
+            if (!hUser32) hUser32 = LoadLibraryExW(L"user32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+            if (hUser32) {
+                FARPROC pTrackPopupMenuEx = GetProcAddress(hUser32, "TrackPopupMenuEx");
+                if (pTrackPopupMenuEx && !WindhawkUtils::SetFunctionHook(
+                        (TrackPopupMenuEx_t)pTrackPopupMenuEx, TrackPopupMenuEx_Hook,
+                        &g_origTrackPopupMenuEx)) {
+                    Wh_Log(L"[STABILITY] TrackPopupMenuEx hook could not be installed");
+                }
+            }
+
+            // Queue all symbol/vtable hooks that might be needed before Wh_ModInit
+            // returns, so Windhawk can apply them as part of normal initialization
+            // without explicit Wh_ApplyHookOperations calls later.
+            PerformBackgroundInit(true);
+
+            {
+                std::lock_guard<std::mutex> lk(g_shellTrayWndMutex);
+                g_lastShellTrayWnd = nullptr;
+            }
+            g_traySubclassWatchdogThread = CreateThread(nullptr, 0, TraySubclassWatchdogThread,
+                                                         nullptr, 0, nullptr);
+            if (!g_traySubclassWatchdogThread) {
+                Wh_Log(L"[STABILITY] Tray watchdog thread was not created (%lu)", GetLastError());
             }
         }
-        
-        // Queue all symbol/vtable hooks that might be needed before Wh_ModInit
-        // returns, so Windhawk can apply them as part of normal initialization
-        // without explicit Wh_ApplyHookOperations calls later.
-        PerformBackgroundInit(true);
 
-        {
-            std::lock_guard<std::mutex> lk(g_shellTrayWndMutex);
-            g_lastShellTrayWnd = nullptr;
-        }
-        g_traySubclassWatchdogThread = CreateThread(nullptr, 0, TraySubclassWatchdogThread, nullptr, 0, nullptr);
+        return TRUE;
+    } catch (const std::exception&) {
+        // If no hook was queued this cleanly unloads; if a rare exception came
+        // after a hook was queued, remain loaded in transparent mode so the
+        // engine can remove the queued operations normally.
+        Wh_Log(L"[STABILITY] Wh_ModInit caught std::exception");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] Wh_ModInit caught an unknown exception");
     }
 
+    g_unloading.store(true, std::memory_order_release);
+    if (g_stopEvent) SetEvent(g_stopEvent);
     return TRUE;
 }
-
-void Wh_ModUninit() {
-    if (g_stopEvent) {
-        SetEvent(g_stopEvent);
-    }
-
+static void StopTraySubclassWatchdog() {
+    // The worker can resolve symbols and queue optional hooks. It must be gone
+    // before Wh_ModBeforeUninit returns, because Windhawk may remove hooks as
+    // soon as that callback finishes.
     if (g_traySubclassWatchdogThread) {
-        WaitForSingleObject(g_traySubclassWatchdogThread, 3000);
+        DWORD wait = WaitForSingleObject(g_traySubclassWatchdogThread, INFINITE);
+        if (wait != WAIT_OBJECT_0) {
+            Wh_Log(L"[STABILITY] Watchdog join failed (%lu)", GetLastError());
+        }
         CloseHandle(g_traySubclassWatchdogThread);
         g_traySubclassWatchdogThread = nullptr;
     }
-    
-    if (g_stopEvent) {
-        CloseHandle(g_stopEvent);
-        g_stopEvent = nullptr;
-    }
-
-    RemoveTraySubclass();
 }
 
-void Wh_ModSettingsChanged() {
-    LoadSettings();
-    InitMappings();
-
-    if (IsShellProcess()) {
-        if (g_settings.redirectSystemTray) {
-            SetupTraySubclass();
-        } else {
-            RemoveTraySubclass();
+void Wh_ModBeforeUninit() {
+    // This callback still runs while original trampolines and subclass helpers
+    // are valid. Stop new custom work first, then remove our external window
+    // callback before Windhawk removes function hooks.
+    try {
+        g_unloading.store(true, std::memory_order_release);
+        if (g_stopEvent) {
+            SetEvent(g_stopEvent);
         }
-        PerformBackgroundInit(true);
+        StopTraySubclassWatchdog();
+        RemoveTraySubclass();
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] Wh_ModBeforeUninit caught std::exception");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] Wh_ModBeforeUninit caught an unknown exception");
+    }
+}
+
+static bool WaitForActiveHooksToDrain() noexcept {
+    constexpr DWORD kMaxWaitMs = 5000;
+    constexpr DWORD kSleepMs = 10;
+    DWORD waited = 0;
+    while (g_activeHookCalls.load(std::memory_order_acquire) > 0 && waited < kMaxWaitMs) {
+        Sleep(kSleepMs);
+        waited += kSleepMs;
+    }
+    const bool drained = g_activeHookCalls.load(std::memory_order_acquire) == 0;
+    if (!drained) {
+        Wh_Log(L"[STABILITY] Hook calls remained active after %lu ms; shared state will be retained for the engine unload guard", kMaxWaitMs);
+    }
+    return drained;
+}
+
+void Wh_ModUninit() {
+    try {
+        g_unloading.store(true, std::memory_order_release);
+        if (g_stopEvent) {
+            SetEvent(g_stopEvent);
+        }
+
+        // The watchdog executes mod code. Do not allow the DLL to unload while
+        // it is still alive; it only waits on g_stopEvent and exits promptly.
+        if (g_traySubclassWatchdogThread) {
+            DWORD wait = WaitForSingleObject(g_traySubclassWatchdogThread, INFINITE);
+            if (wait != WAIT_OBJECT_0) {
+                Wh_Log(L"[STABILITY] Watchdog join failed (%lu)", GetLastError());
+            }
+            CloseHandle(g_traySubclassWatchdogThread);
+            g_traySubclassWatchdogThread = nullptr;
+        }
+
+        const bool hooksDrained = WaitForActiveHooksToDrain();
+        RemoveTraySubclass();
+
+        if (g_stopEvent) {
+            CloseHandle(g_stopEvent);
+            g_stopEvent = nullptr;
+        }
+
+        // Do not free state underneath a hook that did not finish within the
+        // diagnostic wait. Normal module destruction releases it after the
+        // engine completes its own in-flight hook synchronization.
+        if (hooksDrained) {
+            {
+                std::lock_guard<std::mutex> lk(g_bounceGuardMtx);
+                g_bounceGuard.clear();
+            }
+            {
+                std::lock_guard<std::mutex> lk(g_loopGuardMtx);
+                g_loopGuard.clear();
+            }
+            {
+                std::lock_guard<std::mutex> lk(g_mappingsMutex);
+                g_mappings.clear();
+            }
+            g_childEnvBlock.clear();
+        }
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] Wh_ModUninit caught std::exception");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] Wh_ModUninit caught an unknown exception");
+    }
+}
+void Wh_ModSettingsChanged() {
+    if (g_unloading.load(std::memory_order_acquire)) return;
+    try {
+        LoadSettings();
+        InitMappings();
+
+        if (IsShellProcess()) {
+            if (RedirectSystemTrayEnabled()) {
+                SetupTraySubclass();
+            } else {
+                RemoveTraySubclass();
+            }
+            PerformBackgroundInit(true);
+        }
+    } catch (const std::exception&) {
+        Wh_Log(L"[STABILITY] Wh_ModSettingsChanged caught std::exception; previous state is retained where possible");
+    } catch (...) {
+        Wh_Log(L"[STABILITY] Wh_ModSettingsChanged caught an unknown exception; previous state is retained where possible");
     }
 }


### PR DESCRIPTION
This is a maintenance update that makes the mod more stable and safer to use with try-catch, RAII and by trying to reduce potential conflicts with companion mods.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

- Fixed a bug where some hooks were registered but never actually turned on, so a few features could silently stop working after Explorer restarted or after changing a setting
- Cleaned up some unnecessary error-handling code that wasn't actually protecting against anything
- Fixed the "Display" settings redirect being removed by accident, and added a toggle so this mod works together with the Classic Display Control Panel Restorer mod instead of conflicting with it
- Updated the README to be more accurate about what the mod actually protects against

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [X] The submitter, with AI assistance
- - [X] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
