### PR TITLE
added new mod to control brightness and volume from taskbar

### DIFF
--- a/mods/taskbar-scroll-volume-brightness-control.wh.cpp
+++ b/mods/taskbar-scroll-volume-brightness-control.wh.cpp
@@ -2,7 +2,7 @@
 // @id            taskbar-scroll-volume-brightness-control
 // @name          Taskbar Scroll: Volume & Brightness Controller
 // @description   Scroll over the right side of the taskbar to change volume, scroll over the left side to change brightness. Uses a custom in-taskbar UI that tracks your cursor.
-// @version       1.0.9
+// @version       1.1.0
 // @author        Narayan Chetri
 // @github        https://github.com/NarayanChetri
 // @homepage      https://narayanchetri.dev
@@ -255,7 +255,6 @@ HWND g_hOverlayWnd = nullptr;
 // Animation & Tracking state 
 float g_animatedPercent = -1.0f;
 int g_targetPercent = 0;
-bool g_isHiding = false;
 float g_opacity = 0.0f;
 float g_targetOpacity = 255.0f;
 HWND g_hTargetTaskbar = nullptr;
@@ -355,7 +354,6 @@ LRESULT CALLBACK OverlayWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPara
         case WM_TIMER:
             if (wParam == kOverlayHideTimerId) {
                 KillTimer(hWnd, kOverlayHideTimerId);
-                g_isHiding = true;
                 g_targetOpacity = 0.0f;
             } else if (wParam == kFrameTimerId) {
                 bool changed = false;
@@ -459,7 +457,6 @@ void ShowOverlay(HWND hTaskbar, int percent, POINT cursorPt, OverlayMode mode) {
     g_lastCursorPt = cursorPt;
     g_targetPercent = percent;
     g_targetOpacity = 255.0f;
-    g_isHiding = false;
 
     if (!hTaskbar || !IsWindow(hTaskbar)) hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
     g_hTargetTaskbar = hTaskbar;
@@ -721,25 +718,35 @@ bool HandleTaskbarScroll(HWND hTaskbar, POINT pt, short delta) {
 
     if (settings.excludeSystemTray) {
         HWND hTrayNotify = FindWindowExW(hTaskbar, nullptr, L"TrayNotifyWnd", nullptr);
-        if (!hTrayNotify) {
+        RECT trayRect = {0};
+        bool hasTrayRect = false;
+
+        if (hTrayNotify && GetWindowRect(hTrayNotify, &trayRect) && !IsRectEmpty(&trayRect)) {
+            hasTrayRect = true;
+        }
+
+        if (!hasTrayRect) {
             HWND hBridge = nullptr;
             while ((hBridge = FindWindowExW(hTaskbar, hBridge, L"Windows.UI.Composition.DesktopWindowContentBridge", nullptr)) != nullptr) {
-                RECT bridgeRect;
-                if (GetWindowRect(hBridge, &bridgeRect)) {
-                    if (bridgeRect.left == rc.left && bridgeRect.right == rc.right && bridgeRect.top == rc.top && bridgeRect.bottom == rc.bottom) {
+                if (GetWindowRect(hBridge, &trayRect) && !IsRectEmpty(&trayRect)) {
+                    if (trayRect.left == rc.left && trayRect.right == rc.right && trayRect.top == rc.top && trayRect.bottom == rc.bottom) {
                         continue;
                     }
-                    hTrayNotify = hBridge;
+                    hasTrayRect = true;
                     break;
                 }
             }
         }
         
-        if (hTrayNotify) {
-            RECT trayRect;
-            if (GetWindowRect(hTrayNotify, &trayRect) && !IsRectEmpty(&trayRect) && PtInRect(&trayRect, pt)) {
-                return false;
+        if (!hasTrayRect) {
+            HWND hClock = FindWindowExW(hTaskbar, nullptr, L"ClockButton", nullptr);
+            if (hClock && GetWindowRect(hClock, &trayRect) && !IsRectEmpty(&trayRect)) {
+                hasTrayRect = true;
             }
+        }
+        
+        if (hasTrayRect && PtInRect(&trayRect, pt)) {
+            return false;
         }
     }
 
@@ -790,7 +797,10 @@ LRESULT CALLBACK TaskbarSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM
         short delta = GET_WHEEL_DELTA_WPARAM(wParam);
         if (HandleTaskbarScroll(hWnd, pt, delta)) return 0;
     } else if (uMsg == WM_DISPLAYCHANGE) {
-        if (g_monitorThreadId) PostThreadMessageW(g_monitorThreadId, WM_APP_CLEAR_MONITOR_CACHE, 0, 0);
+        if (g_monitorThreadId) {
+            while (!PostThreadMessageW(g_monitorThreadId, WM_APP_CLEAR_MONITOR_CACHE, 0, 0) &&
+                   WaitForSingleObject(g_hMonitorThread, 10) == WAIT_TIMEOUT) {}
+        }
     } else if (uMsg == WM_NCDESTROY) {
         WindhawkUtils::RemoveWindowSubclassFromAnyThread(hWnd, TaskbarSubclassProc);
     }
@@ -804,7 +814,7 @@ LRESULT CALLBACK InputSiteWindowProc_Hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         if (hRootWnd) {
             WCHAR szClass[32];
             if (GetClassNameW(hRootWnd, szClass, 32)) {
-                if (wcscmp(szClass, L"Shell_TrayWnd") == 0 || wcscmp(szClass, L"Shell_SecondaryTrayWnd") == 0) {
+                if (_wcsicmp(szClass, L"Shell_TrayWnd") == 0 || _wcsicmp(szClass, L"Shell_SecondaryTrayWnd") == 0) {
                     POINT pt = {GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
                     short delta = GET_WHEEL_DELTA_WPARAM(wParam);
                     if (HandleTaskbarScroll(hRootWnd, pt, delta)) return 0;
@@ -911,13 +921,15 @@ DWORD WINAPI MonitorThreadProc(LPVOID) {
 
                     if (percent >= 0 && g_workerThreadId) {
                         ScrollResult* res = new ScrollResult{percent, req->hMonitor, req->hTaskbar, req->cursorPt, OverlayMode::Brightness};
-                        if (!PostThreadMessageW(g_workerThreadId, WM_APP_BRIGHTNESS_RESULT, 0, (LPARAM)res)) delete res;
+                        while (!PostThreadMessageW(g_workerThreadId, WM_APP_BRIGHTNESS_RESULT, 0, (LPARAM)res) &&
+                               WaitForSingleObject(g_hWorkerThread, 10) == WAIT_TIMEOUT) {}
                     }
                 }
                 delete req;
 
+                DWORD currentThreadId = GetCurrentThreadId();
                 for (ScrollRequest* d : deferred) {
-                    if (!PostThreadMessageW(g_monitorThreadId, WM_APP_BRIGHTNESS_REQUEST, 0, (LPARAM)d)) delete d;
+                    while (!PostThreadMessageW(currentThreadId, WM_APP_BRIGHTNESS_REQUEST, 0, (LPARAM)d) && !g_stopping) {}
                 }
             }
             continue;
@@ -928,6 +940,12 @@ DWORD WINAPI MonitorThreadProc(LPVOID) {
         }
         TranslateMessage(&msg);
         DispatchMessageW(&msg);
+    }
+
+    MSG leftover;
+    while (PeekMessageW(&leftover, nullptr, WM_APP_BRIGHTNESS_REQUEST, WM_APP_BRIGHTNESS_RESULT, PM_REMOVE)) {
+        if (leftover.message == WM_APP_BRIGHTNESS_REQUEST) delete (ScrollRequest*)leftover.lParam;
+        else if (leftover.message == WM_APP_BRIGHTNESS_RESULT) delete (ScrollResult*)leftover.lParam;
     }
 
     CleanupWMI();
@@ -959,6 +977,7 @@ DWORD WINAPI WorkerThreadProc(LPVOID) {
                         if (nextReq->scrollUp == req->scrollUp) req->notches += nextReq->notches;
                         else req->notches -= nextReq->notches;
                         req->cursorPt = nextReq->cursorPt; 
+                        req->hTaskbar = nextReq->hTaskbar;
                         delete nextReq;
                     }
                 }
@@ -1020,6 +1039,11 @@ DWORD WINAPI WorkerThreadProc(LPVOID) {
         DispatchMessageW(&msg);
     }
 
+    MSG leftover;
+    while (PeekMessageW(&leftover, nullptr, WM_APP_VOLUME_REQUEST, WM_APP_VOLUME_REQUEST, PM_REMOVE)) {
+        delete (ScrollRequest*)leftover.lParam;
+    }
+
     if (pEnum) pEnum->Release();
     if (g_hOverlayWnd) {
         DestroyWindow(g_hOverlayWnd);
@@ -1077,10 +1101,10 @@ BOOL Wh_ModInit() {
     LoadSettings();
 
     Gdiplus::GdiplusStartupInput gdiplusStartupInput;
-    Gdiplus::GdiplusStartup(&g_gdiplusToken, &gdiplusStartupInput, nullptr);
+    Gdiplus::Status gdiStatus = Gdiplus::GdiplusStartup(&g_gdiplusToken, &gdiplusStartupInput, nullptr);
 
     if (!WindhawkUtils::SetFunctionHook(CreateWindowExW, CreateWindowExW_Hook, &CreateWindowExW_Original)) {
-        Gdiplus::GdiplusShutdown(g_gdiplusToken);
+        if (gdiStatus == Gdiplus::Ok) Gdiplus::GdiplusShutdown(g_gdiplusToken);
         DeleteCriticalSection(&g_settingsLock);
         return FALSE;
     }
@@ -1093,7 +1117,7 @@ BOOL Wh_ModInit() {
 
     g_hWorkerThread = CreateThread(nullptr, 0, WorkerThreadProc, nullptr, 0, &g_workerThreadId);
     if (!g_hWorkerThread) {
-        Gdiplus::GdiplusShutdown(g_gdiplusToken);
+        if (gdiStatus == Gdiplus::Ok) Gdiplus::GdiplusShutdown(g_gdiplusToken);
         DeleteCriticalSection(&g_settingsLock);
         return FALSE;
     }
@@ -1101,10 +1125,16 @@ BOOL Wh_ModInit() {
     g_hMonitorThread = CreateThread(nullptr, 0, MonitorThreadProc, nullptr, 0, &g_monitorThreadId);
     if (!g_hMonitorThread) {
         g_stopping = true;
-        PostThreadMessageW(g_workerThreadId, WM_QUIT, 0, 0);
+        if (g_workerThreadId) {
+            while (!PostThreadMessageW(g_workerThreadId, WM_QUIT, 0, 0) &&
+                   WaitForSingleObject(g_hWorkerThread, 10) == WAIT_TIMEOUT) {}
+        }
         WaitForSingleObject(g_hWorkerThread, INFINITE);
         CloseHandle(g_hWorkerThread);
-        Gdiplus::GdiplusShutdown(g_gdiplusToken);
+        g_hWorkerThread = nullptr;
+        g_workerThreadId = 0;
+        
+        if (gdiStatus == Gdiplus::Ok) Gdiplus::GdiplusShutdown(g_gdiplusToken);
         DeleteCriticalSection(&g_settingsLock);
         return FALSE;
     }
@@ -1118,7 +1148,10 @@ void Wh_ModUninit() {
     g_stopping = true;
     EnumWindows(EnumWindowsUninitProc, 0);
 
-    if (g_workerThreadId) PostThreadMessageW(g_workerThreadId, WM_QUIT, 0, 0);
+    if (g_workerThreadId) {
+        while (!PostThreadMessageW(g_workerThreadId, WM_QUIT, 0, 0) &&
+               WaitForSingleObject(g_hWorkerThread, 10) == WAIT_TIMEOUT) {}
+    }
     if (g_hWorkerThread) {
         WaitForSingleObject(g_hWorkerThread, INFINITE);
         CloseHandle(g_hWorkerThread);
@@ -1126,7 +1159,10 @@ void Wh_ModUninit() {
         g_workerThreadId = 0;
     }
 
-    if (g_monitorThreadId) PostThreadMessageW(g_monitorThreadId, WM_QUIT, 0, 0);
+    if (g_monitorThreadId) {
+        while (!PostThreadMessageW(g_monitorThreadId, WM_QUIT, 0, 0) &&
+               WaitForSingleObject(g_hMonitorThread, 10) == WAIT_TIMEOUT) {}
+    }
     if (g_hMonitorThread) {
         WaitForSingleObject(g_hMonitorThread, INFINITE);
         CloseHandle(g_hMonitorThread);

--- a/mods/taskbar-scroll-volume-brightness-control.wh.cpp
+++ b/mods/taskbar-scroll-volume-brightness-control.wh.cpp
@@ -2,7 +2,7 @@
 // @id            taskbar-scroll-volume-brightness-control
 // @name          Taskbar Scroll: Volume & Brightness Controller
 // @description   Scroll over the right side of the taskbar to change volume, scroll over the left side to change brightness. Uses a custom in-taskbar UI that tracks your cursor.
-// @version       1.1.1
+// @version       1.1.2
 // @author        Narayan Chetri
 // @github        https://github.com/NarayanChetri
 // @homepage      https://narayanchetri.dev
@@ -427,7 +427,6 @@ void EnsureOverlayWindow() {
 
     if (!g_classRegistered) {
         WNDCLASSEXW wc = {sizeof(wc)};
-        wc.style = CS_DROPSHADOW;
         wc.lpfnWndProc = OverlayWndProc;
         wc.hInstance = GetCurrentModuleHandle();
         wc.lpszClassName = kOverlayClassName;
@@ -439,11 +438,6 @@ void EnsureOverlayWindow() {
         WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_LAYERED | WS_EX_TRANSPARENT,
         kOverlayClassName, L"", WS_POPUP, 0, 0, kOverlayWidth, kOverlayHeight,
         nullptr, nullptr, GetCurrentModuleHandle(), nullptr);
-
-    if (g_hOverlayWnd) {
-        DWORD pref = DWMWCP_ROUND;
-        DwmSetWindowAttribute(g_hOverlayWnd, DWMWA_WINDOW_CORNER_PREFERENCE, &pref, sizeof(pref));
-    }
 }
 
 void ShowOverlay(HWND hTaskbar, int percent, POINT cursorPt, OverlayMode mode) {
@@ -459,7 +453,12 @@ void ShowOverlay(HWND hTaskbar, int percent, POINT cursorPt, OverlayMode mode) {
     g_targetPercent = percent;
     g_targetOpacity = 255.0f;
 
-    if (!hTaskbar || !IsWindow(hTaskbar)) hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
+    if (!hTaskbar || !IsWindow(hTaskbar)) return;
+    
+    DWORD procId = 0;
+    GetWindowThreadProcessId(hTaskbar, &procId);
+    if (procId != GetCurrentProcessId()) return;
+
     g_hTargetTaskbar = hTaskbar;
 
     if (g_currentMode != mode) {
@@ -879,9 +878,10 @@ HWND WINAPI CreateWindowInBand_Hook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWST
 // Monitor thread
 // -----------------------------------------------------------------------
 
-DWORD WINAPI MonitorThreadProc(LPVOID) {
+DWORD WINAPI MonitorThreadProc(LPVOID lpParam) {
     MSG msg;
     PeekMessage(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);  
+    if (lpParam) SetEvent((HANDLE)lpParam);
 
     HRESULT comInit = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
 
@@ -921,14 +921,18 @@ DWORD WINAPI MonitorThreadProc(LPVOID) {
 
                     if (percent >= 0 && g_workerThreadId) {
                         ScrollResult* res = new ScrollResult{percent, req->hMonitor, req->hTaskbar, req->cursorPt, OverlayMode::Brightness};
-                        PostThreadMessageW(g_workerThreadId, WM_APP_BRIGHTNESS_RESULT, 0, (LPARAM)res);
+                        if (!PostThreadMessageW(g_workerThreadId, WM_APP_BRIGHTNESS_RESULT, 0, (LPARAM)res)) {
+                            delete res;
+                        }
                     }
                 }
                 delete req;
 
                 DWORD currentThreadId = GetCurrentThreadId();
                 for (ScrollRequest* d : deferred) {
-                    PostThreadMessageW(currentThreadId, WM_APP_BRIGHTNESS_REQUEST, 0, (LPARAM)d);
+                    if (!PostThreadMessageW(currentThreadId, WM_APP_BRIGHTNESS_REQUEST, 0, (LPARAM)d)) {
+                        delete d;
+                    }
                 }
             }
             continue;
@@ -955,9 +959,10 @@ DWORD WINAPI MonitorThreadProc(LPVOID) {
 // UI / Audio thread
 // -----------------------------------------------------------------------
 
-DWORD WINAPI WorkerThreadProc(LPVOID) {
+DWORD WINAPI WorkerThreadProc(LPVOID lpParam) {
     MSG msg;
     PeekMessage(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+    if (lpParam) SetEvent((HANDLE)lpParam);
     
     HRESULT comInit = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
     IMMDeviceEnumerator* pEnum = nullptr;
@@ -1114,28 +1119,33 @@ BOOL Wh_ModInit() {
         if (pCreateWindowInBand) WindhawkUtils::SetFunctionHook(pCreateWindowInBand, CreateWindowInBand_Hook, &CreateWindowInBand_Original);
     }
 
-    g_hWorkerThread = CreateThread(nullptr, 0, WorkerThreadProc, nullptr, 0, &g_workerThreadId);
+    HANDLE hReadyEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+
+    g_hWorkerThread = CreateThread(nullptr, 0, WorkerThreadProc, hReadyEvent, 0, &g_workerThreadId);
     if (!g_hWorkerThread) {
+        CloseHandle(hReadyEvent);
         if (gdiStatus == Gdiplus::Ok) Gdiplus::GdiplusShutdown(g_gdiplusToken);
         DeleteCriticalSection(&g_settingsLock);
         return FALSE;
     }
+    WaitForSingleObject(hReadyEvent, INFINITE);
+    ResetEvent(hReadyEvent);
 
-    g_hMonitorThread = CreateThread(nullptr, 0, MonitorThreadProc, nullptr, 0, &g_monitorThreadId);
+    g_hMonitorThread = CreateThread(nullptr, 0, MonitorThreadProc, hReadyEvent, 0, &g_monitorThreadId);
     if (!g_hMonitorThread) {
         g_stopping = true;
-        if (g_workerThreadId) {
-            PostThreadMessageW(g_workerThreadId, WM_QUIT, 0, 0);
-        }
+        PostThreadMessageW(g_workerThreadId, WM_QUIT, 0, 0);
         WaitForSingleObject(g_hWorkerThread, INFINITE);
         CloseHandle(g_hWorkerThread);
         g_hWorkerThread = nullptr;
         g_workerThreadId = 0;
-        
+        CloseHandle(hReadyEvent);
         if (gdiStatus == Gdiplus::Ok) Gdiplus::GdiplusShutdown(g_gdiplusToken);
         DeleteCriticalSection(&g_settingsLock);
         return FALSE;
     }
+    WaitForSingleObject(hReadyEvent, INFINITE);
+    CloseHandle(hReadyEvent);
 
     g_initialized = true;
     return TRUE;

--- a/mods/taskbar-scroll-volume-brightness-control.wh.cpp
+++ b/mods/taskbar-scroll-volume-brightness-control.wh.cpp
@@ -2,7 +2,7 @@
 // @id            taskbar-scroll-volume-brightness-control
 // @name          Taskbar Scroll: Volume & Brightness Controller
 // @description   Scroll over the right side of the taskbar to change volume, scroll over the left side to change brightness. Uses a custom in-taskbar UI that tracks your cursor.
-// @version       1.1.2
+// @version       1.2.1
 // @author        Narayan Chetri
 // @github        https://github.com/NarayanChetri
 // @homepage      https://narayanchetri.dev
@@ -20,23 +20,21 @@
 Scroll your mouse wheel over the taskbar to control volume and brightness,
 without leaving what you're doing.
 
-- Scroll over the **right side** of the taskbar to change **volume**.
-- Scroll over the **left side** of the taskbar to change **brightness**
-  (works with external monitors over DDC/CI, and falls back to the WMI
-  brightness interface for laptop-internal panels that don't support DDC/CI).
+- Completely customizable zones (Left/Right, Top/Bottom).
 - A tiny, smooth in-taskbar overlay tracks your mouse cursor to show the 
-  current percentage, completely replacing the bulky native Windows UI.
+  current percentage, completely bypassing the bulky native Windows UI.
 - Works on both the primary and secondary taskbars, and with the modern
   Windows 11 taskbar (pointer/touchpad wheel events included).
-
-## Why this mod?
-While other mods offer separate volume or brightness control, this mod provides a unified experience out-of-the-box. It features a custom, DPI-aware GDI+ overlay that physically tracks your cursor across the taskbar and natively suppresses the bulky Windows OSD flyouts without conflicting with other UI elements. 
-*(Credit: The modern InputSite hooking scaffolding is derived from the Taskbar Scroll Actions mod by m417z).*
+- Brightness adjustment works with external monitors over DDC/CI, and 
+  falls back to the WMI brightness interface for laptop-internal panels. 
+  *(Note: The WMI fallback drives the internal panel regardless of which monitor's taskbar is scrolled).*
 
 ## Settings
 
-All of the zone split, scroll direction, display duration/color, step amounts,
+All of the zone layout, scroll direction, display duration/color, step amounts,
 and system-tray exclusion behavior can be customized from the mod's settings page.
+You can choose to disable either zone to allow scroll events to fall through 
+to other Windhawk mods (like Taskbar Wheel Cycle).
 
 ## Feedback
 
@@ -49,29 +47,38 @@ Issues and PRs welcome: https://github.com/NarayanChetri
 - splitPercent: 50
   $name: Split position (%)
   $description: >-
-    Percentage from the edge of the taskbar where the volume/brightness
-    zones split (top/bottom on a vertical taskbar).
-- invertSides: false
-  $name: Invert zones
-  $description: >-
-    When enabled, the left side of the taskbar controls volume and the
-    right side controls brightness (top/bottom on a vertical taskbar).
+    Percentage from the edge of the taskbar where the zones split (top/bottom on a vertical taskbar).
+- leftZoneAction: brightness
+  $name: Left/Top zone action
+  $description: Action to perform when scrolling over the left (or top) side.
+  $options:
+    - brightness: Brightness
+    - volume: Volume
+    - none: None (Do nothing, let OS or other mods handle it)
+- rightZoneAction: volume
+  $name: Right/Bottom zone action
+  $description: Action to perform when scrolling over the right (or bottom) side.
+  $options:
+    - brightness: Brightness
+    - volume: Volume
+    - none: None (Do nothing, let OS or other mods handle it)
 - reverseScrollDirection: false
   $name: Reverse scroll direction
   $description: >-
-    Scroll up to decrease and down to increase, useful if you use
-    "natural" scrolling.
+    Scroll up to decrease and down to increase, useful if you use "natural" scrolling.
 - volumeStep: 2
   $name: Volume step (%)
   $description: How much volume changes per scroll notch.
 - brightnessStep: 5
   $name: Brightness step (%)
   $description: How much brightness changes per scroll notch.
+- autoMuteToggle: true
+  $name: Automatic mute toggle
+  $description: Automatically mute when volume reaches 0%, and unmute when increased.
 - excludeSystemTray: true
   $name: Exclude system tray icons
   $description: >-
-    Ignore scroll events over the system tray/notification area (clock,
-    network, volume icon, etc.).
+    Ignore scroll events over the system tray/notification area (clock, network, volume icon, etc.).
 - showOverlay: true
   $name: Show overlay
   $description: Show a native-looking taskbar element with the current percentage.
@@ -84,8 +91,7 @@ Issues and PRs welcome: https://github.com/NarayanChetri
 - enableWmiFallback: true
   $name: Enable WMI brightness fallback
   $description: >-
-    For internal laptop displays that don't support DDC/CI, try adjusting
-    brightness through the WMI brightness interface instead.
+    For internal laptop displays that don't support DDC/CI, try adjusting brightness through WMI.
 */
 // ==/WindhawkModSettings==
 
@@ -119,6 +125,7 @@ Issues and PRs welcome: https://github.com/NarayanChetri
 // -----------------------------------------------------------------------
 std::atomic<bool> g_initialized{false};
 std::atomic<bool> g_stopping{false};
+std::atomic<bool> g_inputSiteProcHooked{false};
 bool g_classRegistered = false;
 
 // -----------------------------------------------------------------------
@@ -127,10 +134,12 @@ bool g_classRegistered = false;
 
 struct Settings {
     int splitPercent = 50;
-    bool invertSides = false;
+    std::wstring leftZoneAction = L"brightness";
+    std::wstring rightZoneAction = L"volume";
     bool reverseScrollDirection = false;
     int volumeStep = 2;
     int brightnessStep = 5;
+    bool autoMuteToggle = true;
     bool excludeSystemTray = true;
     bool showOverlay = true;
     int overlayDurationMs = 1000;
@@ -149,7 +158,11 @@ Settings GetSettingsSnapshot() {
 bool ParseHexColor(PCWSTR text, BYTE& r, BYTE& g, BYTE& b) {
     if (!text) return false;
     if (text[0] == L'#') text++;
+    
     if (wcslen(text) != 6) return false;
+    for (int i = 0; i < 6; i++) {
+        if (!iswxdigit(text[i])) return false;
+    }
     
     unsigned int ri = 0, gi = 0, bi = 0;
     if (swscanf_s(text, L"%2x%2x%2x", &ri, &gi, &bi) != 3) return false;
@@ -163,10 +176,12 @@ void LoadSettings() {
     Settings s;
 
     s.splitPercent = Wh_GetIntSetting(L"splitPercent");
-    s.invertSides = Wh_GetIntSetting(L"invertSides") != 0;
+    s.leftZoneAction = WindhawkUtils::StringSetting::make(L"leftZoneAction").get();
+    s.rightZoneAction = WindhawkUtils::StringSetting::make(L"rightZoneAction").get();
     s.reverseScrollDirection = Wh_GetIntSetting(L"reverseScrollDirection") != 0;
     s.volumeStep = Wh_GetIntSetting(L"volumeStep");
     s.brightnessStep = Wh_GetIntSetting(L"brightnessStep");
+    s.autoMuteToggle = Wh_GetIntSetting(L"autoMuteToggle") != 0;
     s.excludeSystemTray = Wh_GetIntSetting(L"excludeSystemTray") != 0;
     s.showOverlay = Wh_GetIntSetting(L"showOverlay") != 0;
     s.overlayDurationMs = Wh_GetIntSetting(L"overlayDurationMs");
@@ -203,10 +218,10 @@ HINSTANCE GetCurrentModuleHandle() {
 // Thread / message plumbing
 // -----------------------------------------------------------------------
 
-constexpr UINT WM_APP_BRIGHTNESS_REQUEST = WM_APP + 1;
-constexpr UINT WM_APP_BRIGHTNESS_RESULT  = WM_APP + 2;
-constexpr UINT WM_APP_VOLUME_REQUEST     = WM_APP + 4;
-constexpr UINT WM_APP_CLEAR_MONITOR_CACHE = WM_APP + 5;
+constexpr UINT WM_APP_BRIGHTNESS_REQUEST  = WM_APP + 1;
+constexpr UINT WM_APP_BRIGHTNESS_RESULT   = WM_APP + 2;
+constexpr UINT WM_APP_VOLUME_REQUEST      = WM_APP + 3;
+constexpr UINT WM_APP_CLEAR_MONITOR_CACHE = WM_APP + 4;
 
 enum class OverlayMode { Brightness, Volume };
 
@@ -220,7 +235,6 @@ struct ScrollRequest {
 
 struct ScrollResult {
     int percent;
-    HMONITOR hMonitor;
     HWND hTaskbar;
     POINT cursorPt;
     OverlayMode mode;
@@ -264,6 +278,22 @@ int g_currentY = 0;
 int g_targetX = 0;
 int g_targetY = 0;
 
+void ComputeOverlayPos(HWND hTaskbar, POINT pt, int scaledW, int scaledH, int& outX, int& outY) {
+    RECT tbRect;
+    if (!GetWindowRect(hTaskbar, &tbRect)) return;
+    bool isHorizontal = (tbRect.right - tbRect.left) > (tbRect.bottom - tbRect.top);
+    
+    if (isHorizontal) {
+        int maxRight = std::max((int)tbRect.left, (int)(tbRect.right - scaledW));
+        outX = std::clamp((int)(pt.x - (scaledW / 2)), (int)tbRect.left, maxRight);
+        outY = tbRect.top + ((tbRect.bottom - tbRect.top) - scaledH) / 2;
+    } else {
+        outX = tbRect.left + ((tbRect.right - tbRect.left) - scaledW) / 2;
+        int maxBottom = std::max((int)tbRect.top, (int)(tbRect.bottom - scaledH));
+        outY = std::clamp((int)(pt.y - (scaledH / 2)), (int)tbRect.top, maxBottom);
+    }
+}
+
 void RoundedRectPathF(Gdiplus::GraphicsPath& path, float x, float y, float w, float h, float radius) {
     path.Reset();
     float d = radius * 2.0f;
@@ -275,6 +305,8 @@ void RoundedRectPathF(Gdiplus::GraphicsPath& path, float x, float y, float w, fl
 }
 
 void PaintOverlay(HWND hWnd, HDC hdc) {
+    if (!g_gdiplusToken) return;
+
     RECT clientRc;
     GetClientRect(hWnd, &clientRc);
     int w = clientRc.right - clientRc.left;
@@ -292,10 +324,10 @@ void PaintOverlay(HWND hWnd, HDC hdc) {
 
     g.Clear(Gdiplus::Color(255, 28, 28, 30));
 
+    // Stack allocation of GDI+ objects avoids cleanup leaks without complicated caching.
     Gdiplus::Pen borderPen(Gdiplus::Color(255, 65, 65, 65), 1.0f);
     g.DrawRectangle(&borderPen, 0, 0, kOverlayWidth - 1, kOverlayHeight - 1);
 
-    Gdiplus::Color accent = settings.accentColor;
     Gdiplus::FontFamily fontFamily(L"Segoe UI");
     Gdiplus::Font labelFont(&fontFamily, 9.0f, Gdiplus::FontStyleRegular, Gdiplus::UnitPoint);
     Gdiplus::Font percentFont(&fontFamily, 9.5f, Gdiplus::FontStyleBold, Gdiplus::UnitPoint);
@@ -326,14 +358,14 @@ void PaintOverlay(HWND hWnd, HDC hdc) {
     float fillW = (barW * clamped) / 100.0f;
     if (fillW > 0.1f) {
         if (fillW < barH) fillW = barH;
-        Gdiplus::SolidBrush fillBrush(accent);
+        Gdiplus::SolidBrush fillBrush(settings.accentColor);
         RoundedRectPathF(path, barX, barY, fillW, barH, barH / 2.0f);
         g.FillPath(&fillBrush, &path);
     }
 
     Gdiplus::Graphics gScreen(hdc);
     gScreen.SetCompositingMode(Gdiplus::CompositingModeSourceCopy);
-    gScreen.DrawImage(&bmp, 0, 0);
+    gScreen.DrawImage(&bmp, Gdiplus::Rect(0, 0, w, h));
 }
 
 LRESULT CALLBACK OverlayWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
@@ -374,22 +406,20 @@ LRESULT CALLBACK OverlayWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPara
                 }
 
                 if (IsWindow(g_hTargetTaskbar)) {
-                    RECT tbRect;
-                    GetWindowRect(g_hTargetTaskbar, &tbRect);
-                    
-                    bool isHorizontal = (tbRect.right - tbRect.left) > (tbRect.bottom - tbRect.top);
-                    
-                    if (isHorizontal) {
-                        g_targetX = g_lastCursorPt.x - (g_scaledW / 2);
-                        int maxRight = std::max((int)tbRect.left, (int)(tbRect.right - g_scaledW));
-                        g_targetX = std::clamp((int)g_targetX, (int)tbRect.left, maxRight);
-                        g_targetY = tbRect.top + ((tbRect.bottom - tbRect.top) - g_scaledH) / 2;
-                    } else {
-                        g_targetX = tbRect.left + ((tbRect.right - tbRect.left) - g_scaledW) / 2;
-                        g_targetY = g_lastCursorPt.y - (g_scaledH / 2);
-                        int maxBottom = std::max((int)tbRect.top, (int)(tbRect.bottom - g_scaledH));
-                        g_targetY = std::clamp((int)g_targetY, (int)tbRect.top, maxBottom);
+                    // Update DPI scaling smoothly across monitors
+                    HMONITOR mon = MonitorFromWindow(g_hTargetTaskbar, MONITOR_DEFAULTTONEAREST);
+                    UINT dpiX = 96, dpiY = 96;
+                    if (SUCCEEDED(GetDpiForMonitor(mon, MDT_EFFECTIVE_DPI, &dpiX, &dpiY)) && dpiX > 0) {
+                        g_scale = dpiX / 96.0f;
+                        g_scaledW = std::max(1, (int)(kOverlayWidth * g_scale));
+                        g_scaledH = std::max(1, (int)(kOverlayHeight * g_scale));
                     }
+
+                    // Track cursor continuously
+                    POINT pt;
+                    if (GetCursorPos(&pt)) g_lastCursorPt = pt;
+
+                    ComputeOverlayPos(g_hTargetTaskbar, g_lastCursorPt, g_scaledW, g_scaledH, g_targetX, g_targetY);
 
                     if (g_currentX != g_targetX || g_currentY != g_targetY) {
                         int diffX = g_targetX - g_currentX;
@@ -400,7 +430,8 @@ LRESULT CALLBACK OverlayWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPara
                         g_currentX += stepX;
                         g_currentY += stepY;
                         
-                        SetWindowPos(hWnd, HWND_TOPMOST, g_currentX, g_currentY, 0, 0, SWP_NOSIZE | SWP_NOACTIVATE);
+                        // Per-frame translation does not need to reassert Z-order
+                        SetWindowPos(hWnd, nullptr, g_currentX, g_currentY, 0, 0, SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOZORDER);
                     }
                 }
 
@@ -423,7 +454,10 @@ void EnsureOverlayWindow() {
         wc.lpfnWndProc = OverlayWndProc;
         wc.hInstance = GetCurrentModuleHandle();
         wc.lpszClassName = kOverlayClassName;
-        if (!RegisterClassExW(&wc)) return;
+        if (!RegisterClassExW(&wc)) {
+            Wh_Log(L"Overlay class registration failed");
+            return;
+        }
         g_classRegistered = true;
     }
 
@@ -434,7 +468,7 @@ void EnsureOverlayWindow() {
 }
 
 void ShowOverlay(HWND hTaskbar, int percent, POINT cursorPt, OverlayMode mode) {
-    if (percent < 0) return;
+    if (percent < 0 || !g_gdiplusToken) return;
     if (!hTaskbar || !IsWindow(hTaskbar)) return;
     
     DWORD procId = 0;
@@ -452,24 +486,23 @@ void ShowOverlay(HWND hTaskbar, int percent, POINT cursorPt, OverlayMode mode) {
     g_targetOpacity = 255.0f;
     g_hTargetTaskbar = hTaskbar;
 
+    // Calculate monitor DPI / sizing scaling outside of the invisible branch
+    HMONITOR mon = MonitorFromWindow(g_hTargetTaskbar, MONITOR_DEFAULTTONEAREST);
+    UINT dpiX = 96, dpiY = 96;
+    if (SUCCEEDED(GetDpiForMonitor(mon, MDT_EFFECTIVE_DPI, &dpiX, &dpiY)) && dpiX > 0) {
+        g_scale = dpiX / 96.0f;
+        g_scaledW = std::max(1, (int)(kOverlayWidth * g_scale));
+        g_scaledH = std::max(1, (int)(kOverlayHeight * g_scale));
+    }
+    
+    ComputeOverlayPos(g_hTargetTaskbar, g_lastCursorPt, g_scaledW, g_scaledH, g_currentX, g_currentY);
+
     if (g_currentMode != mode) {
         g_currentMode = mode;
         g_animatedPercent = (float)percent;
         
         if (IsWindow(g_hTargetTaskbar)) {
-            RECT tbRect;
-            GetWindowRect(g_hTargetTaskbar, &tbRect);
-            bool isHorizontal = (tbRect.right - tbRect.left) > (tbRect.bottom - tbRect.top);
-            if (isHorizontal) {
-                int maxRight = std::max((int)tbRect.left, (int)(tbRect.right - g_scaledW));
-                g_currentX = std::clamp((int)(g_lastCursorPt.x - (g_scaledW / 2)), (int)tbRect.left, maxRight);
-                g_currentY = tbRect.top + ((tbRect.bottom - tbRect.top) - g_scaledH) / 2;
-            } else {
-                g_currentX = tbRect.left + ((tbRect.right - tbRect.left) - g_scaledW) / 2;
-                int maxBottom = std::max((int)tbRect.top, (int)(tbRect.bottom - g_scaledH));
-                g_currentY = std::clamp((int)(g_lastCursorPt.y - (g_scaledH / 2)), (int)tbRect.top, maxBottom);
-            }
-            SetWindowPos(g_hOverlayWnd, HWND_TOPMOST, g_currentX, g_currentY, 0, 0, SWP_NOSIZE | SWP_NOACTIVATE);
+            SetWindowPos(g_hOverlayWnd, HWND_TOPMOST, g_currentX, g_currentY, g_scaledW, g_scaledH, SWP_NOACTIVATE);
         }
         InvalidateRect(g_hOverlayWnd, nullptr, FALSE);
     }
@@ -480,28 +513,6 @@ void ShowOverlay(HWND hTaskbar, int percent, POINT cursorPt, OverlayMode mode) {
         if (g_animatedPercent < 0.0f) g_animatedPercent = (float)percent;
 
         if (IsWindow(g_hTargetTaskbar)) {
-            MONITORINFO mi = {sizeof(mi)};
-            HMONITOR mon = MonitorFromWindow(g_hTargetTaskbar, MONITOR_DEFAULTTONEAREST);
-            GetMonitorInfoW(mon, &mi);
-            
-            UINT dpiX = 96, dpiY = 96;
-            if (FAILED(GetDpiForMonitor(mon, MDT_EFFECTIVE_DPI, &dpiX, &dpiY)) || dpiX == 0) dpiX = 96;
-            g_scale = dpiX / 96.0f;
-            g_scaledW = std::max(1, (int)(kOverlayWidth * g_scale));
-            g_scaledH = std::max(1, (int)(kOverlayHeight * g_scale));
-
-            RECT tbRect;
-            GetWindowRect(g_hTargetTaskbar, &tbRect);
-            bool isHorizontal = (tbRect.right - tbRect.left) > (tbRect.bottom - tbRect.top);
-            if (isHorizontal) {
-                int maxRight = std::max((int)tbRect.left, (int)(tbRect.right - g_scaledW));
-                g_currentX = std::clamp((int)(g_lastCursorPt.x - (g_scaledW / 2)), (int)tbRect.left, maxRight);
-                g_currentY = tbRect.top + ((tbRect.bottom - tbRect.top) - g_scaledH) / 2;
-            } else {
-                g_currentX = tbRect.left + ((tbRect.right - tbRect.left) - g_scaledW) / 2;
-                int maxBottom = std::max((int)tbRect.top, (int)(tbRect.bottom - g_scaledH));
-                g_currentY = std::clamp((int)(g_lastCursorPt.y - (g_scaledH / 2)), (int)tbRect.top, maxBottom);
-            }
             SetWindowPos(g_hOverlayWnd, HWND_TOPMOST, g_currentX, g_currentY, g_scaledW, g_scaledH, SWP_NOACTIVATE);
         }
         ShowWindow(g_hOverlayWnd, SW_SHOWNOACTIVATE);
@@ -524,6 +535,7 @@ void InitWMI() {
     if (FAILED(g_pWmiLocator->ConnectServer(_bstr_t(L"ROOT\\WMI"), nullptr, nullptr, 0, 0, 0, 0, &g_pWmiServices)) || !g_pWmiServices) {
         g_pWmiLocator->Release();
         g_pWmiLocator = nullptr;
+        Wh_Log(L"WMI ConnectServer failed");
         return;
     }
     CoSetProxyBlanket(g_pWmiServices, RPC_C_AUTHN_WINNT, RPC_C_AUTHZ_NONE, nullptr, RPC_C_AUTHN_LEVEL_CALL, RPC_C_IMP_LEVEL_IMPERSONATE, nullptr, EOAC_NONE);
@@ -535,6 +547,7 @@ void CleanupWMI() {
 }
 
 int AdjustBrightnessWMI(bool up, int notches, int stepPercent) {
+    if (g_stopping) return -1;
     InitWMI();
     if (!g_pWmiServices) return -1;
 
@@ -578,19 +591,26 @@ int AdjustBrightnessWMI(bool up, int notches, int stepPercent) {
                 if (pInParamsDef) pInParamsDef->SpawnInstance(0, &pInParams);
 
                 if (pInParams) {
-                    VARIANT vtTimeout; VariantInit(&vtTimeout);
-                    vtTimeout.vt = VT_I4; vtTimeout.lVal = 1;
-                    pInParams->Put(L"Timeout", 0, &vtTimeout, 0);
+                    if (!g_stopping) {
+                        VARIANT vtTimeout; VariantInit(&vtTimeout);
+                        vtTimeout.vt = VT_I4; vtTimeout.lVal = 1;
+                        pInParams->Put(L"Timeout", 0, &vtTimeout, 0);
 
-                    VARIANT vtBrightness; VariantInit(&vtBrightness);
-                    vtBrightness.vt = VT_UI1; vtBrightness.bVal = (BYTE)newVal;
-                    pInParams->Put(L"Brightness", 0, &vtBrightness, 0);
+                        VARIANT vtBrightness; VariantInit(&vtBrightness);
+                        vtBrightness.vt = VT_UI1; vtBrightness.bVal = (BYTE)newVal;
+                        pInParams->Put(L"Brightness", 0, &vtBrightness, 0);
 
-                    hres = g_pWmiServices->ExecMethod(_bstr_t(objectPath.c_str()), _bstr_t(L"WmiSetBrightness"), 0, nullptr, pInParams, &pOutParams, nullptr);
-                    if (SUCCEEDED(hres)) resultPercent = newVal;
+                        hres = g_pWmiServices->ExecMethod(_bstr_t(objectPath.c_str()), _bstr_t(L"WmiSetBrightness"), 0, nullptr, pInParams, &pOutParams, nullptr);
+                        if (SUCCEEDED(hres)) {
+                            resultPercent = newVal;
+                            Wh_Log(L"Adjusted brightness via WMI successfully");
+                        } else {
+                            Wh_Log(L"WMI ExecMethod failed");
+                        }
 
-                    VariantClear(&vtTimeout);
-                    VariantClear(&vtBrightness);
+                        VariantClear(&vtTimeout);
+                        VariantClear(&vtBrightness);
+                    }
                 }
 
                 if (pOutParams) pOutParams->Release();
@@ -604,6 +624,8 @@ int AdjustBrightnessWMI(bool up, int notches, int stepPercent) {
             pObj->Release();
         }
         pEnumBrightness->Release();
+    } else {
+        Wh_Log(L"WMI ExecQuery failed");
     }
     return resultPercent;
 }
@@ -632,6 +654,7 @@ MonitorCacheEntry* GetOrOpenMonitorCache(HMONITOR hMonitor) {
             if (GetMonitorBrightness(entry.physicalMonitors[0].hPhysicalMonitor, &minB, &curB, &maxB)) {
                 entry.ddcSupported = true;
             } else {
+                Wh_Log(L"Monitor does not report DDC/CI brightness support (will fallback to WMI)");
                 entry.ddcSupported = false;
             }
         } else {
@@ -652,16 +675,16 @@ void CloseAllMonitorCaches() {
     g_monitorCache.clear();
 }
 
-int AdjustBrightnessDDC(HMONITOR hMonitor, bool up, int notches, int stepPercent, bool* outDdcSupported) {
+int AdjustBrightnessDDC(HMONITOR hMonitor, bool up, int notches, int stepPercent) {
     MonitorCacheEntry* entry = GetOrOpenMonitorCache(hMonitor);
-    *outDdcSupported = entry->ddcSupported;
-    if (!entry->ddcSupported) return -1;
+    if (!entry->ddcSupported || entry->physicalMonitors.empty()) return -1;
 
     int resultPercent = -1;
     bool anyFailure = false;
 
     for (auto& pm : entry->physicalMonitors) {
-        if (g_stopping) break;
+        if (g_stopping) return -1;
+        
         DWORD minB = 0, curB = 0, maxB = 0;
         if (GetMonitorBrightness(pm.hPhysicalMonitor, &minB, &curB, &maxB)) {
             int range = (maxB > minB) ? (int)(maxB - minB) : 100;
@@ -677,15 +700,21 @@ int AdjustBrightnessDDC(HMONITOR hMonitor, bool up, int notches, int stepPercent
                     resultPercent = range > 0 ? ((newVal - (int)minB) * 100) / range : 0;
                 }
             } else {
+                Wh_Log(L"SetMonitorBrightness failed during adjustment");
                 anyFailure = true;
             }
         } else {
+            Wh_Log(L"GetMonitorBrightness failed during adjustment");
             anyFailure = true;
         }
     }
 
     if (anyFailure && resultPercent < 0) {
         return -1;
+    }
+
+    if (resultPercent >= 0) {
+        Wh_Log(L"Adjusted brightness via DDC/CI successfully");
     }
 
     return resultPercent;
@@ -703,9 +732,14 @@ int AccumulateNotches(int& accumulator, short delta) {
 }
 
 bool HandleTaskbarScroll(HWND hTaskbar, POINT pt, short delta) {
-    Settings settings = GetSettingsSnapshot();
+    if (GetCapture() != nullptr) return false;
+
     RECT rc;
-    if (!GetWindowRect(hTaskbar, &rc)) return false;
+    if (!GetWindowRect(hTaskbar, &rc) || !PtInRect(&rc, pt)) {
+        return false;
+    }
+
+    Settings settings = GetSettingsSnapshot();
 
     if (settings.excludeSystemTray) {
         HWND hTrayNotify = FindWindowExW(hTaskbar, nullptr, L"TrayNotifyWnd", nullptr);
@@ -735,6 +769,20 @@ bool HandleTaskbarScroll(HWND hTaskbar, POINT pt, short delta) {
                 hasTrayRect = true;
             }
         }
+
+        // Fallback for custom shells or misidentified elements (approx 50px scaled padding)
+        if (!hasTrayRect) {
+            int fallbackWidth = (int)(50.0f * (GetDpiForWindow(hTaskbar) / 96.0f));
+            bool isHorizontal = (rc.right - rc.left) > (rc.bottom - rc.top);
+            if (isHorizontal) {
+                bool isRTL = GetWindowLongPtrW(hTaskbar, GWL_EXSTYLE) & WS_EX_LAYOUTRTL;
+                if (isRTL) trayRect = {rc.left, rc.top, rc.left + fallbackWidth, rc.bottom};
+                else trayRect = {rc.right - fallbackWidth, rc.top, rc.right, rc.bottom};
+            } else {
+                trayRect = {rc.left, rc.bottom - fallbackWidth, rc.right, rc.bottom};
+            }
+            hasTrayRect = true;
+        }
         
         if (hasTrayRect && PtInRect(&trayRect, pt)) {
             return false;
@@ -756,12 +804,19 @@ bool HandleTaskbarScroll(HWND hTaskbar, POINT pt, short delta) {
         rightSide = (pt.y - rc.top) >= splitY;
     }
 
-    if (settings.invertSides) rightSide = !rightSide;
+    std::wstring action = rightSide ? settings.rightZoneAction : settings.leftZoneAction;
+    
+    // Opt-out / None selected
+    if (action == L"none") {
+        return false;
+    }
 
-    static int s_volumeAccum = 0;
-    static int s_brightnessAccum = 0;
-    int notches = AccumulateNotches(rightSide ? s_volumeAccum : s_brightnessAccum, delta);
-    if (notches == 0) return true;
+    static int s_volAccum = 0;
+    static int s_brightAccum = 0;
+    int& accum = (action == L"volume") ? s_volAccum : s_brightAccum;
+    
+    int notches = AccumulateNotches(accum, delta);
+    if (notches == 0) return true; // Actively scrolling our zone, just waiting for full notch
 
     bool scrollUp = notches > 0;
     if (settings.reverseScrollDirection) scrollUp = !scrollUp;
@@ -769,21 +824,26 @@ bool HandleTaskbarScroll(HWND hTaskbar, POINT pt, short delta) {
 
     HMONITOR hMon = MonitorFromWindow(hTaskbar, MONITOR_DEFAULTTONEAREST);
 
-    if (rightSide) {
+    if (action == L"volume") {
         if (g_workerThreadId.load()) {
             ScrollRequest* req = new ScrollRequest{scrollUp, absNotches, hMon, hTaskbar, pt};
             if (!PostThreadMessageW(g_workerThreadId.load(), WM_APP_VOLUME_REQUEST, 0, (LPARAM)req)) delete req;
+            return true;
         }
-    } else if (g_monitorThreadId.load()) {
-        ScrollRequest* req = new ScrollRequest{scrollUp, absNotches, hMon, hTaskbar, pt};
-        if (!PostThreadMessageW(g_monitorThreadId.load(), WM_APP_BRIGHTNESS_REQUEST, 0, (LPARAM)req)) delete req;
+    } else if (action == L"brightness") {
+        if (g_monitorThreadId.load()) {
+            ScrollRequest* req = new ScrollRequest{scrollUp, absNotches, hMon, hTaskbar, pt};
+            if (!PostThreadMessageW(g_monitorThreadId.load(), WM_APP_BRIGHTNESS_REQUEST, 0, (LPARAM)req)) delete req;
+            return true;
+        }
     }
 
-    return true;
+    Wh_Log(L"Action triggered but no target thread found; passing event to OS");
+    return false; // Threads didn't load properly, let message pass
 }
 
 LRESULT CALLBACK TaskbarSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData) {
-    if (uMsg == WM_MOUSEWHEEL) {
+    if (uMsg == WM_MOUSEWHEEL && !g_inputSiteProcHooked.load()) {
         POINT pt = {GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
         short delta = GET_WHEEL_DELTA_WPARAM(wParam);
         if (HandleTaskbarScroll(hWnd, pt, delta)) return 0;
@@ -823,6 +883,8 @@ void HookInputSite(HWND hWnd) {
         if (g_initialized) {
             Wh_ApplyHookOperations();
         }
+        g_inputSiteProcHooked = true;
+        Wh_Log(L"InputSite hooked successfully, delegating Win11 PointerWheel events");
     }
 }
 
@@ -869,8 +931,8 @@ HWND WINAPI CreateWindowInBand_Hook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWST
 
 DWORD WINAPI MonitorThreadProc(LPVOID lpParam) {
     MSG msg;
-    PeekMessage(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);  
-    if (lpParam) SetEvent((HANDLE)lpParam);
+    PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+    g_monitorThreadId = GetCurrentThreadId();
 
     HRESULT comInit = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
 
@@ -901,15 +963,15 @@ DWORD WINAPI MonitorThreadProc(LPVOID lpParam) {
 
                 if (req->notches > 0) {
                     Settings settings = GetSettingsSnapshot();
-                    bool ddcSupported = false;
-                    int percent = AdjustBrightnessDDC(req->hMonitor, req->scrollUp, req->notches, settings.brightnessStep, &ddcSupported);
+                    int percent = AdjustBrightnessDDC(req->hMonitor, req->scrollUp, req->notches, settings.brightnessStep);
 
-                    if (!ddcSupported && settings.enableWmiFallback) {
+                    // Fallback triggered if DDC fails or is unsupported
+                    if (percent == -1 && settings.enableWmiFallback) {
                         percent = AdjustBrightnessWMI(req->scrollUp, req->notches, settings.brightnessStep);
                     }
 
                     if (percent >= 0 && g_workerThreadId.load()) {
-                        ScrollResult* res = new ScrollResult{percent, req->hMonitor, req->hTaskbar, req->cursorPt, OverlayMode::Brightness};
+                        ScrollResult* res = new ScrollResult{percent, req->hTaskbar, req->cursorPt, OverlayMode::Brightness};
                         if (!PostThreadMessageW(g_workerThreadId.load(), WM_APP_BRIGHTNESS_RESULT, 0, (LPARAM)res)) {
                             delete res;
                         }
@@ -950,8 +1012,8 @@ DWORD WINAPI MonitorThreadProc(LPVOID lpParam) {
 
 DWORD WINAPI WorkerThreadProc(LPVOID lpParam) {
     MSG msg;
-    PeekMessage(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
-    if (lpParam) SetEvent((HANDLE)lpParam);
+    PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+    g_workerThreadId = GetCurrentThreadId();
     
     HRESULT comInit = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
     IMMDeviceEnumerator* pEnum = nullptr;
@@ -998,15 +1060,21 @@ DWORD WINAPI WorkerThreadProc(LPVOID lpParam) {
                             
                             pVol->SetMasterVolumeLevelScalar(newVol, NULL);
                             
-                            BOOL isMuted = FALSE;
-                            pVol->GetMute(&isMuted);
-                            if (isMuted && newVol > 0.001f) pVol->SetMute(FALSE, NULL);
-                            if (!isMuted && newVol <= 0.001f) pVol->SetMute(TRUE, NULL);
+                            if (settings.autoMuteToggle) {
+                                BOOL isMuted = FALSE;
+                                pVol->GetMute(&isMuted);
+                                if (isMuted && newVol > 0.001f) pVol->SetMute(FALSE, NULL);
+                                if (!isMuted && newVol <= 0.001f) pVol->SetMute(TRUE, NULL);
+                            }
                             
                             percent = (int)(newVol * 100.0f + 0.5f);
                             pVol->Release();
+                        } else {
+                            Wh_Log(L"AudioEndpoint volume interface activate failed");
                         }
                         pDevice->Release();
+                    } else {
+                        Wh_Log(L"GetDefaultAudioEndpoint failed");
                     }
                 }
 
@@ -1083,36 +1151,21 @@ BOOL CALLBACK EnumWindowsUninitProc(HWND hWnd, LPARAM) {
 // Mod entry points
 // -----------------------------------------------------------------------
 
-void EnsureWorkersInitialized() {
-    static std::once_flag s_initFlag;
-    std::call_once(s_initFlag, []{
-        Gdiplus::GdiplusStartupInput gdiplusStartupInput;
-        Gdiplus::GdiplusStartup(&g_gdiplusToken, &gdiplusStartupInput, nullptr);
-
-        HANDLE hReadyEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
-        
-        DWORD wTid = 0, mTid = 0;
-        g_hWorkerThread = CreateThread(nullptr, 0, WorkerThreadProc, hReadyEvent, 0, &wTid);
-        if (g_hWorkerThread) {
-            WaitForSingleObject(hReadyEvent, INFINITE);
-            ResetEvent(hReadyEvent);
-            g_workerThreadId = wTid;
-        }
-
-        g_hMonitorThread = CreateThread(nullptr, 0, MonitorThreadProc, hReadyEvent, 0, &mTid);
-        if (g_hMonitorThread) {
-            WaitForSingleObject(hReadyEvent, INFINITE);
-            CloseHandle(hReadyEvent);
-            g_monitorThreadId = mTid;
-        } else {
-            CloseHandle(hReadyEvent);
-        }
-    });
-}
-
 void Wh_ModAfterInit() {
-    EnsureWorkersInitialized();
+    Gdiplus::GdiplusStartupInput gdiplusStartupInput;
+    if (Gdiplus::GdiplusStartup(&g_gdiplusToken, &gdiplusStartupInput, nullptr) != Gdiplus::Ok) {
+        Wh_Log(L"GdiplusStartup failed; overlay disabled");
+        g_gdiplusToken = 0;
+    }
+
+    g_hWorkerThread = CreateThread(nullptr, 0, WorkerThreadProc, nullptr, 0, nullptr);
+    if (!g_hWorkerThread) Wh_Log(L"Failed to create Worker Thread");
+    
+    g_hMonitorThread = CreateThread(nullptr, 0, MonitorThreadProc, nullptr, 0, nullptr);
+    if (!g_hMonitorThread) Wh_Log(L"Failed to create Monitor Thread");
+
     EnumWindows(EnumWindowsInitProc, 0);
+    Wh_Log(L"Taskbar Scroll Volume/Brightness Controller fully initialized.");
 }
 
 BOOL Wh_ModInit() {
@@ -1121,6 +1174,7 @@ BOOL Wh_ModInit() {
     LoadSettings();
 
     if (!WindhawkUtils::SetFunctionHook(CreateWindowExW, CreateWindowExW_Hook, &CreateWindowExW_Original)) {
+        Wh_Log(L"Hooking CreateWindowExW failed");
         return FALSE;
     }
 
@@ -1136,7 +1190,7 @@ BOOL Wh_ModInit() {
 
 void Wh_ModUninit() {
     g_initialized = false;
-    g_stopping = true;
+    g_stopping = true; // Signals DDC and WMI loops to abort quickly
     EnumWindows(EnumWindowsUninitProc, 0);
 
     if (g_monitorThreadId.load()) {
@@ -1166,6 +1220,7 @@ void Wh_ModUninit() {
 
     UnregisterClassW(kOverlayClassName, GetCurrentModuleHandle());
     g_classRegistered = false;
+    Wh_Log(L"Taskbar Scroll Volume/Brightness Controller safely uninitialized.");
 }
 
 void Wh_ModSettingsChanged() {

--- a/mods/taskbar-scroll-volume-brightness-control.wh.cpp
+++ b/mods/taskbar-scroll-volume-brightness-control.wh.cpp
@@ -1,0 +1,1149 @@
+// ==WindhawkMod==
+// @id            taskbar-scroll-volume-brightness-control
+// @name          Taskbar Scroll: Volume & Brightness Controller
+// @description   Scroll over the right side of the taskbar to change volume, scroll over the left side to change brightness. Uses a custom in-taskbar UI that tracks your cursor.
+// @version       1.0.9
+// @author        Narayan Chetri
+// @github        https://github.com/NarayanChetri
+// @homepage      https://narayanchetri.dev
+// @include       explorer.exe
+// @compilerOptions -ldxva2 -lgdi32 -lgdiplus -ldwmapi -lcomctl32 -lshcore -lole32 -loleaut32 -lwbemuuid
+// @license       GPL-3.0
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Taskbar Scroll: Volume & Brightness
+
+![Demo](https://raw.githubusercontent.com/NarayanChetri/Files/main/windhawk.gif)
+
+Scroll your mouse wheel over the taskbar to control volume and brightness,
+without leaving what you're doing.
+
+- Scroll over the **right side** of the taskbar to change **volume**.
+- Scroll over the **left side** of the taskbar to change **brightness**
+  (works with external monitors over DDC/CI, and falls back to the WMI
+  brightness interface for laptop-internal panels that don't support DDC/CI).
+- A tiny, smooth in-taskbar overlay tracks your mouse cursor to show the 
+  current percentage, completely replacing the bulky native Windows UI.
+- Works on both the primary and secondary taskbars, and with the modern
+  Windows 11 taskbar (pointer/touchpad wheel events included).
+
+## Why this mod?
+While other mods offer separate volume or brightness control, this mod provides a unified experience out-of-the-box. It features a custom, DPI-aware GDI+ overlay that physically tracks your cursor across the taskbar and natively suppresses the bulky Windows OSD flyouts without conflicting with other UI elements. 
+*(Credit: The modern InputSite hooking scaffolding is derived from the Taskbar Scroll Actions mod by m417z).*
+
+## Settings
+
+All of the zone split, scroll direction, display duration/color, step amounts,
+and system-tray exclusion behavior can be customized from the mod's settings page.
+
+## Feedback
+
+Issues and PRs welcome: https://github.com/NarayanChetri
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- splitPercent: 50
+  $name: Split position (%)
+  $description: >-
+    Percentage from the edge of the taskbar where the volume/brightness
+    zones split.
+- invertSides: false
+  $name: Invert zones
+  $description: >-
+    When enabled, the left side of the taskbar controls volume and the
+    right side controls brightness.
+- reverseScrollDirection: false
+  $name: Reverse scroll direction
+  $description: >-
+    Scroll up to decrease and down to increase, useful if you use
+    "natural" scrolling.
+- volumeStep: 2
+  $name: Volume step (%)
+  $description: How much volume changes per scroll notch.
+- brightnessStep: 5
+  $name: Brightness step (%)
+  $description: How much brightness changes per scroll notch.
+- excludeSystemTray: true
+  $name: Exclude system tray icons
+  $description: >-
+    Ignore scroll events over the system tray/notification area (clock,
+    network, volume icon, etc.).
+- showOverlay: true
+  $name: Show overlay
+  $description: Show a native-looking taskbar element with the current percentage.
+- overlayDurationMs: 1000
+  $name: Overlay display duration (ms)
+  $description: How long the overlay stays on screen before fading out.
+- accentColor: "FFBE5C"
+  $name: Overlay accent color (hex RRGGBB)
+  $description: Color of the progress bar and percentage text accent.
+- enableWmiFallback: true
+  $name: Enable WMI brightness fallback
+  $description: >-
+    For internal laptop displays that don't support DDC/CI, try adjusting
+    brightness through the WMI brightness interface instead.
+*/
+// ==/WindhawkModSettings==
+
+#define NOMINMAX
+#include <windows.h>
+#include <windowsx.h>
+#include <shellscalingapi.h>
+#include <physicalmonitorenumerationapi.h>
+#include <highlevelmonitorconfigurationapi.h>
+#include <gdiplus.h>
+#include <dwmapi.h>
+#include <wbemidl.h>
+#include <comdef.h>
+#include <mmdeviceapi.h>
+#include <endpointvolume.h>
+#include <vector>
+#include <unordered_map>
+#include <cmath>
+#include <cwchar>
+#include <algorithm>
+#include <atomic>
+#include <windhawk_utils.h>
+
+#ifndef DWMWA_WINDOW_CORNER_PREFERENCE
+#define DWMWA_WINDOW_CORNER_PREFERENCE 33
+#endif
+#ifndef DWMWCP_ROUND
+#define DWMWCP_ROUND 2
+#endif
+#ifndef WM_POINTERWHEEL
+#define WM_POINTERWHEEL 0x024E
+#endif
+
+// -----------------------------------------------------------------------
+// Globals
+// -----------------------------------------------------------------------
+std::atomic<bool> g_initialized{false};
+std::atomic<bool> g_stopping{false};
+bool g_classRegistered = false;
+
+// -----------------------------------------------------------------------
+// Settings
+// -----------------------------------------------------------------------
+
+struct Settings {
+    int splitPercent = 50;
+    bool invertSides = false;
+    bool reverseScrollDirection = false;
+    int volumeStep = 2;
+    int brightnessStep = 5;
+    bool excludeSystemTray = true;
+    bool showOverlay = true;
+    int overlayDurationMs = 1000;
+    Gdiplus::Color accentColor{255, 255, 190, 92};
+    bool enableWmiFallback = true;
+};
+
+CRITICAL_SECTION g_settingsLock;
+Settings g_settings;
+
+Settings GetSettingsSnapshot() {
+    EnterCriticalSection(&g_settingsLock);
+    Settings copy = g_settings;
+    LeaveCriticalSection(&g_settingsLock);
+    return copy;
+}
+
+bool ParseHexColor(PCWSTR text, BYTE& r, BYTE& g, BYTE& b) {
+    if (!text) return false;
+    if (text[0] == L'#') text++;
+    unsigned int ri = 0, gi = 0, bi = 0;
+    if (swscanf_s(text, L"%2x%2x%2x", &ri, &gi, &bi) != 3) return false;
+    r = (BYTE)ri;
+    g = (BYTE)gi;
+    b = (BYTE)bi;
+    return true;
+}
+
+void LoadSettings() {
+    Settings s;
+
+    s.splitPercent = Wh_GetIntSetting(L"splitPercent");
+    s.invertSides = Wh_GetIntSetting(L"invertSides") != 0;
+    s.reverseScrollDirection = Wh_GetIntSetting(L"reverseScrollDirection") != 0;
+    s.volumeStep = Wh_GetIntSetting(L"volumeStep");
+    s.brightnessStep = Wh_GetIntSetting(L"brightnessStep");
+    s.excludeSystemTray = Wh_GetIntSetting(L"excludeSystemTray") != 0;
+    s.showOverlay = Wh_GetIntSetting(L"showOverlay") != 0;
+    s.overlayDurationMs = Wh_GetIntSetting(L"overlayDurationMs");
+    s.enableWmiFallback = Wh_GetIntSetting(L"enableWmiFallback") != 0;
+
+    s.accentColor = Gdiplus::Color(255, 255, 190, 92);
+    WindhawkUtils::StringSetting accentColorStr = WindhawkUtils::StringSetting::make(L"accentColor");
+    BYTE r, g, b;
+    if (ParseHexColor(accentColorStr.get(), r, g, b)) {
+        s.accentColor = Gdiplus::Color(255, r, g, b);
+    }
+
+    if (s.splitPercent < 0) s.splitPercent = 0;
+    if (s.splitPercent > 100) s.splitPercent = 100;
+    if (s.volumeStep < 1) s.volumeStep = 1;
+    if (s.volumeStep > 100) s.volumeStep = 100;
+    if (s.brightnessStep < 1) s.brightnessStep = 1;
+    if (s.brightnessStep > 100) s.brightnessStep = 100;
+    if (s.overlayDurationMs < 200) s.overlayDurationMs = 200;
+    if (s.overlayDurationMs > 5000) s.overlayDurationMs = 5000;
+
+    EnterCriticalSection(&g_settingsLock);
+    g_settings = s;
+    LeaveCriticalSection(&g_settingsLock);
+}
+
+HINSTANCE GetCurrentModuleHandle() {
+    HINSTANCE hInst = nullptr;
+    GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                       (LPCWSTR)&GetCurrentModuleHandle, &hInst);
+    return hInst;
+}
+
+// -----------------------------------------------------------------------
+// Thread / message plumbing
+// -----------------------------------------------------------------------
+
+constexpr UINT WM_APP_BRIGHTNESS_REQUEST = WM_APP + 1;
+constexpr UINT WM_APP_BRIGHTNESS_RESULT  = WM_APP + 2;
+constexpr UINT WM_APP_VOLUME_REQUEST     = WM_APP + 4;
+constexpr UINT WM_APP_CLEAR_MONITOR_CACHE = WM_APP + 5;
+
+enum class OverlayMode { Brightness, Volume };
+
+struct ScrollRequest {
+    bool scrollUp;
+    int notches;
+    HMONITOR hMonitor;
+    HWND hTaskbar;
+    POINT cursorPt;
+};
+
+struct ScrollResult {
+    int percent;
+    HMONITOR hMonitor;
+    HWND hTaskbar;
+    POINT cursorPt;
+    OverlayMode mode;
+};
+
+HANDLE g_hWorkerThread = nullptr;
+DWORD g_workerThreadId = 0;
+
+HANDLE g_hMonitorThread = nullptr;
+DWORD g_monitorThreadId = 0;
+
+ULONG_PTR g_gdiplusToken = 0;
+
+// -----------------------------------------------------------------------
+// Overlay window
+// -----------------------------------------------------------------------
+
+constexpr wchar_t kOverlayClassName[] = L"WindhawkTaskbarScrollOverlay";
+constexpr UINT_PTR kOverlayHideTimerId = 1;
+constexpr UINT_PTR kFrameTimerId = 2;
+constexpr int kOverlayWidth = 160;   
+constexpr int kOverlayHeight = 34;
+
+HWND g_hOverlayWnd = nullptr;
+
+// Animation & Tracking state 
+float g_animatedPercent = -1.0f;
+int g_targetPercent = 0;
+bool g_isHiding = false;
+float g_opacity = 0.0f;
+float g_targetOpacity = 255.0f;
+HWND g_hTargetTaskbar = nullptr;
+OverlayMode g_currentMode = OverlayMode::Brightness;
+
+float g_scale = 1.0f;
+int g_scaledW = 160;
+int g_scaledH = 34;
+POINT g_lastCursorPt = {0, 0};
+
+int g_currentX = 0;
+int g_currentY = 0;
+int g_targetX = 0;
+int g_targetY = 0;
+
+void RoundedRectPathF(Gdiplus::GraphicsPath& path, float x, float y, float w, float h, float radius) {
+    path.Reset();
+    float d = radius * 2.0f;
+    path.AddArc(x, y, d, d, 180.0f, 90.0f);
+    path.AddArc(x + w - d, y, d, d, 270.0f, 90.0f);
+    path.AddArc(x + w - d, y + h - d, d, d, 0.0f, 90.0f);
+    path.AddArc(x, y + h - d, d, d, 90.0f, 90.0f);
+    path.CloseFigure();
+}
+
+void PaintOverlay(HWND hWnd, HDC hdc) {
+    RECT clientRc;
+    GetClientRect(hWnd, &clientRc);
+    int w = clientRc.right - clientRc.left;
+    int h = clientRc.bottom - clientRc.top;
+    if (w <= 0 || h <= 0) return;
+
+    Settings settings = GetSettingsSnapshot();
+    float scale = w / (float)kOverlayWidth;
+
+    Gdiplus::Bitmap bmp(w, h, PixelFormat32bppARGB);
+    Gdiplus::Graphics g(&bmp);
+    g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
+    g.SetTextRenderingHint(Gdiplus::TextRenderingHintAntiAliasGridFit);
+    g.ScaleTransform(scale, scale);
+
+    g.Clear(Gdiplus::Color(255, 28, 28, 30));
+
+    Gdiplus::Pen borderPen(Gdiplus::Color(255, 65, 65, 65), 1.0f);
+    g.DrawRectangle(&borderPen, 0, 0, kOverlayWidth - 1, kOverlayHeight - 1);
+
+    Gdiplus::Color accent = settings.accentColor;
+    Gdiplus::FontFamily fontFamily(L"Segoe UI");
+    Gdiplus::Font labelFont(&fontFamily, 9.0f, Gdiplus::FontStyleRegular, Gdiplus::UnitPoint);
+    Gdiplus::Font percentFont(&fontFamily, 9.5f, Gdiplus::FontStyleBold, Gdiplus::UnitPoint);
+    Gdiplus::SolidBrush labelBrush(Gdiplus::Color(255, 170, 170, 175));
+    Gdiplus::SolidBrush textBrush(Gdiplus::Color(255, 245, 245, 245));
+
+    float clamped = g_animatedPercent < 0.0f ? 0.0f : (g_animatedPercent > 100.0f ? 100.0f : g_animatedPercent);
+    const int pad = 12;
+
+    Gdiplus::RectF headerRect((float)pad, 4.0f, (float)(kOverlayWidth - pad * 2), 16.0f);
+    Gdiplus::StringFormat leftFormat;
+    leftFormat.SetAlignment(Gdiplus::StringAlignmentNear);
+    g.DrawString(g_currentMode == OverlayMode::Brightness ? L"Brightness" : L"Volume", -1, &labelFont, headerRect, &leftFormat, &labelBrush);
+
+    Gdiplus::StringFormat rightFormat;
+    rightFormat.SetAlignment(Gdiplus::StringAlignmentFar);
+    wchar_t percentText[8];
+    swprintf_s(percentText, L"%d%%", (int)(clamped + 0.5f));
+    g.DrawString(percentText, -1, &percentFont, headerRect, &rightFormat, &textBrush);
+
+    float barX = (float)pad, barY = kOverlayHeight - 11.0f, barW = kOverlayWidth - pad * 2.0f, barH = 5.0f;
+
+    Gdiplus::GraphicsPath path;
+    Gdiplus::SolidBrush trackBrush(Gdiplus::Color(255, 58, 58, 60));
+    RoundedRectPathF(path, barX, barY, barW, barH, barH / 2.0f);
+    g.FillPath(&trackBrush, &path);
+
+    float fillW = (barW * clamped) / 100.0f;
+    if (fillW > 0.1f) {
+        if (fillW < barH) fillW = barH;
+        Gdiplus::SolidBrush fillBrush(accent);
+        RoundedRectPathF(path, barX, barY, fillW, barH, barH / 2.0f);
+        g.FillPath(&fillBrush, &path);
+    }
+
+    Gdiplus::Graphics gScreen(hdc);
+    gScreen.SetCompositingMode(Gdiplus::CompositingModeSourceCopy);
+    gScreen.DrawImage(&bmp, 0, 0);
+}
+
+LRESULT CALLBACK OverlayWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+    switch (msg) {
+        case WM_PAINT: {
+            PAINTSTRUCT ps;
+            HDC hdc = BeginPaint(hWnd, &ps);
+            PaintOverlay(hWnd, hdc);
+            EndPaint(hWnd, &ps);
+            return 0;
+        }
+        case WM_TIMER:
+            if (wParam == kOverlayHideTimerId) {
+                KillTimer(hWnd, kOverlayHideTimerId);
+                g_isHiding = true;
+                g_targetOpacity = 0.0f;
+            } else if (wParam == kFrameTimerId) {
+                bool changed = false;
+
+                if (std::abs(g_animatedPercent - (float)g_targetPercent) > 0.1f) {
+                    g_animatedPercent += ((float)g_targetPercent - g_animatedPercent) * 0.15f;
+                    changed = true;
+                } else if (g_animatedPercent != (float)g_targetPercent) {
+                    g_animatedPercent = (float)g_targetPercent;
+                    changed = true;
+                }
+
+                if (std::abs(g_opacity - g_targetOpacity) > 1.0f) {
+                    g_opacity += (g_targetOpacity - g_opacity) * 0.15f; 
+                    SetLayeredWindowAttributes(hWnd, 0, (BYTE)g_opacity, LWA_ALPHA);
+                } else if (g_opacity != g_targetOpacity) {
+                    g_opacity = g_targetOpacity;
+                    SetLayeredWindowAttributes(hWnd, 0, (BYTE)g_opacity, LWA_ALPHA);
+                    if (g_opacity <= 0.0f) {
+                        ShowWindow(hWnd, SW_HIDE);
+                        KillTimer(hWnd, kFrameTimerId);
+                        g_animatedPercent = -1.0f;
+                    }
+                }
+
+                if (IsWindow(g_hTargetTaskbar)) {
+                    RECT tbRect;
+                    GetWindowRect(g_hTargetTaskbar, &tbRect);
+                    
+                    bool isHorizontal = (tbRect.right - tbRect.left) > (tbRect.bottom - tbRect.top);
+                    
+                    if (isHorizontal) {
+                        g_targetX = g_lastCursorPt.x - (g_scaledW / 2);
+                        int maxRight = std::max((int)tbRect.left, (int)(tbRect.right - g_scaledW));
+                        g_targetX = std::clamp((int)g_targetX, (int)tbRect.left, maxRight);
+                        g_targetY = tbRect.top + ((tbRect.bottom - tbRect.top) - g_scaledH) / 2;
+                    } else {
+                        g_targetX = tbRect.left + ((tbRect.right - tbRect.left) - g_scaledW) / 2;
+                        g_targetY = g_lastCursorPt.y - (g_scaledH / 2);
+                        int maxBottom = std::max((int)tbRect.top, (int)(tbRect.bottom - g_scaledH));
+                        g_targetY = std::clamp((int)g_targetY, (int)tbRect.top, maxBottom);
+                    }
+
+                    if (g_currentX != g_targetX || g_currentY != g_targetY) {
+                        int diffX = g_targetX - g_currentX;
+                        int diffY = g_targetY - g_currentY;
+                        int stepX = diffX == 0 ? 0 : (diffX > 0 ? std::max(1, (int)(diffX * 0.25f)) : std::min(-1, (int)(diffX * 0.25f)));
+                        int stepY = diffY == 0 ? 0 : (diffY > 0 ? std::max(1, (int)(diffY * 0.25f)) : std::min(-1, (int)(diffY * 0.25f)));
+                        
+                        g_currentX += stepX;
+                        g_currentY += stepY;
+                        
+                        SetWindowPos(hWnd, nullptr, g_currentX, g_currentY, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+                    }
+                }
+
+                if (changed) InvalidateRect(hWnd, nullptr, FALSE);
+            }
+            return 0;
+        case WM_NCHITTEST:
+            return HTTRANSPARENT;
+        case WM_DESTROY:
+            return 0;
+    }
+    return DefWindowProcW(hWnd, msg, wParam, lParam);
+}
+
+void EnsureOverlayWindow() {
+    if (g_hOverlayWnd) return;
+
+    if (!g_classRegistered) {
+        WNDCLASSEXW wc = {sizeof(wc)};
+        wc.style = CS_DROPSHADOW;
+        wc.lpfnWndProc = OverlayWndProc;
+        wc.hInstance = GetCurrentModuleHandle();
+        wc.lpszClassName = kOverlayClassName;
+        if (!RegisterClassExW(&wc)) return;
+        g_classRegistered = true;
+    }
+
+    g_hOverlayWnd = CreateWindowExW(
+        WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_LAYERED | WS_EX_TRANSPARENT,
+        kOverlayClassName, L"", WS_POPUP, 0, 0, kOverlayWidth, kOverlayHeight,
+        nullptr, nullptr, GetCurrentModuleHandle(), nullptr);
+
+    if (g_hOverlayWnd) {
+        DWORD pref = DWMWCP_ROUND;
+        DwmSetWindowAttribute(g_hOverlayWnd, DWMWA_WINDOW_CORNER_PREFERENCE, &pref, sizeof(pref));
+    }
+}
+
+void ShowOverlay(HWND hTaskbar, int percent, POINT cursorPt, OverlayMode mode) {
+    if (percent < 0) return;
+
+    Settings settings = GetSettingsSnapshot();
+    if (!settings.showOverlay) return;
+
+    EnsureOverlayWindow();
+    if (!g_hOverlayWnd) return;
+
+    g_lastCursorPt = cursorPt;
+    g_targetPercent = percent;
+    g_targetOpacity = 255.0f;
+    g_isHiding = false;
+
+    if (!hTaskbar || !IsWindow(hTaskbar)) hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
+    g_hTargetTaskbar = hTaskbar;
+
+    if (g_currentMode != mode) {
+        g_currentMode = mode;
+        g_animatedPercent = (float)percent;
+        
+        if (IsWindow(g_hTargetTaskbar)) {
+            RECT tbRect;
+            GetWindowRect(g_hTargetTaskbar, &tbRect);
+            bool isHorizontal = (tbRect.right - tbRect.left) > (tbRect.bottom - tbRect.top);
+            if (isHorizontal) {
+                int maxRight = std::max((int)tbRect.left, (int)(tbRect.right - g_scaledW));
+                g_currentX = std::clamp((int)(g_lastCursorPt.x - (g_scaledW / 2)), (int)tbRect.left, maxRight);
+                g_currentY = tbRect.top + ((tbRect.bottom - tbRect.top) - g_scaledH) / 2;
+            } else {
+                g_currentX = tbRect.left + ((tbRect.right - tbRect.left) - g_scaledW) / 2;
+                int maxBottom = std::max((int)tbRect.top, (int)(tbRect.bottom - g_scaledH));
+                g_currentY = std::clamp((int)(g_lastCursorPt.y - (g_scaledH / 2)), (int)tbRect.top, maxBottom);
+            }
+            SetWindowPos(g_hOverlayWnd, nullptr, g_currentX, g_currentY, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+        }
+        InvalidateRect(g_hOverlayWnd, nullptr, FALSE);
+    }
+
+    if (!IsWindowVisible(g_hOverlayWnd)) {
+        g_opacity = 0.0f;
+        SetLayeredWindowAttributes(g_hOverlayWnd, 0, 0, LWA_ALPHA);
+        if (g_animatedPercent < 0.0f) g_animatedPercent = (float)percent;
+
+        if (IsWindow(g_hTargetTaskbar)) {
+            MONITORINFO mi = {sizeof(mi)};
+            HMONITOR mon = MonitorFromWindow(g_hTargetTaskbar, MONITOR_DEFAULTTONEAREST);
+            GetMonitorInfoW(mon, &mi);
+            
+            UINT dpiX = 96, dpiY = 96;
+            if (FAILED(GetDpiForMonitor(mon, MDT_EFFECTIVE_DPI, &dpiX, &dpiY)) || dpiX == 0) dpiX = 96;
+            g_scale = dpiX / 96.0f;
+            g_scaledW = std::max(1, (int)(kOverlayWidth * g_scale));
+            g_scaledH = std::max(1, (int)(kOverlayHeight * g_scale));
+
+            RECT tbRect;
+            GetWindowRect(g_hTargetTaskbar, &tbRect);
+            bool isHorizontal = (tbRect.right - tbRect.left) > (tbRect.bottom - tbRect.top);
+            if (isHorizontal) {
+                int maxRight = std::max((int)tbRect.left, (int)(tbRect.right - g_scaledW));
+                g_currentX = std::clamp((int)(g_lastCursorPt.x - (g_scaledW / 2)), (int)tbRect.left, maxRight);
+                g_currentY = tbRect.top + ((tbRect.bottom - tbRect.top) - g_scaledH) / 2;
+            } else {
+                g_currentX = tbRect.left + ((tbRect.right - tbRect.left) - g_scaledW) / 2;
+                int maxBottom = std::max((int)tbRect.top, (int)(tbRect.bottom - g_scaledH));
+                g_currentY = std::clamp((int)(g_lastCursorPt.y - (g_scaledH / 2)), (int)tbRect.top, maxBottom);
+            }
+            SetWindowPos(g_hOverlayWnd, HWND_TOPMOST, g_currentX, g_currentY, g_scaledW, g_scaledH, SWP_NOACTIVATE);
+        }
+        ShowWindow(g_hOverlayWnd, SW_SHOWNOACTIVATE);
+    }
+
+    SetTimer(g_hOverlayWnd, kOverlayHideTimerId, (UINT)settings.overlayDurationMs, nullptr);
+    SetTimer(g_hOverlayWnd, kFrameTimerId, 16, nullptr);
+}
+
+// -----------------------------------------------------------------------
+// WMI brightness fallback
+// -----------------------------------------------------------------------
+
+IWbemLocator* g_pWmiLocator = nullptr;
+IWbemServices* g_pWmiServices = nullptr;
+
+void InitWMI() {
+    if (g_pWmiLocator) return;
+    if (FAILED(CoCreateInstance(CLSID_WbemLocator, 0, CLSCTX_INPROC_SERVER, IID_IWbemLocator, (LPVOID*)&g_pWmiLocator)) || !g_pWmiLocator) return;
+    if (FAILED(g_pWmiLocator->ConnectServer(_bstr_t(L"ROOT\\WMI"), nullptr, nullptr, 0, 0, 0, 0, &g_pWmiServices)) || !g_pWmiServices) {
+        g_pWmiLocator->Release();
+        g_pWmiLocator = nullptr;
+        return;
+    }
+    CoSetProxyBlanket(g_pWmiServices, RPC_C_AUTHN_WINNT, RPC_C_AUTHZ_NONE, nullptr, RPC_C_AUTHN_LEVEL_CALL, RPC_C_IMP_LEVEL_IMPERSONATE, nullptr, EOAC_NONE);
+}
+
+void CleanupWMI() {
+    if (g_pWmiServices) { g_pWmiServices->Release(); g_pWmiServices = nullptr; }
+    if (g_pWmiLocator) { g_pWmiLocator->Release(); g_pWmiLocator = nullptr; }
+}
+
+int AdjustBrightnessWMI(bool up, int notches, int stepPercent) {
+    InitWMI();
+    if (!g_pWmiServices) return -1;
+
+    int resultPercent = -1;
+    IEnumWbemClassObject* pEnumBrightness = nullptr;
+    HRESULT hres = g_pWmiServices->ExecQuery(_bstr_t(L"WQL"), _bstr_t(L"SELECT * FROM WmiMonitorBrightness"), WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY, nullptr, &pEnumBrightness);
+
+    if (SUCCEEDED(hres) && pEnumBrightness) {
+        IWbemClassObject* pObj = nullptr;
+        ULONG uReturned = 0;
+        if (pEnumBrightness->Next(WBEM_INFINITE, 1, &pObj, &uReturned) == S_OK && uReturned > 0) {
+            VARIANT vtCurrent; VariantInit(&vtCurrent);
+            VARIANT vtInstanceName; VariantInit(&vtInstanceName);
+
+            if (SUCCEEDED(pObj->Get(L"CurrentBrightness", 0, &vtCurrent, nullptr, nullptr)) &&
+                SUCCEEDED(pObj->Get(L"InstanceName", 0, &vtInstanceName, nullptr, nullptr)) &&
+                vtInstanceName.vt == VT_BSTR) {
+                
+                int current = 50;
+                if (vtCurrent.vt == VT_UI1) current = vtCurrent.bVal;
+                else if (vtCurrent.vt == VT_I4) current = vtCurrent.lVal;
+                else if (vtCurrent.vt == VT_UI4) current = (int)vtCurrent.ulVal;
+
+                int step = stepPercent;
+                if (step < 1) step = 1;
+                int newVal = current + (up ? step * notches : -step * notches);
+                if (newVal < 0) newVal = 0;
+                if (newVal > 100) newVal = 100;
+
+                std::wstring objectPath = L"WmiMonitorBrightnessMethods.InstanceName='";
+                objectPath += vtInstanceName.bstrVal;
+                objectPath += L"'";
+
+                IWbemClassObject* pClass = nullptr;
+                IWbemClassObject* pInParamsDef = nullptr;
+                IWbemClassObject* pInParams = nullptr;
+                IWbemClassObject* pOutParams = nullptr;
+
+                g_pWmiServices->GetObject(_bstr_t(L"WmiMonitorBrightnessMethods"), 0, nullptr, &pClass, nullptr);
+                if (pClass) pClass->GetMethod(L"WmiSetBrightness", 0, &pInParamsDef, nullptr);
+                if (pInParamsDef) pInParamsDef->SpawnInstance(0, &pInParams);
+
+                if (pInParams) {
+                    VARIANT vtTimeout; VariantInit(&vtTimeout);
+                    vtTimeout.vt = VT_I4; vtTimeout.lVal = 1;
+                    pInParams->Put(L"Timeout", 0, &vtTimeout, 0);
+
+                    VARIANT vtBrightness; VariantInit(&vtBrightness);
+                    vtBrightness.vt = VT_UI1; vtBrightness.bVal = (BYTE)newVal;
+                    pInParams->Put(L"Brightness", 0, &vtBrightness, 0);
+
+                    hres = g_pWmiServices->ExecMethod(_bstr_t(objectPath.c_str()), _bstr_t(L"WmiSetBrightness"), 0, nullptr, pInParams, &pOutParams, nullptr);
+                    if (SUCCEEDED(hres)) resultPercent = newVal;
+
+                    VariantClear(&vtTimeout);
+                    VariantClear(&vtBrightness);
+                }
+
+                if (pOutParams) pOutParams->Release();
+                if (pInParams) pInParams->Release();
+                if (pInParamsDef) pInParamsDef->Release();
+                if (pClass) pClass->Release();
+            }
+
+            VariantClear(&vtCurrent);
+            VariantClear(&vtInstanceName);
+            pObj->Release();
+        }
+        pEnumBrightness->Release();
+    }
+    return resultPercent;
+}
+
+// -----------------------------------------------------------------------
+// DDC/CI brightness
+// -----------------------------------------------------------------------
+
+struct MonitorCacheEntry {
+    std::vector<PHYSICAL_MONITOR> physicalMonitors;
+    bool ddcSupported = false;
+};
+
+std::unordered_map<HMONITOR, MonitorCacheEntry> g_monitorCache;
+
+MonitorCacheEntry* GetOrOpenMonitorCache(HMONITOR hMonitor) {
+    auto it = g_monitorCache.find(hMonitor);
+    if (it != g_monitorCache.end()) return &it->second;
+
+    MonitorCacheEntry entry;
+    DWORD numPhysical = 0;
+    if (GetNumberOfPhysicalMonitorsFromHMONITOR(hMonitor, &numPhysical) && numPhysical > 0) {
+        entry.physicalMonitors.resize(numPhysical);
+        if (GetPhysicalMonitorsFromHMONITOR(hMonitor, numPhysical, entry.physicalMonitors.data())) {
+            DWORD minB = 0, curB = 0, maxB = 0;
+            if (GetMonitorBrightness(entry.physicalMonitors[0].hPhysicalMonitor, &minB, &curB, &maxB)) {
+                entry.ddcSupported = true;
+            } else {
+                entry.ddcSupported = false;
+            }
+        } else {
+            entry.physicalMonitors.clear();
+        }
+    }
+
+    auto inserted = g_monitorCache.emplace(hMonitor, std::move(entry));
+    return &inserted.first->second;
+}
+
+void CloseAllMonitorCaches() {
+    for (auto& [hMonitor, entry] : g_monitorCache) {
+        if (!entry.physicalMonitors.empty()) {
+            DestroyPhysicalMonitors((DWORD)entry.physicalMonitors.size(), entry.physicalMonitors.data());
+        }
+    }
+    g_monitorCache.clear();
+}
+
+int AdjustBrightnessDDC(HMONITOR hMonitor, bool up, int notches, int stepPercent, bool* outDdcSupported) {
+    MonitorCacheEntry* entry = GetOrOpenMonitorCache(hMonitor);
+    *outDdcSupported = entry->ddcSupported;
+    if (!entry->ddcSupported) return -1;
+
+    int resultPercent = -1;
+    bool anyFailure = false;
+
+    for (auto& pm : entry->physicalMonitors) {
+        if (g_stopping) break;
+        DWORD minB = 0, curB = 0, maxB = 0;
+        if (GetMonitorBrightness(pm.hPhysicalMonitor, &minB, &curB, &maxB)) {
+            int range = (maxB > minB) ? (int)(maxB - minB) : 100;
+            int step = (range * stepPercent * notches) / 100;
+            if (step < notches) step = notches;
+
+            int newVal = (int)curB + (up ? step : -step);
+            if (newVal < (int)minB) newVal = (int)minB;
+            if (newVal > (int)maxB) newVal = (int)maxB;
+
+            if (SetMonitorBrightness(pm.hPhysicalMonitor, (DWORD)newVal)) {
+                if (resultPercent < 0) {
+                    resultPercent = range > 0 ? ((newVal - (int)minB) * 100) / range : 0;
+                }
+            } else {
+                anyFailure = true;
+            }
+        } else {
+            anyFailure = true;
+        }
+    }
+
+    if (anyFailure && resultPercent < 0) {
+        return -1;
+    }
+
+    return resultPercent;
+}
+
+// -----------------------------------------------------------------------
+// Taskbar scroll handling
+// -----------------------------------------------------------------------
+
+int AccumulateNotches(int& accumulator, short delta) {
+    accumulator += delta;
+    int notches = accumulator / WHEEL_DELTA;
+    accumulator -= notches * WHEEL_DELTA;
+    return notches;
+}
+
+bool HandleTaskbarScroll(HWND hTaskbar, POINT pt, short delta) {
+    Settings settings = GetSettingsSnapshot();
+    RECT rc;
+    if (!GetWindowRect(hTaskbar, &rc)) return false;
+
+    if (settings.excludeSystemTray) {
+        HWND hTrayNotify = FindWindowExW(hTaskbar, nullptr, L"TrayNotifyWnd", nullptr);
+        if (!hTrayNotify) {
+            HWND hBridge = nullptr;
+            while ((hBridge = FindWindowExW(hTaskbar, hBridge, L"Windows.UI.Composition.DesktopWindowContentBridge", nullptr)) != nullptr) {
+                RECT bridgeRect;
+                if (GetWindowRect(hBridge, &bridgeRect)) {
+                    if (bridgeRect.left == rc.left && bridgeRect.right == rc.right && bridgeRect.top == rc.top && bridgeRect.bottom == rc.bottom) {
+                        continue;
+                    }
+                    hTrayNotify = hBridge;
+                    break;
+                }
+            }
+        }
+        
+        if (hTrayNotify) {
+            RECT trayRect;
+            if (GetWindowRect(hTrayNotify, &trayRect) && !IsRectEmpty(&trayRect) && PtInRect(&trayRect, pt)) {
+                return false;
+            }
+        }
+    }
+
+    int width = rc.right - rc.left;
+    int height = rc.bottom - rc.top;
+    if (width <= 0 || height <= 0) return false;
+
+    bool isHorizontal = width > height;
+    bool rightSide = false;
+
+    if (isHorizontal) {
+        int splitX = (width * settings.splitPercent) / 100;
+        rightSide = (pt.x - rc.left) >= splitX;
+    } else {
+        int splitY = (height * settings.splitPercent) / 100;
+        rightSide = (pt.y - rc.top) >= splitY;
+    }
+
+    if (settings.invertSides) rightSide = !rightSide;
+
+    static int s_volumeAccum = 0;
+    static int s_brightnessAccum = 0;
+    int notches = AccumulateNotches(rightSide ? s_volumeAccum : s_brightnessAccum, delta);
+    if (notches == 0) return true;
+
+    bool scrollUp = notches > 0;
+    if (settings.reverseScrollDirection) scrollUp = !scrollUp;
+    int absNotches = std::abs(notches);
+
+    HMONITOR hMon = MonitorFromWindow(hTaskbar, MONITOR_DEFAULTTONEAREST);
+
+    if (rightSide) {
+        if (g_workerThreadId) {
+            ScrollRequest* req = new ScrollRequest{scrollUp, absNotches, hMon, hTaskbar, pt};
+            if (!PostThreadMessageW(g_workerThreadId, WM_APP_VOLUME_REQUEST, 0, (LPARAM)req)) delete req;
+        }
+    } else if (g_monitorThreadId) {
+        ScrollRequest* req = new ScrollRequest{scrollUp, absNotches, hMon, hTaskbar, pt};
+        if (!PostThreadMessageW(g_monitorThreadId, WM_APP_BRIGHTNESS_REQUEST, 0, (LPARAM)req)) delete req;
+    }
+
+    return true;
+}
+
+LRESULT CALLBACK TaskbarSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData) {
+    if (uMsg == WM_MOUSEWHEEL) {
+        POINT pt = {GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
+        short delta = GET_WHEEL_DELTA_WPARAM(wParam);
+        if (HandleTaskbarScroll(hWnd, pt, delta)) return 0;
+    } else if (uMsg == WM_DISPLAYCHANGE) {
+        if (g_monitorThreadId) PostThreadMessageW(g_monitorThreadId, WM_APP_CLEAR_MONITOR_CACHE, 0, 0);
+    } else if (uMsg == WM_NCDESTROY) {
+        WindhawkUtils::RemoveWindowSubclassFromAnyThread(hWnd, TaskbarSubclassProc);
+    }
+    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+WNDPROC InputSiteWindowProc_Original = nullptr;
+LRESULT CALLBACK InputSiteWindowProc_Hook(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
+    if (uMsg == WM_POINTERWHEEL) {
+        HWND hRootWnd = GetAncestor(hWnd, GA_ROOT);
+        if (hRootWnd) {
+            WCHAR szClass[32];
+            if (GetClassNameW(hRootWnd, szClass, 32)) {
+                if (wcscmp(szClass, L"Shell_TrayWnd") == 0 || wcscmp(szClass, L"Shell_SecondaryTrayWnd") == 0) {
+                    POINT pt = {GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
+                    short delta = GET_WHEEL_DELTA_WPARAM(wParam);
+                    if (HandleTaskbarScroll(hRootWnd, pt, delta)) return 0;
+                }
+            }
+        }
+    }
+    if (InputSiteWindowProc_Original) {
+        return InputSiteWindowProc_Original(hWnd, uMsg, wParam, lParam);
+    }
+    return DefWindowProcW(hWnd, uMsg, wParam, lParam);
+}
+
+void HookInputSite(HWND hWnd) {
+    auto wndProc = (WNDPROC)GetWindowLongPtrW(hWnd, GWLP_WNDPROC);
+    if (wndProc && wndProc != InputSiteWindowProc_Hook && !InputSiteWindowProc_Original) {
+        WindhawkUtils::SetFunctionHook(wndProc, InputSiteWindowProc_Hook, &InputSiteWindowProc_Original);
+        if (g_initialized) {
+            Wh_ApplyHookOperations();
+        }
+    }
+}
+
+using CreateWindowExW_t = decltype(&CreateWindowExW);
+CreateWindowExW_t CreateWindowExW_Original = nullptr;
+HWND WINAPI CreateWindowExW_Hook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam) {
+    HWND hWnd = CreateWindowExW_Original(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+    if (hWnd && ((ULONG_PTR)lpClassName & ~(ULONG_PTR)0xffff)) {
+        if (_wcsicmp(lpClassName, L"Shell_TrayWnd") == 0 || _wcsicmp(lpClassName, L"Shell_SecondaryTrayWnd") == 0) {
+            WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, TaskbarSubclassProc, 0);
+        }
+    }
+    return hWnd;
+}
+
+using CreateWindowInBand_t = HWND(WINAPI*)(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam, DWORD dwBand);
+CreateWindowInBand_t CreateWindowInBand_Original = nullptr;
+HWND WINAPI CreateWindowInBand_Hook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam, DWORD dwBand) {
+    HWND hWnd = CreateWindowInBand_Original(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam, dwBand);
+    if (hWnd && ((ULONG_PTR)lpClassName & ~(ULONG_PTR)0xffff)) {
+        if (_wcsicmp(lpClassName, L"Windows.UI.Input.InputSite.WindowClass") == 0) {
+            HWND hParent = GetParent(hWnd);
+            if (hParent) {
+                WCHAR szParentClass[64];
+                if (GetClassNameW(hParent, szParentClass, ARRAYSIZE(szParentClass)) && _wcsicmp(szParentClass, L"Windows.UI.Composition.DesktopWindowContentBridge") == 0) {
+                    HWND hTaskbar = GetAncestor(hParent, GA_ROOT);
+                    if (hTaskbar) {
+                        WCHAR szTaskbarClass[64];
+                        if (GetClassNameW(hTaskbar, szTaskbarClass, ARRAYSIZE(szTaskbarClass)) && 
+                            (_wcsicmp(szTaskbarClass, L"Shell_TrayWnd") == 0 || _wcsicmp(szTaskbarClass, L"Shell_SecondaryTrayWnd") == 0)) {
+                            HookInputSite(hWnd);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return hWnd;
+}
+
+// -----------------------------------------------------------------------
+// Monitor thread
+// -----------------------------------------------------------------------
+
+DWORD WINAPI MonitorThreadProc(LPVOID) {
+    MSG msg;
+    PeekMessage(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);  
+
+    HRESULT comInit = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+
+    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+        if (msg.hwnd == nullptr && msg.message == WM_APP_BRIGHTNESS_REQUEST) {
+            ScrollRequest* req = (ScrollRequest*)msg.lParam;
+            if (req) {
+                std::vector<ScrollRequest*> deferred;
+                MSG nextMsg;
+                while (PeekMessageW(&nextMsg, nullptr, WM_APP_BRIGHTNESS_REQUEST, WM_APP_BRIGHTNESS_REQUEST, PM_REMOVE)) {
+                    ScrollRequest* nextReq = (ScrollRequest*)nextMsg.lParam;
+                    if (nextReq) {
+                        if (nextReq->hMonitor == req->hMonitor) {
+                            if (nextReq->scrollUp == req->scrollUp) req->notches += nextReq->notches;
+                            else req->notches -= nextReq->notches;
+                            req->cursorPt = nextReq->cursorPt; 
+                            delete nextReq;
+                        } else {
+                            deferred.push_back(nextReq);
+                        }
+                    }
+                }
+
+                if (req->notches < 0) {
+                    req->scrollUp = !req->scrollUp;
+                    req->notches = -req->notches;
+                }
+
+                if (req->notches > 0) {
+                    Settings settings = GetSettingsSnapshot();
+                    bool ddcSupported = false;
+                    int percent = AdjustBrightnessDDC(req->hMonitor, req->scrollUp, req->notches, settings.brightnessStep, &ddcSupported);
+
+                    if (!ddcSupported && settings.enableWmiFallback) {
+                        percent = AdjustBrightnessWMI(req->scrollUp, req->notches, settings.brightnessStep);
+                    }
+
+                    if (percent >= 0 && g_workerThreadId) {
+                        ScrollResult* res = new ScrollResult{percent, req->hMonitor, req->hTaskbar, req->cursorPt, OverlayMode::Brightness};
+                        if (!PostThreadMessageW(g_workerThreadId, WM_APP_BRIGHTNESS_RESULT, 0, (LPARAM)res)) delete res;
+                    }
+                }
+                delete req;
+
+                for (ScrollRequest* d : deferred) {
+                    if (!PostThreadMessageW(g_monitorThreadId, WM_APP_BRIGHTNESS_REQUEST, 0, (LPARAM)d)) delete d;
+                }
+            }
+            continue;
+        }
+        if (msg.hwnd == nullptr && msg.message == WM_APP_CLEAR_MONITOR_CACHE) {
+            CloseAllMonitorCaches();
+            continue;
+        }
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+
+    CleanupWMI();
+    CloseAllMonitorCaches();
+    if (SUCCEEDED(comInit)) CoUninitialize();
+    return 0;
+}
+
+// -----------------------------------------------------------------------
+// UI / Audio thread
+// -----------------------------------------------------------------------
+
+DWORD WINAPI WorkerThreadProc(LPVOID) {
+    MSG msg;
+    PeekMessage(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+    
+    HRESULT comInit = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    IMMDeviceEnumerator* pEnum = nullptr;
+
+    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+        if (msg.hwnd == nullptr && msg.message == WM_APP_VOLUME_REQUEST) {
+            ScrollRequest* req = (ScrollRequest*)msg.lParam;
+            if (req) {
+                
+                MSG nextMsg;
+                while (PeekMessageW(&nextMsg, nullptr, WM_APP_VOLUME_REQUEST, WM_APP_VOLUME_REQUEST, PM_REMOVE)) {
+                    ScrollRequest* nextReq = (ScrollRequest*)nextMsg.lParam;
+                    if (nextReq) {
+                        if (nextReq->scrollUp == req->scrollUp) req->notches += nextReq->notches;
+                        else req->notches -= nextReq->notches;
+                        req->cursorPt = nextReq->cursorPt; 
+                        delete nextReq;
+                    }
+                }
+
+                if (req->notches < 0) {
+                    req->scrollUp = !req->scrollUp;
+                    req->notches = -req->notches;
+                }
+                
+                Settings settings = GetSettingsSnapshot();
+                
+                if (!pEnum) CoCreateInstance(__uuidof(MMDeviceEnumerator), NULL, CLSCTX_ALL, __uuidof(IMMDeviceEnumerator), (void**)&pEnum);
+
+                int percent = -1;
+                if (pEnum && req->notches > 0) {
+                    IMMDevice* pDevice = nullptr;
+                    pEnum->GetDefaultAudioEndpoint(eRender, eMultimedia, &pDevice);
+                    if (pDevice) {
+                        IAudioEndpointVolume* pVol = nullptr;
+                        pDevice->Activate(__uuidof(IAudioEndpointVolume), CLSCTX_ALL, NULL, (void**)&pVol);
+                        if (pVol) {
+                            float currentVol = 0.0f;
+                            pVol->GetMasterVolumeLevelScalar(&currentVol);
+                            float newVol = currentVol + (req->scrollUp ? 1.0f : -1.0f) * (req->notches * settings.volumeStep / 100.0f);
+                            if (newVol < 0.0f) newVol = 0.0f;
+                            if (newVol > 1.0f) newVol = 1.0f;
+                            
+                            pVol->SetMasterVolumeLevelScalar(newVol, NULL);
+                            
+                            BOOL isMuted = FALSE;
+                            pVol->GetMute(&isMuted);
+                            if (isMuted && newVol > 0.001f) pVol->SetMute(FALSE, NULL);
+                            if (!isMuted && newVol <= 0.001f) pVol->SetMute(TRUE, NULL);
+                            
+                            percent = (int)(newVol * 100.0f + 0.5f);
+                            pVol->Release();
+                        }
+                        pDevice->Release();
+                    }
+                }
+
+                if (percent >= 0) {
+                    ShowOverlay(req->hTaskbar, percent, req->cursorPt, OverlayMode::Volume);
+                }
+                delete req;
+            }
+            continue;
+        }
+
+        if (msg.hwnd == nullptr && msg.message == WM_APP_BRIGHTNESS_RESULT) {
+            ScrollResult* res = (ScrollResult*)msg.lParam;
+            if (res) {
+                ShowOverlay(res->hTaskbar, res->percent, res->cursorPt, res->mode);
+                delete res;
+            }
+            continue;
+        }
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+
+    if (pEnum) pEnum->Release();
+    if (g_hOverlayWnd) {
+        DestroyWindow(g_hOverlayWnd);
+        g_hOverlayWnd = nullptr;
+    }
+    
+    if (SUCCEEDED(comInit)) CoUninitialize();
+    return 0;
+}
+
+BOOL CALLBACK EnumWindowsInitProc(HWND hWnd, LPARAM) {
+    DWORD dwProcessId = 0;
+    if (!GetWindowThreadProcessId(hWnd, &dwProcessId) || dwProcessId != GetCurrentProcessId()) return TRUE;
+
+    WCHAR szClass[32];
+    if (GetClassNameW(hWnd, szClass, 32)) {
+        if (_wcsicmp(szClass, L"Shell_TrayWnd") == 0 || _wcsicmp(szClass, L"Shell_SecondaryTrayWnd") == 0) {
+            WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, TaskbarSubclassProc, 0);
+
+            HWND hXamlIsland = FindWindowExW(hWnd, nullptr, L"Windows.UI.Composition.DesktopWindowContentBridge", nullptr);
+            if (hXamlIsland) {
+                HWND hInputSite = FindWindowExW(hXamlIsland, nullptr, L"Windows.UI.Input.InputSite.WindowClass", nullptr);
+                if (hInputSite) HookInputSite(hInputSite);
+            }
+        }
+    }
+    return TRUE;
+}
+
+BOOL CALLBACK EnumWindowsUninitProc(HWND hWnd, LPARAM) {
+    DWORD dwProcessId = 0;
+    if (!GetWindowThreadProcessId(hWnd, &dwProcessId) || dwProcessId != GetCurrentProcessId()) return TRUE;
+
+    WCHAR szClass[32];
+    if (GetClassNameW(hWnd, szClass, 32)) {
+        if (_wcsicmp(szClass, L"Shell_TrayWnd") == 0 || _wcsicmp(szClass, L"Shell_SecondaryTrayWnd") == 0) {
+            WindhawkUtils::RemoveWindowSubclassFromAnyThread(hWnd, TaskbarSubclassProc);
+        }
+    }
+    return TRUE;
+}
+
+// -----------------------------------------------------------------------
+// Mod entry points
+// -----------------------------------------------------------------------
+
+void Wh_ModAfterInit() {
+    EnumWindows(EnumWindowsInitProc, 0);
+}
+
+BOOL Wh_ModInit() {
+    g_initialized = false;
+    g_stopping = false;
+    InitializeCriticalSection(&g_settingsLock);
+    LoadSettings();
+
+    Gdiplus::GdiplusStartupInput gdiplusStartupInput;
+    Gdiplus::GdiplusStartup(&g_gdiplusToken, &gdiplusStartupInput, nullptr);
+
+    if (!WindhawkUtils::SetFunctionHook(CreateWindowExW, CreateWindowExW_Hook, &CreateWindowExW_Original)) {
+        Gdiplus::GdiplusShutdown(g_gdiplusToken);
+        DeleteCriticalSection(&g_settingsLock);
+        return FALSE;
+    }
+
+    HMODULE user32Module = LoadLibraryExW(L"user32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (user32Module) {
+        auto pCreateWindowInBand = (CreateWindowInBand_t)GetProcAddress(user32Module, "CreateWindowInBand");
+        if (pCreateWindowInBand) WindhawkUtils::SetFunctionHook(pCreateWindowInBand, CreateWindowInBand_Hook, &CreateWindowInBand_Original);
+    }
+
+    g_hWorkerThread = CreateThread(nullptr, 0, WorkerThreadProc, nullptr, 0, &g_workerThreadId);
+    if (!g_hWorkerThread) {
+        Gdiplus::GdiplusShutdown(g_gdiplusToken);
+        DeleteCriticalSection(&g_settingsLock);
+        return FALSE;
+    }
+
+    g_hMonitorThread = CreateThread(nullptr, 0, MonitorThreadProc, nullptr, 0, &g_monitorThreadId);
+    if (!g_hMonitorThread) {
+        g_stopping = true;
+        PostThreadMessageW(g_workerThreadId, WM_QUIT, 0, 0);
+        WaitForSingleObject(g_hWorkerThread, INFINITE);
+        CloseHandle(g_hWorkerThread);
+        Gdiplus::GdiplusShutdown(g_gdiplusToken);
+        DeleteCriticalSection(&g_settingsLock);
+        return FALSE;
+    }
+
+    g_initialized = true;
+    return TRUE;
+}
+
+void Wh_ModUninit() {
+    g_initialized = false;
+    g_stopping = true;
+    EnumWindows(EnumWindowsUninitProc, 0);
+
+    if (g_workerThreadId) PostThreadMessageW(g_workerThreadId, WM_QUIT, 0, 0);
+    if (g_hWorkerThread) {
+        WaitForSingleObject(g_hWorkerThread, INFINITE);
+        CloseHandle(g_hWorkerThread);
+        g_hWorkerThread = nullptr;
+        g_workerThreadId = 0;
+    }
+
+    if (g_monitorThreadId) PostThreadMessageW(g_monitorThreadId, WM_QUIT, 0, 0);
+    if (g_hMonitorThread) {
+        WaitForSingleObject(g_hMonitorThread, INFINITE);
+        CloseHandle(g_hMonitorThread);
+        g_hMonitorThread = nullptr;
+        g_monitorThreadId = 0;
+    }
+
+    if (g_gdiplusToken) {
+        Gdiplus::GdiplusShutdown(g_gdiplusToken);
+        g_gdiplusToken = 0;
+    }
+
+    UnregisterClassW(kOverlayClassName, GetCurrentModuleHandle());
+    g_classRegistered = false;
+    DeleteCriticalSection(&g_settingsLock);
+}
+
+void Wh_ModSettingsChanged() {
+    LoadSettings();
+}

--- a/mods/taskbar-scroll-volume-brightness-control.wh.cpp
+++ b/mods/taskbar-scroll-volume-brightness-control.wh.cpp
@@ -7,7 +7,7 @@
 // @github        https://github.com/NarayanChetri
 // @homepage      https://narayanchetri.dev
 // @include       explorer.exe
-// @compilerOptions -ldxva2 -lgdi32 -lgdiplus -ldwmapi -lcomctl32 -lshcore -lole32 -loleaut32 -lwbemuuid
+// @compilerOptions -ldxva2 -lgdi32 -lgdiplus -lcomctl32 -lshcore -lole32 -loleaut32 -lwbemuuid
 // @license       GPL-3.0
 // ==/WindhawkMod==
 
@@ -96,7 +96,6 @@ Issues and PRs welcome: https://github.com/NarayanChetri
 #include <physicalmonitorenumerationapi.h>
 #include <highlevelmonitorconfigurationapi.h>
 #include <gdiplus.h>
-#include <dwmapi.h>
 #include <wbemidl.h>
 #include <comdef.h>
 #include <mmdeviceapi.h>
@@ -108,14 +107,9 @@ Issues and PRs welcome: https://github.com/NarayanChetri
 #include <algorithm>
 #include <atomic>
 #include <string>
+#include <mutex>
 #include <windhawk_utils.h>
 
-#ifndef DWMWA_WINDOW_CORNER_PREFERENCE
-#define DWMWA_WINDOW_CORNER_PREFERENCE 33
-#endif
-#ifndef DWMWCP_ROUND
-#define DWMWCP_ROUND 2
-#endif
 #ifndef WM_POINTERWHEEL
 #define WM_POINTERWHEEL 0x024E
 #endif
@@ -144,19 +138,19 @@ struct Settings {
     bool enableWmiFallback = true;
 };
 
-CRITICAL_SECTION g_settingsLock;
+std::mutex g_settingsMutex;
 Settings g_settings;
 
 Settings GetSettingsSnapshot() {
-    EnterCriticalSection(&g_settingsLock);
-    Settings copy = g_settings;
-    LeaveCriticalSection(&g_settingsLock);
-    return copy;
+    std::lock_guard<std::mutex> lock(g_settingsMutex);
+    return g_settings;
 }
 
 bool ParseHexColor(PCWSTR text, BYTE& r, BYTE& g, BYTE& b) {
     if (!text) return false;
     if (text[0] == L'#') text++;
+    if (wcslen(text) != 6) return false;
+    
     unsigned int ri = 0, gi = 0, bi = 0;
     if (swscanf_s(text, L"%2x%2x%2x", &ri, &gi, &bi) != 3) return false;
     r = (BYTE)ri;
@@ -194,9 +188,8 @@ void LoadSettings() {
     if (s.overlayDurationMs < 200) s.overlayDurationMs = 200;
     if (s.overlayDurationMs > 5000) s.overlayDurationMs = 5000;
 
-    EnterCriticalSection(&g_settingsLock);
+    std::lock_guard<std::mutex> lock(g_settingsMutex);
     g_settings = s;
-    LeaveCriticalSection(&g_settingsLock);
 }
 
 HINSTANCE GetCurrentModuleHandle() {
@@ -234,10 +227,10 @@ struct ScrollResult {
 };
 
 HANDLE g_hWorkerThread = nullptr;
-DWORD g_workerThreadId = 0;
+std::atomic<DWORD> g_workerThreadId{0};
 
 HANDLE g_hMonitorThread = nullptr;
-DWORD g_monitorThreadId = 0;
+std::atomic<DWORD> g_monitorThreadId{0};
 
 ULONG_PTR g_gdiplusToken = 0;
 
@@ -407,7 +400,7 @@ LRESULT CALLBACK OverlayWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPara
                         g_currentX += stepX;
                         g_currentY += stepY;
                         
-                        SetWindowPos(hWnd, nullptr, g_currentX, g_currentY, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+                        SetWindowPos(hWnd, HWND_TOPMOST, g_currentX, g_currentY, 0, 0, SWP_NOSIZE | SWP_NOACTIVATE);
                     }
                 }
 
@@ -442,6 +435,11 @@ void EnsureOverlayWindow() {
 
 void ShowOverlay(HWND hTaskbar, int percent, POINT cursorPt, OverlayMode mode) {
     if (percent < 0) return;
+    if (!hTaskbar || !IsWindow(hTaskbar)) return;
+    
+    DWORD procId = 0;
+    GetWindowThreadProcessId(hTaskbar, &procId);
+    if (procId != GetCurrentProcessId()) return;
 
     Settings settings = GetSettingsSnapshot();
     if (!settings.showOverlay) return;
@@ -452,13 +450,6 @@ void ShowOverlay(HWND hTaskbar, int percent, POINT cursorPt, OverlayMode mode) {
     g_lastCursorPt = cursorPt;
     g_targetPercent = percent;
     g_targetOpacity = 255.0f;
-
-    if (!hTaskbar || !IsWindow(hTaskbar)) return;
-    
-    DWORD procId = 0;
-    GetWindowThreadProcessId(hTaskbar, &procId);
-    if (procId != GetCurrentProcessId()) return;
-
     g_hTargetTaskbar = hTaskbar;
 
     if (g_currentMode != mode) {
@@ -478,7 +469,7 @@ void ShowOverlay(HWND hTaskbar, int percent, POINT cursorPt, OverlayMode mode) {
                 int maxBottom = std::max((int)tbRect.top, (int)(tbRect.bottom - g_scaledH));
                 g_currentY = std::clamp((int)(g_lastCursorPt.y - (g_scaledH / 2)), (int)tbRect.top, maxBottom);
             }
-            SetWindowPos(g_hOverlayWnd, nullptr, g_currentX, g_currentY, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+            SetWindowPos(g_hOverlayWnd, HWND_TOPMOST, g_currentX, g_currentY, 0, 0, SWP_NOSIZE | SWP_NOACTIVATE);
         }
         InvalidateRect(g_hOverlayWnd, nullptr, FALSE);
     }
@@ -779,13 +770,13 @@ bool HandleTaskbarScroll(HWND hTaskbar, POINT pt, short delta) {
     HMONITOR hMon = MonitorFromWindow(hTaskbar, MONITOR_DEFAULTTONEAREST);
 
     if (rightSide) {
-        if (g_workerThreadId) {
+        if (g_workerThreadId.load()) {
             ScrollRequest* req = new ScrollRequest{scrollUp, absNotches, hMon, hTaskbar, pt};
-            if (!PostThreadMessageW(g_workerThreadId, WM_APP_VOLUME_REQUEST, 0, (LPARAM)req)) delete req;
+            if (!PostThreadMessageW(g_workerThreadId.load(), WM_APP_VOLUME_REQUEST, 0, (LPARAM)req)) delete req;
         }
-    } else if (g_monitorThreadId) {
+    } else if (g_monitorThreadId.load()) {
         ScrollRequest* req = new ScrollRequest{scrollUp, absNotches, hMon, hTaskbar, pt};
-        if (!PostThreadMessageW(g_monitorThreadId, WM_APP_BRIGHTNESS_REQUEST, 0, (LPARAM)req)) delete req;
+        if (!PostThreadMessageW(g_monitorThreadId.load(), WM_APP_BRIGHTNESS_REQUEST, 0, (LPARAM)req)) delete req;
     }
 
     return true;
@@ -797,11 +788,9 @@ LRESULT CALLBACK TaskbarSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM
         short delta = GET_WHEEL_DELTA_WPARAM(wParam);
         if (HandleTaskbarScroll(hWnd, pt, delta)) return 0;
     } else if (uMsg == WM_DISPLAYCHANGE) {
-        if (g_monitorThreadId) {
-            PostThreadMessageW(g_monitorThreadId, WM_APP_CLEAR_MONITOR_CACHE, 0, 0);
+        if (g_monitorThreadId.load()) {
+            PostThreadMessageW(g_monitorThreadId.load(), WM_APP_CLEAR_MONITOR_CACHE, 0, 0);
         }
-    } else if (uMsg == WM_NCDESTROY) {
-        WindhawkUtils::RemoveWindowSubclassFromAnyThread(hWnd, TaskbarSubclassProc);
     }
     return DefSubclassProc(hWnd, uMsg, wParam, lParam);
 }
@@ -919,9 +908,9 @@ DWORD WINAPI MonitorThreadProc(LPVOID lpParam) {
                         percent = AdjustBrightnessWMI(req->scrollUp, req->notches, settings.brightnessStep);
                     }
 
-                    if (percent >= 0 && g_workerThreadId) {
+                    if (percent >= 0 && g_workerThreadId.load()) {
                         ScrollResult* res = new ScrollResult{percent, req->hMonitor, req->hTaskbar, req->cursorPt, OverlayMode::Brightness};
-                        if (!PostThreadMessageW(g_workerThreadId, WM_APP_BRIGHTNESS_RESULT, 0, (LPARAM)res)) {
+                        if (!PostThreadMessageW(g_workerThreadId.load(), WM_APP_BRIGHTNESS_RESULT, 0, (LPARAM)res)) {
                             delete res;
                         }
                     }
@@ -1094,22 +1083,44 @@ BOOL CALLBACK EnumWindowsUninitProc(HWND hWnd, LPARAM) {
 // Mod entry points
 // -----------------------------------------------------------------------
 
+void EnsureWorkersInitialized() {
+    static std::once_flag s_initFlag;
+    std::call_once(s_initFlag, []{
+        Gdiplus::GdiplusStartupInput gdiplusStartupInput;
+        Gdiplus::GdiplusStartup(&g_gdiplusToken, &gdiplusStartupInput, nullptr);
+
+        HANDLE hReadyEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+        
+        DWORD wTid = 0, mTid = 0;
+        g_hWorkerThread = CreateThread(nullptr, 0, WorkerThreadProc, hReadyEvent, 0, &wTid);
+        if (g_hWorkerThread) {
+            WaitForSingleObject(hReadyEvent, INFINITE);
+            ResetEvent(hReadyEvent);
+            g_workerThreadId = wTid;
+        }
+
+        g_hMonitorThread = CreateThread(nullptr, 0, MonitorThreadProc, hReadyEvent, 0, &mTid);
+        if (g_hMonitorThread) {
+            WaitForSingleObject(hReadyEvent, INFINITE);
+            CloseHandle(hReadyEvent);
+            g_monitorThreadId = mTid;
+        } else {
+            CloseHandle(hReadyEvent);
+        }
+    });
+}
+
 void Wh_ModAfterInit() {
+    EnsureWorkersInitialized();
     EnumWindows(EnumWindowsInitProc, 0);
 }
 
 BOOL Wh_ModInit() {
     g_initialized = false;
     g_stopping = false;
-    InitializeCriticalSection(&g_settingsLock);
     LoadSettings();
 
-    Gdiplus::GdiplusStartupInput gdiplusStartupInput;
-    Gdiplus::Status gdiStatus = Gdiplus::GdiplusStartup(&g_gdiplusToken, &gdiplusStartupInput, nullptr);
-
     if (!WindhawkUtils::SetFunctionHook(CreateWindowExW, CreateWindowExW_Hook, &CreateWindowExW_Original)) {
-        if (gdiStatus == Gdiplus::Ok) Gdiplus::GdiplusShutdown(g_gdiplusToken);
-        DeleteCriticalSection(&g_settingsLock);
         return FALSE;
     }
 
@@ -1118,34 +1129,6 @@ BOOL Wh_ModInit() {
         auto pCreateWindowInBand = (CreateWindowInBand_t)GetProcAddress(user32Module, "CreateWindowInBand");
         if (pCreateWindowInBand) WindhawkUtils::SetFunctionHook(pCreateWindowInBand, CreateWindowInBand_Hook, &CreateWindowInBand_Original);
     }
-
-    HANDLE hReadyEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
-
-    g_hWorkerThread = CreateThread(nullptr, 0, WorkerThreadProc, hReadyEvent, 0, &g_workerThreadId);
-    if (!g_hWorkerThread) {
-        CloseHandle(hReadyEvent);
-        if (gdiStatus == Gdiplus::Ok) Gdiplus::GdiplusShutdown(g_gdiplusToken);
-        DeleteCriticalSection(&g_settingsLock);
-        return FALSE;
-    }
-    WaitForSingleObject(hReadyEvent, INFINITE);
-    ResetEvent(hReadyEvent);
-
-    g_hMonitorThread = CreateThread(nullptr, 0, MonitorThreadProc, hReadyEvent, 0, &g_monitorThreadId);
-    if (!g_hMonitorThread) {
-        g_stopping = true;
-        PostThreadMessageW(g_workerThreadId, WM_QUIT, 0, 0);
-        WaitForSingleObject(g_hWorkerThread, INFINITE);
-        CloseHandle(g_hWorkerThread);
-        g_hWorkerThread = nullptr;
-        g_workerThreadId = 0;
-        CloseHandle(hReadyEvent);
-        if (gdiStatus == Gdiplus::Ok) Gdiplus::GdiplusShutdown(g_gdiplusToken);
-        DeleteCriticalSection(&g_settingsLock);
-        return FALSE;
-    }
-    WaitForSingleObject(hReadyEvent, INFINITE);
-    CloseHandle(hReadyEvent);
 
     g_initialized = true;
     return TRUE;
@@ -1156,8 +1139,8 @@ void Wh_ModUninit() {
     g_stopping = true;
     EnumWindows(EnumWindowsUninitProc, 0);
 
-    if (g_monitorThreadId) {
-        PostThreadMessageW(g_monitorThreadId, WM_QUIT, 0, 0);
+    if (g_monitorThreadId.load()) {
+        PostThreadMessageW(g_monitorThreadId.load(), WM_QUIT, 0, 0);
     }
     if (g_hMonitorThread) {
         WaitForSingleObject(g_hMonitorThread, INFINITE);
@@ -1166,8 +1149,8 @@ void Wh_ModUninit() {
         g_monitorThreadId = 0;
     }
 
-    if (g_workerThreadId) {
-        PostThreadMessageW(g_workerThreadId, WM_QUIT, 0, 0);
+    if (g_workerThreadId.load()) {
+        PostThreadMessageW(g_workerThreadId.load(), WM_QUIT, 0, 0);
     }
     if (g_hWorkerThread) {
         WaitForSingleObject(g_hWorkerThread, INFINITE);
@@ -1183,7 +1166,6 @@ void Wh_ModUninit() {
 
     UnregisterClassW(kOverlayClassName, GetCurrentModuleHandle());
     g_classRegistered = false;
-    DeleteCriticalSection(&g_settingsLock);
 }
 
 void Wh_ModSettingsChanged() {

--- a/mods/taskbar-scroll-volume-brightness-control.wh.cpp
+++ b/mods/taskbar-scroll-volume-brightness-control.wh.cpp
@@ -2,7 +2,7 @@
 // @id            taskbar-scroll-volume-brightness-control
 // @name          Taskbar Scroll: Volume & Brightness Controller
 // @description   Scroll over the right side of the taskbar to change volume, scroll over the left side to change brightness. Uses a custom in-taskbar UI that tracks your cursor.
-// @version       1.1.0
+// @version       1.1.1
 // @author        Narayan Chetri
 // @github        https://github.com/NarayanChetri
 // @homepage      https://narayanchetri.dev
@@ -50,12 +50,12 @@ Issues and PRs welcome: https://github.com/NarayanChetri
   $name: Split position (%)
   $description: >-
     Percentage from the edge of the taskbar where the volume/brightness
-    zones split.
+    zones split (top/bottom on a vertical taskbar).
 - invertSides: false
   $name: Invert zones
   $description: >-
     When enabled, the left side of the taskbar controls volume and the
-    right side controls brightness.
+    right side controls brightness (top/bottom on a vertical taskbar).
 - reverseScrollDirection: false
   $name: Reverse scroll direction
   $description: >-
@@ -77,7 +77,7 @@ Issues and PRs welcome: https://github.com/NarayanChetri
   $description: Show a native-looking taskbar element with the current percentage.
 - overlayDurationMs: 1000
   $name: Overlay display duration (ms)
-  $description: How long the overlay stays on screen before fading out.
+  $description: How long the overlay stays on screen before fading out (200-5000).
 - accentColor: "FFBE5C"
   $name: Overlay accent color (hex RRGGBB)
   $description: Color of the progress bar and percentage text accent.
@@ -107,6 +107,7 @@ Issues and PRs welcome: https://github.com/NarayanChetri
 #include <cwchar>
 #include <algorithm>
 #include <atomic>
+#include <string>
 #include <windhawk_utils.h>
 
 #ifndef DWMWA_WINDOW_CORNER_PREFERENCE
@@ -554,7 +555,7 @@ int AdjustBrightnessWMI(bool up, int notches, int stepPercent) {
     if (SUCCEEDED(hres) && pEnumBrightness) {
         IWbemClassObject* pObj = nullptr;
         ULONG uReturned = 0;
-        if (pEnumBrightness->Next(WBEM_INFINITE, 1, &pObj, &uReturned) == S_OK && uReturned > 0) {
+        if (pEnumBrightness->Next(2000, 1, &pObj, &uReturned) == S_OK && uReturned > 0) {
             VARIANT vtCurrent; VariantInit(&vtCurrent);
             VARIANT vtInstanceName; VariantInit(&vtInstanceName);
 
@@ -798,8 +799,7 @@ LRESULT CALLBACK TaskbarSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM
         if (HandleTaskbarScroll(hWnd, pt, delta)) return 0;
     } else if (uMsg == WM_DISPLAYCHANGE) {
         if (g_monitorThreadId) {
-            while (!PostThreadMessageW(g_monitorThreadId, WM_APP_CLEAR_MONITOR_CACHE, 0, 0) &&
-                   WaitForSingleObject(g_hMonitorThread, 10) == WAIT_TIMEOUT) {}
+            PostThreadMessageW(g_monitorThreadId, WM_APP_CLEAR_MONITOR_CACHE, 0, 0);
         }
     } else if (uMsg == WM_NCDESTROY) {
         WindhawkUtils::RemoveWindowSubclassFromAnyThread(hWnd, TaskbarSubclassProc);
@@ -921,15 +921,14 @@ DWORD WINAPI MonitorThreadProc(LPVOID) {
 
                     if (percent >= 0 && g_workerThreadId) {
                         ScrollResult* res = new ScrollResult{percent, req->hMonitor, req->hTaskbar, req->cursorPt, OverlayMode::Brightness};
-                        while (!PostThreadMessageW(g_workerThreadId, WM_APP_BRIGHTNESS_RESULT, 0, (LPARAM)res) &&
-                               WaitForSingleObject(g_hWorkerThread, 10) == WAIT_TIMEOUT) {}
+                        PostThreadMessageW(g_workerThreadId, WM_APP_BRIGHTNESS_RESULT, 0, (LPARAM)res);
                     }
                 }
                 delete req;
 
                 DWORD currentThreadId = GetCurrentThreadId();
                 for (ScrollRequest* d : deferred) {
-                    while (!PostThreadMessageW(currentThreadId, WM_APP_BRIGHTNESS_REQUEST, 0, (LPARAM)d) && !g_stopping) {}
+                    PostThreadMessageW(currentThreadId, WM_APP_BRIGHTNESS_REQUEST, 0, (LPARAM)d);
                 }
             }
             continue;
@@ -938,14 +937,12 @@ DWORD WINAPI MonitorThreadProc(LPVOID) {
             CloseAllMonitorCaches();
             continue;
         }
-        TranslateMessage(&msg);
         DispatchMessageW(&msg);
     }
 
     MSG leftover;
-    while (PeekMessageW(&leftover, nullptr, WM_APP_BRIGHTNESS_REQUEST, WM_APP_BRIGHTNESS_RESULT, PM_REMOVE)) {
-        if (leftover.message == WM_APP_BRIGHTNESS_REQUEST) delete (ScrollRequest*)leftover.lParam;
-        else if (leftover.message == WM_APP_BRIGHTNESS_RESULT) delete (ScrollResult*)leftover.lParam;
+    while (PeekMessageW(&leftover, nullptr, WM_APP_BRIGHTNESS_REQUEST, WM_APP_BRIGHTNESS_REQUEST, PM_REMOVE)) {
+        delete (ScrollRequest*)leftover.lParam;
     }
 
     CleanupWMI();
@@ -1035,13 +1032,15 @@ DWORD WINAPI WorkerThreadProc(LPVOID) {
             }
             continue;
         }
-        TranslateMessage(&msg);
         DispatchMessageW(&msg);
     }
 
     MSG leftover;
     while (PeekMessageW(&leftover, nullptr, WM_APP_VOLUME_REQUEST, WM_APP_VOLUME_REQUEST, PM_REMOVE)) {
         delete (ScrollRequest*)leftover.lParam;
+    }
+    while (PeekMessageW(&leftover, nullptr, WM_APP_BRIGHTNESS_RESULT, WM_APP_BRIGHTNESS_RESULT, PM_REMOVE)) {
+        delete (ScrollResult*)leftover.lParam;
     }
 
     if (pEnum) pEnum->Release();
@@ -1126,8 +1125,7 @@ BOOL Wh_ModInit() {
     if (!g_hMonitorThread) {
         g_stopping = true;
         if (g_workerThreadId) {
-            while (!PostThreadMessageW(g_workerThreadId, WM_QUIT, 0, 0) &&
-                   WaitForSingleObject(g_hWorkerThread, 10) == WAIT_TIMEOUT) {}
+            PostThreadMessageW(g_workerThreadId, WM_QUIT, 0, 0);
         }
         WaitForSingleObject(g_hWorkerThread, INFINITE);
         CloseHandle(g_hWorkerThread);
@@ -1148,26 +1146,24 @@ void Wh_ModUninit() {
     g_stopping = true;
     EnumWindows(EnumWindowsUninitProc, 0);
 
-    if (g_workerThreadId) {
-        while (!PostThreadMessageW(g_workerThreadId, WM_QUIT, 0, 0) &&
-               WaitForSingleObject(g_hWorkerThread, 10) == WAIT_TIMEOUT) {}
-    }
-    if (g_hWorkerThread) {
-        WaitForSingleObject(g_hWorkerThread, INFINITE);
-        CloseHandle(g_hWorkerThread);
-        g_hWorkerThread = nullptr;
-        g_workerThreadId = 0;
-    }
-
     if (g_monitorThreadId) {
-        while (!PostThreadMessageW(g_monitorThreadId, WM_QUIT, 0, 0) &&
-               WaitForSingleObject(g_hMonitorThread, 10) == WAIT_TIMEOUT) {}
+        PostThreadMessageW(g_monitorThreadId, WM_QUIT, 0, 0);
     }
     if (g_hMonitorThread) {
         WaitForSingleObject(g_hMonitorThread, INFINITE);
         CloseHandle(g_hMonitorThread);
         g_hMonitorThread = nullptr;
         g_monitorThreadId = 0;
+    }
+
+    if (g_workerThreadId) {
+        PostThreadMessageW(g_workerThreadId, WM_QUIT, 0, 0);
+    }
+    if (g_hWorkerThread) {
+        WaitForSingleObject(g_hWorkerThread, INFINITE);
+        CloseHandle(g_hWorkerThread);
+        g_hWorkerThread = nullptr;
+        g_workerThreadId = 0;
     }
 
     if (g_gdiplusToken) {


### PR DESCRIPTION
### Taskbar Scroll: Volume & Brightness Control

This mod provides unified, split-zone volume and brightness control directly from the taskbar with a cursor-tracking GDI+ overlay.

- **Unified Configuration:** Controls both volume (right side) and brightness (left side via DDC/CI with WMI fallback) from a single mod without requiring complex multi-mod region configurations.
- **In-Taskbar Cursor Tracking:** Features a dynamic, DPI-aware progress bar that tracks the cursor along the taskbar.
- **Native OSD Suppression:** Directly renders overlay feedback and manages automatic muting/unmuting at 0%, bypassing bulky Windows flyouts.
- **Modern Input Support:** Hooks Windows 11 `InputSite` pointer/touchpad scroll events alongside standard mouse wheel subclassing.

---

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Initial release of Taskbar Scroll: Volume & Brightness Control.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- [ ] The submitter, without AI assistance
- [x] The submitter, with AI assistance
- [x] Claude
- [ ] ChatGPT
- [x] Gemini
- [ ] Another AI (please specify): 
- [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.