### PR TITLE
Update Move and Gather Windows to 0.1.2

### DIFF
--- a/mods/gather-windows-to-monitor.wh.cpp
+++ b/mods/gather-windows-to-monitor.wh.cpp
@@ -1,7 +1,7 @@
 // ==WindhawkMod==
 // @id              gather-windows-to-monitor
-// @name            Gather Windows To Display
-// @description     Move one window or gather eligible open windows to a chosen display with global hotkeys
+// @name            Move and Gather Windows
+// @description     Move or gather windows with global hotkeys and remap numbered shortcuts to the intended displays
 // @version         0.1.2
 // @author          Fred
 // @github          https://github.com/fjdiazt
@@ -11,42 +11,102 @@
 
 // ==WindhawkModReadme==
 /*
-# Gather Windows To Display
+# Move and Gather Windows
 
-Global hotkeys move the foreground window or gather visible application windows
-to a selected display work area.
+Move the active window, or gather eligible open windows, to a chosen display with
+global shortcuts. Windows are placed inside the usable desktop area so taskbars
+remain clear. Windows already on the destination display are left unchanged.
 
-By default, `Ctrl+Alt+Shift+W` moves the foreground window to the primary display,
-and `Ctrl+Alt+Shift+1` through `Ctrl+Alt+Shift+5` move it to a numbered display.
-`Ctrl+Alt+Shift+P` gathers to the primary display, `Ctrl+Alt+Shift+M` gathers to
-the display under the mouse, and `Ctrl+Alt+Shift+A` gathers to the active window's
-display. Numbered gather actions are available but disabled by default.
+Numbered shortcuts can be remapped to the displays you intend without changing
+the shortcuts themselves. This is useful when Windows and Windhawk number displays
+differently or when reconnecting a display changes their order.
 
-If a numbered display is unavailable, the primary display is used. After an update,
-an existing gather shortcut keeps priority over a conflicting new move shortcut;
-change either shortcut in settings to enable both actions.
+## Move foreground window shortcuts
 
-Configure hotkeys in Windhawk settings. Use strings such as `Ctrl+Alt+Shift+1`,
-`Ctrl+Win+M`, `F9`, or `None`.
+These settings move only the window you are currently using.
 
-Window size behavior can preserve dimensions or scale them proportionally between
-the source and target display work areas.
+* **Move foreground window to primary display** defaults to
+  `Ctrl+Alt+Shift+W`.
+* **Move foreground window to display 1-5** default to
+  `Ctrl+Alt+Shift+1` through `Ctrl+Alt+Shift+5`.
 
-Skipped by default: minimized windows, hidden windows, tool windows,
-desktop/taskbar/shell UI, cloaked UWP/helper windows, and untitled windows.
+## Gather shortcuts
 
-The foreground-window action ignores the owned-window and untitled-window filters.
-The fullscreen setting applies to every action. Windows already on the target display
-are left unchanged. Gather actions restore maximized windows before moving them and
-leave them restored for arranging; the foreground-window action re-maximizes them on
-the target display. Moved windows are raised above existing target-display windows
-without taking focus.
+These settings move all eligible open windows.
 
-Enable logging in Windhawk to see per-window skip reasons.
+* **Gather to primary display** defaults to `Ctrl+Alt+Shift+P`.
+* **Gather to display under mouse** defaults to `Ctrl+Alt+Shift+M`.
+* **Gather to foreground window display** defaults to `Ctrl+Alt+Shift+A`.
+  The active window chooses the destination; all eligible windows are gathered
+  there.
+* **Gather to display 1-5** are disabled by default. Set any of them to a
+  shortcut when needed.
 
-Known limitations: numbered display actions use detection order, which can differ
-from the display numbers in Windows Settings. Moving minimized windows without restoring is
-not attempted because it is not reliable for all apps.
+Hotkeys accept values such as `Ctrl+Alt+Shift+1`, `Ctrl+Win+M`, `F9`, or `None`.
+If two actions use the same shortcut, the older action keeps it and the conflict
+is logged. This protects existing shortcuts after an update.
+
+## Display order override
+
+Numbered move and gather actions normally use the order in which Windhawk detects
+your displays. That order can differ from the numbers in Windows Settings and can
+change after displays are connected or disconnected. **Display order override**
+changes what "display 1", "display 2", and so on mean while keeping every hotkey
+unchanged.
+
+Enter a comma-separated list containing `primary` or detected display numbers:
+
+* `primary,3` keeps display 1 tied to whichever display is currently primary and
+  makes detected display 3 become display 2.
+* `4,3` makes detected display 4 become display 1 and detected display 3 become
+  display 2.
+
+Displays not listed keep their detected order after the listed displays. For
+example, if the detected order is `1,2,3,4`, the override `4,3` produces
+`4,3,1,2`. The override affects numbered move and gather actions only. Primary,
+mouse, and active-window destinations are unchanged.
+
+Leave the setting empty to use detection order. An invalid value rejects the
+whole override and safely returns to detection order. Enable Windhawk logging to
+see both the detected order and the final numbered order. These lines appear when
+the mod starts, settings change, or the display layout changes.
+
+If a numbered destination is unavailable, the primary display is used.
+
+## Window handling settings
+
+* **Skip minimized windows** ignores minimized windows immediately.
+* **Restore minimized windows before moving** applies when skipping is off.
+  When both settings are off, minimized windows remain skipped because moving
+  them without restoring is unreliable.
+* **Skip fullscreen windows** avoids disturbing fullscreen apps and games. It
+  applies to both single-window moves and gather actions.
+* **Window size behavior** controls resizing at the destination. **Fit** shrinks
+  only windows that are too large, **Preserve** never resizes, and **Scale**
+  adjusts size in proportion to the destination display.
+* **Cascade windows** offsets gathered windows so they do not completely overlap.
+* **Cascade offset in pixels** controls the distance between cascaded windows.
+* **Window anchor** chooses the starting position: center, top left, or mouse
+  cursor.
+* **Include owned windows/popups** includes dialogs and secondary windows attached
+  to another app window during gather actions.
+* **Debug logging** records why individual windows were skipped. Leave it off
+  unless troubleshooting.
+
+## Behavior and limitations
+
+Hidden windows, desktop and taskbar windows, system interface windows, helper
+windows, and tool windows are intentionally skipped. Gather actions also skip
+untitled windows. Active-window actions can still move a window with no title or
+a window attached to another app window.
+
+Moved windows are raised above windows already on the destination display without
+taking keyboard focus. A moved maximized active window is maximized again on the
+destination. Gathered maximized windows are restored so they can be arranged.
+
+Detected display numbers are Windhawk's numbers, not necessarily the numbers shown
+in Windows Settings. Moving a minimized window without restoring it is not
+supported because applications handle that inconsistently.
 */
 // ==/WindhawkModReadme==
 
@@ -56,19 +116,19 @@ not attempted because it is not reliable for all apps.
   $name: Move foreground window to primary display
 - HotkeyForegroundMonitor1: "Ctrl+Alt+Shift+1"
   $name: Move foreground window to display 1
-  $description: Uses the first display detected by Windhawk, which may not be display 1 in Windows Settings.
+  $description: Uses display 1 after applying Display order override.
 - HotkeyForegroundMonitor2: "Ctrl+Alt+Shift+2"
   $name: Move foreground window to display 2
-  $description: Uses the second display detected by Windhawk, which may not be display 2 in Windows Settings.
+  $description: Uses display 2 after applying Display order override.
 - HotkeyForegroundMonitor3: "Ctrl+Alt+Shift+3"
   $name: Move foreground window to display 3
-  $description: Uses the third display detected by Windhawk, which may not be display 3 in Windows Settings.
+  $description: Uses display 3 after applying Display order override.
 - HotkeyForegroundMonitor4: "Ctrl+Alt+Shift+4"
   $name: Move foreground window to display 4
-  $description: Uses the fourth display detected by Windhawk, which may not be display 4 in Windows Settings.
+  $description: Uses display 4 after applying Display order override.
 - HotkeyForegroundMonitor5: "Ctrl+Alt+Shift+5"
   $name: Move foreground window to display 5
-  $description: Uses the fifth display detected by Windhawk, which may not be display 5 in Windows Settings.
+  $description: Uses display 5 after applying Display order override.
 - HotkeyPrimary: "Ctrl+Alt+Shift+P"
   $name: Gather to primary display
 - HotkeyMouse: "Ctrl+Alt+Shift+M"
@@ -78,19 +138,28 @@ not attempted because it is not reliable for all apps.
   $description: Moves all eligible windows to the display containing the active window.
 - HotkeyMonitor1: "None"
   $name: Gather to display 1
-  $description: Uses the first display detected by Windhawk, which may not be display 1 in Windows Settings.
+  $description: Uses display 1 after applying Display order override.
 - HotkeyMonitor2: "None"
   $name: Gather to display 2
-  $description: Uses the second display detected by Windhawk, which may not be display 2 in Windows Settings.
+  $description: Uses display 2 after applying Display order override.
 - HotkeyMonitor3: "None"
   $name: Gather to display 3
-  $description: Uses the third display detected by Windhawk, which may not be display 3 in Windows Settings.
+  $description: Uses display 3 after applying Display order override.
 - HotkeyMonitor4: "None"
   $name: Gather to display 4
-  $description: Uses the fourth display detected by Windhawk, which may not be display 4 in Windows Settings.
+  $description: Uses display 4 after applying Display order override.
 - HotkeyMonitor5: "None"
   $name: Gather to display 5
-  $description: Uses the fifth display detected by Windhawk, which may not be display 5 in Windows Settings.
+  $description: Uses display 5 after applying Display order override.
+- DisplayOrder: ""
+  $name: Display order override
+  $description: >-
+    Remaps what numbered move and gather shortcuts target without rebinding them.
+    Enter comma-separated primary or detected display numbers. Example: primary,3
+    keeps display 1 tied to the current primary display after reconnects and makes
+    detected display 3 become display 2. Unlisted displays keep detected order.
+    Enable Windhawk logging to see detected numbers. Invalid values are ignored;
+    leave empty for detection order.
 - SkipMinimized: false
   $name: Skip minimized windows
 - RestoreMinimized: false
@@ -121,6 +190,9 @@ not attempted because it is not reliable for all apps.
 - IncludeOwnedWindows: true
   $name: Include owned windows/popups
   $description: Also moves dialogs and secondary windows attached to another app window.
+- DebugLogging: false
+  $name: Debug logging
+  $description: Logs why individual windows were skipped. Enable only while troubleshooting.
 */
 // ==/WindhawkModSettings==
 
@@ -132,6 +204,7 @@ not attempted because it is not reliable for all apps.
 #include <atomic>
 #include <cwctype>
 #include <string>
+#include <string_view>
 #include <vector>
 
 enum class TargetMode {
@@ -180,6 +253,12 @@ enum class SizeMode {
     Scale,
 };
 
+struct DisplayOrderOverride {
+    bool valid;
+    int entries[5];  // -1 is the current primary display; 0-4 are detected indices.
+    size_t count;
+};
+
 struct Settings {
     bool skipMinimized;
     bool restoreMinimized;
@@ -189,6 +268,8 @@ struct Settings {
     int cascadeOffset;
     AnchorMode anchor;
     bool includeOwnedWindows;
+    bool debugLogging;
+    DisplayOrderOverride displayOrder;
     std::wstring hotkeys[(int)TargetMode::Count];
 };
 
@@ -197,6 +278,7 @@ struct MonitorInfo {
     RECT monitor;
     RECT work;
     bool primary;
+    size_t detectedIndex;
 };
 
 struct Hotkey {
@@ -247,11 +329,83 @@ static_assert(!IsForegroundOnlyAction(TargetMode::Monitor5));
 static_assert(NumberedDisplayIndex(TargetMode::ForegroundMonitor2) == 1);
 static_assert(NumberedDisplayIndex(TargetMode::Monitor5) == 4);
 
+constexpr bool IsDisplayOrderSpace(wchar_t c) {
+    return c == L' ' || c == L'\t' || c == L'\r' || c == L'\n';
+}
+
+constexpr std::wstring_view TrimDisplayOrderToken(std::wstring_view text) {
+    while (!text.empty() && IsDisplayOrderSpace(text.front())) {
+        text.remove_prefix(1);
+    }
+    while (!text.empty() && IsDisplayOrderSpace(text.back())) {
+        text.remove_suffix(1);
+    }
+    return text;
+}
+
+constexpr bool IsPrimaryDisplayOrderToken(std::wstring_view text) {
+    constexpr std::wstring_view primary = L"primary";
+    if (text.size() != primary.size()) return false;
+    for (size_t i = 0; i < primary.size(); i++) {
+        wchar_t c = text[i];
+        if (c >= L'A' && c <= L'Z') c += L'a' - L'A';
+        if (c != primary[i]) return false;
+    }
+    return true;
+}
+
+constexpr DisplayOrderOverride ParseDisplayOrder(std::wstring_view text) {
+    DisplayOrderOverride result{ true, {}, 0 };
+    text = TrimDisplayOrderToken(text);
+    while (!text.empty()) {
+        size_t comma = text.find(L',');
+        std::wstring_view token =
+            TrimDisplayOrderToken(text.substr(0, comma));
+        int entry;
+        if (IsPrimaryDisplayOrderToken(token)) {
+            entry = -1;
+        } else if (token.size() == 1 && token[0] >= L'1' &&
+                   token[0] <= L'5') {
+            entry = token[0] - L'1';
+        } else {
+            return { false, {}, 0 };
+        }
+
+        if (result.count == ARRAYSIZE(result.entries)) {
+            return { false, {}, 0 };
+        }
+        for (size_t i = 0; i < result.count; i++) {
+            if (result.entries[i] == entry) return { false, {}, 0 };
+        }
+        result.entries[result.count++] = entry;
+
+        if (comma == std::wstring_view::npos) break;
+        text.remove_prefix(comma + 1);
+        if (TrimDisplayOrderToken(text).empty()) return { false, {}, 0 };
+    }
+    return result;
+}
+
+constexpr auto kDisplayOrderPrimaryTest = ParseDisplayOrder(L"primary, 3");
+static_assert(kDisplayOrderPrimaryTest.valid &&
+              kDisplayOrderPrimaryTest.count == 2 &&
+              kDisplayOrderPrimaryTest.entries[0] == -1 &&
+              kDisplayOrderPrimaryTest.entries[1] == 2);
+constexpr auto kDisplayOrderNumericTest = ParseDisplayOrder(L"4,3");
+static_assert(kDisplayOrderNumericTest.valid &&
+              kDisplayOrderNumericTest.entries[0] == 3 &&
+              kDisplayOrderNumericTest.entries[1] == 2);
+static_assert(ParseDisplayOrder(L"").valid);
+static_assert(ParseDisplayOrder(L"3,3").valid == false);
+static_assert(ParseDisplayOrder(L"primary,").valid == false);
+static_assert(ParseDisplayOrder(L"leftmost").valid == false);
+
 constexpr UINT WM_APP_RELOAD = WM_APP + 1;
 constexpr UINT WM_APP_STOP = WM_APP + 2;
 
 Settings g_settings{};
 std::vector<Hotkey> g_hotkeys;
+std::wstring g_lastDisplayTopology;
 HANDLE g_worker;
 std::atomic<DWORD> g_workerThreadId{};
 HANDLE g_workerReady;
@@ -289,6 +443,14 @@ void LoadSettings() {
     g_settings.hotkeys[(int)TargetMode::Monitor5] = GetStringSetting(L"HotkeyMonitor5");
     g_settings.hotkeys[(int)TargetMode::Mouse] = GetStringSetting(L"HotkeyMouse");
     g_settings.hotkeys[(int)TargetMode::Foreground] = GetStringSetting(L"HotkeyForeground");
+    std::wstring displayOrderText = GetStringSetting(L"DisplayOrder");
+    g_settings.displayOrder = ParseDisplayOrder(displayOrderText);
+    if (!g_settings.displayOrder.valid) {
+        Wh_Log(L"Invalid display order override: %s. Using detected order; "
+               L"expected primary or numbers 1-5 separated by commas",
+               displayOrderText.c_str());
+        g_settings.displayOrder = ParseDisplayOrder(L"");
+    }
     g_settings.skipMinimized = Wh_GetIntSetting(L"SkipMinimized") != 0;
     g_settings.restoreMinimized = Wh_GetIntSetting(L"RestoreMinimized") != 0;
     g_settings.skipFullscreen = Wh_GetIntSetting(L"SkipFullscreen") != 0;
@@ -297,6 +459,8 @@ void LoadSettings() {
     g_settings.cascadeOffset = std::max(0, Wh_GetIntSetting(L"CascadeOffset"));
     g_settings.anchor = ParseAnchorMode(GetStringSetting(L"Anchor"));
     g_settings.includeOwnedWindows = Wh_GetIntSetting(L"IncludeOwnedWindows") != 0;
+    g_settings.debugLogging = Wh_GetIntSetting(L"DebugLogging") != 0;
+    g_lastDisplayTopology.clear();
 }
 
 std::wstring TrimUpper(std::wstring s) {
@@ -422,6 +586,8 @@ void UnregisterConfiguredHotkeys() {
 
 void RegisterConfiguredHotkeys() {
     UnregisterConfiguredHotkeys();
+    int registered = 0;
+    int disabled = 0;
 
     // Existing actions register first so an update never changes what an
     // already-configured shortcut does when a new default uses the same keys.
@@ -448,7 +614,7 @@ void RegisterConfiguredHotkeys() {
         const std::wstring& configured = g_settings.hotkeys[(int)modes[i]];
         HotkeyParseResult parseResult = ParseHotkey(configured, &modifiers, &vk);
         if (parseResult == HotkeyParseResult::Disabled) {
-            Wh_Log(L"Hotkey disabled: %s", names[i]);
+            disabled++;
             continue;
         }
         if (parseResult == HotkeyParseResult::Invalid) {
@@ -472,13 +638,13 @@ void RegisterConfiguredHotkeys() {
         int id = 100 + i;
         if (RegisterHotKey(nullptr, id, modifiers, vk)) {
             g_hotkeys.push_back({ id, modifiers, vk, modes[i], names[i] });
-            Wh_Log(L"Hotkey registered: %s = %s", names[i],
-                   configured.c_str());
+            registered++;
         } else {
             Wh_Log(L"Hotkey register failed: %s = %s, error=%u", names[i],
                    configured.c_str(), GetLastError());
         }
     }
+    Wh_Log(L"Hotkeys ready: registered=%d disabled=%d", registered, disabled);
 }
 
 BOOL CALLBACK MonitorEnumProc(HMONITOR monitor, HDC, LPRECT, LPARAM lParam) {
@@ -487,23 +653,85 @@ BOOL CALLBACK MonitorEnumProc(HMONITOR monitor, HDC, LPRECT, LPARAM lParam) {
     mi.cbSize = sizeof(mi);
     if (GetMonitorInfo(monitor, &mi)) {
         monitors->push_back({ monitor, mi.rcMonitor, mi.rcWork,
-                              (mi.dwFlags & MONITORINFOF_PRIMARY) != 0 });
+                              (mi.dwFlags & MONITORINFOF_PRIMARY) != 0,
+                              monitors->size() + 1 });
     }
     return TRUE;
 }
 
-std::vector<MonitorInfo> GetMonitors() {
-    std::vector<MonitorInfo> monitors;
-    EnumDisplayMonitors(nullptr, nullptr, MonitorEnumProc, (LPARAM)&monitors);
-    Wh_Log(L"Displays: %zu", monitors.size());
-    for (size_t i = 0; i < monitors.size(); i++) {
-        const RECT& m = monitors[i].monitor;
-        const RECT& w = monitors[i].work;
-        Wh_Log(L"Display %zu%s: bounds=(%ld,%ld,%ld,%ld) work=(%ld,%ld,%ld,%ld)",
-               i + 1, monitors[i].primary ? L" primary" : L"", m.left, m.top,
-               m.right, m.bottom, w.left, w.top, w.right, w.bottom);
+std::vector<MonitorInfo> ApplyDisplayOrder(
+    const std::vector<MonitorInfo>& detected) {
+    std::vector<MonitorInfo> ordered;
+    ordered.reserve(detected.size());
+    std::vector<bool> used(detected.size());
+
+    for (size_t i = 0; i < g_settings.displayOrder.count; i++) {
+        int entry = g_settings.displayOrder.entries[i];
+        size_t detectedIndex = detected.size();
+        if (entry == -1) {
+            for (size_t j = 0; j < detected.size(); j++) {
+                if (detected[j].primary) {
+                    detectedIndex = j;
+                    break;
+                }
+            }
+        } else {
+            detectedIndex = (size_t)entry;
+        }
+
+        if (detectedIndex < detected.size() && !used[detectedIndex]) {
+            ordered.push_back(detected[detectedIndex]);
+            used[detectedIndex] = true;
+        }
     }
-    return monitors;
+
+    for (size_t i = 0; i < detected.size(); i++) {
+        if (!used[i]) ordered.push_back(detected[i]);
+    }
+    return ordered;
+}
+
+void LogDisplayTopology(const std::vector<MonitorInfo>& detected,
+                        const std::vector<MonitorInfo>& ordered) {
+    std::wstring detectedText = L"Detected displays:";
+    for (const MonitorInfo& display : detected) {
+        LONG width = display.monitor.right - display.monitor.left;
+        LONG height = display.monitor.bottom - display.monitor.top;
+        detectedText += L" " + std::to_wstring(display.detectedIndex) + L"=" +
+                        std::to_wstring(width) + L"x" +
+                        std::to_wstring(height) + L"@(" +
+                        std::to_wstring(display.monitor.left) + L"," +
+                        std::to_wstring(display.monitor.top) + L")";
+        if (display.primary) detectedText += L" primary";
+        detectedText += L";";
+    }
+    if (detected.empty()) detectedText += L" none";
+
+    std::wstring orderText = L"Numbered display order:";
+    for (size_t i = 0; i < ordered.size(); i++) {
+        orderText += L" " + std::to_wstring(i + 1) + L"=detected " +
+                     std::to_wstring(ordered[i].detectedIndex);
+        if (ordered[i].primary) orderText += L" primary";
+        orderText += L";";
+    }
+    if (ordered.empty()) orderText += L" none";
+
+    std::wstring topology = detectedText + L"|" + orderText;
+    if (topology == g_lastDisplayTopology) return;
+    g_lastDisplayTopology = topology;
+    Wh_Log(L"%s", detectedText.c_str());
+    Wh_Log(L"%s", orderText.c_str());
+}
+
+std::vector<MonitorInfo> GetMonitors() {
+    std::vector<MonitorInfo> detected;
+    if (!EnumDisplayMonitors(nullptr, nullptr, MonitorEnumProc,
+                             (LPARAM)&detected)) {
+        Wh_Log(L"Display enumeration failed: error=%u", GetLastError());
+    }
+    std::vector<MonitorInfo> ordered = ApplyDisplayOrder(detected);
+    LogDisplayTopology(detected, ordered);
+    return ordered;
 }
 
 const MonitorInfo* PrimaryMonitor(const std::vector<MonitorInfo>& monitors) {
@@ -644,6 +872,7 @@ bool IsEligibleWindow(HWND hwnd, SkipReason* reason, bool bulk) {
 }
 
 void DebugLogSkipReason(HWND hwnd, SkipReason reason) {
+    if (!g_settings.debugLogging) return;
     wchar_t title[128]{};
     wchar_t className[128]{};
     GetWindowText(hwnd, title, ARRAYSIZE(title));
@@ -729,10 +958,11 @@ bool MoveWindowToMonitor(HWND hwnd, const MonitorInfo& target, int cascadeIndex,
         UINT demoteFlags = SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE |
                            SWP_NOOWNERZORDER | SWP_ASYNCWINDOWPOS;
         if (!SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0, demoteFlags)) {
-            Wh_Log(L"Failed to clear topmost for hwnd=%p, retrying", hwnd);
+            DWORD firstError = GetLastError();
             if (!SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0,
                               demoteFlags)) {
-                Wh_Log(L"Failed to clear topmost for hwnd=%p", hwnd);
+                Wh_Log(L"Failed to restore normal window level: hwnd=%p "
+                       L"errors=%u,%u", hwnd, firstError, GetLastError());
             }
         }
     }
@@ -779,8 +1009,12 @@ void GatherWindows(TargetMode mode) {
         return;
     }
 
-    Wh_Log(L"Target work area: (%ld,%ld,%ld,%ld)", target->work.left, target->work.top,
-           target->work.right, target->work.bottom);
+    if (g_settings.debugLogging) {
+        Wh_Log(L"Target: detected display %zu%s work=(%ld,%ld,%ld,%ld)",
+               target->detectedIndex, target->primary ? L" primary" : L"",
+               target->work.left, target->work.top, target->work.right,
+               target->work.bottom);
+    }
     bool foregroundOnly = IsForegroundOnlyAction(mode);
     GatherState state{ target,
                        !foregroundOnly,
@@ -813,12 +1047,13 @@ DWORD WINAPI WorkerMain(LPVOID) {
 
     LoadSettings();
     RegisterConfiguredHotkeys();
+    GetMonitors();
 
     while (GetMessage(&msg, nullptr, 0, 0) > 0) {
         if (msg.message == WM_HOTKEY) {
             for (const Hotkey& hotkey : g_hotkeys) {
                 if (hotkey.id == (int)msg.wParam) {
-                    Wh_Log(L"Hotkey pressed: %s", hotkey.name);
+                    Wh_Log(L"Action: %s", hotkey.name);
                     GatherWindows(hotkey.mode);
                     break;
                 }
@@ -826,6 +1061,7 @@ DWORD WINAPI WorkerMain(LPVOID) {
         } else if (msg.message == WM_APP_RELOAD) {
             LoadSettings();
             RegisterConfiguredHotkeys();
+            GetMonitors();
         } else if (msg.message == WM_APP_STOP) {
             break;
         }
@@ -893,7 +1129,6 @@ bool g_isToolModProcessLauncher;
 HANDLE g_toolModProcessMutex;
 
 void WINAPI EntryPoint_Hook() {
-    Wh_Log(L">");
     ExitThread(0);
 }
 

--- a/mods/gather-windows-to-monitor.wh.cpp
+++ b/mods/gather-windows-to-monitor.wh.cpp
@@ -17,8 +17,8 @@ Move the active window, or gather eligible open windows, to a chosen display wit
 global shortcuts. Windows are placed inside the usable desktop area so taskbars
 remain clear. Windows already on the destination display are left unchanged.
 
-Numbered shortcuts follow the `DISPLAY1`, `DISPLAY2`, and other names assigned by
-Windows. They can be remapped without changing the shortcuts themselves.
+Numbered shortcuts follow connected Windows display device names in numeric order.
+They can be remapped without changing the shortcuts themselves.
 
 ## Choosing between similar mods
 
@@ -55,9 +55,10 @@ is logged. This protects existing shortcuts after an update.
 
 ## Display order override
 
-Numbered move and gather actions normally follow Windows display device names in
-numeric order: `DISPLAY1`, `DISPLAY2`, and so on. **Display order override** changes
-what "display 1", "display 2", and so on mean while keeping every hotkey unchanged.
+Numbered move and gather actions normally number connected displays contiguously
+using Windows device-name order. For example, connected `DISPLAY4` and `DISPLAY6`
+become display 1 and display 2. **Display order override** changes what "display 1",
+"display 2", and so on mean while keeping every hotkey unchanged.
 
 Enter a comma-separated list containing `primary` or display device names. Both
 `DISPLAY4` and the full `\\.\DISPLAY4` form are accepted:
@@ -80,12 +81,22 @@ Add-Type -AssemblyName System.Windows.Forms
     Select-Object DeviceName, Primary, Bounds
 ```
 
-Leave the setting empty to use automatic `DISPLAY` number order. An invalid value
+Leave the setting empty to use automatic connected-display order. An invalid value
 rejects the whole override and safely returns to automatic order. Windhawk logging
 also shows connected device names and the final numbered order when the mod starts,
-settings change, or the display layout changes.
+settings change, or an action runs after the display layout changes.
 
 If a numbered destination is unavailable, the primary display is used.
+
+## Updating shortcut and window selection defaults
+
+Numbered shortcuts now move the foreground window by default. After updating,
+`Ctrl+Alt+Shift+1` through `Ctrl+Alt+Shift+3` move one window instead of gathering;
+numbered gather shortcuts are disabled until configured. Explicitly saved shortcuts
+keep their existing values and take priority if a new default conflicts.
+
+Gather actions now include owned windows and popups by default. Turn off **Include
+owned windows/popups** to keep dialogs and secondary windows in place.
 
 ## Updating window size settings
 
@@ -129,6 +140,7 @@ behavior, where skipping took priority.
   cursor.
 * **Include owned windows/popups** includes dialogs and secondary windows attached
   to another app window during gather actions.
+
 ## Behavior and limitations
 
 Hidden windows, desktop and taskbar windows, system interface windows, helper
@@ -194,7 +206,7 @@ applications handle that inconsistently.
     \\.\DISPLAY4. Example: primary,DISPLAY3 keeps display 1 tied to the current
     primary display and makes DISPLAY3 become display 2. Missing displays keep
     their slots; unlisted displays follow in automatic order. An invalid override
-    uses automatic order. Leave empty for automatic DISPLAY number order.
+    uses automatic order. Leave empty to number connected displays by DISPLAY name.
 - RestoreMinimized: skip
   $name: Minimized windows
   $description: Choose whether minimized windows stay minimized or are restored and moved.
@@ -751,20 +763,18 @@ std::vector<MonitorInfo> ApplyDisplayOrder(
                          }
                          return a.detectedIndex < b.detectedIndex;
                      });
+    if (!g_settings.displayOrder.count) return automatic;
+
     std::vector<MonitorInfo> ordered;
-    size_t slotCount = g_settings.displayOrder.count
-                           ? g_settings.displayOrder.count
-                           : 5;
+    size_t slotCount = g_settings.displayOrder.count;
     ordered.reserve(slotCount + detected.size());
     std::vector<bool> used(detected.size());
 
     for (size_t i = 0; i < slotCount; i++) {
-        DisplayOrderOverride::Entry entry = g_settings.displayOrder.count
-                                                ? g_settings.displayOrder.entries[i]
-                                                : DisplayOrderOverride::Entry{
-                                                      false, (int)i + 1 };
+        DisplayOrderOverride::Entry entry = g_settings.displayOrder.entries[i];
         size_t detectedIndex = detected.size();
         for (size_t j = 0; j < detected.size(); j++) {
+            if (used[j]) continue;
             if ((entry.primary && detected[j].primary) ||
                 (!entry.primary &&
                  detected[j].displayNumber == entry.displayNumber)) {
@@ -843,9 +853,12 @@ void LogCurrentDisplayTopology() {
 
 const MonitorInfo* PrimaryMonitor(const std::vector<MonitorInfo>& monitors) {
     for (const MonitorInfo& monitor : monitors) {
-        if (monitor.primary) return &monitor;
+        if (monitor.primary && monitor.handle) return &monitor;
     }
-    return monitors.empty() ? nullptr : &monitors[0];
+    for (const MonitorInfo& monitor : monitors) {
+        if (monitor.handle) return &monitor;
+    }
+    return nullptr;
 }
 
 const MonitorInfo* MonitorByHandle(const std::vector<MonitorInfo>& monitors, HMONITOR handle) {
@@ -990,6 +1003,10 @@ void DebugLogSkipReason(HWND hwnd, SkipReason reason) {
 bool MoveWindowToMonitor(HWND hwnd, const MonitorInfo& target, int cascadeIndex,
                          bool bulk) {
     if (!IsWindow(hwnd)) return false;
+    if (!target.handle || target.work.right <= target.work.left ||
+        target.work.bottom <= target.work.top) {
+        return false;
+    }
     HMONITOR sourceHandle = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
     if (sourceHandle == target.handle) return false;
     const RECT& workArea = target.work;
@@ -1002,6 +1019,12 @@ bool MoveWindowToMonitor(HWND hwnd, const MonitorInfo& target, int cascadeIndex,
         if (!GetWindowPlacement(hwnd, &placement)) return false;
         rect = placement.rcNormalPosition;
     } else if (!GetWindowRect(hwnd, &rect)) {
+        return false;
+    }
+
+    MONITORINFO sourceInfo{ sizeof(sourceInfo) };
+    if (g_settings.sizeMode == SizeMode::Scale &&
+        !GetMonitorInfo(sourceHandle, &sourceInfo)) {
         return false;
     }
 
@@ -1018,8 +1041,6 @@ bool MoveWindowToMonitor(HWND hwnd, const MonitorInfo& target, int cascadeIndex,
                                      workWidth, workHeight);
 
     if (g_settings.sizeMode == SizeMode::Scale) {
-        MONITORINFO sourceInfo{ sizeof(sourceInfo) };
-        if (!GetMonitorInfo(sourceHandle, &sourceInfo)) return false;
         int sourceWorkWidth = sourceInfo.rcWork.right - sourceInfo.rcWork.left;
         int sourceWorkHeight = sourceInfo.rcWork.bottom - sourceInfo.rcWork.top;
         width = ScaleDimensionForWorkArea(width, sourceWorkWidth, workWidth);

--- a/mods/gather-windows-to-monitor.wh.cpp
+++ b/mods/gather-windows-to-monitor.wh.cpp
@@ -59,6 +59,7 @@ Numbered move and gather actions normally number connected displays contiguously
 using Windows device-name order. For example, connected `DISPLAY4` and `DISPLAY6`
 become display 1 and display 2. **Display order override** changes what "display 1",
 "display 2", and so on mean while keeping every hotkey unchanged.
+These shortcut numbers may differ from numbers shown in Windows Settings.
 
 Enter up to five comma-separated entries containing `primary` or display device
 names. Both `DISPLAY4` and the full `\\.\DISPLAY4` form are accepted:
@@ -68,10 +69,11 @@ names. Both `DISPLAY4` and the full `\\.\DISPLAY4` form are accepted:
 * `\\.\DISPLAY4,\\.\DISPLAY3` accepts names copied directly from PowerShell.
 
 Each listed name keeps its numbered slot even while that display is disconnected;
-using that shortcut temporarily falls back to the primary display. Unlisted
-connected displays follow in normal `DISPLAY` number order. The override affects
-numbered move and gather actions only. Primary, mouse, and active-window
-destinations are unchanged.
+using that shortcut while it is disconnected does nothing. Unlisted connected
+displays follow in normal `DISPLAY` number order. The override affects numbered
+move and gather actions only. Primary, mouse, and active-window destinations are
+unchanged. Avoid listing both `primary` and its device name because they refer to
+the same display.
 
 To find the names assigned to connected displays, run this in Windows PowerShell:
 
@@ -86,7 +88,7 @@ rejects the whole override and safely returns to automatic order. Windhawk loggi
 also shows connected device names and the final numbered order when the mod starts,
 settings change, or an action runs after the display layout changes.
 
-If a numbered destination is unavailable, the primary display is used.
+If a numbered destination is unavailable, the action is skipped.
 
 ## Updating shortcut and window selection defaults
 
@@ -100,7 +102,7 @@ owned windows/popups** to keep dialogs and secondary windows in place.
 
 ## Updating window size settings
 
-Earlier versions used **Window size behavior** together with a separate
+Earlier versions used **Preserve window size** together with a separate
 **Shrink oversized windows to fit** switch. After updating, verify the new
 **Window size behavior** setting:
 
@@ -151,6 +153,9 @@ destination. Gathered maximized windows are restored so they can be arranged.
 
 Moving a minimized window without restoring it is not supported because
 applications handle that inconsistently.
+
+DPI-unaware windows can be resized by Windows when moved between displays with
+different scaling, even when **Preserve** is selected.
 */
 // ==/WindhawkModReadme==
 
@@ -691,6 +696,7 @@ void RegisterConfiguredHotkeys() {
         L"foreground to display 3", L"foreground to display 4",
         L"foreground to display 5",
     };
+    static_assert(ARRAYSIZE(modes) == ARRAYSIZE(names));
 
     for (size_t i = 0; i < ARRAYSIZE(modes); i++) {
         UINT modifiers = 0;
@@ -865,7 +871,10 @@ const MonitorInfo* MonitorByHandle(const std::vector<MonitorInfo>& monitors, HMO
 }
 
 const MonitorInfo* ResolveTargetMonitor(TargetMode mode, const std::vector<MonitorInfo>& monitors) {
-    if (monitors.empty()) return nullptr;
+    if (monitors.empty()) {
+        Wh_Log(L"No displays found");
+        return nullptr;
+    }
     if (mode == TargetMode::Primary || mode == TargetMode::ForegroundPrimary) {
         return PrimaryMonitor(monitors);
     }
@@ -875,8 +884,8 @@ const MonitorInfo* ResolveTargetMonitor(TargetMode mode, const std::vector<Monit
         if (index < monitors.size() && monitors[index].handle) {
             return &monitors[index];
         }
-        Wh_Log(L"Requested display %zu missing; using primary", index + 1);
-        return PrimaryMonitor(monitors);
+        Wh_Log(L"Requested display %zu missing; action skipped", index + 1);
+        return nullptr;
     }
     if (mode == TargetMode::Mouse) {
         POINT pt{};
@@ -986,6 +995,11 @@ bool IsEligibleWindow(HWND hwnd, SkipReason* reason, bool bulk) {
 }
 
 void DebugLogSkipReason(HWND hwnd, SkipReason reason) {
+    if (reason == SkipReason::Invalid || reason == SkipReason::Invisible ||
+        reason == SkipReason::Cloaked || reason == SkipReason::DesktopShell ||
+        reason == SkipReason::ToolWindow) {
+        return;
+    }
     wchar_t title[128]{};
     wchar_t className[128]{};
     GetWindowText(hwnd, title, ARRAYSIZE(title));
@@ -1138,10 +1152,7 @@ BOOL CALLBACK GatherEnumProc(HWND hwnd, LPARAM lParam) {
 void GatherWindows(TargetMode mode) {
     auto monitors = GetMonitors();
     const MonitorInfo* target = ResolveTargetMonitor(mode, monitors);
-    if (!target) {
-        Wh_Log(L"No displays found");
-        return;
-    }
+    if (!target) return;
 
     Wh_Log(L"Target: %s%s work=(%ld,%ld,%ld,%ld)",
            target->deviceName.c_str(), target->primary ? L" primary" : L"",
@@ -1180,11 +1191,18 @@ void GatherWindows(TargetMode mode) {
 
 DWORD WINAPI WorkerMain(LPVOID) {
     // Keep window and display rectangles in one physical-pixel coordinate space.
-    DPI_AWARENESS_CONTEXT previousDpiContext =
-        SetThreadDpiAwarenessContext(
+    using SetThreadDpiAwarenessContext_t =
+        DPI_AWARENESS_CONTEXT(WINAPI*)(DPI_AWARENESS_CONTEXT);
+    auto setThreadDpiAwarenessContext =
+        reinterpret_cast<SetThreadDpiAwarenessContext_t>(GetProcAddress(
+            GetModuleHandleW(L"user32.dll"), "SetThreadDpiAwarenessContext"));
+    DPI_AWARENESS_CONTEXT previousDpiContext = nullptr;
+    if (setThreadDpiAwarenessContext) {
+        previousDpiContext = setThreadDpiAwarenessContext(
             DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-    if (!previousDpiContext) {
-        previousDpiContext = SetThreadDpiAwarenessContext(
+    }
+    if (setThreadDpiAwarenessContext && !previousDpiContext) {
+        previousDpiContext = setThreadDpiAwarenessContext(
             DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
         if (previousDpiContext) {
             Wh_Log(L"Per-display DPI mode: v1 fallback");
@@ -1223,7 +1241,7 @@ DWORD WINAPI WorkerMain(LPVOID) {
     UnregisterConfiguredHotkeys();
     g_workerThreadId = 0;
     if (previousDpiContext) {
-        SetThreadDpiAwarenessContext(previousDpiContext);
+        setThreadDpiAwarenessContext(previousDpiContext);
     }
     return 0;
 }

--- a/mods/gather-windows-to-monitor.wh.cpp
+++ b/mods/gather-windows-to-monitor.wh.cpp
@@ -70,15 +70,13 @@ not attempted because it is not reliable for all apps.
 - SkipFullscreen: true
   $name: Skip fullscreen windows
   $description: Applies to every action, including moving only the active window.
-- SizeMode: preserve
+- SizeMode: fit
   $name: Window size behavior
-  $description: Preserve keeps each window's current size. Scale adjusts its size for the destination monitor.
+  $description: Fit shrinks only oversized windows. Preserve never resizes. Scale resizes all windows for the destination monitor.
   $options:
-  - preserve: Preserve
+  - fit: Fit oversized windows (default)
+  - preserve: Always preserve size
   - scale: Scale proportionally
-- ShrinkOversized: true
-  $name: Shrink oversized windows to fit
-  $description: Keeps windows usable when target monitor is smaller.
 - CascadeWindows: true
   $name: Cascade windows
   $description: Offsets moved windows so they do not completely overlap.
@@ -140,6 +138,7 @@ enum class AnchorMode {
 };
 
 enum class SizeMode {
+    Fit,
     Preserve,
     Scale,
 };
@@ -149,7 +148,6 @@ struct Settings {
     bool restoreMinimized;
     bool skipFullscreen;
     SizeMode sizeMode;
-    bool shrinkOversized;
     bool cascadeWindows;
     int cascadeOffset;
     AnchorMode anchor;
@@ -225,7 +223,6 @@ void LoadSettings() {
     g_settings.restoreMinimized = Wh_GetIntSetting(L"RestoreMinimized") != 0;
     g_settings.skipFullscreen = Wh_GetIntSetting(L"SkipFullscreen") != 0;
     g_settings.sizeMode = ParseSizeMode(GetStringSetting(L"SizeMode"));
-    g_settings.shrinkOversized = Wh_GetIntSetting(L"ShrinkOversized") != 0;
     g_settings.cascadeWindows = Wh_GetIntSetting(L"CascadeWindows") != 0;
     g_settings.cascadeOffset = std::max(0, Wh_GetIntSetting(L"CascadeOffset"));
     g_settings.anchor = ParseAnchorMode(GetStringSetting(L"Anchor"));
@@ -250,57 +247,100 @@ AnchorMode ParseAnchorMode(const std::wstring& text) {
 }
 
 SizeMode ParseSizeMode(const std::wstring& text) {
-    return TrimUpper(text) == L"SCALE" ? SizeMode::Scale
-                                        : SizeMode::Preserve;
+    std::wstring value = TrimUpper(text);
+    if (value == L"PRESERVE") return SizeMode::Preserve;
+    if (value == L"SCALE") return SizeMode::Scale;
+    return SizeMode::Fit;
 }
 
-UINT VkFromToken(const std::wstring& key) {
-    if (key.empty()) return 0;
-    if (key.size() == 1 && key[0] >= L'A' && key[0] <= L'Z') return key[0];
-    if (key.size() == 1 && key[0] >= L'0' && key[0] <= L'9') return key[0];
-    if (key[0] == L'F' && key.size() <= 3) {
-        int n = _wtoi(key.c_str() + 1);
-        if (n >= 1 && n <= 24) return VK_F1 + n - 1;
+bool TryParseVirtualKey(const std::wstring& key, UINT* vk) {
+    struct NamedVirtualKey {
+        const wchar_t* name;
+        UINT value;
+    };
+    static constexpr NamedVirtualKey namedKeys[] = {
+        { L"LEFT", VK_LEFT },       { L"RIGHT", VK_RIGHT },
+        { L"UP", VK_UP },           { L"DOWN", VK_DOWN },
+        { L"HOME", VK_HOME },       { L"END", VK_END },
+        { L"PGUP", VK_PRIOR },      { L"PAGEUP", VK_PRIOR },
+        { L"PGDN", VK_NEXT },       { L"PAGEDOWN", VK_NEXT },
+        { L"INSERT", VK_INSERT },   { L"INS", VK_INSERT },
+        { L"DELETE", VK_DELETE },   { L"DEL", VK_DELETE },
+        { L"SPACE", VK_SPACE },     { L"TAB", VK_TAB },
+        { L"ESC", VK_ESCAPE },      { L"ESCAPE", VK_ESCAPE },
+        { L"BACKSPACE", VK_BACK },
+    };
+
+    UINT parsed = 0;
+    if (key.size() == 1 &&
+        ((key[0] >= L'A' && key[0] <= L'Z') ||
+         (key[0] >= L'0' && key[0] <= L'9'))) {
+        parsed = key[0];
+    } else if (key.size() >= 2 && key.size() <= 3 && key[0] == L'F') {
+        if (key[1] == L'0') return false;
+        int number = 0;
+        for (size_t i = 1; i < key.size(); i++) {
+            if (key[i] < L'0' || key[i] > L'9') return false;
+            number = number * 10 + key[i] - L'0';
+        }
+        if (number >= 1 && number <= 24) parsed = VK_F1 + number - 1;
+    } else {
+        for (const NamedVirtualKey& namedKey : namedKeys) {
+            if (key == namedKey.name) {
+                parsed = namedKey.value;
+                break;
+            }
+        }
     }
-    if (key == L"LEFT") return VK_LEFT;
-    if (key == L"RIGHT") return VK_RIGHT;
-    if (key == L"UP") return VK_UP;
-    if (key == L"DOWN") return VK_DOWN;
-    if (key == L"HOME") return VK_HOME;
-    if (key == L"END") return VK_END;
-    if (key == L"PGUP" || key == L"PAGEUP") return VK_PRIOR;
-    if (key == L"PGDN" || key == L"PAGEDOWN") return VK_NEXT;
-    if (key == L"INSERT" || key == L"INS") return VK_INSERT;
-    if (key == L"DELETE" || key == L"DEL") return VK_DELETE;
-    if (key == L"SPACE") return VK_SPACE;
-    if (key == L"TAB") return VK_TAB;
-    if (key == L"ESC" || key == L"ESCAPE") return VK_ESCAPE;
-    if (key == L"BACKSPACE") return VK_BACK;
-    return 0;
+
+    if (!parsed) return false;
+    *vk = parsed;
+    return true;
 }
 
-bool ParseHotkey(const std::wstring& text, UINT* modifiers, UINT* vk) {
+enum class HotkeyParseResult {
+    Valid,
+    Disabled,
+    Invalid,
+};
+
+HotkeyParseResult ParseHotkey(const std::wstring& text, UINT* modifiers,
+                              UINT* vk) {
     std::wstring s = TrimUpper(text);
     if (s.empty() || s == L"NONE" || s == L"DISABLED") {
-        return false;
+        return HotkeyParseResult::Disabled;
     }
 
-    *modifiers = MOD_NOREPEAT;
-    *vk = 0;
+    UINT parsedModifiers = MOD_NOREPEAT;
+    UINT parsedVk = 0;
     size_t start = 0;
     for (;;) {
         size_t pos = s.find(L'+', start);
         std::wstring token = TrimUpper(s.substr(start, pos - start));
-        if (token == L"CTRL" || token == L"CONTROL") *modifiers |= MOD_CONTROL;
-        else if (token == L"ALT") *modifiers |= MOD_ALT;
-        else if (token == L"SHIFT") *modifiers |= MOD_SHIFT;
-        else if (token == L"WIN" || token == L"WINDOWS") *modifiers |= MOD_WIN;
-        else *vk = VkFromToken(token);
+        if (token == L"CTRL" || token == L"CONTROL") {
+            parsedModifiers |= MOD_CONTROL;
+        } else if (token == L"ALT") {
+            parsedModifiers |= MOD_ALT;
+        } else if (token == L"SHIFT") {
+            parsedModifiers |= MOD_SHIFT;
+        } else if (token == L"WIN" || token == L"WINDOWS") {
+            parsedModifiers |= MOD_WIN;
+        } else {
+            UINT tokenVk = 0;
+            if (parsedVk || !TryParseVirtualKey(token, &tokenVk)) {
+                return HotkeyParseResult::Invalid;
+            }
+            parsedVk = tokenVk;
+        }
 
         if (pos == std::wstring::npos) break;
         start = pos + 1;
     }
-    return *vk != 0;
+
+    if (!parsedVk) return HotkeyParseResult::Invalid;
+    *modifiers = parsedModifiers;
+    *vk = parsedVk;
+    return HotkeyParseResult::Valid;
 }
 
 void UnregisterConfiguredHotkeys() {
@@ -326,8 +366,14 @@ void RegisterConfiguredHotkeys() {
     for (size_t i = 0; i < ARRAYSIZE(modes); i++) {
         UINT modifiers = 0;
         UINT vk = 0;
-        if (!ParseHotkey(g_settings.hotkeys[(int)modes[i]], &modifiers, &vk)) {
+        const std::wstring& configured = g_settings.hotkeys[(int)modes[i]];
+        HotkeyParseResult parseResult = ParseHotkey(configured, &modifiers, &vk);
+        if (parseResult == HotkeyParseResult::Disabled) {
             Wh_Log(L"Hotkey disabled: %s", names[i]);
+            continue;
+        }
+        if (parseResult == HotkeyParseResult::Invalid) {
+            Wh_Log(L"Invalid hotkey: %s = %s", names[i], configured.c_str());
             continue;
         }
 
@@ -335,10 +381,10 @@ void RegisterConfiguredHotkeys() {
         if (RegisterHotKey(nullptr, id, modifiers, vk)) {
             g_hotkeys.push_back({ id, modifiers, vk, modes[i], names[i] });
             Wh_Log(L"Hotkey registered: %s = %s", names[i],
-                   g_settings.hotkeys[(int)modes[i]].c_str());
+                   configured.c_str());
         } else {
             Wh_Log(L"Hotkey register failed: %s = %s, error=%u", names[i],
-                   g_settings.hotkeys[(int)modes[i]].c_str(), GetLastError());
+                   configured.c_str(), GetLastError());
         }
     }
 }
@@ -549,7 +595,7 @@ bool MoveWindowToMonitor(HWND hwnd, const MonitorInfo& target, int cascadeIndex,
         width = ScaleDimensionForWorkArea(width, sourceWorkWidth, workWidth);
         height = ScaleDimensionForWorkArea(height, sourceWorkHeight, workHeight);
     }
-    if (g_settings.shrinkOversized) {
+    if (g_settings.sizeMode != SizeMode::Preserve) {
         width = std::min(width, workWidth);
         height = std::min(height, workHeight);
     }
@@ -582,8 +628,7 @@ bool MoveWindowToMonitor(HWND hwnd, const MonitorInfo& target, int cascadeIndex,
     }
 
     UINT flags = SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_ASYNCWINDOWPOS;
-    if (g_settings.sizeMode == SizeMode::Preserve &&
-        !g_settings.shrinkOversized) {
+    if (g_settings.sizeMode == SizeMode::Preserve) {
         flags |= SWP_NOSIZE;
     }
     bool moved = SetWindowPos(hwnd, HWND_TOPMOST, x, y, width, height, flags) != FALSE;

--- a/mods/gather-windows-to-monitor.wh.cpp
+++ b/mods/gather-windows-to-monitor.wh.cpp
@@ -2,7 +2,7 @@
 // @id              gather-windows-to-monitor
 // @name            Gather Windows To Monitor
 // @description     Move eligible open windows to a chosen monitor with global hotkeys
-// @version         0.1.1
+// @version         0.1.2
 // @author          Fred
 // @github          https://github.com/fjdiazt
 // @include         windhawk.exe
@@ -20,14 +20,19 @@ By default, `Ctrl+Alt+Shift+W` moves only the foreground window to the primary m
 Configure hotkeys in Windhawk settings. Use strings such as `Ctrl+Alt+Shift+1`,
 `Ctrl+Win+M`, `F9`, or `None`.
 
+Window size behavior can preserve dimensions or scale them proportionally between
+the source and target monitor work areas.
+
 Skipped by default: minimized windows, fullscreen windows/games, hidden windows,
 tool windows, owned popups, desktop/taskbar/shell UI, cloaked UWP/helper windows,
 and untitled windows.
 
-The foreground-window action ignores the fullscreen, owned-window, and untitled-window
-filters. Windows already on the target monitor are left unchanged. Gather actions
-restore maximized windows before moving them and leave them restored for arranging;
-the foreground-window action re-maximizes them on the target monitor.
+The foreground-window action ignores the owned-window and untitled-window filters.
+The fullscreen setting applies to every action. Windows already on the target monitor
+are left unchanged. Gather actions restore maximized windows before moving them and
+leave them restored for arranging; the foreground-window action re-maximizes them on
+the target monitor. Moved windows are raised above existing target-monitor windows
+without taking focus.
 
 Enable logging in Windhawk to see per-window skip reasons.
 
@@ -45,37 +50,50 @@ not attempted because it is not reliable for all apps.
   $name: Move foreground window to primary monitor
 - HotkeyMonitor1: "Ctrl+Alt+Shift+1"
   $name: Gather to monitor 1
+  $description: Uses the first monitor detected by Windhawk, which may not be display 1 in Windows Settings.
 - HotkeyMonitor2: "Ctrl+Alt+Shift+2"
   $name: Gather to monitor 2
+  $description: Uses the second monitor detected by Windhawk, which may not be display 2 in Windows Settings.
 - HotkeyMonitor3: "Ctrl+Alt+Shift+3"
   $name: Gather to monitor 3
+  $description: Uses the third monitor detected by Windhawk, which may not be display 3 in Windows Settings.
 - HotkeyMouse: "Ctrl+Alt+Shift+M"
   $name: Gather to monitor under mouse
 - HotkeyForeground: "Ctrl+Alt+Shift+A"
   $name: Gather to foreground window monitor
+  $description: Moves all eligible windows to the monitor containing the active window.
 - SkipMinimized: true
   $name: Skip minimized windows
 - RestoreMinimized: false
   $name: Restore minimized windows before moving
+  $description: Used only when Skip minimized windows is turned off.
 - SkipFullscreen: true
   $name: Skip fullscreen windows
-- PreserveSize: true
-  $name: Preserve window size
+  $description: Applies to every action, including moving only the active window.
+- SizeMode: preserve
+  $name: Window size behavior
+  $description: Preserve keeps each window's current size. Scale adjusts its size for the destination monitor.
+  $options:
+  - preserve: Preserve
+  - scale: Scale proportionally
 - ShrinkOversized: true
   $name: Shrink oversized windows to fit
   $description: Keeps windows usable when target monitor is smaller.
 - CascadeWindows: true
   $name: Cascade windows
+  $description: Offsets moved windows so they do not completely overlap.
 - CascadeOffset: 24
   $name: Cascade offset in pixels
 - Anchor: center
   $name: Window anchor
+  $description: Chooses the starting position for moved windows.
   $options:
   - center: Center
   - top-left: Top left
   - mouse: Mouse cursor
 - IncludeOwnedWindows: false
   $name: Include owned windows/popups
+  $description: Also moves dialogs and secondary windows attached to another app window.
 */
 // ==/WindhawkModSettings==
 
@@ -111,6 +129,7 @@ enum class SkipReason {
     Minimized,
     MinimizedNoRestore,
     Fullscreen,
+    AlreadyOnTarget,
     BadRect,
 };
 
@@ -120,11 +139,16 @@ enum class AnchorMode {
     Mouse,
 };
 
+enum class SizeMode {
+    Preserve,
+    Scale,
+};
+
 struct Settings {
     bool skipMinimized;
     bool restoreMinimized;
     bool skipFullscreen;
-    bool preserveSize;
+    SizeMode sizeMode;
     bool shrinkOversized;
     bool cascadeWindows;
     int cascadeOffset;
@@ -148,6 +172,25 @@ struct Hotkey {
     const wchar_t* name;
 };
 
+constexpr int CascadeOffsetForIndex(int step, int available, size_t index) {
+    if (step <= 0 || available <= 0) return 0;
+    int positionCount = available / step + 1;
+    return (int)(index % (size_t)positionCount) * step;
+}
+static_assert(CascadeOffsetForIndex(24, 120, 5) == 120);
+static_assert(CascadeOffsetForIndex(24, 120, 6) == 0);
+
+constexpr int ScaleDimensionForWorkArea(int dimension, int sourceExtent,
+                                        int targetExtent) {
+    if (dimension <= 0 || sourceExtent <= 0 || targetExtent <= 0) {
+        return dimension;
+    }
+    int scaled = (int)((long long)dimension * targetExtent / sourceExtent);
+    return std::max(1, scaled);
+}
+static_assert(ScaleDimensionForWorkArea(800, 1920, 1280) == 533);
+static_assert(ScaleDimensionForWorkArea(1, 7680, 800) == 1);
+
 constexpr UINT WM_APP_RELOAD = WM_APP + 1;
 constexpr UINT WM_APP_STOP = WM_APP + 2;
 
@@ -167,6 +210,7 @@ std::wstring GetStringSetting(const wchar_t* name) {
 }
 
 AnchorMode ParseAnchorMode(const std::wstring& text);
+SizeMode ParseSizeMode(const std::wstring& text);
 
 void LoadSettings() {
     g_settings.hotkeys[(int)TargetMode::Primary] = GetStringSetting(L"HotkeyPrimary");
@@ -180,7 +224,7 @@ void LoadSettings() {
     g_settings.skipMinimized = Wh_GetIntSetting(L"SkipMinimized") != 0;
     g_settings.restoreMinimized = Wh_GetIntSetting(L"RestoreMinimized") != 0;
     g_settings.skipFullscreen = Wh_GetIntSetting(L"SkipFullscreen") != 0;
-    g_settings.preserveSize = Wh_GetIntSetting(L"PreserveSize") != 0;
+    g_settings.sizeMode = ParseSizeMode(GetStringSetting(L"SizeMode"));
     g_settings.shrinkOversized = Wh_GetIntSetting(L"ShrinkOversized") != 0;
     g_settings.cascadeWindows = Wh_GetIntSetting(L"CascadeWindows") != 0;
     g_settings.cascadeOffset = std::max(0, Wh_GetIntSetting(L"CascadeOffset"));
@@ -203,6 +247,11 @@ AnchorMode ParseAnchorMode(const std::wstring& text) {
     if (s == L"TOP-LEFT" || s == L"TOPLEFT") return AnchorMode::TopLeft;
     if (s == L"MOUSE") return AnchorMode::Mouse;
     return AnchorMode::Center;
+}
+
+SizeMode ParseSizeMode(const std::wstring& text) {
+    return TrimUpper(text) == L"SCALE" ? SizeMode::Scale
+                                        : SizeMode::Preserve;
 }
 
 UINT VkFromToken(const std::wstring& key) {
@@ -408,6 +457,7 @@ const wchar_t* SkipReasonText(SkipReason reason) {
         case SkipReason::Minimized: return L"minimized";
         case SkipReason::MinimizedNoRestore: return L"minimized without restore";
         case SkipReason::Fullscreen: return L"fullscreen";
+        case SkipReason::AlreadyOnTarget: return L"already on target monitor";
         case SkipReason::BadRect: return L"bad rect";
         default: return L"none";
     }
@@ -447,7 +497,7 @@ bool IsEligibleWindow(HWND hwnd, SkipReason* reason, bool bulk) {
         *reason = SkipReason::BadRect;
         return false;
     }
-    if (bulk && g_settings.skipFullscreen && IsLikelyFullscreen(hwnd, rect)) {
+    if (g_settings.skipFullscreen && IsLikelyFullscreen(hwnd, rect)) {
         *reason = SkipReason::Fullscreen;
         return false;
     }
@@ -465,10 +515,12 @@ void DebugLogSkipReason(HWND hwnd, SkipReason reason) {
 bool MoveWindowToMonitor(HWND hwnd, const MonitorInfo& target, int cascadeIndex,
                          bool bulk) {
     if (!IsWindow(hwnd)) return false;
-    if (MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) == target.handle) return false;
+    HMONITOR sourceHandle = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+    if (sourceHandle == target.handle) return false;
     const RECT& workArea = target.work;
     bool wasMaximized = IsZoomed(hwnd);
     bool wasMinimized = IsIconic(hwnd);
+    bool wasTopmost = (GetWindowLongPtr(hwnd, GWL_EXSTYLE) & WS_EX_TOPMOST) != 0;
 
     RECT rect{};
     if (wasMaximized || wasMinimized) {
@@ -489,7 +541,15 @@ bool MoveWindowToMonitor(HWND hwnd, const MonitorInfo& target, int cascadeIndex,
     int workWidth = workArea.right - workArea.left;
     int workHeight = workArea.bottom - workArea.top;
 
-    if (!g_settings.preserveSize || g_settings.shrinkOversized) {
+    if (g_settings.sizeMode == SizeMode::Scale) {
+        MONITORINFO sourceInfo{ sizeof(sourceInfo) };
+        if (!GetMonitorInfo(sourceHandle, &sourceInfo)) return false;
+        int sourceWorkWidth = sourceInfo.rcWork.right - sourceInfo.rcWork.left;
+        int sourceWorkHeight = sourceInfo.rcWork.bottom - sourceInfo.rcWork.top;
+        width = ScaleDimensionForWorkArea(width, sourceWorkWidth, workWidth);
+        height = ScaleDimensionForWorkArea(height, sourceWorkHeight, workHeight);
+    }
+    if (g_settings.shrinkOversized) {
         width = std::min(width, workWidth);
         height = std::min(height, workHeight);
     }
@@ -506,14 +566,6 @@ bool MoveWindowToMonitor(HWND hwnd, const MonitorInfo& target, int cascadeIndex,
         y = pt.y;
     }
 
-    int offset = g_settings.cascadeWindows ? g_settings.cascadeOffset * cascadeIndex : 0;
-    x += offset;
-    y += offset;
-    if (x + width > workArea.right || y + height > workArea.bottom) {
-        x = workArea.left;
-        y = workArea.top;
-    }
-
     int minX = (int)workArea.left;
     int minY = (int)workArea.top;
     int maxX = (int)std::max(workArea.left, workArea.right - std::min(width, workWidth));
@@ -521,12 +573,31 @@ bool MoveWindowToMonitor(HWND hwnd, const MonitorInfo& target, int cascadeIndex,
     x = std::clamp(x, minX, maxX);
     y = std::clamp(y, minY, maxY);
 
-    UINT flags = SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOOWNERZORDER |
-                 SWP_ASYNCWINDOWPOS;
-    if (g_settings.preserveSize && !g_settings.shrinkOversized) {
+    if (g_settings.cascadeWindows) {
+        int availableOffset = std::min(maxX - x, maxY - y);
+        int offset = CascadeOffsetForIndex(g_settings.cascadeOffset,
+                                           availableOffset, cascadeIndex);
+        x += offset;
+        y += offset;
+    }
+
+    UINT flags = SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_ASYNCWINDOWPOS;
+    if (g_settings.sizeMode == SizeMode::Preserve &&
+        !g_settings.shrinkOversized) {
         flags |= SWP_NOSIZE;
     }
-    bool moved = SetWindowPos(hwnd, nullptr, x, y, width, height, flags) != FALSE;
+    bool moved = SetWindowPos(hwnd, HWND_TOPMOST, x, y, width, height, flags) != FALSE;
+    if (moved && !wasTopmost) {
+        UINT demoteFlags = SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE |
+                           SWP_NOOWNERZORDER | SWP_ASYNCWINDOWPOS;
+        if (!SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0, demoteFlags)) {
+            Wh_Log(L"Failed to clear topmost for hwnd=%p, retrying", hwnd);
+            if (!SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0,
+                              demoteFlags)) {
+                Wh_Log(L"Failed to clear topmost for hwnd=%p", hwnd);
+            }
+        }
+    }
     if (wasMaximized && (!moved || !bulk)) {
         ShowWindowAsync(hwnd, SW_MAXIMIZE);
     }
@@ -536,6 +607,7 @@ bool MoveWindowToMonitor(HWND hwnd, const MonitorInfo& target, int cascadeIndex,
 struct GatherState {
     const MonitorInfo* target;
     bool bulk;
+    std::vector<HWND> windows;
     int found;
     int moved;
     int skipped;
@@ -549,14 +621,15 @@ BOOL CALLBACK GatherEnumProc(HWND hwnd, LPARAM lParam) {
         DebugLogSkipReason(hwnd, reason);
         return TRUE;
     }
+    if (MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) ==
+        state->target->handle) {
+        state->skipped++;
+        DebugLogSkipReason(hwnd, SkipReason::AlreadyOnTarget);
+        return TRUE;
+    }
 
     state->found++;
-    if (MoveWindowToMonitor(hwnd, *state->target, state->moved, state->bulk)) {
-        state->moved++;
-    } else {
-        state->skipped++;
-        DebugLogSkipReason(hwnd, SkipReason::Invalid);
-    }
+    state->windows.push_back(hwnd);
     return TRUE;
 }
 
@@ -572,6 +645,7 @@ void GatherWindows(TargetMode mode) {
            target->work.right, target->work.bottom);
     GatherState state{ target,
                        mode != TargetMode::ForegroundPrimary,
+                       {},
                        0,
                        0,
                        0 };
@@ -579,6 +653,15 @@ void GatherWindows(TargetMode mode) {
         GatherEnumProc(GetForegroundWindow(), (LPARAM)&state);
     } else {
         EnumWindows(GatherEnumProc, (LPARAM)&state);
+    }
+    for (size_t i = state.windows.size(); i-- > 0;) {
+        HWND hwnd = state.windows[i];
+        if (MoveWindowToMonitor(hwnd, *state.target, (int)i, state.bulk)) {
+            state.moved++;
+        } else {
+            state.skipped++;
+            DebugLogSkipReason(hwnd, SkipReason::Invalid);
+        }
     }
     Wh_Log(L"Gather done: found=%d moved=%d skipped=%d", state.found, state.moved, state.skipped);
 }

--- a/mods/gather-windows-to-monitor.wh.cpp
+++ b/mods/gather-windows-to-monitor.wh.cpp
@@ -195,12 +195,12 @@ applications handle that inconsistently.
     primary display and makes DISPLAY3 become display 2. Missing displays keep
     their slots; unlisted displays follow in automatic order. An invalid override
     uses automatic order. Leave empty for automatic DISPLAY number order.
-- RestoreMinimized: 0
+- RestoreMinimized: skip
   $name: Minimized windows
   $description: Choose whether minimized windows stay minimized or are restored and moved.
   $options:
-  - 0: Skip minimized windows (default)
-  - 1: Restore and move minimized windows
+  - skip: Skip minimized windows (default)
+  - restore: Restore and move minimized windows
 - SkipFullscreen: true
   $name: Skip fullscreen windows
   $description: Applies to every action, including moving only the active window.
@@ -527,7 +527,9 @@ void LoadSettings() {
                displayOrderText.c_str());
         g_settings.displayOrder = ParseDisplayOrder(L"");
     }
-    g_settings.restoreMinimized = Wh_GetIntSetting(L"RestoreMinimized") != 0;
+    g_settings.restoreMinimized =
+        Wh_GetIntSetting(L"RestoreMinimized") != 0 ||
+        GetStringSetting(L"RestoreMinimized") == L"restore";
     g_settings.skipFullscreen = Wh_GetIntSetting(L"SkipFullscreen") != 0;
     g_settings.sizeMode = ParseSizeMode(GetStringSetting(L"SizeMode"));
     g_settings.cascadeWindows = Wh_GetIntSetting(L"CascadeWindows") != 0;

--- a/mods/gather-windows-to-monitor.wh.cpp
+++ b/mods/gather-windows-to-monitor.wh.cpp
@@ -1,7 +1,7 @@
 // ==WindhawkMod==
 // @id              gather-windows-to-monitor
-// @name            Gather Windows To Monitor
-// @description     Move eligible open windows to a chosen monitor with global hotkeys
+// @name            Gather Windows To Display
+// @description     Move one window or gather eligible open windows to a chosen display with global hotkeys
 // @version         0.1.2
 // @author          Fred
 // @github          https://github.com/fjdiazt
@@ -11,68 +11,91 @@
 
 // ==WindhawkModReadme==
 /*
-# Gather Windows To Monitor
+# Gather Windows To Display
 
-Global hotkeys gather visible application windows to a selected monitor work area.
+Global hotkeys move the foreground window or gather visible application windows
+to a selected display work area.
 
-By default, `Ctrl+Alt+Shift+W` moves only the foreground window to the primary monitor.
+By default, `Ctrl+Alt+Shift+W` moves the foreground window to the primary display,
+and `Ctrl+Alt+Shift+1` through `Ctrl+Alt+Shift+5` move it to a numbered display.
+Numbered gather actions are available but disabled by default.
 
 Configure hotkeys in Windhawk settings. Use strings such as `Ctrl+Alt+Shift+1`,
 `Ctrl+Win+M`, `F9`, or `None`.
 
 Window size behavior can preserve dimensions or scale them proportionally between
-the source and target monitor work areas.
+the source and target display work areas.
 
-Skipped by default: minimized windows, fullscreen windows/games, hidden windows,
-tool windows, owned popups, desktop/taskbar/shell UI, cloaked UWP/helper windows,
-and untitled windows.
+Skipped by default: minimized windows, hidden windows, tool windows,
+desktop/taskbar/shell UI, cloaked UWP/helper windows, and untitled windows.
 
 The foreground-window action ignores the owned-window and untitled-window filters.
-The fullscreen setting applies to every action. Windows already on the target monitor
+The fullscreen setting applies to every action. Windows already on the target display
 are left unchanged. Gather actions restore maximized windows before moving them and
 leave them restored for arranging; the foreground-window action re-maximizes them on
-the target monitor. Moved windows are raised above existing target-monitor windows
+the target display. Moved windows are raised above existing target-display windows
 without taking focus.
 
 Enable logging in Windhawk to see per-window skip reasons.
 
-Known limitations: monitor number hotkeys use Win32 monitor enumeration order, not
-the Windows Settings display number. Moving minimized windows without restoring is
+Known limitations: numbered display actions use detection order, which can differ
+from the display numbers in Windows Settings. Moving minimized windows without restoring is
 not attempted because it is not reliable for all apps.
 */
 // ==/WindhawkModReadme==
 
 // ==WindhawkModSettings==
 /*
-- HotkeyPrimary: "Ctrl+Alt+Shift+P"
-  $name: Gather to primary monitor
 - HotkeyForegroundPrimary: "Ctrl+Alt+Shift+W"
-  $name: Move foreground window to primary monitor
-- HotkeyMonitor1: "Ctrl+Alt+Shift+1"
-  $name: Gather to monitor 1
-  $description: Uses the first monitor detected by Windhawk, which may not be display 1 in Windows Settings.
-- HotkeyMonitor2: "Ctrl+Alt+Shift+2"
-  $name: Gather to monitor 2
-  $description: Uses the second monitor detected by Windhawk, which may not be display 2 in Windows Settings.
-- HotkeyMonitor3: "Ctrl+Alt+Shift+3"
-  $name: Gather to monitor 3
-  $description: Uses the third monitor detected by Windhawk, which may not be display 3 in Windows Settings.
+  $name: Move foreground window to primary display
+- HotkeyForegroundMonitor1: "Ctrl+Alt+Shift+1"
+  $name: Move foreground window to display 1
+  $description: Uses the first display detected by Windhawk, which may not be display 1 in Windows Settings.
+- HotkeyForegroundMonitor2: "Ctrl+Alt+Shift+2"
+  $name: Move foreground window to display 2
+  $description: Uses the second display detected by Windhawk, which may not be display 2 in Windows Settings.
+- HotkeyForegroundMonitor3: "Ctrl+Alt+Shift+3"
+  $name: Move foreground window to display 3
+  $description: Uses the third display detected by Windhawk, which may not be display 3 in Windows Settings.
+- HotkeyForegroundMonitor4: "Ctrl+Alt+Shift+4"
+  $name: Move foreground window to display 4
+  $description: Uses the fourth display detected by Windhawk, which may not be display 4 in Windows Settings.
+- HotkeyForegroundMonitor5: "Ctrl+Alt+Shift+5"
+  $name: Move foreground window to display 5
+  $description: Uses the fifth display detected by Windhawk, which may not be display 5 in Windows Settings.
+- HotkeyPrimary: "Ctrl+Alt+Shift+P"
+  $name: Gather to primary display
 - HotkeyMouse: "Ctrl+Alt+Shift+M"
-  $name: Gather to monitor under mouse
+  $name: Gather to display under mouse
 - HotkeyForeground: "Ctrl+Alt+Shift+A"
-  $name: Gather to foreground window monitor
-  $description: Moves all eligible windows to the monitor containing the active window.
-- SkipMinimized: true
+  $name: Gather to foreground window display
+  $description: Moves all eligible windows to the display containing the active window.
+- HotkeyMonitor1: "None"
+  $name: Gather to display 1
+  $description: Uses the first display detected by Windhawk, which may not be display 1 in Windows Settings.
+- HotkeyMonitor2: "None"
+  $name: Gather to display 2
+  $description: Uses the second display detected by Windhawk, which may not be display 2 in Windows Settings.
+- HotkeyMonitor3: "None"
+  $name: Gather to display 3
+  $description: Uses the third display detected by Windhawk, which may not be display 3 in Windows Settings.
+- HotkeyMonitor4: "None"
+  $name: Gather to display 4
+  $description: Uses the fourth display detected by Windhawk, which may not be display 4 in Windows Settings.
+- HotkeyMonitor5: "None"
+  $name: Gather to display 5
+  $description: Uses the fifth display detected by Windhawk, which may not be display 5 in Windows Settings.
+- SkipMinimized: false
   $name: Skip minimized windows
 - RestoreMinimized: false
   $name: Restore minimized windows before moving
   $description: Used only when Skip minimized windows is turned off.
-- SkipFullscreen: true
+- SkipFullscreen: false
   $name: Skip fullscreen windows
   $description: Applies to every action, including moving only the active window.
 - SizeMode: fit
   $name: Window size behavior
-  $description: Fit shrinks only oversized windows. Preserve never resizes. Scale resizes all windows for the destination monitor.
+  $description: Fit shrinks only oversized windows. Preserve never resizes. Scale resizes all windows for the destination display.
   $options:
   - fit: Fit oversized windows (default)
   - preserve: Always preserve size
@@ -89,7 +112,7 @@ not attempted because it is not reliable for all apps.
   - center: Center
   - top-left: Top left
   - mouse: Mouse cursor
-- IncludeOwnedWindows: false
+- IncludeOwnedWindows: true
   $name: Include owned windows/popups
   $description: Also moves dialogs and secondary windows attached to another app window.
 */
@@ -108,11 +131,19 @@ not attempted because it is not reliable for all apps.
 enum class TargetMode {
     Primary,
     ForegroundPrimary,
+    ForegroundMonitor1,
+    ForegroundMonitor2,
+    ForegroundMonitor3,
+    ForegroundMonitor4,
+    ForegroundMonitor5,
     Monitor1,
     Monitor2,
     Monitor3,
+    Monitor4,
+    Monitor5,
     Mouse,
     Foreground,
+    Count,
 };
 
 enum class SkipReason {
@@ -152,7 +183,7 @@ struct Settings {
     int cascadeOffset;
     AnchorMode anchor;
     bool includeOwnedWindows;
-    std::wstring hotkeys[7];
+    std::wstring hotkeys[(int)TargetMode::Count];
 };
 
 struct MonitorInfo {
@@ -189,6 +220,27 @@ constexpr int ScaleDimensionForWorkArea(int dimension, int sourceExtent,
 static_assert(ScaleDimensionForWorkArea(800, 1920, 1280) == 533);
 static_assert(ScaleDimensionForWorkArea(1, 7680, 800) == 1);
 
+constexpr bool IsForegroundOnlyAction(TargetMode mode) {
+    return mode == TargetMode::ForegroundPrimary ||
+           (mode >= TargetMode::ForegroundMonitor1 &&
+            mode <= TargetMode::ForegroundMonitor5);
+}
+
+constexpr int NumberedDisplayIndex(TargetMode mode) {
+    if (mode >= TargetMode::ForegroundMonitor1 &&
+        mode <= TargetMode::ForegroundMonitor5) {
+        return (int)mode - (int)TargetMode::ForegroundMonitor1;
+    }
+    if (mode >= TargetMode::Monitor1 && mode <= TargetMode::Monitor5) {
+        return (int)mode - (int)TargetMode::Monitor1;
+    }
+    return -1;
+}
+static_assert(IsForegroundOnlyAction(TargetMode::ForegroundMonitor5));
+static_assert(!IsForegroundOnlyAction(TargetMode::Monitor5));
+static_assert(NumberedDisplayIndex(TargetMode::ForegroundMonitor2) == 1);
+static_assert(NumberedDisplayIndex(TargetMode::Monitor5) == 4);
+
 constexpr UINT WM_APP_RELOAD = WM_APP + 1;
 constexpr UINT WM_APP_STOP = WM_APP + 2;
 
@@ -214,9 +266,21 @@ void LoadSettings() {
     g_settings.hotkeys[(int)TargetMode::Primary] = GetStringSetting(L"HotkeyPrimary");
     g_settings.hotkeys[(int)TargetMode::ForegroundPrimary] =
         GetStringSetting(L"HotkeyForegroundPrimary");
+    g_settings.hotkeys[(int)TargetMode::ForegroundMonitor1] =
+        GetStringSetting(L"HotkeyForegroundMonitor1");
+    g_settings.hotkeys[(int)TargetMode::ForegroundMonitor2] =
+        GetStringSetting(L"HotkeyForegroundMonitor2");
+    g_settings.hotkeys[(int)TargetMode::ForegroundMonitor3] =
+        GetStringSetting(L"HotkeyForegroundMonitor3");
+    g_settings.hotkeys[(int)TargetMode::ForegroundMonitor4] =
+        GetStringSetting(L"HotkeyForegroundMonitor4");
+    g_settings.hotkeys[(int)TargetMode::ForegroundMonitor5] =
+        GetStringSetting(L"HotkeyForegroundMonitor5");
     g_settings.hotkeys[(int)TargetMode::Monitor1] = GetStringSetting(L"HotkeyMonitor1");
     g_settings.hotkeys[(int)TargetMode::Monitor2] = GetStringSetting(L"HotkeyMonitor2");
     g_settings.hotkeys[(int)TargetMode::Monitor3] = GetStringSetting(L"HotkeyMonitor3");
+    g_settings.hotkeys[(int)TargetMode::Monitor4] = GetStringSetting(L"HotkeyMonitor4");
+    g_settings.hotkeys[(int)TargetMode::Monitor5] = GetStringSetting(L"HotkeyMonitor5");
     g_settings.hotkeys[(int)TargetMode::Mouse] = GetStringSetting(L"HotkeyMouse");
     g_settings.hotkeys[(int)TargetMode::Foreground] = GetStringSetting(L"HotkeyForeground");
     g_settings.skipMinimized = Wh_GetIntSetting(L"SkipMinimized") != 0;
@@ -353,14 +417,23 @@ void UnregisterConfiguredHotkeys() {
 void RegisterConfiguredHotkeys() {
     UnregisterConfiguredHotkeys();
 
+    // Existing actions register first so an update never changes what an
+    // already-configured shortcut does when a new default uses the same keys.
     const TargetMode modes[] = {
         TargetMode::Primary, TargetMode::ForegroundPrimary, TargetMode::Monitor1,
-        TargetMode::Monitor2, TargetMode::Monitor3, TargetMode::Mouse,
-        TargetMode::Foreground,
+        TargetMode::Monitor2, TargetMode::Monitor3, TargetMode::Monitor4,
+        TargetMode::Monitor5, TargetMode::Mouse, TargetMode::Foreground,
+        TargetMode::ForegroundMonitor1, TargetMode::ForegroundMonitor2,
+        TargetMode::ForegroundMonitor3, TargetMode::ForegroundMonitor4,
+        TargetMode::ForegroundMonitor5,
     };
     const wchar_t* names[] = {
-        L"primary", L"foreground to primary", L"monitor 1", L"monitor 2",
-        L"monitor 3", L"mouse", L"foreground",
+        L"primary display", L"foreground to primary display", L"display 1",
+        L"display 2", L"display 3", L"display 4", L"display 5",
+        L"display under mouse", L"foreground window display",
+        L"foreground to display 1", L"foreground to display 2",
+        L"foreground to display 3", L"foreground to display 4",
+        L"foreground to display 5",
     };
 
     for (size_t i = 0; i < ARRAYSIZE(modes); i++) {
@@ -374,6 +447,19 @@ void RegisterConfiguredHotkeys() {
         }
         if (parseResult == HotkeyParseResult::Invalid) {
             Wh_Log(L"Invalid hotkey: %s = %s", names[i], configured.c_str());
+            continue;
+        }
+
+        const Hotkey* conflict = nullptr;
+        for (const Hotkey& hotkey : g_hotkeys) {
+            if (hotkey.modifiers == modifiers && hotkey.vk == vk) {
+                conflict = &hotkey;
+                break;
+            }
+        }
+        if (conflict) {
+            Wh_Log(L"Hotkey conflict: %s = %s already used by %s; skipping",
+                   names[i], configured.c_str(), conflict->name);
             continue;
         }
 
@@ -403,11 +489,11 @@ BOOL CALLBACK MonitorEnumProc(HMONITOR monitor, HDC, LPRECT, LPARAM lParam) {
 std::vector<MonitorInfo> GetMonitors() {
     std::vector<MonitorInfo> monitors;
     EnumDisplayMonitors(nullptr, nullptr, MonitorEnumProc, (LPARAM)&monitors);
-    Wh_Log(L"Monitors: %zu", monitors.size());
+    Wh_Log(L"Displays: %zu", monitors.size());
     for (size_t i = 0; i < monitors.size(); i++) {
         const RECT& m = monitors[i].monitor;
         const RECT& w = monitors[i].work;
-        Wh_Log(L"Monitor %zu%s: monitor=(%ld,%ld,%ld,%ld) work=(%ld,%ld,%ld,%ld)",
+        Wh_Log(L"Display %zu%s: bounds=(%ld,%ld,%ld,%ld) work=(%ld,%ld,%ld,%ld)",
                i + 1, monitors[i].primary ? L" primary" : L"", m.left, m.top,
                m.right, m.bottom, w.left, w.top, w.right, w.bottom);
     }
@@ -433,10 +519,11 @@ const MonitorInfo* ResolveTargetMonitor(TargetMode mode, const std::vector<Monit
     if (mode == TargetMode::Primary || mode == TargetMode::ForegroundPrimary) {
         return PrimaryMonitor(monitors);
     }
-    if (mode == TargetMode::Monitor1 || mode == TargetMode::Monitor2 || mode == TargetMode::Monitor3) {
-        size_t index = (size_t)mode - (size_t)TargetMode::Monitor1;
+    int numberedIndex = NumberedDisplayIndex(mode);
+    if (numberedIndex >= 0) {
+        size_t index = (size_t)numberedIndex;
         if (index < monitors.size()) return &monitors[index];
-        Wh_Log(L"Requested monitor %zu missing; using primary", index + 1);
+        Wh_Log(L"Requested display %zu missing; using primary", index + 1);
         return PrimaryMonitor(monitors);
     }
     if (mode == TargetMode::Mouse) {
@@ -503,7 +590,7 @@ const wchar_t* SkipReasonText(SkipReason reason) {
         case SkipReason::Minimized: return L"minimized";
         case SkipReason::MinimizedNoRestore: return L"minimized without restore";
         case SkipReason::Fullscreen: return L"fullscreen";
-        case SkipReason::AlreadyOnTarget: return L"already on target monitor";
+        case SkipReason::AlreadyOnTarget: return L"already on target display";
         case SkipReason::BadRect: return L"bad rect";
         default: return L"none";
     }
@@ -682,19 +769,20 @@ void GatherWindows(TargetMode mode) {
     auto monitors = GetMonitors();
     const MonitorInfo* target = ResolveTargetMonitor(mode, monitors);
     if (!target) {
-        Wh_Log(L"No monitors found");
+        Wh_Log(L"No displays found");
         return;
     }
 
     Wh_Log(L"Target work area: (%ld,%ld,%ld,%ld)", target->work.left, target->work.top,
            target->work.right, target->work.bottom);
+    bool foregroundOnly = IsForegroundOnlyAction(mode);
     GatherState state{ target,
-                       mode != TargetMode::ForegroundPrimary,
+                       !foregroundOnly,
                        {},
                        0,
                        0,
                        0 };
-    if (mode == TargetMode::ForegroundPrimary) {
+    if (foregroundOnly) {
         GatherEnumProc(GetForegroundWindow(), (LPARAM)&state);
     } else {
         EnumWindows(GatherEnumProc, (LPARAM)&state);

--- a/mods/gather-windows-to-monitor.wh.cpp
+++ b/mods/gather-windows-to-monitor.wh.cpp
@@ -60,8 +60,8 @@ using Windows device-name order. For example, connected `DISPLAY4` and `DISPLAY6
 become display 1 and display 2. **Display order override** changes what "display 1",
 "display 2", and so on mean while keeping every hotkey unchanged.
 
-Enter a comma-separated list containing `primary` or display device names. Both
-`DISPLAY4` and the full `\\.\DISPLAY4` form are accepted:
+Enter up to five comma-separated entries containing `primary` or display device
+names. Both `DISPLAY4` and the full `\\.\DISPLAY4` form are accepted:
 
 * `primary,DISPLAY3` keeps display 1 tied to whichever display is currently
   primary and makes `DISPLAY3` become display 2.
@@ -117,20 +117,17 @@ should check this dropdown once after installing the new version.
 ## Updating minimized window settings
 
 The previous two minimized-window checkboxes are now one **Minimized windows**
-dropdown. The existing **Restore minimized windows before moving** value is kept:
-
-* Off maps to **Skip minimized windows**.
-* On maps to **Restore and move minimized windows**.
-
-If both old checkboxes were on, select **Skip minimized windows** to keep the old
-behavior, where skipping took priority.
+dropdown. If minimized windows were restored and moved before updating, select
+**Restore and move minimized windows** once. Otherwise, the new default continues
+skipping minimized windows.
 
 ## Window handling settings
 
 * **Minimized windows** chooses whether minimized windows are skipped or restored
   and moved. Skipping is the default.
-* **Skip fullscreen windows** avoids disturbing fullscreen apps and games. It
-  applies to both single-window moves and gather actions.
+* **Skip fullscreen windows during gather** avoids sweeping fullscreen apps and
+  games into a bulk gather. An explicit foreground-window shortcut still moves
+  the selected fullscreen window.
 * **Window size behavior** controls resizing at the destination. **Fit** shrinks
   only windows that are too large, **Preserve** never resizes, and **Scale**
   adjusts size in proportion to the destination display.
@@ -202,20 +199,20 @@ applications handle that inconsistently.
   $name: Display order override
   $description: >-
     Remaps what numbered move and gather shortcuts target without rebinding them.
-    Enter comma-separated primary or display names such as DISPLAY4 or
+    Enter up to five comma-separated primary or display names such as DISPLAY4 or
     \\.\DISPLAY4. Example: primary,DISPLAY3 keeps display 1 tied to the current
     primary display and makes DISPLAY3 become display 2. Missing displays keep
     their slots; unlisted displays follow in automatic order. An invalid override
     uses automatic order. Leave empty to number connected displays by DISPLAY name.
-- RestoreMinimized: skip
+- MinimizedMode: skip
   $name: Minimized windows
   $description: Choose whether minimized windows stay minimized or are restored and moved.
   $options:
   - skip: Skip minimized windows (default)
   - restore: Restore and move minimized windows
 - SkipFullscreen: true
-  $name: Skip fullscreen windows
-  $description: Applies to every action, including moving only the active window.
+  $name: Skip fullscreen windows during gather
+  $description: Foreground-window shortcuts still move the selected fullscreen window.
 - SizeMode: fit
   $name: Window size behavior
   $description: Fit shrinks only oversized windows. Preserve never resizes. Scale resizes all windows for the destination display.
@@ -540,8 +537,7 @@ void LoadSettings() {
         g_settings.displayOrder = ParseDisplayOrder(L"");
     }
     g_settings.restoreMinimized =
-        Wh_GetIntSetting(L"RestoreMinimized") != 0 ||
-        GetStringSetting(L"RestoreMinimized") == L"restore";
+        GetStringSetting(L"MinimizedMode") == L"restore";
     g_settings.skipFullscreen = Wh_GetIntSetting(L"SkipFullscreen") != 0;
     g_settings.sizeMode = ParseSizeMode(GetStringSetting(L"SizeMode"));
     g_settings.cascadeWindows = Wh_GetIntSetting(L"CascadeWindows") != 0;
@@ -891,20 +887,17 @@ const MonitorInfo* ResolveTargetMonitor(TargetMode mode, const std::vector<Monit
     return MonitorByHandle(monitors, MonitorFromWindow(foreground, MONITOR_DEFAULTTOPRIMARY));
 }
 
-bool IsClass(HWND hwnd, const wchar_t* name) {
-    wchar_t className[128]{};
-    return GetClassName(hwnd, className, ARRAYSIZE(className)) &&
-           _wcsicmp(className, name) == 0;
-}
-
 bool IsShellClass(HWND hwnd) {
     const wchar_t* shellClasses[] = {
         L"Progman", L"WorkerW", L"Shell_TrayWnd", L"Shell_SecondaryTrayWnd",
         L"DV2ControlHost", L"Windows.UI.Core.CoreWindow", L"XamlExplorerHostIslandWindow",
         L"NotifyIconOverflowWindow", L"MultitaskingViewFrame", L"Windows.UI.Composition.DesktopWindowContentBridge",
     };
-    for (const wchar_t* name : shellClasses) {
-        if (IsClass(hwnd, name)) return true;
+    wchar_t className[128]{};
+    if (GetClassName(hwnd, className, ARRAYSIZE(className))) {
+        for (const wchar_t* name : shellClasses) {
+            if (_wcsicmp(className, name) == 0) return true;
+        }
     }
     return hwnd == GetDesktopWindow() || hwnd == GetShellWindow();
 }
@@ -955,7 +948,6 @@ bool IsEligibleWindow(HWND hwnd, SkipReason* reason, bool bulk) {
     *reason = SkipReason::None;
     if (!IsWindow(hwnd)) { *reason = SkipReason::Invalid; return false; }
     if (!IsWindowVisible(hwnd)) { *reason = SkipReason::Invisible; return false; }
-    if (IsCloaked(hwnd)) { *reason = SkipReason::Cloaked; return false; }
     if (IsShellClass(hwnd)) { *reason = SkipReason::DesktopShell; return false; }
 
     LONG_PTR exStyle = GetWindowLongPtr(hwnd, GWL_EXSTYLE);
@@ -963,6 +955,7 @@ bool IsEligibleWindow(HWND hwnd, SkipReason* reason, bool bulk) {
         *reason = SkipReason::ToolWindow;
         return false;
     }
+    if (IsCloaked(hwnd)) { *reason = SkipReason::Cloaked; return false; }
     if (bulk && !g_settings.includeOwnedWindows && GetWindow(hwnd, GW_OWNER)) {
         *reason = SkipReason::OwnedWindow;
         return false;
@@ -985,7 +978,7 @@ bool IsEligibleWindow(HWND hwnd, SkipReason* reason, bool bulk) {
         *reason = SkipReason::BadRect;
         return false;
     }
-    if (g_settings.skipFullscreen && IsLikelyFullscreen(hwnd, rect)) {
+    if (bulk && g_settings.skipFullscreen && IsLikelyFullscreen(hwnd, rect)) {
         *reason = SkipReason::Fullscreen;
         return false;
     }

--- a/mods/gather-windows-to-monitor.wh.cpp
+++ b/mods/gather-windows-to-monitor.wh.cpp
@@ -18,7 +18,13 @@ to a selected display work area.
 
 By default, `Ctrl+Alt+Shift+W` moves the foreground window to the primary display,
 and `Ctrl+Alt+Shift+1` through `Ctrl+Alt+Shift+5` move it to a numbered display.
-Numbered gather actions are available but disabled by default.
+`Ctrl+Alt+Shift+P` gathers to the primary display, `Ctrl+Alt+Shift+M` gathers to
+the display under the mouse, and `Ctrl+Alt+Shift+A` gathers to the active window's
+display. Numbered gather actions are available but disabled by default.
+
+If a numbered display is unavailable, the primary display is used. After an update,
+an existing gather shortcut keeps priority over a conflicting new move shortcut;
+change either shortcut in settings to enable both actions.
 
 Configure hotkeys in Windhawk settings. Use strings such as `Ctrl+Alt+Shift+1`,
 `Ctrl+Win+M`, `F9`, or `None`.

--- a/mods/gather-windows-to-monitor.wh.cpp
+++ b/mods/gather-windows-to-monitor.wh.cpp
@@ -17,9 +17,16 @@ Move the active window, or gather eligible open windows, to a chosen display wit
 global shortcuts. Windows are placed inside the usable desktop area so taskbars
 remain clear. Windows already on the destination display are left unchanged.
 
-Numbered shortcuts can be remapped to the displays you intend without changing
-the shortcuts themselves. This is useful when Windows and Windhawk number displays
-differently or when reconnecting a display changes their order.
+Numbered shortcuts follow the `DISPLAY1`, `DISPLAY2`, and other names assigned by
+Windows. They can be remapped without changing the shortcuts themselves.
+
+## Choosing between similar mods
+
+This mod is useful when you want shortcuts for the primary, numbered, mouse, or
+active-window display, or when you want to gather multiple windows at once. The
+**Move Window to Monitor** mod is a simpler alternative when you only want to move
+the active window to the nearest display above, below, left, or right with arrow
+shortcuts. Both mods can be installed, but their shortcuts must not conflict.
 
 ## Move foreground window shortcuts
 
@@ -48,37 +55,69 @@ is logged. This protects existing shortcuts after an update.
 
 ## Display order override
 
-Numbered move and gather actions normally use the order in which Windhawk detects
-your displays. That order can differ from the numbers in Windows Settings and can
-change after displays are connected or disconnected. **Display order override**
-changes what "display 1", "display 2", and so on mean while keeping every hotkey
-unchanged.
+Numbered move and gather actions normally follow Windows display device names in
+numeric order: `DISPLAY1`, `DISPLAY2`, and so on. **Display order override** changes
+what "display 1", "display 2", and so on mean while keeping every hotkey unchanged.
 
-Enter a comma-separated list containing `primary` or detected display numbers:
+Enter a comma-separated list containing `primary` or display device names. Both
+`DISPLAY4` and the full `\\.\DISPLAY4` form are accepted:
 
-* `primary,3` keeps display 1 tied to whichever display is currently primary and
-  makes detected display 3 become display 2.
-* `4,3` makes detected display 4 become display 1 and detected display 3 become
-  display 2.
+* `primary,DISPLAY3` keeps display 1 tied to whichever display is currently
+  primary and makes `DISPLAY3` become display 2.
+* `\\.\DISPLAY4,\\.\DISPLAY3` accepts names copied directly from PowerShell.
 
-Displays not listed keep their detected order after the listed displays. For
-example, if the detected order is `1,2,3,4`, the override `4,3` produces
-`4,3,1,2`. The override affects numbered move and gather actions only. Primary,
-mouse, and active-window destinations are unchanged.
+Each listed name keeps its numbered slot even while that display is disconnected;
+using that shortcut temporarily falls back to the primary display. Unlisted
+connected displays follow in normal `DISPLAY` number order. The override affects
+numbered move and gather actions only. Primary, mouse, and active-window
+destinations are unchanged.
 
-Leave the setting empty to use detection order. An invalid value rejects the
-whole override and safely returns to detection order. Enable Windhawk logging to
-see both the detected order and the final numbered order. These lines appear when
-the mod starts, settings change, or the display layout changes.
+To find the names assigned to connected displays, run this in Windows PowerShell:
+
+```powershell
+Add-Type -AssemblyName System.Windows.Forms
+[System.Windows.Forms.Screen]::AllScreens |
+    Select-Object DeviceName, Primary, Bounds
+```
+
+Leave the setting empty to use automatic `DISPLAY` number order. An invalid value
+rejects the whole override and safely returns to automatic order. Windhawk logging
+also shows connected device names and the final numbered order when the mod starts,
+settings change, or the display layout changes.
 
 If a numbered destination is unavailable, the primary display is used.
 
+## Updating window size settings
+
+Earlier versions used **Window size behavior** together with a separate
+**Shrink oversized windows to fit** switch. After updating, verify the new
+**Window size behavior** setting:
+
+* **Preserve** with shrinking on maps to **Fit oversized windows**.
+* **Preserve** with shrinking off maps to **Always preserve size**.
+* **Scale proportionally** with shrinking on maps to **Scale proportionally**.
+* **Scale proportionally** with shrinking off also maps most closely to
+  **Scale proportionally**, but oversized windows are now kept within the
+  destination display.
+
+Windhawk can retain an existing value during an update, so customized users
+should check this dropdown once after installing the new version.
+
+## Updating minimized window settings
+
+The previous two minimized-window checkboxes are now one **Minimized windows**
+dropdown. The existing **Restore minimized windows before moving** value is kept:
+
+* Off maps to **Skip minimized windows**.
+* On maps to **Restore and move minimized windows**.
+
+If both old checkboxes were on, select **Skip minimized windows** to keep the old
+behavior, where skipping took priority.
+
 ## Window handling settings
 
-* **Skip minimized windows** ignores minimized windows immediately.
-* **Restore minimized windows before moving** applies when skipping is off.
-  When both settings are off, minimized windows remain skipped because moving
-  them without restoring is unreliable.
+* **Minimized windows** chooses whether minimized windows are skipped or restored
+  and moved. Skipping is the default.
 * **Skip fullscreen windows** avoids disturbing fullscreen apps and games. It
   applies to both single-window moves and gather actions.
 * **Window size behavior** controls resizing at the destination. **Fit** shrinks
@@ -101,9 +140,8 @@ Moved windows are raised above windows already on the destination display withou
 taking keyboard focus. A moved maximized active window is maximized again on the
 destination. Gathered maximized windows are restored so they can be arranged.
 
-Detected display numbers are Windhawk's numbers, not necessarily the numbers shown
-in Windows Settings. Moving a minimized window without restoring it is not
-supported because applications handle that inconsistently.
+Moving a minimized window without restoring it is not supported because
+applications handle that inconsistently.
 */
 // ==/WindhawkModReadme==
 
@@ -152,16 +190,17 @@ supported because applications handle that inconsistently.
   $name: Display order override
   $description: >-
     Remaps what numbered move and gather shortcuts target without rebinding them.
-    Enter comma-separated primary or detected display numbers. Example: primary,3
-    keeps display 1 tied to the current primary display after reconnects and makes
-    detected display 3 become display 2. Unlisted displays keep detected order.
-    Enable Windhawk logging to see detected numbers. Invalid values are ignored;
-    leave empty for detection order.
-- SkipMinimized: false
-  $name: Skip minimized windows
-- RestoreMinimized: false
-  $name: Restore minimized windows before moving
-  $description: Used only when Skip minimized windows is turned off.
+    Enter comma-separated primary or display names such as DISPLAY4 or
+    \\.\DISPLAY4. Example: primary,DISPLAY3 keeps display 1 tied to the current
+    primary display and makes DISPLAY3 become display 2. Missing displays keep
+    their slots; unlisted displays follow in automatic order. An invalid override
+    uses automatic order. Leave empty for automatic DISPLAY number order.
+- RestoreMinimized: 0
+  $name: Minimized windows
+  $description: Choose whether minimized windows stay minimized or are restored and moved.
+  $options:
+  - 0: Skip minimized windows (default)
+  - 1: Restore and move minimized windows
 - SkipFullscreen: true
   $name: Skip fullscreen windows
   $description: Applies to every action, including moving only the active window.
@@ -192,10 +231,13 @@ supported because applications handle that inconsistently.
 
 #include <dwmapi.h>
 #include <shellapi.h>
+#include <windhawk_utils.h>
 #include <windows.h>
 
 #include <algorithm>
 #include <atomic>
+#include <climits>
+#include <cstdlib>
 #include <cwctype>
 #include <string>
 #include <string_view>
@@ -229,7 +271,6 @@ enum class SkipReason {
     OwnedWindow,
     Untitled,
     Minimized,
-    MinimizedNoRestore,
     Fullscreen,
     AlreadyOnTarget,
     BadRect,
@@ -249,12 +290,14 @@ enum class SizeMode {
 
 struct DisplayOrderOverride {
     bool valid;
-    int entries[5];  // -1 is the current primary display; 0-4 are detected indices.
+    struct Entry {
+        bool primary;
+        int displayNumber;
+    } entries[5];
     size_t count;
 };
 
 struct Settings {
-    bool skipMinimized;
     bool restoreMinimized;
     bool skipFullscreen;
     SizeMode sizeMode;
@@ -272,6 +315,8 @@ struct MonitorInfo {
     RECT work;
     bool primary;
     size_t detectedIndex;
+    int displayNumber;
+    std::wstring deviceName;
 };
 
 struct Hotkey {
@@ -300,6 +345,17 @@ constexpr int ScaleDimensionForWorkArea(int dimension, int sourceExtent,
 }
 static_assert(ScaleDimensionForWorkArea(800, 1920, 1280) == 533);
 static_assert(ScaleDimensionForWorkArea(1, 7680, 800) == 1);
+
+constexpr bool ShouldResizeWindow(SizeMode mode, int width, int height,
+                                  int workWidth, int workHeight) {
+    return mode == SizeMode::Scale ||
+           (mode == SizeMode::Fit &&
+            (width > workWidth || height > workHeight));
+}
+static_assert(!ShouldResizeWindow(SizeMode::Preserve, 2000, 1200, 1000, 800));
+static_assert(!ShouldResizeWindow(SizeMode::Fit, 800, 600, 1000, 800));
+static_assert(ShouldResizeWindow(SizeMode::Fit, 1200, 600, 1000, 800));
+static_assert(ShouldResizeWindow(SizeMode::Scale, 800, 600, 1000, 800));
 
 constexpr bool IsForegroundOnlyAction(TargetMode mode) {
     return mode == TargetMode::ForegroundPrimary ||
@@ -347,6 +403,31 @@ constexpr bool IsPrimaryDisplayOrderToken(std::wstring_view text) {
     return true;
 }
 
+constexpr int ParseDisplayDeviceNumber(std::wstring_view text) {
+    text = TrimDisplayOrderToken(text);
+    constexpr std::wstring_view pathPrefix = L"\\\\.\\";
+    if (text.starts_with(pathPrefix)) {
+        text.remove_prefix(pathPrefix.size());
+    }
+
+    constexpr std::wstring_view displayPrefix = L"DISPLAY";
+    if (text.size() <= displayPrefix.size()) return 0;
+    for (size_t i = 0; i < displayPrefix.size(); i++) {
+        wchar_t c = text[i];
+        if (c >= L'a' && c <= L'z') c -= L'a' - L'A';
+        if (c != displayPrefix[i]) return 0;
+    }
+
+    int number = 0;
+    for (wchar_t c : text.substr(displayPrefix.size())) {
+        if (c < L'0' || c > L'9') return 0;
+        int digit = c - L'0';
+        if (number > (INT_MAX - digit) / 10) return 0;
+        number = number * 10 + digit;
+    }
+    return number;
+}
+
 constexpr DisplayOrderOverride ParseDisplayOrder(std::wstring_view text) {
     DisplayOrderOverride result{ true, {}, 0 };
     text = TrimDisplayOrderToken(text);
@@ -354,21 +435,22 @@ constexpr DisplayOrderOverride ParseDisplayOrder(std::wstring_view text) {
         size_t comma = text.find(L',');
         std::wstring_view token =
             TrimDisplayOrderToken(text.substr(0, comma));
-        int entry;
+        DisplayOrderOverride::Entry entry{};
         if (IsPrimaryDisplayOrderToken(token)) {
-            entry = -1;
-        } else if (token.size() == 1 && token[0] >= L'1' &&
-                   token[0] <= L'5') {
-            entry = token[0] - L'1';
+            entry.primary = true;
         } else {
-            return { false, {}, 0 };
+            entry.displayNumber = ParseDisplayDeviceNumber(token);
+            if (!entry.displayNumber) return { false, {}, 0 };
         }
 
         if (result.count == ARRAYSIZE(result.entries)) {
             return { false, {}, 0 };
         }
         for (size_t i = 0; i < result.count; i++) {
-            if (result.entries[i] == entry) return { false, {}, 0 };
+            if (result.entries[i].primary == entry.primary &&
+                result.entries[i].displayNumber == entry.displayNumber) {
+                return { false, {}, 0 };
+            }
         }
         result.entries[result.count++] = entry;
 
@@ -379,19 +461,25 @@ constexpr DisplayOrderOverride ParseDisplayOrder(std::wstring_view text) {
     return result;
 }
 
-constexpr auto kDisplayOrderPrimaryTest = ParseDisplayOrder(L"primary, 3");
+constexpr auto kDisplayOrderPrimaryTest =
+    ParseDisplayOrder(L"primary, DISPLAY3");
 static_assert(kDisplayOrderPrimaryTest.valid &&
               kDisplayOrderPrimaryTest.count == 2 &&
-              kDisplayOrderPrimaryTest.entries[0] == -1 &&
-              kDisplayOrderPrimaryTest.entries[1] == 2);
-constexpr auto kDisplayOrderNumericTest = ParseDisplayOrder(L"4,3");
-static_assert(kDisplayOrderNumericTest.valid &&
-              kDisplayOrderNumericTest.entries[0] == 3 &&
-              kDisplayOrderNumericTest.entries[1] == 2);
+              kDisplayOrderPrimaryTest.entries[0].primary &&
+              kDisplayOrderPrimaryTest.entries[1].displayNumber == 3);
+constexpr auto kDisplayOrderPathTest =
+    ParseDisplayOrder(L"\\\\.\\DISPLAY4, display3");
+static_assert(kDisplayOrderPathTest.valid &&
+              kDisplayOrderPathTest.entries[0].displayNumber == 4 &&
+              kDisplayOrderPathTest.entries[1].displayNumber == 3);
 static_assert(ParseDisplayOrder(L"").valid);
-static_assert(ParseDisplayOrder(L"3,3").valid == false);
+static_assert(ParseDisplayOrder(L"DISPLAY3,display3").valid == false);
 static_assert(ParseDisplayOrder(L"primary,").valid == false);
 static_assert(ParseDisplayOrder(L"leftmost").valid == false);
+static_assert(ParseDisplayOrder(L"DISPLAY4").valid);
+static_assert(ParseDisplayOrder(L"\\\\.\\DISPLAY4").valid);
+static_assert(ParseDisplayOrder(L"DISPLAY0").valid == false);
+static_assert(ParseDisplayOrder(L"4,3").valid == false);
 
 constexpr UINT WM_APP_RELOAD = WM_APP + 1;
 constexpr UINT WM_APP_STOP = WM_APP + 2;
@@ -404,12 +492,7 @@ std::atomic<DWORD> g_workerThreadId{};
 HANDLE g_workerReady;
 
 std::wstring GetStringSetting(const wchar_t* name) {
-    PCWSTR raw = Wh_GetStringSetting(name);
-    std::wstring value = raw ? raw : L"";
-    if (raw) {
-        Wh_FreeStringSetting(raw);
-    }
-    return value;
+    return WindhawkUtils::StringSetting::make(name).get();
 }
 
 AnchorMode ParseAnchorMode(const std::wstring& text);
@@ -439,12 +522,11 @@ void LoadSettings() {
     std::wstring displayOrderText = GetStringSetting(L"DisplayOrder");
     g_settings.displayOrder = ParseDisplayOrder(displayOrderText);
     if (!g_settings.displayOrder.valid) {
-        Wh_Log(L"Invalid display order override: %s. Using detected order; "
-               L"expected primary or numbers 1-5 separated by commas",
+        Wh_Log(L"Invalid display order override: %s. Using automatic order; "
+               L"expected primary or DISPLAY<number> separated by commas",
                displayOrderText.c_str());
         g_settings.displayOrder = ParseDisplayOrder(L"");
     }
-    g_settings.skipMinimized = Wh_GetIntSetting(L"SkipMinimized") != 0;
     g_settings.restoreMinimized = Wh_GetIntSetting(L"RestoreMinimized") != 0;
     g_settings.skipFullscreen = Wh_GetIntSetting(L"SkipFullscreen") != 0;
     g_settings.sizeMode = ParseSizeMode(GetStringSetting(L"SizeMode"));
@@ -641,55 +723,81 @@ void RegisterConfiguredHotkeys() {
 
 BOOL CALLBACK MonitorEnumProc(HMONITOR monitor, HDC, LPRECT, LPARAM lParam) {
     auto monitors = reinterpret_cast<std::vector<MonitorInfo>*>(lParam);
-    MONITORINFO mi{};
+    MONITORINFOEXW mi{};
     mi.cbSize = sizeof(mi);
-    if (GetMonitorInfo(monitor, &mi)) {
+    if (GetMonitorInfoW(monitor, &mi)) {
         monitors->push_back({ monitor, mi.rcMonitor, mi.rcWork,
                               (mi.dwFlags & MONITORINFOF_PRIMARY) != 0,
-                              monitors->size() + 1 });
+                              monitors->size() + 1,
+                              ParseDisplayDeviceNumber(mi.szDevice),
+                              mi.szDevice });
     }
     return TRUE;
 }
 
 std::vector<MonitorInfo> ApplyDisplayOrder(
     const std::vector<MonitorInfo>& detected) {
+    std::vector<MonitorInfo> automatic = detected;
+    std::stable_sort(automatic.begin(), automatic.end(),
+                     [](const MonitorInfo& a, const MonitorInfo& b) {
+                         if (!!a.displayNumber != !!b.displayNumber) {
+                             return a.displayNumber != 0;
+                         }
+                         if (a.displayNumber &&
+                             a.displayNumber != b.displayNumber) {
+                             return a.displayNumber < b.displayNumber;
+                         }
+                         return a.detectedIndex < b.detectedIndex;
+                     });
     std::vector<MonitorInfo> ordered;
-    ordered.reserve(detected.size());
+    size_t slotCount = g_settings.displayOrder.count
+                           ? g_settings.displayOrder.count
+                           : 5;
+    ordered.reserve(slotCount + detected.size());
     std::vector<bool> used(detected.size());
 
-    for (size_t i = 0; i < g_settings.displayOrder.count; i++) {
-        int entry = g_settings.displayOrder.entries[i];
+    for (size_t i = 0; i < slotCount; i++) {
+        DisplayOrderOverride::Entry entry = g_settings.displayOrder.count
+                                                ? g_settings.displayOrder.entries[i]
+                                                : DisplayOrderOverride::Entry{
+                                                      false, (int)i + 1 };
         size_t detectedIndex = detected.size();
-        if (entry == -1) {
-            for (size_t j = 0; j < detected.size(); j++) {
-                if (detected[j].primary) {
-                    detectedIndex = j;
-                    break;
-                }
+        for (size_t j = 0; j < detected.size(); j++) {
+            if ((entry.primary && detected[j].primary) ||
+                (!entry.primary &&
+                 detected[j].displayNumber == entry.displayNumber)) {
+                detectedIndex = j;
+                break;
             }
-        } else {
-            detectedIndex = (size_t)entry;
         }
 
-        if (detectedIndex < detected.size() && !used[detectedIndex]) {
+        if (detectedIndex < detected.size()) {
             ordered.push_back(detected[detectedIndex]);
             used[detectedIndex] = true;
+        } else {
+            std::wstring name = entry.primary
+                                    ? L"primary"
+                                    : L"\\\\.\\DISPLAY" +
+                                          std::to_wstring(entry.displayNumber);
+            ordered.push_back({ nullptr, {}, {}, false, 0,
+                                entry.displayNumber, name });
         }
     }
 
-    for (size_t i = 0; i < detected.size(); i++) {
-        if (!used[i]) ordered.push_back(detected[i]);
+    for (const MonitorInfo& display : automatic) {
+        size_t detectedIndex = display.detectedIndex - 1;
+        if (!used[detectedIndex]) ordered.push_back(display);
     }
     return ordered;
 }
 
 void LogDisplayTopology(const std::vector<MonitorInfo>& detected,
                         const std::vector<MonitorInfo>& ordered) {
-    std::wstring detectedText = L"Detected displays:";
+    std::wstring detectedText = L"Displays:";
     for (const MonitorInfo& display : detected) {
         LONG width = display.monitor.right - display.monitor.left;
         LONG height = display.monitor.bottom - display.monitor.top;
-        detectedText += L" " + std::to_wstring(display.detectedIndex) + L"=" +
+        detectedText += L" " + display.deviceName + L"=" +
                         std::to_wstring(width) + L"x" +
                         std::to_wstring(height) + L"@(" +
                         std::to_wstring(display.monitor.left) + L"," +
@@ -701,8 +809,9 @@ void LogDisplayTopology(const std::vector<MonitorInfo>& detected,
 
     std::wstring orderText = L"Numbered display order:";
     for (size_t i = 0; i < ordered.size(); i++) {
-        orderText += L" " + std::to_wstring(i + 1) + L"=detected " +
-                     std::to_wstring(ordered[i].detectedIndex);
+        orderText += L" " + std::to_wstring(i + 1) + L"=" +
+                     ordered[i].deviceName;
+        if (!ordered[i].handle) orderText += L" missing";
         if (ordered[i].primary) orderText += L" primary";
         orderText += L";";
     }
@@ -724,6 +833,10 @@ std::vector<MonitorInfo> GetMonitors() {
     std::vector<MonitorInfo> ordered = ApplyDisplayOrder(detected);
     LogDisplayTopology(detected, ordered);
     return ordered;
+}
+
+void LogCurrentDisplayTopology() {
+    (void)GetMonitors();
 }
 
 const MonitorInfo* PrimaryMonitor(const std::vector<MonitorInfo>& monitors) {
@@ -748,7 +861,9 @@ const MonitorInfo* ResolveTargetMonitor(TargetMode mode, const std::vector<Monit
     int numberedIndex = NumberedDisplayIndex(mode);
     if (numberedIndex >= 0) {
         size_t index = (size_t)numberedIndex;
-        if (index < monitors.size()) return &monitors[index];
+        if (index < monitors.size() && monitors[index].handle) {
+            return &monitors[index];
+        }
         Wh_Log(L"Requested display %zu missing; using primary", index + 1);
         return PrimaryMonitor(monitors);
     }
@@ -814,7 +929,6 @@ const wchar_t* SkipReasonText(SkipReason reason) {
         case SkipReason::OwnedWindow: return L"owned popup";
         case SkipReason::Untitled: return L"empty title";
         case SkipReason::Minimized: return L"minimized";
-        case SkipReason::MinimizedNoRestore: return L"minimized without restore";
         case SkipReason::Fullscreen: return L"fullscreen";
         case SkipReason::AlreadyOnTarget: return L"already on target display";
         case SkipReason::BadRect: return L"bad rect";
@@ -846,9 +960,9 @@ bool IsEligibleWindow(HWND hwnd, SkipReason* reason, bool bulk) {
         return false;
     }
 
-    if (IsIconic(hwnd)) {
-        if (g_settings.skipMinimized) { *reason = SkipReason::Minimized; return false; }
-        if (!g_settings.restoreMinimized) { *reason = SkipReason::MinimizedNoRestore; return false; }
+    if (IsIconic(hwnd) && !g_settings.restoreMinimized) {
+        *reason = SkipReason::Minimized;
+        return false;
     }
 
     RECT rect{};
@@ -879,7 +993,6 @@ bool MoveWindowToMonitor(HWND hwnd, const MonitorInfo& target, int cascadeIndex,
     const RECT& workArea = target.work;
     bool wasMaximized = IsZoomed(hwnd);
     bool wasMinimized = IsIconic(hwnd);
-    bool wasTopmost = (GetWindowLongPtr(hwnd, GWL_EXSTYLE) & WS_EX_TOPMOST) != 0;
 
     RECT rect{};
     if (wasMaximized || wasMinimized) {
@@ -899,6 +1012,8 @@ bool MoveWindowToMonitor(HWND hwnd, const MonitorInfo& target, int cascadeIndex,
     int height = rect.bottom - rect.top;
     int workWidth = workArea.right - workArea.left;
     int workHeight = workArea.bottom - workArea.top;
+    bool resize = ShouldResizeWindow(g_settings.sizeMode, width, height,
+                                     workWidth, workHeight);
 
     if (g_settings.sizeMode == SizeMode::Scale) {
         MONITORINFO sourceInfo{ sizeof(sourceInfo) };
@@ -908,7 +1023,7 @@ bool MoveWindowToMonitor(HWND hwnd, const MonitorInfo& target, int cascadeIndex,
         width = ScaleDimensionForWorkArea(width, sourceWorkWidth, workWidth);
         height = ScaleDimensionForWorkArea(height, sourceWorkHeight, workHeight);
     }
-    if (g_settings.sizeMode != SizeMode::Preserve) {
+    if (resize) {
         width = std::min(width, workWidth);
         height = std::min(height, workHeight);
     }
@@ -940,34 +1055,47 @@ bool MoveWindowToMonitor(HWND hwnd, const MonitorInfo& target, int cascadeIndex,
         y += offset;
     }
 
-    UINT flags = SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_ASYNCWINDOWPOS;
-    if (g_settings.sizeMode == SizeMode::Preserve) {
+    UINT flags = SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOZORDER |
+                 SWP_ASYNCWINDOWPOS;
+    if (!resize) {
         flags |= SWP_NOSIZE;
     }
-    bool moved = SetWindowPos(hwnd, HWND_TOPMOST, x, y, width, height, flags) != FALSE;
-    if (moved && !wasTopmost) {
-        UINT demoteFlags = SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE |
-                           SWP_NOOWNERZORDER | SWP_ASYNCWINDOWPOS;
-        if (!SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0, demoteFlags)) {
-            DWORD firstError = GetLastError();
-            if (!SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0,
-                              demoteFlags)) {
-                Wh_Log(L"Failed to restore normal window level: hwnd=%p "
-                       L"errors=%u,%u", hwnd, firstError, GetLastError());
-            }
-        }
-    }
-    if (wasMaximized && (!moved || !bulk)) {
+    bool moved = SetWindowPos(hwnd, nullptr, x, y, width, height, flags) != FALSE;
+    if (wasMaximized && !bulk) {
         ShowWindowAsync(hwnd, SW_MAXIMIZE);
     }
     return moved;
+}
+
+bool RaiseMovedWindows(const std::vector<HWND>& movedWindows) {
+    std::vector<HWND> windows;
+    windows.reserve(movedWindows.size());
+    for (auto it = movedWindows.rbegin(); it != movedWindows.rend(); ++it) {
+        HWND hwnd = *it;
+        if (IsWindow(hwnd) && !IsHungAppWindow(hwnd) &&
+            !(GetWindowLongPtr(hwnd, GWL_EXSTYLE) & WS_EX_TOPMOST)) {
+            windows.push_back(hwnd);
+        }
+    }
+    if (windows.empty()) return true;
+
+    HDWP batch = BeginDeferWindowPos((int)windows.size());
+    if (!batch) return false;
+
+    HWND insertAfter = HWND_TOP;
+    UINT flags = SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOOWNERZORDER;
+    for (HWND hwnd : windows) {
+        batch = DeferWindowPos(batch, hwnd, insertAfter, 0, 0, 0, 0, flags);
+        if (!batch) return false;
+        insertAfter = hwnd;
+    }
+    return EndDeferWindowPos(batch) != FALSE;
 }
 
 struct GatherState {
     const MonitorInfo* target;
     bool bulk;
     std::vector<HWND> windows;
-    int found;
     int moved;
     int skipped;
 };
@@ -987,7 +1115,6 @@ BOOL CALLBACK GatherEnumProc(HWND hwnd, LPARAM lParam) {
         return TRUE;
     }
 
-    state->found++;
     state->windows.push_back(hwnd);
     return TRUE;
 }
@@ -1000,8 +1127,8 @@ void GatherWindows(TargetMode mode) {
         return;
     }
 
-    Wh_Log(L"Target: detected display %zu%s work=(%ld,%ld,%ld,%ld)",
-           target->detectedIndex, target->primary ? L" primary" : L"",
+    Wh_Log(L"Target: %s%s work=(%ld,%ld,%ld,%ld)",
+           target->deviceName.c_str(), target->primary ? L" primary" : L"",
            target->work.left, target->work.top, target->work.right,
            target->work.bottom);
     bool foregroundOnly = IsForegroundOnlyAction(mode);
@@ -1009,26 +1136,47 @@ void GatherWindows(TargetMode mode) {
                        !foregroundOnly,
                        {},
                        0,
-                       0,
                        0 };
     if (foregroundOnly) {
         GatherEnumProc(GetForegroundWindow(), (LPARAM)&state);
     } else {
         EnumWindows(GatherEnumProc, (LPARAM)&state);
     }
+    std::vector<HWND> movedWindows;
+    movedWindows.reserve(state.windows.size());
     for (size_t i = state.windows.size(); i-- > 0;) {
         HWND hwnd = state.windows[i];
         if (MoveWindowToMonitor(hwnd, *state.target, (int)i, state.bulk)) {
             state.moved++;
+            movedWindows.push_back(hwnd);
         } else {
             state.skipped++;
             DebugLogSkipReason(hwnd, SkipReason::Invalid);
         }
     }
-    Wh_Log(L"Gather done: found=%d moved=%d skipped=%d", state.found, state.moved, state.skipped);
+    if (!RaiseMovedWindows(movedWindows)) {
+        Wh_Log(L"Failed to raise one or more moved windows: error=%u",
+               GetLastError());
+    }
+    Wh_Log(L"Gather done: found=%d moved=%d skipped=%d",
+           (int)state.windows.size(), state.moved, state.skipped);
 }
 
 DWORD WINAPI WorkerMain(LPVOID) {
+    // Keep window and display rectangles in one physical-pixel coordinate space.
+    DPI_AWARENESS_CONTEXT previousDpiContext =
+        SetThreadDpiAwarenessContext(
+            DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+    if (!previousDpiContext) {
+        previousDpiContext = SetThreadDpiAwarenessContext(
+            DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
+        if (previousDpiContext) {
+            Wh_Log(L"Per-display DPI mode: v1 fallback");
+        } else {
+            Wh_Log(L"Could not enable per-display DPI mode");
+        }
+    }
+
     g_workerThreadId = GetCurrentThreadId();
     MSG msg;
     PeekMessage(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
@@ -1036,7 +1184,7 @@ DWORD WINAPI WorkerMain(LPVOID) {
 
     LoadSettings();
     RegisterConfiguredHotkeys();
-    GetMonitors();
+    LogCurrentDisplayTopology();
 
     while (GetMessage(&msg, nullptr, 0, 0) > 0) {
         if (msg.message == WM_HOTKEY) {
@@ -1050,7 +1198,7 @@ DWORD WINAPI WorkerMain(LPVOID) {
         } else if (msg.message == WM_APP_RELOAD) {
             LoadSettings();
             RegisterConfiguredHotkeys();
-            GetMonitors();
+            LogCurrentDisplayTopology();
         } else if (msg.message == WM_APP_STOP) {
             break;
         }
@@ -1058,6 +1206,9 @@ DWORD WINAPI WorkerMain(LPVOID) {
 
     UnregisterConfiguredHotkeys();
     g_workerThreadId = 0;
+    if (previousDpiContext) {
+        SetThreadDpiAwarenessContext(previousDpiContext);
+    }
     return 0;
 }
 

--- a/mods/gather-windows-to-monitor.wh.cpp
+++ b/mods/gather-windows-to-monitor.wh.cpp
@@ -90,9 +90,6 @@ If a numbered destination is unavailable, the primary display is used.
   cursor.
 * **Include owned windows/popups** includes dialogs and secondary windows attached
   to another app window during gather actions.
-* **Debug logging** records why individual windows were skipped. Leave it off
-  unless troubleshooting.
-
 ## Behavior and limitations
 
 Hidden windows, desktop and taskbar windows, system interface windows, helper
@@ -165,7 +162,7 @@ supported because applications handle that inconsistently.
 - RestoreMinimized: false
   $name: Restore minimized windows before moving
   $description: Used only when Skip minimized windows is turned off.
-- SkipFullscreen: false
+- SkipFullscreen: true
   $name: Skip fullscreen windows
   $description: Applies to every action, including moving only the active window.
 - SizeMode: fit
@@ -190,9 +187,6 @@ supported because applications handle that inconsistently.
 - IncludeOwnedWindows: true
   $name: Include owned windows/popups
   $description: Also moves dialogs and secondary windows attached to another app window.
-- DebugLogging: false
-  $name: Debug logging
-  $description: Logs why individual windows were skipped. Enable only while troubleshooting.
 */
 // ==/WindhawkModSettings==
 
@@ -268,7 +262,6 @@ struct Settings {
     int cascadeOffset;
     AnchorMode anchor;
     bool includeOwnedWindows;
-    bool debugLogging;
     DisplayOrderOverride displayOrder;
     std::wstring hotkeys[(int)TargetMode::Count];
 };
@@ -459,7 +452,6 @@ void LoadSettings() {
     g_settings.cascadeOffset = std::max(0, Wh_GetIntSetting(L"CascadeOffset"));
     g_settings.anchor = ParseAnchorMode(GetStringSetting(L"Anchor"));
     g_settings.includeOwnedWindows = Wh_GetIntSetting(L"IncludeOwnedWindows") != 0;
-    g_settings.debugLogging = Wh_GetIntSetting(L"DebugLogging") != 0;
     g_lastDisplayTopology.clear();
 }
 
@@ -872,7 +864,6 @@ bool IsEligibleWindow(HWND hwnd, SkipReason* reason, bool bulk) {
 }
 
 void DebugLogSkipReason(HWND hwnd, SkipReason reason) {
-    if (!g_settings.debugLogging) return;
     wchar_t title[128]{};
     wchar_t className[128]{};
     GetWindowText(hwnd, title, ARRAYSIZE(title));
@@ -1009,12 +1000,10 @@ void GatherWindows(TargetMode mode) {
         return;
     }
 
-    if (g_settings.debugLogging) {
-        Wh_Log(L"Target: detected display %zu%s work=(%ld,%ld,%ld,%ld)",
-               target->detectedIndex, target->primary ? L" primary" : L"",
-               target->work.left, target->work.top, target->work.right,
-               target->work.bottom);
-    }
+    Wh_Log(L"Target: detected display %zu%s work=(%ld,%ld,%ld,%ld)",
+           target->detectedIndex, target->primary ? L" primary" : L"",
+           target->work.left, target->work.top, target->work.right,
+           target->work.bottom);
     bool foregroundOnly = IsForegroundOnlyAction(mode);
     GatherState state{ target,
                        !foregroundOnly,
@@ -1125,10 +1114,12 @@ void WhTool_ModUninit() {
 // * WhTool_ModUninit
 //
 // Currently, other callbacks are not supported.
+
 bool g_isToolModProcessLauncher;
 HANDLE g_toolModProcessMutex;
 
 void WINAPI EntryPoint_Hook() {
+    Wh_Log(L">");
     ExitThread(0);
 }
 
@@ -1138,6 +1129,7 @@ BOOL Wh_ModInit() {
         sessionId == 0) {
         return FALSE;
     }
+
     bool isExcluded = false;
     bool isToolModProcess = false;
     bool isCurrentToolModProcess = false;
@@ -1147,6 +1139,7 @@ BOOL Wh_ModInit() {
         Wh_Log(L"CommandLineToArgvW failed");
         return FALSE;
     }
+
     for (int i = 1; i < argc; i++) {
         if (wcscmp(argv[i], L"-service") == 0 ||
             wcscmp(argv[i], L"-service-start") == 0 ||
@@ -1155,6 +1148,7 @@ BOOL Wh_ModInit() {
             break;
         }
     }
+
     for (int i = 1; i < argc - 1; i++) {
         if (wcscmp(argv[i], L"-tool-mod") == 0) {
             isToolModProcess = true;
@@ -1170,6 +1164,7 @@ BOOL Wh_ModInit() {
     if (isExcluded) {
         return FALSE;
     }
+
     if (isCurrentToolModProcess) {
         g_toolModProcessMutex =
             CreateMutex(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
@@ -1182,6 +1177,7 @@ BOOL Wh_ModInit() {
             Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
             ExitProcess(1);
         }
+
         if (!WhTool_ModInit()) {
             ExitProcess(1);
         }
@@ -1193,6 +1189,7 @@ BOOL Wh_ModInit() {
 
         DWORD entryPointRVA = ntHeaders->OptionalHeader.AddressOfEntryPoint;
         void* entryPoint = (BYTE*)dosHeader + entryPointRVA;
+
         Wh_SetFunctionHook(entryPoint, (void*)EntryPoint_Hook, nullptr);
         return TRUE;
     }
@@ -1209,6 +1206,7 @@ void Wh_ModAfterInit() {
     if (!g_isToolModProcessLauncher) {
         return;
     }
+
     WCHAR currentProcessPath[MAX_PATH];
     switch (GetModuleFileName(nullptr, currentProcessPath,
                               ARRAYSIZE(currentProcessPath))) {
@@ -1217,11 +1215,13 @@ void Wh_ModAfterInit() {
             Wh_Log(L"GetModuleFileName failed");
             return;
     }
+
     WCHAR
     commandLine[MAX_PATH + 2 +
                 (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
     swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
                WH_MOD_ID);
+
     HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
     if (!kernelModule) {
         kernelModule = GetModuleHandle(L"kernel32.dll");
@@ -1230,6 +1230,7 @@ void Wh_ModAfterInit() {
             return;
         }
     }
+
     using CreateProcessInternalW_t = BOOL(WINAPI*)(
         HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
         LPSECURITY_ATTRIBUTES lpProcessAttributes,
@@ -1245,6 +1246,7 @@ void Wh_ModAfterInit() {
         Wh_Log(L"No CreateProcessInternalW");
         return;
     }
+
     STARTUPINFO si{
         .cb = sizeof(STARTUPINFO),
         .dwFlags = STARTF_FORCEOFFFEEDBACK,
@@ -1256,6 +1258,7 @@ void Wh_ModAfterInit() {
         Wh_Log(L"CreateProcess failed");
         return;
     }
+
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
 }

--- a/mods/gather-windows-to-monitor.wh.cpp
+++ b/mods/gather-windows-to-monitor.wh.cpp
@@ -207,8 +207,9 @@ different scaling, even when **Preserve** is selected.
     Enter up to five comma-separated primary or display names such as DISPLAY4 or
     \\.\DISPLAY4. Example: primary,DISPLAY3 keeps display 1 tied to the current
     primary display and makes DISPLAY3 become display 2. Missing displays keep
-    their slots; unlisted displays follow in automatic order. An invalid override
-    uses automatic order. Leave empty to number connected displays by DISPLAY name.
+    their slots and their shortcuts do nothing; unlisted displays follow in
+    automatic order. An invalid override uses automatic order. Leave empty to
+    number connected displays by DISPLAY name.
 - MinimizedMode: skip
   $name: Minimized windows
   $description: Choose whether minimized windows stay minimized or are restored and moved.
@@ -864,19 +865,22 @@ const MonitorInfo* PrimaryMonitor(const std::vector<MonitorInfo>& monitors) {
 }
 
 const MonitorInfo* MonitorByHandle(const std::vector<MonitorInfo>& monitors, HMONITOR handle) {
-    for (const MonitorInfo& monitor : monitors) {
-        if (monitor.handle == handle) return &monitor;
+    if (handle) {
+        for (const MonitorInfo& monitor : monitors) {
+            if (monitor.handle == handle) return &monitor;
+        }
     }
     return PrimaryMonitor(monitors);
 }
 
 const MonitorInfo* ResolveTargetMonitor(TargetMode mode, const std::vector<MonitorInfo>& monitors) {
-    if (monitors.empty()) {
+    const MonitorInfo* primary = PrimaryMonitor(monitors);
+    if (!primary) {
         Wh_Log(L"No displays found");
         return nullptr;
     }
     if (mode == TargetMode::Primary || mode == TargetMode::ForegroundPrimary) {
-        return PrimaryMonitor(monitors);
+        return primary;
     }
     int numberedIndex = NumberedDisplayIndex(mode);
     if (numberedIndex >= 0) {


### PR DESCRIPTION
## Changelog

* Add shortcuts for moving the foreground window to the primary or numbered displays 1-5.
* Default numbered shortcuts to moving one window for new installations while preserving existing users' configured gather shortcuts.
* Use stable Windows display device names for numbered destinations, with optional remapping for custom display order.
* Leave windows already on the destination display unchanged and raise moved windows without stealing focus or changing topmost state.
* Improve mixed-DPI movement and avoid activation after failed gather moves.
* Replace overlapping minimized-window checkboxes with one clear behavior dropdown and document setting migration.
* Add clearer window sizing options, hotkey validation, concise diagnostics, and display 4-5 actions.

## Validation

* Compiled successfully for x86, x64, and ARM64.
* Tested successfully in a local Windhawk installation.
* Repository validation runs through the pull request checks.