### PR TITLE
Add Taskbar collapse to running apps mod

### DIFF
--- a/mods/taskbar-collapse-to-running.wh.cpp
+++ b/mods/taskbar-collapse-to-running.wh.cpp
@@ -7,7 +7,7 @@
 // @github          https://github.com/LarsGudm
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -DWINVER=0x0A00 -lole32 -loleaut32 -lruntimeobject -lshcore -luser32
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lshcore -luser32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -2208,7 +2208,8 @@ HMODULE GetTaskbarViewModuleHandle() {
 }
 
 bool HookTaskbarViewDllSymbols(HMODULE module) {
-    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+    // Taskbar.View.dll, ExplorerExtensions.dll
+    WindhawkUtils::SYMBOL_HOOK taskbarViewDllHooks[] = {
         {
             {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarFrame,struct winrt::Windows::UI::Xaml::Controls::IControlOverrides>::OnPointerMoved(void *))"},
             &TaskbarFrame_OnPointerMoved_Original,
@@ -2234,8 +2235,8 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
         },
     };
 
-    if (!WindhawkUtils::HookSymbols(module, symbolHooks,
-                                    ARRAYSIZE(symbolHooks))) {
+    if (!WindhawkUtils::HookSymbols(module, taskbarViewDllHooks,
+                                    ARRAYSIZE(taskbarViewDllHooks))) {
         DebugFileLog(L"HookSymbols FAILED - mod will not load");
         return false;
     }

--- a/mods/taskbar-collapse-to-running.wh.cpp
+++ b/mods/taskbar-collapse-to-running.wh.cpp
@@ -185,6 +185,7 @@ using winrt::Windows::Foundation::Numerics::float3;
 
 typedef void (*RunFromWindowThreadProc_t)(PVOID);
 void RunOnAllTaskbarThreads(RunFromWindowThreadProc_t proc, PVOID param);
+bool PointerClearsSurfaces(void* key, Point framePt);
 
 // Quiet time on the taskbar before the tick drops to the sleep rate.
 constexpr ULONGLONG kSleepAfterMs = 2 * 60 * 1000;
@@ -235,7 +236,6 @@ enum class AnimKind { Accordion, GapClose };
 struct {
     std::atomic<RevealTrigger> revealTrigger;
     std::atomic<bool> revealOnStart;
-    std::atomic<bool> collapsed;
     std::atomic<int> restSpeedPxPerSec;
     std::atomic<int> revealDelayMs;
     std::atomic<int> elementPaddingPx;
@@ -290,6 +290,11 @@ std::atomic<bool> g_lastPointerQualified = false;
 double g_speedSamplePrevMs = 0;
 POINT g_speedSamplePrevPos = {};
 
+// Last cheap-qualified pointer sample, letting the tick finish qualification
+// for a parked cursor. Ticks and hooks share the taskbar UI thread.
+void* g_lastQualifiedKey = nullptr;
+Point g_lastQualifiedFramePt = {};
+
 // Bumped by the hotkey and settings changes; a context seeing a new value
 // applies once without animation. Lets other threads request an instant apply
 // without touching contexts or blocking on their message queues.
@@ -303,6 +308,9 @@ std::atomic<int> g_pendingWakes = 0;
 // Unadvise, which does not fence a callback already in flight.
 std::atomic<int> g_sinkCallbacks = 0;
 
+// Serializes hotkey thread start/stop: Wh_ModSettingsChanged and the
+// LoadLibraryExW hook run on different threads.
+std::mutex g_hotkeyThreadMutex;
 HANDLE g_hotkeyThread = nullptr;
 DWORD g_hotkeyThreadId = 0;
 // Signalled once the worker owns a message queue, so WM_QUIT cannot be posted
@@ -1321,7 +1329,12 @@ void OnTimerTick(void* key) {
             if (!CursorOverAnyTaskbar()) {
                 g_emptyHoverSinceTick = 0;
             } else if (now - since >= (ULONGLONG)g_settings.revealDelayMs) {
-                g_revealed = true;
+                if (PointerClearsSurfaces(g_lastQualifiedKey,
+                                          g_lastQualifiedFramePt)) {
+                    g_revealed = true;
+                } else {
+                    g_lastPointerQualified = false;
+                }
                 g_emptyHoverSinceTick = 0;
             }
         }
@@ -1333,6 +1346,15 @@ void OnTimerTick(void* key) {
     // apply so an empty button walk does not swallow it.
     uint64_t instantGen = g_instantApplyGen;
     bool instant = ctx->instantGenSeen != instantGen;
+
+    // Watchdog: CompositionTarget::Rendering stops when the bar is not being
+    // composed (auto-hide, fullscreen occlusion), which can strand an
+    // animation mid-flight. Finish it here.
+    if (ctx->animActive &&
+        NowMs() - ctx->animStartMs >
+            (double)g_settings.animationDurationMs * 3.0 + 1000.0) {
+        StopAnimation(*ctx);
+    }
 
     // While the accordion runs toward the right state, leave it alone: the
     // rendering callback owns the buttons, and reconciliation here would fight
@@ -1386,9 +1408,8 @@ void RegisterFrame(void* key, FrameworkElement frame) {
         [key](IInspectable const&, IInspectable const&) { OnTimerTick(key); });
     ctx.timer.Start();
 
-    (*g_frames)[key] = ctx;
-
     Wh_Log(L"Registered taskbar frame on thread %u", ctx.threadId);
+    g_frames->insert_or_assign(key, std::move(ctx));
 }
 
 bool IsFrameRegistered(void* key) {
@@ -1566,12 +1587,16 @@ bool ProbeStripIsClear(FrameworkElement frame, Point framePt, double padding) {
     return true;
 }
 
-// True when this pointer position is somewhere a reveal may start from.
+// Cheap per-move half of qualification: enough to arm or clear the dwell.
+// Records the sample so the flip can finish qualification later.
 bool PointerQualifiesForReveal(void* key,
                                Input::PointerRoutedEventArgs const& args) {
     if (!IsPointerOverEmptySpace(args)) {
         return false;
     }
+
+    g_lastQualifiedKey = key;
+    g_lastQualifiedFramePt = Point{0, 0};
 
     if (g_settings.elementPaddingPx <= 0) {
         return true;
@@ -1587,6 +1612,23 @@ bool PointerQualifiesForReveal(void* key,
     if (!IsPointerClearOfButtons(*ctx, frame, framePt,
                                  g_settings.elementPaddingPx)) {
         return false;
+    }
+
+    g_lastQualifiedFramePt = framePt;
+    return true;
+}
+
+// Expensive half, run once right before a reveal fires rather than per move:
+// screen-space seam probes and full hit-tests of the bar.
+bool PointerClearsSurfaces(void* key, Point framePt) {
+    if (g_settings.elementPaddingPx <= 0) {
+        return true;
+    }
+
+    FrameContext* ctx = GetFrameContext(key);
+    FrameworkElement frame = ctx ? ctx->frame.get() : nullptr;
+    if (!ctx || !frame) {
+        return true;
     }
 
     // Catches bar content living on a separate surface, which no visual-tree
@@ -1711,6 +1753,13 @@ void HandlePointerMoved(void* pThis, void* pArgs) {
         return;
     }
 
+    // The expensive checks run once, at the flip.
+    if (!PointerClearsSurfaces(key, g_lastQualifiedFramePt)) {
+        g_lastPointerQualified = false;
+        g_emptyHoverSinceTick = 0;
+        return;
+    }
+
     g_revealed = true;
     g_emptyHoverSinceTick = 0;
     ApplyOnThisThreadNow();
@@ -1801,7 +1850,8 @@ void HandlePointerReleased(void* pThis, void* pArgs) {
         return;
     }
 
-    if (!PointerQualifiesForReveal(key, args)) {
+    if (!PointerQualifiesForReveal(key, args) ||
+        !PointerClearsSurfaces(key, g_lastQualifiedFramePt)) {
         return;
     }
 
@@ -2114,6 +2164,7 @@ DWORD WINAPI HotkeyThreadProc(LPVOID param) {
 }
 
 void StartHotkeyThread() {
+    std::lock_guard<std::mutex> guard(g_hotkeyThreadMutex);
     if (g_hotkeyThread) {
         return;
     }
@@ -2151,6 +2202,7 @@ void StartHotkeyThread() {
 // Waits without a timeout on purpose: the mod is unloaded the moment teardown
 // returns, so a thread still running here would resume inside a freed image.
 void StopHotkeyThread() {
+    std::lock_guard<std::mutex> guard(g_hotkeyThreadMutex);
     if (!g_hotkeyThread) {
         return;
     }
@@ -2277,11 +2329,17 @@ void CleanupOnThisThread() {
             continue;
         }
 
-        if (it->second.timer) {
-            it->second.timer.Stop();
-            it->second.timer.Tick(it->second.tickToken);
+        // Guarded: this runs inside a CALLWNDPROC hook or a dispatcher
+        // lambda, and a throw escaping either is fatal or hangs the unload.
+        // The erase must run regardless, or the straggler sweep re-finds it.
+        try {
+            if (it->second.timer) {
+                it->second.timer.Stop();
+                it->second.timer.Tick(it->second.tickToken);
+            }
+            RestoreFrame(it->second);
+        } catch (winrt::hresult_error const&) {
         }
-        RestoreFrame(it->second);
         g_frames->erase(it);
     }
 }
@@ -2289,16 +2347,15 @@ void CleanupOnThisThread() {
 // ------------------------------------------------------------------ lifetime
 
 void LoadSettings() {
-    g_settings.collapsed = Wh_GetIntSetting(L"Collapsed") != 0;
-
     g_settings.revealOnStart = Wh_GetIntSetting(L"RevealOnStart") != 0;
 
+    // Unrecognized values fall back to Click, matching the shipped default.
     auto trigger = WindhawkUtils::StringSetting::make(L"RevealTrigger");
-    g_settings.revealTrigger = RevealTrigger::Hover;
-    if (wcscmp(trigger.get(), L"rest") == 0) {
+    g_settings.revealTrigger = RevealTrigger::Click;
+    if (wcscmp(trigger.get(), L"hover") == 0) {
+        g_settings.revealTrigger = RevealTrigger::Hover;
+    } else if (wcscmp(trigger.get(), L"rest") == 0) {
         g_settings.revealTrigger = RevealTrigger::Rest;
-    } else if (wcscmp(trigger.get(), L"click") == 0) {
-        g_settings.revealTrigger = RevealTrigger::Click;
     } else if (wcscmp(trigger.get(), L"never") == 0) {
         g_settings.revealTrigger = RevealTrigger::Never;
     }
@@ -2343,7 +2400,7 @@ void LoadSettings() {
         g_settings.runningNameMarker = marker.get();
     }
 
-    g_collapseEnabled = g_settings.collapsed.load();
+    g_collapseEnabled = Wh_GetIntSetting(L"Collapsed") != 0;
     g_revealed = false;
     g_revealedByStart = false;
     g_emptyHoverSinceTick = 0;
@@ -2400,6 +2457,9 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
         (int)(TaskbarFrame_OnPointerReleased_Original != nullptr),
         (int)(TaskbarFrame_OnPointerExited_Original != nullptr),
         (int)(TaskbarFrame_MeasureOverride_Original != nullptr));
+    if (!TaskbarFrame_OnPointerReleased_Original) {
+        Wh_Log(L"OnPointerReleased hook missing, click reveal will not work");
+    }
     return true;
 }
 
@@ -2529,17 +2589,29 @@ void Wh_ModBeforeUninit() {
     // to clean up and wait for it. Timers and rendering hooks must come off on
     // their own thread, and dropping the map here would neither stop them nor
     // release their XAML objects safely.
-    std::vector<winrt::Windows::UI::Core::CoreDispatcher> stragglers;
+    std::vector<std::pair<winrt::Windows::UI::Core::CoreDispatcher, DWORD>>
+        stragglers;
     {
         std::lock_guard<std::mutex> guard(g_framesMutex);
         for (auto& [key, ctx] : *g_frames) {
             if (ctx.dispatcher) {
-                stragglers.push_back(ctx.dispatcher);
+                stragglers.emplace_back(ctx.dispatcher, ctx.threadId);
             }
         }
     }
 
-    for (auto& dispatcher : stragglers) {
+    for (auto& [dispatcher, threadId] : stragglers) {
+        // A thread that already exited can never run the lambda; waiting on
+        // it would hang the unload for nothing.
+        if (HANDLE hThread = OpenThread(SYNCHRONIZE, FALSE, threadId)) {
+            bool exited = WaitForSingleObject(hThread, 0) == WAIT_OBJECT_0;
+            CloseHandle(hThread);
+            if (exited) {
+                continue;
+            }
+        } else {
+            continue;
+        }
         HANDLE done = CreateEvent(nullptr, TRUE, FALSE, nullptr);
         if (!done) {
             continue;
@@ -2549,7 +2621,12 @@ void Wh_ModBeforeUninit() {
             dispatcher.RunAsync(
                 winrt::Windows::UI::Core::CoreDispatcherPriority::High,
                 [done]() {
-                    CleanupOnThisThread();
+                    // The signal must fire even if cleanup throws, or the
+                    // unbounded wait below never returns.
+                    try {
+                        CleanupOnThisThread();
+                    } catch (...) {
+                    }
                     SetEvent(done);
                 });
             queued = true;
@@ -2572,12 +2649,12 @@ void Wh_ModBeforeUninit() {
     }
 
     // Anything still present could not be reached on its own thread; leaving
-    // its references alive is safer than releasing them from here. An empty
-    // map can go completely, buckets and all.
+    // its references alive is safer than releasing them from here. The empty
+    // map is deliberately never reset(): hooks stay live until this returns
+    // and their g_unloading checks are unlocked, so a disengaged optional
+    // could be dereferenced mid-preemption.
     std::lock_guard<std::mutex> guard(g_framesMutex);
-    if (g_frames->empty()) {
-        g_frames.reset();
-    } else {
+    if (!g_frames->empty()) {
         Wh_Log(L"%u taskbar contexts could not be cleaned up",
                (unsigned)g_frames->size());
     }

--- a/mods/taskbar-collapse-to-running.wh.cpp
+++ b/mods/taskbar-collapse-to-running.wh.cpp
@@ -7,7 +7,7 @@
 // @github          https://github.com/LarsGudm
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lshcore -luser32
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -15,9 +15,9 @@
 # Taskbar collapse to running apps
 
 Hides pinned taskbar icons whose app is not running. Icons hide and unhide in
-place, so pinned order is never touched. Windows' reorder slide is stripped;
-the optional accordion animates spacing only, and an app closing while
-collapsed eases its gap shut.
+place, so pinned order is never touched.
+
+![Demo](https://i.imgur.com/jgDv8Su.gif)
 
 ## Revealing
 
@@ -45,12 +45,16 @@ change **Running-app text in button names**, or clear it.
 * After 2 quiet minutes checks drop to the sleep rate; any taskbar activity
   wakes it instantly.
 * Built and tested on Windows 11 build 26200 with a left-aligned,
-  single-monitor taskbar. Other builds can name taskbar internals differently;
-  if icons are classified wrongly, the diagnostics log shows why.
-* Diagnostics: set `kDebugLogging` in the source; log lands at
-  `%TEMP%\taskbar-collapse-debug.log`.
+  single-monitor taskbar. Other builds can name taskbar internals differently.
+* Revealing is shared across monitors: revealing one taskbar reveals them all.
+* With Click, a click on empty taskbar reaches other mods bound to the same
+  spot too, so one click can trigger both.
+* Disabling the mod restores hidden icons and the animations it stripped, with
+  one exception: Windows' icon appear/disappear animation on buttons the mod
+  actually hid stays off until Explorer restarts, because that property cannot
+  be read back to restore it.
 
-Licensed MIT. Thanks to https://easings.net/ for easing code.
+Licensed MIT. Thanks to https://easings.net/ for the easing curve values.
 */
 // ==/WindhawkModReadme==
 
@@ -79,7 +83,9 @@ Licensed MIT. Thanks to https://easings.net/ for easing code.
     How slow the cursor must be moving across empty taskbar area to count as resting (only applies to: Reveal trigger > Rest)
 - Collapsed: true
   $name: Collapse taskbar
-  $description: Hide pinned icons whose app is not running. This is the same switch the hotkey flips.
+  $description: >-
+    Hide pinned icons whose app is not running. The hotkey flips the same
+    switch, but only until settings are saved again, which restores this box.
 - ElementPaddingPx: 24
   $name: Padding around elements (px)
   $description: >-
@@ -87,12 +93,12 @@ Licensed MIT. Thanks to https://easings.net/ for easing code.
 - HoverGraceMs: 150
   $name: Grace period (ms)
   $description: How long the cursor may be off the taskbar before it collapses again.
-- RefreshIntervalMs: 50
+- RefreshIntervalMs: 250
   $name: Refresh interval (ms)
   $description: >-
-    How often running state and cursor position are re-checked. Also the
-    worst-case delay on the hotkey. Floored at 10, because nothing on screen
-    can change faster than a frame anyway.
+    How often running state and cursor position are re-checked. Whether an app
+    is running changes at human speed, so this can be slow; it only matters
+    while a reveal, dwell or animation is being timed. 10 to 2000.
 - SleepEnabled: true
   $name: Sleep when idle
   $description: >-
@@ -121,7 +127,7 @@ Licensed MIT. Thanks to https://easings.net/ for easing code.
   $description: >-
     How far the accordion stretches, as a percentage of the width the hidden
     icons actually take up. 100 stretches by exactly the space they occupy, so
-    the animation scales itself to how many icons are pinned.
+    the animation scales itself to how many icons are pinned. 0 to 200.
 - Hotkey: Ctrl+Alt+T
   $name: Toggle hotkey
   $description: Modifiers Ctrl, Alt, Shift, Win plus one of A-Z, 0-9, F1-F24, Space. Leave empty for no hotkey.
@@ -131,7 +137,8 @@ Licensed MIT. Thanks to https://easings.net/ for easing code.
     A button whose accessibility name contains this text counts as running,
     whatever its icons look like. Windows writes names such as
     "Notepad - 1 running window pinned". Change this if your Windows is not in
-    English, or clear it to rely on the running indicator alone.
+    English, or clear it to rely on the running indicator alone. A pinned app
+    whose own name contains this text always counts as running.
 */
 // ==/WindhawkModSettings==
 
@@ -159,13 +166,13 @@ Licensed MIT. Thanks to https://easings.net/ for easing code.
 #include <algorithm>
 #include <atomic>
 #include <chrono>
-#include <cstdarg>
-#include <cstdio>
+#include <cmath>
 #include <cstdlib>
 #include <cwctype>
 #include <functional>
 #include <limits>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -178,10 +185,6 @@ using winrt::Windows::Foundation::Numerics::float3;
 
 typedef void (*RunFromWindowThreadProc_t)(PVOID);
 void RunOnAllTaskbarThreads(RunFromWindowThreadProc_t proc, PVOID param);
-
-// Flip to true and recompile to write diagnostics (button classification,
-// element trees, tick cost) to %TEMP%\taskbar-collapse-debug.log.
-constexpr bool kDebugLogging = false;
 
 // Quiet time on the taskbar before the tick drops to the sleep rate.
 constexpr ULONGLONG kSleepAfterMs = 2 * 60 * 1000;
@@ -197,16 +200,34 @@ struct EasingCurve {
     double y2;
 };
 
-// Thanks to https://easings.net/ for easing code.
+// Thanks to https://easings.net/ for the easing curve values.
 constexpr EasingCurve kEaseInOutSine{0.37, 0.0, 0.63, 1.0};
 constexpr EasingCurve kEaseInOutCubic{0.65, 0.0, 0.35, 1.0};
 constexpr EasingCurve kEaseInOutCirc{0.85, 0.0, 0.15, 1.0};
 
+// Settings store the curve as an id, not the struct: a settings change on
+// another thread must not be readable half-updated mid-animation.
+enum class CurveId { Sine, Cubic, Circ };
+
+EasingCurve const& CurveFor(CurveId id) {
+    switch (id) {
+        case CurveId::Cubic:
+            return kEaseInOutCubic;
+        case CurveId::Circ:
+            return kEaseInOutCirc;
+        default:
+            return kEaseInOutSine;
+    }
+}
+
 enum class AnimationMode { None, Spacing };
 enum class RevealTrigger { Never, Hover, Rest, Click };
 
-// Accordion is the reveal/collapse transition; GapClose eases the row shut
-// over the width of an icon hidden mid-steady-state, when its app closes.
+// Accordion is the reveal/collapse transition. GapClose handles an icon
+// hidden mid-steady-state, when its app closes: the icon is faded but keeps
+// its slot for the first half, so layout itself holds the gap and there are
+// no translations for the taskbar to fight over, then the midpoint collapses
+// it and the row eases shut.
 enum class AnimKind { Accordion, GapClose };
 
 struct {
@@ -221,7 +242,7 @@ struct {
     bool sleepEnabled;
     int sleepIntervalMs;
     AnimationMode animationMode;
-    EasingCurve animationCurve;
+    CurveId animationCurve;
     int animationDurationMs;
     int animationAmplitudePct;
     std::wstring runningNameMarker;
@@ -267,22 +288,35 @@ std::atomic<bool> g_lastPointerQualified = false;
 double g_speedSamplePrevMs = 0;
 POINT g_speedSamplePrevPos = {};
 
-std::atomic<bool> g_debugDumpPending = false;
-
 // Bumped by the hotkey and settings changes; a context seeing a new value
 // applies once without animation. Lets other threads request an instant apply
 // without touching contexts or blocking on their message queues.
 std::atomic<uint64_t> g_instantApplyGen = 0;
 
+// Wakes queued to taskbar dispatchers that have not run yet; unload waits for
+// zero so no queued lambda outlives the DLL.
+std::atomic<int> g_pendingWakes = 0;
+
+// Start-menu callbacks currently executing; teardown waits for zero after
+// Unadvise, which does not fence a callback already in flight.
+std::atomic<int> g_sinkCallbacks = 0;
+
 HANDLE g_hotkeyThread = nullptr;
 DWORD g_hotkeyThreadId = 0;
+// Signalled once the worker owns a message queue, so WM_QUIT cannot be posted
+// before one exists and be dropped.
+HANDLE g_hotkeyThreadReady = nullptr;
 
-// A button with its animations stripped, holding the originals to put back.
+// Per-button state: the animations stripped from it, the originals to put
+// back, and its resolved running indicator so the tick need not re-walk the
+// subtree. The indicator is created lazily by Windows, so a null cache entry
+// is re-resolved rather than trusted.
 struct DeanimatedButton {
     winrt::weak_ref<FrameworkElement> button;
     Media::Animation::TransitionCollection originalTransitions{nullptr};
     winrt::Windows::UI::Composition::ImplicitAnimationCollection
         originalImplicit{nullptr};
+    winrt::weak_ref<FrameworkElement> runningIndicator;
 };
 
 // State for one taskbar, touched only by that taskbar's own UI thread, except
@@ -310,11 +344,17 @@ struct FrameContext {
     // Collapse state the running animation is heading towards.
     bool animTargetCollapse = false;
     double animStartMs = 0;
+    // Amplitude for this run, snapshotted at StartAnimation so both halves
+    // of the accordion stretch by the same width.
+    double animAmplitude = 0;
     // Whether the midpoint icon swap has happened yet.
     bool animSwapped = false;
-    // GapClose only: measured start offset per animButtons entry, held for the
-    // first half of the animation and eased to zero over the second.
+    // GapClose only: offsets back to pre-collapse positions, measured at the
+    // midpoint and eased to zero over the second half.
     std::vector<float> animGapOffsets;
+    // GapClose only: buttons faded out but not yet collapsed, with their
+    // original opacities; emptied when the midpoint collapses them for real.
+    std::vector<std::pair<FrameworkElement, double>> pendingHide;
     // Strong refs for the animation's few hundred ms, so every frame works on
     // the same set without re-walking the tree. Emptied when it stops.
     std::vector<FrameworkElement> animButtons;
@@ -326,19 +366,15 @@ struct FrameContext {
 
     // Last g_instantApplyGen this context consumed.
     uint64_t instantGenSeen = 0;
-
-    int lastLoggedCollapse = -1;
-    int lastLoggedButtons = -1;
-    int lastLoggedHidden = -1;
-
-    // Cost of the refresh tick, reported periodically while logging is on.
-    int applySamples = 0;
-    double applyTotalUs = 0;
-    double applyWorstUs = 0;
 };
 
 std::mutex g_framesMutex;
-std::unordered_map<void*, FrameContext> g_frames;
+
+// Never destroyed: the contexts hold UI-thread-affine XAML objects, and at
+// process shutdown the CRT would release them from the wrong thread with the
+// XAML core already gone. Real release happens in CleanupOnThisThread.
+[[clang::no_destroy]] std::optional<std::unordered_map<void*, FrameContext>>
+    g_frames{std::in_place};
 
 FrameContext* GetFrameContext(void* key);
 
@@ -360,53 +396,12 @@ std::wstring CopyRunningMarker() {
     return g_settings.runningNameMarker;
 }
 
-std::mutex g_debugFileMutex;
-int g_debugLinesWritten = 0;
-
-// Mirrors a line to the Windhawk log and to %TEMP%\taskbar-collapse-debug.log.
-void DebugFileLog(PCWSTR format, ...) {
-    if (!kDebugLogging) {
-        return;
-    }
-
-    WCHAR buffer[1024];
-    va_list args;
-    va_start(args, format);
-    _vsnwprintf(buffer, ARRAYSIZE(buffer) - 1, format, args);
-    va_end(args);
-    buffer[ARRAYSIZE(buffer) - 1] = L'\0';
-
-    Wh_Log(L"%s", buffer);
-
-    std::lock_guard<std::mutex> guard(g_debugFileMutex);
-    if (g_debugLinesWritten >= 2000) {
-        return;
-    }
-    g_debugLinesWritten++;
-
-    WCHAR path[MAX_PATH];
-    DWORD len = GetTempPathW(ARRAYSIZE(path), path);
-    if (len == 0 || len > ARRAYSIZE(path) - 40) {
-        return;
-    }
-    wcscat_s(path, L"taskbar-collapse-debug.log");
-
-    FILE* f = _wfopen(path, L"a, ccs=UTF-8");
-    if (!f) {
-        return;
-    }
-    ULONGLONG tick = GetTickCount64();
-    fwprintf(f, L"[%8llu.%03llu t%05lu] %s\n", tick / 1000, tick % 1000,
-             GetCurrentThreadId(), buffer);
-    fclose(f);
-}
-
 // ---------------------------------------------------------------- visual tree
 
 // Calls back for each direct child, stopping at the first callback that returns true.
 FrameworkElement EnumChildElements(
     FrameworkElement element,
-    std::function<bool(FrameworkElement)> enumCallback) {
+    std::function<bool(FrameworkElement)> const& enumCallback) {
     int childrenCount = Media::VisualTreeHelper::GetChildrenCount(element);
 
     for (int i = 0; i < childrenCount; i++) {
@@ -490,9 +485,16 @@ bool ContainsNoCase(std::wstring_view haystack, std::wstring_view needle) {
     return it != haystack.end();
 }
 
-// True while the indicator element exists and is positively shown.
-bool IndicatorSaysRunning(FrameworkElement button) {
-    FrameworkElement indicator = FindRunningIndicator(button);
+// True while the indicator element exists and is positively shown. The caller
+// passes its cached indicator, and gets back whatever was resolved so the
+// subtree walk happens once per button rather than once per tick.
+bool IndicatorSaysRunning(FrameworkElement button,
+                          FrameworkElement& indicatorInOut) {
+    FrameworkElement indicator = indicatorInOut;
+    if (!indicator) {
+        indicator = FindRunningIndicator(button);
+        indicatorInOut = indicator;
+    }
     if (!indicator) {
         return false;
     }
@@ -520,8 +522,10 @@ bool IndicatorSaysRunning(FrameworkElement button) {
 // Do not make this an AND: hiding must require both signals to agree, or a
 // running app disappears from the taskbar. Indicator goes first so the name,
 // which allocates a string, is only fetched for idle-looking buttons.
-bool IsButtonRunning(FrameworkElement button, std::wstring_view marker) {
-    if (IndicatorSaysRunning(button)) {
+bool IsButtonRunning(FrameworkElement button,
+                     std::wstring_view marker,
+                     FrameworkElement& indicatorInOut) {
+    if (IndicatorSaysRunning(button, indicatorInOut)) {
         return true;
     }
 
@@ -533,53 +537,6 @@ bool IsButtonRunning(FrameworkElement button, std::wstring_view marker) {
     }
 
     return false;
-}
-
-// ------------------------------------------------------------------ diagnostics
-
-void DumpButtonTree(FrameworkElement element, int depth, int indent) {
-    if (!element || depth < 0) {
-        return;
-    }
-
-    EnumChildElements(element, [&](FrameworkElement child) {
-        DebugFileLog(L"%*s%s [%s] vis=%d op=%.2f size=%.1fx%.1f", indent * 2,
-                     L"", winrt::get_class_name(child).c_str(),
-                     child.Name().c_str(), (int)child.Visibility(),
-                     child.Opacity(), child.ActualWidth(),
-                     child.ActualHeight());
-        DumpButtonTree(child, depth - 1, indent + 1);
-        return false;
-    });
-}
-
-// Logs every button's running verdict and the evidence behind it.
-void DumpButtons(std::vector<FrameworkElement> const& buttons,
-                 bool repeaterFound) {
-    DebugFileLog(L"=== dump: repeater=%d buttons=%u ===", (int)repeaterFound,
-                 (unsigned)buttons.size());
-
-    std::wstring marker = CopyRunningMarker();
-    for (auto const& button : buttons) {
-        auto label = Automation::AutomationProperties::GetName(button);
-        auto indicator = FindRunningIndicator(button);
-        if (indicator) {
-            DebugFileLog(
-                L"button '%s': indicator [%s] vis=%d op=%.2f size=%.1fx%.1f -> running=%d",
-                label.c_str(), indicator.Name().c_str(),
-                (int)indicator.Visibility(), indicator.Opacity(),
-                indicator.ActualWidth(), indicator.ActualHeight(),
-                (int)IsButtonRunning(button, marker));
-        } else {
-            DebugFileLog(L"button '%s': no indicator element -> running=%d",
-                         label.c_str(), (int)IsButtonRunning(button, marker));
-        }
-    }
-
-    if (!buttons.empty()) {
-        DebugFileLog(L"=== full tree of first button ===");
-        DumpButtonTree(buttons[0], 4, 1);
-    }
 }
 
 // ------------------------------------------------------------------- applying
@@ -645,7 +602,7 @@ bool CursorOverAnyTaskbar() {
     DWORD threadId = GetWindowThreadProcessId(hRoot, &processId);
     if (threadId && processId == GetCurrentProcessId()) {
         std::lock_guard<std::mutex> guard(g_framesMutex);
-        for (auto& [key, ctx] : g_frames) {
+        for (auto& [key, ctx] : *g_frames) {
             if (ctx.threadId == threadId) {
                 return true;
             }
@@ -657,7 +614,8 @@ bool CursorOverAnyTaskbar() {
 
 // Clears the implicit show/hide animations, which otherwise keep rendering a
 // hidden button's ghost until their farewell animation finishes. They have no
-// getter, so the strip is permanent for the element's lifetime.
+// getter, so this cannot be undone; call it only for buttons actually being
+// hidden, never for every button on every pass.
 void ClearImplicitShowHide(FrameworkElement const& button) {
     try {
         Hosting::ElementCompositionPreview::SetImplicitShowAnimation(button,
@@ -698,14 +656,6 @@ void DeanimateButton(FrameContext& ctx, FrameworkElement button) {
         entry.originalTransitions = transitions;
         entry.originalImplicit = implicit_;
         ctx.deanimated.push_back(entry);
-
-        if (kDebugLogging) {
-            auto label = Automation::AutomationProperties::GetName(button);
-            DebugFileLog(L"deanimate '%s': transitions=%d implicit=%d",
-                         label.c_str(),
-                         transitions ? (int)transitions.Size() : 0,
-                         implicit_ ? (int)implicit_.Size() : 0);
-        }
     } else {
         // Animations that appeared after first sight still belong to Windows;
         // capture them so unload restores the real originals.
@@ -723,7 +673,6 @@ void DeanimateButton(FrameContext& ctx, FrameworkElement button) {
     if (visual && implicit_) {
         visual.ImplicitAnimations(nullptr);
     }
-    ClearImplicitShowHide(button);
 }
 
 void ReanimateButtons(FrameContext& ctx) {
@@ -805,43 +754,67 @@ void ClearSpacing(std::vector<FrameworkElement> const& buttons) {
 }
 
 // Hides or shows the managed buttons, recording only the ones it hid itself.
-// With outHiddenCount set, reports how many buttons this pass hid.
-void SetCollapseState(FrameContext& ctx,
-                      std::vector<FrameworkElement> const& buttons,
-                      bool collapse,
-                      int* outHiddenCount = nullptr) {
+// With deferHide set, a button to hide is faded in place instead and handed
+// back for FinalizePendingHides to collapse at the animation midpoint.
+void SetCollapseState(
+    FrameContext& ctx,
+    std::vector<FrameworkElement> const& buttons,
+    bool collapse,
+    std::vector<std::pair<FrameworkElement, double>>* deferHide = nullptr) {
     std::wstring marker = CopyRunningMarker();
     double idleVisibleWidth = 0;
+    bool idleSetComplete = true;
 
     for (auto const& button : buttons) {
         bool weHidIt = TakeFromHiddenSet(ctx.hiddenByUs, button, false);
-        bool running = IsButtonRunning(button, marker);
+
+        DeanimatedButton* state = nullptr;
+        for (auto& entry : ctx.deanimated) {
+            if (entry.button.get() == button) {
+                state = &entry;
+                break;
+            }
+        }
+
+        FrameworkElement indicator =
+            state ? state->runningIndicator.get() : nullptr;
+        bool running = IsButtonRunning(button, marker, indicator);
+        if (state && indicator && !state->runningIndicator.get()) {
+            state->runningIndicator = winrt::make_weak(indicator);
+        }
+
         bool shouldHide = collapse && !running;
 
-        // Measured before any visibility flip below, while layout is real.
-        if (!running && button.Visibility() == Visibility::Visible) {
-            idleVisibleWidth += button.ActualWidth();
+        // Measured before any visibility flip below, while layout is real. A
+        // pass that sees an already-hidden idle button measures a partial
+        // set, which must not overwrite the full-set cache.
+        if (!running) {
+            if (button.Visibility() == Visibility::Visible) {
+                idleVisibleWidth += button.ActualWidth();
+            } else {
+                idleSetComplete = false;
+            }
         }
 
         if (shouldHide) {
-            if (weHidIt) {
-                // Re-asserted in case the taskbar re-showed it, or a recorded
-                // hide could stick as visible forever.
-                if (button.Visibility() == Visibility::Visible) {
+            // Buttons Windows already hid stay unrecorded, so they are never
+            // restored on this mod's behalf. A recorded hide is re-asserted
+            // in case the taskbar re-showed it, or it could stick as visible
+            // forever.
+            if (button.Visibility() == Visibility::Visible) {
+                if (deferHide) {
+                    deferHide->emplace_back(button, button.Opacity());
+                    button.Opacity(0);
+                } else {
+                    // Re-stripped at the moment it matters: Windows can have
+                    // re-installed the hide animation since first sight, and
+                    // its ghost is what neighbours would slide across.
+                    ClearImplicitShowHide(button);
                     button.Visibility(Visibility::Collapsed);
+                    if (!weHidIt) {
+                        ctx.hiddenByUs.push_back(winrt::make_weak(button));
+                    }
                 }
-            } else if (button.Visibility() == Visibility::Visible) {
-                if (outHiddenCount) {
-                    (*outHiddenCount)++;
-                }
-                // Re-stripped at the moment it matters: Windows can have
-                // re-installed the hide animation since first sight, and its
-                // ghost is what neighbours would slide across.
-                ClearImplicitShowHide(button);
-                // Buttons Windows already hid stay unrecorded, so they are
-                // never restored on this mod's behalf.
-                button.Visibility(Visibility::Collapsed);
-                ctx.hiddenByUs.push_back(winrt::make_weak(button));
             }
         } else if (weHidIt) {
             button.Visibility(Visibility::Visible);
@@ -849,7 +822,7 @@ void SetCollapseState(FrameContext& ctx,
         }
     }
 
-    if (idleVisibleWidth > 0.5) {
+    if (idleSetComplete && idleVisibleWidth > 0.5) {
         ctx.idleWidth = idleVisibleWidth;
     }
 
@@ -909,7 +882,30 @@ void SortButtonsByPosition(std::vector<FrameworkElement>& buttons,
     }
 }
 
+// Completes deferred hides: restores each faded button's opacity and
+// collapses it for real, recording it as ours to restore unless Windows got
+// to it first.
+void FinalizePendingHides(FrameContext& ctx) {
+    for (auto& entry : ctx.pendingHide) {
+        try {
+            entry.first.Opacity(entry.second);
+            if (entry.first.Visibility() == Visibility::Visible) {
+                ClearImplicitShowHide(entry.first);
+                entry.first.Visibility(Visibility::Collapsed);
+                if (!TakeFromHiddenSet(ctx.hiddenByUs, entry.first, false)) {
+                    ctx.hiddenByUs.push_back(winrt::make_weak(entry.first));
+                }
+            }
+        } catch (winrt::hresult_error const&) {
+        }
+    }
+    ctx.pendingHide.clear();
+}
+
+// Stops any animation; deferred hides complete instantly rather than revert,
+// since the hidden state is where the interrupted animation was heading.
 void StopAnimation(FrameContext& ctx) {
+    FinalizePendingHides(ctx);
     ctx.animActive = false;
     ctx.animSwapped = false;
     UnhookRendering(ctx);
@@ -925,6 +921,8 @@ void StartAnimation(FrameContext& ctx,
     ctx.animKind = AnimKind::Accordion;
     ctx.animTargetCollapse = targetCollapse;
     ctx.animStartMs = NowMs();
+    ctx.animAmplitude =
+        ctx.idleWidth * (double)g_settings.animationAmplitudePct / 100.0;
     ctx.animSwapped = false;
     ctx.animButtons = std::move(buttons);
     ctx.animGapOffsets.clear();
@@ -934,30 +932,29 @@ void StartAnimation(FrameContext& ctx,
     HookRendering(ctx, ctx.key);
 }
 
-// After hiding icons mid-steady-state, freezes every survivor at its old
-// position, holds the vacated gap open for the first half of the animation,
-// then eases it shut. Offsets are measured, before layout against after, so
-// any taskbar alignment and any number of simultaneous gaps come out right.
-void StartGapCloseAnimation(FrameContext& ctx,
-                            std::vector<FrameworkElement> const& buttons,
-                            FrameworkElement frame) {
-    ctx.animButtons.clear();
-    ctx.animGapOffsets.clear();
-
-    // Layout has not run since the hide, so positions still read pre-gap.
+// Midpoint of a gap close: freezes every visible survivor at its pre-collapse
+// position. Positions are sampled before layout runs, layout is forced, and
+// the per-button offsets back to the old spots are applied immediately, so
+// this very frame already holds. Offsets are measured, before layout against
+// after, so any taskbar alignment and any number of simultaneous gaps come
+// out right.
+void MeasureGapOffsets(FrameContext& ctx, FrameworkElement frame) {
+    std::vector<FrameworkElement> survivors;
     std::vector<double> oldX;
-    for (auto const& button : buttons) {
+    for (auto const& button : ctx.animButtons) {
         if (button.Visibility() != Visibility::Visible) {
             continue;
         }
         try {
             double x =
                 button.TransformToVisual(frame).TransformPoint(Point{0, 0}).X;
-            ctx.animButtons.push_back(button);
+            survivors.push_back(button);
             oldX.push_back(x);
         } catch (winrt::hresult_error const&) {
         }
     }
+    ctx.animButtons = std::move(survivors);
+    ctx.animGapOffsets.clear();
     if (ctx.animButtons.empty()) {
         return;
     }
@@ -983,11 +980,25 @@ void StartGapCloseAnimation(FrameContext& ctx,
         ctx.animGapOffsets.push_back((float)offset);
     }
     if (!anyMoved) {
-        ctx.animButtons.clear();
         ctx.animGapOffsets.clear();
         return;
     }
 
+    for (size_t i = 0; i < ctx.animButtons.size(); i++) {
+        ctx.animButtons[i].Translation(float3{ctx.animGapOffsets[i], 0, 0});
+    }
+}
+
+// Begins the two-phase gap close for buttons hidden mid-steady-state. They
+// are already faded by SetCollapseState and the row has not moved; the
+// rendering tick collapses them at the midpoint and eases the gap shut.
+void StartGapCloseAnimation(
+    FrameContext& ctx,
+    std::vector<FrameworkElement> const& buttons,
+    std::vector<std::pair<FrameworkElement, double>> pendingHide) {
+    ctx.animButtons = buttons;
+    ctx.animGapOffsets.clear();
+    ctx.pendingHide = std::move(pendingHide);
     ctx.animActive = true;
     ctx.animKind = AnimKind::GapClose;
     // Matches the applied state so the tick keeps its hands off while it runs.
@@ -995,19 +1006,16 @@ void StartGapCloseAnimation(FrameContext& ctx,
     ctx.animStartMs = NowMs();
     ctx.animSwapped = false;
     HookRendering(ctx, ctx.key);
-
-    // Applied now so this very frame already shows the held positions.
-    for (size_t i = 0; i < ctx.animButtons.size(); i++) {
-        ctx.animButtons[i].Translation(float3{ctx.animGapOffsets[i], 0, 0});
-    }
 }
 
 // Brings one taskbar in line with the requested collapse state. Never runs
 // while an animation is active; OnTimerTick stops the animation first.
-void ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
+// Reports whether it could act, so a pending instant request survives an
+// empty button walk during a taskbar rebuild.
+bool ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
     auto frame = ctx.frame.get();
     if (!frame) {
-        return;
+        return false;
     }
 
     // The buttons' container, remembered from the last successful walk, keeps
@@ -1026,17 +1034,13 @@ void ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
         }
     }
 
-    if (kDebugLogging && g_debugDumpPending.exchange(false)) {
-        DumpButtons(buttons, (bool)ctx.repeater.get());
-    }
-
     ctx.lastButtons.clear();
     for (auto& button : buttons) {
         ctx.lastButtons.push_back(winrt::make_weak(button));
     }
 
     if (buttons.empty()) {
-        return;
+        return false;
     }
 
     if (!g_unloading) {
@@ -1050,8 +1054,7 @@ void ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
 
     if (!instant && (collapse ? 1 : 0) != ctx.appliedCollapse) {
         StartAnimation(ctx, std::move(buttons), collapse);
-        DebugFileLog(L"anim start: target=%d", (int)collapse);
-        return;
+        return true;
     }
 
     // Steady-state hides, an app closing while collapsed, close their gap
@@ -1059,24 +1062,13 @@ void ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
     bool animateGaps = !instant && !g_unloading &&
                        g_settings.animationMode == AnimationMode::Spacing &&
                        (collapse ? 1 : 0) == ctx.appliedCollapse;
-    int hiddenCount = 0;
+    std::vector<std::pair<FrameworkElement, double>> deferHide;
     SetCollapseState(ctx, buttons, collapse,
-                     animateGaps ? &hiddenCount : nullptr);
-    if (hiddenCount > 0) {
-        StartGapCloseAnimation(ctx, buttons, frame);
-        DebugFileLog(L"gap close: %d icons", hiddenCount);
+                     animateGaps ? &deferHide : nullptr);
+    if (!deferHide.empty()) {
+        StartGapCloseAnimation(ctx, buttons, std::move(deferHide));
     }
-
-    if ((int)collapse != ctx.lastLoggedCollapse ||
-        (int)buttons.size() != ctx.lastLoggedButtons ||
-        (int)ctx.hiddenByUs.size() != ctx.lastLoggedHidden) {
-        ctx.lastLoggedCollapse = (int)collapse;
-        ctx.lastLoggedButtons = (int)buttons.size();
-        ctx.lastLoggedHidden = (int)ctx.hiddenByUs.size();
-        DebugFileLog(L"apply: collapse=%d buttons=%d hidden=%d",
-                     ctx.lastLoggedCollapse, ctx.lastLoggedButtons,
-                     ctx.lastLoggedHidden);
-    }
+    return true;
 }
 
 // Drives one frame of the accordion. Spacing is the only thing animated.
@@ -1101,18 +1093,34 @@ void OnRenderingTick(void* key) {
     double t = duration > 0
                    ? std::clamp((NowMs() - ctx->animStartMs) / duration, 0.0, 1.0)
                    : 1.0;
-    double eased = CubicBezierEase(g_settings.animationCurve, t);
+    double eased = CubicBezierEase(CurveFor(g_settings.animationCurve), t);
 
     if (ctx->animKind == AnimKind::GapClose) {
         if (t >= 1.0) {
             StopAnimation(*ctx);
             return;
         }
-        // First half holds the gap open, so Windows' own icon-close flourish
-        // plays out in empty space; second half eases it shut.
-        double closeT = t <= 0.5 ? 0.0 : (t - 0.5) * 2.0;
+        // First half: the doomed buttons are faded but still laid out, so
+        // layout itself holds the gap and Windows' own close flourish plays
+        // out invisibly, with no translations to fight over. The midpoint
+        // collapses them for real; the second half eases the survivors home.
+        if (t < 0.5) {
+            return;
+        }
+        if (!ctx->animSwapped) {
+            ctx->animSwapped = true;
+            FinalizePendingHides(*ctx);
+            if (auto frame = ctx->frame.get()) {
+                MeasureGapOffsets(*ctx, frame);
+            }
+            if (ctx->animGapOffsets.empty()) {
+                StopAnimation(*ctx);
+                return;
+            }
+        }
+        double closeT = (t - 0.5) * 2.0;
         double factor =
-            1.0 - CubicBezierEase(g_settings.animationCurve, closeT);
+            1.0 - CubicBezierEase(CurveFor(g_settings.animationCurve), closeT);
         for (size_t i = 0; i < ctx->animButtons.size(); i++) {
             ctx->animButtons[i].Translation(
                 float3{(float)(ctx->animGapOffsets[i] * factor), 0, 0});
@@ -1137,8 +1145,9 @@ void OnRenderingTick(void* key) {
                 std::wstring marker = CopyRunningMarker();
                 double width = 0;
                 for (auto& button : ctx->animButtons) {
+                    FrameworkElement indicator = nullptr;
                     if (button.Visibility() == Visibility::Visible &&
-                        !IsButtonRunning(button, marker)) {
+                        !IsButtonRunning(button, marker, indicator)) {
                         width += button.ActualWidth();
                     }
                 }
@@ -1151,10 +1160,10 @@ void OnRenderingTick(void* key) {
     }
 
     // Amplitude scales with the width the hidden icons actually occupy, so the
-    // animation adapts to how many icons are pinned. idleWidth only changes at
-    // the swap, so each half of the accordion stays internally consistent.
-    double amplitude =
-        ctx->idleWidth * (double)g_settings.animationAmplitudePct / 100.0;
+    // animation adapts to how many icons are pinned. Snapshotted at
+    // StartAnimation so both halves stretch by one value; the swap only
+    // rewrites idleWidth for later runs.
+    double amplitude = ctx->animAmplitude;
 
     if (t >= 1.0) {
         StopAnimation(*ctx);
@@ -1194,8 +1203,8 @@ void OnTimerTick(void* key) {
     FrameContext* ctx = nullptr;
     {
         std::lock_guard<std::mutex> guard(g_framesMutex);
-        auto it = g_frames.find(key);
-        if (it == g_frames.end()) {
+        auto it = g_frames->find(key);
+        if (it == g_frames->end()) {
             return;
         }
         ctx = &it->second;
@@ -1210,7 +1219,7 @@ void OnTimerTick(void* key) {
             ctx->timer.Stop();
             ctx->timer.Tick(ctx->tickToken);
         }
-        g_frames.erase(key);
+        g_frames->erase(key);
         return;
     }
 
@@ -1220,24 +1229,26 @@ void OnTimerTick(void* key) {
     }
 
     ULONGLONG now = GetTickCount64();
-
-    // Anything mid-interaction pins the fast rate; only a settled, untouched
-    // taskbar sleeps. Waking is handled by the pointer hook, not here.
-    bool sleep = g_settings.sleepEnabled && !g_revealed && !ctx->animActive &&
-                 g_emptyHoverSinceTick == 0 &&
-                 now - g_lastActivityTick >= kSleepAfterMs;
-    g_sleeping = sleep;
-
-    int wantedIntervalMs =
-        sleep ? g_settings.sleepIntervalMs : g_settings.refreshIntervalMs;
-    if (ctx->intervalMs != wantedIntervalMs) {
-        ctx->intervalMs = wantedIntervalMs;
-        ctx->timer.Interval(std::chrono::milliseconds(wantedIntervalMs));
-        DebugFileLog(L"tick interval -> %d ms", wantedIntervalMs);
-    }
     RevealTrigger trigger = g_settings.revealTrigger;
     bool hoverLike =
         trigger == RevealTrigger::Hover || trigger == RevealTrigger::Rest;
+
+    // The fast rate only buys anything while something is timing out: an
+    // animation, a dwell being counted, or a hover reveal aging on its grace
+    // period. A click reveal is stable, so it does not hold the rate up.
+    bool timingSomething = ctx->animActive || g_emptyHoverSinceTick != 0 ||
+                           (g_revealed && hoverLike && !g_revealedByStart);
+    bool sleep = g_settings.sleepEnabled && !timingSomething &&
+                 now - g_lastActivityTick >= kSleepAfterMs;
+    g_sleeping = sleep;
+
+    int wantedIntervalMs = (timingSomething || !sleep)
+                               ? g_settings.refreshIntervalMs
+                               : g_settings.sleepIntervalMs;
+    if (ctx->intervalMs != wantedIntervalMs) {
+        ctx->intervalMs = wantedIntervalMs;
+        ctx->timer.Interval(std::chrono::milliseconds(wantedIntervalMs));
+    }
 
     // Cursor speed from screen-space deltas between ticks. The dt guard keeps
     // a second taskbar's tick in the same instant from producing garbage.
@@ -1308,10 +1319,10 @@ void OnTimerTick(void* key) {
 
     bool desired = g_collapseEnabled && !g_revealed;
 
-    // Consumes at most one pending instant-apply request.
+    // At most one pending instant-apply request, consumed on a successful
+    // apply so an empty button walk does not swallow it.
     uint64_t instantGen = g_instantApplyGen;
     bool instant = ctx->instantGenSeen != instantGen;
-    ctx->instantGenSeen = instantGen;
 
     // While the accordion runs toward the right state, leave it alone: the
     // rendering callback owns the buttons, and reconciliation here would fight
@@ -1323,28 +1334,8 @@ void OnTimerTick(void* key) {
         StopAnimation(*ctx);
     }
 
-    if (!kDebugLogging) {
-        ApplyToFrame(*ctx, desired, instant);
-        return;
-    }
-
-    double beforeMs = NowMs();
-    ApplyToFrame(*ctx, desired, instant);
-    double microseconds = (NowMs() - beforeMs) * 1000.0;
-
-    ctx->applySamples++;
-    ctx->applyTotalUs += microseconds;
-    ctx->applyWorstUs = std::max(ctx->applyWorstUs, microseconds);
-
-    if (ctx->applySamples >= 100) {
-        DebugFileLog(L"cost: %d ticks, avg %.0f us, worst %.0f us, %.2f%% of a "
-                     L"16.7 ms frame",
-                     ctx->applySamples, ctx->applyTotalUs / ctx->applySamples,
-                     ctx->applyWorstUs,
-                     ctx->applyTotalUs / ctx->applySamples / 16700.0 * 100.0);
-        ctx->applySamples = 0;
-        ctx->applyTotalUs = 0;
-        ctx->applyWorstUs = 0;
+    if (ApplyToFrame(*ctx, desired, instant)) {
+        ctx->instantGenSeen = instantGen;
     }
 }
 
@@ -1352,8 +1343,14 @@ void OnTimerTick(void* key) {
 void RegisterFrame(void* key, FrameworkElement frame) {
     std::lock_guard<std::mutex> guard(g_framesMutex);
 
-    auto it = g_frames.find(key);
-    if (it != g_frames.end()) {
+    // Checked under the lock: a hook that passed its unlocked g_unloading
+    // check must not insert a live timer after the cleanup sweeps ran.
+    if (g_unloading) {
+        return;
+    }
+
+    auto it = g_frames->find(key);
+    if (it != g_frames->end()) {
         if (it->second.frame.get()) {
             return;
         }
@@ -1362,7 +1359,7 @@ void RegisterFrame(void* key, FrameworkElement frame) {
             it->second.timer.Stop();
             it->second.timer.Tick(it->second.tickToken);
         }
-        g_frames.erase(it);
+        g_frames->erase(it);
     }
 
     FrameContext ctx;
@@ -1379,24 +1376,22 @@ void RegisterFrame(void* key, FrameworkElement frame) {
         [key](IInspectable const&, IInspectable const&) { OnTimerTick(key); });
     ctx.timer.Start();
 
-    g_frames[key] = ctx;
-    g_debugDumpPending = kDebugLogging;
+    (*g_frames)[key] = ctx;
 
-    DebugFileLog(L"registered taskbar frame %p on thread %u", key,
-                 ctx.threadId);
+    Wh_Log(L"Registered taskbar frame on thread %u", ctx.threadId);
 }
 
 bool IsFrameRegistered(void* key) {
     std::lock_guard<std::mutex> guard(g_framesMutex);
-    return g_frames.find(key) != g_frames.end();
+    return g_frames->find(key) != g_frames->end();
 }
 
 // Map entries keep a stable address and each context belongs to a single UI
 // thread, so the returned pointer stays valid after the lock is released.
 FrameContext* GetFrameContext(void* key) {
     std::lock_guard<std::mutex> guard(g_framesMutex);
-    auto it = g_frames.find(key);
-    return it == g_frames.end() ? nullptr : &it->second;
+    auto it = g_frames->find(key);
+    return it == g_frames->end() ? nullptr : &it->second;
 }
 
 // Applies to the taskbars owned by the calling thread, skipping the tick's wait.
@@ -1405,7 +1400,7 @@ void ApplyOnThisThreadNow() {
     DWORD threadId = GetCurrentThreadId();
     {
         std::lock_guard<std::mutex> guard(g_framesMutex);
-        for (auto& [key, ctx] : g_frames) {
+        for (auto& [key, ctx] : *g_frames) {
             if (ctx.threadId == threadId) {
                 keys.push_back(key);
             }
@@ -1420,10 +1415,14 @@ void ApplyOnThisThreadNow() {
 // Queues a wake on every taskbar's own UI thread. Non-blocking, so it is safe
 // from the worker thread; a hung taskbar just processes it late.
 void WakeAllFramesAsync() {
+    if (g_unloading) {
+        return;
+    }
+
     std::vector<winrt::Windows::UI::Core::CoreDispatcher> dispatchers;
     {
         std::lock_guard<std::mutex> guard(g_framesMutex);
-        for (auto& [key, ctx] : g_frames) {
+        for (auto& [key, ctx] : *g_frames) {
             if (ctx.dispatcher) {
                 dispatchers.push_back(ctx.dispatcher);
             }
@@ -1431,15 +1430,23 @@ void WakeAllFramesAsync() {
     }
 
     for (auto& dispatcher : dispatchers) {
+        g_pendingWakes++;
         try {
             dispatcher.RunAsync(
                 winrt::Windows::UI::Core::CoreDispatcherPriority::Normal,
                 []() {
+                    // The decrement must run even if the apply throws, or
+                    // unload's drain wait stalls on the count.
                     if (!g_unloading) {
-                        ApplyOnThisThreadNow();
+                        try {
+                            ApplyOnThisThreadNow();
+                        } catch (...) {
+                        }
                     }
+                    g_pendingWakes--;
                 });
         } catch (winrt::hresult_error const&) {
+            g_pendingWakes--;
         }
     }
 }
@@ -1574,15 +1581,31 @@ bool PointerQualifiesForReveal(void* key,
 
     // Catches bar content living on a separate surface, which no visual-tree
     // probe can reach: a different window within the padding is a seam, not
-    // empty space.
+    // empty space. The padding is in DIPs and these are screen pixels, so it
+    // is scaled, or the guard shrinks on a high-DPI display. Probes that land
+    // outside the bar's own window are the screen edge or the next monitor,
+    // not a seam, or the bar's outer ends could never start a reveal.
     POINT screenPt;
     if (GetCursorPos(&screenPt)) {
         HWND hAt = WindowFromPoint(screenPt);
-        POINT leftPt{screenPt.x - g_settings.elementPaddingPx, screenPt.y};
-        POINT rightPt{screenPt.x + g_settings.elementPaddingPx, screenPt.y};
-        if (hAt &&
-            (WindowFromPoint(leftPt) != hAt || WindowFromPoint(rightPt) != hAt)) {
-            return false;
+        if (hAt) {
+            UINT dpi = GetDpiForWindow(hAt);
+            int paddingPx =
+                MulDiv(g_settings.elementPaddingPx, dpi ? (int)dpi : 96, 96);
+            HWND hBar = GetAncestor(hAt, GA_ROOT);
+            RECT barRect{};
+            bool haveRect = hBar && GetWindowRect(hBar, &barRect);
+            POINT probes[2] = {{screenPt.x - paddingPx, screenPt.y},
+                               {screenPt.x + paddingPx, screenPt.y}};
+            for (POINT const& probe : probes) {
+                if (haveRect &&
+                    (probe.x < barRect.left || probe.x >= barRect.right)) {
+                    continue;
+                }
+                if (WindowFromPoint(probe) != hAt) {
+                    return false;
+                }
+            }
         }
     }
 
@@ -1607,24 +1630,26 @@ void* FrameKeyFromThis(void* pThis, FrameworkElement* elementOut) {
     return key;
 }
 
-using TaskbarFrame_OnPointerMoved_t = int(WINAPI*)(void* pThis, void* pArgs);
-TaskbarFrame_OnPointerMoved_t TaskbarFrame_OnPointerMoved_Original;
-int WINAPI TaskbarFrame_OnPointerMoved_Hook(void* pThis, void* pArgs) {
-    int ret = TaskbarFrame_OnPointerMoved_Original(pThis, pArgs);
+// The hooks below fill raw COM ABI vtable slots, so each body lives in a
+// helper wrapped in a catch-all: an exception escaping a slot would unwind
+// into XAML and take explorer down.
 
+using TaskbarFrame_OnPointerMoved_t = int(__cdecl*)(void* pThis, void* pArgs);
+TaskbarFrame_OnPointerMoved_t TaskbarFrame_OnPointerMoved_Original;
+void HandlePointerMoved(void* pThis, void* pArgs) {
     if (g_unloading) {
-        return ret;
+        return;
     }
 
     FrameworkElement element = nullptr;
     void* key = FrameKeyFromThis(pThis, &element);
     if (!key) {
-        return ret;
+        return;
     }
 
     if (!IsFrameRegistered(key)) {
         if (winrt::get_class_name(element) != L"Taskbar.TaskbarFrame") {
-            return ret;
+            return;
         }
         RegisterFrame(key, element);
     }
@@ -1642,7 +1667,7 @@ int WINAPI TaskbarFrame_OnPointerMoved_Hook(void* pThis, void* pArgs) {
     RevealTrigger trigger = g_settings.revealTrigger;
     if ((trigger != RevealTrigger::Hover && trigger != RevealTrigger::Rest) ||
         !g_collapseEnabled || g_revealed) {
-        return ret;
+        return;
     }
 
     Input::PointerRoutedEventArgs args = nullptr;
@@ -1650,20 +1675,20 @@ int WINAPI TaskbarFrame_OnPointerMoved_Hook(void* pThis, void* pArgs) {
         ->QueryInterface(winrt::guid_of<Input::PointerRoutedEventArgs>(),
                          winrt::put_abi(args));
     if (!args) {
-        return ret;
+        return;
     }
 
     if (!PointerQualifiesForReveal(key, args)) {
         g_lastPointerQualified = false;
         g_emptyHoverSinceTick = 0;
-        return ret;
+        return;
     }
     g_lastPointerQualified = true;
 
     if (trigger == RevealTrigger::Rest &&
         g_cursorSpeedPxS > (double)g_settings.restSpeedPxPerSec) {
         g_emptyHoverSinceTick = 0;
-        return ret;
+        return;
     }
 
     ULONGLONG now = GetTickCount64();
@@ -1673,47 +1698,83 @@ int WINAPI TaskbarFrame_OnPointerMoved_Hook(void* pThis, void* pArgs) {
         since = now;
     }
     if (now - since < (ULONGLONG)g_settings.revealDelayMs) {
-        return ret;
+        return;
     }
 
     g_revealed = true;
     g_emptyHoverSinceTick = 0;
     ApplyOnThisThreadNow();
+}
 
+int __cdecl TaskbarFrame_OnPointerMoved_Hook(void* pThis, void* pArgs) {
+    int ret = TaskbarFrame_OnPointerMoved_Original(pThis, pArgs);
+    try {
+        HandlePointerMoved(pThis, pArgs);
+    } catch (...) {
+    }
     return ret;
 }
 
 // Leaving the frame ends any pending qualification, so resting on the tray or
-// beyond it cannot inherit one from the last touch of bare taskbar.
-using TaskbarFrame_OnPointerExited_t = int(WINAPI*)(void* pThis, void* pArgs);
+// beyond it cannot inherit one from the last touch of bare taskbar. Exits
+// also bubble up from child elements and other pointers while the cursor is
+// still inside, so a position still within the frame keeps the state.
+using TaskbarFrame_OnPointerExited_t = int(__cdecl*)(void* pThis, void* pArgs);
 TaskbarFrame_OnPointerExited_t TaskbarFrame_OnPointerExited_Original;
-int WINAPI TaskbarFrame_OnPointerExited_Hook(void* pThis, void* pArgs) {
-    int ret = TaskbarFrame_OnPointerExited_Original(pThis, pArgs);
+void HandlePointerExited(void* pThis, void* pArgs) {
+    if (g_unloading) {
+        return;
+    }
 
-    if (!g_unloading) {
+    bool stillInside = false;
+    FrameworkElement element = nullptr;
+    FrameKeyFromThis(pThis, &element);
+    if (element && pArgs) {
+        Input::PointerRoutedEventArgs args = nullptr;
+        ((IUnknown*)pArgs)
+            ->QueryInterface(winrt::guid_of<Input::PointerRoutedEventArgs>(),
+                             winrt::put_abi(args));
+        if (args) {
+            try {
+                Point pt = args.GetCurrentPoint(element).Position();
+                stillInside = pt.X >= 0 && pt.Y >= 0 &&
+                              pt.X < element.ActualWidth() &&
+                              pt.Y < element.ActualHeight();
+            } catch (winrt::hresult_error const&) {
+            }
+        }
+    }
+
+    if (!stillInside) {
         g_lastPointerQualified = false;
         g_emptyHoverSinceTick = 0;
     }
+}
 
+int __cdecl TaskbarFrame_OnPointerExited_Hook(void* pThis, void* pArgs) {
+    int ret = TaskbarFrame_OnPointerExited_Original(pThis, pArgs);
+    try {
+        HandlePointerExited(pThis, pArgs);
+    } catch (...) {
+    }
     return ret;
 }
 
 // Toggles the reveal on a click landing on bare taskbar. Released rather than
 // pressed, so dragging off the taskbar and letting go does not count.
-using TaskbarFrame_OnPointerReleased_t = int(WINAPI*)(void* pThis, void* pArgs);
+using TaskbarFrame_OnPointerReleased_t = int(__cdecl*)(void* pThis,
+                                                       void* pArgs);
 TaskbarFrame_OnPointerReleased_t TaskbarFrame_OnPointerReleased_Original;
-int WINAPI TaskbarFrame_OnPointerReleased_Hook(void* pThis, void* pArgs) {
-    int ret = TaskbarFrame_OnPointerReleased_Original(pThis, pArgs);
-
+void HandlePointerReleased(void* pThis, void* pArgs) {
     if (g_unloading || g_settings.revealTrigger != RevealTrigger::Click ||
         !g_collapseEnabled) {
-        return ret;
+        return;
     }
 
     FrameworkElement element = nullptr;
     void* key = FrameKeyFromThis(pThis, &element);
     if (!key || !IsFrameRegistered(key)) {
-        return ret;
+        return;
     }
 
     Input::PointerRoutedEventArgs args = nullptr;
@@ -1721,57 +1782,80 @@ int WINAPI TaskbarFrame_OnPointerReleased_Hook(void* pThis, void* pArgs) {
         ->QueryInterface(winrt::guid_of<Input::PointerRoutedEventArgs>(),
                          winrt::put_abi(args));
     if (!args) {
-        return ret;
+        return;
     }
 
     // Left button only: right-click belongs to the taskbar's context menu.
     if (args.GetCurrentPoint(nullptr).Properties().PointerUpdateKind() !=
         winrt::Windows::UI::Input::PointerUpdateKind::LeftButtonReleased) {
-        return ret;
+        return;
     }
 
     if (!PointerQualifiesForReveal(key, args)) {
-        return ret;
+        return;
     }
 
-    g_revealed = !g_revealed;
+    // Atomic flip: two taskbars' release hooks can race on this.
+    bool revealed = g_revealed.load();
+    while (!g_revealed.compare_exchange_weak(revealed, !revealed)) {
+    }
     g_emptyHoverSinceTick = 0;
-    DebugFileLog(L"empty-area click toggled reveal to %d", (int)g_revealed);
     ApplyOnThisThreadNow();
+}
 
+int __cdecl TaskbarFrame_OnPointerReleased_Hook(void* pThis, void* pArgs) {
+    int ret = TaskbarFrame_OnPointerReleased_Original(pThis, pArgs);
+    try {
+        HandlePointerReleased(pThis, pArgs);
+    } catch (...) {
+    }
     return ret;
 }
 
 // Second discovery path, for taskbars the cursor has not visited yet.
 using TaskbarFrame_MeasureOverride_t =
-    int(WINAPI*)(void* pThis,
-                 winrt::Windows::Foundation::Size size,
-                 winrt::Windows::Foundation::Size* resultSize);
+    int(__cdecl*)(void* pThis,
+                  winrt::Windows::Foundation::Size size,
+                  winrt::Windows::Foundation::Size* resultSize);
 TaskbarFrame_MeasureOverride_t TaskbarFrame_MeasureOverride_Original;
-int WINAPI TaskbarFrame_MeasureOverride_Hook(
-    void* pThis,
-    winrt::Windows::Foundation::Size size,
-    winrt::Windows::Foundation::Size* resultSize) {
-    int ret = TaskbarFrame_MeasureOverride_Original(pThis, size, resultSize);
-
-    if (g_unloading) {
-        return ret;
+void HandleFrameMeasure(void* pThis) {
+    // This is the layout hot path, so a frame already adopted is dismissed on
+    // a raw pointer compare, before any QueryInterface or lock. The pointer is
+    // stable per frame for this interface slot; the slot is per-thread since
+    // each taskbar measures only on its own UI thread, so it stays hot with
+    // any number of monitors.
+    thread_local void* knownThis = nullptr;
+    if (g_unloading || knownThis == pThis) {
+        return;
     }
 
-    // Taskbar layout changes when apps open, close, or badges update — all
-    // activity, so a sleeping mod notices churn within one slow tick.
-    g_lastActivityTick = GetTickCount64();
-
+    // Deliberately does not count as activity: the taskbar remeasures for
+    // clocks, badges and tray churn, which would keep the mod awake forever.
+    // A sleeping tick still notices icon changes within one slow interval.
     FrameworkElement element = nullptr;
     void* key = FrameKeyFromThis(pThis, &element);
-    if (!key || IsFrameRegistered(key)) {
-        return ret;
+    if (!key) {
+        return;
+    }
+    if (IsFrameRegistered(key)) {
+        knownThis = pThis;
+        return;
     }
 
     if (winrt::get_class_name(element) == L"Taskbar.TaskbarFrame") {
         RegisterFrame(key, element);
     }
+}
 
+int __cdecl TaskbarFrame_MeasureOverride_Hook(
+    void* pThis,
+    winrt::Windows::Foundation::Size size,
+    winrt::Windows::Foundation::Size* resultSize) {
+    int ret = TaskbarFrame_MeasureOverride_Original(pThis, size, resultSize);
+    try {
+        HandleFrameMeasure(pThis);
+    } catch (...) {
+    }
     return ret;
 }
 
@@ -1807,17 +1891,24 @@ bool ParseHotkey(std::wstring spec, UINT* modifiers, UINT* vk) {
             } else if (token == L"win") {
                 *modifiers |= MOD_WIN;
             } else if (token == L"space") {
+                if (*vk) {
+                    return false;
+                }
                 *vk = VK_SPACE;
             } else if (token.size() == 1 &&
                        ((token[0] >= L'a' && token[0] <= L'z') ||
                         (token[0] >= L'0' && token[0] <= L'9'))) {
+                if (*vk) {
+                    return false;
+                }
                 *vk = towupper(token[0]);
             } else if (token[0] == L'f' && token.size() >= 2 &&
                        token.size() <= 3) {
                 int n = _wtoi(token.c_str() + 1);
-                if (n >= 1 && n <= 24) {
-                    *vk = VK_F1 + n - 1;
+                if (n < 1 || n > 24 || *vk) {
+                    return false;
                 }
+                *vk = VK_F1 + n - 1;
             } else {
                 return false;
             }
@@ -1835,14 +1926,17 @@ bool ParseHotkey(std::wstring spec, UINT* modifiers, UINT* vk) {
 // Flips state and queues non-blocking wakes; never waits on a taskbar thread,
 // or unloading the mod could strand the worker against a hung message queue.
 void ToggleCollapse() {
-    bool enabled = !g_collapseEnabled.load();
-    g_collapseEnabled = enabled;
+    // Atomic flip: LoadSettings writes this concurrently on settings saves.
+    bool prev = g_collapseEnabled.load();
+    while (!g_collapseEnabled.compare_exchange_weak(prev, !prev)) {
+    }
+    bool enabled = !prev;
     g_revealed = false;
     g_revealedByStart = false;
     g_emptyHoverSinceTick = 0;
     g_lastActivityTick = GetTickCount64();
     g_instantApplyGen++;
-    DebugFileLog(L"hotkey toggled collapse to %d", (int)enabled);
+    Wh_Log(L"Hotkey toggled collapse to %d", (int)enabled);
     WakeAllFramesAsync();
 }
 
@@ -1855,22 +1949,27 @@ void OnStartMenuVisibility(bool visible) {
         if (!g_revealed.exchange(true)) {
             g_revealedByStart = true;
             g_lastActivityTick = GetTickCount64();
-            DebugFileLog(L"start menu opened -> reveal");
+            Wh_Log(L"Start menu opened, revealing");
             WakeAllFramesAsync();
         }
         return;
     }
 
     if (g_revealedByStart.exchange(false)) {
-        // With the cursor on the taskbar the reveal is handed to the normal
-        // grace rules instead of collapsing under a click in progress.
-        if (CursorOverAnyTaskbar()) {
+        // With the cursor on the taskbar, hover-like triggers hand the reveal
+        // to the normal grace rules instead of collapsing under a click in
+        // progress. Click and hotkey-only have no aging rules that could ever
+        // end it, so for them the reveal ends with Start.
+        RevealTrigger trigger = g_settings.revealTrigger;
+        bool hoverLike = trigger == RevealTrigger::Hover ||
+                         trigger == RevealTrigger::Rest;
+        if (hoverLike && CursorOverAnyTaskbar()) {
             g_lastCursorInsideTick = GetTickCount64();
         } else {
             g_revealed = false;
         }
         g_lastActivityTick = GetTickCount64();
-        DebugFileLog(L"start menu closed");
+        Wh_Log(L"Start menu closed");
         WakeAllFramesAsync();
     }
 }
@@ -1881,6 +1980,9 @@ class StartVisibilitySink final : public IAppVisibilityEvents {
    public:
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid,
                                              void** ppvObject) override {
+        if (!ppvObject) {
+            return E_POINTER;
+        }
         if (riid == __uuidof(IUnknown) || riid == __uuidof(IAppVisibilityEvents)) {
             *ppvObject = static_cast<IAppVisibilityEvents*>(this);
             AddRef();
@@ -1911,7 +2013,15 @@ class StartVisibilitySink final : public IAppVisibilityEvents {
 
     HRESULT STDMETHODCALLTYPE
     LauncherVisibilityChange(BOOL currentVisibleState) override {
-        OnStartMenuVisibility(currentVisibleState != FALSE);
+        // Counted so teardown can wait out a call in flight; Unadvise alone
+        // does not fence one that already started. The catch keeps both the
+        // COM ABI and the decrement safe.
+        g_sinkCallbacks++;
+        try {
+            OnStartMenuVisibility(currentVisibleState != FALSE);
+        } catch (...) {
+        }
+        g_sinkCallbacks--;
         return S_OK;
     }
 
@@ -1921,7 +2031,19 @@ class StartVisibilitySink final : public IAppVisibilityEvents {
 
 // Owns the hotkey registration and the Start-menu watcher; WM_QUIT ends it.
 DWORD WINAPI HotkeyThreadProc(LPVOID param) {
-    winrt::init_apartment(winrt::apartment_type::multi_threaded);
+    // Force the message queue into existence and announce it before anything
+    // slow, so teardown's WM_QUIT always lands.
+    MSG queuePrimer;
+    PeekMessage(&queuePrimer, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+    SetEvent(g_hotkeyThreadReady);
+
+    // A raw thread entry: an escaping exception would terminate explorer.
+    try {
+        winrt::init_apartment(winrt::apartment_type::multi_threaded);
+    } catch (winrt::hresult_error const&) {
+        Wh_Log(L"init_apartment failed, hotkey thread not running");
+        return 0;
+    }
 
     ULONG_PTR packed = (ULONG_PTR)param;
     UINT modifiers = (UINT)(packed >> 16);
@@ -1958,6 +2080,11 @@ DWORD WINAPI HotkeyThreadProc(LPVOID param) {
     if (appVisibility && adviseCookie) {
         appVisibility->Unadvise(adviseCookie);
     }
+    // A callback that slipped past Unadvise may still be running; wait it out
+    // before the sink can be freed or the mod unloaded.
+    while (g_sinkCallbacks.load() > 0) {
+        Sleep(1);
+    }
     if (sink) {
         sink->Release();
     }
@@ -1971,15 +2098,15 @@ DWORD WINAPI HotkeyThreadProc(LPVOID param) {
 }
 
 void StartHotkeyThread() {
-    PCWSTR spec = Wh_GetStringSetting(L"Hotkey");
+    auto spec = WindhawkUtils::StringSetting::make(L"Hotkey");
     UINT modifiers = 0;
     UINT vk = 0;
-    bool valid = spec && ParseHotkey(spec, &modifiers, &vk);
-    if (spec) {
-        Wh_FreeStringSetting(spec);
-    }
+    bool valid = ParseHotkey(spec.get(), &modifiers, &vk);
 
     if (!valid) {
+        if (*spec.get()) {
+            Wh_Log(L"Hotkey spec not understood, hotkey disabled");
+        }
         modifiers = 0;
         vk = 0;
     }
@@ -1987,20 +2114,35 @@ void StartHotkeyThread() {
         return;
     }
 
+    g_hotkeyThreadReady = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+    if (!g_hotkeyThreadReady) {
+        return;
+    }
+
     ULONG_PTR packed = ((ULONG_PTR)modifiers << 16) | vk;
     g_hotkeyThread = CreateThread(nullptr, 0, HotkeyThreadProc, (LPVOID)packed,
                                   0, &g_hotkeyThreadId);
+    if (!g_hotkeyThread) {
+        CloseHandle(g_hotkeyThreadReady);
+        g_hotkeyThreadReady = nullptr;
+    }
 }
 
+// Waits without a timeout on purpose: the mod is unloaded the moment teardown
+// returns, so a thread still running here would resume inside a freed image.
 void StopHotkeyThread() {
     if (!g_hotkeyThread) {
         return;
     }
 
+    WaitForSingleObject(g_hotkeyThreadReady, INFINITE);
     PostThreadMessage(g_hotkeyThreadId, WM_QUIT, 0, 0);
-    WaitForSingleObject(g_hotkeyThread, 2000);
+    WaitForSingleObject(g_hotkeyThread, INFINITE);
+
     CloseHandle(g_hotkeyThread);
+    CloseHandle(g_hotkeyThreadReady);
     g_hotkeyThread = nullptr;
+    g_hotkeyThreadReady = nullptr;
     g_hotkeyThreadId = 0;
 }
 
@@ -2097,7 +2239,7 @@ void CleanupOnThisThread() {
 
     {
         std::lock_guard<std::mutex> guard(g_framesMutex);
-        for (auto& [key, ctx] : g_frames) {
+        for (auto& [key, ctx] : *g_frames) {
             if (ctx.threadId == threadId) {
                 keys.push_back(key);
             }
@@ -2106,8 +2248,8 @@ void CleanupOnThisThread() {
 
     std::lock_guard<std::mutex> guard(g_framesMutex);
     for (void* key : keys) {
-        auto it = g_frames.find(key);
-        if (it == g_frames.end()) {
+        auto it = g_frames->find(key);
+        if (it == g_frames->end()) {
             continue;
         }
 
@@ -2116,7 +2258,7 @@ void CleanupOnThisThread() {
             it->second.timer.Tick(it->second.tickToken);
         }
         RestoreFrame(it->second);
-        g_frames.erase(it);
+        g_frames->erase(it);
     }
 }
 
@@ -2127,17 +2269,14 @@ void LoadSettings() {
 
     g_settings.revealOnStart = Wh_GetIntSetting(L"RevealOnStart") != 0;
 
+    auto trigger = WindhawkUtils::StringSetting::make(L"RevealTrigger");
     g_settings.revealTrigger = RevealTrigger::Hover;
-    PCWSTR trigger = Wh_GetStringSetting(L"RevealTrigger");
-    if (trigger) {
-        if (wcscmp(trigger, L"rest") == 0) {
-            g_settings.revealTrigger = RevealTrigger::Rest;
-        } else if (wcscmp(trigger, L"click") == 0) {
-            g_settings.revealTrigger = RevealTrigger::Click;
-        } else if (wcscmp(trigger, L"never") == 0) {
-            g_settings.revealTrigger = RevealTrigger::Never;
-        }
-        Wh_FreeStringSetting(trigger);
+    if (wcscmp(trigger.get(), L"rest") == 0) {
+        g_settings.revealTrigger = RevealTrigger::Rest;
+    } else if (wcscmp(trigger.get(), L"click") == 0) {
+        g_settings.revealTrigger = RevealTrigger::Click;
+    } else if (wcscmp(trigger.get(), L"never") == 0) {
+        g_settings.revealTrigger = RevealTrigger::Never;
     }
 
     g_settings.restSpeedPxPerSec =
@@ -2161,33 +2300,23 @@ void LoadSettings() {
     g_settings.animationAmplitudePct =
         std::clamp(Wh_GetIntSetting(L"AnimationAmplitudePct"), 0, 200);
 
-    g_settings.animationMode = AnimationMode::None;
-    PCWSTR mode = Wh_GetStringSetting(L"AnimationMode");
-    if (mode) {
-        if (wcscmp(mode, L"spacing") == 0) {
-            g_settings.animationMode = AnimationMode::Spacing;
-        }
-        Wh_FreeStringSetting(mode);
+    auto mode = WindhawkUtils::StringSetting::make(L"AnimationMode");
+    g_settings.animationMode = wcscmp(mode.get(), L"spacing") == 0
+                                   ? AnimationMode::Spacing
+                                   : AnimationMode::None;
+
+    auto curve = WindhawkUtils::StringSetting::make(L"AnimationCurve");
+    g_settings.animationCurve = CurveId::Sine;
+    if (wcscmp(curve.get(), L"cubic") == 0) {
+        g_settings.animationCurve = CurveId::Cubic;
+    } else if (wcscmp(curve.get(), L"circ") == 0) {
+        g_settings.animationCurve = CurveId::Circ;
     }
 
-    g_settings.animationCurve = kEaseInOutSine;
-    PCWSTR curve = Wh_GetStringSetting(L"AnimationCurve");
-    if (curve) {
-        if (wcscmp(curve, L"cubic") == 0) {
-            g_settings.animationCurve = kEaseInOutCubic;
-        } else if (wcscmp(curve, L"circ") == 0) {
-            g_settings.animationCurve = kEaseInOutCirc;
-        }
-        Wh_FreeStringSetting(curve);
-    }
-
-    PCWSTR marker = Wh_GetStringSetting(L"RunningNameMarker");
+    auto marker = WindhawkUtils::StringSetting::make(L"RunningNameMarker");
     {
         std::lock_guard<std::mutex> guard(g_settingsMutex);
-        g_settings.runningNameMarker = marker ? marker : L"";
-    }
-    if (marker) {
-        Wh_FreeStringSetting(marker);
+        g_settings.runningNameMarker = marker.get();
     }
 
     g_collapseEnabled = g_settings.collapsed;
@@ -2196,7 +2325,6 @@ void LoadSettings() {
     g_emptyHoverSinceTick = 0;
     g_lastPointerQualified = false;
     g_lastActivityTick = GetTickCount64();
-    g_debugDumpPending = kDebugLogging;
 }
 
 HMODULE GetTaskbarViewModuleHandle() {
@@ -2237,11 +2365,11 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
 
     if (!WindhawkUtils::HookSymbols(module, taskbarViewDllHooks,
                                     ARRAYSIZE(taskbarViewDllHooks))) {
-        DebugFileLog(L"HookSymbols FAILED - mod will not load");
+        Wh_Log(L"HookSymbols failed, mod will not load");
         return false;
     }
 
-    DebugFileLog(
+    Wh_Log(
         L"HookSymbols ok (OnPointerMoved=%d OnPointerReleased=%d "
         L"MeasureOverride=%d)",
         (int)(TaskbarFrame_OnPointerMoved_Original != nullptr),
@@ -2277,13 +2405,6 @@ BOOL Wh_ModInit() {
 
     LoadSettings();
 
-    DebugFileLog(
-        L"=== init " WH_MOD_VERSION
-        L" collapsed=%d trigger=%d delay=%d padding=%d grace=%d refresh=%d ===",
-        (int)g_settings.collapsed, (int)g_settings.revealTrigger,
-        g_settings.revealDelayMs, g_settings.elementPaddingPx,
-        g_settings.hoverGraceMs, g_settings.refreshIntervalMs);
-
     if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
         g_taskbarViewDllLoaded = true;
         if (!HookTaskbarViewDllSymbols(taskbarViewModule)) {
@@ -2291,8 +2412,16 @@ BOOL Wh_ModInit() {
         }
     } else {
         HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
+        if (!kernelBaseModule) {
+            Wh_Log(L"kernelbase.dll not found");
+            return FALSE;
+        }
         auto pKernelBaseLoadLibraryExW = (decltype(&LoadLibraryExW))
             GetProcAddress(kernelBaseModule, "LoadLibraryExW");
+        if (!pKernelBaseLoadLibraryExW) {
+            Wh_Log(L"LoadLibraryExW not found in kernelbase.dll");
+            return FALSE;
+        }
         WindhawkUtils::SetFunctionHook(pKernelBaseLoadLibraryExW,
                                        LoadLibraryExW_Hook,
                                        &LoadLibraryExW_Original);
@@ -2306,6 +2435,17 @@ BOOL Wh_ModInit() {
 void Wh_ModAfterInit() {
     if (g_taskbarViewDllLoaded) {
         g_hooksApplied = true;
+        return;
+    }
+
+    // Try again in case Taskbar.View.dll loaded between Wh_ModInit's check
+    // and the LoadLibraryExW hook going live.
+    HMODULE taskbarViewModule = GetTaskbarViewModuleHandle();
+    if (taskbarViewModule && !g_taskbarViewDllLoaded.exchange(true)) {
+        if (HookTaskbarViewDllSymbols(taskbarViewModule) &&
+            !g_hooksApplied.exchange(true)) {
+            Wh_ApplyHookOperations();
+        }
     }
 }
 
@@ -2315,9 +2455,6 @@ void Wh_ModSettingsChanged() {
     StopHotkeyThread();
     LoadSettings();
     StartHotkeyThread();
-
-    DebugFileLog(L"=== settings changed: collapsed=%d trigger=%d ===",
-                 (int)g_settings.collapsed, (int)g_settings.revealTrigger);
 
     g_instantApplyGen++;
 }
@@ -2336,7 +2473,7 @@ void Wh_ModBeforeUninit() {
     std::vector<DWORD> leftoverThreads;
     {
         std::lock_guard<std::mutex> guard(g_framesMutex);
-        for (auto& [key, ctx] : g_frames) {
+        for (auto& [key, ctx] : *g_frames) {
             leftoverThreads.push_back(ctx.threadId);
         }
     }
@@ -2355,6 +2492,55 @@ void Wh_ModBeforeUninit() {
         }
     }
 
+    // Last resort for a context with no reachable window: ask its dispatcher
+    // to clean up and wait for it. Timers and rendering hooks must come off on
+    // their own thread, and dropping the map here would neither stop them nor
+    // release their XAML objects safely.
+    std::vector<winrt::Windows::UI::Core::CoreDispatcher> stragglers;
+    {
+        std::lock_guard<std::mutex> guard(g_framesMutex);
+        for (auto& [key, ctx] : *g_frames) {
+            if (ctx.dispatcher) {
+                stragglers.push_back(ctx.dispatcher);
+            }
+        }
+    }
+
+    for (auto& dispatcher : stragglers) {
+        HANDLE done = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+        if (!done) {
+            continue;
+        }
+        bool queued = false;
+        try {
+            dispatcher.RunAsync(
+                winrt::Windows::UI::Core::CoreDispatcherPriority::High,
+                [done]() {
+                    CleanupOnThisThread();
+                    SetEvent(done);
+                });
+            queued = true;
+        } catch (winrt::hresult_error const&) {
+        }
+        // On timeout the queued lambda still owns SetEvent(done), so the
+        // handle is deliberately leaked rather than recycled under it.
+        if (!queued || WaitForSingleObject(done, 5000) == WAIT_OBJECT_0) {
+            CloseHandle(done);
+        }
+    }
+
+    // Wakes still queued to taskbar dispatchers hold code from this DLL; the
+    // threads are pumping (they just serviced the cleanup), so give their
+    // queues a bounded moment to run the leftovers down.
+    for (int i = 0; i < 500 && g_pendingWakes.load() > 0; i++) {
+        Sleep(10);
+    }
+
+    // Anything still present could not be reached on its own thread; leaving
+    // its references alive is safer than releasing them from here.
     std::lock_guard<std::mutex> guard(g_framesMutex);
-    g_frames.clear();
+    if (!g_frames->empty()) {
+        Wh_Log(L"%u taskbar contexts could not be cleaned up",
+               (unsigned)g_frames->size());
+    }
 }

--- a/mods/taskbar-collapse-to-running.wh.cpp
+++ b/mods/taskbar-collapse-to-running.wh.cpp
@@ -41,19 +41,8 @@ or closes. While nothing is happening, it does nothing at all.
 icons and tray alike; **Reveal delay** requires the cursor to stay put first.
 
 ## Notes
-
-* Windows 11 only. Win+number still counts pinned items the way Windows does.
-* Built and tested on Windows 11 build 26200 with a left-aligned,
-  single-monitor taskbar. Other builds can name taskbar internals differently.
-* Revealing is shared across monitors: revealing one taskbar reveals them all.
-* With Click, a click on empty taskbar reaches other mods bound to the same
-  spot too, so one click can trigger both.
-* Disabling the mod restores hidden icons and the animations it stripped, with
-  one exception: Windows' icon appear/disappear animation on buttons the mod
-  actually hid stays off until Explorer restarts, because that property cannot
-  be read back to restore it.
-
-Licensed MIT. Thanks to https://easings.net/ for the easing curve values.
+* Built with Claude and tested on Windows 11 build 26200.
+* Thanks to https://easings.net/ for the easing curve values.
 */
 // ==/WindhawkModReadme==
 
@@ -74,7 +63,8 @@ Licensed MIT. Thanks to https://easings.net/ for the easing curve values.
 - RevealDelayMs: 30
   $name: Reveal delay (ms)
   $description: >-
-    How long the cursor must stay in the empty taskbar area before the icons come back.
+    How long the cursor must stay in the empty taskbar area before the icons
+    come back (only applies to: Reveal trigger > Hover / Rest)
 - RestSpeedPxPerSec: 300
   $name: Rest speed (px/s)
   $description: >-
@@ -84,13 +74,15 @@ Licensed MIT. Thanks to https://easings.net/ for the easing curve values.
   $description: >-
     Hide pinned icons whose app is not running. The hotkey flips the same
     switch, but only until settings are saved again, which restores this box.
-- ElementPaddingPx: 24
+- ElementPaddingPx: 12
   $name: Padding around elements (px)
   $description: >-
     Safe area around every taskbar element to prevent unwanted transitions.
 - HoverGraceMs: 150
   $name: Grace period (ms)
-  $description: How long the cursor may be off the taskbar before it collapses again.
+  $description: >-
+    How long the cursor may be off the taskbar before it collapses again
+    (only applies to: Reveal trigger > Hover / Rest)
 - AnimationMode: spacing
   $name: Reveal animation
   $description: >-
@@ -107,11 +99,13 @@ Licensed MIT. Thanks to https://easings.net/ for the easing curve values.
 - AnimationDurationMs: 160
   $name: Animation length (ms)
 - AnimationAmplitudePct: 40
-  $name: Animation amplitude (%)
+  $name: Snappiness (%)
   $description: >-
-    How far the accordion stretches, as a percentage of the width the hidden
-    icons actually take up. 100 stretches by exactly the space they occupy, so
-    the animation scales itself to how many icons are pinned. 0 to 200.
+    How much of the motion the mid-transition cut takes. On a left-aligned
+    taskbar the accordion stretches by this share of the hidden icons' width
+    and the cut flips it. On a centered taskbar spacing is left alone;
+    instead this share of the row's travel is skipped at the cut. 0 is fully
+    smooth, 100 is maximum snap.
 - Hotkey: Ctrl+Alt+T
   $name: Toggle hotkey
   $description: Modifiers Ctrl, Alt, Shift, Win plus one of A-Z, 0-9, F1-F24, Space. Leave empty for no hotkey.
@@ -124,6 +118,10 @@ Licensed MIT. Thanks to https://easings.net/ for the easing curve values.
 
 // winbase.h's GetCurrentTime macro collides with the XAML animation headers.
 #undef GetCurrentTime
+
+#ifndef SPI_SETLOGICALDPIOVERRIDE
+#define SPI_SETLOGICALDPIOVERRIDE 0x009F
+#endif
 
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
@@ -163,6 +161,9 @@ void RunOnAllTaskbarThreads(RunFromWindowThreadProc_t proc, PVOID param);
 bool PointerClearsSurfaces(void* key, Point framePt);
 void ApplyOnThisThreadNow();
 void WakeAllFramesAsync();
+void StartHotkeyThread();
+void NudgeTaskbarsForDiscovery();
+bool PostApply(winrt::Windows::UI::Core::CoreDispatcher const& dispatcher);
 
 // Pointer-event gap after which the cursor counts as parked.
 constexpr double kSpeedSampleStaleMs = 150.0;
@@ -199,14 +200,13 @@ EasingCurve const& CurveFor(CurveId id) {
 enum class AnimationMode { None, Spacing };
 enum class RevealTrigger { Never, Hover, Rest, Click };
 
-// GapClose: hide an icon instantly, hold its gap open until the taskbar
-// stops churning, then ease the row shut.
+// GapClose: hide an icon instantly, hold its gap open a beat, then ease the
+// row shut.
 enum class AnimKind { Accordion, GapClose };
 
-// Quiet time after the last button churn before the gap eases shut, and the
-// longest the gap may hold open waiting for it.
-constexpr double kGapSettleMs = 250.0;
-constexpr double kGapHoldMaxMs = 1000.0;
+// How long a closed icon's gap holds before easing shut: enough for
+// Windows' close churn to pass, short enough to read as one motion.
+constexpr double kGapHoldMs = 250.0;
 
 struct {
     std::atomic<RevealTrigger> revealTrigger;
@@ -244,9 +244,6 @@ POINT g_speedSamplePrevPos = {};
 
 void* g_lastQualifiedKey = nullptr;
 Point g_lastQualifiedFramePt = {};
-
-// Last TaskListButton state churn; the gap-close hold waits for quiet.
-std::atomic<double> g_lastButtonChurnMs = 0;
 
 // Bumped by hotkey/settings; a new value applies once, without animation.
 std::atomic<uint64_t> g_instantApplyGen = 0;
@@ -294,10 +291,43 @@ struct FrameContext {
     double animStartMs = 0;
     // Snapshot at StartAnimation, so both accordion halves use one value.
     double animAmplitude = 0;
+    bool animCentered = false;
+    // Accordion playback table, computed before the first frame renders:
+    // start and destination for every strip element, fold order per phase.
+    // The tick only interpolates; reality diverging from the table kills
+    // the run and lands the target instantly.
+    struct PlanEntry {
+        FrameworkElement element{nullptr};
+        double startX = 0;
+        double finalX = 0;
+        // Participation per phase (folds/renders); on a reveal, appearing
+        // icons hold live-but-transparent slots, so actual Visibility in
+        // phase one is tracked separately for the divergence guard.
+        bool visibleBefore = false;
+        bool visibleAfter = false;
+        bool visiblePhase1 = false;
+        int foldBefore = -1;
+        int foldAfter = -1;
+    };
+    std::vector<PlanEntry> animPlan;
+    int animFoldCountBefore = 0;
+    int animFoldCountAfter = 0;
+    // Strip child count when the run began; a change is divergence.
+    int animChildCount = -1;
     bool animSwapped = false;
+    // Collapse run ended; the real hides land on the next dispatcher pass.
+    bool animFinalizePending = false;
     std::vector<float> animGapOffsets;
-    // GapClose: collapsed at start, held transparent until the run ends.
-    std::vector<std::pair<FrameworkElement, double>> gapHidden;
+    struct GapHidden {
+        FrameworkElement element{nullptr};
+        double opacity = 1;
+        double maxWidth = 0;
+    };
+    // GapClose: collapsed at start, held transparent and widthless until the
+    // run ends, so a re-show by Windows neither draws nor takes space. The
+    // accordion reveal reuses it for appearing icons held transparent until
+    // the apex; StopAnimation restores whatever is left either way.
+    std::vector<GapHidden> gapHidden;
     std::vector<FrameworkElement> animButtons;
     // Idle icons' width while visible; hidden ones measure zero.
     double idleWidth = 0;
@@ -442,7 +472,7 @@ bool CursorOverAnyTaskbar() {
     }
 
     WCHAR className[64];
-    if (!GetClassName(hRoot, className, ARRAYSIZE(className))) {
+    if (!GetClassNameW(hRoot, className, ARRAYSIZE(className))) {
         return false;
     }
 
@@ -464,6 +494,17 @@ bool CursorOverAnyTaskbar() {
     }
 
     return false;
+}
+
+// Alignment from TaskbarAl: 1 or missing = centred (the Windows 11 default).
+bool TaskbarIsCentered() {
+    DWORD value = 1;
+    DWORD size = sizeof(value);
+    RegGetValueW(HKEY_CURRENT_USER,
+                 L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\"
+                 L"Advanced",
+                 L"TaskbarAl", RRF_RT_REG_DWORD, nullptr, &value, &size);
+    return value != 0;
 }
 
 // No getter, so irreversible: only call for buttons actually being hidden.
@@ -567,29 +608,13 @@ double CubicBezierEase(EasingCurve const& curve, double t) {
 
 // ---------------------------------------------------------------- animation
 
-// Leftmost held still; deliberately no re-centre compensation.
-void ApplySpacing(std::vector<FrameworkElement> const& buttons,
-                  double totalExtra) {
-    std::vector<FrameworkElement const*> visible;
-    for (auto const& button : buttons) {
-        if (button.Visibility() == Visibility::Visible) {
-            visible.push_back(&button);
-        } else {
-            button.Translation(float3{0, 0, 0});
-        }
-    }
-
-    int gaps = (int)visible.size() - 1;
-    double perGap = gaps > 0 ? totalExtra / gaps : 0;
-
-    for (int i = 0; i < (int)visible.size(); i++) {
-        visible[i]->Translation(float3{(float)(i * perGap), 0, 0});
-    }
-}
-
+// Per-element fence: one dead element must not strand the rest translated.
 void ClearSpacing(std::vector<FrameworkElement> const& buttons) {
     for (auto const& button : buttons) {
-        button.Translation(float3{0, 0, 0});
+        try {
+            button.Translation(float3{0, 0, 0});
+        } catch (winrt::hresult_error const&) {
+        }
     }
 }
 
@@ -623,7 +648,11 @@ void SetCollapseState(
                     deferHide->emplace_back(button, button.Opacity());
                     button.Opacity(0);
                 } else {
-                    ClearImplicitShowHide(button);
+                    // Irreversible strip, so only where the mod's own
+                    // animation would fight the ghost; None keeps Windows'.
+                    if (g_settings.animationMode == AnimationMode::Spacing) {
+                        ClearImplicitShowHide(button);
+                    }
                     button.Visibility(Visibility::Collapsed);
                     if (!weHidIt) {
                         ctx.hiddenByUs.push_back(winrt::make_weak(button));
@@ -706,7 +735,12 @@ void CollapseDeferredHides(
                 if (!TakeFromHiddenSet(ctx.hiddenByUs, entry.first, false)) {
                     ctx.hiddenByUs.push_back(winrt::make_weak(entry.first));
                 }
-                ctx.gapHidden.push_back(std::move(entry));
+                FrameContext::GapHidden held;
+                held.element = entry.first;
+                held.opacity = entry.second;
+                held.maxWidth = entry.first.MaxWidth();
+                entry.first.MaxWidth(0);
+                ctx.gapHidden.push_back(std::move(held));
             } else {
                 // Windows hid it itself; not ours to keep.
                 entry.first.Opacity(entry.second);
@@ -718,20 +752,268 @@ void CollapseDeferredHides(
 }
 
 void StopAnimation(FrameContext& ctx) {
-    // Collapsed since the start, so the opacity restore is invisible here.
+    // Collapsed since the start, so these restores are invisible here.
     for (auto& entry : ctx.gapHidden) {
         try {
-            entry.first.Opacity(entry.second);
+            entry.element.MaxWidth(entry.maxWidth);
+            entry.element.Opacity(entry.opacity);
         } catch (winrt::hresult_error const&) {
         }
     }
     ctx.gapHidden.clear();
     ctx.animActive = false;
     ctx.animSwapped = false;
+    ctx.animFinalizePending = false;
     UnhookRendering(ctx);
     ClearSpacing(ctx.animButtons);
+    for (auto& entry : ctx.animPlan) {
+        try {
+            entry.element.Translation(float3{0, 0, 0});
+        } catch (winrt::hresult_error const&) {
+        }
+    }
+    ctx.animPlan.clear();
+    ctx.animChildCount = -1;
     ctx.animButtons.clear();
     ctx.animGapOffsets.clear();
+}
+
+int CountStripChildren(FrameContext& ctx) {
+    auto repeater = ctx.repeater.get();
+    if (!repeater) {
+        return -1;
+    }
+    int count = 0;
+    EnumChildElements(repeater, [&](FrameworkElement) {
+        count++;
+        return false;
+    });
+    return count;
+}
+
+// Computes the whole run before the first frame renders: flip to the
+// destination, lay out, measure, flip back — invisible, all in this pass.
+// Elements visible on only one side get the missing coordinate from their
+// measured neighbours' displacement, interpolated once, here. The tick
+// then only plays the table back.
+bool BuildAnimPlan(FrameContext& ctx,
+                   FrameworkElement frame,
+                   bool targetCollapse) {
+    ctx.animPlan.clear();
+    ctx.animFoldCountBefore = 0;
+    ctx.animFoldCountAfter = 0;
+    ctx.animChildCount = CountStripChildren(ctx);
+
+    std::vector<FrameworkElement> elements;
+    if (auto repeater = ctx.repeater.get()) {
+        EnumChildElements(repeater, [&](FrameworkElement child) {
+            elements.push_back(child);
+            return false;
+        });
+    }
+    if (elements.empty()) {
+        elements = ctx.animButtons;
+        ctx.animChildCount = (int)elements.size();
+    }
+
+    auto measure = [&](FrameworkElement const& element, double* x) {
+        if (element.Visibility() != Visibility::Visible) {
+            return false;
+        }
+        try {
+            *x = element.TransformToVisual(frame)
+                     .TransformPoint(Point{0, 0})
+                     .X;
+            return true;
+        } catch (winrt::hresult_error const&) {
+            return false;
+        }
+    };
+
+    for (auto const& element : elements) {
+        FrameContext::PlanEntry entry;
+        entry.element = element;
+        entry.visibleBefore = measure(element, &entry.startX);
+        ctx.animPlan.push_back(std::move(entry));
+    }
+
+    bool priorCollapse = ctx.appliedCollapse == 1;
+    SetCollapseState(ctx, ctx.animButtons, targetCollapse);
+    frame.UpdateLayout();
+    for (auto& entry : ctx.animPlan) {
+        entry.visibleAfter = measure(entry.element, &entry.finalX);
+    }
+    if (targetCollapse) {
+        // Collapse animates over the old layout; put it back. A reveal
+        // keeps the final layout live from frame one instead.
+        SetCollapseState(ctx, ctx.animButtons, priorCollapse);
+        frame.UpdateLayout();
+    }
+
+    // haveStart: one-sided entries that only have startX get finalX synth'd
+    // (disappearing); the other call fills startX for appearing ones.
+    auto fill = [&](bool haveStart) {
+        std::vector<FrameContext::PlanEntry*> known;
+        std::vector<FrameContext::PlanEntry*> missing;
+        for (auto& entry : ctx.animPlan) {
+            if (entry.visibleBefore && entry.visibleAfter) {
+                known.push_back(&entry);
+            } else if (haveStart ? entry.visibleBefore : entry.visibleAfter) {
+                missing.push_back(&entry);
+            }
+        }
+        auto key = [&](FrameContext::PlanEntry* entry) {
+            return haveStart ? entry->startX : entry->finalX;
+        };
+        auto deltaOf = [&](FrameContext::PlanEntry* entry) {
+            return haveStart ? entry->finalX - entry->startX
+                             : entry->startX - entry->finalX;
+        };
+        std::stable_sort(
+            known.begin(), known.end(),
+            [&](FrameContext::PlanEntry* a, FrameContext::PlanEntry* b) {
+                return key(a) < key(b);
+            });
+        for (auto* entry : missing) {
+            double k = key(entry);
+            FrameContext::PlanEntry* left = nullptr;
+            FrameContext::PlanEntry* right = nullptr;
+            for (auto* candidate : known) {
+                if (key(candidate) <= k) {
+                    left = candidate;
+                } else {
+                    right = candidate;
+                    break;
+                }
+            }
+            double delta = 0;
+            if (left && right) {
+                double span = key(right) - key(left);
+                double u = span > 0.5 ? (k - key(left)) / span : 0.5;
+                delta = deltaOf(left) + (deltaOf(right) - deltaOf(left)) * u;
+            } else if (left) {
+                delta = deltaOf(left);
+            } else if (right) {
+                delta = deltaOf(right);
+            }
+            if (haveStart) {
+                entry->finalX = entry->startX + delta;
+            } else {
+                entry->startX = entry->finalX + delta;
+            }
+        }
+    };
+    fill(true);
+    fill(false);
+
+    // Fold order per phase, task buttons only, fixed here once.
+    auto assignFold = [&](bool beforePhase, int* outCount) {
+        std::vector<FrameContext::PlanEntry*> phase;
+        for (auto& entry : ctx.animPlan) {
+            bool visible =
+                beforePhase ? entry.visibleBefore : entry.visibleAfter;
+            if (!visible) {
+                continue;
+            }
+            for (auto const& button : ctx.animButtons) {
+                if (button == entry.element) {
+                    phase.push_back(&entry);
+                    break;
+                }
+            }
+        }
+        std::stable_sort(
+            phase.begin(), phase.end(),
+            [&](FrameContext::PlanEntry* a, FrameContext::PlanEntry* b) {
+                return (beforePhase ? a->startX : a->finalX) <
+                       (beforePhase ? b->startX : b->finalX);
+            });
+        for (int i = 0; i < (int)phase.size(); i++) {
+            if (beforePhase) {
+                phase[i]->foldBefore = i;
+            } else {
+                phase[i]->foldAfter = i;
+            }
+        }
+        *outCount = (int)phase.size();
+    };
+    assignFold(true, &ctx.animFoldCountBefore);
+    assignFold(false, &ctx.animFoldCountAfter);
+
+    // Reveal: appearing icons hold their slots transparently until the apex
+    // flips their opacity — a composition-only cut that cannot tear against
+    // the translations. Survivors are frozen at their old visuals here,
+    // before anything renders.
+    if (!targetCollapse) {
+        for (auto& entry : ctx.animPlan) {
+            try {
+                if (!entry.visibleBefore && entry.visibleAfter) {
+                    FrameContext::GapHidden held;
+                    held.element = entry.element;
+                    held.opacity = entry.element.Opacity();
+                    held.maxWidth = entry.element.MaxWidth();
+                    entry.element.Opacity(0);
+                    ctx.gapHidden.push_back(std::move(held));
+                    entry.element.Translation(float3{0, 0, 0});
+                } else if (entry.visibleBefore) {
+                    entry.element.Translation(
+                        float3{(float)(entry.startX - entry.finalX), 0, 0});
+                }
+            } catch (winrt::hresult_error const&) {
+            }
+        }
+    }
+    for (auto& entry : ctx.animPlan) {
+        try {
+            entry.visiblePhase1 =
+                entry.element.Visibility() == Visibility::Visible;
+        } catch (winrt::hresult_error const&) {
+            entry.visiblePhase1 = entry.visibleBefore;
+        }
+    }
+
+    return !ctx.animPlan.empty();
+}
+
+// Lands a finished collapse run: the real hides, the translation zeroing
+// and the opacity restores in one dispatcher pass, off the render clock —
+// where commits have proven atomic (the reveal's start-of-run flip). Every
+// step is fenced so a throw cannot strand a partial landing, and a
+// follow-up pass re-checks for stragglers.
+void FinalizeCollapseRun(FrameContext& ctx) {
+    ctx.animFinalizePending = false;
+    Wh_Log(L"Collapse finalize: landing");
+    // Windows re-arms its reposition animations between the apex and here;
+    // strip them again, or the layout flip glides or strands the survivors.
+    for (auto& entry : ctx.animPlan) {
+        try {
+            DeanimateButton(ctx, entry.element);
+        } catch (winrt::hresult_error const&) {
+        }
+    }
+    std::vector<FrameworkElement> buttons = ctx.animButtons;
+    try {
+        SetCollapseState(ctx, buttons, true);
+    } catch (winrt::hresult_error const&) {
+        Wh_Log(L"Collapse finalize: SetCollapseState threw");
+    }
+    StopAnimation(ctx);
+    // Belt: nothing translated may survive the landing.
+    if (auto repeater = ctx.repeater.get()) {
+        EnumChildElements(repeater, [](FrameworkElement child) {
+            try {
+                auto translation = child.Translation();
+                if (translation.x != 0 || translation.y != 0) {
+                    Wh_Log(L"Collapse finalize: stray translation swept");
+                    child.Translation(float3{0, 0, 0});
+                }
+            } catch (winrt::hresult_error const&) {
+            }
+            return false;
+        });
+    }
+    // And one verification pass right behind it.
+    PostApply(ctx.dispatcher);
 }
 
 void StartAnimation(FrameContext& ctx,
@@ -743,11 +1025,20 @@ void StartAnimation(FrameContext& ctx,
     ctx.animStartMs = NowMs();
     ctx.animAmplitude =
         ctx.idleWidth * (double)g_settings.animationAmplitudePct / 100.0;
+    ctx.animCentered = TaskbarIsCentered();
     ctx.animSwapped = false;
     ctx.animButtons = std::move(buttons);
     ctx.animGapOffsets.clear();
+    bool planned = false;
     if (auto frame = ctx.frame.get()) {
         SortButtonsByPosition(ctx.animButtons, frame);
+        planned = BuildAnimPlan(ctx, frame, targetCollapse);
+    }
+    if (!planned) {
+        // No table, no playback: land the target instantly.
+        SetCollapseState(ctx, ctx.animButtons, targetCollapse);
+        StopAnimation(ctx);
+        return;
     }
     HookRendering(ctx, ctx.key);
 }
@@ -830,7 +1121,19 @@ void StartGapCloseAnimation(
     FrameContext& ctx,
     std::vector<FrameworkElement> const& buttons,
     std::vector<std::pair<FrameworkElement, double>> deferHide) {
-    ctx.animButtons = buttons;
+    // Hold everything the repeater lays out — on a centred bar Start and
+    // search shift too — so the whole strip freezes and eases as one.
+    ctx.animButtons.clear();
+    if (auto repeater = ctx.repeater.get()) {
+        EnumChildElements(repeater, [&](FrameworkElement child) {
+            ctx.animButtons.push_back(child);
+            return false;
+        });
+    }
+    if (ctx.animButtons.empty()) {
+        ctx.animButtons = buttons;
+    }
+    ctx.animChildCount = CountStripChildren(ctx);
     ctx.animGapOffsets.clear();
     ctx.animActive = true;
     ctx.animKind = AnimKind::GapClose;
@@ -887,6 +1190,14 @@ bool ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
             for (auto& button : buttons) {
                 DeanimateButton(ctx, button);
             }
+            // Start/search recentre with the row; their own slide lags the
+            // choreography, so they go still too. Restored with the rest.
+            if (auto repeater = ctx.repeater.get()) {
+                EnumChildElements(repeater, [&](FrameworkElement child) {
+                    DeanimateButton(ctx, child);
+                    return false;
+                });
+            }
         }
     }
 
@@ -906,6 +1217,21 @@ bool ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
                      animateGaps ? &deferHide : nullptr);
     if (!deferHide.empty()) {
         StartGapCloseAnimation(ctx, buttons, std::move(deferHide));
+    } else if (!ctx.animActive) {
+        // Steady state: a recycled container can resurface carrying a stale
+        // offset from an earlier run, which reads as jumbled spacing. Sweep.
+        if (auto repeater = ctx.repeater.get()) {
+            EnumChildElements(repeater, [](FrameworkElement child) {
+                try {
+                    auto translation = child.Translation();
+                    if (translation.x != 0 || translation.y != 0) {
+                        child.Translation(float3{0, 0, 0});
+                    }
+                } catch (winrt::hresult_error const&) {
+                }
+                return false;
+            });
+        }
     }
     return true;
 }
@@ -929,6 +1255,26 @@ void OnRenderingTick(void* key) {
     double eased = CubicBezierEase(CurveFor(g_settings.animationCurve), t);
 
     if (ctx->animKind == AnimKind::GapClose) {
+        // An element joining or leaving the strip mid-run, or a held
+        // survivor vanishing, is divergence: land the final state instantly
+        // instead of animating a stale plan.
+        int childCount = CountStripChildren(*ctx);
+        if (ctx->animChildCount >= 0 && childCount >= 0 &&
+            childCount != ctx->animChildCount) {
+            StopAnimation(*ctx);
+            return;
+        }
+        try {
+            for (auto& button : ctx->animButtons) {
+                if (button.Visibility() != Visibility::Visible) {
+                    StopAnimation(*ctx);
+                    return;
+                }
+            }
+        } catch (winrt::hresult_error const&) {
+            StopAnimation(*ctx);
+            return;
+        }
         // Windows' close churn can re-show what just got hidden, any frame;
         // re-assert every frame. gapHidden stays transparent for the whole
         // run, so a lost visibility race still renders empty.
@@ -937,13 +1283,17 @@ void OnRenderingTick(void* key) {
             for (size_t i = 0; i < ctx->gapHidden.size();) {
                 auto& entry = ctx->gapHidden[i];
                 // Relaunched mid-run: the button is Windows' again.
-                if (TaskListButton_IsRunning(entry.first)) {
-                    entry.first.Opacity(entry.second);
+                if (TaskListButton_IsRunning(entry.element)) {
+                    entry.element.MaxWidth(entry.maxWidth);
+                    entry.element.Opacity(entry.opacity);
                     ctx->gapHidden.erase(ctx->gapHidden.begin() + i);
                     continue;
                 }
-                if (entry.first.Opacity() != 0.0) {
-                    entry.first.Opacity(0);
+                if (entry.element.Opacity() != 0.0) {
+                    entry.element.Opacity(0);
+                }
+                if (entry.element.MaxWidth() != 0.0) {
+                    entry.element.MaxWidth(0);
                 }
                 i++;
             }
@@ -968,10 +1318,9 @@ void OnRenderingTick(void* key) {
         }
 
         if (!ctx->animSwapped) {
-            // Gap held open; the ease starts once the taskbar goes quiet.
+            // Gap holds open for a fixed beat, then the ease takes over.
             double now = NowMs();
-            if (now - g_lastButtonChurnMs.load() < kGapSettleMs &&
-                now - ctx->animStartMs < kGapHoldMaxMs) {
+            if (now - ctx->animStartMs < kGapHoldMs) {
                 return;
             }
             ctx->animSwapped = true;
@@ -996,16 +1345,78 @@ void OnRenderingTick(void* key) {
         return;
     }
 
-    if (t >= 0.5 && !ctx->animSwapped) {
-        SetCollapseState(*ctx, ctx->animButtons, ctx->animTargetCollapse);
-        // The flip can prompt fresh animations while the tick is paused.
-        for (auto& button : ctx->animButtons) {
-            DeanimateButton(*ctx, button);
+    // Accordion playback. Reality must match the table; an element joining,
+    // leaving, or flipping phase off-script kills the run and lands the
+    // target instantly.
+    bool diverged = false;
+    int childCount = CountStripChildren(*ctx);
+    if (ctx->animChildCount >= 0 && childCount >= 0 &&
+        childCount != ctx->animChildCount) {
+        diverged = true;
+    }
+    if (!diverged) {
+        try {
+            for (auto& entry : ctx->animPlan) {
+                // Collapse hides nothing until the end; reveal's phase two
+                // expects the full set.
+                bool expect = ctx->animSwapped && !ctx->animTargetCollapse
+                                  ? entry.visibleAfter
+                                  : entry.visiblePhase1;
+                if ((entry.element.Visibility() == Visibility::Visible) !=
+                    expect) {
+                    diverged = true;
+                    break;
+                }
+            }
+        } catch (winrt::hresult_error const&) {
+            diverged = true;
         }
-        if (auto frame = ctx->frame.get()) {
-            frame.UpdateLayout();
-            SortButtonsByPosition(ctx->animButtons, frame);
-            if (!ctx->animTargetCollapse) {
+    }
+    if (diverged) {
+        // Land first, then clean: the reverse order flashes the full row.
+        // Stripped again first, or the landing glides on Windows' re-armed
+        // animations.
+        bool target = ctx->animTargetCollapse;
+        std::vector<FrameworkElement> buttons = ctx->animButtons;
+        for (auto& entry : ctx->animPlan) {
+            try {
+                DeanimateButton(*ctx, entry.element);
+            } catch (winrt::hresult_error const&) {
+            }
+        }
+        SetCollapseState(*ctx, buttons, target);
+        StopAnimation(*ctx);
+        return;
+    }
+
+    if (t >= 0.5 && !ctx->animSwapped) {
+        ctx->animSwapped = true;
+        // The apex cut is opacity only, both ways; the layout never moves
+        // mid-run. Reveal flips the appearing icons in; collapse flips the
+        // disappearing ones out, and their real hides land at the end.
+        if (ctx->animTargetCollapse) {
+            for (auto& entry : ctx->animPlan) {
+                try {
+                    if (entry.visibleBefore && !entry.visibleAfter) {
+                        FrameContext::GapHidden held;
+                        held.element = entry.element;
+                        held.opacity = entry.element.Opacity();
+                        held.maxWidth = entry.element.MaxWidth();
+                        entry.element.Opacity(0);
+                        ctx->gapHidden.push_back(std::move(held));
+                    }
+                } catch (winrt::hresult_error const&) {
+                }
+            }
+        } else {
+            for (auto& entry : ctx->gapHidden) {
+                try {
+                    entry.element.Opacity(entry.opacity);
+                } catch (winrt::hresult_error const&) {
+                }
+            }
+            ctx->gapHidden.clear();
+            if (ctx->frame.get()) {
                 double width = 0;
                 for (auto& button : ctx->animButtons) {
                     if (button.Visibility() == Visibility::Visible &&
@@ -1018,22 +1429,70 @@ void OnRenderingTick(void* key) {
                 }
             }
         }
-        ctx->animSwapped = true;
+        // The flip can prompt fresh animations while the tick is paused.
+        for (auto& button : ctx->animButtons) {
+            DeanimateButton(*ctx, button);
+        }
     }
 
-    double amplitude = ctx->animAmplitude;
-
     if (t >= 1.0) {
+        if (ctx->animTargetCollapse) {
+            // Land the layout off the render clock; the next dispatcher
+            // pass commits hides, translations and opacities together.
+            ctx->animFinalizePending = true;
+            UnhookRendering(*ctx);
+            PostApply(ctx->dispatcher);
+            return;
+        }
         StopAnimation(*ctx);
         return;
     }
 
+    // Travel comes from the table. Left-aligned adds the fold on top — the
+    // stretch, flipped at the cut, day one's accordion. Centred leaves the
+    // spacing alone: Snappiness instead skips that share of the travel at
+    // the cut, masked by the icon swap.
     double direction = ctx->animTargetCollapse ? -1.0 : 1.0;
-    double totalExtra = ctx->animSwapped
-                            ? -direction * amplitude * (1 - eased)
-                            : direction * amplitude * eased;
+    double progress = eased;
+    double perGap = 0;
+    if (ctx->animCentered) {
+        double skip = (double)g_settings.animationAmplitudePct / 100.0;
+        progress = eased * (1 - skip) + (ctx->animSwapped ? skip : 0);
+    } else {
+        double foldExtra = direction * ctx->animAmplitude *
+                           (ctx->animSwapped ? 1 - eased : eased);
+        int gaps = (ctx->animSwapped ? ctx->animFoldCountAfter
+                                     : ctx->animFoldCountBefore) -
+                   1;
+        perGap = gaps > 0 ? foldExtra / gaps : 0;
+    }
 
-    ApplySpacing(ctx->animButtons, totalExtra);
+    try {
+        for (auto& entry : ctx->animPlan) {
+            bool visible = ctx->animSwapped ? entry.visibleAfter
+                                            : entry.visibleBefore;
+            if (!visible) {
+                entry.element.Translation(float3{0, 0, 0});
+                continue;
+            }
+            // One continuous expression per direction, no apex switch:
+            // reveal runs on the final layout throughout, collapse on the
+            // starting layout throughout.
+            double travel =
+                ctx->animTargetCollapse
+                    ? (entry.finalX - entry.startX) * progress
+                    : (entry.startX - entry.finalX) * (1 - progress);
+            double decoration = 0;
+            if (!ctx->animCentered) {
+                int fold = ctx->animSwapped ? entry.foldAfter
+                                            : entry.foldBefore;
+                decoration = fold >= 0 ? fold * perGap : 0;
+            }
+            entry.element.Translation(
+                float3{(float)(travel + decoration), 0, 0});
+        }
+    } catch (winrt::hresult_error const&) {
+    }
 }
 
 void RestoreFrame(FrameContext& ctx) {
@@ -1041,7 +1500,10 @@ void RestoreFrame(FrameContext& ctx) {
 
     for (auto& weak : ctx.lastButtons) {
         if (auto button = weak.get()) {
-            button.Translation(float3{0, 0, 0});
+            try {
+                button.Translation(float3{0, 0, 0});
+            } catch (winrt::hresult_error const&) {
+            }
         }
     }
 
@@ -1078,7 +1540,14 @@ void OnTimerTick(void* key) {
     }
 
     if (g_unloading) {
+        // Full teardown: a Tick handler must not outlive the unload sweeps.
         RestoreFrame(*ctx);
+        std::lock_guard<std::mutex> guard(g_framesMutex);
+        if (ctx->timer) {
+            ctx->timer.Stop();
+            ctx->timer.Tick(ctx->tickToken);
+        }
+        g_frames->erase(key);
         return;
     }
 
@@ -1155,23 +1624,33 @@ void OnTimerTick(void* key) {
     uint64_t instantGen = g_instantApplyGen;
     bool instant = ctx->instantGenSeen != instantGen;
 
+    // A finished collapse lands here, in dispatcher context.
+    if (ctx->animFinalizePending) {
+        FinalizeCollapseRun(*ctx);
+    }
+
     // Watchdog: Rendering stops when the bar is not being composed.
     if (ctx->animActive &&
         NowMs() - ctx->animStartMs >
             (double)g_settings.animationDurationMs * 3.0 + 1000.0) {
-        // Land the target, or the next apply starts the same animation again.
-        if (ctx->animKind == AnimKind::Accordion && !ctx->animSwapped) {
+        // Land the target, or the next apply starts the same animation
+        // again. Idempotent for a reveal that already landed.
+        if (ctx->animKind == AnimKind::Accordion) {
             SetCollapseState(*ctx, ctx->animButtons, ctx->animTargetCollapse);
         }
         StopAnimation(*ctx);
     }
 
-    // A running animation toward the right state owns the buttons.
+    // A running animation toward the right state owns the buttons. Killing
+    // one mid-flight lands instantly: a toggle faster than the animation
+    // is an instant flip, never a second animation.
+    bool killed = false;
     if (ctx->animActive && (instant || desired != ctx->animTargetCollapse)) {
         StopAnimation(*ctx);
+        killed = true;
     }
     if (!ctx->animActive) {
-        if (ApplyToFrame(*ctx, desired, instant)) {
+        if (ApplyToFrame(*ctx, desired, instant || killed)) {
             ctx->instantGenSeen = instantGen;
             ctx->applyRetries = 0;
         } else if (ctx->applyRetries > 0) {
@@ -1277,6 +1756,8 @@ void RegisterFrame(void* key, FrameworkElement frame) {
             it->second.applyPosted = false;
         }
     }
+    // Late Taskbar.View.dll loads skip the loader-lock path; catch up here.
+    StartHotkeyThread();
 }
 
 // A dead frame at a recycled address must not block re-registration.
@@ -1695,7 +2176,7 @@ int __cdecl TaskbarFrame_OnPointerExited_Hook(void* pThis, void* pArgs) {
     return ret;
 }
 
-// Released, not pressed: dragging off and letting go must not count.
+// Acts on release; where the release lands is all that decides.
 using TaskbarFrame_OnPointerReleased_t = int(__cdecl*)(void* pThis,
                                                        void* pArgs);
 TaskbarFrame_OnPointerReleased_t TaskbarFrame_OnPointerReleased_Original;
@@ -1790,7 +2271,6 @@ using TaskListButton_UpdateVisualStates_t = void(__cdecl*)(void* pThis);
 TaskListButton_UpdateVisualStates_t TaskListButton_UpdateVisualStates_Original;
 void __cdecl TaskListButton_UpdateVisualStates_Hook(void* pThis) {
     TaskListButton_UpdateVisualStates_Original(pThis);
-    g_lastButtonChurnMs = NowMs();
     if (g_unloading) {
         return;
     }
@@ -1900,6 +2380,16 @@ void ToggleCollapse() {
     g_instantApplyGen++;
     Wh_Log(L"Hotkey toggled collapse to %d", (int)enabled);
     WakeAllFramesAsync();
+
+    // Nothing registered: the wake reached no one; nudge discovery.
+    bool anyFrames;
+    {
+        std::lock_guard<std::mutex> guard(g_framesMutex);
+        anyFrames = !g_frames->empty();
+    }
+    if (!anyFrames) {
+        NudgeTaskbarsForDiscovery();
+    }
 }
 
 void OnStartMenuVisibility(bool visible) {
@@ -1977,6 +2467,11 @@ class StartVisibilitySink final : public IAppVisibilityEvents {
 
     HRESULT STDMETHODCALLTYPE
     LauncherVisibilityChange(BOOL currentVisibleState) override {
+        // One log so a build where IAppVisibility goes silent is diagnosable.
+        static std::atomic<bool> seen = false;
+        if (!seen.exchange(true)) {
+            Wh_Log(L"Start visibility events active");
+        }
         // Counted so teardown can wait out a call in flight.
         g_sinkCallbacks++;
         try {
@@ -1994,7 +2489,7 @@ class StartVisibilitySink final : public IAppVisibilityEvents {
 DWORD WINAPI HotkeyThreadProc(LPVOID param) {
     // Create and announce the queue before anything slow: WM_QUIT must land.
     MSG queuePrimer;
-    PeekMessage(&queuePrimer, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+    PeekMessageW(&queuePrimer, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
     SetEvent(g_hotkeyThreadReady);
 
     // A raw thread entry: an escaping exception would terminate explorer.
@@ -2031,7 +2526,7 @@ DWORD WINAPI HotkeyThreadProc(LPVOID param) {
     }
 
     MSG msg;
-    while (GetMessage(&msg, nullptr, 0, 0) > 0) {
+    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
         if (msg.message == WM_HOTKEY && msg.wParam == 1) {
             ToggleCollapse();
         }
@@ -2058,7 +2553,9 @@ DWORD WINAPI HotkeyThreadProc(LPVOID param) {
 
 void StartHotkeyThread() {
     std::lock_guard<std::mutex> guard(g_hotkeyThreadMutex);
-    if (g_hotkeyThread) {
+    // The unloading check closes the race with StopHotkeyThread: a start
+    // that lost this lock to unload must not spawn into a dying image.
+    if (g_hotkeyThread || g_unloading) {
         return;
     }
 
@@ -2078,7 +2575,7 @@ void StartHotkeyThread() {
         return;
     }
 
-    g_hotkeyThreadReady = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+    g_hotkeyThreadReady = CreateEventW(nullptr, TRUE, FALSE, nullptr);
     if (!g_hotkeyThreadReady) {
         return;
     }
@@ -2100,7 +2597,7 @@ void StopHotkeyThread() {
     }
 
     WaitForSingleObject(g_hotkeyThreadReady, INFINITE);
-    PostThreadMessage(g_hotkeyThreadId, WM_QUIT, 0, 0);
+    PostThreadMessageW(g_hotkeyThreadId, WM_QUIT, 0, 0);
     WaitForSingleObject(g_hotkeyThread, INFINITE);
 
     CloseHandle(g_hotkeyThread);
@@ -2116,7 +2613,7 @@ bool RunFromWindowThread(HWND hWnd,
                          RunFromWindowThreadProc_t proc,
                          PVOID procParam) {
     static const UINT runFromWindowThreadRegisteredMsg =
-        RegisterWindowMessage(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
+        RegisterWindowMessageW(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
 
     struct RUN_FROM_WINDOW_THREAD_PARAM {
         RunFromWindowThreadProc_t proc;
@@ -2133,7 +2630,7 @@ bool RunFromWindowThread(HWND hWnd,
         return true;
     }
 
-    HHOOK hook = SetWindowsHookEx(
+    HHOOK hook = SetWindowsHookExW(
         WH_CALLWNDPROC,
         [](int nCode, WPARAM wParam, LPARAM lParam) -> LRESULT {
             if (nCode == HC_ACTION) {
@@ -2154,7 +2651,7 @@ bool RunFromWindowThread(HWND hWnd,
     RUN_FROM_WINDOW_THREAD_PARAM param;
     param.proc = proc;
     param.procParam = procParam;
-    SendMessage(hWnd, runFromWindowThreadRegisteredMsg, 0, (LPARAM)&param);
+    SendMessageW(hWnd, runFromWindowThreadRegisteredMsg, 0, (LPARAM)&param);
 
     UnhookWindowsHookEx(hook);
     return true;
@@ -2182,12 +2679,12 @@ void RunOnAllTaskbarThreads(RunFromWindowThreadProc_t proc, PVOID param) {
 
     // Iterated: the first Shell_TrayWnd can belong to another process.
     HWND hPrimary = nullptr;
-    while ((hPrimary = FindWindowEx(nullptr, hPrimary, L"Shell_TrayWnd",
+    while ((hPrimary = FindWindowExW(nullptr, hPrimary, L"Shell_TrayWnd",
                                     nullptr))) {
         consider(hPrimary);
     }
     HWND hSecondary = nullptr;
-    while ((hSecondary = FindWindowEx(nullptr, hSecondary,
+    while ((hSecondary = FindWindowExW(nullptr, hSecondary,
                                       L"Shell_SecondaryTrayWnd", nullptr))) {
         consider(hSecondary);
     }
@@ -2197,37 +2694,58 @@ void RunOnAllTaskbarThreads(RunFromWindowThreadProc_t proc, PVOID param) {
     }
 }
 
+// Kicks TrayUI::_HandleSettingChange down its DPI path (the taskbar-icon-size
+// pattern), whose recompute re-measures the XAML frame and fires the hooked
+// MeasureOverride — discovery for taskbars idle since before the mod loaded.
+void NudgeTaskbarsForDiscovery() {
+    auto nudge = [](HWND hWnd) {
+        DWORD processId = 0;
+        if (GetWindowThreadProcessId(hWnd, &processId) &&
+            processId == GetCurrentProcessId()) {
+            SendMessageTimeoutW(hWnd, WM_SETTINGCHANGE,
+                                SPI_SETLOGICALDPIOVERRIDE, 0,
+                                SMTO_ABORTIFHUNG, 1000, nullptr);
+        }
+    };
+    HWND hWnd = nullptr;
+    while ((hWnd = FindWindowExW(nullptr, hWnd, L"Shell_TrayWnd", nullptr))) {
+        nudge(hWnd);
+    }
+    hWnd = nullptr;
+    while ((hWnd = FindWindowExW(nullptr, hWnd, L"Shell_SecondaryTrayWnd",
+                                 nullptr))) {
+        nudge(hWnd);
+    }
+}
+
 void CleanupOnThisThread() {
     DWORD threadId = GetCurrentThreadId();
-    std::vector<void*> keys;
+    std::vector<FrameContext> mine;
 
     {
         std::lock_guard<std::mutex> guard(g_framesMutex);
-        for (auto& [key, ctx] : *g_frames) {
-            if (ctx.threadId == threadId) {
-                keys.push_back(key);
+        for (auto it = g_frames->begin(); it != g_frames->end();) {
+            if (it->second.threadId == threadId) {
+                mine.push_back(std::move(it->second));
+                it = g_frames->erase(it);
+            } else {
+                ++it;
             }
         }
     }
 
-    std::lock_guard<std::mutex> guard(g_framesMutex);
-    for (void* key : keys) {
-        auto it = g_frames->find(key);
-        if (it == g_frames->end()) {
-            continue;
-        }
-
-        // Runs inside a CALLWNDPROC hook or dispatcher lambda; an escaping
-        // throw is fatal or hangs unload. The erase must always run.
+    // Outside the lock: XAML teardown can re-enter hooks that take it. The
+    // contexts die here, on their owning thread. Runs inside a CALLWNDPROC
+    // hook or dispatcher lambda; an escaping throw is fatal or hangs unload.
+    for (auto& ctx : mine) {
         try {
-            if (it->second.timer) {
-                it->second.timer.Stop();
-                it->second.timer.Tick(it->second.tickToken);
+            if (ctx.timer) {
+                ctx.timer.Stop();
+                ctx.timer.Tick(ctx.tickToken);
             }
-            RestoreFrame(it->second);
+            RestoreFrame(ctx);
         } catch (winrt::hresult_error const&) {
         }
-        g_frames->erase(it);
     }
 }
 
@@ -2259,7 +2777,7 @@ void LoadSettings() {
     g_settings.animationDurationMs =
         std::clamp(Wh_GetIntSetting(L"AnimationDurationMs"), 0, 5000);
     g_settings.animationAmplitudePct =
-        std::clamp(Wh_GetIntSetting(L"AnimationAmplitudePct"), 0, 200);
+        std::clamp(Wh_GetIntSetting(L"AnimationAmplitudePct"), 0, 100);
 
     auto mode = WindhawkUtils::StringSetting::make(L"AnimationMode");
     g_settings.animationMode = wcscmp(mode.get(), L"spacing") == 0
@@ -2282,9 +2800,9 @@ void LoadSettings() {
 }
 
 HMODULE GetTaskbarViewModuleHandle() {
-    HMODULE module = GetModuleHandle(L"Taskbar.View.dll");
+    HMODULE module = GetModuleHandleW(L"Taskbar.View.dll");
     if (!module) {
-        module = GetModuleHandle(L"ExplorerExtensions.dll");
+        module = GetModuleHandleW(L"ExplorerExtensions.dll");
     }
     return module;
 }
@@ -2358,10 +2876,11 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
 
     if (!g_taskbarViewDllLoaded && GetTaskbarViewModuleHandle() == module &&
         !g_taskbarViewDllLoaded.exchange(true)) {
-        // The exchange makes this exactly-once; no second flag needed.
+        // The exchange makes this exactly-once; no second flag needed. The
+        // hotkey thread is NOT started here: this runs under the loader
+        // lock, and a new thread blocks on it. RegisterFrame starts it.
         if (HookTaskbarViewDllSymbols(module)) {
             Wh_ApplyHookOperations();
-            StartHotkeyThread();
         }
     }
 
@@ -2382,7 +2901,7 @@ BOOL Wh_ModInit() {
         // must not grab the hotkey or the Start watcher.
         StartHotkeyThread();
     } else {
-        HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
+        HMODULE kernelBaseModule = GetModuleHandleW(L"kernelbase.dll");
         if (!kernelBaseModule) {
             Wh_Log(L"kernelbase.dll not found");
             return FALSE;
@@ -2402,17 +2921,20 @@ BOOL Wh_ModInit() {
 }
 
 void Wh_ModAfterInit() {
-    if (g_taskbarViewDllLoaded) {
-        return;
+    if (!g_taskbarViewDllLoaded) {
+        // Retry for a load that raced the LoadLibraryExW hook going live.
+        HMODULE taskbarViewModule = GetTaskbarViewModuleHandle();
+        if (taskbarViewModule && !g_taskbarViewDllLoaded.exchange(true)) {
+            if (HookTaskbarViewDllSymbols(taskbarViewModule)) {
+                Wh_ApplyHookOperations();
+                StartHotkeyThread();
+            }
+        }
     }
 
-    // Retry for a load that raced the LoadLibraryExW hook going live.
-    HMODULE taskbarViewModule = GetTaskbarViewModuleHandle();
-    if (taskbarViewModule && !g_taskbarViewDllLoaded.exchange(true)) {
-        if (HookTaskbarViewDllSymbols(taskbarViewModule)) {
-            Wh_ApplyHookOperations();
-            StartHotkeyThread();
-        }
+    // An already-idle taskbar fires no hook on its own.
+    if (g_taskbarViewDllLoaded) {
+        NudgeTaskbarsForDiscovery();
     }
 }
 
@@ -2428,6 +2950,16 @@ void Wh_ModSettingsChanged() {
     g_instantApplyGen++;
     // The timers are stopped while idle, so the new settings must be pushed.
     WakeAllFramesAsync();
+
+    // Nothing registered yet: the wake reached no one; nudge discovery.
+    bool anyFrames;
+    {
+        std::lock_guard<std::mutex> guard(g_framesMutex);
+        anyFrames = !g_frames->empty();
+    }
+    if (!anyFrames && g_taskbarViewDllLoaded) {
+        NudgeTaskbarsForDiscovery();
+    }
 }
 
 void Wh_ModBeforeUninit() {
@@ -2483,7 +3015,7 @@ void Wh_ModBeforeUninit() {
             CloseHandle(hThread);
             continue;
         }
-        HANDLE done = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+        HANDLE done = CreateEventW(nullptr, TRUE, FALSE, nullptr);
         if (!done) {
             CloseHandle(hThread);
             continue;

--- a/mods/taskbar-collapse-to-running.wh.cpp
+++ b/mods/taskbar-collapse-to-running.wh.cpp
@@ -5,6 +5,7 @@
 // @version         1.0.0
 // @author          Lars
 // @github          https://github.com/LarsGudm
+// @license         MIT
 // @include         explorer.exe
 // @architecture    x86-64
 // @compilerOptions -lole32 -loleaut32 -lruntimeobject
@@ -63,9 +64,9 @@ Licensed MIT. Thanks to https://easings.net/ for the easing curve values.
 - RevealTrigger: click
   $name: Reveal trigger
   $options:
-  - hover: Hover
-  - rest: Rest
   - click: Click
+  - rest: Rest
+  - hover: Hover
   - never: None, hotkey only
 - RevealOnStart: false
   $name: Reveal while Start is open
@@ -190,6 +191,10 @@ bool PointerClearsSurfaces(void* key, Point framePt);
 // Quiet time on the taskbar before the tick drops to the sleep rate.
 constexpr ULONGLONG kSleepAfterMs = 2 * 60 * 1000;
 
+// Pointer-event gap after which the cursor counts as parked and the speed
+// sample as stale. The hook and the tick must agree on this.
+constexpr double kSpeedSampleStaleMs = 150.0;
+
 // Named element Windows creates inside a task button only while its app runs.
 constexpr PCWSTR kRunningIndicatorName = L"RunningIndicator";
 
@@ -206,8 +211,8 @@ constexpr EasingCurve kEaseInOutSine{0.37, 0.0, 0.63, 1.0};
 constexpr EasingCurve kEaseInOutCubic{0.65, 0.0, 0.35, 1.0};
 constexpr EasingCurve kEaseInOutCirc{0.85, 0.0, 0.15, 1.0};
 
-// Settings store the curve as an id, not the struct: a settings change on
-// another thread must not be readable half-updated mid-animation.
+// Stored as an id: a cross-thread settings change must never be readable
+// half-updated mid-animation.
 enum class CurveId { Sine, Cubic, Circ };
 
 EasingCurve const& CurveFor(CurveId id) {
@@ -224,11 +229,9 @@ EasingCurve const& CurveFor(CurveId id) {
 enum class AnimationMode { None, Spacing };
 enum class RevealTrigger { Never, Hover, Rest, Click };
 
-// Accordion is the reveal/collapse transition. GapClose handles an icon
-// hidden mid-steady-state, when its app closes: the icon is faded but keeps
-// its slot for the first half, so layout itself holds the gap and there are
-// no translations for the taskbar to fight over, then the midpoint collapses
-// it and the row eases shut.
+// Accordion is the reveal/collapse transition. GapClose fades an icon hidden
+// mid-steady-state, holds its slot for the first half, then eases the row
+// shut — layout holds the gap, so there is nothing to fight the taskbar over.
 enum class AnimKind { Accordion, GapClose };
 
 // Scalars are atomic: LoadSettings writes them on Windhawk's thread while
@@ -263,8 +266,7 @@ std::atomic<bool> g_collapseEnabled = true;
 // Whether hover is currently holding every icon visible.
 std::atomic<bool> g_revealed = false;
 
-// Whether the current reveal was caused by the Start menu opening; it pins the
-// reveal against grace aging until Start closes.
+// Reveal caused by Start opening; pinned against grace aging until it closes.
 std::atomic<bool> g_revealedByStart = false;
 
 // Tick when the cursor was last over a taskbar; the grace period counts from here.
@@ -273,54 +275,46 @@ std::atomic<ULONGLONG> g_lastCursorInsideTick = 0;
 // Tick when the cursor entered the empty area, or 0 when it is not there.
 std::atomic<ULONGLONG> g_emptyHoverSinceTick = 0;
 
-// Tick of the last taskbar activity (pointer, layout, hotkey, settings); the
-// sleep countdown runs from here.
+// Last taskbar activity (pointer, hotkey, settings); sleep counts from here.
 std::atomic<ULONGLONG> g_lastActivityTick = 0;
 
-// True while ticks run at the sleep rate; the pointer hook uses it to snap
-// the timer back to full speed on the first touch.
+// True at the sleep rate; the pointer hook snaps the timer back on touch.
 std::atomic<bool> g_sleeping = false;
 
-// Rest trigger: cursor speed in px/s, measured between refresh ticks from
-// screen coordinates, and whether the last pointer event sat in the
-// qualifying empty area. Together they let a parked cursor finish a reveal
-// after pointer events have stopped coming.
+// Rest trigger: speed in px/s from pointer-event deltas plus its sample time.
+// A parked cursor produces no events, so a stale sample reads as zero and the
+// tick can finish its reveal.
 std::atomic<double> g_cursorSpeedPxS = 0;
+std::atomic<double> g_speedSampleMs = 0;
+std::atomic<bool> g_speedMeasured = false;
 std::atomic<bool> g_lastPointerQualified = false;
-double g_speedSamplePrevMs = 0;
 POINT g_speedSamplePrevPos = {};
 
-// Last cheap-qualified pointer sample, letting the tick finish qualification
-// for a parked cursor. Ticks and hooks share the taskbar UI thread.
+// Last cheap-qualified sample, so the tick can finish qualification for a
+// parked cursor. Ticks and hooks share the taskbar UI thread.
 void* g_lastQualifiedKey = nullptr;
 Point g_lastQualifiedFramePt = {};
 
-// Bumped by the hotkey and settings changes; a context seeing a new value
-// applies once without animation. Lets other threads request an instant apply
-// without touching contexts or blocking on their message queues.
+// Bumped by hotkey/settings; a context seeing a new value applies once
+// without animation, with no cross-thread blocking.
 std::atomic<uint64_t> g_instantApplyGen = 0;
 
-// Wakes queued to taskbar dispatchers that have not run yet; unload waits for
-// zero so no queued lambda outlives the DLL.
+// Wakes queued but not yet run; unload drains this to zero.
 std::atomic<int> g_pendingWakes = 0;
 
-// Start-menu callbacks currently executing; teardown waits for zero after
-// Unadvise, which does not fence a callback already in flight.
+// Start-menu callbacks in flight; teardown waits for zero after Unadvise,
+// which does not fence a callback already running.
 std::atomic<int> g_sinkCallbacks = 0;
 
-// Serializes hotkey thread start/stop: Wh_ModSettingsChanged and the
-// LoadLibraryExW hook run on different threads.
+// Serializes start/stop across Windhawk's thread and the LoadLibraryExW hook.
 std::mutex g_hotkeyThreadMutex;
 HANDLE g_hotkeyThread = nullptr;
 DWORD g_hotkeyThreadId = 0;
-// Signalled once the worker owns a message queue, so WM_QUIT cannot be posted
-// before one exists and be dropped.
+// Signalled once the worker owns a message queue, so WM_QUIT cannot be lost.
 HANDLE g_hotkeyThreadReady = nullptr;
 
-// Per-button state: the animations stripped from it, the originals to put
-// back, and its resolved running indicator so the tick need not re-walk the
-// subtree. The indicator is created lazily by Windows, so a null cache entry
-// is re-resolved rather than trusted.
+// Per-button: stripped animations, their originals for restore, and a cached
+// running indicator (created lazily by Windows, so null is re-resolved).
 struct DeanimatedButton {
     winrt::weak_ref<FrameworkElement> button;
     Media::Animation::TransitionCollection originalTransitions{nullptr};
@@ -329,10 +323,10 @@ struct DeanimatedButton {
     winrt::weak_ref<FrameworkElement> runningIndicator;
 };
 
-// State for one taskbar, touched only by that taskbar's own UI thread, except
-// dispatcher, which other threads copy under g_framesMutex to queue wakes.
+// State for one taskbar, touched only by its own UI thread, except
+// dispatcher, which other threads copy under g_framesMutex.
 struct FrameContext {
-    // This context's key in g_frames, so callbacks can find their way back.
+    // Key in g_frames, for callbacks.
     void* key = nullptr;
     winrt::Windows::UI::Core::CoreDispatcher dispatcher{nullptr};
     winrt::weak_ref<FrameworkElement> frame;
@@ -354,22 +348,18 @@ struct FrameContext {
     // Collapse state the running animation is heading towards.
     bool animTargetCollapse = false;
     double animStartMs = 0;
-    // Amplitude for this run, snapshotted at StartAnimation so both halves
-    // of the accordion stretch by the same width.
+    // Snapshot at StartAnimation, so both accordion halves use one value.
     double animAmplitude = 0;
     // Whether the midpoint icon swap has happened yet.
     bool animSwapped = false;
-    // GapClose only: offsets back to pre-collapse positions, measured at the
-    // midpoint and eased to zero over the second half.
+    // GapClose: offsets back to pre-collapse spots, eased to zero.
     std::vector<float> animGapOffsets;
-    // GapClose only: buttons faded out but not yet collapsed, with their
-    // original opacities; emptied when the midpoint collapses them for real.
+    // GapClose: faded but not yet collapsed buttons, with their opacities.
     std::vector<std::pair<FrameworkElement, double>> pendingHide;
-    // Strong refs for the animation's few hundred ms, so every frame works on
-    // the same set without re-walking the tree. Emptied when it stops.
+    // Strong refs while animating; emptied on stop.
     std::vector<FrameworkElement> animButtons;
-    // Width the idle icons occupy, measured while they are visible. Hidden
-    // icons measure zero, so this cache is what the amplitude scales from.
+    // Idle icons' width, measured while visible (hidden icons measure zero);
+    // the amplitude scales from this cache.
     double idleWidth = 0;
     winrt::event_token renderingToken{};
     bool renderingHooked = false;
@@ -380,16 +370,14 @@ struct FrameContext {
 
 std::mutex g_framesMutex;
 
-// Never destroyed: the contexts hold UI-thread-affine XAML objects, and at
-// process shutdown the CRT would release them from the wrong thread with the
-// XAML core already gone. Real release happens in CleanupOnThisThread.
+// Never destroyed: CRT shutdown would release UI-thread-affine XAML objects
+// from the wrong thread. Real release happens in CleanupOnThisThread.
 [[clang::no_destroy]] std::optional<std::unordered_map<void*, FrameContext>>
     g_frames{std::in_place};
 
 FrameContext* GetFrameContext(void* key);
 
-// Millisecond clock for animation timing. GetTickCount64's ~16 ms quantum is
-// too coarse for a ~120 ms animation and reads as stutter.
+// Animation clock; GetTickCount64's ~16 ms quantum reads as stutter.
 double NowMs() {
     static const double frequency = [] {
         LARGE_INTEGER f;
@@ -429,9 +417,8 @@ FrameworkElement EnumChildElements(
     return nullptr;
 }
 
-// Single walk finding the indicator: an exact RunningIndicator wins, any other
-// name containing "Running" is the fallback. Do not widen the fallback to
-// "Indicator": it would match ProgressIndicator and misread idle apps.
+// Exact RunningIndicator wins; a name containing "Running" is the fallback.
+// Do not widen to "Indicator": ProgressIndicator would misread idle apps.
 void FindRunningIndicatorWalk(FrameworkElement element,
                               int depth,
                               FrameworkElement& exact,
@@ -495,9 +482,8 @@ bool ContainsNoCase(std::wstring_view haystack, std::wstring_view needle) {
     return it != haystack.end();
 }
 
-// True while the indicator element exists and is positively shown. The caller
-// passes its cached indicator, and gets back whatever was resolved so the
-// subtree walk happens once per button rather than once per tick.
+// True while the indicator exists and is positively shown. The resolved
+// indicator is handed back so the subtree walk runs once per button.
 bool IndicatorSaysRunning(FrameworkElement button,
                           FrameworkElement& indicatorInOut) {
     FrameworkElement indicator = indicatorInOut;
@@ -515,9 +501,8 @@ bool IndicatorSaysRunning(FrameworkElement button,
         return false;
     }
 
-    // Size is a layout result and collapsed buttons are never laid out. Do not
-    // drop the laid-out guard: a hidden button could then never report running
-    // again, and would stay hidden for as long as its app lives.
+    // Collapsed buttons are never laid out. Do not drop the laid-out guard:
+    // a hidden button could then never report running again.
     bool buttonLaidOut = button.Visibility() == Visibility::Visible &&
                          button.ActualWidth() > 0.5;
     if (buttonLaidOut &&
@@ -528,10 +513,8 @@ bool IndicatorSaysRunning(FrameworkElement button,
     return true;
 }
 
-// True if either the indicator element or the accessibility name says running.
-// Do not make this an AND: hiding must require both signals to agree, or a
-// running app disappears from the taskbar. Indicator goes first so the name,
-// which allocates a string, is only fetched for idle-looking buttons.
+// OR of the indicator and the accessibility name. Do not make this an AND, or
+// a running app disappears. Indicator first; the name allocates a string.
 bool IsButtonRunning(FrameworkElement button,
                      std::wstring_view marker,
                      FrameworkElement& indicatorInOut) {
@@ -551,8 +534,7 @@ bool IsButtonRunning(FrameworkElement button,
 
 // ------------------------------------------------------------------- applying
 
-// Reports whether the set holds this element, dropping dead entries as it goes,
-// and removes the match when remove is set.
+// Membership test that prunes dead entries; removes the match when asked.
 bool TakeFromHiddenSet(std::vector<winrt::weak_ref<FrameworkElement>>& hidden,
                        FrameworkElement const& element,
                        bool remove) {
@@ -605,9 +587,8 @@ bool CursorOverAnyTaskbar() {
         return true;
     }
 
-    // Jump lists and thumbnail previews are separate popup windows, but they
-    // live on the taskbar's own UI thread. They count as taskbar, or the grace
-    // period would collapse the bar under a menu the user is navigating.
+    // Jump lists and previews are separate popups on the taskbar's own
+    // thread; they count as taskbar, or grace collapses under an open menu.
     DWORD processId = 0;
     DWORD threadId = GetWindowThreadProcessId(hRoot, &processId);
     if (threadId && processId == GetCurrentProcessId()) {
@@ -622,10 +603,9 @@ bool CursorOverAnyTaskbar() {
     return false;
 }
 
-// Clears the implicit show/hide animations, which otherwise keep rendering a
-// hidden button's ghost until their farewell animation finishes. They have no
-// getter, so this cannot be undone; call it only for buttons actually being
-// hidden, never for every button on every pass.
+// Kills the ghost a hidden button renders until its farewell animation ends.
+// No getter, so irreversible: only call for buttons actually being hidden,
+// never on every pass.
 void ClearImplicitShowHide(FrameworkElement const& button) {
     try {
         Hosting::ElementCompositionPreview::SetImplicitShowAnimation(button,
@@ -636,13 +616,11 @@ void ClearImplicitShowHide(FrameworkElement const& button) {
     }
 }
 
-// Clears both animation paths on a button: the XAML transition and the
-// composition implicit animations, keeping the originals for ReanimateButtons.
+// Strips XAML transitions and composition implicit animations, keeping the
+// originals for ReanimateButtons.
 void DeanimateButton(FrameContext& ctx, FrameworkElement button) {
-    // Runs every pass. Do not reduce this to strip-once-per-button: Windows
-    // installs a button's animations at its own pace, and one stripped too
-    // early keeps its reorder slide forever. The ledger exists only so
-    // unloading can put the originals back; dead entries are pruned here.
+    // Runs every pass, not strip-once: Windows installs animations at its own
+    // pace, and one stripped too early keeps its reorder slide forever.
     DeanimatedButton* known = nullptr;
     for (size_t i = 0; i < ctx.deanimated.size();) {
         auto resolved = ctx.deanimated[i].button.get();
@@ -667,8 +645,7 @@ void DeanimateButton(FrameContext& ctx, FrameworkElement button) {
         entry.originalImplicit = implicit_;
         ctx.deanimated.push_back(entry);
     } else {
-        // Animations that appeared after first sight still belong to Windows;
-        // capture them so unload restores the real originals.
+        // Late-appearing animations still belong to Windows; keep for restore.
         if (transitions && !known->originalTransitions) {
             known->originalTransitions = transitions;
         }
@@ -734,10 +711,9 @@ double CubicBezierEase(EasingCurve const& curve, double t) {
 
 // ---------------------------------------------------------------- animation
 
-// Spreads totalExtra across the gaps between visible buttons, holding the
-// leftmost one still. Windows re-centres the group itself, so the group is
-// deliberately not shifted to compensate: the correction would dwarf the
-// amplitude and read as the whole row charging across the screen.
+// Spreads totalExtra across the gaps between visible buttons, leftmost held
+// still. Deliberately no re-centre compensation: it would dwarf the amplitude
+// and read as the row charging across the screen.
 void ApplySpacing(std::vector<FrameworkElement> const& buttons,
                   double totalExtra) {
     std::vector<FrameworkElement const*> visible;
@@ -764,8 +740,7 @@ void ClearSpacing(std::vector<FrameworkElement> const& buttons) {
 }
 
 // Hides or shows the managed buttons, recording only the ones it hid itself.
-// With deferHide set, a button to hide is faded in place instead and handed
-// back for FinalizePendingHides to collapse at the animation midpoint.
+// With deferHide set, hides are faded in place for FinalizePendingHides.
 void SetCollapseState(
     FrameContext& ctx,
     std::vector<FrameworkElement> const& buttons,
@@ -795,9 +770,8 @@ void SetCollapseState(
 
         bool shouldHide = collapse && !running;
 
-        // Measured before any visibility flip below, while layout is real. A
-        // pass that sees an already-hidden idle button measures a partial
-        // set, which must not overwrite the full-set cache.
+        // Measured before any flip, while layout is real. A partial idle set
+        // (some already hidden) must not overwrite the full-set cache.
         if (!running) {
             if (button.Visibility() == Visibility::Visible) {
                 idleVisibleWidth += button.ActualWidth();
@@ -807,17 +781,14 @@ void SetCollapseState(
         }
 
         if (shouldHide) {
-            // Buttons Windows already hid stay unrecorded, so they are never
-            // restored on this mod's behalf. A recorded hide is re-asserted
-            // in case the taskbar re-showed it, or it could stick as visible
-            // forever.
+            // Windows' own hides stay unrecorded, never restored on its
+            // behalf. A recorded hide is re-asserted, or it sticks visible.
             if (button.Visibility() == Visibility::Visible) {
                 if (deferHide) {
                     deferHide->emplace_back(button, button.Opacity());
                     button.Opacity(0);
                 } else {
-                    // Re-stripped at the moment it matters: Windows can have
-                    // re-installed the hide animation since first sight, and
+                    // Re-stripped now: the hide animation may be back, and
                     // its ghost is what neighbours would slide across.
                     ClearImplicitShowHide(button);
                     button.Visibility(Visibility::Collapsed);
@@ -860,10 +831,8 @@ void UnhookRendering(FrameContext& ctx) {
     ctx.renderingHooked = false;
 }
 
-// Tree order is not visual order: the taskbar's repeater recycles elements,
-// so a newly pinned app can land anywhere in the child list. Spacing is dealt
-// out by list index, so the list is sorted by on-screen position; hidden
-// buttons sink to the back and get re-sorted after the swap shows them.
+// Tree order is not visual order (the repeater recycles) and spacing is dealt
+// by index, so sort by on-screen X; hidden buttons sink to the back.
 void SortButtonsByPosition(std::vector<FrameworkElement>& buttons,
                            FrameworkElement frame) {
     std::vector<std::pair<double, FrameworkElement>> keyed;
@@ -892,9 +861,8 @@ void SortButtonsByPosition(std::vector<FrameworkElement>& buttons,
     }
 }
 
-// Completes deferred hides: restores each faded button's opacity and
-// collapses it for real, recording it as ours to restore unless Windows got
-// to it first.
+// Completes deferred hides: opacity back, collapse for real, record as ours
+// unless Windows hid it first.
 void FinalizePendingHides(FrameContext& ctx) {
     for (auto& entry : ctx.pendingHide) {
         try {
@@ -912,8 +880,8 @@ void FinalizePendingHides(FrameContext& ctx) {
     ctx.pendingHide.clear();
 }
 
-// Stops any animation; deferred hides complete instantly rather than revert,
-// since the hidden state is where the interrupted animation was heading.
+// Deferred hides complete rather than revert: hidden is where the
+// interrupted animation was heading.
 void StopAnimation(FrameContext& ctx) {
     FinalizePendingHides(ctx);
     ctx.animActive = false;
@@ -942,12 +910,9 @@ void StartAnimation(FrameContext& ctx,
     HookRendering(ctx, ctx.key);
 }
 
-// Midpoint of a gap close: freezes every visible survivor at its pre-collapse
-// position. Positions are sampled before layout runs, layout is forced, and
-// the per-button offsets back to the old spots are applied immediately, so
-// this very frame already holds. Offsets are measured, before layout against
-// after, so any taskbar alignment and any number of simultaneous gaps come
-// out right.
+// Gap-close midpoint: freezes visible survivors at their pre-collapse spots.
+// Sample X, force layout, apply offsets in this same frame. Measured, so any
+// alignment and any number of simultaneous gaps come out right.
 void MeasureGapOffsets(FrameContext& ctx, FrameworkElement frame) {
     std::vector<FrameworkElement> survivors;
     std::vector<double> oldX;
@@ -999,9 +964,8 @@ void MeasureGapOffsets(FrameContext& ctx, FrameworkElement frame) {
     }
 }
 
-// Begins the two-phase gap close for buttons hidden mid-steady-state. They
-// are already faded by SetCollapseState and the row has not moved; the
-// rendering tick collapses them at the midpoint and eases the gap shut.
+// Buttons are already faded by SetCollapseState and the row has not moved;
+// the rendering tick takes it from the midpoint.
 void StartGapCloseAnimation(
     FrameContext& ctx,
     std::vector<FrameworkElement> const& buttons,
@@ -1018,18 +982,16 @@ void StartGapCloseAnimation(
     HookRendering(ctx, ctx.key);
 }
 
-// Brings one taskbar in line with the requested collapse state. Never runs
-// while an animation is active; OnTimerTick stops the animation first.
-// Reports whether it could act, so a pending instant request survives an
-// empty button walk during a taskbar rebuild.
+// Brings one taskbar to the requested state; never runs mid-animation, the
+// caller stops the animation first. Reports whether it could act, so a
+// pending instant request survives an empty button walk.
 bool ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
     auto frame = ctx.frame.get();
     if (!frame) {
         return false;
     }
 
-    // The buttons' container, remembered from the last successful walk, keeps
-    // the collection off the full-tree search.
+    // The cached container keeps the walk off the full tree.
     std::vector<FrameworkElement> buttons;
     if (auto repeater = ctx.repeater.get()) {
         CollectTaskListButtons(repeater, 3, buttons);
@@ -1055,10 +1017,8 @@ bool ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
 
     if (!g_unloading) {
         if (!g_collapseEnabled && ctx.hiddenByUs.empty()) {
-            // Collapse is switched off and nothing is left hidden: the
-            // taskbar gets its own animations back while the mod idles.
-            // Stripping resumes the moment collapse returns. A mere reveal
-            // keeps stripping, since a collapse can follow at any moment.
+            // Collapse off, nothing hidden: the taskbar gets its animations
+            // back. A mere reveal keeps stripping — collapse can follow.
             ReanimateButtons(ctx);
         } else {
             for (auto& button : buttons) {
@@ -1075,8 +1035,7 @@ bool ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
         return true;
     }
 
-    // Steady-state hides, an app closing while collapsed, close their gap
-    // with the easing instead of snapping.
+    // Steady-state hides (an app closing while collapsed) ease shut.
     bool animateGaps = !instant && !g_unloading &&
                        g_settings.animationMode == AnimationMode::Spacing &&
                        (collapse ? 1 : 0) == ctx.appliedCollapse;
@@ -1089,13 +1048,10 @@ bool ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
     return true;
 }
 
-// Drives one frame of the accordion. Spacing is the only thing animated.
-//
-// One easing curve spans the whole duration and the icon swap sits at its
-// midpoint, which is its steepest part. Revealing, the collapsed set stretches
-// open, the full set cuts in squeezed shut, then relaxes to its natural
-// spacing. Collapsing runs that backwards: the full set squeezes shut, the
-// collapsed set cuts in stretched open, then closes to its natural spacing.
+// Drives one animation frame; spacing is all that is animated. One curve
+// spans the run with the icon swap at its steepest midpoint: the old set
+// stretches open, the new set cuts in squeezed, then relaxes to natural
+// spacing. Collapse runs the same backwards.
 void OnRenderingTick(void* key) {
     FrameContext* ctx = GetFrameContext(key);
     if (!ctx || !ctx->animActive) {
@@ -1118,10 +1074,9 @@ void OnRenderingTick(void* key) {
             StopAnimation(*ctx);
             return;
         }
-        // First half: the doomed buttons are faded but still laid out, so
-        // layout itself holds the gap and Windows' own close flourish plays
-        // out invisibly, with no translations to fight over. The midpoint
-        // collapses them for real; the second half eases the survivors home.
+        // Hold: faded buttons still occupy layout, so nothing can be fought
+        // over and Windows' close flourish plays invisibly. The midpoint
+        // collapses them for real; the second half eases survivors home.
         if (t < 0.5) {
             return;
         }
@@ -1148,14 +1103,12 @@ void OnRenderingTick(void* key) {
 
     if (t >= 0.5 && !ctx->animSwapped) {
         SetCollapseState(*ctx, ctx->animButtons, ctx->animTargetCollapse);
-        // The visibility flip can prompt Windows to install animations while
-        // the reconcile tick is paused, so strip again right here.
+        // The flip can prompt fresh animations while the tick is paused.
         for (auto& button : ctx->animButtons) {
             DeanimateButton(*ctx, button);
         }
-        // Forcing layout gives the new visible set real positions now, so the
-        // re-sort and this frame's offsets land in true left-to-right order,
-        // and a reveal's just-shown icons get their widths into the cache.
+        // Forced layout gives the new set real positions for the re-sort,
+        // and just-shown icons get their widths into the cache.
         if (auto frame = ctx->frame.get()) {
             frame.UpdateLayout();
             SortButtonsByPosition(ctx->animButtons, frame);
@@ -1177,10 +1130,8 @@ void OnRenderingTick(void* key) {
         ctx->animSwapped = true;
     }
 
-    // Amplitude scales with the width the hidden icons actually occupy, so the
-    // animation adapts to how many icons are pinned. Snapshotted at
-    // StartAnimation so both halves stretch by one value; the swap only
-    // rewrites idleWidth for later runs.
+    // Scales with the hidden icons' width; snapshotted so both halves use one
+    // value — the swap rewrites idleWidth for later runs only.
     double amplitude = ctx->animAmplitude;
 
     if (t >= 1.0) {
@@ -1229,8 +1180,7 @@ void OnTimerTick(void* key) {
     }
 
     if (!ctx->frame.get()) {
-        // The rendering hook must go too, or its handler outlives the entry,
-        // forces a render every vsync, and dangles after the mod unloads.
+        // The rendering hook must go too, or it dangles after unload.
         StopAnimation(*ctx);
         std::lock_guard<std::mutex> guard(g_framesMutex);
         if (ctx->timer) {
@@ -1251,9 +1201,8 @@ void OnTimerTick(void* key) {
     bool hoverLike =
         trigger == RevealTrigger::Hover || trigger == RevealTrigger::Rest;
 
-    // The fast rate only buys anything while something is timing out: an
-    // animation, a dwell being counted, or a hover reveal aging on its grace
-    // period. A click reveal is stable, so it does not hold the rate up.
+    // The fast rate only pays while something is timing out; a click reveal
+    // is stable and does not hold it up.
     bool timingSomething = ctx->animActive || g_emptyHoverSinceTick != 0 ||
                            (g_revealed && hoverLike && !g_revealedByStart);
     bool sleep = g_settings.sleepEnabled && !timingSomething &&
@@ -1266,25 +1215,6 @@ void OnTimerTick(void* key) {
     if (ctx->intervalMs != wantedIntervalMs) {
         ctx->intervalMs = wantedIntervalMs;
         ctx->timer.Interval(std::chrono::milliseconds(wantedIntervalMs));
-    }
-
-    // Cursor speed from screen-space deltas between ticks. The dt guard keeps
-    // a second taskbar's tick in the same instant from producing garbage.
-    if (trigger == RevealTrigger::Rest) {
-        POINT pt;
-        if (GetCursorPos(&pt)) {
-            double nowMs = NowMs();
-            double dt = nowMs - g_speedSamplePrevMs;
-            if (g_speedSamplePrevMs > 0 && dt >= 5.0) {
-                double dx = (double)(pt.x - g_speedSamplePrevPos.x);
-                double dy = (double)(pt.y - g_speedSamplePrevPos.y);
-                g_cursorSpeedPxS = sqrt(dx * dx + dy * dy) * 1000.0 / dt;
-            }
-            if (dt >= 5.0 || g_speedSamplePrevMs == 0) {
-                g_speedSamplePrevMs = nowMs;
-                g_speedSamplePrevPos = pt;
-            }
-        }
     }
 
     if (g_revealed) {
@@ -1311,19 +1241,21 @@ void OnTimerTick(void* key) {
         }
     } else if (hoverLike && g_collapseEnabled) {
         if (trigger == RevealTrigger::Rest) {
-            if (g_cursorSpeedPxS > (double)g_settings.restSpeedPxPerSec) {
-                // Moving too fast resets the dwell; resting time is continuous.
+            // Stale sample = no events = parked, so speed reads as zero.
+            double speed = NowMs() - g_speedSampleMs > kSpeedSampleStaleMs
+                               ? 0.0
+                               : g_cursorSpeedPxS.load();
+            if (speed > (double)g_settings.restSpeedPxPerSec) {
+                // Moving too fast resets the dwell; resting is continuous.
                 g_emptyHoverSinceTick = 0;
             } else if (g_emptyHoverSinceTick == 0 && g_lastPointerQualified &&
                        CursorOverAnyTaskbar()) {
-                // A parked cursor produces no pointer events, so the dwell is
-                // armed here, trusting the last event's position check.
+                // Parked cursors produce no events; arm off the last check.
                 g_emptyHoverSinceTick = now;
             }
         }
 
-        // Completes a reveal for a cursor that has stopped moving and so no
-        // longer produces the pointer events that would finish the delay.
+        // Completes the delay for a cursor that stopped producing events.
         ULONGLONG since = g_emptyHoverSinceTick;
         if (since != 0) {
             if (!CursorOverAnyTaskbar()) {
@@ -1347,18 +1279,16 @@ void OnTimerTick(void* key) {
     uint64_t instantGen = g_instantApplyGen;
     bool instant = ctx->instantGenSeen != instantGen;
 
-    // Watchdog: CompositionTarget::Rendering stops when the bar is not being
-    // composed (auto-hide, fullscreen occlusion), which can strand an
-    // animation mid-flight. Finish it here.
+    // Watchdog: Rendering stops when the bar is not composed (auto-hide,
+    // fullscreen occlusion), stranding an animation. Finish it here.
     if (ctx->animActive &&
         NowMs() - ctx->animStartMs >
             (double)g_settings.animationDurationMs * 3.0 + 1000.0) {
         StopAnimation(*ctx);
     }
 
-    // While the accordion runs toward the right state, leave it alone: the
-    // rendering callback owns the buttons, and reconciliation here would fight
-    // it for them. A flipped target or an instant request stops it first.
+    // An animation toward the right state is left alone — the rendering
+    // callback owns the buttons. A flipped target or instant request stops it.
     if (ctx->animActive) {
         if (!instant && desired == ctx->animTargetCollapse) {
             return;
@@ -1417,8 +1347,8 @@ bool IsFrameRegistered(void* key) {
     return g_frames->find(key) != g_frames->end();
 }
 
-// Map entries keep a stable address and each context belongs to a single UI
-// thread, so the returned pointer stays valid after the lock is released.
+// Entries have stable addresses and single-thread owners, so the returned
+// pointer outlives the lock.
 FrameContext* GetFrameContext(void* key) {
     std::lock_guard<std::mutex> guard(g_framesMutex);
     auto it = g_frames->find(key);
@@ -1443,8 +1373,8 @@ void ApplyOnThisThreadNow() {
     }
 }
 
-// Queues a wake on every taskbar's own UI thread. Non-blocking, so it is safe
-// from the worker thread; a hung taskbar just processes it late.
+// Non-blocking wake on every taskbar's own thread; a hung taskbar is late,
+// never blocking the caller.
 void WakeAllFramesAsync() {
     if (g_unloading) {
         return;
@@ -1541,9 +1471,8 @@ bool IsPointerClearOfButtons(FrameContext& ctx,
     return true;
 }
 
-// Hit-tests the point and its padded neighbours from the bar's root, so Start,
-// widgets, and the tray, a sibling of the task-area frame, get the same
-// clearance as task icons without knowing their shapes.
+// Hit-tests the point and its padded neighbours from the bar's root, so
+// Start, widgets and the tray get the same clearance without knowing shapes.
 bool ProbeStripIsClear(FrameworkElement frame, Point framePt, double padding) {
     Point hostPt = framePt;
     FrameworkElement root = frame;
@@ -1631,12 +1560,11 @@ bool PointerClearsSurfaces(void* key, Point framePt) {
         return true;
     }
 
-    // Catches bar content living on a separate surface, which no visual-tree
-    // probe can reach: a different window within the padding is a seam, not
-    // empty space. The padding is in DIPs and these are screen pixels, so it
-    // is scaled, or the guard shrinks on a high-DPI display. Probes that land
-    // outside the bar's own window are the screen edge or the next monitor,
-    // not a seam, or the bar's outer ends could never start a reveal.
+    // A different window within the padding is a seam no visual-tree probe
+    // can see (tray content lives on its own surface). Padding scaled to
+    // pixels for high DPI. Probes past the bar's own window are the screen
+    // edge or the next monitor, not a seam, or the bar's outer ends could
+    // never start a reveal.
     POINT screenPt;
     if (GetCursorPos(&screenPt)) {
         HWND hAt = WindowFromPoint(screenPt);
@@ -1664,10 +1592,8 @@ bool PointerClearsSurfaces(void* key, Point framePt) {
     return ProbeStripIsClear(frame, framePt, g_settings.elementPaddingPx);
 }
 
-// The frame's identity across hooks. The hooks see different interface
-// pointers for the same TaskbarFrame object, and keying on them raw would
-// register the same taskbar twice — two timers and two animation drivers
-// fighting over the same buttons. QI to one shared interface canonicalizes.
+// Hooks see different interface pointers for one object; raw keys would
+// register the same taskbar twice. QI to one interface canonicalizes.
 void* FrameKeyFromThis(void* pThis, FrameworkElement* elementOut) {
     FrameworkElement element = nullptr;
     ((IUnknown*)pThis)
@@ -1682,9 +1608,8 @@ void* FrameKeyFromThis(void* pThis, FrameworkElement* elementOut) {
     return key;
 }
 
-// The hooks below fill raw COM ABI vtable slots, so each body lives in a
-// helper wrapped in a catch-all: an exception escaping a slot would unwind
-// into XAML and take explorer down.
+// Hook bodies live in helpers wrapped in a catch-all: an exception escaping
+// a raw COM ABI slot would unwind into XAML and take explorer down.
 
 using TaskbarFrame_OnPointerMoved_t = int(__cdecl*)(void* pThis, void* pArgs);
 TaskbarFrame_OnPointerMoved_t TaskbarFrame_OnPointerMoved_Original;
@@ -1710,8 +1635,7 @@ void HandlePointerMoved(void* pThis, void* pArgs) {
     g_lastCursorInsideTick = pointerNow;
     g_lastActivityTick = pointerNow;
 
-    // First touch of a sleeping taskbar restores the fast tick immediately,
-    // before any reveal logic can depend on its cadence.
+    // First touch restores the fast tick before reveal logic depends on it.
     if (g_sleeping.exchange(false)) {
         ApplyOnThisThreadNow();
     }
@@ -1720,6 +1644,40 @@ void HandlePointerMoved(void* pThis, void* pArgs) {
     if ((trigger != RevealTrigger::Hover && trigger != RevealTrigger::Rest) ||
         !g_collapseEnabled || g_revealed) {
         return;
+    }
+
+    // Speed from event-to-event deltas, lightly smoothed. Under 1 ms is two
+    // frames in the same instant and would divide into garbage. A gap over
+    // kSpeedSampleStaleMs is a pause: its first event carries no measurement
+    // and must not fall through to the arming logic below.
+    if (trigger == RevealTrigger::Rest) {
+        POINT pt;
+        if (GetCursorPos(&pt)) {
+            double nowMs = NowMs();
+            double prevMs = g_speedSampleMs.load();
+            double dt = nowMs - prevMs;
+            if (prevMs == 0 || dt > kSpeedSampleStaleMs) {
+                g_cursorSpeedPxS = 0;
+                g_speedMeasured = false;
+                g_speedSampleMs = nowMs;
+                g_speedSamplePrevPos = pt;
+                return;
+            }
+            if (dt >= 1.0) {
+                double dx = (double)(pt.x - g_speedSamplePrevPos.x);
+                double dy = (double)(pt.y - g_speedSamplePrevPos.y);
+                double instant = sqrt(dx * dx + dy * dy) * 1000.0 / dt;
+                // Seeded with the first measurement, never averaged against
+                // the reset zero, or the gate is blind for several events.
+                g_cursorSpeedPxS =
+                    g_speedMeasured
+                        ? (g_cursorSpeedPxS.load() + instant) * 0.5
+                        : instant;
+                g_speedMeasured = true;
+                g_speedSampleMs = nowMs;
+                g_speedSamplePrevPos = pt;
+            }
+        }
     }
 
     Input::PointerRoutedEventArgs args = nullptr;
@@ -1737,6 +1695,7 @@ void HandlePointerMoved(void* pThis, void* pArgs) {
     }
     g_lastPointerQualified = true;
 
+    // Fresh by construction: sampled just above in this same event.
     if (trigger == RevealTrigger::Rest &&
         g_cursorSpeedPxS > (double)g_settings.restSpeedPxPerSec) {
         g_emptyHoverSinceTick = 0;
@@ -1774,10 +1733,9 @@ int __cdecl TaskbarFrame_OnPointerMoved_Hook(void* pThis, void* pArgs) {
     return ret;
 }
 
-// Leaving the frame ends any pending qualification, so resting on the tray or
-// beyond it cannot inherit one from the last touch of bare taskbar. Exits
-// also bubble up from child elements and other pointers while the cursor is
-// still inside, so a position still within the frame keeps the state.
+// Leaving the frame ends pending qualification, so the tray cannot inherit
+// it. Exits also bubble from children and other pointers, so a position
+// still inside the frame keeps the state.
 using TaskbarFrame_OnPointerExited_t = int(__cdecl*)(void* pThis, void* pArgs);
 TaskbarFrame_OnPointerExited_t TaskbarFrame_OnPointerExited_Original;
 void HandlePointerExited(void* pThis, void* pArgs) {
@@ -1879,32 +1837,16 @@ using TaskbarFrame_MeasureOverride_t =
                   winrt::Windows::Foundation::Size* resultSize);
 TaskbarFrame_MeasureOverride_t TaskbarFrame_MeasureOverride_Original;
 void HandleFrameMeasure(void* pThis) {
-    // This is the layout hot path, so a frame already adopted is dismissed on
-    // raw pointer compares, before any QueryInterface or lock. The pointer is
-    // stable per frame for this interface slot. Primary and secondary
-    // taskbars share one UI thread, so a few per-thread slots keep the fast
-    // path hot with multiple monitors.
-    thread_local void* knownFrames[4] = {};
-    thread_local unsigned knownNext = 0;
+    // Layout hot path: cheapest guard first.
     if (g_unloading) {
         return;
     }
-    for (void* known : knownFrames) {
-        if (known == pThis) {
-            return;
-        }
-    }
 
-    // Deliberately does not count as activity: the taskbar remeasures for
-    // clocks, badges and tray churn, which would keep the mod awake forever.
-    // A sleeping tick still notices icon changes within one slow interval.
+    // Not counted as activity: remeasures for clocks and badges would keep
+    // the mod awake forever.
     FrameworkElement element = nullptr;
     void* key = FrameKeyFromThis(pThis, &element);
-    if (!key) {
-        return;
-    }
-    if (IsFrameRegistered(key)) {
-        knownFrames[knownNext++ & 3] = pThis;
+    if (!key || IsFrameRegistered(key)) {
         return;
     }
 
@@ -1989,8 +1931,7 @@ bool ParseHotkey(std::wstring spec, UINT* modifiers, UINT* vk) {
     return *vk != 0;
 }
 
-// Flips state and queues non-blocking wakes; never waits on a taskbar thread,
-// or unloading the mod could strand the worker against a hung message queue.
+// Never waits on a taskbar thread, or unload could strand the worker.
 void ToggleCollapse() {
     // Atomic flip: LoadSettings writes this concurrently on settings saves.
     bool prev = g_collapseEnabled.load();
@@ -2000,6 +1941,7 @@ void ToggleCollapse() {
     g_revealed = false;
     g_revealedByStart = false;
     g_emptyHoverSinceTick = 0;
+    g_lastPointerQualified = false;
     g_lastActivityTick = GetTickCount64();
     g_instantApplyGen++;
     Wh_Log(L"Hotkey toggled collapse to %d", (int)enabled);
@@ -2022,10 +1964,9 @@ void OnStartMenuVisibility(bool visible) {
     }
 
     if (g_revealedByStart.exchange(false)) {
-        // With the cursor on the taskbar, hover-like triggers hand the reveal
-        // to the normal grace rules instead of collapsing under a click in
-        // progress. Click and hotkey-only have no aging rules that could ever
-        // end it, so for them the reveal ends with Start.
+        // Hover-like triggers hand over to grace rules instead of collapsing
+        // under a click in progress. Click/hotkey have no aging that could
+        // ever end it, so their reveal ends with Start.
         RevealTrigger trigger = g_settings.revealTrigger;
         bool hoverLike = trigger == RevealTrigger::Hover ||
                          trigger == RevealTrigger::Rest;
@@ -2079,9 +2020,9 @@ class StartVisibilitySink final : public IAppVisibilityEvents {
 
     HRESULT STDMETHODCALLTYPE
     LauncherVisibilityChange(BOOL currentVisibleState) override {
-        // Counted so teardown can wait out a call in flight; Unadvise alone
-        // does not fence one that already started. The catch keeps both the
-        // COM ABI and the decrement safe.
+        // Counted so teardown can wait out a call in flight; Unadvise does
+        // not fence one already started. The catch keeps the ABI and the
+        // decrement safe.
         g_sinkCallbacks++;
         try {
             OnStartMenuVisibility(currentVisibleState != FALSE);
@@ -2097,8 +2038,7 @@ class StartVisibilitySink final : public IAppVisibilityEvents {
 
 // Owns the hotkey registration and the Start-menu watcher; WM_QUIT ends it.
 DWORD WINAPI HotkeyThreadProc(LPVOID param) {
-    // Force the message queue into existence and announce it before anything
-    // slow, so teardown's WM_QUIT always lands.
+    // Create and announce the queue before anything slow: WM_QUIT must land.
     MSG queuePrimer;
     PeekMessage(&queuePrimer, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
     SetEvent(g_hotkeyThreadReady);
@@ -2146,8 +2086,7 @@ DWORD WINAPI HotkeyThreadProc(LPVOID param) {
     if (appVisibility && adviseCookie) {
         appVisibility->Unadvise(adviseCookie);
     }
-    // A callback that slipped past Unadvise may still be running; wait it out
-    // before the sink can be freed or the mod unloaded.
+    // A callback that slipped past Unadvise may still be running.
     while (g_sinkCallbacks.load() > 0) {
         Sleep(1);
     }
@@ -2329,9 +2268,8 @@ void CleanupOnThisThread() {
             continue;
         }
 
-        // Guarded: this runs inside a CALLWNDPROC hook or a dispatcher
-        // lambda, and a throw escaping either is fatal or hangs the unload.
-        // The erase must run regardless, or the straggler sweep re-finds it.
+        // Runs inside a CALLWNDPROC hook or dispatcher lambda; an escaping
+        // throw is fatal or hangs unload. The erase must always run.
         try {
             if (it->second.timer) {
                 it->second.timer.Stop();
@@ -2560,9 +2498,8 @@ void Wh_ModBeforeUninit() {
 
     RunOnAllTaskbarThreads([](PVOID) { CleanupOnThisThread(); }, nullptr);
 
-    // Second sweep for contexts whose taskbar window the class-name search
-    // missed (mid-recreate): every context's timer must be stopped on its own
-    // thread, or it fires after the DLL is gone.
+    // Second sweep for windows the class-name search missed (mid-recreate):
+    // every timer must stop on its own thread, or it outlives the DLL.
     std::vector<DWORD> leftoverThreads;
     {
         std::lock_guard<std::mutex> guard(g_framesMutex);
@@ -2585,10 +2522,8 @@ void Wh_ModBeforeUninit() {
         }
     }
 
-    // Last resort for a context with no reachable window: ask its dispatcher
-    // to clean up and wait for it. Timers and rendering hooks must come off on
-    // their own thread, and dropping the map here would neither stop them nor
-    // release their XAML objects safely.
+    // Last resort for a context with no reachable window: its dispatcher
+    // cleans up. Timers and rendering hooks must come off on their own thread.
     std::vector<std::pair<winrt::Windows::UI::Core::CoreDispatcher, DWORD>>
         stragglers;
     {
@@ -2632,27 +2567,22 @@ void Wh_ModBeforeUninit() {
             queued = true;
         } catch (winrt::hresult_error const&) {
         }
-        // Unbounded on purpose: giving up would let the queued lambda run
-        // inside a freed image. A wedged taskbar hangs the unload instead,
-        // which is recoverable.
+        // Unbounded: giving up would let the lambda run in a freed image. A
+        // wedged taskbar hangs the unload instead, which is recoverable.
         if (!queued || WaitForSingleObject(done, INFINITE) == WAIT_OBJECT_0) {
             CloseHandle(done);
         }
     }
 
-    // Wakes still queued to taskbar dispatchers hold code from this DLL; the
-    // threads are pumping (they just serviced the cleanup) and no new wakes
-    // can be queued. Unbounded on purpose: proceeding would let a queued
-    // lambda run inside a freed image.
+    // Queued wakes hold DLL code, and no new ones can be queued; the threads
+    // are pumping (they just serviced the cleanup). Unbounded, as above.
     while (g_pendingWakes.load() > 0) {
         Sleep(10);
     }
 
-    // Anything still present could not be reached on its own thread; leaving
-    // its references alive is safer than releasing them from here. The empty
-    // map is deliberately never reset(): hooks stay live until this returns
-    // and their g_unloading checks are unlocked, so a disengaged optional
-    // could be dereferenced mid-preemption.
+    // Leftovers could not be reached on their own thread; leaving references
+    // alive beats releasing them from here. Never reset() the empty map:
+    // hooks stay live past this point with unlocked g_unloading checks.
     std::lock_guard<std::mutex> guard(g_framesMutex);
     if (!g_frames->empty()) {
         Wh_Log(L"%u taskbar contexts could not be cleaned up",

--- a/mods/taskbar-collapse-to-running.wh.cpp
+++ b/mods/taskbar-collapse-to-running.wh.cpp
@@ -132,7 +132,6 @@ Licensed MIT. Thanks to https://easings.net/ for the easing curve values.
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Input.h>
 #include <winrt/Windows.UI.Xaml.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
 #include <winrt/Windows.UI.Xaml.Input.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
@@ -307,7 +306,9 @@ struct FrameContext {
     // Coalesces UpdateVisualStates bursts; cleared when the apply runs.
     bool applyPosted = false;
     // Retry budget for an apply that found no buttons (taskbar mid-rebuild).
+    // Armed once per generation, or a buttonless frame re-arms forever.
     int applyRetries = 0;
+    uint64_t retriesArmedGen = std::numeric_limits<uint64_t>::max();
     uint64_t instantGenSeen = 0;
 };
 
@@ -781,7 +782,9 @@ void MeasureGapOffsets(FrameContext& ctx, FrameworkElement frame) {
     bool reShown = false;
     for (auto& weak : ctx.hiddenByUs) {
         if (auto button = weak.get()) {
-            if (button.Visibility() == Visibility::Visible) {
+            // Running is a genuine launch, not a re-show; let it by.
+            if (button.Visibility() == Visibility::Visible &&
+                !TaskListButton_IsRunning(button)) {
                 ClearImplicitShowHide(button);
                 button.Visibility(Visibility::Collapsed);
                 reShown = true;
@@ -931,14 +934,24 @@ void OnRenderingTick(void* key) {
         // run, so a lost visibility race still renders empty.
         try {
             bool repaired = false;
-            for (auto& entry : ctx->gapHidden) {
+            for (size_t i = 0; i < ctx->gapHidden.size();) {
+                auto& entry = ctx->gapHidden[i];
+                // Relaunched mid-run: the button is Windows' again.
+                if (TaskListButton_IsRunning(entry.first)) {
+                    entry.first.Opacity(entry.second);
+                    ctx->gapHidden.erase(ctx->gapHidden.begin() + i);
+                    continue;
+                }
                 if (entry.first.Opacity() != 0.0) {
                     entry.first.Opacity(0);
                 }
+                i++;
             }
             for (auto& weak : ctx->hiddenByUs) {
                 if (auto button = weak.get()) {
-                    if (button.Visibility() == Visibility::Visible) {
+                    // Running is a genuine launch, not a re-show; let it by.
+                    if (button.Visibility() == Visibility::Visible &&
+                        !TaskListButton_IsRunning(button)) {
                         ClearImplicitShowHide(button);
                         button.Visibility(Visibility::Collapsed);
                         repaired = true;
@@ -1146,6 +1159,10 @@ void OnTimerTick(void* key) {
     if (ctx->animActive &&
         NowMs() - ctx->animStartMs >
             (double)g_settings.animationDurationMs * 3.0 + 1000.0) {
+        // Land the target, or the next apply starts the same animation again.
+        if (ctx->animKind == AnimKind::Accordion && !ctx->animSwapped) {
+            SetCollapseState(*ctx, ctx->animButtons, ctx->animTargetCollapse);
+        }
         StopAnimation(*ctx);
     }
 
@@ -1159,8 +1176,10 @@ void OnTimerTick(void* key) {
             ctx->applyRetries = 0;
         } else if (ctx->applyRetries > 0) {
             ctx->applyRetries--;
-        } else if (instant || ctx->appliedCollapse < 0) {
+        } else if (ctx->retriesArmedGen != instantGen &&
+                   (instant || ctx->appliedCollapse < 0)) {
             ctx->applyRetries = 20;
+            ctx->retriesArmedGen = instantGen;
         }
     }
 
@@ -1260,9 +1279,11 @@ void RegisterFrame(void* key, FrameworkElement frame) {
     }
 }
 
+// A dead frame at a recycled address must not block re-registration.
 bool IsFrameRegistered(void* key) {
     std::lock_guard<std::mutex> guard(g_framesMutex);
-    return g_frames->find(key) != g_frames->end();
+    auto it = g_frames->find(key);
+    return it != g_frames->end() && it->second.frame.get() != nullptr;
 }
 
 // Stable addresses, single-thread owners; the pointer outlives the lock.

--- a/mods/taskbar-collapse-to-running.wh.cpp
+++ b/mods/taskbar-collapse-to-running.wh.cpp
@@ -20,6 +20,12 @@ place, so pinned order is never touched.
 
 ![Demo](https://i.imgur.com/jgDv8Su.gif)
 
+(Hovering effect not included. Check out "Taskbar Dock Animation" by Ph0en1x-dev for that!)
+
+Running state is read straight from the taskbar's own buttons, so detection
+is exact and language-independent, and the mod reacts the moment an app opens
+or closes. While nothing is happening, it does nothing at all.
+
 ## Revealing
 
 * **Click** (default) — left-click empty taskbar to toggle; right-click stays
@@ -34,17 +40,9 @@ place, so pinned order is never touched.
 **Padding around elements** keeps reveals clear of every taskbar element,
 icons and tray alike; **Reveal delay** requires the cursor to stay put first.
 
-## Running detection
-
-Two signals, either one keeps an icon visible: the button's accessibility name
-("… 1 running window") and the running-indicator element. Non-English Windows:
-change **Running-app text in button names**, or clear it.
-
 ## Notes
 
 * Windows 11 only. Win+number still counts pinned items the way Windows does.
-* After 2 quiet minutes checks drop to the sleep rate; any taskbar activity
-  wakes it instantly.
 * Built and tested on Windows 11 build 26200 with a left-aligned,
   single-monitor taskbar. Other builds can name taskbar internals differently.
 * Revealing is shared across monitors: revealing one taskbar reveals them all.
@@ -72,8 +70,7 @@ Licensed MIT. Thanks to https://easings.net/ for the easing curve values.
   $name: Reveal while Start is open
   $description: >-
     Opening Start, by the Windows key or the Start button, shows every icon and
-    keeps them shown until Start closes. Works with any reveal trigger and
-    wakes the mod from sleep.
+    keeps them shown until Start closes. Works with any reveal trigger.
 - RevealDelayMs: 30
   $name: Reveal delay (ms)
   $description: >-
@@ -94,20 +91,6 @@ Licensed MIT. Thanks to https://easings.net/ for the easing curve values.
 - HoverGraceMs: 150
   $name: Grace period (ms)
   $description: How long the cursor may be off the taskbar before it collapses again.
-- RefreshIntervalMs: 250
-  $name: Refresh interval (ms)
-  $description: >-
-    How often running state and cursor position are re-checked. Whether an app
-    is running changes at human speed, so this can be slow; it only matters
-    while a reveal, dwell or animation is being timed. 10 to 2000.
-- SleepEnabled: true
-  $name: Sleep when idle
-  $description: >-
-    After 2 minutes with no taskbar activity, drop to the sleep rate below.
-    Touching the taskbar wakes it instantly, so nothing feels slower.
-- SleepIntervalMs: 1000
-  $name: Sleep check rate (ms)
-  $description: How often to check while asleep. 500 to 3000.
 - AnimationMode: spacing
   $name: Reveal animation
   $description: >-
@@ -132,14 +115,6 @@ Licensed MIT. Thanks to https://easings.net/ for the easing curve values.
 - Hotkey: Ctrl+Alt+T
   $name: Toggle hotkey
   $description: Modifiers Ctrl, Alt, Shift, Win plus one of A-Z, 0-9, F1-F24, Space. Leave empty for no hotkey.
-- RunningNameMarker: running window
-  $name: Running-app text in button names
-  $description: >-
-    A button whose accessibility name contains this text counts as running,
-    whatever its icons look like. Windows writes names such as
-    "Notepad - 1 running window pinned". Change this if your Windows is not in
-    English, or clear it to rely on the running indicator alone. A pinned app
-    whose own name contains this text always counts as running.
 */
 // ==/WindhawkModSettings==
 
@@ -157,7 +132,6 @@ Licensed MIT. Thanks to https://easings.net/ for the easing curve values.
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Input.h>
 #include <winrt/Windows.UI.Xaml.h>
-#include <winrt/Windows.UI.Xaml.Automation.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
 #include <winrt/Windows.UI.Xaml.Input.h>
@@ -172,6 +146,7 @@ Licensed MIT. Thanks to https://easings.net/ for the easing curve values.
 #include <cwctype>
 #include <functional>
 #include <limits>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -187,18 +162,15 @@ using winrt::Windows::Foundation::Numerics::float3;
 typedef void (*RunFromWindowThreadProc_t)(PVOID);
 void RunOnAllTaskbarThreads(RunFromWindowThreadProc_t proc, PVOID param);
 bool PointerClearsSurfaces(void* key, Point framePt);
+void ApplyOnThisThreadNow();
+void WakeAllFramesAsync();
 
-// Quiet time on the taskbar before the tick drops to the sleep rate.
-constexpr ULONGLONG kSleepAfterMs = 2 * 60 * 1000;
-
-// Pointer-event gap after which the cursor counts as parked and the speed
-// sample as stale. The hook and the tick must agree on this.
+// Pointer-event gap after which the cursor counts as parked.
 constexpr double kSpeedSampleStaleMs = 150.0;
 
-// Named element Windows creates inside a task button only while its app runs.
-constexpr PCWSTR kRunningIndicatorName = L"RunningIndicator";
+// Tick rate while something is timed; the timer never runs otherwise.
+constexpr int kTimerIntervalMs = 100;
 
-// A CSS cubic-bezier(x1, y1, x2, y2) curve; endpoints are fixed at 0 and 1.
 struct EasingCurve {
     double x1;
     double y1;
@@ -211,8 +183,7 @@ constexpr EasingCurve kEaseInOutSine{0.37, 0.0, 0.63, 1.0};
 constexpr EasingCurve kEaseInOutCubic{0.65, 0.0, 0.35, 1.0};
 constexpr EasingCurve kEaseInOutCirc{0.85, 0.0, 0.15, 1.0};
 
-// Stored as an id: a cross-thread settings change must never be readable
-// half-updated mid-animation.
+// An id, so a settings change can never be read half-updated.
 enum class CurveId { Sine, Cubic, Circ };
 
 EasingCurve const& CurveFor(CurveId id) {
@@ -229,13 +200,15 @@ EasingCurve const& CurveFor(CurveId id) {
 enum class AnimationMode { None, Spacing };
 enum class RevealTrigger { Never, Hover, Rest, Click };
 
-// Accordion is the reveal/collapse transition. GapClose fades an icon hidden
-// mid-steady-state, holds its slot for the first half, then eases the row
-// shut — layout holds the gap, so there is nothing to fight the taskbar over.
+// GapClose: hide an icon instantly, hold its gap open until the taskbar
+// stops churning, then ease the row shut.
 enum class AnimKind { Accordion, GapClose };
 
-// Scalars are atomic: LoadSettings writes them on Windhawk's thread while
-// taskbar threads read them mid-tick.
+// Quiet time after the last button churn before the gap eases shut, and the
+// longest the gap may hold open waiting for it.
+constexpr double kGapSettleMs = 250.0;
+constexpr double kGapHoldMaxMs = 1000.0;
+
 struct {
     std::atomic<RevealTrigger> revealTrigger;
     std::atomic<bool> revealOnStart;
@@ -243,67 +216,46 @@ struct {
     std::atomic<int> revealDelayMs;
     std::atomic<int> elementPaddingPx;
     std::atomic<int> hoverGraceMs;
-    std::atomic<int> refreshIntervalMs;
-    std::atomic<bool> sleepEnabled;
-    std::atomic<int> sleepIntervalMs;
     std::atomic<AnimationMode> animationMode;
     std::atomic<CurveId> animationCurve;
     std::atomic<int> animationDurationMs;
     std::atomic<int> animationAmplitudePct;
-    std::wstring runningNameMarker;
 } g_settings;
-
-// Guards runningNameMarker only.
-std::mutex g_settingsMutex;
 
 std::atomic<bool> g_unloading = false;
 std::atomic<bool> g_taskbarViewDllLoaded = false;
-std::atomic<bool> g_hooksApplied = false;
 
-// Whether icons should be collapsed; the settings checkbox and the hotkey both write it.
 std::atomic<bool> g_collapseEnabled = true;
 
-// Whether hover is currently holding every icon visible.
 std::atomic<bool> g_revealed = false;
 
 // Reveal caused by Start opening; pinned against grace aging until it closes.
 std::atomic<bool> g_revealedByStart = false;
 
-// Tick when the cursor was last over a taskbar; the grace period counts from here.
 std::atomic<ULONGLONG> g_lastCursorInsideTick = 0;
 
-// Tick when the cursor entered the empty area, or 0 when it is not there.
 std::atomic<ULONGLONG> g_emptyHoverSinceTick = 0;
 
-// Last taskbar activity (pointer, hotkey, settings); sleep counts from here.
-std::atomic<ULONGLONG> g_lastActivityTick = 0;
-
-// True at the sleep rate; the pointer hook snaps the timer back on touch.
-std::atomic<bool> g_sleeping = false;
-
-// Rest trigger: speed in px/s from pointer-event deltas plus its sample time.
-// A parked cursor produces no events, so a stale sample reads as zero and the
-// tick can finish its reveal.
+// Rest speed from pointer-event deltas; a stale sample reads as zero (parked).
 std::atomic<double> g_cursorSpeedPxS = 0;
 std::atomic<double> g_speedSampleMs = 0;
 std::atomic<bool> g_speedMeasured = false;
 std::atomic<bool> g_lastPointerQualified = false;
 POINT g_speedSamplePrevPos = {};
 
-// Last cheap-qualified sample, so the tick can finish qualification for a
-// parked cursor. Ticks and hooks share the taskbar UI thread.
 void* g_lastQualifiedKey = nullptr;
 Point g_lastQualifiedFramePt = {};
 
-// Bumped by hotkey/settings; a context seeing a new value applies once
-// without animation, with no cross-thread blocking.
+// Last TaskListButton state churn; the gap-close hold waits for quiet.
+std::atomic<double> g_lastButtonChurnMs = 0;
+
+// Bumped by hotkey/settings; a new value applies once, without animation.
 std::atomic<uint64_t> g_instantApplyGen = 0;
 
 // Wakes queued but not yet run; unload drains this to zero.
 std::atomic<int> g_pendingWakes = 0;
 
-// Start-menu callbacks in flight; teardown waits for zero after Unadvise,
-// which does not fence a callback already running.
+// Sink callbacks in flight; teardown waits for zero (Unadvise does not fence).
 std::atomic<int> g_sinkCallbacks = 0;
 
 // Serializes start/stop across Windhawk's thread and the LoadLibraryExW hook.
@@ -313,20 +265,16 @@ DWORD g_hotkeyThreadId = 0;
 // Signalled once the worker owns a message queue, so WM_QUIT cannot be lost.
 HANDLE g_hotkeyThreadReady = nullptr;
 
-// Per-button: stripped animations, their originals for restore, and a cached
-// running indicator (created lazily by Windows, so null is re-resolved).
 struct DeanimatedButton {
     winrt::weak_ref<FrameworkElement> button;
     Media::Animation::TransitionCollection originalTransitions{nullptr};
     winrt::Windows::UI::Composition::ImplicitAnimationCollection
         originalImplicit{nullptr};
-    winrt::weak_ref<FrameworkElement> runningIndicator;
 };
 
-// State for one taskbar, touched only by its own UI thread, except
-// dispatcher, which other threads copy under g_framesMutex.
+// Owned by its taskbar's UI thread; only dispatcher is read cross-thread,
+// under g_framesMutex.
 struct FrameContext {
-    // Key in g_frames, for callbacks.
     void* key = nullptr;
     winrt::Windows::UI::Core::CoreDispatcher dispatcher{nullptr};
     winrt::weak_ref<FrameworkElement> frame;
@@ -334,10 +282,8 @@ struct FrameContext {
     DispatcherTimer timer{nullptr};
     winrt::event_token tickToken{};
     DWORD threadId = 0;
-    int intervalMs = 0;
     // Buttons this mod hid, and therefore the only ones it may show again.
     std::vector<winrt::weak_ref<FrameworkElement>> hiddenByUs;
-    // Last seen buttons, for the pointer hook's padding test.
     std::vector<winrt::weak_ref<FrameworkElement>> lastButtons;
     std::vector<DeanimatedButton> deanimated;
 
@@ -345,33 +291,29 @@ struct FrameContext {
     int appliedCollapse = -1;
     bool animActive = false;
     AnimKind animKind = AnimKind::Accordion;
-    // Collapse state the running animation is heading towards.
     bool animTargetCollapse = false;
     double animStartMs = 0;
     // Snapshot at StartAnimation, so both accordion halves use one value.
     double animAmplitude = 0;
-    // Whether the midpoint icon swap has happened yet.
     bool animSwapped = false;
-    // GapClose: offsets back to pre-collapse spots, eased to zero.
     std::vector<float> animGapOffsets;
-    // GapClose: faded but not yet collapsed buttons, with their opacities.
-    std::vector<std::pair<FrameworkElement, double>> pendingHide;
-    // Strong refs while animating; emptied on stop.
+    // GapClose: collapsed at start, held transparent until the run ends.
+    std::vector<std::pair<FrameworkElement, double>> gapHidden;
     std::vector<FrameworkElement> animButtons;
-    // Idle icons' width, measured while visible (hidden icons measure zero);
-    // the amplitude scales from this cache.
+    // Idle icons' width while visible; hidden ones measure zero.
     double idleWidth = 0;
     winrt::event_token renderingToken{};
     bool renderingHooked = false;
-
-    // Last g_instantApplyGen this context consumed.
+    // Coalesces UpdateVisualStates bursts; cleared when the apply runs.
+    bool applyPosted = false;
+    // Retry budget for an apply that found no buttons (taskbar mid-rebuild).
+    int applyRetries = 0;
     uint64_t instantGenSeen = 0;
 };
 
 std::mutex g_framesMutex;
 
-// Never destroyed: CRT shutdown would release UI-thread-affine XAML objects
-// from the wrong thread. Real release happens in CleanupOnThisThread.
+// Never destroyed: CRT shutdown would release XAML from the wrong thread.
 [[clang::no_destroy]] std::optional<std::unordered_map<void*, FrameContext>>
     g_frames{std::in_place};
 
@@ -389,14 +331,8 @@ double NowMs() {
     return (double)counter.QuadPart * 1000.0 / frequency;
 }
 
-std::wstring CopyRunningMarker() {
-    std::lock_guard<std::mutex> guard(g_settingsMutex);
-    return g_settings.runningNameMarker;
-}
-
 // ---------------------------------------------------------------- visual tree
 
-// Calls back for each direct child, stopping at the first callback that returns true.
 FrameworkElement EnumChildElements(
     FrameworkElement element,
     std::function<bool(FrameworkElement)> const& enumCallback) {
@@ -417,39 +353,6 @@ FrameworkElement EnumChildElements(
     return nullptr;
 }
 
-// Exact RunningIndicator wins; a name containing "Running" is the fallback.
-// Do not widen to "Indicator": ProgressIndicator would misread idle apps.
-void FindRunningIndicatorWalk(FrameworkElement element,
-                              int depth,
-                              FrameworkElement& exact,
-                              FrameworkElement& partial) {
-    if (!element || depth < 0 || exact) {
-        return;
-    }
-
-    EnumChildElements(element, [&](FrameworkElement child) {
-        auto nameHstring = child.Name();
-        std::wstring_view name(nameHstring);
-        if (name == kRunningIndicatorName) {
-            exact = child;
-            return true;
-        }
-        if (!partial && name.find(L"Running") != std::wstring_view::npos) {
-            partial = child;
-        }
-        FindRunningIndicatorWalk(child, depth - 1, exact, partial);
-        return (bool)exact;
-    });
-}
-
-FrameworkElement FindRunningIndicator(FrameworkElement button) {
-    FrameworkElement exact = nullptr;
-    FrameworkElement partial = nullptr;
-    FindRunningIndicatorWalk(button, 6, exact, partial);
-    return exact ? exact : partial;
-}
-
-// Collects app buttons, excluding the panel classes nested inside each one.
 void CollectTaskListButtons(FrameworkElement root,
                             int depth,
                             std::vector<FrameworkElement>& out) {
@@ -470,71 +373,31 @@ void CollectTaskListButtons(FrameworkElement root,
     });
 }
 
-bool ContainsNoCase(std::wstring_view haystack, std::wstring_view needle) {
-    if (needle.empty() || needle.size() > haystack.size()) {
-        return false;
-    }
+// The taskbar's own running state; a mandatory symbol, so a build missing it
+// refuses to load rather than mis-hide.
+using TaskListButton_get_IsRunning_t = HRESULT(__cdecl*)(void* pThis,
+                                                         bool* running);
+TaskListButton_get_IsRunning_t TaskListButton_get_IsRunning_Original;
 
-    auto it = std::search(haystack.begin(), haystack.end(), needle.begin(),
-                          needle.end(), [](wchar_t a, wchar_t b) {
-                              return towlower(a) == towlower(b);
-                          });
-    return it != haystack.end();
-}
-
-// True while the indicator exists and is positively shown. The resolved
-// indicator is handed back so the subtree walk runs once per button.
-bool IndicatorSaysRunning(FrameworkElement button,
-                          FrameworkElement& indicatorInOut) {
-    FrameworkElement indicator = indicatorInOut;
-    if (!indicator) {
-        indicator = FindRunningIndicator(button);
-        indicatorInOut = indicator;
-    }
-    if (!indicator) {
-        return false;
-    }
-    if (indicator.Visibility() != Visibility::Visible) {
-        return false;
-    }
-    if (indicator.Opacity() <= 0.01) {
-        return false;
-    }
-
-    // Collapsed buttons are never laid out. Do not drop the laid-out guard:
-    // a hidden button could then never report running again.
-    bool buttonLaidOut = button.Visibility() == Visibility::Visible &&
-                         button.ActualWidth() > 0.5;
-    if (buttonLaidOut &&
-        (indicator.ActualWidth() <= 0.5 || indicator.ActualHeight() <= 0.5)) {
-        return false;
-    }
-
-    return true;
-}
-
-// OR of the indicator and the accessibility name. Do not make this an AND, or
-// a running app disappears. Indicator first; the name allocates a string.
-bool IsButtonRunning(FrameworkElement button,
-                     std::wstring_view marker,
-                     FrameworkElement& indicatorInOut) {
-    if (IndicatorSaysRunning(button, indicatorInOut)) {
+// Fails open: hide only on a positive answer from the exact runtime class.
+bool TaskListButton_IsRunning(FrameworkElement taskListButtonElement) {
+    if (!TaskListButton_get_IsRunning_Original ||
+        winrt::get_class_name(taskListButtonElement) !=
+            L"Taskbar.TaskListButton") {
         return true;
     }
-
-    if (!marker.empty()) {
-        auto name = Automation::AutomationProperties::GetName(button);
-        if (ContainsNoCase(std::wstring_view(name), marker)) {
-            return true;
-        }
+    bool isRunning = false;
+    if (FAILED(TaskListButton_get_IsRunning_Original(
+            winrt::get_abi(taskListButtonElement
+                               .as<winrt::Windows::Foundation::IUnknown>()),
+            &isRunning))) {
+        return true;
     }
-
-    return false;
+    return isRunning;
 }
 
 // ------------------------------------------------------------------- applying
 
-// Membership test that prunes dead entries; removes the match when asked.
 bool TakeFromHiddenSet(std::vector<winrt::weak_ref<FrameworkElement>>& hidden,
                        FrameworkElement const& element,
                        bool remove) {
@@ -587,8 +450,7 @@ bool CursorOverAnyTaskbar() {
         return true;
     }
 
-    // Jump lists and previews are separate popups on the taskbar's own
-    // thread; they count as taskbar, or grace collapses under an open menu.
+    // Popups on a taskbar thread count as taskbar, or grace collapses menus.
     DWORD processId = 0;
     DWORD threadId = GetWindowThreadProcessId(hRoot, &processId);
     if (threadId && processId == GetCurrentProcessId()) {
@@ -603,9 +465,7 @@ bool CursorOverAnyTaskbar() {
     return false;
 }
 
-// Kills the ghost a hidden button renders until its farewell animation ends.
-// No getter, so irreversible: only call for buttons actually being hidden,
-// never on every pass.
+// No getter, so irreversible: only call for buttons actually being hidden.
 void ClearImplicitShowHide(FrameworkElement const& button) {
     try {
         Hosting::ElementCompositionPreview::SetImplicitShowAnimation(button,
@@ -616,11 +476,8 @@ void ClearImplicitShowHide(FrameworkElement const& button) {
     }
 }
 
-// Strips XAML transitions and composition implicit animations, keeping the
-// originals for ReanimateButtons.
 void DeanimateButton(FrameContext& ctx, FrameworkElement button) {
-    // Runs every pass, not strip-once: Windows installs animations at its own
-    // pace, and one stripped too early keeps its reorder slide forever.
+    // Every pass, not strip-once: one stripped too early slides forever.
     DeanimatedButton* known = nullptr;
     for (size_t i = 0; i < ctx.deanimated.size();) {
         auto resolved = ctx.deanimated[i].button.get();
@@ -645,7 +502,6 @@ void DeanimateButton(FrameContext& ctx, FrameworkElement button) {
         entry.originalImplicit = implicit_;
         ctx.deanimated.push_back(entry);
     } else {
-        // Late-appearing animations still belong to Windows; keep for restore.
         if (transitions && !known->originalTransitions) {
             known->originalTransitions = transitions;
         }
@@ -686,7 +542,6 @@ double BezierAxis(double p1, double p2, double u) {
     return 3 * p1 * v * v * u + 3 * p2 * v * u * u + u * u * u;
 }
 
-// Maps linear progress through a CSS-style cubic-bezier curve.
 double CubicBezierEase(EasingCurve const& curve, double t) {
     if (t <= 0) {
         return 0;
@@ -711,9 +566,7 @@ double CubicBezierEase(EasingCurve const& curve, double t) {
 
 // ---------------------------------------------------------------- animation
 
-// Spreads totalExtra across the gaps between visible buttons, leftmost held
-// still. Deliberately no re-centre compensation: it would dwarf the amplitude
-// and read as the row charging across the screen.
+// Leftmost held still; deliberately no re-centre compensation.
 void ApplySpacing(std::vector<FrameworkElement> const& buttons,
                   double totalExtra) {
     std::vector<FrameworkElement const*> visible;
@@ -739,39 +592,21 @@ void ClearSpacing(std::vector<FrameworkElement> const& buttons) {
     }
 }
 
-// Hides or shows the managed buttons, recording only the ones it hid itself.
-// With deferHide set, hides are faded in place for FinalizePendingHides.
+// With deferHide set, hides are only faded; CollapseDeferredHides lands them.
 void SetCollapseState(
     FrameContext& ctx,
     std::vector<FrameworkElement> const& buttons,
     bool collapse,
     std::vector<std::pair<FrameworkElement, double>>* deferHide = nullptr) {
-    std::wstring marker = CopyRunningMarker();
     double idleVisibleWidth = 0;
     bool idleSetComplete = true;
 
     for (auto const& button : buttons) {
         bool weHidIt = TakeFromHiddenSet(ctx.hiddenByUs, button, false);
-
-        DeanimatedButton* state = nullptr;
-        for (auto& entry : ctx.deanimated) {
-            if (entry.button.get() == button) {
-                state = &entry;
-                break;
-            }
-        }
-
-        FrameworkElement indicator =
-            state ? state->runningIndicator.get() : nullptr;
-        bool running = IsButtonRunning(button, marker, indicator);
-        if (state && indicator && !state->runningIndicator.get()) {
-            state->runningIndicator = winrt::make_weak(indicator);
-        }
-
+        bool running = TaskListButton_IsRunning(button);
         bool shouldHide = collapse && !running;
 
-        // Measured before any flip, while layout is real. A partial idle set
-        // (some already hidden) must not overwrite the full-set cache.
+        // Measured pre-flip; a partial idle set must not overwrite the cache.
         if (!running) {
             if (button.Visibility() == Visibility::Visible) {
                 idleVisibleWidth += button.ActualWidth();
@@ -781,15 +616,12 @@ void SetCollapseState(
         }
 
         if (shouldHide) {
-            // Windows' own hides stay unrecorded, never restored on its
-            // behalf. A recorded hide is re-asserted, or it sticks visible.
+            // Windows' own hides stay unrecorded; recorded ones re-assert.
             if (button.Visibility() == Visibility::Visible) {
                 if (deferHide) {
                     deferHide->emplace_back(button, button.Opacity());
                     button.Opacity(0);
                 } else {
-                    // Re-stripped now: the hide animation may be back, and
-                    // its ghost is what neighbours would slide across.
                     ClearImplicitShowHide(button);
                     button.Visibility(Visibility::Collapsed);
                     if (!weHidIt) {
@@ -831,8 +663,7 @@ void UnhookRendering(FrameContext& ctx) {
     ctx.renderingHooked = false;
 }
 
-// Tree order is not visual order (the repeater recycles) and spacing is dealt
-// by index, so sort by on-screen X; hidden buttons sink to the back.
+// Tree order is not visual order; sort by on-screen X, hidden to the back.
 void SortButtonsByPosition(std::vector<FrameworkElement>& buttons,
                            FrameworkElement frame) {
     std::vector<std::pair<double, FrameworkElement>> keyed;
@@ -861,29 +692,39 @@ void SortButtonsByPosition(std::vector<FrameworkElement>& buttons,
     }
 }
 
-// Completes deferred hides: opacity back, collapse for real, record as ours
-// unless Windows hid it first.
-void FinalizePendingHides(FrameContext& ctx) {
-    for (auto& entry : ctx.pendingHide) {
+// Lands the deferred hides for real, kept transparent until the run ends so
+// a re-show by Windows renders empty instead of flashing.
+void CollapseDeferredHides(
+    FrameContext& ctx,
+    std::vector<std::pair<FrameworkElement, double>>& deferHide) {
+    for (auto& entry : deferHide) {
         try {
-            entry.first.Opacity(entry.second);
             if (entry.first.Visibility() == Visibility::Visible) {
                 ClearImplicitShowHide(entry.first);
                 entry.first.Visibility(Visibility::Collapsed);
                 if (!TakeFromHiddenSet(ctx.hiddenByUs, entry.first, false)) {
                     ctx.hiddenByUs.push_back(winrt::make_weak(entry.first));
                 }
+                ctx.gapHidden.push_back(std::move(entry));
+            } else {
+                // Windows hid it itself; not ours to keep.
+                entry.first.Opacity(entry.second);
             }
         } catch (winrt::hresult_error const&) {
         }
     }
-    ctx.pendingHide.clear();
+    deferHide.clear();
 }
 
-// Deferred hides complete rather than revert: hidden is where the
-// interrupted animation was heading.
 void StopAnimation(FrameContext& ctx) {
-    FinalizePendingHides(ctx);
+    // Collapsed since the start, so the opacity restore is invisible here.
+    for (auto& entry : ctx.gapHidden) {
+        try {
+            entry.first.Opacity(entry.second);
+        } catch (winrt::hresult_error const&) {
+        }
+    }
+    ctx.gapHidden.clear();
     ctx.animActive = false;
     ctx.animSwapped = false;
     UnhookRendering(ctx);
@@ -910,9 +751,7 @@ void StartAnimation(FrameContext& ctx,
     HookRendering(ctx, ctx.key);
 }
 
-// Gap-close midpoint: freezes visible survivors at their pre-collapse spots.
-// Sample X, force layout, apply offsets in this same frame. Measured, so any
-// alignment and any number of simultaneous gaps come out right.
+// Freeze survivors at their pre-collapse X, in this same pass.
 void MeasureGapOffsets(FrameContext& ctx, FrameworkElement frame) {
     std::vector<FrameworkElement> survivors;
     std::vector<double> oldX;
@@ -935,6 +774,24 @@ void MeasureGapOffsets(FrameContext& ctx, FrameworkElement frame) {
     }
 
     frame.UpdateLayout();
+
+    // A re-show landing inside that layout pass reads as gaps already
+    // closed and would kill the hold with the icon back; repair, lay out
+    // again.
+    bool reShown = false;
+    for (auto& weak : ctx.hiddenByUs) {
+        if (auto button = weak.get()) {
+            if (button.Visibility() == Visibility::Visible) {
+                ClearImplicitShowHide(button);
+                button.Visibility(Visibility::Collapsed);
+                reShown = true;
+            }
+        }
+    }
+    if (reShown) {
+        Wh_Log(L"GapClose: re-show during gap measurement, repaired");
+        frame.UpdateLayout();
+    }
 
     bool anyMoved = false;
     for (size_t i = 0; i < ctx.animButtons.size(); i++) {
@@ -964,34 +821,39 @@ void MeasureGapOffsets(FrameContext& ctx, FrameworkElement frame) {
     }
 }
 
-// Buttons are already faded by SetCollapseState and the row has not moved;
-// the rendering tick takes it from the midpoint.
+// The hide lands here and now; survivors freeze mid-gap in the same pass.
+// The rendering tick waits out Windows' close churn, then eases the gap shut.
 void StartGapCloseAnimation(
     FrameContext& ctx,
     std::vector<FrameworkElement> const& buttons,
-    std::vector<std::pair<FrameworkElement, double>> pendingHide) {
+    std::vector<std::pair<FrameworkElement, double>> deferHide) {
     ctx.animButtons = buttons;
     ctx.animGapOffsets.clear();
-    ctx.pendingHide = std::move(pendingHide);
     ctx.animActive = true;
     ctx.animKind = AnimKind::GapClose;
     // Matches the applied state so the tick keeps its hands off while it runs.
     ctx.animTargetCollapse = ctx.appliedCollapse == 1;
     ctx.animStartMs = NowMs();
     ctx.animSwapped = false;
+    CollapseDeferredHides(ctx, deferHide);
+    if (auto frame = ctx.frame.get()) {
+        MeasureGapOffsets(ctx, frame);
+    }
+    if (ctx.animGapOffsets.empty()) {
+        // No gap to close (rightmost icons); the hide already landed.
+        StopAnimation(ctx);
+        return;
+    }
     HookRendering(ctx, ctx.key);
 }
 
-// Brings one taskbar to the requested state; never runs mid-animation, the
-// caller stops the animation first. Reports whether it could act, so a
-// pending instant request survives an empty button walk.
+// Never runs mid-animation; reports false so pending work can retry.
 bool ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
     auto frame = ctx.frame.get();
     if (!frame) {
         return false;
     }
 
-    // The cached container keeps the walk off the full tree.
     std::vector<FrameworkElement> buttons;
     if (auto repeater = ctx.repeater.get()) {
         CollectTaskListButtons(repeater, 3, buttons);
@@ -1017,8 +879,6 @@ bool ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
 
     if (!g_unloading) {
         if (!g_collapseEnabled && ctx.hiddenByUs.empty()) {
-            // Collapse off, nothing hidden: the taskbar gets its animations
-            // back. A mere reveal keeps stripping — collapse can follow.
             ReanimateButtons(ctx);
         } else {
             for (auto& button : buttons) {
@@ -1035,7 +895,6 @@ bool ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
         return true;
     }
 
-    // Steady-state hides (an app closing while collapsed) ease shut.
     bool animateGaps = !instant && !g_unloading &&
                        g_settings.animationMode == AnimationMode::Spacing &&
                        (collapse ? 1 : 0) == ctx.appliedCollapse;
@@ -1048,10 +907,7 @@ bool ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
     return true;
 }
 
-// Drives one animation frame; spacing is all that is animated. One curve
-// spans the run with the icon swap at its steepest midpoint: the old set
-// stretches open, the new set cuts in squeezed, then relaxes to natural
-// spacing. Collapse runs the same backwards.
+// One curve spans the run; the icon swap sits at its steepest midpoint.
 void OnRenderingTick(void* key) {
     FrameContext* ctx = GetFrameContext(key);
     if (!ctx || !ctx->animActive) {
@@ -1070,28 +926,54 @@ void OnRenderingTick(void* key) {
     double eased = CubicBezierEase(CurveFor(g_settings.animationCurve), t);
 
     if (ctx->animKind == AnimKind::GapClose) {
-        if (t >= 1.0) {
+        // Windows' close churn can re-show what just got hidden, any frame;
+        // re-assert every frame. gapHidden stays transparent for the whole
+        // run, so a lost visibility race still renders empty.
+        try {
+            bool repaired = false;
+            for (auto& entry : ctx->gapHidden) {
+                if (entry.first.Opacity() != 0.0) {
+                    entry.first.Opacity(0);
+                }
+            }
+            for (auto& weak : ctx->hiddenByUs) {
+                if (auto button = weak.get()) {
+                    if (button.Visibility() == Visibility::Visible) {
+                        ClearImplicitShowHide(button);
+                        button.Visibility(Visibility::Collapsed);
+                        repaired = true;
+                    }
+                }
+            }
+            // Same-frame layout, or survivors render once at shifted spots.
+            if (repaired) {
+                if (auto frame = ctx->frame.get()) {
+                    frame.UpdateLayout();
+                }
+            }
+        } catch (winrt::hresult_error const&) {
+        }
+
+        if (!ctx->animSwapped) {
+            // Gap held open; the ease starts once the taskbar goes quiet.
+            double now = NowMs();
+            if (now - g_lastButtonChurnMs.load() < kGapSettleMs &&
+                now - ctx->animStartMs < kGapHoldMaxMs) {
+                return;
+            }
+            ctx->animSwapped = true;
+            ctx->animStartMs = now;
+            return;
+        }
+
+        double closeT =
+            duration > 0
+                ? std::clamp((NowMs() - ctx->animStartMs) / duration, 0.0, 1.0)
+                : 1.0;
+        if (closeT >= 1.0) {
             StopAnimation(*ctx);
             return;
         }
-        // Hold: faded buttons still occupy layout, so nothing can be fought
-        // over and Windows' close flourish plays invisibly. The midpoint
-        // collapses them for real; the second half eases survivors home.
-        if (t < 0.5) {
-            return;
-        }
-        if (!ctx->animSwapped) {
-            ctx->animSwapped = true;
-            FinalizePendingHides(*ctx);
-            if (auto frame = ctx->frame.get()) {
-                MeasureGapOffsets(*ctx, frame);
-            }
-            if (ctx->animGapOffsets.empty()) {
-                StopAnimation(*ctx);
-                return;
-            }
-        }
-        double closeT = (t - 0.5) * 2.0;
         double factor =
             1.0 - CubicBezierEase(CurveFor(g_settings.animationCurve), closeT);
         for (size_t i = 0; i < ctx->animButtons.size(); i++) {
@@ -1107,18 +989,14 @@ void OnRenderingTick(void* key) {
         for (auto& button : ctx->animButtons) {
             DeanimateButton(*ctx, button);
         }
-        // Forced layout gives the new set real positions for the re-sort,
-        // and just-shown icons get their widths into the cache.
         if (auto frame = ctx->frame.get()) {
             frame.UpdateLayout();
             SortButtonsByPosition(ctx->animButtons, frame);
             if (!ctx->animTargetCollapse) {
-                std::wstring marker = CopyRunningMarker();
                 double width = 0;
                 for (auto& button : ctx->animButtons) {
-                    FrameworkElement indicator = nullptr;
                     if (button.Visibility() == Visibility::Visible &&
-                        !IsButtonRunning(button, marker, indicator)) {
+                        !TaskListButton_IsRunning(button)) {
                         width += button.ActualWidth();
                     }
                 }
@@ -1130,8 +1008,6 @@ void OnRenderingTick(void* key) {
         ctx->animSwapped = true;
     }
 
-    // Scales with the hidden icons' width; snapshotted so both halves use one
-    // value — the swap rewrites idleWidth for later runs only.
     double amplitude = ctx->animAmplitude;
 
     if (t >= 1.0) {
@@ -1139,7 +1015,6 @@ void OnRenderingTick(void* key) {
         return;
     }
 
-    // Collapsing is the reveal played backwards, so every offset flips sign.
     double direction = ctx->animTargetCollapse ? -1.0 : 1.0;
     double totalExtra = ctx->animSwapped
                             ? -direction * amplitude * (1 - eased)
@@ -1148,7 +1023,6 @@ void OnRenderingTick(void* key) {
     ApplySpacing(ctx->animButtons, totalExtra);
 }
 
-// Puts one taskbar back exactly as it was found.
 void RestoreFrame(FrameContext& ctx) {
     StopAnimation(ctx);
 
@@ -1167,7 +1041,6 @@ void RestoreFrame(FrameContext& ctx) {
     ReanimateButtons(ctx);
 }
 
-// Drives one taskbar: ages out the hover reveal, then applies the result.
 void OnTimerTick(void* key) {
     FrameContext* ctx = nullptr;
     {
@@ -1200,22 +1073,9 @@ void OnTimerTick(void* key) {
     RevealTrigger trigger = g_settings.revealTrigger;
     bool hoverLike =
         trigger == RevealTrigger::Hover || trigger == RevealTrigger::Rest;
-
-    // The fast rate only pays while something is timing out; a click reveal
-    // is stable and does not hold it up.
-    bool timingSomething = ctx->animActive || g_emptyHoverSinceTick != 0 ||
-                           (g_revealed && hoverLike && !g_revealedByStart);
-    bool sleep = g_settings.sleepEnabled && !timingSomething &&
-                 now - g_lastActivityTick >= kSleepAfterMs;
-    g_sleeping = sleep;
-
-    int wantedIntervalMs = (timingSomething || !sleep)
-                               ? g_settings.refreshIntervalMs.load()
-                               : g_settings.sleepIntervalMs.load();
-    if (ctx->intervalMs != wantedIntervalMs) {
-        ctx->intervalMs = wantedIntervalMs;
-        ctx->timer.Interval(std::chrono::milliseconds(wantedIntervalMs));
-    }
+    bool cursorInside = CursorOverAnyTaskbar();
+    // A flip must reach every monitor; only a posted wake does that now.
+    bool flipped = false;
 
     if (g_revealed) {
         if (!g_collapseEnabled ||
@@ -1223,123 +1083,181 @@ void OnTimerTick(void* key) {
             g_revealed = false;
             g_revealedByStart = false;
             g_emptyHoverSinceTick = 0;
+            flipped = true;
         } else if (g_revealedByStart) {
-            // Pinned while Start is open; the worker thread ends it on close.
-            // Keeping the grace timestamp fresh hands over cleanly if the
-            // cursor is on the taskbar when Start goes away.
+            // Pinned while Start is open; the worker ends it on close.
             g_lastCursorInsideTick = now;
         } else if (hoverLike) {
-            // A click reveal stays until it is clicked away, so only hovering
-            // ages out on the grace period.
-            if (CursorOverAnyTaskbar()) {
+            // Only hover ages out on grace; a click reveal stays.
+            if (cursorInside) {
                 g_lastCursorInsideTick = now;
             } else if (now - g_lastCursorInsideTick >
                        (ULONGLONG)g_settings.hoverGraceMs) {
                 g_revealed = false;
                 g_emptyHoverSinceTick = 0;
+                flipped = true;
             }
         }
     } else if (hoverLike && g_collapseEnabled) {
+        // The tick has the last word on the latch; exit events can be missed.
+        if (!cursorInside) {
+            g_lastPointerQualified = false;
+            g_emptyHoverSinceTick = 0;
+        }
+
         if (trigger == RevealTrigger::Rest) {
-            // Stale sample = no events = parked, so speed reads as zero.
             double speed = NowMs() - g_speedSampleMs > kSpeedSampleStaleMs
                                ? 0.0
                                : g_cursorSpeedPxS.load();
             if (speed > (double)g_settings.restSpeedPxPerSec) {
-                // Moving too fast resets the dwell; resting is continuous.
                 g_emptyHoverSinceTick = 0;
             } else if (g_emptyHoverSinceTick == 0 && g_lastPointerQualified &&
-                       CursorOverAnyTaskbar()) {
+                       cursorInside) {
                 // Parked cursors produce no events; arm off the last check.
                 g_emptyHoverSinceTick = now;
             }
         }
 
-        // Completes the delay for a cursor that stopped producing events.
         ULONGLONG since = g_emptyHoverSinceTick;
-        if (since != 0) {
-            if (!CursorOverAnyTaskbar()) {
-                g_emptyHoverSinceTick = 0;
-            } else if (now - since >= (ULONGLONG)g_settings.revealDelayMs) {
-                if (PointerClearsSurfaces(g_lastQualifiedKey,
-                                          g_lastQualifiedFramePt)) {
-                    g_revealed = true;
-                } else {
-                    g_lastPointerQualified = false;
-                }
-                g_emptyHoverSinceTick = 0;
+        if (since != 0 && cursorInside &&
+            now - since >= (ULONGLONG)g_settings.revealDelayMs) {
+            if (PointerClearsSurfaces(g_lastQualifiedKey,
+                                      g_lastQualifiedFramePt)) {
+                g_revealed = true;
+                flipped = true;
+            } else {
+                g_lastPointerQualified = false;
             }
+            g_emptyHoverSinceTick = 0;
         }
+    }
+
+    if (flipped) {
+        WakeAllFramesAsync();
     }
 
     bool desired = g_collapseEnabled && !g_revealed;
 
-    // At most one pending instant-apply request, consumed on a successful
-    // apply so an empty button walk does not swallow it.
+    // Consumed only on a successful apply.
     uint64_t instantGen = g_instantApplyGen;
     bool instant = ctx->instantGenSeen != instantGen;
 
-    // Watchdog: Rendering stops when the bar is not composed (auto-hide,
-    // fullscreen occlusion), stranding an animation. Finish it here.
+    // Watchdog: Rendering stops when the bar is not being composed.
     if (ctx->animActive &&
         NowMs() - ctx->animStartMs >
             (double)g_settings.animationDurationMs * 3.0 + 1000.0) {
         StopAnimation(*ctx);
     }
 
-    // An animation toward the right state is left alone — the rendering
-    // callback owns the buttons. A flipped target or instant request stops it.
-    if (ctx->animActive) {
-        if (!instant && desired == ctx->animTargetCollapse) {
-            return;
-        }
+    // A running animation toward the right state owns the buttons.
+    if (ctx->animActive && (instant || desired != ctx->animTargetCollapse)) {
         StopAnimation(*ctx);
     }
+    if (!ctx->animActive) {
+        if (ApplyToFrame(*ctx, desired, instant)) {
+            ctx->instantGenSeen = instantGen;
+            ctx->applyRetries = 0;
+        } else if (ctx->applyRetries > 0) {
+            ctx->applyRetries--;
+        } else if (instant || ctx->appliedCollapse < 0) {
+            ctx->applyRetries = 20;
+        }
+    }
 
-    if (ApplyToFrame(*ctx, desired, instant)) {
-        ctx->instantGenSeen = instantGen;
+    // The timer runs only while something needs a clock; everything else
+    // arrives as events. Reveal terms are global: cost, not correctness.
+    bool timing = ctx->animActive || g_emptyHoverSinceTick != 0 ||
+                  (g_revealed && hoverLike && !g_revealedByStart) ||
+                  (hoverLike && g_collapseEnabled && !g_revealed &&
+                   g_lastPointerQualified) ||
+                  ctx->applyRetries > 0;
+    if (timing != ctx->timer.IsEnabled()) {
+        if (timing) {
+            ctx->timer.Start();
+        } else {
+            ctx->timer.Stop();
+        }
     }
 }
 
-// Adopts a taskbar and starts its timer; runs on that taskbar's UI thread.
-void RegisterFrame(void* key, FrameworkElement frame) {
-    std::lock_guard<std::mutex> guard(g_framesMutex);
-
-    // Checked under the lock: a hook that passed its unlocked g_unloading
-    // check must not insert a live timer after the cleanup sweeps ran.
+// The decrement is tied to the delegate's LIFETIME, so a dropped wake still
+// counts down. Increment first: a throwing ctor calls the deleter.
+bool PostApply(winrt::Windows::UI::Core::CoreDispatcher const& dispatcher) {
+    g_pendingWakes++;
+    auto pending =
+        std::shared_ptr<void>(nullptr, [](void*) { g_pendingWakes--; });
+    // The count must never rise after unload's drain saw zero.
     if (g_unloading) {
-        return;
+        return false;
     }
+    try {
+        dispatcher.RunAsync(
+            winrt::Windows::UI::Core::CoreDispatcherPriority::Normal,
+            [pending]() {
+                if (!g_unloading) {
+                    try {
+                        ApplyOnThisThreadNow();
+                    } catch (...) {
+                    }
+                }
+            });
+        return true;
+    } catch (winrt::hresult_error const&) {
+        return false;
+    }
+}
 
-    auto it = g_frames->find(key);
-    if (it != g_frames->end()) {
-        if (it->second.frame.get()) {
+// Timer created stopped; the first apply is posted, never run inline.
+void RegisterFrame(void* key, FrameworkElement frame) {
+    winrt::Windows::UI::Core::CoreDispatcher dispatcher{nullptr};
+    {
+        std::lock_guard<std::mutex> guard(g_framesMutex);
+
+        // Under the lock: must not insert a live timer after cleanup ran.
+        if (g_unloading) {
             return;
         }
-        StopAnimation(it->second);
-        if (it->second.timer) {
-            it->second.timer.Stop();
-            it->second.timer.Tick(it->second.tickToken);
+
+        auto it = g_frames->find(key);
+        if (it != g_frames->end()) {
+            if (it->second.frame.get()) {
+                return;
+            }
+            StopAnimation(it->second);
+            if (it->second.timer) {
+                it->second.timer.Stop();
+                it->second.timer.Tick(it->second.tickToken);
+            }
+            g_frames->erase(it);
         }
-        g_frames->erase(it);
+
+        FrameContext ctx;
+        ctx.key = key;
+        ctx.instantGenSeen = g_instantApplyGen;
+        ctx.frame = winrt::make_weak(frame);
+        ctx.dispatcher = frame.Dispatcher();
+        ctx.threadId = GetCurrentThreadId();
+        ctx.applyPosted = true;
+
+        ctx.timer = DispatcherTimer();
+        ctx.timer.Interval(std::chrono::milliseconds(kTimerIntervalMs));
+        ctx.tickToken = ctx.timer.Tick([key](IInspectable const&,
+                                             IInspectable const&) {
+            OnTimerTick(key);
+        });
+
+        dispatcher = ctx.dispatcher;
+        Wh_Log(L"Registered taskbar frame on thread %u", ctx.threadId);
+        g_frames->insert_or_assign(key, std::move(ctx));
     }
-
-    FrameContext ctx;
-    ctx.key = key;
-    ctx.instantGenSeen = g_instantApplyGen;
-    ctx.frame = winrt::make_weak(frame);
-    ctx.dispatcher = frame.Dispatcher();
-    ctx.threadId = GetCurrentThreadId();
-    ctx.intervalMs = g_settings.refreshIntervalMs;
-
-    ctx.timer = DispatcherTimer();
-    ctx.timer.Interval(std::chrono::milliseconds(ctx.intervalMs));
-    ctx.tickToken = ctx.timer.Tick(
-        [key](IInspectable const&, IInspectable const&) { OnTimerTick(key); });
-    ctx.timer.Start();
-
-    Wh_Log(L"Registered taskbar frame on thread %u", ctx.threadId);
-    g_frames->insert_or_assign(key, std::move(ctx));
+    // Outside the lock: the one COM call this function makes.
+    if (!PostApply(dispatcher)) {
+        std::lock_guard<std::mutex> guard(g_framesMutex);
+        auto it = g_frames->find(key);
+        if (it != g_frames->end()) {
+            it->second.applyPosted = false;
+        }
+    }
 }
 
 bool IsFrameRegistered(void* key) {
@@ -1347,15 +1265,13 @@ bool IsFrameRegistered(void* key) {
     return g_frames->find(key) != g_frames->end();
 }
 
-// Entries have stable addresses and single-thread owners, so the returned
-// pointer outlives the lock.
+// Stable addresses, single-thread owners; the pointer outlives the lock.
 FrameContext* GetFrameContext(void* key) {
     std::lock_guard<std::mutex> guard(g_framesMutex);
     auto it = g_frames->find(key);
     return it == g_frames->end() ? nullptr : &it->second;
 }
 
-// Applies to the taskbars owned by the calling thread, skipping the tick's wait.
 void ApplyOnThisThreadNow() {
     std::vector<void*> keys;
     DWORD threadId = GetCurrentThreadId();
@@ -1363,6 +1279,7 @@ void ApplyOnThisThreadNow() {
         std::lock_guard<std::mutex> guard(g_framesMutex);
         for (auto& [key, ctx] : *g_frames) {
             if (ctx.threadId == threadId) {
+                ctx.applyPosted = false;
                 keys.push_back(key);
             }
         }
@@ -1373,8 +1290,17 @@ void ApplyOnThisThreadNow() {
     }
 }
 
-// Non-blocking wake on every taskbar's own thread; a hung taskbar is late,
-// never blocking the caller.
+// OnTimerTick stops them again once nothing is being timed.
+void StartTimersOnThisThread() {
+    DWORD threadId = GetCurrentThreadId();
+    std::lock_guard<std::mutex> guard(g_framesMutex);
+    for (auto& [key, ctx] : *g_frames) {
+        if (ctx.threadId == threadId && ctx.timer && !ctx.timer.IsEnabled()) {
+            ctx.timer.Start();
+        }
+    }
+}
+
 void WakeAllFramesAsync() {
     if (g_unloading) {
         return;
@@ -1391,30 +1317,12 @@ void WakeAllFramesAsync() {
     }
 
     for (auto& dispatcher : dispatchers) {
-        g_pendingWakes++;
-        try {
-            dispatcher.RunAsync(
-                winrt::Windows::UI::Core::CoreDispatcherPriority::Normal,
-                []() {
-                    // The decrement must run even if the apply throws, or
-                    // unload's drain wait stalls on the count.
-                    if (!g_unloading) {
-                        try {
-                            ApplyOnThisThreadNow();
-                        } catch (...) {
-                        }
-                    }
-                    g_pendingWakes--;
-                });
-        } catch (winrt::hresult_error const&) {
-            g_pendingWakes--;
-        }
+        PostApply(dispatcher);
     }
 }
 
 // --------------------------------------------------------------------- hover
 
-// True when nothing button-like sits between the hit-tested element and the frame.
 bool IsPointerOverEmptySpace(Input::PointerRoutedEventArgs const& args) {
     auto source = args.OriginalSource().try_as<DependencyObject>();
 
@@ -1436,7 +1344,6 @@ bool IsPointerOverEmptySpace(Input::PointerRoutedEventArgs const& args) {
     return true;
 }
 
-// True when the point clears every visible button by padding, in frame coordinates.
 bool IsPointerClearOfButtons(FrameContext& ctx,
                              FrameworkElement frame,
                              Point point,
@@ -1471,8 +1378,7 @@ bool IsPointerClearOfButtons(FrameContext& ctx,
     return true;
 }
 
-// Hit-tests the point and its padded neighbours from the bar's root, so
-// Start, widgets and the tray get the same clearance without knowing shapes.
+// From the bar's root, so tray/Start/widgets get the same clearance.
 bool ProbeStripIsClear(FrameworkElement frame, Point framePt, double padding) {
     Point hostPt = framePt;
     FrameworkElement root = frame;
@@ -1516,8 +1422,7 @@ bool ProbeStripIsClear(FrameworkElement frame, Point framePt, double padding) {
     return true;
 }
 
-// Cheap per-move half of qualification: enough to arm or clear the dwell.
-// Records the sample so the flip can finish qualification later.
+// Cheap per-move half: enough to arm or clear the dwell.
 bool PointerQualifiesForReveal(void* key,
                                Input::PointerRoutedEventArgs const& args) {
     if (!IsPointerOverEmptySpace(args)) {
@@ -1547,24 +1452,28 @@ bool PointerQualifiesForReveal(void* key,
     return true;
 }
 
-// Expensive half, run once right before a reveal fires rather than per move:
-// screen-space seam probes and full hit-tests of the bar.
+// Expensive half, run once at the flip rather than per move.
 bool PointerClearsSurfaces(void* key, Point framePt) {
     if (g_settings.elementPaddingPx <= 0) {
         return true;
     }
 
     FrameContext* ctx = GetFrameContext(key);
-    FrameworkElement frame = ctx ? ctx->frame.get() : nullptr;
-    if (!ctx || !frame) {
+    FrameworkElement frame = nullptr;
+    if (ctx) {
+        // Fail open: any tick may resolve another thread's frame here.
+        try {
+            frame = ctx->frame.get();
+        } catch (winrt::hresult_error const&) {
+            return true;
+        }
+    }
+    if (!frame) {
         return true;
     }
 
-    // A different window within the padding is a seam no visual-tree probe
-    // can see (tray content lives on its own surface). Padding scaled to
-    // pixels for high DPI. Probes past the bar's own window are the screen
-    // edge or the next monitor, not a seam, or the bar's outer ends could
-    // never start a reveal.
+    // A different window within the padding is a seam; probes past the bar's
+    // own window are the screen edge or the next monitor, not a seam.
     POINT screenPt;
     if (GetCursorPos(&screenPt)) {
         HWND hAt = WindowFromPoint(screenPt);
@@ -1592,8 +1501,7 @@ bool PointerClearsSurfaces(void* key, Point framePt) {
     return ProbeStripIsClear(frame, framePt, g_settings.elementPaddingPx);
 }
 
-// Hooks see different interface pointers for one object; raw keys would
-// register the same taskbar twice. QI to one interface canonicalizes.
+// QI to one interface: raw hook pointers differ per interface slot.
 void* FrameKeyFromThis(void* pThis, FrameworkElement* elementOut) {
     FrameworkElement element = nullptr;
     ((IUnknown*)pThis)
@@ -1608,8 +1516,7 @@ void* FrameKeyFromThis(void* pThis, FrameworkElement* elementOut) {
     return key;
 }
 
-// Hook bodies live in helpers wrapped in a catch-all: an exception escaping
-// a raw COM ABI slot would unwind into XAML and take explorer down.
+// Catch-all per hook: an exception across the COM ABI kills explorer.
 
 using TaskbarFrame_OnPointerMoved_t = int(__cdecl*)(void* pThis, void* pArgs);
 TaskbarFrame_OnPointerMoved_t TaskbarFrame_OnPointerMoved_Original;
@@ -1631,14 +1538,7 @@ void HandlePointerMoved(void* pThis, void* pArgs) {
         RegisterFrame(key, element);
     }
 
-    ULONGLONG pointerNow = GetTickCount64();
-    g_lastCursorInsideTick = pointerNow;
-    g_lastActivityTick = pointerNow;
-
-    // First touch restores the fast tick before reveal logic depends on it.
-    if (g_sleeping.exchange(false)) {
-        ApplyOnThisThreadNow();
-    }
+    g_lastCursorInsideTick = GetTickCount64();
 
     RevealTrigger trigger = g_settings.revealTrigger;
     if ((trigger != RevealTrigger::Hover && trigger != RevealTrigger::Rest) ||
@@ -1646,10 +1546,8 @@ void HandlePointerMoved(void* pThis, void* pArgs) {
         return;
     }
 
-    // Speed from event-to-event deltas, lightly smoothed. Under 1 ms is two
-    // frames in the same instant and would divide into garbage. A gap over
-    // kSpeedSampleStaleMs is a pause: its first event carries no measurement
-    // and must not fall through to the arming logic below.
+    // Under 1 ms would divide into garbage; a gap over stale is a pause
+    // whose first event has no measurement and must not arm anything.
     if (trigger == RevealTrigger::Rest) {
         POINT pt;
         if (GetCursorPos(&pt)) {
@@ -1667,8 +1565,7 @@ void HandlePointerMoved(void* pThis, void* pArgs) {
                 double dx = (double)(pt.x - g_speedSamplePrevPos.x);
                 double dy = (double)(pt.y - g_speedSamplePrevPos.y);
                 double instant = sqrt(dx * dx + dy * dy) * 1000.0 / dt;
-                // Seeded with the first measurement, never averaged against
-                // the reset zero, or the gate is blind for several events.
+                // Seeded, never averaged with the reset zero.
                 g_cursorSpeedPxS =
                     g_speedMeasured
                         ? (g_cursorSpeedPxS.load() + instant) * 0.5
@@ -1694,8 +1591,8 @@ void HandlePointerMoved(void* pThis, void* pArgs) {
         return;
     }
     g_lastPointerQualified = true;
+    StartTimersOnThisThread();
 
-    // Fresh by construction: sampled just above in this same event.
     if (trigger == RevealTrigger::Rest &&
         g_cursorSpeedPxS > (double)g_settings.restSpeedPxPerSec) {
         g_emptyHoverSinceTick = 0;
@@ -1712,7 +1609,6 @@ void HandlePointerMoved(void* pThis, void* pArgs) {
         return;
     }
 
-    // The expensive checks run once, at the flip.
     if (!PointerClearsSurfaces(key, g_lastQualifiedFramePt)) {
         g_lastPointerQualified = false;
         g_emptyHoverSinceTick = 0;
@@ -1722,6 +1618,8 @@ void HandlePointerMoved(void* pThis, void* pArgs) {
     g_revealed = true;
     g_emptyHoverSinceTick = 0;
     ApplyOnThisThreadNow();
+    // Other monitors' taskbars have no running timer to notice the flip.
+    WakeAllFramesAsync();
 }
 
 int __cdecl TaskbarFrame_OnPointerMoved_Hook(void* pThis, void* pArgs) {
@@ -1733,9 +1631,8 @@ int __cdecl TaskbarFrame_OnPointerMoved_Hook(void* pThis, void* pArgs) {
     return ret;
 }
 
-// Leaving the frame ends pending qualification, so the tray cannot inherit
-// it. Exits also bubble from children and other pointers, so a position
-// still inside the frame keeps the state.
+// Exits bubble from children and other pointers too; a position still
+// inside the frame keeps the state.
 using TaskbarFrame_OnPointerExited_t = int(__cdecl*)(void* pThis, void* pArgs);
 TaskbarFrame_OnPointerExited_t TaskbarFrame_OnPointerExited_Original;
 void HandlePointerExited(void* pThis, void* pArgs) {
@@ -1777,8 +1674,7 @@ int __cdecl TaskbarFrame_OnPointerExited_Hook(void* pThis, void* pArgs) {
     return ret;
 }
 
-// Toggles the reveal on a click landing on bare taskbar. Released rather than
-// pressed, so dragging off the taskbar and letting go does not count.
+// Released, not pressed: dragging off and letting go must not count.
 using TaskbarFrame_OnPointerReleased_t = int(__cdecl*)(void* pThis,
                                                        void* pArgs);
 TaskbarFrame_OnPointerReleased_t TaskbarFrame_OnPointerReleased_Original;
@@ -1819,6 +1715,8 @@ void HandlePointerReleased(void* pThis, void* pArgs) {
     }
     g_emptyHoverSinceTick = 0;
     ApplyOnThisThreadNow();
+    // Other monitors' taskbars have no running timer to notice the flip.
+    WakeAllFramesAsync();
 }
 
 int __cdecl TaskbarFrame_OnPointerReleased_Hook(void* pThis, void* pArgs) {
@@ -1842,8 +1740,6 @@ void HandleFrameMeasure(void* pThis) {
         return;
     }
 
-    // Not counted as activity: remeasures for clocks and badges would keep
-    // the mod awake forever.
     FrameworkElement element = nullptr;
     void* key = FrameKeyFromThis(pThis, &element);
     if (!key || IsFrameRegistered(key)) {
@@ -1867,9 +1763,47 @@ int __cdecl TaskbarFrame_MeasureOverride_Hook(
     return ret;
 }
 
+// Fired on button state changes (launch/close/active). The apply is posted,
+// never inline: heavy work in the update pass risks rerendering loops.
+using TaskListButton_UpdateVisualStates_t = void(__cdecl*)(void* pThis);
+TaskListButton_UpdateVisualStates_t TaskListButton_UpdateVisualStates_Original;
+void __cdecl TaskListButton_UpdateVisualStates_Hook(void* pThis) {
+    TaskListButton_UpdateVisualStates_Original(pThis);
+    g_lastButtonChurnMs = NowMs();
+    if (g_unloading) {
+        return;
+    }
+    try {
+        winrt::Windows::UI::Core::CoreDispatcher dispatcher{nullptr};
+        DWORD threadId = GetCurrentThreadId();
+        {
+            std::lock_guard<std::mutex> guard(g_framesMutex);
+            for (auto& [key, ctx] : *g_frames) {
+                if (ctx.threadId == threadId && ctx.dispatcher) {
+                    if (ctx.applyPosted) {
+                        return;
+                    }
+                    ctx.applyPosted = true;
+                    dispatcher = ctx.dispatcher;
+                    break;
+                }
+            }
+        }
+        if (dispatcher && !PostApply(dispatcher)) {
+            // Failed post: un-latch, or this thread goes deaf to events.
+            std::lock_guard<std::mutex> guard(g_framesMutex);
+            for (auto& [key, ctx] : *g_frames) {
+                if (ctx.threadId == threadId) {
+                    ctx.applyPosted = false;
+                }
+            }
+        }
+    } catch (...) {
+    }
+}
+
 // -------------------------------------------------------------------- hotkey
 
-// Parses "Ctrl+Alt+T" into RegisterHotKey arguments; false if there is no key.
 bool ParseHotkey(std::wstring spec, UINT* modifiers, UINT* vk) {
     *modifiers = 0;
     *vk = 0;
@@ -1942,7 +1876,6 @@ void ToggleCollapse() {
     g_revealedByStart = false;
     g_emptyHoverSinceTick = 0;
     g_lastPointerQualified = false;
-    g_lastActivityTick = GetTickCount64();
     g_instantApplyGen++;
     Wh_Log(L"Hotkey toggled collapse to %d", (int)enabled);
     WakeAllFramesAsync();
@@ -1954,9 +1887,16 @@ void OnStartMenuVisibility(bool visible) {
     }
 
     if (visible) {
-        if (!g_revealed.exchange(true)) {
+        bool wasRevealed = g_revealed.exchange(true);
+        RevealTrigger trigger = g_settings.revealTrigger;
+        bool hoverLike = trigger == RevealTrigger::Hover ||
+                         trigger == RevealTrigger::Rest;
+        // Adopt an in-flight hover reveal or grace ages it out under Start;
+        // a click reveal stays its own, so Start-close cannot cancel it.
+        if (!wasRevealed || hoverLike) {
             g_revealedByStart = true;
-            g_lastActivityTick = GetTickCount64();
+        }
+        if (!wasRevealed) {
             Wh_Log(L"Start menu opened, revealing");
             WakeAllFramesAsync();
         }
@@ -1964,9 +1904,7 @@ void OnStartMenuVisibility(bool visible) {
     }
 
     if (g_revealedByStart.exchange(false)) {
-        // Hover-like triggers hand over to grace rules instead of collapsing
-        // under a click in progress. Click/hotkey have no aging that could
-        // ever end it, so their reveal ends with Start.
+        // Hover hands over to grace; click/hotkey reveals end with Start.
         RevealTrigger trigger = g_settings.revealTrigger;
         bool hoverLike = trigger == RevealTrigger::Hover ||
                          trigger == RevealTrigger::Rest;
@@ -1975,14 +1913,12 @@ void OnStartMenuVisibility(bool visible) {
         } else {
             g_revealed = false;
         }
-        g_lastActivityTick = GetTickCount64();
         Wh_Log(L"Start menu closed");
         WakeAllFramesAsync();
     }
 }
 
-// Shell-provided notification for the Start menu opening and closing; the
-// callbacks arrive on COM worker threads and touch only thread-safe state.
+// Callbacks arrive on COM worker threads; only thread-safe state here.
 class StartVisibilitySink final : public IAppVisibilityEvents {
    public:
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid,
@@ -2020,9 +1956,7 @@ class StartVisibilitySink final : public IAppVisibilityEvents {
 
     HRESULT STDMETHODCALLTYPE
     LauncherVisibilityChange(BOOL currentVisibleState) override {
-        // Counted so teardown can wait out a call in flight; Unadvise does
-        // not fence one already started. The catch keeps the ABI and the
-        // decrement safe.
+        // Counted so teardown can wait out a call in flight.
         g_sinkCallbacks++;
         try {
             OnStartMenuVisibility(currentVisibleState != FALSE);
@@ -2036,7 +1970,6 @@ class StartVisibilitySink final : public IAppVisibilityEvents {
     LONG m_refCount = 1;
 };
 
-// Owns the hotkey registration and the Start-menu watcher; WM_QUIT ends it.
 DWORD WINAPI HotkeyThreadProc(LPVOID param) {
     // Create and announce the queue before anything slow: WM_QUIT must land.
     MSG queuePrimer;
@@ -2138,8 +2071,7 @@ void StartHotkeyThread() {
     }
 }
 
-// Waits without a timeout on purpose: the mod is unloaded the moment teardown
-// returns, so a thread still running here would resume inside a freed image.
+// Unbounded on purpose: a surviving thread would resume in a freed image.
 void StopHotkeyThread() {
     std::lock_guard<std::mutex> guard(g_hotkeyThreadMutex);
     if (!g_hotkeyThread) {
@@ -2159,7 +2091,6 @@ void StopHotkeyThread() {
 
 // ------------------------------------------------------- taskbar UI threads
 
-// Runs proc on the thread owning hWnd and waits for it to finish.
 bool RunFromWindowThread(HWND hWnd,
                          RunFromWindowThreadProc_t proc,
                          PVOID procParam) {
@@ -2208,8 +2139,7 @@ bool RunFromWindowThread(HWND hWnd,
     return true;
 }
 
-// Runs proc once per taskbar UI thread. Do not call while holding
-// g_framesMutex: it blocks until each target thread has run proc.
+// Do not call holding g_framesMutex: blocks on each target thread.
 void RunOnAllTaskbarThreads(RunFromWindowThreadProc_t proc, PVOID param) {
     std::vector<HWND> windows;
     std::vector<DWORD> threadIds;
@@ -2229,8 +2159,7 @@ void RunOnAllTaskbarThreads(RunFromWindowThreadProc_t proc, PVOID param) {
         windows.push_back(hWnd);
     };
 
-    // Iterated rather than a single FindWindow: the first Shell_TrayWnd on
-    // the desktop can belong to another process.
+    // Iterated: the first Shell_TrayWnd can belong to another process.
     HWND hPrimary = nullptr;
     while ((hPrimary = FindWindowEx(nullptr, hPrimary, L"Shell_TrayWnd",
                                     nullptr))) {
@@ -2247,7 +2176,6 @@ void RunOnAllTaskbarThreads(RunFromWindowThreadProc_t proc, PVOID param) {
     }
 }
 
-// Stops the timers and restores the taskbars owned by the calling thread.
 void CleanupOnThisThread() {
     DWORD threadId = GetCurrentThreadId();
     std::vector<void*> keys;
@@ -2287,7 +2215,6 @@ void CleanupOnThisThread() {
 void LoadSettings() {
     g_settings.revealOnStart = Wh_GetIntSetting(L"RevealOnStart") != 0;
 
-    // Unrecognized values fall back to Click, matching the shipped default.
     auto trigger = WindhawkUtils::StringSetting::make(L"RevealTrigger");
     g_settings.revealTrigger = RevealTrigger::Click;
     if (wcscmp(trigger.get(), L"hover") == 0) {
@@ -2307,12 +2234,6 @@ void LoadSettings() {
         std::clamp(Wh_GetIntSetting(L"ElementPaddingPx"), 0, 200);
     g_settings.hoverGraceMs =
         std::clamp(Wh_GetIntSetting(L"HoverGraceMs"), 0, 5000);
-    g_settings.refreshIntervalMs =
-        std::clamp(Wh_GetIntSetting(L"RefreshIntervalMs"), 10, 2000);
-
-    g_settings.sleepEnabled = Wh_GetIntSetting(L"SleepEnabled") != 0;
-    g_settings.sleepIntervalMs =
-        std::clamp(Wh_GetIntSetting(L"SleepIntervalMs"), 500, 3000);
 
     g_settings.animationDurationMs =
         std::clamp(Wh_GetIntSetting(L"AnimationDurationMs"), 0, 5000);
@@ -2332,18 +2253,11 @@ void LoadSettings() {
         g_settings.animationCurve = CurveId::Circ;
     }
 
-    auto marker = WindhawkUtils::StringSetting::make(L"RunningNameMarker");
-    {
-        std::lock_guard<std::mutex> guard(g_settingsMutex);
-        g_settings.runningNameMarker = marker.get();
-    }
-
     g_collapseEnabled = Wh_GetIntSetting(L"Collapsed") != 0;
     g_revealed = false;
     g_revealedByStart = false;
     g_emptyHoverSinceTick = 0;
     g_lastPointerQualified = false;
-    g_lastActivityTick = GetTickCount64();
 }
 
 HMODULE GetTaskbarViewModuleHandle() {
@@ -2380,6 +2294,15 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
             TaskbarFrame_MeasureOverride_Hook,
             true,
         },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListButton,struct winrt::Taskbar::ITaskListButton>::get_IsRunning(bool *))"},
+            &TaskListButton_get_IsRunning_Original,
+        },
+        {
+            {LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateVisualStates(void))"},
+            &TaskListButton_UpdateVisualStates_Original,
+            TaskListButton_UpdateVisualStates_Hook,
+        },
     };
 
     if (!WindhawkUtils::HookSymbols(module, symbolHooks,
@@ -2414,10 +2337,9 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
 
     if (!g_taskbarViewDllLoaded && GetTaskbarViewModuleHandle() == module &&
         !g_taskbarViewDllLoaded.exchange(true)) {
+        // The exchange makes this exactly-once; no second flag needed.
         if (HookTaskbarViewDllSymbols(module)) {
-            if (!g_hooksApplied.exchange(true)) {
-                Wh_ApplyHookOperations();
-            }
+            Wh_ApplyHookOperations();
             StartHotkeyThread();
         }
     }
@@ -2435,8 +2357,8 @@ BOOL Wh_ModInit() {
         if (!HookTaskbarViewDllSymbols(taskbarViewModule)) {
             return FALSE;
         }
-        // Only the explorer.exe that owns the taskbar loads Taskbar.View.dll;
-        // other instances must not grab the hotkey or the Start watcher.
+        // Only the shell explorer loads Taskbar.View.dll; other instances
+        // must not grab the hotkey or the Start watcher.
         StartHotkeyThread();
     } else {
         HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
@@ -2460,18 +2382,14 @@ BOOL Wh_ModInit() {
 
 void Wh_ModAfterInit() {
     if (g_taskbarViewDllLoaded) {
-        g_hooksApplied = true;
         return;
     }
 
-    // Try again in case Taskbar.View.dll loaded between Wh_ModInit's check
-    // and the LoadLibraryExW hook going live.
+    // Retry for a load that raced the LoadLibraryExW hook going live.
     HMODULE taskbarViewModule = GetTaskbarViewModuleHandle();
     if (taskbarViewModule && !g_taskbarViewDllLoaded.exchange(true)) {
         if (HookTaskbarViewDllSymbols(taskbarViewModule)) {
-            if (!g_hooksApplied.exchange(true)) {
-                Wh_ApplyHookOperations();
-            }
+            Wh_ApplyHookOperations();
             StartHotkeyThread();
         }
     }
@@ -2482,12 +2400,13 @@ void Wh_ModSettingsChanged() {
 
     StopHotkeyThread();
     LoadSettings();
-    // Never started in explorer.exe instances that do not own the taskbar.
     if (g_taskbarViewDllLoaded) {
         StartHotkeyThread();
     }
 
     g_instantApplyGen++;
+    // The timers are stopped while idle, so the new settings must be pushed.
+    WakeAllFramesAsync();
 }
 
 void Wh_ModBeforeUninit() {
@@ -2498,8 +2417,7 @@ void Wh_ModBeforeUninit() {
 
     RunOnAllTaskbarThreads([](PVOID) { CleanupOnThisThread(); }, nullptr);
 
-    // Second sweep for windows the class-name search missed (mid-recreate):
-    // every timer must stop on its own thread, or it outlives the DLL.
+    // Second sweep: every timer must stop on its own thread.
     std::vector<DWORD> leftoverThreads;
     {
         std::lock_guard<std::mutex> guard(g_framesMutex);
@@ -2522,8 +2440,7 @@ void Wh_ModBeforeUninit() {
         }
     }
 
-    // Last resort for a context with no reachable window: its dispatcher
-    // cleans up. Timers and rendering hooks must come off on their own thread.
+    // Last resort: the context's dispatcher cleans up on its own thread.
     std::vector<std::pair<winrt::Windows::UI::Core::CoreDispatcher, DWORD>>
         stragglers;
     {
@@ -2536,53 +2453,59 @@ void Wh_ModBeforeUninit() {
     }
 
     for (auto& [dispatcher, threadId] : stragglers) {
-        // A thread that already exited can never run the lambda; waiting on
-        // it would hang the unload for nothing.
-        if (HANDLE hThread = OpenThread(SYNCHRONIZE, FALSE, threadId)) {
-            bool exited = WaitForSingleObject(hThread, 0) == WAIT_OBJECT_0;
+        HANDLE hThread = OpenThread(SYNCHRONIZE, FALSE, threadId);
+        if (!hThread) {
+            continue;
+        }
+        if (WaitForSingleObject(hThread, 0) == WAIT_OBJECT_0) {
+            // Already gone: nothing on that thread can ever run the lambda.
             CloseHandle(hThread);
-            if (exited) {
-                continue;
-            }
-        } else {
             continue;
         }
         HANDLE done = CreateEvent(nullptr, TRUE, FALSE, nullptr);
         if (!done) {
+            CloseHandle(hThread);
             continue;
         }
         bool queued = false;
-        try {
-            dispatcher.RunAsync(
-                winrt::Windows::UI::Core::CoreDispatcherPriority::High,
-                [done]() {
-                    // The signal must fire even if cleanup throws, or the
-                    // unbounded wait below never returns.
-                    try {
-                        CleanupOnThisThread();
-                    } catch (...) {
-                    }
-                    SetEvent(done);
-                });
-            queued = true;
-        } catch (winrt::hresult_error const&) {
+        {
+            // Signalled on delegate DESTRUCTION, even if dropped uninvoked.
+            auto signal = std::shared_ptr<void>(
+                nullptr, [done](void*) { SetEvent(done); });
+            try {
+                dispatcher.RunAsync(
+                    winrt::Windows::UI::Core::CoreDispatcherPriority::High,
+                    [signal]() {
+                        try {
+                            CleanupOnThisThread();
+                        } catch (...) {
+                        }
+                    });
+                queued = true;
+            } catch (winrt::hresult_error const&) {
+            }
         }
-        // Unbounded: giving up would let the lambda run in a freed image. A
-        // wedged taskbar hangs the unload instead, which is recoverable.
-        if (!queued || WaitForSingleObject(done, INFINITE) == WAIT_OBJECT_0) {
+        if (queued) {
+            // Unbounded: giving up lets the lambda run in a freed image. On
+            // thread death the event is deliberately leaked (delegate owns it).
+            HANDLE waits[2] = {done, hThread};
+            if (WaitForMultipleObjects(2, waits, FALSE, INFINITE) ==
+                WAIT_OBJECT_0) {
+                CloseHandle(done);
+            }
+        } else {
             CloseHandle(done);
         }
+        CloseHandle(hThread);
     }
 
-    // Queued wakes hold DLL code, and no new ones can be queued; the threads
-    // are pumping (they just serviced the cleanup). Unbounded, as above.
+    // Lifetime-tied counter: a dropped wake still counts down. Unbounded.
     while (g_pendingWakes.load() > 0) {
         Sleep(10);
     }
 
-    // Leftovers could not be reached on their own thread; leaving references
-    // alive beats releasing them from here. Never reset() the empty map:
-    // hooks stay live past this point with unlocked g_unloading checks.
+    // Leftovers stay referenced (safer than a wrong-thread release). Never
+    // reset() the map: hooks still run unlocked g_unloading checks.
     std::lock_guard<std::mutex> guard(g_framesMutex);
     if (!g_frames->empty()) {
         Wh_Log(L"%u taskbar contexts could not be cleaned up",

--- a/mods/taskbar-collapse-to-running.wh.cpp
+++ b/mods/taskbar-collapse-to-running.wh.cpp
@@ -230,25 +230,27 @@ enum class RevealTrigger { Never, Hover, Rest, Click };
 // it and the row eases shut.
 enum class AnimKind { Accordion, GapClose };
 
+// Scalars are atomic: LoadSettings writes them on Windhawk's thread while
+// taskbar threads read them mid-tick.
 struct {
-    RevealTrigger revealTrigger;
-    bool revealOnStart;
-    bool collapsed;
-    int restSpeedPxPerSec;
-    int revealDelayMs;
-    int elementPaddingPx;
-    int hoverGraceMs;
-    int refreshIntervalMs;
-    bool sleepEnabled;
-    int sleepIntervalMs;
-    AnimationMode animationMode;
-    CurveId animationCurve;
-    int animationDurationMs;
-    int animationAmplitudePct;
+    std::atomic<RevealTrigger> revealTrigger;
+    std::atomic<bool> revealOnStart;
+    std::atomic<bool> collapsed;
+    std::atomic<int> restSpeedPxPerSec;
+    std::atomic<int> revealDelayMs;
+    std::atomic<int> elementPaddingPx;
+    std::atomic<int> hoverGraceMs;
+    std::atomic<int> refreshIntervalMs;
+    std::atomic<bool> sleepEnabled;
+    std::atomic<int> sleepIntervalMs;
+    std::atomic<AnimationMode> animationMode;
+    std::atomic<CurveId> animationCurve;
+    std::atomic<int> animationDurationMs;
+    std::atomic<int> animationAmplitudePct;
     std::wstring runningNameMarker;
 } g_settings;
 
-// Guards runningNameMarker; every other field is a scalar read directly.
+// Guards runningNameMarker only.
 std::mutex g_settingsMutex;
 
 std::atomic<bool> g_unloading = false;
@@ -1044,8 +1046,16 @@ bool ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
     }
 
     if (!g_unloading) {
-        for (auto& button : buttons) {
-            DeanimateButton(ctx, button);
+        if (!g_collapseEnabled && ctx.hiddenByUs.empty()) {
+            // Collapse is switched off and nothing is left hidden: the
+            // taskbar gets its own animations back while the mod idles.
+            // Stripping resumes the moment collapse returns. A mere reveal
+            // keeps stripping, since a collapse can follow at any moment.
+            ReanimateButtons(ctx);
+        } else {
+            for (auto& button : buttons) {
+                DeanimateButton(ctx, button);
+            }
         }
     }
 
@@ -1243,8 +1253,8 @@ void OnTimerTick(void* key) {
     g_sleeping = sleep;
 
     int wantedIntervalMs = (timingSomething || !sleep)
-                               ? g_settings.refreshIntervalMs
-                               : g_settings.sleepIntervalMs;
+                               ? g_settings.refreshIntervalMs.load()
+                               : g_settings.sleepIntervalMs.load();
     if (ctx->intervalMs != wantedIntervalMs) {
         ctx->intervalMs = wantedIntervalMs;
         ctx->timer.Interval(std::chrono::milliseconds(wantedIntervalMs));
@@ -1820,13 +1830,19 @@ using TaskbarFrame_MeasureOverride_t =
 TaskbarFrame_MeasureOverride_t TaskbarFrame_MeasureOverride_Original;
 void HandleFrameMeasure(void* pThis) {
     // This is the layout hot path, so a frame already adopted is dismissed on
-    // a raw pointer compare, before any QueryInterface or lock. The pointer is
-    // stable per frame for this interface slot; the slot is per-thread since
-    // each taskbar measures only on its own UI thread, so it stays hot with
-    // any number of monitors.
-    thread_local void* knownThis = nullptr;
-    if (g_unloading || knownThis == pThis) {
+    // raw pointer compares, before any QueryInterface or lock. The pointer is
+    // stable per frame for this interface slot. Primary and secondary
+    // taskbars share one UI thread, so a few per-thread slots keep the fast
+    // path hot with multiple monitors.
+    thread_local void* knownFrames[4] = {};
+    thread_local unsigned knownNext = 0;
+    if (g_unloading) {
         return;
+    }
+    for (void* known : knownFrames) {
+        if (known == pThis) {
+            return;
+        }
     }
 
     // Deliberately does not count as activity: the taskbar remeasures for
@@ -1838,7 +1854,7 @@ void HandleFrameMeasure(void* pThis) {
         return;
     }
     if (IsFrameRegistered(key)) {
-        knownThis = pThis;
+        knownFrames[knownNext++ & 3] = pThis;
         return;
     }
 
@@ -2098,6 +2114,10 @@ DWORD WINAPI HotkeyThreadProc(LPVOID param) {
 }
 
 void StartHotkeyThread() {
+    if (g_hotkeyThread) {
+        return;
+    }
+
     auto spec = WindhawkUtils::StringSetting::make(L"Hotkey");
     UINT modifiers = 0;
     UINT vk = 0;
@@ -2218,8 +2238,12 @@ void RunOnAllTaskbarThreads(RunFromWindowThreadProc_t proc, PVOID param) {
         windows.push_back(hWnd);
     };
 
-    if (HWND hWnd = FindWindow(L"Shell_TrayWnd", nullptr)) {
-        consider(hWnd);
+    // Iterated rather than a single FindWindow: the first Shell_TrayWnd on
+    // the desktop can belong to another process.
+    HWND hPrimary = nullptr;
+    while ((hPrimary = FindWindowEx(nullptr, hPrimary, L"Shell_TrayWnd",
+                                    nullptr))) {
+        consider(hPrimary);
     }
     HWND hSecondary = nullptr;
     while ((hSecondary = FindWindowEx(nullptr, hSecondary,
@@ -2319,7 +2343,7 @@ void LoadSettings() {
         g_settings.runningNameMarker = marker.get();
     }
 
-    g_collapseEnabled = g_settings.collapsed;
+    g_collapseEnabled = g_settings.collapsed.load();
     g_revealed = false;
     g_revealedByStart = false;
     g_emptyHoverSinceTick = 0;
@@ -2337,7 +2361,7 @@ HMODULE GetTaskbarViewModuleHandle() {
 
 bool HookTaskbarViewDllSymbols(HMODULE module) {
     // Taskbar.View.dll, ExplorerExtensions.dll
-    WindhawkUtils::SYMBOL_HOOK taskbarViewDllHooks[] = {
+    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
             {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarFrame,struct winrt::Windows::UI::Xaml::Controls::IControlOverrides>::OnPointerMoved(void *))"},
             &TaskbarFrame_OnPointerMoved_Original,
@@ -2363,17 +2387,18 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
         },
     };
 
-    if (!WindhawkUtils::HookSymbols(module, taskbarViewDllHooks,
-                                    ARRAYSIZE(taskbarViewDllHooks))) {
+    if (!WindhawkUtils::HookSymbols(module, symbolHooks,
+                                    ARRAYSIZE(symbolHooks))) {
         Wh_Log(L"HookSymbols failed, mod will not load");
         return false;
     }
 
     Wh_Log(
         L"HookSymbols ok (OnPointerMoved=%d OnPointerReleased=%d "
-        L"MeasureOverride=%d)",
+        L"OnPointerExited=%d MeasureOverride=%d)",
         (int)(TaskbarFrame_OnPointerMoved_Original != nullptr),
         (int)(TaskbarFrame_OnPointerReleased_Original != nullptr),
+        (int)(TaskbarFrame_OnPointerExited_Original != nullptr),
         (int)(TaskbarFrame_MeasureOverride_Original != nullptr));
     return true;
 }
@@ -2391,9 +2416,11 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
 
     if (!g_taskbarViewDllLoaded && GetTaskbarViewModuleHandle() == module &&
         !g_taskbarViewDllLoaded.exchange(true)) {
-        if (HookTaskbarViewDllSymbols(module) &&
-            !g_hooksApplied.exchange(true)) {
-            Wh_ApplyHookOperations();
+        if (HookTaskbarViewDllSymbols(module)) {
+            if (!g_hooksApplied.exchange(true)) {
+                Wh_ApplyHookOperations();
+            }
+            StartHotkeyThread();
         }
     }
 
@@ -2410,6 +2437,9 @@ BOOL Wh_ModInit() {
         if (!HookTaskbarViewDllSymbols(taskbarViewModule)) {
             return FALSE;
         }
+        // Only the explorer.exe that owns the taskbar loads Taskbar.View.dll;
+        // other instances must not grab the hotkey or the Start watcher.
+        StartHotkeyThread();
     } else {
         HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
         if (!kernelBaseModule) {
@@ -2427,8 +2457,6 @@ BOOL Wh_ModInit() {
                                        &LoadLibraryExW_Original);
     }
 
-    StartHotkeyThread();
-
     return TRUE;
 }
 
@@ -2442,9 +2470,11 @@ void Wh_ModAfterInit() {
     // and the LoadLibraryExW hook going live.
     HMODULE taskbarViewModule = GetTaskbarViewModuleHandle();
     if (taskbarViewModule && !g_taskbarViewDllLoaded.exchange(true)) {
-        if (HookTaskbarViewDllSymbols(taskbarViewModule) &&
-            !g_hooksApplied.exchange(true)) {
-            Wh_ApplyHookOperations();
+        if (HookTaskbarViewDllSymbols(taskbarViewModule)) {
+            if (!g_hooksApplied.exchange(true)) {
+                Wh_ApplyHookOperations();
+            }
+            StartHotkeyThread();
         }
     }
 }
@@ -2454,7 +2484,10 @@ void Wh_ModSettingsChanged() {
 
     StopHotkeyThread();
     LoadSettings();
-    StartHotkeyThread();
+    // Never started in explorer.exe instances that do not own the taskbar.
+    if (g_taskbarViewDllLoaded) {
+        StartHotkeyThread();
+    }
 
     g_instantApplyGen++;
 }
@@ -2522,24 +2555,29 @@ void Wh_ModBeforeUninit() {
             queued = true;
         } catch (winrt::hresult_error const&) {
         }
-        // On timeout the queued lambda still owns SetEvent(done), so the
-        // handle is deliberately leaked rather than recycled under it.
-        if (!queued || WaitForSingleObject(done, 5000) == WAIT_OBJECT_0) {
+        // Unbounded on purpose: giving up would let the queued lambda run
+        // inside a freed image. A wedged taskbar hangs the unload instead,
+        // which is recoverable.
+        if (!queued || WaitForSingleObject(done, INFINITE) == WAIT_OBJECT_0) {
             CloseHandle(done);
         }
     }
 
     // Wakes still queued to taskbar dispatchers hold code from this DLL; the
-    // threads are pumping (they just serviced the cleanup), so give their
-    // queues a bounded moment to run the leftovers down.
-    for (int i = 0; i < 500 && g_pendingWakes.load() > 0; i++) {
+    // threads are pumping (they just serviced the cleanup) and no new wakes
+    // can be queued. Unbounded on purpose: proceeding would let a queued
+    // lambda run inside a freed image.
+    while (g_pendingWakes.load() > 0) {
         Sleep(10);
     }
 
     // Anything still present could not be reached on its own thread; leaving
-    // its references alive is safer than releasing them from here.
+    // its references alive is safer than releasing them from here. An empty
+    // map can go completely, buckets and all.
     std::lock_guard<std::mutex> guard(g_framesMutex);
-    if (!g_frames->empty()) {
+    if (g_frames->empty()) {
+        g_frames.reset();
+    } else {
         Wh_Log(L"%u taskbar contexts could not be cleaned up",
                (unsigned)g_frames->size());
     }

--- a/mods/taskbar-collapse-to-running.wh.cpp
+++ b/mods/taskbar-collapse-to-running.wh.cpp
@@ -1,0 +1,2359 @@
+// ==WindhawkMod==
+// @id              taskbar-collapse-to-running
+// @name            Taskbar collapse to running apps
+// @description     Hides pinned taskbar icons whose app is not running. Hover, rest on, or click the empty taskbar to reveal them.
+// @version         1.0.0
+// @author          Lars
+// @github          https://github.com/LarsGudm
+// @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -DWINVER=0x0A00 -lole32 -loleaut32 -lruntimeobject -lshcore -luser32
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Taskbar collapse to running apps
+
+Hides pinned taskbar icons whose app is not running. Icons hide and unhide in
+place, so pinned order is never touched. Windows' reorder slide is stripped;
+the optional accordion animates spacing only, and an app closing while
+collapsed eases its gap shut.
+
+## Revealing
+
+* **Click** (default) — left-click empty taskbar to toggle; right-click stays
+  Windows'.
+* **Hover** — rest the cursor on empty taskbar; collapses again a grace period
+  after the cursor leaves.
+* **Rest** — hover, but only below **Rest speed**, so sweeping past does nothing.
+* **Start** — optional, off by default: everything shows while Start is open.
+* **Hotkey** (`Ctrl+Alt+T`) and the Collapse checkbox flip the whole mod,
+  always instantly.
+
+**Padding around elements** keeps reveals clear of every taskbar element,
+icons and tray alike; **Reveal delay** requires the cursor to stay put first.
+
+## Running detection
+
+Two signals, either one keeps an icon visible: the button's accessibility name
+("… 1 running window") and the running-indicator element. Non-English Windows:
+change **Running-app text in button names**, or clear it.
+
+## Notes
+
+* Windows 11 only. Win+number still counts pinned items the way Windows does.
+* After 2 quiet minutes checks drop to the sleep rate; any taskbar activity
+  wakes it instantly.
+* Built and tested on Windows 11 build 26200 with a left-aligned,
+  single-monitor taskbar. Other builds can name taskbar internals differently;
+  if icons are classified wrongly, the diagnostics log shows why.
+* Diagnostics: set `kDebugLogging` in the source; log lands at
+  `%TEMP%\taskbar-collapse-debug.log`.
+
+Licensed MIT. Thanks to https://easings.net/ for easing code.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- RevealTrigger: click
+  $name: Reveal trigger
+  $options:
+  - hover: Hover
+  - rest: Rest
+  - click: Click
+  - never: None, hotkey only
+- RevealOnStart: false
+  $name: Reveal while Start is open
+  $description: >-
+    Opening Start, by the Windows key or the Start button, shows every icon and
+    keeps them shown until Start closes. Works with any reveal trigger and
+    wakes the mod from sleep.
+- RevealDelayMs: 30
+  $name: Reveal delay (ms)
+  $description: >-
+    How long the cursor must stay in the empty taskbar area before the icons come back.
+- RestSpeedPxPerSec: 300
+  $name: Rest speed (px/s)
+  $description: >-
+    How slow the cursor must be moving across empty taskbar area to count as resting (only applies to: Reveal trigger > Rest)
+- Collapsed: true
+  $name: Collapse taskbar
+  $description: Hide pinned icons whose app is not running. This is the same switch the hotkey flips.
+- ElementPaddingPx: 24
+  $name: Padding around elements (px)
+  $description: >-
+    Safe area around every taskbar element to prevent unwanted transitions.
+- HoverGraceMs: 150
+  $name: Grace period (ms)
+  $description: How long the cursor may be off the taskbar before it collapses again.
+- RefreshIntervalMs: 50
+  $name: Refresh interval (ms)
+  $description: >-
+    How often running state and cursor position are re-checked. Also the
+    worst-case delay on the hotkey. Floored at 10, because nothing on screen
+    can change faster than a frame anyway.
+- SleepEnabled: true
+  $name: Sleep when idle
+  $description: >-
+    After 2 minutes with no taskbar activity, drop to the sleep rate below.
+    Touching the taskbar wakes it instantly, so nothing feels slower.
+- SleepIntervalMs: 1000
+  $name: Sleep check rate (ms)
+  $description: How often to check while asleep. 500 to 3000.
+- AnimationMode: spacing
+  $name: Reveal animation
+  $description: >-
+    How revealing and collapsing are animated.
+  $options:
+  - none: None
+  - spacing: Accordion
+- AnimationCurve: circ
+  $name: Easing curve
+  $options:
+  - sine: easeInOutSine
+  - cubic: easeInOutCubic
+  - circ: easeInOutCirc
+- AnimationDurationMs: 160
+  $name: Animation length (ms)
+- AnimationAmplitudePct: 40
+  $name: Animation amplitude (%)
+  $description: >-
+    How far the accordion stretches, as a percentage of the width the hidden
+    icons actually take up. 100 stretches by exactly the space they occupy, so
+    the animation scales itself to how many icons are pinned.
+- Hotkey: Ctrl+Alt+T
+  $name: Toggle hotkey
+  $description: Modifiers Ctrl, Alt, Shift, Win plus one of A-Z, 0-9, F1-F24, Space. Leave empty for no hotkey.
+- RunningNameMarker: running window
+  $name: Running-app text in button names
+  $description: >-
+    A button whose accessibility name contains this text counts as running,
+    whatever its icons look like. Windows writes names such as
+    "Notepad - 1 running window pinned". Change this if your Windows is not in
+    English, or clear it to rely on the running indicator alone.
+*/
+// ==/WindhawkModSettings==
+
+#include <windhawk_utils.h>
+
+#include <shobjidl.h>
+
+// winbase.h's GetCurrentTime macro collides with the XAML animation headers.
+#undef GetCurrentTime
+
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Foundation.Numerics.h>
+#include <winrt/Windows.UI.Composition.h>
+#include <winrt/Windows.UI.Core.h>
+#include <winrt/Windows.UI.Input.h>
+#include <winrt/Windows.UI.Xaml.h>
+#include <winrt/Windows.UI.Xaml.Automation.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Hosting.h>
+#include <winrt/Windows.UI.Xaml.Input.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
+#include <winrt/Windows.UI.Xaml.Media.Animation.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cwctype>
+#include <functional>
+#include <limits>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+using namespace winrt::Windows::UI::Xaml;
+using winrt::Windows::Foundation::IInspectable;
+using winrt::Windows::Foundation::Point;
+using winrt::Windows::Foundation::Numerics::float3;
+
+typedef void (*RunFromWindowThreadProc_t)(PVOID);
+void RunOnAllTaskbarThreads(RunFromWindowThreadProc_t proc, PVOID param);
+
+// Flip to true and recompile to write diagnostics (button classification,
+// element trees, tick cost) to %TEMP%\taskbar-collapse-debug.log.
+constexpr bool kDebugLogging = false;
+
+// Quiet time on the taskbar before the tick drops to the sleep rate.
+constexpr ULONGLONG kSleepAfterMs = 2 * 60 * 1000;
+
+// Named element Windows creates inside a task button only while its app runs.
+constexpr PCWSTR kRunningIndicatorName = L"RunningIndicator";
+
+// A CSS cubic-bezier(x1, y1, x2, y2) curve; endpoints are fixed at 0 and 1.
+struct EasingCurve {
+    double x1;
+    double y1;
+    double x2;
+    double y2;
+};
+
+// Thanks to https://easings.net/ for easing code.
+constexpr EasingCurve kEaseInOutSine{0.37, 0.0, 0.63, 1.0};
+constexpr EasingCurve kEaseInOutCubic{0.65, 0.0, 0.35, 1.0};
+constexpr EasingCurve kEaseInOutCirc{0.85, 0.0, 0.15, 1.0};
+
+enum class AnimationMode { None, Spacing };
+enum class RevealTrigger { Never, Hover, Rest, Click };
+
+// Accordion is the reveal/collapse transition; GapClose eases the row shut
+// over the width of an icon hidden mid-steady-state, when its app closes.
+enum class AnimKind { Accordion, GapClose };
+
+struct {
+    RevealTrigger revealTrigger;
+    bool revealOnStart;
+    bool collapsed;
+    int restSpeedPxPerSec;
+    int revealDelayMs;
+    int elementPaddingPx;
+    int hoverGraceMs;
+    int refreshIntervalMs;
+    bool sleepEnabled;
+    int sleepIntervalMs;
+    AnimationMode animationMode;
+    EasingCurve animationCurve;
+    int animationDurationMs;
+    int animationAmplitudePct;
+    std::wstring runningNameMarker;
+} g_settings;
+
+// Guards runningNameMarker; every other field is a scalar read directly.
+std::mutex g_settingsMutex;
+
+std::atomic<bool> g_unloading = false;
+std::atomic<bool> g_taskbarViewDllLoaded = false;
+std::atomic<bool> g_hooksApplied = false;
+
+// Whether icons should be collapsed; the settings checkbox and the hotkey both write it.
+std::atomic<bool> g_collapseEnabled = true;
+
+// Whether hover is currently holding every icon visible.
+std::atomic<bool> g_revealed = false;
+
+// Whether the current reveal was caused by the Start menu opening; it pins the
+// reveal against grace aging until Start closes.
+std::atomic<bool> g_revealedByStart = false;
+
+// Tick when the cursor was last over a taskbar; the grace period counts from here.
+std::atomic<ULONGLONG> g_lastCursorInsideTick = 0;
+
+// Tick when the cursor entered the empty area, or 0 when it is not there.
+std::atomic<ULONGLONG> g_emptyHoverSinceTick = 0;
+
+// Tick of the last taskbar activity (pointer, layout, hotkey, settings); the
+// sleep countdown runs from here.
+std::atomic<ULONGLONG> g_lastActivityTick = 0;
+
+// True while ticks run at the sleep rate; the pointer hook uses it to snap
+// the timer back to full speed on the first touch.
+std::atomic<bool> g_sleeping = false;
+
+// Rest trigger: cursor speed in px/s, measured between refresh ticks from
+// screen coordinates, and whether the last pointer event sat in the
+// qualifying empty area. Together they let a parked cursor finish a reveal
+// after pointer events have stopped coming.
+std::atomic<double> g_cursorSpeedPxS = 0;
+std::atomic<bool> g_lastPointerQualified = false;
+double g_speedSamplePrevMs = 0;
+POINT g_speedSamplePrevPos = {};
+
+std::atomic<bool> g_debugDumpPending = false;
+
+// Bumped by the hotkey and settings changes; a context seeing a new value
+// applies once without animation. Lets other threads request an instant apply
+// without touching contexts or blocking on their message queues.
+std::atomic<uint64_t> g_instantApplyGen = 0;
+
+HANDLE g_hotkeyThread = nullptr;
+DWORD g_hotkeyThreadId = 0;
+
+// A button with its animations stripped, holding the originals to put back.
+struct DeanimatedButton {
+    winrt::weak_ref<FrameworkElement> button;
+    Media::Animation::TransitionCollection originalTransitions{nullptr};
+    winrt::Windows::UI::Composition::ImplicitAnimationCollection
+        originalImplicit{nullptr};
+};
+
+// State for one taskbar, touched only by that taskbar's own UI thread, except
+// dispatcher, which other threads copy under g_framesMutex to queue wakes.
+struct FrameContext {
+    // This context's key in g_frames, so callbacks can find their way back.
+    void* key = nullptr;
+    winrt::Windows::UI::Core::CoreDispatcher dispatcher{nullptr};
+    winrt::weak_ref<FrameworkElement> frame;
+    winrt::weak_ref<FrameworkElement> repeater;
+    DispatcherTimer timer{nullptr};
+    winrt::event_token tickToken{};
+    DWORD threadId = 0;
+    int intervalMs = 0;
+    // Buttons this mod hid, and therefore the only ones it may show again.
+    std::vector<winrt::weak_ref<FrameworkElement>> hiddenByUs;
+    // Last seen buttons, for the pointer hook's padding test.
+    std::vector<winrt::weak_ref<FrameworkElement>> lastButtons;
+    std::vector<DeanimatedButton> deanimated;
+
+    // Visibility state currently on screen; -1 until the first apply.
+    int appliedCollapse = -1;
+    bool animActive = false;
+    AnimKind animKind = AnimKind::Accordion;
+    // Collapse state the running animation is heading towards.
+    bool animTargetCollapse = false;
+    double animStartMs = 0;
+    // Whether the midpoint icon swap has happened yet.
+    bool animSwapped = false;
+    // GapClose only: measured start offset per animButtons entry, held for the
+    // first half of the animation and eased to zero over the second.
+    std::vector<float> animGapOffsets;
+    // Strong refs for the animation's few hundred ms, so every frame works on
+    // the same set without re-walking the tree. Emptied when it stops.
+    std::vector<FrameworkElement> animButtons;
+    // Width the idle icons occupy, measured while they are visible. Hidden
+    // icons measure zero, so this cache is what the amplitude scales from.
+    double idleWidth = 0;
+    winrt::event_token renderingToken{};
+    bool renderingHooked = false;
+
+    // Last g_instantApplyGen this context consumed.
+    uint64_t instantGenSeen = 0;
+
+    int lastLoggedCollapse = -1;
+    int lastLoggedButtons = -1;
+    int lastLoggedHidden = -1;
+
+    // Cost of the refresh tick, reported periodically while logging is on.
+    int applySamples = 0;
+    double applyTotalUs = 0;
+    double applyWorstUs = 0;
+};
+
+std::mutex g_framesMutex;
+std::unordered_map<void*, FrameContext> g_frames;
+
+FrameContext* GetFrameContext(void* key);
+
+// Millisecond clock for animation timing. GetTickCount64's ~16 ms quantum is
+// too coarse for a ~120 ms animation and reads as stutter.
+double NowMs() {
+    static const double frequency = [] {
+        LARGE_INTEGER f;
+        QueryPerformanceFrequency(&f);
+        return (double)f.QuadPart;
+    }();
+    LARGE_INTEGER counter;
+    QueryPerformanceCounter(&counter);
+    return (double)counter.QuadPart * 1000.0 / frequency;
+}
+
+std::wstring CopyRunningMarker() {
+    std::lock_guard<std::mutex> guard(g_settingsMutex);
+    return g_settings.runningNameMarker;
+}
+
+std::mutex g_debugFileMutex;
+int g_debugLinesWritten = 0;
+
+// Mirrors a line to the Windhawk log and to %TEMP%\taskbar-collapse-debug.log.
+void DebugFileLog(PCWSTR format, ...) {
+    if (!kDebugLogging) {
+        return;
+    }
+
+    WCHAR buffer[1024];
+    va_list args;
+    va_start(args, format);
+    _vsnwprintf(buffer, ARRAYSIZE(buffer) - 1, format, args);
+    va_end(args);
+    buffer[ARRAYSIZE(buffer) - 1] = L'\0';
+
+    Wh_Log(L"%s", buffer);
+
+    std::lock_guard<std::mutex> guard(g_debugFileMutex);
+    if (g_debugLinesWritten >= 2000) {
+        return;
+    }
+    g_debugLinesWritten++;
+
+    WCHAR path[MAX_PATH];
+    DWORD len = GetTempPathW(ARRAYSIZE(path), path);
+    if (len == 0 || len > ARRAYSIZE(path) - 40) {
+        return;
+    }
+    wcscat_s(path, L"taskbar-collapse-debug.log");
+
+    FILE* f = _wfopen(path, L"a, ccs=UTF-8");
+    if (!f) {
+        return;
+    }
+    ULONGLONG tick = GetTickCount64();
+    fwprintf(f, L"[%8llu.%03llu t%05lu] %s\n", tick / 1000, tick % 1000,
+             GetCurrentThreadId(), buffer);
+    fclose(f);
+}
+
+// ---------------------------------------------------------------- visual tree
+
+// Calls back for each direct child, stopping at the first callback that returns true.
+FrameworkElement EnumChildElements(
+    FrameworkElement element,
+    std::function<bool(FrameworkElement)> enumCallback) {
+    int childrenCount = Media::VisualTreeHelper::GetChildrenCount(element);
+
+    for (int i = 0; i < childrenCount; i++) {
+        auto child = Media::VisualTreeHelper::GetChild(element, i)
+                         .try_as<FrameworkElement>();
+        if (!child) {
+            continue;
+        }
+
+        if (enumCallback(child)) {
+            return child;
+        }
+    }
+
+    return nullptr;
+}
+
+// Single walk finding the indicator: an exact RunningIndicator wins, any other
+// name containing "Running" is the fallback. Do not widen the fallback to
+// "Indicator": it would match ProgressIndicator and misread idle apps.
+void FindRunningIndicatorWalk(FrameworkElement element,
+                              int depth,
+                              FrameworkElement& exact,
+                              FrameworkElement& partial) {
+    if (!element || depth < 0 || exact) {
+        return;
+    }
+
+    EnumChildElements(element, [&](FrameworkElement child) {
+        auto nameHstring = child.Name();
+        std::wstring_view name(nameHstring);
+        if (name == kRunningIndicatorName) {
+            exact = child;
+            return true;
+        }
+        if (!partial && name.find(L"Running") != std::wstring_view::npos) {
+            partial = child;
+        }
+        FindRunningIndicatorWalk(child, depth - 1, exact, partial);
+        return (bool)exact;
+    });
+}
+
+FrameworkElement FindRunningIndicator(FrameworkElement button) {
+    FrameworkElement exact = nullptr;
+    FrameworkElement partial = nullptr;
+    FindRunningIndicatorWalk(button, 6, exact, partial);
+    return exact ? exact : partial;
+}
+
+// Collects app buttons, excluding the panel classes nested inside each one.
+void CollectTaskListButtons(FrameworkElement root,
+                            int depth,
+                            std::vector<FrameworkElement>& out) {
+    if (!root || depth < 0) {
+        return;
+    }
+
+    EnumChildElements(root, [&](FrameworkElement child) {
+        auto classNameHstring = winrt::get_class_name(child);
+        std::wstring_view className(classNameHstring);
+        if (className.find(L"TaskListButton") != std::wstring_view::npos &&
+            className.find(L"Panel") == std::wstring_view::npos) {
+            out.push_back(child);
+        } else {
+            CollectTaskListButtons(child, depth - 1, out);
+        }
+        return false;
+    });
+}
+
+bool ContainsNoCase(std::wstring_view haystack, std::wstring_view needle) {
+    if (needle.empty() || needle.size() > haystack.size()) {
+        return false;
+    }
+
+    auto it = std::search(haystack.begin(), haystack.end(), needle.begin(),
+                          needle.end(), [](wchar_t a, wchar_t b) {
+                              return towlower(a) == towlower(b);
+                          });
+    return it != haystack.end();
+}
+
+// True while the indicator element exists and is positively shown.
+bool IndicatorSaysRunning(FrameworkElement button) {
+    FrameworkElement indicator = FindRunningIndicator(button);
+    if (!indicator) {
+        return false;
+    }
+    if (indicator.Visibility() != Visibility::Visible) {
+        return false;
+    }
+    if (indicator.Opacity() <= 0.01) {
+        return false;
+    }
+
+    // Size is a layout result and collapsed buttons are never laid out. Do not
+    // drop the laid-out guard: a hidden button could then never report running
+    // again, and would stay hidden for as long as its app lives.
+    bool buttonLaidOut = button.Visibility() == Visibility::Visible &&
+                         button.ActualWidth() > 0.5;
+    if (buttonLaidOut &&
+        (indicator.ActualWidth() <= 0.5 || indicator.ActualHeight() <= 0.5)) {
+        return false;
+    }
+
+    return true;
+}
+
+// True if either the indicator element or the accessibility name says running.
+// Do not make this an AND: hiding must require both signals to agree, or a
+// running app disappears from the taskbar. Indicator goes first so the name,
+// which allocates a string, is only fetched for idle-looking buttons.
+bool IsButtonRunning(FrameworkElement button, std::wstring_view marker) {
+    if (IndicatorSaysRunning(button)) {
+        return true;
+    }
+
+    if (!marker.empty()) {
+        auto name = Automation::AutomationProperties::GetName(button);
+        if (ContainsNoCase(std::wstring_view(name), marker)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+// ------------------------------------------------------------------ diagnostics
+
+void DumpButtonTree(FrameworkElement element, int depth, int indent) {
+    if (!element || depth < 0) {
+        return;
+    }
+
+    EnumChildElements(element, [&](FrameworkElement child) {
+        DebugFileLog(L"%*s%s [%s] vis=%d op=%.2f size=%.1fx%.1f", indent * 2,
+                     L"", winrt::get_class_name(child).c_str(),
+                     child.Name().c_str(), (int)child.Visibility(),
+                     child.Opacity(), child.ActualWidth(),
+                     child.ActualHeight());
+        DumpButtonTree(child, depth - 1, indent + 1);
+        return false;
+    });
+}
+
+// Logs every button's running verdict and the evidence behind it.
+void DumpButtons(std::vector<FrameworkElement> const& buttons,
+                 bool repeaterFound) {
+    DebugFileLog(L"=== dump: repeater=%d buttons=%u ===", (int)repeaterFound,
+                 (unsigned)buttons.size());
+
+    std::wstring marker = CopyRunningMarker();
+    for (auto const& button : buttons) {
+        auto label = Automation::AutomationProperties::GetName(button);
+        auto indicator = FindRunningIndicator(button);
+        if (indicator) {
+            DebugFileLog(
+                L"button '%s': indicator [%s] vis=%d op=%.2f size=%.1fx%.1f -> running=%d",
+                label.c_str(), indicator.Name().c_str(),
+                (int)indicator.Visibility(), indicator.Opacity(),
+                indicator.ActualWidth(), indicator.ActualHeight(),
+                (int)IsButtonRunning(button, marker));
+        } else {
+            DebugFileLog(L"button '%s': no indicator element -> running=%d",
+                         label.c_str(), (int)IsButtonRunning(button, marker));
+        }
+    }
+
+    if (!buttons.empty()) {
+        DebugFileLog(L"=== full tree of first button ===");
+        DumpButtonTree(buttons[0], 4, 1);
+    }
+}
+
+// ------------------------------------------------------------------- applying
+
+// Reports whether the set holds this element, dropping dead entries as it goes,
+// and removes the match when remove is set.
+bool TakeFromHiddenSet(std::vector<winrt::weak_ref<FrameworkElement>>& hidden,
+                       FrameworkElement const& element,
+                       bool remove) {
+    bool found = false;
+
+    for (size_t i = 0; i < hidden.size();) {
+        auto resolved = hidden[i].get();
+        if (!resolved) {
+            hidden.erase(hidden.begin() + i);
+            continue;
+        }
+
+        if (resolved == element) {
+            found = true;
+            if (remove) {
+                hidden.erase(hidden.begin() + i);
+                continue;
+            }
+        }
+
+        i++;
+    }
+
+    return found;
+}
+
+bool CursorOverAnyTaskbar() {
+    POINT pt;
+    if (!GetCursorPos(&pt)) {
+        return false;
+    }
+
+    HWND hWnd = WindowFromPoint(pt);
+    if (!hWnd) {
+        return false;
+    }
+
+    HWND hRoot = GetAncestor(hWnd, GA_ROOT);
+    if (!hRoot) {
+        return false;
+    }
+
+    WCHAR className[64];
+    if (!GetClassName(hRoot, className, ARRAYSIZE(className))) {
+        return false;
+    }
+
+    if (wcscmp(className, L"Shell_TrayWnd") == 0 ||
+        wcscmp(className, L"Shell_SecondaryTrayWnd") == 0) {
+        return true;
+    }
+
+    // Jump lists and thumbnail previews are separate popup windows, but they
+    // live on the taskbar's own UI thread. They count as taskbar, or the grace
+    // period would collapse the bar under a menu the user is navigating.
+    DWORD processId = 0;
+    DWORD threadId = GetWindowThreadProcessId(hRoot, &processId);
+    if (threadId && processId == GetCurrentProcessId()) {
+        std::lock_guard<std::mutex> guard(g_framesMutex);
+        for (auto& [key, ctx] : g_frames) {
+            if (ctx.threadId == threadId) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+// Clears the implicit show/hide animations, which otherwise keep rendering a
+// hidden button's ghost until their farewell animation finishes. They have no
+// getter, so the strip is permanent for the element's lifetime.
+void ClearImplicitShowHide(FrameworkElement const& button) {
+    try {
+        Hosting::ElementCompositionPreview::SetImplicitShowAnimation(button,
+                                                                     nullptr);
+        Hosting::ElementCompositionPreview::SetImplicitHideAnimation(button,
+                                                                     nullptr);
+    } catch (winrt::hresult_error const&) {
+    }
+}
+
+// Clears both animation paths on a button: the XAML transition and the
+// composition implicit animations, keeping the originals for ReanimateButtons.
+void DeanimateButton(FrameContext& ctx, FrameworkElement button) {
+    // Runs every pass. Do not reduce this to strip-once-per-button: Windows
+    // installs a button's animations at its own pace, and one stripped too
+    // early keeps its reorder slide forever. The ledger exists only so
+    // unloading can put the originals back; dead entries are pruned here.
+    DeanimatedButton* known = nullptr;
+    for (size_t i = 0; i < ctx.deanimated.size();) {
+        auto resolved = ctx.deanimated[i].button.get();
+        if (!resolved) {
+            ctx.deanimated.erase(ctx.deanimated.begin() + i);
+            continue;
+        }
+        if (resolved == button) {
+            known = &ctx.deanimated[i];
+        }
+        i++;
+    }
+
+    auto visual = Hosting::ElementCompositionPreview::GetElementVisual(button);
+    auto transitions = button.Transitions();
+    auto implicit_ = visual ? visual.ImplicitAnimations() : nullptr;
+
+    if (!known) {
+        DeanimatedButton entry;
+        entry.button = winrt::make_weak(button);
+        entry.originalTransitions = transitions;
+        entry.originalImplicit = implicit_;
+        ctx.deanimated.push_back(entry);
+
+        if (kDebugLogging) {
+            auto label = Automation::AutomationProperties::GetName(button);
+            DebugFileLog(L"deanimate '%s': transitions=%d implicit=%d",
+                         label.c_str(),
+                         transitions ? (int)transitions.Size() : 0,
+                         implicit_ ? (int)implicit_.Size() : 0);
+        }
+    } else {
+        // Animations that appeared after first sight still belong to Windows;
+        // capture them so unload restores the real originals.
+        if (transitions && !known->originalTransitions) {
+            known->originalTransitions = transitions;
+        }
+        if (implicit_ && !known->originalImplicit) {
+            known->originalImplicit = implicit_;
+        }
+    }
+
+    if (transitions) {
+        button.Transitions(nullptr);
+    }
+    if (visual && implicit_) {
+        visual.ImplicitAnimations(nullptr);
+    }
+    ClearImplicitShowHide(button);
+}
+
+void ReanimateButtons(FrameContext& ctx) {
+    for (auto& entry : ctx.deanimated) {
+        auto button = entry.button.get();
+        if (!button) {
+            continue;
+        }
+
+        button.Transitions(entry.originalTransitions);
+        if (auto visual =
+                Hosting::ElementCompositionPreview::GetElementVisual(button)) {
+            visual.ImplicitAnimations(entry.originalImplicit);
+        }
+    }
+    ctx.deanimated.clear();
+}
+
+// ------------------------------------------------------------------ easing
+
+// One axis of a cubic bezier whose endpoints are fixed at 0 and 1.
+double BezierAxis(double p1, double p2, double u) {
+    double v = 1 - u;
+    return 3 * p1 * v * v * u + 3 * p2 * v * u * u + u * u * u;
+}
+
+// Maps linear progress through a CSS-style cubic-bezier curve.
+double CubicBezierEase(EasingCurve const& curve, double t) {
+    if (t <= 0) {
+        return 0;
+    }
+    if (t >= 1) {
+        return 1;
+    }
+
+    double lo = 0;
+    double hi = 1;
+    for (int i = 0; i < 24; i++) {
+        double mid = (lo + hi) * 0.5;
+        if (BezierAxis(curve.x1, curve.x2, mid) < t) {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+
+    return BezierAxis(curve.y1, curve.y2, (lo + hi) * 0.5);
+}
+
+// ---------------------------------------------------------------- animation
+
+// Spreads totalExtra across the gaps between visible buttons, holding the
+// leftmost one still. Windows re-centres the group itself, so the group is
+// deliberately not shifted to compensate: the correction would dwarf the
+// amplitude and read as the whole row charging across the screen.
+void ApplySpacing(std::vector<FrameworkElement> const& buttons,
+                  double totalExtra) {
+    std::vector<FrameworkElement const*> visible;
+    for (auto const& button : buttons) {
+        if (button.Visibility() == Visibility::Visible) {
+            visible.push_back(&button);
+        } else {
+            button.Translation(float3{0, 0, 0});
+        }
+    }
+
+    int gaps = (int)visible.size() - 1;
+    double perGap = gaps > 0 ? totalExtra / gaps : 0;
+
+    for (int i = 0; i < (int)visible.size(); i++) {
+        visible[i]->Translation(float3{(float)(i * perGap), 0, 0});
+    }
+}
+
+void ClearSpacing(std::vector<FrameworkElement> const& buttons) {
+    for (auto const& button : buttons) {
+        button.Translation(float3{0, 0, 0});
+    }
+}
+
+// Hides or shows the managed buttons, recording only the ones it hid itself.
+// With outHiddenCount set, reports how many buttons this pass hid.
+void SetCollapseState(FrameContext& ctx,
+                      std::vector<FrameworkElement> const& buttons,
+                      bool collapse,
+                      int* outHiddenCount = nullptr) {
+    std::wstring marker = CopyRunningMarker();
+    double idleVisibleWidth = 0;
+
+    for (auto const& button : buttons) {
+        bool weHidIt = TakeFromHiddenSet(ctx.hiddenByUs, button, false);
+        bool running = IsButtonRunning(button, marker);
+        bool shouldHide = collapse && !running;
+
+        // Measured before any visibility flip below, while layout is real.
+        if (!running && button.Visibility() == Visibility::Visible) {
+            idleVisibleWidth += button.ActualWidth();
+        }
+
+        if (shouldHide) {
+            if (weHidIt) {
+                // Re-asserted in case the taskbar re-showed it, or a recorded
+                // hide could stick as visible forever.
+                if (button.Visibility() == Visibility::Visible) {
+                    button.Visibility(Visibility::Collapsed);
+                }
+            } else if (button.Visibility() == Visibility::Visible) {
+                if (outHiddenCount) {
+                    (*outHiddenCount)++;
+                }
+                // Re-stripped at the moment it matters: Windows can have
+                // re-installed the hide animation since first sight, and its
+                // ghost is what neighbours would slide across.
+                ClearImplicitShowHide(button);
+                // Buttons Windows already hid stay unrecorded, so they are
+                // never restored on this mod's behalf.
+                button.Visibility(Visibility::Collapsed);
+                ctx.hiddenByUs.push_back(winrt::make_weak(button));
+            }
+        } else if (weHidIt) {
+            button.Visibility(Visibility::Visible);
+            TakeFromHiddenSet(ctx.hiddenByUs, button, true);
+        }
+    }
+
+    if (idleVisibleWidth > 0.5) {
+        ctx.idleWidth = idleVisibleWidth;
+    }
+
+    ctx.appliedCollapse = collapse ? 1 : 0;
+}
+
+void OnRenderingTick(void* key);
+
+void HookRendering(FrameContext& ctx, void* key) {
+    if (ctx.renderingHooked) {
+        return;
+    }
+    ctx.renderingToken = Media::CompositionTarget::Rendering(
+        [key](IInspectable const&, IInspectable const&) {
+            OnRenderingTick(key);
+        });
+    ctx.renderingHooked = true;
+}
+
+void UnhookRendering(FrameContext& ctx) {
+    if (!ctx.renderingHooked) {
+        return;
+    }
+    Media::CompositionTarget::Rendering(ctx.renderingToken);
+    ctx.renderingHooked = false;
+}
+
+// Tree order is not visual order: the taskbar's repeater recycles elements,
+// so a newly pinned app can land anywhere in the child list. Spacing is dealt
+// out by list index, so the list is sorted by on-screen position; hidden
+// buttons sink to the back and get re-sorted after the swap shows them.
+void SortButtonsByPosition(std::vector<FrameworkElement>& buttons,
+                           FrameworkElement frame) {
+    std::vector<std::pair<double, FrameworkElement>> keyed;
+    keyed.reserve(buttons.size());
+
+    for (auto& button : buttons) {
+        double x = std::numeric_limits<double>::max();
+        if (button.Visibility() == Visibility::Visible) {
+            try {
+                x = button.TransformToVisual(frame)
+                        .TransformPoint(Point{0, 0})
+                        .X;
+            } catch (winrt::hresult_error const&) {
+            }
+        }
+        keyed.emplace_back(x, button);
+    }
+
+    std::stable_sort(keyed.begin(), keyed.end(),
+                     [](auto const& a, auto const& b) {
+                         return a.first < b.first;
+                     });
+
+    for (size_t i = 0; i < buttons.size(); i++) {
+        buttons[i] = keyed[i].second;
+    }
+}
+
+void StopAnimation(FrameContext& ctx) {
+    ctx.animActive = false;
+    ctx.animSwapped = false;
+    UnhookRendering(ctx);
+    ClearSpacing(ctx.animButtons);
+    ctx.animButtons.clear();
+    ctx.animGapOffsets.clear();
+}
+
+void StartAnimation(FrameContext& ctx,
+                    std::vector<FrameworkElement> buttons,
+                    bool targetCollapse) {
+    ctx.animActive = true;
+    ctx.animKind = AnimKind::Accordion;
+    ctx.animTargetCollapse = targetCollapse;
+    ctx.animStartMs = NowMs();
+    ctx.animSwapped = false;
+    ctx.animButtons = std::move(buttons);
+    ctx.animGapOffsets.clear();
+    if (auto frame = ctx.frame.get()) {
+        SortButtonsByPosition(ctx.animButtons, frame);
+    }
+    HookRendering(ctx, ctx.key);
+}
+
+// After hiding icons mid-steady-state, freezes every survivor at its old
+// position, holds the vacated gap open for the first half of the animation,
+// then eases it shut. Offsets are measured, before layout against after, so
+// any taskbar alignment and any number of simultaneous gaps come out right.
+void StartGapCloseAnimation(FrameContext& ctx,
+                            std::vector<FrameworkElement> const& buttons,
+                            FrameworkElement frame) {
+    ctx.animButtons.clear();
+    ctx.animGapOffsets.clear();
+
+    // Layout has not run since the hide, so positions still read pre-gap.
+    std::vector<double> oldX;
+    for (auto const& button : buttons) {
+        if (button.Visibility() != Visibility::Visible) {
+            continue;
+        }
+        try {
+            double x =
+                button.TransformToVisual(frame).TransformPoint(Point{0, 0}).X;
+            ctx.animButtons.push_back(button);
+            oldX.push_back(x);
+        } catch (winrt::hresult_error const&) {
+        }
+    }
+    if (ctx.animButtons.empty()) {
+        return;
+    }
+
+    frame.UpdateLayout();
+
+    bool anyMoved = false;
+    for (size_t i = 0; i < ctx.animButtons.size(); i++) {
+        double offset = 0;
+        try {
+            double newX = ctx.animButtons[i]
+                              .TransformToVisual(frame)
+                              .TransformPoint(Point{0, 0})
+                              .X;
+            offset = oldX[i] - newX;
+        } catch (winrt::hresult_error const&) {
+        }
+        if (offset > 0.5 || offset < -0.5) {
+            anyMoved = true;
+        } else {
+            offset = 0;
+        }
+        ctx.animGapOffsets.push_back((float)offset);
+    }
+    if (!anyMoved) {
+        ctx.animButtons.clear();
+        ctx.animGapOffsets.clear();
+        return;
+    }
+
+    ctx.animActive = true;
+    ctx.animKind = AnimKind::GapClose;
+    // Matches the applied state so the tick keeps its hands off while it runs.
+    ctx.animTargetCollapse = ctx.appliedCollapse == 1;
+    ctx.animStartMs = NowMs();
+    ctx.animSwapped = false;
+    HookRendering(ctx, ctx.key);
+
+    // Applied now so this very frame already shows the held positions.
+    for (size_t i = 0; i < ctx.animButtons.size(); i++) {
+        ctx.animButtons[i].Translation(float3{ctx.animGapOffsets[i], 0, 0});
+    }
+}
+
+// Brings one taskbar in line with the requested collapse state. Never runs
+// while an animation is active; OnTimerTick stops the animation first.
+void ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
+    auto frame = ctx.frame.get();
+    if (!frame) {
+        return;
+    }
+
+    // The buttons' container, remembered from the last successful walk, keeps
+    // the collection off the full-tree search.
+    std::vector<FrameworkElement> buttons;
+    if (auto repeater = ctx.repeater.get()) {
+        CollectTaskListButtons(repeater, 3, buttons);
+    }
+    if (buttons.empty()) {
+        CollectTaskListButtons(frame, 8, buttons);
+        if (!buttons.empty()) {
+            if (auto parent = Media::VisualTreeHelper::GetParent(buttons[0])
+                                  .try_as<FrameworkElement>()) {
+                ctx.repeater = winrt::make_weak(parent);
+            }
+        }
+    }
+
+    if (kDebugLogging && g_debugDumpPending.exchange(false)) {
+        DumpButtons(buttons, (bool)ctx.repeater.get());
+    }
+
+    ctx.lastButtons.clear();
+    for (auto& button : buttons) {
+        ctx.lastButtons.push_back(winrt::make_weak(button));
+    }
+
+    if (buttons.empty()) {
+        return;
+    }
+
+    if (!g_unloading) {
+        for (auto& button : buttons) {
+            DeanimateButton(ctx, button);
+        }
+    }
+
+    bool instant = instantRequested || ctx.appliedCollapse < 0 ||
+                   g_settings.animationMode == AnimationMode::None;
+
+    if (!instant && (collapse ? 1 : 0) != ctx.appliedCollapse) {
+        StartAnimation(ctx, std::move(buttons), collapse);
+        DebugFileLog(L"anim start: target=%d", (int)collapse);
+        return;
+    }
+
+    // Steady-state hides, an app closing while collapsed, close their gap
+    // with the easing instead of snapping.
+    bool animateGaps = !instant && !g_unloading &&
+                       g_settings.animationMode == AnimationMode::Spacing &&
+                       (collapse ? 1 : 0) == ctx.appliedCollapse;
+    int hiddenCount = 0;
+    SetCollapseState(ctx, buttons, collapse,
+                     animateGaps ? &hiddenCount : nullptr);
+    if (hiddenCount > 0) {
+        StartGapCloseAnimation(ctx, buttons, frame);
+        DebugFileLog(L"gap close: %d icons", hiddenCount);
+    }
+
+    if ((int)collapse != ctx.lastLoggedCollapse ||
+        (int)buttons.size() != ctx.lastLoggedButtons ||
+        (int)ctx.hiddenByUs.size() != ctx.lastLoggedHidden) {
+        ctx.lastLoggedCollapse = (int)collapse;
+        ctx.lastLoggedButtons = (int)buttons.size();
+        ctx.lastLoggedHidden = (int)ctx.hiddenByUs.size();
+        DebugFileLog(L"apply: collapse=%d buttons=%d hidden=%d",
+                     ctx.lastLoggedCollapse, ctx.lastLoggedButtons,
+                     ctx.lastLoggedHidden);
+    }
+}
+
+// Drives one frame of the accordion. Spacing is the only thing animated.
+//
+// One easing curve spans the whole duration and the icon swap sits at its
+// midpoint, which is its steepest part. Revealing, the collapsed set stretches
+// open, the full set cuts in squeezed shut, then relaxes to its natural
+// spacing. Collapsing runs that backwards: the full set squeezes shut, the
+// collapsed set cuts in stretched open, then closes to its natural spacing.
+void OnRenderingTick(void* key) {
+    FrameContext* ctx = GetFrameContext(key);
+    if (!ctx || !ctx->animActive) {
+        return;
+    }
+
+    if (g_unloading || ctx->animButtons.empty()) {
+        StopAnimation(*ctx);
+        return;
+    }
+
+    double duration = (double)g_settings.animationDurationMs;
+    double t = duration > 0
+                   ? std::clamp((NowMs() - ctx->animStartMs) / duration, 0.0, 1.0)
+                   : 1.0;
+    double eased = CubicBezierEase(g_settings.animationCurve, t);
+
+    if (ctx->animKind == AnimKind::GapClose) {
+        if (t >= 1.0) {
+            StopAnimation(*ctx);
+            return;
+        }
+        // First half holds the gap open, so Windows' own icon-close flourish
+        // plays out in empty space; second half eases it shut.
+        double closeT = t <= 0.5 ? 0.0 : (t - 0.5) * 2.0;
+        double factor =
+            1.0 - CubicBezierEase(g_settings.animationCurve, closeT);
+        for (size_t i = 0; i < ctx->animButtons.size(); i++) {
+            ctx->animButtons[i].Translation(
+                float3{(float)(ctx->animGapOffsets[i] * factor), 0, 0});
+        }
+        return;
+    }
+
+    if (t >= 0.5 && !ctx->animSwapped) {
+        SetCollapseState(*ctx, ctx->animButtons, ctx->animTargetCollapse);
+        // The visibility flip can prompt Windows to install animations while
+        // the reconcile tick is paused, so strip again right here.
+        for (auto& button : ctx->animButtons) {
+            DeanimateButton(*ctx, button);
+        }
+        // Forcing layout gives the new visible set real positions now, so the
+        // re-sort and this frame's offsets land in true left-to-right order,
+        // and a reveal's just-shown icons get their widths into the cache.
+        if (auto frame = ctx->frame.get()) {
+            frame.UpdateLayout();
+            SortButtonsByPosition(ctx->animButtons, frame);
+            if (!ctx->animTargetCollapse) {
+                std::wstring marker = CopyRunningMarker();
+                double width = 0;
+                for (auto& button : ctx->animButtons) {
+                    if (button.Visibility() == Visibility::Visible &&
+                        !IsButtonRunning(button, marker)) {
+                        width += button.ActualWidth();
+                    }
+                }
+                if (width > 0.5) {
+                    ctx->idleWidth = width;
+                }
+            }
+        }
+        ctx->animSwapped = true;
+    }
+
+    // Amplitude scales with the width the hidden icons actually occupy, so the
+    // animation adapts to how many icons are pinned. idleWidth only changes at
+    // the swap, so each half of the accordion stays internally consistent.
+    double amplitude =
+        ctx->idleWidth * (double)g_settings.animationAmplitudePct / 100.0;
+
+    if (t >= 1.0) {
+        StopAnimation(*ctx);
+        return;
+    }
+
+    // Collapsing is the reveal played backwards, so every offset flips sign.
+    double direction = ctx->animTargetCollapse ? -1.0 : 1.0;
+    double totalExtra = ctx->animSwapped
+                            ? -direction * amplitude * (1 - eased)
+                            : direction * amplitude * eased;
+
+    ApplySpacing(ctx->animButtons, totalExtra);
+}
+
+// Puts one taskbar back exactly as it was found.
+void RestoreFrame(FrameContext& ctx) {
+    StopAnimation(ctx);
+
+    for (auto& weak : ctx.lastButtons) {
+        if (auto button = weak.get()) {
+            button.Translation(float3{0, 0, 0});
+        }
+    }
+
+    for (auto& weak : ctx.hiddenByUs) {
+        if (auto button = weak.get()) {
+            button.Visibility(Visibility::Visible);
+        }
+    }
+    ctx.hiddenByUs.clear();
+    ReanimateButtons(ctx);
+}
+
+// Drives one taskbar: ages out the hover reveal, then applies the result.
+void OnTimerTick(void* key) {
+    FrameContext* ctx = nullptr;
+    {
+        std::lock_guard<std::mutex> guard(g_framesMutex);
+        auto it = g_frames.find(key);
+        if (it == g_frames.end()) {
+            return;
+        }
+        ctx = &it->second;
+    }
+
+    if (!ctx->frame.get()) {
+        // The rendering hook must go too, or its handler outlives the entry,
+        // forces a render every vsync, and dangles after the mod unloads.
+        StopAnimation(*ctx);
+        std::lock_guard<std::mutex> guard(g_framesMutex);
+        if (ctx->timer) {
+            ctx->timer.Stop();
+            ctx->timer.Tick(ctx->tickToken);
+        }
+        g_frames.erase(key);
+        return;
+    }
+
+    if (g_unloading) {
+        RestoreFrame(*ctx);
+        return;
+    }
+
+    ULONGLONG now = GetTickCount64();
+
+    // Anything mid-interaction pins the fast rate; only a settled, untouched
+    // taskbar sleeps. Waking is handled by the pointer hook, not here.
+    bool sleep = g_settings.sleepEnabled && !g_revealed && !ctx->animActive &&
+                 g_emptyHoverSinceTick == 0 &&
+                 now - g_lastActivityTick >= kSleepAfterMs;
+    g_sleeping = sleep;
+
+    int wantedIntervalMs =
+        sleep ? g_settings.sleepIntervalMs : g_settings.refreshIntervalMs;
+    if (ctx->intervalMs != wantedIntervalMs) {
+        ctx->intervalMs = wantedIntervalMs;
+        ctx->timer.Interval(std::chrono::milliseconds(wantedIntervalMs));
+        DebugFileLog(L"tick interval -> %d ms", wantedIntervalMs);
+    }
+    RevealTrigger trigger = g_settings.revealTrigger;
+    bool hoverLike =
+        trigger == RevealTrigger::Hover || trigger == RevealTrigger::Rest;
+
+    // Cursor speed from screen-space deltas between ticks. The dt guard keeps
+    // a second taskbar's tick in the same instant from producing garbage.
+    if (trigger == RevealTrigger::Rest) {
+        POINT pt;
+        if (GetCursorPos(&pt)) {
+            double nowMs = NowMs();
+            double dt = nowMs - g_speedSamplePrevMs;
+            if (g_speedSamplePrevMs > 0 && dt >= 5.0) {
+                double dx = (double)(pt.x - g_speedSamplePrevPos.x);
+                double dy = (double)(pt.y - g_speedSamplePrevPos.y);
+                g_cursorSpeedPxS = sqrt(dx * dx + dy * dy) * 1000.0 / dt;
+            }
+            if (dt >= 5.0 || g_speedSamplePrevMs == 0) {
+                g_speedSamplePrevMs = nowMs;
+                g_speedSamplePrevPos = pt;
+            }
+        }
+    }
+
+    if (g_revealed) {
+        if (!g_collapseEnabled ||
+            (trigger == RevealTrigger::Never && !g_revealedByStart)) {
+            g_revealed = false;
+            g_revealedByStart = false;
+            g_emptyHoverSinceTick = 0;
+        } else if (g_revealedByStart) {
+            // Pinned while Start is open; the worker thread ends it on close.
+            // Keeping the grace timestamp fresh hands over cleanly if the
+            // cursor is on the taskbar when Start goes away.
+            g_lastCursorInsideTick = now;
+        } else if (hoverLike) {
+            // A click reveal stays until it is clicked away, so only hovering
+            // ages out on the grace period.
+            if (CursorOverAnyTaskbar()) {
+                g_lastCursorInsideTick = now;
+            } else if (now - g_lastCursorInsideTick >
+                       (ULONGLONG)g_settings.hoverGraceMs) {
+                g_revealed = false;
+                g_emptyHoverSinceTick = 0;
+            }
+        }
+    } else if (hoverLike && g_collapseEnabled) {
+        if (trigger == RevealTrigger::Rest) {
+            if (g_cursorSpeedPxS > (double)g_settings.restSpeedPxPerSec) {
+                // Moving too fast resets the dwell; resting time is continuous.
+                g_emptyHoverSinceTick = 0;
+            } else if (g_emptyHoverSinceTick == 0 && g_lastPointerQualified &&
+                       CursorOverAnyTaskbar()) {
+                // A parked cursor produces no pointer events, so the dwell is
+                // armed here, trusting the last event's position check.
+                g_emptyHoverSinceTick = now;
+            }
+        }
+
+        // Completes a reveal for a cursor that has stopped moving and so no
+        // longer produces the pointer events that would finish the delay.
+        ULONGLONG since = g_emptyHoverSinceTick;
+        if (since != 0) {
+            if (!CursorOverAnyTaskbar()) {
+                g_emptyHoverSinceTick = 0;
+            } else if (now - since >= (ULONGLONG)g_settings.revealDelayMs) {
+                g_revealed = true;
+                g_emptyHoverSinceTick = 0;
+            }
+        }
+    }
+
+    bool desired = g_collapseEnabled && !g_revealed;
+
+    // Consumes at most one pending instant-apply request.
+    uint64_t instantGen = g_instantApplyGen;
+    bool instant = ctx->instantGenSeen != instantGen;
+    ctx->instantGenSeen = instantGen;
+
+    // While the accordion runs toward the right state, leave it alone: the
+    // rendering callback owns the buttons, and reconciliation here would fight
+    // it for them. A flipped target or an instant request stops it first.
+    if (ctx->animActive) {
+        if (!instant && desired == ctx->animTargetCollapse) {
+            return;
+        }
+        StopAnimation(*ctx);
+    }
+
+    if (!kDebugLogging) {
+        ApplyToFrame(*ctx, desired, instant);
+        return;
+    }
+
+    double beforeMs = NowMs();
+    ApplyToFrame(*ctx, desired, instant);
+    double microseconds = (NowMs() - beforeMs) * 1000.0;
+
+    ctx->applySamples++;
+    ctx->applyTotalUs += microseconds;
+    ctx->applyWorstUs = std::max(ctx->applyWorstUs, microseconds);
+
+    if (ctx->applySamples >= 100) {
+        DebugFileLog(L"cost: %d ticks, avg %.0f us, worst %.0f us, %.2f%% of a "
+                     L"16.7 ms frame",
+                     ctx->applySamples, ctx->applyTotalUs / ctx->applySamples,
+                     ctx->applyWorstUs,
+                     ctx->applyTotalUs / ctx->applySamples / 16700.0 * 100.0);
+        ctx->applySamples = 0;
+        ctx->applyTotalUs = 0;
+        ctx->applyWorstUs = 0;
+    }
+}
+
+// Adopts a taskbar and starts its timer; runs on that taskbar's UI thread.
+void RegisterFrame(void* key, FrameworkElement frame) {
+    std::lock_guard<std::mutex> guard(g_framesMutex);
+
+    auto it = g_frames.find(key);
+    if (it != g_frames.end()) {
+        if (it->second.frame.get()) {
+            return;
+        }
+        StopAnimation(it->second);
+        if (it->second.timer) {
+            it->second.timer.Stop();
+            it->second.timer.Tick(it->second.tickToken);
+        }
+        g_frames.erase(it);
+    }
+
+    FrameContext ctx;
+    ctx.key = key;
+    ctx.instantGenSeen = g_instantApplyGen;
+    ctx.frame = winrt::make_weak(frame);
+    ctx.dispatcher = frame.Dispatcher();
+    ctx.threadId = GetCurrentThreadId();
+    ctx.intervalMs = g_settings.refreshIntervalMs;
+
+    ctx.timer = DispatcherTimer();
+    ctx.timer.Interval(std::chrono::milliseconds(ctx.intervalMs));
+    ctx.tickToken = ctx.timer.Tick(
+        [key](IInspectable const&, IInspectable const&) { OnTimerTick(key); });
+    ctx.timer.Start();
+
+    g_frames[key] = ctx;
+    g_debugDumpPending = kDebugLogging;
+
+    DebugFileLog(L"registered taskbar frame %p on thread %u", key,
+                 ctx.threadId);
+}
+
+bool IsFrameRegistered(void* key) {
+    std::lock_guard<std::mutex> guard(g_framesMutex);
+    return g_frames.find(key) != g_frames.end();
+}
+
+// Map entries keep a stable address and each context belongs to a single UI
+// thread, so the returned pointer stays valid after the lock is released.
+FrameContext* GetFrameContext(void* key) {
+    std::lock_guard<std::mutex> guard(g_framesMutex);
+    auto it = g_frames.find(key);
+    return it == g_frames.end() ? nullptr : &it->second;
+}
+
+// Applies to the taskbars owned by the calling thread, skipping the tick's wait.
+void ApplyOnThisThreadNow() {
+    std::vector<void*> keys;
+    DWORD threadId = GetCurrentThreadId();
+    {
+        std::lock_guard<std::mutex> guard(g_framesMutex);
+        for (auto& [key, ctx] : g_frames) {
+            if (ctx.threadId == threadId) {
+                keys.push_back(key);
+            }
+        }
+    }
+
+    for (void* key : keys) {
+        OnTimerTick(key);
+    }
+}
+
+// Queues a wake on every taskbar's own UI thread. Non-blocking, so it is safe
+// from the worker thread; a hung taskbar just processes it late.
+void WakeAllFramesAsync() {
+    std::vector<winrt::Windows::UI::Core::CoreDispatcher> dispatchers;
+    {
+        std::lock_guard<std::mutex> guard(g_framesMutex);
+        for (auto& [key, ctx] : g_frames) {
+            if (ctx.dispatcher) {
+                dispatchers.push_back(ctx.dispatcher);
+            }
+        }
+    }
+
+    for (auto& dispatcher : dispatchers) {
+        try {
+            dispatcher.RunAsync(
+                winrt::Windows::UI::Core::CoreDispatcherPriority::Normal,
+                []() {
+                    if (!g_unloading) {
+                        ApplyOnThisThreadNow();
+                    }
+                });
+        } catch (winrt::hresult_error const&) {
+        }
+    }
+}
+
+// --------------------------------------------------------------------- hover
+
+// True when nothing button-like sits between the hit-tested element and the frame.
+bool IsPointerOverEmptySpace(Input::PointerRoutedEventArgs const& args) {
+    auto source = args.OriginalSource().try_as<DependencyObject>();
+
+    for (int i = 0; source && i < 16; i++) {
+        if (auto element = source.try_as<FrameworkElement>()) {
+            auto classNameHstring = winrt::get_class_name(element);
+            std::wstring_view className(classNameHstring);
+            if (className == L"Taskbar.TaskbarFrame") {
+                break;
+            }
+            if (className.find(L"Button") != std::wstring_view::npos ||
+                className.find(L"SystemTray") != std::wstring_view::npos) {
+                return false;
+            }
+        }
+        source = Media::VisualTreeHelper::GetParent(source);
+    }
+
+    return true;
+}
+
+// True when the point clears every visible button by padding, in frame coordinates.
+bool IsPointerClearOfButtons(FrameContext& ctx,
+                             FrameworkElement frame,
+                             Point point,
+                             double padding) {
+    for (auto& weak : ctx.lastButtons) {
+        auto button = weak.get();
+        if (!button || button.Visibility() != Visibility::Visible) {
+            continue;
+        }
+
+        double width = button.ActualWidth();
+        double height = button.ActualHeight();
+        if (width <= 0.5 || height <= 0.5) {
+            continue;
+        }
+
+        Point origin{0, 0};
+        try {
+            origin = button.TransformToVisual(frame).TransformPoint(origin);
+        } catch (winrt::hresult_error const&) {
+            continue;
+        }
+
+        if (point.X >= origin.X - padding &&
+            point.X <= origin.X + width + padding &&
+            point.Y >= origin.Y - padding &&
+            point.Y <= origin.Y + height + padding) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// Hit-tests the point and its padded neighbours from the bar's root, so Start,
+// widgets, and the tray, a sibling of the task-area frame, get the same
+// clearance as task icons without knowing their shapes.
+bool ProbeStripIsClear(FrameworkElement frame, Point framePt, double padding) {
+    Point hostPt = framePt;
+    FrameworkElement root = frame;
+    try {
+        hostPt = frame.TransformToVisual(nullptr).TransformPoint(framePt);
+        for (auto parent = frame; parent;) {
+            parent = Media::VisualTreeHelper::GetParent(parent)
+                         .try_as<FrameworkElement>();
+            if (parent) {
+                root = parent;
+            }
+        }
+    } catch (winrt::hresult_error const&) {
+        return true;
+    }
+
+    double offsets[3] = {-padding, 0, padding};
+    for (double dx : offsets) {
+        Point probe{(float)(hostPt.X + dx), hostPt.Y};
+        try {
+            auto hits = Media::VisualTreeHelper::FindElementsInHostCoordinates(
+                probe, root);
+            for (auto const& hit : hits) {
+                auto element = hit.try_as<FrameworkElement>();
+                if (!element) {
+                    continue;
+                }
+                auto classNameHstring = winrt::get_class_name(element);
+                std::wstring_view className(classNameHstring);
+                if (className.find(L"Button") != std::wstring_view::npos ||
+                    className.find(L"SystemTray") != std::wstring_view::npos ||
+                    className.find(L"TaskItemThumbnail") !=
+                        std::wstring_view::npos) {
+                    return false;
+                }
+            }
+        } catch (winrt::hresult_error const&) {
+        }
+    }
+
+    return true;
+}
+
+// True when this pointer position is somewhere a reveal may start from.
+bool PointerQualifiesForReveal(void* key,
+                               Input::PointerRoutedEventArgs const& args) {
+    if (!IsPointerOverEmptySpace(args)) {
+        return false;
+    }
+
+    if (g_settings.elementPaddingPx <= 0) {
+        return true;
+    }
+
+    FrameContext* ctx = GetFrameContext(key);
+    FrameworkElement frame = ctx ? ctx->frame.get() : nullptr;
+    if (!ctx || !frame) {
+        return true;
+    }
+
+    Point framePt = args.GetCurrentPoint(frame).Position();
+    if (!IsPointerClearOfButtons(*ctx, frame, framePt,
+                                 g_settings.elementPaddingPx)) {
+        return false;
+    }
+
+    // Catches bar content living on a separate surface, which no visual-tree
+    // probe can reach: a different window within the padding is a seam, not
+    // empty space.
+    POINT screenPt;
+    if (GetCursorPos(&screenPt)) {
+        HWND hAt = WindowFromPoint(screenPt);
+        POINT leftPt{screenPt.x - g_settings.elementPaddingPx, screenPt.y};
+        POINT rightPt{screenPt.x + g_settings.elementPaddingPx, screenPt.y};
+        if (hAt &&
+            (WindowFromPoint(leftPt) != hAt || WindowFromPoint(rightPt) != hAt)) {
+            return false;
+        }
+    }
+
+    return ProbeStripIsClear(frame, framePt, g_settings.elementPaddingPx);
+}
+
+// The frame's identity across hooks. The hooks see different interface
+// pointers for the same TaskbarFrame object, and keying on them raw would
+// register the same taskbar twice — two timers and two animation drivers
+// fighting over the same buttons. QI to one shared interface canonicalizes.
+void* FrameKeyFromThis(void* pThis, FrameworkElement* elementOut) {
+    FrameworkElement element = nullptr;
+    ((IUnknown*)pThis)
+        ->QueryInterface(winrt::guid_of<FrameworkElement>(),
+                         winrt::put_abi(element));
+    if (!element) {
+        return nullptr;
+    }
+
+    void* key = winrt::get_abi(element);
+    *elementOut = std::move(element);
+    return key;
+}
+
+using TaskbarFrame_OnPointerMoved_t = int(WINAPI*)(void* pThis, void* pArgs);
+TaskbarFrame_OnPointerMoved_t TaskbarFrame_OnPointerMoved_Original;
+int WINAPI TaskbarFrame_OnPointerMoved_Hook(void* pThis, void* pArgs) {
+    int ret = TaskbarFrame_OnPointerMoved_Original(pThis, pArgs);
+
+    if (g_unloading) {
+        return ret;
+    }
+
+    FrameworkElement element = nullptr;
+    void* key = FrameKeyFromThis(pThis, &element);
+    if (!key) {
+        return ret;
+    }
+
+    if (!IsFrameRegistered(key)) {
+        if (winrt::get_class_name(element) != L"Taskbar.TaskbarFrame") {
+            return ret;
+        }
+        RegisterFrame(key, element);
+    }
+
+    ULONGLONG pointerNow = GetTickCount64();
+    g_lastCursorInsideTick = pointerNow;
+    g_lastActivityTick = pointerNow;
+
+    // First touch of a sleeping taskbar restores the fast tick immediately,
+    // before any reveal logic can depend on its cadence.
+    if (g_sleeping.exchange(false)) {
+        ApplyOnThisThreadNow();
+    }
+
+    RevealTrigger trigger = g_settings.revealTrigger;
+    if ((trigger != RevealTrigger::Hover && trigger != RevealTrigger::Rest) ||
+        !g_collapseEnabled || g_revealed) {
+        return ret;
+    }
+
+    Input::PointerRoutedEventArgs args = nullptr;
+    ((IUnknown*)pArgs)
+        ->QueryInterface(winrt::guid_of<Input::PointerRoutedEventArgs>(),
+                         winrt::put_abi(args));
+    if (!args) {
+        return ret;
+    }
+
+    if (!PointerQualifiesForReveal(key, args)) {
+        g_lastPointerQualified = false;
+        g_emptyHoverSinceTick = 0;
+        return ret;
+    }
+    g_lastPointerQualified = true;
+
+    if (trigger == RevealTrigger::Rest &&
+        g_cursorSpeedPxS > (double)g_settings.restSpeedPxPerSec) {
+        g_emptyHoverSinceTick = 0;
+        return ret;
+    }
+
+    ULONGLONG now = GetTickCount64();
+    ULONGLONG since = g_emptyHoverSinceTick;
+    if (since == 0) {
+        g_emptyHoverSinceTick = now;
+        since = now;
+    }
+    if (now - since < (ULONGLONG)g_settings.revealDelayMs) {
+        return ret;
+    }
+
+    g_revealed = true;
+    g_emptyHoverSinceTick = 0;
+    ApplyOnThisThreadNow();
+
+    return ret;
+}
+
+// Leaving the frame ends any pending qualification, so resting on the tray or
+// beyond it cannot inherit one from the last touch of bare taskbar.
+using TaskbarFrame_OnPointerExited_t = int(WINAPI*)(void* pThis, void* pArgs);
+TaskbarFrame_OnPointerExited_t TaskbarFrame_OnPointerExited_Original;
+int WINAPI TaskbarFrame_OnPointerExited_Hook(void* pThis, void* pArgs) {
+    int ret = TaskbarFrame_OnPointerExited_Original(pThis, pArgs);
+
+    if (!g_unloading) {
+        g_lastPointerQualified = false;
+        g_emptyHoverSinceTick = 0;
+    }
+
+    return ret;
+}
+
+// Toggles the reveal on a click landing on bare taskbar. Released rather than
+// pressed, so dragging off the taskbar and letting go does not count.
+using TaskbarFrame_OnPointerReleased_t = int(WINAPI*)(void* pThis, void* pArgs);
+TaskbarFrame_OnPointerReleased_t TaskbarFrame_OnPointerReleased_Original;
+int WINAPI TaskbarFrame_OnPointerReleased_Hook(void* pThis, void* pArgs) {
+    int ret = TaskbarFrame_OnPointerReleased_Original(pThis, pArgs);
+
+    if (g_unloading || g_settings.revealTrigger != RevealTrigger::Click ||
+        !g_collapseEnabled) {
+        return ret;
+    }
+
+    FrameworkElement element = nullptr;
+    void* key = FrameKeyFromThis(pThis, &element);
+    if (!key || !IsFrameRegistered(key)) {
+        return ret;
+    }
+
+    Input::PointerRoutedEventArgs args = nullptr;
+    ((IUnknown*)pArgs)
+        ->QueryInterface(winrt::guid_of<Input::PointerRoutedEventArgs>(),
+                         winrt::put_abi(args));
+    if (!args) {
+        return ret;
+    }
+
+    // Left button only: right-click belongs to the taskbar's context menu.
+    if (args.GetCurrentPoint(nullptr).Properties().PointerUpdateKind() !=
+        winrt::Windows::UI::Input::PointerUpdateKind::LeftButtonReleased) {
+        return ret;
+    }
+
+    if (!PointerQualifiesForReveal(key, args)) {
+        return ret;
+    }
+
+    g_revealed = !g_revealed;
+    g_emptyHoverSinceTick = 0;
+    DebugFileLog(L"empty-area click toggled reveal to %d", (int)g_revealed);
+    ApplyOnThisThreadNow();
+
+    return ret;
+}
+
+// Second discovery path, for taskbars the cursor has not visited yet.
+using TaskbarFrame_MeasureOverride_t =
+    int(WINAPI*)(void* pThis,
+                 winrt::Windows::Foundation::Size size,
+                 winrt::Windows::Foundation::Size* resultSize);
+TaskbarFrame_MeasureOverride_t TaskbarFrame_MeasureOverride_Original;
+int WINAPI TaskbarFrame_MeasureOverride_Hook(
+    void* pThis,
+    winrt::Windows::Foundation::Size size,
+    winrt::Windows::Foundation::Size* resultSize) {
+    int ret = TaskbarFrame_MeasureOverride_Original(pThis, size, resultSize);
+
+    if (g_unloading) {
+        return ret;
+    }
+
+    // Taskbar layout changes when apps open, close, or badges update — all
+    // activity, so a sleeping mod notices churn within one slow tick.
+    g_lastActivityTick = GetTickCount64();
+
+    FrameworkElement element = nullptr;
+    void* key = FrameKeyFromThis(pThis, &element);
+    if (!key || IsFrameRegistered(key)) {
+        return ret;
+    }
+
+    if (winrt::get_class_name(element) == L"Taskbar.TaskbarFrame") {
+        RegisterFrame(key, element);
+    }
+
+    return ret;
+}
+
+// -------------------------------------------------------------------- hotkey
+
+// Parses "Ctrl+Alt+T" into RegisterHotKey arguments; false if there is no key.
+bool ParseHotkey(std::wstring spec, UINT* modifiers, UINT* vk) {
+    *modifiers = 0;
+    *vk = 0;
+
+    size_t pos = 0;
+    while (pos <= spec.size()) {
+        size_t plus = spec.find(L'+', pos);
+        std::wstring token = spec.substr(
+            pos, plus == std::wstring::npos ? std::wstring::npos : plus - pos);
+
+        size_t first = token.find_first_not_of(L" \t");
+        size_t last = token.find_last_not_of(L" \t");
+        token = (first == std::wstring::npos)
+                    ? L""
+                    : token.substr(first, last - first + 1);
+        for (auto& c : token) {
+            c = towlower(c);
+        }
+
+        if (!token.empty()) {
+            if (token == L"ctrl" || token == L"control") {
+                *modifiers |= MOD_CONTROL;
+            } else if (token == L"alt") {
+                *modifiers |= MOD_ALT;
+            } else if (token == L"shift") {
+                *modifiers |= MOD_SHIFT;
+            } else if (token == L"win") {
+                *modifiers |= MOD_WIN;
+            } else if (token == L"space") {
+                *vk = VK_SPACE;
+            } else if (token.size() == 1 &&
+                       ((token[0] >= L'a' && token[0] <= L'z') ||
+                        (token[0] >= L'0' && token[0] <= L'9'))) {
+                *vk = towupper(token[0]);
+            } else if (token[0] == L'f' && token.size() >= 2 &&
+                       token.size() <= 3) {
+                int n = _wtoi(token.c_str() + 1);
+                if (n >= 1 && n <= 24) {
+                    *vk = VK_F1 + n - 1;
+                }
+            } else {
+                return false;
+            }
+        }
+
+        if (plus == std::wstring::npos) {
+            break;
+        }
+        pos = plus + 1;
+    }
+
+    return *vk != 0;
+}
+
+// Flips state and queues non-blocking wakes; never waits on a taskbar thread,
+// or unloading the mod could strand the worker against a hung message queue.
+void ToggleCollapse() {
+    bool enabled = !g_collapseEnabled.load();
+    g_collapseEnabled = enabled;
+    g_revealed = false;
+    g_revealedByStart = false;
+    g_emptyHoverSinceTick = 0;
+    g_lastActivityTick = GetTickCount64();
+    g_instantApplyGen++;
+    DebugFileLog(L"hotkey toggled collapse to %d", (int)enabled);
+    WakeAllFramesAsync();
+}
+
+void OnStartMenuVisibility(bool visible) {
+    if (g_unloading || !g_settings.revealOnStart || !g_collapseEnabled) {
+        return;
+    }
+
+    if (visible) {
+        if (!g_revealed.exchange(true)) {
+            g_revealedByStart = true;
+            g_lastActivityTick = GetTickCount64();
+            DebugFileLog(L"start menu opened -> reveal");
+            WakeAllFramesAsync();
+        }
+        return;
+    }
+
+    if (g_revealedByStart.exchange(false)) {
+        // With the cursor on the taskbar the reveal is handed to the normal
+        // grace rules instead of collapsing under a click in progress.
+        if (CursorOverAnyTaskbar()) {
+            g_lastCursorInsideTick = GetTickCount64();
+        } else {
+            g_revealed = false;
+        }
+        g_lastActivityTick = GetTickCount64();
+        DebugFileLog(L"start menu closed");
+        WakeAllFramesAsync();
+    }
+}
+
+// Shell-provided notification for the Start menu opening and closing; the
+// callbacks arrive on COM worker threads and touch only thread-safe state.
+class StartVisibilitySink final : public IAppVisibilityEvents {
+   public:
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid,
+                                             void** ppvObject) override {
+        if (riid == __uuidof(IUnknown) || riid == __uuidof(IAppVisibilityEvents)) {
+            *ppvObject = static_cast<IAppVisibilityEvents*>(this);
+            AddRef();
+            return S_OK;
+        }
+        *ppvObject = nullptr;
+        return E_NOINTERFACE;
+    }
+
+    ULONG STDMETHODCALLTYPE AddRef() override {
+        return (ULONG)InterlockedIncrement(&m_refCount);
+    }
+
+    ULONG STDMETHODCALLTYPE Release() override {
+        ULONG remaining = (ULONG)InterlockedDecrement(&m_refCount);
+        if (remaining == 0) {
+            delete this;
+        }
+        return remaining;
+    }
+
+    HRESULT STDMETHODCALLTYPE
+    AppVisibilityOnMonitorChanged(HMONITOR,
+                                  MONITOR_APP_VISIBILITY,
+                                  MONITOR_APP_VISIBILITY) override {
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE
+    LauncherVisibilityChange(BOOL currentVisibleState) override {
+        OnStartMenuVisibility(currentVisibleState != FALSE);
+        return S_OK;
+    }
+
+   private:
+    LONG m_refCount = 1;
+};
+
+// Owns the hotkey registration and the Start-menu watcher; WM_QUIT ends it.
+DWORD WINAPI HotkeyThreadProc(LPVOID param) {
+    winrt::init_apartment(winrt::apartment_type::multi_threaded);
+
+    ULONG_PTR packed = (ULONG_PTR)param;
+    UINT modifiers = (UINT)(packed >> 16);
+    UINT vk = (UINT)(packed & 0xFFFF);
+
+    bool hotkeyRegistered =
+        vk != 0 && RegisterHotKey(nullptr, 1, modifiers | MOD_NOREPEAT, vk);
+    if (vk != 0 && !hotkeyRegistered) {
+        Wh_Log(L"RegisterHotKey failed, error %u", GetLastError());
+    }
+
+    winrt::com_ptr<IAppVisibility> appVisibility;
+    DWORD adviseCookie = 0;
+    StartVisibilitySink* sink = nullptr;
+    if (SUCCEEDED(CoCreateInstance(__uuidof(AppVisibility), nullptr,
+                                   CLSCTX_ALL,
+                                   IID_PPV_ARGS(appVisibility.put())))) {
+        sink = new StartVisibilitySink();
+        if (FAILED(appVisibility->Advise(sink, &adviseCookie))) {
+            adviseCookie = 0;
+            Wh_Log(L"IAppVisibility::Advise failed");
+        }
+    } else {
+        Wh_Log(L"AppVisibility unavailable, start menu reveal inactive");
+    }
+
+    MSG msg;
+    while (GetMessage(&msg, nullptr, 0, 0) > 0) {
+        if (msg.message == WM_HOTKEY && msg.wParam == 1) {
+            ToggleCollapse();
+        }
+    }
+
+    if (appVisibility && adviseCookie) {
+        appVisibility->Unadvise(adviseCookie);
+    }
+    if (sink) {
+        sink->Release();
+    }
+    appVisibility = nullptr;
+    if (hotkeyRegistered) {
+        UnregisterHotKey(nullptr, 1);
+    }
+
+    winrt::uninit_apartment();
+    return 0;
+}
+
+void StartHotkeyThread() {
+    PCWSTR spec = Wh_GetStringSetting(L"Hotkey");
+    UINT modifiers = 0;
+    UINT vk = 0;
+    bool valid = spec && ParseHotkey(spec, &modifiers, &vk);
+    if (spec) {
+        Wh_FreeStringSetting(spec);
+    }
+
+    if (!valid) {
+        modifiers = 0;
+        vk = 0;
+    }
+    if (!valid && !g_settings.revealOnStart) {
+        return;
+    }
+
+    ULONG_PTR packed = ((ULONG_PTR)modifiers << 16) | vk;
+    g_hotkeyThread = CreateThread(nullptr, 0, HotkeyThreadProc, (LPVOID)packed,
+                                  0, &g_hotkeyThreadId);
+}
+
+void StopHotkeyThread() {
+    if (!g_hotkeyThread) {
+        return;
+    }
+
+    PostThreadMessage(g_hotkeyThreadId, WM_QUIT, 0, 0);
+    WaitForSingleObject(g_hotkeyThread, 2000);
+    CloseHandle(g_hotkeyThread);
+    g_hotkeyThread = nullptr;
+    g_hotkeyThreadId = 0;
+}
+
+// ------------------------------------------------------- taskbar UI threads
+
+// Runs proc on the thread owning hWnd and waits for it to finish.
+bool RunFromWindowThread(HWND hWnd,
+                         RunFromWindowThreadProc_t proc,
+                         PVOID procParam) {
+    static const UINT runFromWindowThreadRegisteredMsg =
+        RegisterWindowMessage(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
+
+    struct RUN_FROM_WINDOW_THREAD_PARAM {
+        RunFromWindowThreadProc_t proc;
+        PVOID procParam;
+    };
+
+    DWORD dwThreadId = GetWindowThreadProcessId(hWnd, nullptr);
+    if (dwThreadId == 0) {
+        return false;
+    }
+
+    if (dwThreadId == GetCurrentThreadId()) {
+        proc(procParam);
+        return true;
+    }
+
+    HHOOK hook = SetWindowsHookEx(
+        WH_CALLWNDPROC,
+        [](int nCode, WPARAM wParam, LPARAM lParam) -> LRESULT {
+            if (nCode == HC_ACTION) {
+                const CWPSTRUCT* cwp = (const CWPSTRUCT*)lParam;
+                if (cwp->message == runFromWindowThreadRegisteredMsg) {
+                    RUN_FROM_WINDOW_THREAD_PARAM* param =
+                        (RUN_FROM_WINDOW_THREAD_PARAM*)cwp->lParam;
+                    param->proc(param->procParam);
+                }
+            }
+            return CallNextHookEx(nullptr, nCode, wParam, lParam);
+        },
+        nullptr, dwThreadId);
+    if (!hook) {
+        return false;
+    }
+
+    RUN_FROM_WINDOW_THREAD_PARAM param;
+    param.proc = proc;
+    param.procParam = procParam;
+    SendMessage(hWnd, runFromWindowThreadRegisteredMsg, 0, (LPARAM)&param);
+
+    UnhookWindowsHookEx(hook);
+    return true;
+}
+
+// Runs proc once per taskbar UI thread. Do not call while holding
+// g_framesMutex: it blocks until each target thread has run proc.
+void RunOnAllTaskbarThreads(RunFromWindowThreadProc_t proc, PVOID param) {
+    std::vector<HWND> windows;
+    std::vector<DWORD> threadIds;
+
+    auto consider = [&](HWND hWnd) {
+        DWORD processId = 0;
+        DWORD threadId = GetWindowThreadProcessId(hWnd, &processId);
+        if (!threadId || processId != GetCurrentProcessId()) {
+            return;
+        }
+        for (DWORD seen : threadIds) {
+            if (seen == threadId) {
+                return;
+            }
+        }
+        threadIds.push_back(threadId);
+        windows.push_back(hWnd);
+    };
+
+    if (HWND hWnd = FindWindow(L"Shell_TrayWnd", nullptr)) {
+        consider(hWnd);
+    }
+    HWND hSecondary = nullptr;
+    while ((hSecondary = FindWindowEx(nullptr, hSecondary,
+                                      L"Shell_SecondaryTrayWnd", nullptr))) {
+        consider(hSecondary);
+    }
+
+    for (HWND hWnd : windows) {
+        RunFromWindowThread(hWnd, proc, param);
+    }
+}
+
+// Stops the timers and restores the taskbars owned by the calling thread.
+void CleanupOnThisThread() {
+    DWORD threadId = GetCurrentThreadId();
+    std::vector<void*> keys;
+
+    {
+        std::lock_guard<std::mutex> guard(g_framesMutex);
+        for (auto& [key, ctx] : g_frames) {
+            if (ctx.threadId == threadId) {
+                keys.push_back(key);
+            }
+        }
+    }
+
+    std::lock_guard<std::mutex> guard(g_framesMutex);
+    for (void* key : keys) {
+        auto it = g_frames.find(key);
+        if (it == g_frames.end()) {
+            continue;
+        }
+
+        if (it->second.timer) {
+            it->second.timer.Stop();
+            it->second.timer.Tick(it->second.tickToken);
+        }
+        RestoreFrame(it->second);
+        g_frames.erase(it);
+    }
+}
+
+// ------------------------------------------------------------------ lifetime
+
+void LoadSettings() {
+    g_settings.collapsed = Wh_GetIntSetting(L"Collapsed") != 0;
+
+    g_settings.revealOnStart = Wh_GetIntSetting(L"RevealOnStart") != 0;
+
+    g_settings.revealTrigger = RevealTrigger::Hover;
+    PCWSTR trigger = Wh_GetStringSetting(L"RevealTrigger");
+    if (trigger) {
+        if (wcscmp(trigger, L"rest") == 0) {
+            g_settings.revealTrigger = RevealTrigger::Rest;
+        } else if (wcscmp(trigger, L"click") == 0) {
+            g_settings.revealTrigger = RevealTrigger::Click;
+        } else if (wcscmp(trigger, L"never") == 0) {
+            g_settings.revealTrigger = RevealTrigger::Never;
+        }
+        Wh_FreeStringSetting(trigger);
+    }
+
+    g_settings.restSpeedPxPerSec =
+        std::clamp(Wh_GetIntSetting(L"RestSpeedPxPerSec"), 10, 10000);
+
+    g_settings.revealDelayMs =
+        std::clamp(Wh_GetIntSetting(L"RevealDelayMs"), 0, 5000);
+    g_settings.elementPaddingPx =
+        std::clamp(Wh_GetIntSetting(L"ElementPaddingPx"), 0, 200);
+    g_settings.hoverGraceMs =
+        std::clamp(Wh_GetIntSetting(L"HoverGraceMs"), 0, 5000);
+    g_settings.refreshIntervalMs =
+        std::clamp(Wh_GetIntSetting(L"RefreshIntervalMs"), 10, 2000);
+
+    g_settings.sleepEnabled = Wh_GetIntSetting(L"SleepEnabled") != 0;
+    g_settings.sleepIntervalMs =
+        std::clamp(Wh_GetIntSetting(L"SleepIntervalMs"), 500, 3000);
+
+    g_settings.animationDurationMs =
+        std::clamp(Wh_GetIntSetting(L"AnimationDurationMs"), 0, 5000);
+    g_settings.animationAmplitudePct =
+        std::clamp(Wh_GetIntSetting(L"AnimationAmplitudePct"), 0, 200);
+
+    g_settings.animationMode = AnimationMode::None;
+    PCWSTR mode = Wh_GetStringSetting(L"AnimationMode");
+    if (mode) {
+        if (wcscmp(mode, L"spacing") == 0) {
+            g_settings.animationMode = AnimationMode::Spacing;
+        }
+        Wh_FreeStringSetting(mode);
+    }
+
+    g_settings.animationCurve = kEaseInOutSine;
+    PCWSTR curve = Wh_GetStringSetting(L"AnimationCurve");
+    if (curve) {
+        if (wcscmp(curve, L"cubic") == 0) {
+            g_settings.animationCurve = kEaseInOutCubic;
+        } else if (wcscmp(curve, L"circ") == 0) {
+            g_settings.animationCurve = kEaseInOutCirc;
+        }
+        Wh_FreeStringSetting(curve);
+    }
+
+    PCWSTR marker = Wh_GetStringSetting(L"RunningNameMarker");
+    {
+        std::lock_guard<std::mutex> guard(g_settingsMutex);
+        g_settings.runningNameMarker = marker ? marker : L"";
+    }
+    if (marker) {
+        Wh_FreeStringSetting(marker);
+    }
+
+    g_collapseEnabled = g_settings.collapsed;
+    g_revealed = false;
+    g_revealedByStart = false;
+    g_emptyHoverSinceTick = 0;
+    g_lastPointerQualified = false;
+    g_lastActivityTick = GetTickCount64();
+    g_debugDumpPending = kDebugLogging;
+}
+
+HMODULE GetTaskbarViewModuleHandle() {
+    HMODULE module = GetModuleHandle(L"Taskbar.View.dll");
+    if (!module) {
+        module = GetModuleHandle(L"ExplorerExtensions.dll");
+    }
+    return module;
+}
+
+bool HookTaskbarViewDllSymbols(HMODULE module) {
+    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarFrame,struct winrt::Windows::UI::Xaml::Controls::IControlOverrides>::OnPointerMoved(void *))"},
+            &TaskbarFrame_OnPointerMoved_Original,
+            TaskbarFrame_OnPointerMoved_Hook,
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarFrame,struct winrt::Windows::UI::Xaml::Controls::IControlOverrides>::OnPointerReleased(void *))"},
+            &TaskbarFrame_OnPointerReleased_Original,
+            TaskbarFrame_OnPointerReleased_Hook,
+            true,
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarFrame,struct winrt::Windows::UI::Xaml::Controls::IControlOverrides>::OnPointerExited(void *))"},
+            &TaskbarFrame_OnPointerExited_Original,
+            TaskbarFrame_OnPointerExited_Hook,
+            true,
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarFrame,struct winrt::Windows::UI::Xaml::IFrameworkElementOverrides>::MeasureOverride(struct winrt::Windows::Foundation::Size,struct winrt::Windows::Foundation::Size *))"},
+            &TaskbarFrame_MeasureOverride_Original,
+            TaskbarFrame_MeasureOverride_Hook,
+            true,
+        },
+    };
+
+    if (!WindhawkUtils::HookSymbols(module, symbolHooks,
+                                    ARRAYSIZE(symbolHooks))) {
+        DebugFileLog(L"HookSymbols FAILED - mod will not load");
+        return false;
+    }
+
+    DebugFileLog(
+        L"HookSymbols ok (OnPointerMoved=%d OnPointerReleased=%d "
+        L"MeasureOverride=%d)",
+        (int)(TaskbarFrame_OnPointerMoved_Original != nullptr),
+        (int)(TaskbarFrame_OnPointerReleased_Original != nullptr),
+        (int)(TaskbarFrame_MeasureOverride_Original != nullptr));
+    return true;
+}
+
+// Catches a Taskbar.View.dll that loads after this mod does.
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+LoadLibraryExW_t LoadLibraryExW_Original;
+HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
+                                   HANDLE hFile,
+                                   DWORD dwFlags) {
+    HMODULE module = LoadLibraryExW_Original(lpLibFileName, hFile, dwFlags);
+    if (!module) {
+        return module;
+    }
+
+    if (!g_taskbarViewDllLoaded && GetTaskbarViewModuleHandle() == module &&
+        !g_taskbarViewDllLoaded.exchange(true)) {
+        if (HookTaskbarViewDllSymbols(module) &&
+            !g_hooksApplied.exchange(true)) {
+            Wh_ApplyHookOperations();
+        }
+    }
+
+    return module;
+}
+
+BOOL Wh_ModInit() {
+    Wh_Log(L"Init");
+
+    LoadSettings();
+
+    DebugFileLog(
+        L"=== init " WH_MOD_VERSION
+        L" collapsed=%d trigger=%d delay=%d padding=%d grace=%d refresh=%d ===",
+        (int)g_settings.collapsed, (int)g_settings.revealTrigger,
+        g_settings.revealDelayMs, g_settings.elementPaddingPx,
+        g_settings.hoverGraceMs, g_settings.refreshIntervalMs);
+
+    if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
+        g_taskbarViewDllLoaded = true;
+        if (!HookTaskbarViewDllSymbols(taskbarViewModule)) {
+            return FALSE;
+        }
+    } else {
+        HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
+        auto pKernelBaseLoadLibraryExW = (decltype(&LoadLibraryExW))
+            GetProcAddress(kernelBaseModule, "LoadLibraryExW");
+        WindhawkUtils::SetFunctionHook(pKernelBaseLoadLibraryExW,
+                                       LoadLibraryExW_Hook,
+                                       &LoadLibraryExW_Original);
+    }
+
+    StartHotkeyThread();
+
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    if (g_taskbarViewDllLoaded) {
+        g_hooksApplied = true;
+    }
+}
+
+void Wh_ModSettingsChanged() {
+    Wh_Log(L"Settings changed");
+
+    StopHotkeyThread();
+    LoadSettings();
+    StartHotkeyThread();
+
+    DebugFileLog(L"=== settings changed: collapsed=%d trigger=%d ===",
+                 (int)g_settings.collapsed, (int)g_settings.revealTrigger);
+
+    g_instantApplyGen++;
+}
+
+void Wh_ModBeforeUninit() {
+    Wh_Log(L"Uninit");
+
+    g_unloading = true;
+    StopHotkeyThread();
+
+    RunOnAllTaskbarThreads([](PVOID) { CleanupOnThisThread(); }, nullptr);
+
+    // Second sweep for contexts whose taskbar window the class-name search
+    // missed (mid-recreate): every context's timer must be stopped on its own
+    // thread, or it fires after the DLL is gone.
+    std::vector<DWORD> leftoverThreads;
+    {
+        std::lock_guard<std::mutex> guard(g_framesMutex);
+        for (auto& [key, ctx] : g_frames) {
+            leftoverThreads.push_back(ctx.threadId);
+        }
+    }
+    for (DWORD threadId : leftoverThreads) {
+        HWND hAny = nullptr;
+        EnumThreadWindows(
+            threadId,
+            [](HWND hWnd, LPARAM lParam) -> BOOL {
+                *(HWND*)lParam = hWnd;
+                return FALSE;
+            },
+            (LPARAM)&hAny);
+        if (hAny) {
+            RunFromWindowThread(
+                hAny, [](PVOID) { CleanupOnThisThread(); }, nullptr);
+        }
+    }
+
+    std::lock_guard<std::mutex> guard(g_framesMutex);
+    g_frames.clear();
+}

--- a/mods/taskbar-collapse-to-running.wh.cpp
+++ b/mods/taskbar-collapse-to-running.wh.cpp
@@ -20,7 +20,7 @@ place, so pinned order is never touched.
 
 ![Demo](https://i.imgur.com/jgDv8Su.gif)
 
-(Hovering effect not included. Check out "Taskbar Dock Animation" by Ph0en1x-dev for that!)
+*Hovering effect not included. Check out "Taskbar Dock Animation" by Ph0en1x-dev!
 
 Running state is read straight from the taskbar's own buttons, so detection
 is exact and language-independent, and the mod reacts the moment an app opens
@@ -83,13 +83,14 @@ icons and tray alike; **Reveal delay** requires the cursor to stay put first.
   $description: >-
     How long the cursor may be off the taskbar before it collapses again
     (only applies to: Reveal trigger > Hover / Rest)
-- AnimationMode: spacing
+- AnimationMode: slide
   $name: Reveal animation
   $description: >-
-    How revealing and collapsing are animated.
+    How revealing and collapsing are animated. Slide moves the icons to their
+    new spots; None flips them instantly.
   $options:
   - none: None
-  - spacing: Accordion
+  - slide: Slide
 - AnimationCurve: circ
   $name: Easing curve
   $options:
@@ -98,17 +99,26 @@ icons and tray alike; **Reveal delay** requires the cursor to stay put first.
   - circ: easeInOutCirc
 - AnimationDurationMs: 160
   $name: Animation length (ms)
-- AnimationAmplitudePct: 40
+- SnappinessPct: 40
   $name: Snappiness (%)
   $description: >-
-    How much of the motion the mid-transition cut takes. On a left-aligned
-    taskbar the accordion stretches by this share of the hidden icons' width
-    and the cut flips it. On a centered taskbar spacing is left alone;
-    instead this share of the row's travel is skipped at the cut. 0 is fully
-    smooth, 100 is maximum snap.
+    How much of the motion the mid-transition cut takes. The icons travel to
+    their new spots, and this share of that journey is skipped at the cut,
+    where the icons swapping hides the jump. 0 is fully smooth, 100 is
+    maximum snap.
 - Hotkey: Ctrl+Alt+T
   $name: Toggle hotkey
   $description: Modifiers Ctrl, Alt, Shift, Win plus one of A-Z, 0-9, F1-F24, Space. Leave empty for no hotkey.
+- DiagLog: false
+  $name: Diagnostic log
+  $description: >-
+    Write the animation engine's internal state to the Windhawk log on every
+    run. Very verbose; only for bug reports.
+- DiagStray: false
+  $name: Stray highlight log
+  $description: >-
+    Log each stray highlight box the mod removes, and any that slips through
+    mid-run. Silent while nothing is wrong.
 */
 // ==/WindhawkModSettings==
 
@@ -129,6 +139,8 @@ icons and tray alike; **Reveal delay** requires the cursor to stay put first.
 #include <winrt/Windows.UI.Composition.h>
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Input.h>
+#include <winrt/Windows.UI.Xaml.Automation.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
 #include <winrt/Windows.UI.Xaml.Input.h>
@@ -160,7 +172,7 @@ typedef void (*RunFromWindowThreadProc_t)(PVOID);
 void RunOnAllTaskbarThreads(RunFromWindowThreadProc_t proc, PVOID param);
 bool PointerClearsSurfaces(void* key, Point framePt);
 void ApplyOnThisThreadNow();
-void WakeAllFramesAsync();
+void WakeAllFramesAsync(bool skipCurrentThread = false);
 void StartHotkeyThread();
 void NudgeTaskbarsForDiscovery();
 bool PostApply(winrt::Windows::UI::Core::CoreDispatcher const& dispatcher);
@@ -197,7 +209,7 @@ EasingCurve const& CurveFor(CurveId id) {
     }
 }
 
-enum class AnimationMode { None, Spacing };
+enum class AnimationMode { None, Slide };
 enum class RevealTrigger { Never, Hover, Rest, Click };
 
 // GapClose: hide an icon instantly, hold its gap open a beat, then ease the
@@ -218,8 +230,25 @@ struct {
     std::atomic<AnimationMode> animationMode;
     std::atomic<CurveId> animationCurve;
     std::atomic<int> animationDurationMs;
-    std::atomic<int> animationAmplitudePct;
+    std::atomic<int> snappinessPct;
 } g_settings;
+
+// Diagnostic output, off unless its setting is on. Argument evaluation is
+// skipped too, so a disabled line costs nothing.
+std::atomic<bool> g_diagLog{false};
+std::atomic<bool> g_diagStray{false};
+#define DIAG_LOG(...)                    \
+    do {                                 \
+        if (g_diagLog.load()) {          \
+            Wh_Log(__VA_ARGS__);         \
+        }                                \
+    } while (0)
+#define STRAY_LOG(...)                   \
+    do {                                 \
+        if (g_diagStray.load()) {        \
+            Wh_Log(__VA_ARGS__);         \
+        }                                \
+    } while (0)
 
 std::atomic<bool> g_unloading = false;
 std::atomic<bool> g_taskbarViewDllLoaded = false;
@@ -230,6 +259,17 @@ std::atomic<bool> g_revealed = false;
 
 // Reveal caused by Start opening; pinned against grace aging until it closes.
 std::atomic<bool> g_revealedByStart = false;
+
+// Sticky reveal survives explorer restarts. Start-pinned reveals do not
+// count, and a restored hover reveal just ages out on grace.
+std::atomic<int> g_lastSavedRevealed = -1;
+
+void PersistRevealState() {
+    int value = g_revealed && !g_revealedByStart ? 1 : 0;
+    if (g_lastSavedRevealed.exchange(value) != value) {
+        Wh_SetIntValue(L"RevealedState", value);
+    }
+}
 
 std::atomic<ULONGLONG> g_lastCursorInsideTick = 0;
 
@@ -268,6 +308,23 @@ struct DeanimatedButton {
         originalImplicit{nullptr};
 };
 
+// The slide: one TranslateTransform per strip element, riding in the
+// element's RenderTransform. Never UIElement.Translation: Windows animates
+// that facade itself, and on a button where Windows has also enabled the
+// composition translation channel, every zero crossing of the facade tears
+// XAML's transform expressions down and back up. One lost race there draws
+// the icon a slot off until Explorer restarts.
+struct SlideEntry {
+    winrt::weak_ref<FrameworkElement> element;
+    Media::TranslateTransform transform{nullptr};
+    // Container the transform rides in. Taskbar Dock Animation keeps its own
+    // TransformGroup here, so ours is appended to a foreign group rather than
+    // replacing it; a plain foreign transform gets wrapped in a group of ours.
+    Media::TransformGroup group{nullptr};
+    Media::Transform wrapped{nullptr};
+    bool groupOurs = false;
+};
+
 // Owned by its taskbar's UI thread; only dispatcher is read cross-thread,
 // under g_framesMutex.
 struct FrameContext {
@@ -280,18 +337,24 @@ struct FrameContext {
     DWORD threadId = 0;
     // Buttons this mod hid, and therefore the only ones it may show again.
     std::vector<winrt::weak_ref<FrameworkElement>> hiddenByUs;
+    // Abandoned containers hidden on sight. Tracked so the judgement is
+    // never permanent: one that turns out to be a real button gets shown
+    // again the moment it has an icon.
+    std::vector<winrt::weak_ref<FrameworkElement>> phantomHidden;
     std::vector<winrt::weak_ref<FrameworkElement>> lastButtons;
     std::vector<DeanimatedButton> deanimated;
+    std::vector<SlideEntry> slides;
 
     // Visibility state currently on screen; -1 until the first apply.
     int appliedCollapse = -1;
+    // When a collapse last landed hides; arms the ghost guard for a beat.
+    double collapseLandedMs = 0;
+    // Diag: at-rest row sample due after a run ends.
+    double diagSampleMs = 0;
     bool animActive = false;
     AnimKind animKind = AnimKind::Accordion;
     bool animTargetCollapse = false;
     double animStartMs = 0;
-    // Snapshot at StartAnimation, so both accordion halves use one value.
-    double animAmplitude = 0;
-    bool animCentered = false;
     // Accordion playback table, computed before the first frame renders:
     // start and destination for every strip element, fold order per phase.
     // The tick only interpolates; reality diverging from the table kills
@@ -300,18 +363,19 @@ struct FrameContext {
         FrameworkElement element{nullptr};
         double startX = 0;
         double finalX = 0;
-        // Participation per phase (folds/renders); on a reveal, appearing
-        // icons hold live-but-transparent slots, so actual Visibility in
-        // phase one is tracked separately for the divergence guard.
+        // On the bar per phase (folds/renders). Windows parks overflowed
+        // icons off-screen instead of hiding them, so these are not raw
+        // Visibility; actual Visibility is tracked separately for the
+        // divergence guard.
         bool visibleBefore = false;
         bool visibleAfter = false;
         bool visiblePhase1 = false;
-        int foldBefore = -1;
-        int foldAfter = -1;
+        // Off the bar in both phases — in the overflow throughout, so it has
+        // no spot to animate to or from. Left alone: never folded, never
+        // counted, never translated.
+        bool animate = true;
     };
     std::vector<PlanEntry> animPlan;
-    int animFoldCountBefore = 0;
-    int animFoldCountAfter = 0;
     // Strip child count when the run began; a change is divergence.
     int animChildCount = -1;
     bool animSwapped = false;
@@ -329,8 +393,6 @@ struct FrameContext {
     // the apex; StopAnimation restores whatever is left either way.
     std::vector<GapHidden> gapHidden;
     std::vector<FrameworkElement> animButtons;
-    // Idle icons' width while visible; hidden ones measure zero.
-    double idleWidth = 0;
     winrt::event_token renderingToken{};
     bool renderingHooked = false;
     // Coalesces UpdateVisualStates bursts; cleared when the apply runs.
@@ -349,6 +411,11 @@ std::mutex g_framesMutex;
     g_frames{std::in_place};
 
 FrameContext* GetFrameContext(void* key);
+bool HasVisibleIcon(FrameworkElement root, int depth);
+int HidePhantomButtons(FrameContext& ctx,
+                       FrameworkElement repeater,
+                       FrameworkElement frame,
+                       PCWSTR where);
 
 // Animation clock; GetTickCount64's ~16 ms quantum reads as stutter.
 double NowMs() {
@@ -496,28 +563,6 @@ bool CursorOverAnyTaskbar() {
     return false;
 }
 
-// Alignment from TaskbarAl: 1 or missing = centred (the Windows 11 default).
-bool TaskbarIsCentered() {
-    DWORD value = 1;
-    DWORD size = sizeof(value);
-    RegGetValueW(HKEY_CURRENT_USER,
-                 L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\"
-                 L"Advanced",
-                 L"TaskbarAl", RRF_RT_REG_DWORD, nullptr, &value, &size);
-    return value != 0;
-}
-
-// No getter, so irreversible: only call for buttons actually being hidden.
-void ClearImplicitShowHide(FrameworkElement const& button) {
-    try {
-        Hosting::ElementCompositionPreview::SetImplicitShowAnimation(button,
-                                                                     nullptr);
-        Hosting::ElementCompositionPreview::SetImplicitHideAnimation(button,
-                                                                     nullptr);
-    } catch (winrt::hresult_error const&) {
-    }
-}
-
 void DeanimateButton(FrameContext& ctx, FrameworkElement button) {
     // Every pass, not strip-once: one stripped too early slides forever.
     DeanimatedButton* known = nullptr;
@@ -552,11 +597,38 @@ void DeanimateButton(FrameContext& ctx, FrameworkElement button) {
         }
     }
 
+    if (transitions || (visual && implicit_)) {
+        try {
+            DIAG_LOG(L"[diag] strip T=%d I=%d %s", transitions ? 1 : 0,
+                   (visual && implicit_) ? 1 : 0,
+                   winrt::Windows::UI::Xaml::Automation::AutomationProperties::GetName(button).c_str());
+        } catch (winrt::hresult_error const&) {
+        }
+    }
     if (transitions) {
         button.Transitions(nullptr);
     }
     if (visual && implicit_) {
         visual.ImplicitAnimations(nullptr);
+    }
+}
+
+// Windows' own show/hide and reposition animations fight our choreography,
+// so they come off for the length of a run and go back on when it ends.
+// Held only that long on purpose: a container Windows is animating out gets
+// parked off-screen by the end of that animation, and killing it permanently
+// strands the container in the row, visible and half-built.
+void DeanimateRunSet(FrameContext& ctx,
+                     std::vector<FrameworkElement> const& buttons) {
+    for (auto const& button : buttons) {
+        DeanimateButton(ctx, button);
+    }
+    // Start and search recentre with the row, so they go still too.
+    if (auto repeater = ctx.repeater.get()) {
+        EnumChildElements(repeater, [&](FrameworkElement child) {
+            DeanimateButton(ctx, child);
+            return false;
+        });
     }
 }
 
@@ -608,13 +680,137 @@ double CubicBezierEase(EasingCurve const& curve, double t) {
 
 // ---------------------------------------------------------------- animation
 
-// Per-element fence: one dead element must not strand the rest translated.
-void ClearSpacing(std::vector<FrameworkElement> const& buttons) {
-    for (auto const& button : buttons) {
+// Identity, not interface pointer: the same object answers with a different
+// pointer per interface.
+bool SameObject(IInspectable const& a, IInspectable const& b) {
+    if (!a || !b) {
+        return !a && !b;
+    }
+    return a.as<winrt::Windows::Foundation::IUnknown>() ==
+           b.as<winrt::Windows::Foundation::IUnknown>();
+}
+
+SlideEntry* FindSlide(FrameContext& ctx, FrameworkElement const& element) {
+    SlideEntry* found = nullptr;
+    for (size_t i = 0; i < ctx.slides.size();) {
+        auto resolved = ctx.slides[i].element.get();
+        if (!resolved) {
+            ctx.slides.erase(ctx.slides.begin() + i);
+            continue;
+        }
+        if (resolved == element) {
+            found = &ctx.slides[i];
+        }
+        i++;
+    }
+    return found;
+}
+
+// Seats the slide transform where XAML reads it. Re-checked on every write:
+// another mod can replace RenderTransform at any time (Taskbar Dock
+// Animation does), and a write into a stranded transform moves nothing.
+SlideEntry* EnsureSlide(FrameContext& ctx, FrameworkElement const& element) {
+    SlideEntry* entry = FindSlide(ctx, element);
+    if (!entry) {
+        SlideEntry fresh;
+        fresh.element = winrt::make_weak(element);
+        fresh.transform = Media::TranslateTransform();
+        ctx.slides.push_back(std::move(fresh));
+        entry = &ctx.slides.back();
+    }
+    auto current = element.RenderTransform();
+    bool attached = entry->group ? SameObject(current, entry->group)
+                                 : SameObject(current, entry->transform);
+    if (attached) {
+        return entry;
+    }
+    entry->group = nullptr;
+    entry->wrapped = nullptr;
+    entry->groupOurs = false;
+    if (!current) {
+        element.RenderTransform(entry->transform);
+    } else if (auto group = current.try_as<Media::TransformGroup>()) {
+        group.Children().Append(entry->transform);
+        entry->group = group;
+    } else {
+        auto wrapper = Media::TransformGroup();
+        wrapper.Children().Append(current);
+        wrapper.Children().Append(entry->transform);
+        element.RenderTransform(wrapper);
+        entry->group = wrapper;
+        entry->wrapped = current;
+        entry->groupOurs = true;
+    }
+    return entry;
+}
+
+// The only writer of the slide. A zero for an element never slid is a no-op,
+// so landings and sweeps do not seat transforms on untouched buttons.
+void SetSlideX(FrameContext& ctx, FrameworkElement const& element, double x) {
+    try {
+        if (x == 0 && !FindSlide(ctx, element)) {
+            return;
+        }
+        EnsureSlide(ctx, element)->transform.X(x);
+    } catch (winrt::hresult_error const&) {
+    }
+}
+
+double GetSlideX(FrameContext& ctx, FrameworkElement const& element) {
+    try {
+        if (auto entry = FindSlide(ctx, element)) {
+            return entry->transform.X();
+        }
+    } catch (winrt::hresult_error const&) {
+    }
+    return 0;
+}
+
+// Undoes every seat: nothing of the mod's may stay in a RenderTransform.
+void DetachSlides(FrameContext& ctx) {
+    for (auto& entry : ctx.slides) {
+        auto element = entry.element.get();
+        if (!element) {
+            continue;
+        }
         try {
-            button.Translation(float3{0, 0, 0});
+            entry.transform.X(0);
+            auto current = element.RenderTransform();
+            if (entry.group) {
+                if (SameObject(current, entry.group)) {
+                    if (entry.groupOurs) {
+                        element.RenderTransform(entry.wrapped);
+                    } else {
+                        auto children = entry.group.Children();
+                        uint32_t index = 0;
+                        if (children.IndexOf(entry.transform, index)) {
+                            children.RemoveAt(index);
+                        }
+                    }
+                }
+            } else if (SameObject(current, entry.transform)) {
+                element.RenderTransform(nullptr);
+            }
         } catch (winrt::hresult_error const&) {
         }
+    }
+    ctx.slides.clear();
+}
+
+// A parked overflow container sits far off the bar. Windows' domain: its
+// running state is the husk's, not the app's, so it is never judged.
+bool IsParkedOffBar(FrameContext& ctx, FrameworkElement const& button) {
+    auto frame = ctx.frame.get();
+    if (!frame) {
+        return false;
+    }
+    try {
+        double x =
+            button.TransformToVisual(frame).TransformPoint(Point{0, 0}).X;
+        double frameWidth = frame.ActualWidth();
+        return x < -1 || (frameWidth > 0 && x > frameWidth);
+    } catch (winrt::hresult_error const&) {
+        return false;
     }
 }
 
@@ -624,21 +820,16 @@ void SetCollapseState(
     std::vector<FrameworkElement> const& buttons,
     bool collapse,
     std::vector<std::pair<FrameworkElement, double>>* deferHide = nullptr) {
-    double idleVisibleWidth = 0;
-    bool idleSetComplete = true;
-
+    int diagHid = 0;
+    int diagDeferred = 0;
+    int diagShown = 0;
     for (auto const& button : buttons) {
         bool weHidIt = TakeFromHiddenSet(ctx.hiddenByUs, button, false);
         bool running = TaskListButton_IsRunning(button);
         bool shouldHide = collapse && !running;
 
-        // Measured pre-flip; a partial idle set must not overwrite the cache.
-        if (!running) {
-            if (button.Visibility() == Visibility::Visible) {
-                idleVisibleWidth += button.ActualWidth();
-            } else {
-                idleSetComplete = false;
-            }
+        if (shouldHide && IsParkedOffBar(ctx, button)) {
+            continue;
         }
 
         if (shouldHide) {
@@ -647,26 +838,44 @@ void SetCollapseState(
                 if (deferHide) {
                     deferHide->emplace_back(button, button.Opacity());
                     button.Opacity(0);
+                    diagDeferred++;
                 } else {
-                    // Irreversible strip, so only where the mod's own
-                    // animation would fight the ghost; None keeps Windows'.
-                    if (g_settings.animationMode == AnimationMode::Spacing) {
-                        ClearImplicitShowHide(button);
-                    }
                     button.Visibility(Visibility::Collapsed);
                     if (!weHidIt) {
                         ctx.hiddenByUs.push_back(winrt::make_weak(button));
                     }
+                    diagHid++;
                 }
             }
         } else if (weHidIt) {
-            button.Visibility(Visibility::Visible);
-            TakeFromHiddenSet(ctx.hiddenByUs, button, true);
+            // No icon and not running: a container Windows retired after
+            // we hid it. Shown, it draws its leftover plate over the icon
+            // in that slot now. Record kept; it returns once it runs.
+            if (!running && !HasVisibleIcon(button, 3)) {
+                if (!collapse && ctx.appliedCollapse == 1) {
+                    try {
+                        STRAY_LOG(L"Kept hidden (no icon): %s",
+                                  winrt::Windows::UI::Xaml::Automation::AutomationProperties::GetName(button).c_str());
+                    } catch (winrt::hresult_error const&) {
+                    }
+                }
+            } else {
+                button.Visibility(Visibility::Visible);
+                TakeFromHiddenSet(ctx.hiddenByUs, button, true);
+                diagShown++;
+            }
         }
     }
+    if (diagHid || diagDeferred || diagShown) {
+        DIAG_LOG(L"[diag] SetCollapseState collapse=%d hid=%d deferred=%d "
+               L"shown=%d",
+               (int)collapse, diagHid, diagDeferred, diagShown);
+    }
 
-    if (idleSetComplete && idleVisibleWidth > 0.5) {
-        ctx.idleWidth = idleVisibleWidth;
+    // Fresh hides free space, and Windows' overflow drain follows; arm the
+    // ghost guard so a surfacing non-running icon dies before it renders.
+    if (collapse && (diagHid > 0 || diagDeferred > 0)) {
+        ctx.collapseLandedMs = NowMs();
     }
 
     ctx.appliedCollapse = collapse ? 1 : 0;
@@ -693,35 +902,6 @@ void UnhookRendering(FrameContext& ctx) {
     ctx.renderingHooked = false;
 }
 
-// Tree order is not visual order; sort by on-screen X, hidden to the back.
-void SortButtonsByPosition(std::vector<FrameworkElement>& buttons,
-                           FrameworkElement frame) {
-    std::vector<std::pair<double, FrameworkElement>> keyed;
-    keyed.reserve(buttons.size());
-
-    for (auto& button : buttons) {
-        double x = std::numeric_limits<double>::max();
-        if (button.Visibility() == Visibility::Visible) {
-            try {
-                x = button.TransformToVisual(frame)
-                        .TransformPoint(Point{0, 0})
-                        .X;
-            } catch (winrt::hresult_error const&) {
-            }
-        }
-        keyed.emplace_back(x, button);
-    }
-
-    std::stable_sort(keyed.begin(), keyed.end(),
-                     [](auto const& a, auto const& b) {
-                         return a.first < b.first;
-                     });
-
-    for (size_t i = 0; i < buttons.size(); i++) {
-        buttons[i] = keyed[i].second;
-    }
-}
-
 // Lands the deferred hides for real, kept transparent until the run ends so
 // a re-show by Windows renders empty instead of flashing.
 void CollapseDeferredHides(
@@ -730,7 +910,6 @@ void CollapseDeferredHides(
     for (auto& entry : deferHide) {
         try {
             if (entry.first.Visibility() == Visibility::Visible) {
-                ClearImplicitShowHide(entry.first);
                 entry.first.Visibility(Visibility::Collapsed);
                 if (!TakeFromHiddenSet(ctx.hiddenByUs, entry.first, false)) {
                     ctx.hiddenByUs.push_back(winrt::make_weak(entry.first));
@@ -752,6 +931,13 @@ void CollapseDeferredHides(
 }
 
 void StopAnimation(FrameContext& ctx) {
+    if (ctx.animActive) {
+        DIAG_LOG(L"[diag] StopAnimation kind=%d target=%d", (int)ctx.animKind,
+               (int)ctx.animTargetCollapse);
+        if (g_diagLog.load()) {
+            ctx.diagSampleMs = NowMs() + 400.0;
+        }
+    }
     // Collapsed since the start, so these restores are invisible here.
     for (auto& entry : ctx.gapHidden) {
         try {
@@ -765,17 +951,62 @@ void StopAnimation(FrameContext& ctx) {
     ctx.animSwapped = false;
     ctx.animFinalizePending = false;
     UnhookRendering(ctx);
-    ClearSpacing(ctx.animButtons);
+    // Per element: one dead element must not strand the rest slid.
+    for (auto const& button : ctx.animButtons) {
+        SetSlideX(ctx, button, 0);
+    }
     for (auto& entry : ctx.animPlan) {
-        try {
-            entry.element.Translation(float3{0, 0, 0});
-        } catch (winrt::hresult_error const&) {
-        }
+        SetSlideX(ctx, entry.element, 0);
     }
     ctx.animPlan.clear();
     ctx.animChildCount = -1;
     ctx.animButtons.clear();
     ctx.animGapOffsets.clear();
+}
+
+// The first visible icon image inside a button: the glyph the eye tracks.
+FrameworkElement FindVisibleIcon(FrameworkElement root, int depth) {
+    if (!root || depth < 0) {
+        return nullptr;
+    }
+    FrameworkElement found = nullptr;
+    EnumChildElements(root, [&](FrameworkElement child) {
+        try {
+            if (child.Visibility() == Visibility::Visible &&
+                winrt::get_class_name(child) ==
+                    L"Windows.UI.Xaml.Controls.Image") {
+                found = child;
+                return true;
+            }
+        } catch (winrt::hresult_error const&) {
+        }
+        found = FindVisibleIcon(child, depth - 1);
+        return found != nullptr;
+    });
+    return found;
+}
+
+// The promoted-slot divider: a hairline rectangle spanning the button.
+FrameworkElement FindDividerRect(FrameworkElement root, int depth) {
+    if (!root || depth < 0) {
+        return nullptr;
+    }
+    FrameworkElement found = nullptr;
+    EnumChildElements(root, [&](FrameworkElement child) {
+        try {
+            if (child.Visibility() == Visibility::Visible &&
+                child.ActualWidth() < 2.0 && child.ActualHeight() >= 24.0 &&
+                winrt::get_class_name(child) ==
+                    L"Windows.UI.Xaml.Shapes.Rectangle") {
+                found = child;
+                return true;
+            }
+        } catch (winrt::hresult_error const&) {
+        }
+        found = FindDividerRect(child, depth - 1);
+        return found != nullptr;
+    });
+    return found;
 }
 
 int CountStripChildren(FrameContext& ctx) {
@@ -800,8 +1031,6 @@ bool BuildAnimPlan(FrameContext& ctx,
                    FrameworkElement frame,
                    bool targetCollapse) {
     ctx.animPlan.clear();
-    ctx.animFoldCountBefore = 0;
-    ctx.animFoldCountAfter = 0;
     ctx.animChildCount = CountStripChildren(ctx);
 
     std::vector<FrameworkElement> elements;
@@ -816,6 +1045,16 @@ bool BuildAnimPlan(FrameContext& ctx,
         ctx.animChildCount = (int)elements.size();
     }
 
+    double frameWidth = 0;
+    try {
+        frameWidth = frame.ActualWidth();
+    } catch (winrt::hresult_error const&) {
+    }
+
+    // On the bar: visible and inside the strip. An icon the row pushed past
+    // its edge is parked off-screen, still Visible, so it counts as absent —
+    // there is no spot on screen to animate it to or from. x is written
+    // either way, and overwritten by the synthesis below when it is needed.
     auto measure = [&](FrameworkElement const& element, double* x) {
         if (element.Visibility() != Visibility::Visible) {
             return false;
@@ -824,30 +1063,144 @@ bool BuildAnimPlan(FrameContext& ctx,
             *x = element.TransformToVisual(frame)
                      .TransformPoint(Point{0, 0})
                      .X;
-            return true;
+            double width = element.ActualWidth();
+            bool onBar = frameWidth <= 0 ||
+                         (*x >= -1 && *x + width <= frameWidth + 1);
+            // The divider visual state widens the button beside the chevron
+            // and shifts its glyph inside, so the button edge lies about
+            // where the icon is. Track the glyph itself when there is one.
+            if (onBar) {
+                if (auto icon = FindVisibleIcon(element, 3)) {
+                    *x = icon.TransformToVisual(frame)
+                             .TransformPoint(Point{0, 0})
+                             .X;
+                }
+            }
+            return onBar;
         } catch (winrt::hresult_error const&) {
             return false;
         }
     };
 
+    DIAG_LOG(L"[diag] plan target=%d frameWidth=%.1f children=%d elements=%d",
+           (int)targetCollapse, frameWidth, ctx.animChildCount,
+           (int)elements.size());
+    int diagIndex = 0;
     for (auto const& element : elements) {
         FrameContext::PlanEntry entry;
         entry.element = element;
         entry.visibleBefore = measure(element, &entry.startX);
+        try {
+            float3 diagOff{0, 0, 0};
+            float diagM41 = 0;
+            if (auto visual = g_diagLog.load()
+                                  ? Hosting::ElementCompositionPreview::
+                                        GetElementVisual(element)
+                                  : nullptr) {
+                diagOff = visual.Offset();
+                diagM41 = visual.TransformMatrix().m41;
+            }
+            DIAG_LOG(L"[diag] %d before onBar=%d x=%.1f w=%.1f off=%.1f "
+                   L"m41=%.1f %s",
+                   diagIndex, (int)entry.visibleBefore, entry.startX,
+                   element.ActualWidth(), diagOff.x, diagM41,
+                   winrt::Windows::UI::Xaml::Automation::AutomationProperties::GetName(element).c_str());
+        } catch (winrt::hresult_error const&) {
+        }
+        diagIndex++;
         ctx.animPlan.push_back(std::move(entry));
     }
 
     bool priorCollapse = ctx.appliedCollapse == 1;
     SetCollapseState(ctx, ctx.animButtons, targetCollapse);
-    frame.UpdateLayout();
+    // Overflow membership cascades: hiding icons can free enough room that
+    // Windows pulls others back out of the overflow menu, which re-runs
+    // layout again. One pass measures a half-settled row, so the slide
+    // animates to spots Windows then overrules. Settle it fully first.
+    for (int pass = 0; pass < 3; pass++) {
+        frame.UpdateLayout();
+    }
+    // The flip can seat a retired container back in the row, on top of a
+    // real icon; the pre-plan check ran while it was still collapsed.
+    if (auto repeater = ctx.repeater.get()) {
+        if (HidePhantomButtons(ctx, repeater, frame, L"plan") > 0) {
+            frame.UpdateLayout();
+        }
+    }
+    try {
+        DIAG_LOG(L"[diag] after layout: children=%d frameWidth=%.1f",
+               CountStripChildren(ctx), frame.ActualWidth());
+    } catch (winrt::hresult_error const&) {
+    }
+    diagIndex = 0;
     for (auto& entry : ctx.animPlan) {
         entry.visibleAfter = measure(entry.element, &entry.finalX);
+        entry.animate = entry.visibleBefore || entry.visibleAfter;
+        try {
+            DIAG_LOG(L"[diag] %d after  onBar=%d x=%.1f w=%.1f animate=%d",
+                   diagIndex, (int)entry.visibleAfter, entry.finalX,
+                   entry.element.ActualWidth(), (int)entry.animate);
+        } catch (winrt::hresult_error const&) {
+        }
+        diagIndex++;
+    }
+    // A chevron leaving the bar dies at frame one: the collapsed row has no
+    // overflow, so the control is Windows' to retire. Held invisible in its
+    // slot (no reflow mid-plan), never folded; the landing takes it.
+    if (targetCollapse) {
+        for (auto& entry : ctx.animPlan) {
+            if (!entry.animate || !entry.visibleBefore || entry.visibleAfter) {
+                continue;
+            }
+            try {
+                if (winrt::get_class_name(entry.element) !=
+                    L"Taskbar.OverflowToggleButton") {
+                    continue;
+                }
+                FrameContext::GapHidden held;
+                held.element = entry.element;
+                held.opacity = entry.element.Opacity();
+                held.maxWidth = entry.element.MaxWidth();
+                entry.element.Opacity(0);
+                ctx.gapHidden.push_back(std::move(held));
+                entry.animate = false;
+            } catch (winrt::hresult_error const&) {
+            }
+        }
+    }
+    // The promoted-slot divider: only the widened button beside the chevron
+    // carries one. The icon slides on; its line dies at frame one, and the
+    // collapsed row has no promoted slot for it to return to.
+    if (targetCollapse) {
+        for (auto& entry : ctx.animPlan) {
+            if (!entry.animate || !entry.visibleBefore) {
+                continue;
+            }
+            try {
+                if (entry.element.ActualWidth() <= 34.0 ||
+                    winrt::get_class_name(entry.element) !=
+                        L"Taskbar.TaskListButton") {
+                    continue;
+                }
+                if (auto divider = FindDividerRect(entry.element, 3)) {
+                    FrameContext::GapHidden held;
+                    held.element = divider;
+                    held.opacity = divider.Opacity();
+                    held.maxWidth = divider.MaxWidth();
+                    divider.Opacity(0);
+                    ctx.gapHidden.push_back(std::move(held));
+                }
+            } catch (winrt::hresult_error const&) {
+            }
+        }
     }
     if (targetCollapse) {
         // Collapse animates over the old layout; put it back. A reveal
         // keeps the final layout live from frame one instead.
         SetCollapseState(ctx, ctx.animButtons, priorCollapse);
-        frame.UpdateLayout();
+        for (int pass = 0; pass < 3; pass++) {
+            frame.UpdateLayout();
+        }
     }
 
     // haveStart: one-sided entries that only have startX get finalX synth'd
@@ -856,6 +1209,9 @@ bool BuildAnimPlan(FrameContext& ctx,
         std::vector<FrameContext::PlanEntry*> known;
         std::vector<FrameContext::PlanEntry*> missing;
         for (auto& entry : ctx.animPlan) {
+            if (!entry.animate) {
+                continue;
+            }
             if (entry.visibleBefore && entry.visibleAfter) {
                 known.push_back(&entry);
             } else if (haveStart ? entry.visibleBefore : entry.visibleAfter) {
@@ -906,39 +1262,72 @@ bool BuildAnimPlan(FrameContext& ctx,
     fill(true);
     fill(false);
 
-    // Fold order per phase, task buttons only, fixed here once.
-    auto assignFold = [&](bool beforePhase, int* outCount) {
-        std::vector<FrameContext::PlanEntry*> phase;
+    // Icons on the bar in a phase; only their absence matters, for the
+    // anchor below.
+    auto countOnBar = [&](bool beforePhase) {
+        int count = 0;
         for (auto& entry : ctx.animPlan) {
             bool visible =
                 beforePhase ? entry.visibleBefore : entry.visibleAfter;
-            if (!visible) {
+            if (!visible || !entry.animate) {
                 continue;
             }
             for (auto const& button : ctx.animButtons) {
                 if (button == entry.element) {
-                    phase.push_back(&entry);
+                    count++;
                     break;
                 }
             }
         }
-        std::stable_sort(
-            phase.begin(), phase.end(),
-            [&](FrameContext::PlanEntry* a, FrameContext::PlanEntry* b) {
-                return (beforePhase ? a->startX : a->finalX) <
-                       (beforePhase ? b->startX : b->finalX);
-            });
-        for (int i = 0; i < (int)phase.size(); i++) {
-            if (beforePhase) {
-                phase[i]->foldBefore = i;
-            } else {
-                phase[i]->foldAfter = i;
+        return count;
+    };
+
+    // With no icons at all on one side of the cut, the ones appearing (or
+    // vanishing) have no neighbour to take a position from, so the synthesis
+    // above leaves them where they land and they pop in place. Fan them out
+    // of — or into — the right edge of whatever stays on screen, which is
+    // Start, so the motion still reads as a fold.
+    auto anchorToVisible = [&](bool beforePhase) {
+        double anchor = 0;
+        bool have = false;
+        for (auto& entry : ctx.animPlan) {
+            if (!entry.animate ||
+                (beforePhase ? !entry.visibleBefore : !entry.visibleAfter)) {
+                continue;
+            }
+            double right = beforePhase ? entry.startX : entry.finalX;
+            try {
+                right += entry.element.ActualWidth();
+            } catch (winrt::hresult_error const&) {
+            }
+            if (!have || right > anchor) {
+                anchor = right;
+                have = true;
             }
         }
-        *outCount = (int)phase.size();
+        if (!have) {
+            return;
+        }
+        for (auto& entry : ctx.animPlan) {
+            bool otherSideOnly =
+                beforePhase ? (!entry.visibleBefore && entry.visibleAfter)
+                            : (entry.visibleBefore && !entry.visibleAfter);
+            if (!otherSideOnly || !entry.animate) {
+                continue;
+            }
+            if (beforePhase) {
+                entry.startX = anchor;
+            } else {
+                entry.finalX = anchor;
+            }
+        }
     };
-    assignFold(true, &ctx.animFoldCountBefore);
-    assignFold(false, &ctx.animFoldCountAfter);
+    if (countOnBar(true) == 0) {
+        anchorToVisible(true);
+    }
+    if (countOnBar(false) == 0) {
+        anchorToVisible(false);
+    }
 
     // Reveal: appearing icons hold their slots transparently until the apex
     // flips their opacity — a composition-only cut that cannot tear against
@@ -946,6 +1335,9 @@ bool BuildAnimPlan(FrameContext& ctx,
     // before anything renders.
     if (!targetCollapse) {
         for (auto& entry : ctx.animPlan) {
+            if (!entry.animate) {
+                continue;
+            }
             try {
                 if (!entry.visibleBefore && entry.visibleAfter) {
                     FrameContext::GapHidden held;
@@ -954,11 +1346,20 @@ bool BuildAnimPlan(FrameContext& ctx,
                     held.maxWidth = entry.element.MaxWidth();
                     entry.element.Opacity(0);
                     ctx.gapHidden.push_back(std::move(held));
-                    entry.element.Translation(float3{0, 0, 0});
+                    SetSlideX(ctx, entry.element, 0);
                 } else if (entry.visibleBefore) {
-                    entry.element.Translation(
-                        float3{(float)(entry.startX - entry.finalX), 0, 0});
+                    SetSlideX(ctx, entry.element,
+                              entry.startX - entry.finalX);
                 }
+            } catch (winrt::hresult_error const&) {
+            }
+        }
+    }
+    // Seat every slide here, in dispatcher context, not in the first tick.
+    for (auto& entry : ctx.animPlan) {
+        if (entry.animate) {
+            try {
+                EnsureSlide(ctx, entry.element);
             } catch (winrt::hresult_error const&) {
             }
         }
@@ -972,7 +1373,347 @@ bool BuildAnimPlan(FrameContext& ctx,
         }
     }
 
+    // The flips above storm UpdateVisualStates, and Windows re-arms its
+    // reposition animations off it — inside this same pass, after the
+    // apply's strip. Stripped again last, or the commit animates.
+    DeanimateRunSet(ctx, ctx.animButtons);
+
     return !ctx.animPlan.empty();
+}
+
+bool HasVisibleIcon(FrameworkElement root, int depth) {
+    if (!root || depth < 0) {
+        return false;
+    }
+    bool found = false;
+    EnumChildElements(root, [&](FrameworkElement child) {
+        if (found) {
+            return false;
+        }
+        try {
+            if (child.Visibility() == Visibility::Visible &&
+                winrt::get_class_name(child) ==
+                    L"Windows.UI.Xaml.Controls.Image") {
+                found = true;
+                return false;
+            }
+        } catch (winrt::hresult_error const&) {
+        }
+        if (HasVisibleIcon(child, depth - 1)) {
+            found = true;
+        }
+        return false;
+    });
+    return found;
+}
+
+// A container the taskbar started tearing down and left in the row: a spare
+// task button, icon already dropped, sitting on top of a real one instead of
+// parked off-screen. It draws its background plate over that icon — the
+// stray highlight. Nothing legitimately puts two buttons at one spot, and a
+// real one always has its icon, so the pair identifies it beyond doubt.
+// Hiding it is what the teardown would have done; Windows shows the
+// container again itself if it reuses it.
+// Undoes a phantom judgement that turned out to be wrong. A container the
+// taskbar really was discarding never gets its icon back; a real button
+// whose icon was merely still loading does, and comes straight back.
+void RestoreRepairedPhantoms(FrameContext& ctx, FrameworkElement frame) {
+    for (size_t i = 0; i < ctx.phantomHidden.size();) {
+        auto element = ctx.phantomHidden[i].get();
+        if (!element) {
+            ctx.phantomHidden.erase(ctx.phantomHidden.begin() + i);
+            continue;
+        }
+        // Restore the moment the reason to hide it stops holding: it has an
+        // icon after all, or it is no longer in the row. Nothing this mod
+        // hides on suspicion may outlive the suspicion.
+        bool restore = false;
+        PCWSTR why = L"threw";
+        double x = 0;
+        try {
+            x = element.TransformToVisual(frame).TransformPoint(Point{0, 0}).X;
+            double frameWidth = frame.ActualWidth();
+            if (HasVisibleIcon(element, 3)) {
+                why = L"has icon";
+                restore = true;
+            } else if (x < 0 || (frameWidth > 0 && x > frameWidth)) {
+                why = L"off bar";
+                restore = true;
+            }
+        } catch (winrt::hresult_error const&) {
+            restore = true;
+        }
+        if (!restore) {
+            i++;
+            continue;
+        }
+        std::wstring name = L"?";
+        try {
+            name = std::wstring(winrt::Windows::UI::Xaml::Automation::AutomationProperties::GetName(element));
+        } catch (winrt::hresult_error const&) {
+        }
+        try {
+            STRAY_LOG(L"Phantom restored (%s) at x=%.1f: %s", why, x,
+                      name.c_str());
+            element.Visibility(Visibility::Visible);
+        } catch (winrt::hresult_error const&) {
+        }
+        ctx.phantomHidden.erase(ctx.phantomHidden.begin() + i);
+    }
+}
+
+int HidePhantomButtons(FrameContext& ctx,
+                       FrameworkElement repeater,
+                       FrameworkElement frame,
+                       PCWSTR where) {
+    struct Candidate {
+        FrameworkElement element{nullptr};
+        double x = 0;
+        bool hasIcon = false;
+    };
+    std::vector<Candidate> row;
+
+    EnumChildElements(repeater, [&](FrameworkElement child) {
+        try {
+            if (child.Visibility() != Visibility::Visible) {
+                return false;
+            }
+            auto classNameHstring = winrt::get_class_name(child);
+            std::wstring_view className(classNameHstring);
+            if (className.find(L"TaskListButton") == std::wstring_view::npos ||
+                className.find(L"Panel") != std::wstring_view::npos) {
+                return false;
+            }
+            Candidate candidate;
+            candidate.element = child;
+            candidate.x =
+                child.TransformToVisual(frame).TransformPoint(Point{0, 0}).X;
+            // Only judge what is actually in the row. Parked containers and
+            // overflow-menu entries live thousands of pixels off-screen, and
+            // they are none of this check's business.
+            double frameWidth = frame.ActualWidth();
+            if (candidate.x < 0 || (frameWidth > 0 && candidate.x > frameWidth)) {
+                return false;
+            }
+            candidate.hasIcon = HasVisibleIcon(child, 3);
+            row.push_back(std::move(candidate));
+        } catch (winrt::hresult_error const&) {
+        }
+        return false;
+    });
+
+    int hidden = 0;
+    for (auto& candidate : row) {
+        if (candidate.hasIcon) {
+            continue;
+        }
+        for (auto& other : row) {
+            if (other.element == candidate.element || !other.hasIcon) {
+                continue;
+            }
+            if (std::abs(candidate.x - other.x) > 1.0) {
+                continue;
+            }
+            // Names first, on their own: the hide must not hang on a log.
+            std::wstring candName = L"?";
+            std::wstring otherName = L"?";
+            try {
+                candName = std::wstring(winrt::Windows::UI::Xaml::Automation::AutomationProperties::GetName(candidate.element));
+                otherName = std::wstring(winrt::Windows::UI::Xaml::Automation::AutomationProperties::GetName(other.element));
+            } catch (winrt::hresult_error const&) {
+            }
+            try {
+                STRAY_LOG(L"Phantom hidden (%s) at x=%.1f: %s over %s", where,
+                          candidate.x, candName.c_str(), otherName.c_str());
+                candidate.element.Visibility(Visibility::Collapsed);
+                ctx.phantomHidden.push_back(
+                    winrt::make_weak(candidate.element));
+                hidden++;
+            } catch (winrt::hresult_error const&) {
+            }
+            break;
+        }
+    }
+    return hidden;
+}
+
+// Checks the row against both ways this mod can leave an icon mispositioned:
+// an offset it never cleared, and a width it pinned to zero and never put
+// back — the second reads as an icon squashed to nothing behind its
+// neighbour, and no offset sweep would ever see it. Repairs and names
+// whichever it finds. Elements deliberately held for a running animation
+// are skipped.
+int VerifyRowSettled(FrameContext& ctx, FrameworkElement root, int depth) {
+    if (!root || depth < 0) {
+        return 0;
+    }
+
+    int repairs = 0;
+    EnumChildElements(root, [&](FrameworkElement child) {
+        bool held = false;
+        for (auto& entry : ctx.gapHidden) {
+            if (entry.element == child) {
+                held = true;
+                break;
+            }
+        }
+
+        if (!held) {
+            try {
+                double slide = GetSlideX(ctx, child);
+                if (slide != 0) {
+                    auto name = winrt::Windows::UI::Xaml::Automation::
+                        AutomationProperties::GetName(child);
+                    Wh_Log(L"Settle repair: slide %.1f on %s (%s)", slide,
+                           winrt::get_class_name(child).c_str(), name.c_str());
+                    SetSlideX(ctx, child, 0);
+                    repairs++;
+                }
+                // Windows' own channel; read for the log, never written.
+                auto translation = child.Translation();
+                if (translation.x != 0 || translation.y != 0) {
+                    DIAG_LOG(L"[diag] facade offset %.1f,%.1f on %s",
+                             translation.x, translation.y,
+                             winrt::get_class_name(child).c_str());
+                }
+                // Shown but fully transparent: it holds its slot and stays
+                // clickable while drawing nothing — a gap in the row. Only
+                // this mod fades a taskbar element, so this one is ours.
+                if (child.Visibility() == Visibility::Visible &&
+                    child.Opacity() == 0.0) {
+                    auto name = winrt::Windows::UI::Xaml::Automation::
+                        AutomationProperties::GetName(child);
+                    Wh_Log(L"Settle repair: zero opacity on %s (%s)",
+                           winrt::get_class_name(child).c_str(), name.c_str());
+                    child.ClearValue(UIElement::OpacityProperty());
+                    repairs++;
+                }
+                // Only this mod pins a taskbar element to zero width, so a
+                // visible one still pinned is ours and never restored.
+                if (child.Visibility() == Visibility::Visible &&
+                    child.MaxWidth() == 0.0) {
+                    auto name = winrt::Windows::UI::Xaml::Automation::
+                        AutomationProperties::GetName(child);
+                    Wh_Log(L"Settle repair: zero width on %s (%s)",
+                           winrt::get_class_name(child).c_str(), name.c_str());
+                    child.ClearValue(FrameworkElement::MaxWidthProperty());
+                    repairs++;
+                }
+            } catch (winrt::hresult_error const&) {
+            }
+        }
+
+        repairs += VerifyRowSettled(ctx, child, depth - 1);
+        return false;
+    });
+    return repairs;
+}
+
+// Composition-side reads XAML cannot see: the hand-off visual and the
+// internal visuals above it (the first parent carries the Translation
+// facade). Read only. anim letters: A = an animation is bound, - = none.
+void DiagDumpVisualChain(FrameworkElement const& button, PCWSTR tag) {
+    using namespace winrt::Windows::UI::Composition;
+    try {
+        auto visual =
+            Hosting::ElementCompositionPreview::GetElementVisual(button);
+        if (!visual) {
+            return;
+        }
+        auto name = winrt::Windows::UI::Xaml::Automation::AutomationProperties::
+            GetName(button);
+        auto bound = [](CompositionObject const& object,
+                        PCWSTR property) -> wchar_t {
+            try {
+                return object.TryGetAnimationController(property) ? L'A'
+                                                                  : L'-';
+            } catch (winrt::hresult_error const&) {
+                return L'?';
+            }
+        };
+        float3 slide{0, 0, 0};
+        int status =
+            (int)visual.Properties().TryGetVector3(L"Translation", slide);
+        DIAG_LOG(L"[diag] %s chain v: psT=%d/%.1f op=%.2f sc=%.2f vis=%d "
+                 L"w=%.1f clip=%d anim[T,O,S,P,M]=%c%c%c%c%c %s",
+                 tag, status, slide.x, visual.Opacity(), visual.Scale().x,
+                 (int)visual.IsVisible(), visual.Size().x,
+                 visual.Clip() ? 1 : 0, bound(visual.Properties(), L"Translation"),
+                 bound(visual, L"Offset"), bound(visual, L"Scale"),
+                 bound(visual, L"Opacity"), bound(visual, L"TransformMatrix"),
+                 name.c_str());
+        ContainerVisual parent = visual.Parent();
+        for (int level = 1; parent && level <= 3; level++) {
+            DIAG_LOG(L"[diag] %s chain p%d: off=%.1f m41=%.1f op=%.2f vis=%d "
+                     L"clip=%d anim[O,M]=%c%c %s",
+                     tag, level, parent.Offset().x,
+                     parent.TransformMatrix().m41, parent.Opacity(),
+                     (int)parent.IsVisible(), parent.Clip() ? 1 : 0,
+                     bound(parent, L"Offset"), bound(parent, L"TransformMatrix"),
+                     winrt::get_class_name(parent).c_str());
+            parent = parent.Parent();
+        }
+        if (auto icon = FindVisibleIcon(button, 3)) {
+            auto translation = icon.Translation();
+            DIAG_LOG(L"[diag] %s chain icon: tx=%.1f ty=%.1f op=%.2f", tag,
+                     translation.x, translation.y, icon.Opacity());
+        }
+    } catch (winrt::hresult_error const&) {
+    }
+}
+
+void DiagDumpRow(FrameContext& ctx, PCWSTR tag) {
+    if (!g_diagLog.load()) {
+        return;
+    }
+    auto frame = ctx.frame.get();
+    auto repeater = ctx.repeater.get();
+    if (!frame || !repeater) {
+        return;
+    }
+    double frameWidth = 0;
+    try {
+        frameWidth = frame.ActualWidth();
+    } catch (winrt::hresult_error const&) {
+    }
+    EnumChildElements(repeater, [&](FrameworkElement child) {
+        try {
+            bool visible = child.Visibility() == Visibility::Visible;
+            double x = child.TransformToVisual(frame)
+                           .TransformPoint(Point{0, 0})
+                           .X;
+            auto translation = child.Translation();
+            double opacity = child.Opacity();
+            double maxWidth = child.MaxWidth();
+            bool parked = x < -1 || (frameWidth > 0 && x > frameWidth);
+            if (visible && !parked &&
+                winrt::get_class_name(child) == L"Taskbar.TaskListButton") {
+                float3 off{0, 0, 0};
+                float m41 = 0;
+                if (auto visual = Hosting::ElementCompositionPreview::
+                        GetElementVisual(child)) {
+                    off = visual.Offset();
+                    m41 = visual.TransformMatrix().m41;
+                }
+                DIAG_LOG(L"[diag] %s comp: x=%.1f sx=%.1f tx=%.1f off=%.1f "
+                         L"m41=%.1f %s",
+                       tag, x, GetSlideX(ctx, child), translation.x, off.x,
+                       m41,
+                       winrt::Windows::UI::Xaml::Automation::AutomationProperties::GetName(child).c_str());
+                DiagDumpVisualChain(child, tag);
+            }
+            bool anomaly = visible && (translation.x != 0 || opacity == 0.0 ||
+                                       maxWidth == 0.0 || parked);
+            if (anomaly) {
+                DIAG_LOG(L"[diag] %s: x=%.1f tx=%.1f op=%.2f mw=%.0f %s", tag,
+                       x, translation.x, opacity,
+                       maxWidth > 1e9 ? -1.0 : maxWidth,
+                       winrt::Windows::UI::Xaml::Automation::AutomationProperties::GetName(child).c_str());
+            }
+        } catch (winrt::hresult_error const&) {
+        }
+        return false;
+    });
 }
 
 // Lands a finished collapse run: the real hides, the translation zeroing
@@ -982,7 +1723,9 @@ bool BuildAnimPlan(FrameContext& ctx,
 // follow-up pass re-checks for stragglers.
 void FinalizeCollapseRun(FrameContext& ctx) {
     ctx.animFinalizePending = false;
-    Wh_Log(L"Collapse finalize: landing");
+    DIAG_LOG(L"[diag] finalize: plan=%d gapHidden=%d hiddenByUs=%d",
+           (int)ctx.animPlan.size(), (int)ctx.gapHidden.size(),
+           (int)ctx.hiddenByUs.size());
     // Windows re-arms its reposition animations between the apex and here;
     // strip them again, or the layout flip glides or strands the survivors.
     for (auto& entry : ctx.animPlan) {
@@ -997,41 +1740,167 @@ void FinalizeCollapseRun(FrameContext& ctx) {
     } catch (winrt::hresult_error const&) {
         Wh_Log(L"Collapse finalize: SetCollapseState threw");
     }
-    StopAnimation(ctx);
-    // Belt: nothing translated may survive the landing.
-    if (auto repeater = ctx.repeater.get()) {
-        EnumChildElements(repeater, [](FrameworkElement child) {
-            try {
-                auto translation = child.Translation();
-                if (translation.x != 0 || translation.y != 0) {
-                    Wh_Log(L"Collapse finalize: stray translation swept");
-                    child.Translation(float3{0, 0, 0});
-                }
-            } catch (winrt::hresult_error const&) {
-            }
-            return false;
-        });
+    // The hides storm UpdateVisualStates and Windows re-arms off it before
+    // this pass commits. Flush the storm, strip what it armed; only then
+    // clear the translations, so the commit lands dead.
+    if (auto frame = ctx.frame.get()) {
+        try {
+            frame.UpdateLayout();
+        } catch (winrt::hresult_error const&) {
+        }
     }
+    // The flush pulls Windows' overflow drain in synchronously, and the
+    // drain can surface freshly drained non-running icons. Hide them in
+    // this same pass, or they render for a frame and a gap-close chases
+    // them; flush again so the strip sees the settled row.
+    try {
+        SetCollapseState(ctx, buttons, true);
+    } catch (winrt::hresult_error const&) {
+    }
+    if (auto frame = ctx.frame.get()) {
+        try {
+            frame.UpdateLayout();
+        } catch (winrt::hresult_error const&) {
+        }
+    }
+    DeanimateRunSet(ctx, buttons);
+    StopAnimation(ctx);
+    // Belt, from the frame rather than the row: the cached container can be
+    // the wrong one, and this must not depend on it being right.
+    if (auto frame = ctx.frame.get()) {
+        if (int repaired = VerifyRowSettled(ctx, frame, 5)) {
+            Wh_Log(L"Collapse finalize: verify repaired %d", repaired);
+        }
+        if (auto repeater = ctx.repeater.get()) {
+            HidePhantomButtons(ctx, repeater, frame, L"finalize");
+        }
+    }
+    DiagDumpRow(ctx, L"finalize-end");
     // And one verification pass right behind it.
     PostApply(ctx.dispatcher);
+}
+
+void DiagDumpChrome(FrameworkElement root,
+                    FrameworkElement frame,
+                    int depth) {
+    if (!g_diagLog.load() || !root || depth < 0) {
+        return;
+    }
+    EnumChildElements(root, [&](FrameworkElement child) {
+        try {
+            auto cls = winrt::get_class_name(child);
+            std::wstring_view v(cls);
+            bool realButton = v.size() >= 6 &&
+                              v.substr(v.size() - 6) == L"Button";
+            double w = child.ActualWidth();
+            double x = child.TransformToVisual(frame)
+                           .TransformPoint(Point{0, 0})
+                           .X;
+            DIAG_LOG(L"[diag] chrome d%d x=%.1f w=%.1f h=%.1f vis=%d op=%.2f %s",
+                   depth, x, w, child.ActualHeight(),
+                   (int)(child.Visibility() == Visibility::Visible),
+                   child.Opacity(), cls.c_str());
+            bool wide = w > 34.0 && w < 100.0 && x > -1;
+            if (!realButton || wide) {
+                DiagDumpChrome(child, frame, depth - 1);
+            }
+        } catch (winrt::hresult_error const&) {
+        }
+        return false;
+    });
+}
+
+// Stray-highlight hunt: a visible button container with no icon is the
+// only XAML-side trace of the box. Its plate brush can read transparent
+// while stale content still draws, so every field the mod acts on is
+// printed. Silent while the strip is healthy.
+void DiagDumpStrays(FrameContext& ctx, PCWSTR tag) {
+    if (!g_diagStray.load()) {
+        return;
+    }
+    auto frame = ctx.frame.get();
+    auto repeater = ctx.repeater.get();
+    if (!frame || !repeater) {
+        return;
+    }
+    double frameWidth = 0;
+    try {
+        frameWidth = frame.ActualWidth();
+    } catch (winrt::hresult_error const&) {
+    }
+    EnumChildElements(repeater, [&](FrameworkElement child) {
+        try {
+            if (child.Visibility() != Visibility::Visible ||
+                winrt::get_class_name(child) != L"Taskbar.TaskListButton" ||
+                HasVisibleIcon(child, 3)) {
+                return false;
+            }
+            double x =
+                child.TransformToVisual(frame).TransformPoint(Point{0, 0}).X;
+            if (x < -1 || (frameWidth > 0 && x > frameWidth)) {
+                return false;
+            }
+            // First lit plate brush, if the container still holds one.
+            wchar_t plate[16] = L"none";
+            std::function<bool(FrameworkElement, int)> findPlate =
+                [&](FrameworkElement root, int depth) {
+                    if (!root || depth < 0) {
+                        return false;
+                    }
+                    return EnumChildElements(root, [&](FrameworkElement node) {
+                        if (auto border = node.try_as<Controls::Border>()) {
+                            auto bg = border.Background();
+                            auto solid =
+                                bg ? bg.try_as<Media::SolidColorBrush>()
+                                   : nullptr;
+                            if (solid && solid.Color().A > 0) {
+                                auto c = solid.Color();
+                                swprintf_s(plate, L"%02X%02X%02X%02X", c.A,
+                                           c.R, c.G, c.B);
+                                return true;
+                            }
+                        }
+                        return findPlate(node, depth - 1);
+                    }) != nullptr;
+                };
+            findPlate(child, 3);
+            bool phantom = false;
+            for (auto& weak : ctx.phantomHidden) {
+                if (weak.get() == child) {
+                    phantom = true;
+                    break;
+                }
+            }
+            Wh_Log(L"[stray] %s: x=%.1f op=%.2f running=%d ours=%d "
+                   L"phantom=%d plate=%s %s",
+                   tag, x, child.Opacity(),
+                   (int)TaskListButton_IsRunning(child),
+                   (int)TakeFromHiddenSet(ctx.hiddenByUs, child, false),
+                   (int)phantom, plate,
+                   winrt::Windows::UI::Xaml::Automation::AutomationProperties::GetName(child).c_str());
+        } catch (winrt::hresult_error const&) {
+        }
+        return false;
+    });
 }
 
 void StartAnimation(FrameContext& ctx,
                     std::vector<FrameworkElement> buttons,
                     bool targetCollapse) {
+    DIAG_LOG(L"[diag] StartAnimation target=%d buttons=%d",
+           (int)targetCollapse, (int)buttons.size());
+    if (auto frame = ctx.frame.get()) {
+        DiagDumpChrome(frame, frame, 8);
+    }
     ctx.animActive = true;
     ctx.animKind = AnimKind::Accordion;
     ctx.animTargetCollapse = targetCollapse;
     ctx.animStartMs = NowMs();
-    ctx.animAmplitude =
-        ctx.idleWidth * (double)g_settings.animationAmplitudePct / 100.0;
-    ctx.animCentered = TaskbarIsCentered();
     ctx.animSwapped = false;
     ctx.animButtons = std::move(buttons);
-    ctx.animGapOffsets.clear();
     bool planned = false;
     if (auto frame = ctx.frame.get()) {
-        SortButtonsByPosition(ctx.animButtons, frame);
+        // No pre-sort: the plan assigns fold order from measured X itself.
         planned = BuildAnimPlan(ctx, frame, targetCollapse);
     }
     if (!planned) {
@@ -1040,6 +1909,7 @@ void StartAnimation(FrameContext& ctx,
         StopAnimation(ctx);
         return;
     }
+    DiagDumpStrays(ctx, L"run-start");
     HookRendering(ctx, ctx.key);
 }
 
@@ -1076,7 +1946,6 @@ void MeasureGapOffsets(FrameContext& ctx, FrameworkElement frame) {
             // Running is a genuine launch, not a re-show; let it by.
             if (button.Visibility() == Visibility::Visible &&
                 !TaskListButton_IsRunning(button)) {
-                ClearImplicitShowHide(button);
                 button.Visibility(Visibility::Collapsed);
                 reShown = true;
             }
@@ -1111,7 +1980,7 @@ void MeasureGapOffsets(FrameContext& ctx, FrameworkElement frame) {
     }
 
     for (size_t i = 0; i < ctx.animButtons.size(); i++) {
-        ctx.animButtons[i].Translation(float3{ctx.animGapOffsets[i], 0, 0});
+        SetSlideX(ctx, ctx.animButtons[i], ctx.animGapOffsets[i]);
     }
 }
 
@@ -1121,6 +1990,7 @@ void StartGapCloseAnimation(
     FrameContext& ctx,
     std::vector<FrameworkElement> const& buttons,
     std::vector<std::pair<FrameworkElement, double>> deferHide) {
+    DIAG_LOG(L"[diag] StartGapClose deferHide=%d", (int)deferHide.size());
     // Hold everything the repeater lays out — on a centred bar Start and
     // search shift too — so the whole strip freezes and eases as one.
     ctx.animButtons.clear();
@@ -1150,6 +2020,17 @@ void StartGapCloseAnimation(
         StopAnimation(ctx);
         return;
     }
+    float diagMax = 0;
+    for (float offset : ctx.animGapOffsets) {
+        if (std::abs(offset) > std::abs(diagMax)) {
+            diagMax = offset;
+        }
+    }
+    DIAG_LOG(L"[diag] StartGapClose survivors=%d maxOffset=%.1f",
+           (int)ctx.animButtons.size(), diagMax);
+    // The hide and the freeze committed by this pass re-armed Windows'
+    // animations mid-pass; strip last so the commit lands dead.
+    DeanimateRunSet(ctx, ctx.animButtons);
     HookRendering(ctx, ctx.key);
 }
 
@@ -1162,7 +2043,18 @@ bool ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
 
     std::vector<FrameworkElement> buttons;
     if (auto repeater = ctx.repeater.get()) {
-        CollectTaskListButtons(repeater, 3, buttons);
+        // A rebuild (a DPI change, say) can leave the cached container alive
+        // but detached, still handing back stale buttons. Re-discover then.
+        bool attached = false;
+        try {
+            attached = Media::VisualTreeHelper::GetParent(repeater) != nullptr;
+        } catch (winrt::hresult_error const&) {
+        }
+        if (attached) {
+            CollectTaskListButtons(repeater, 3, buttons);
+        } else {
+            ctx.repeater = nullptr;
+        }
     }
     if (buttons.empty()) {
         CollectTaskListButtons(frame, 8, buttons);
@@ -1174,35 +2066,47 @@ bool ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
         }
     }
 
+    // Before anything measures or counts: an abandoned container is a
+    // visible button to every line below, so it would join the plan, skew
+    // the counts and draw its plate over a real icon.
+    RestoreRepairedPhantoms(ctx, frame);
+    if (auto repeater = ctx.repeater.get()) {
+        if (HidePhantomButtons(ctx, repeater, frame, L"apply") > 0) {
+            buttons.clear();
+            CollectTaskListButtons(repeater, 3, buttons);
+        }
+    }
+
+    // Only replace the known-good set on success: a rebuild that walks up
+    // empty must not leave IsPointerClearOfButtons with nothing to test.
+    if (buttons.empty()) {
+        return false;
+    }
+
     ctx.lastButtons.clear();
     for (auto& button : buttons) {
         ctx.lastButtons.push_back(winrt::make_weak(button));
     }
 
-    if (buttons.empty()) {
-        return false;
-    }
-
+    // Windows animates these same icons, and a hidden one keeps its old spot
+    // — so anything it plays lands from the wrong place and fights whatever
+    // we are doing. Its animations stay off for as long as the mod manages
+    // the row, and come back when it stops.
     if (!g_unloading) {
         if (!g_collapseEnabled && ctx.hiddenByUs.empty()) {
             ReanimateButtons(ctx);
+            DetachSlides(ctx);
         } else {
-            for (auto& button : buttons) {
-                DeanimateButton(ctx, button);
-            }
-            // Start/search recentre with the row; their own slide lags the
-            // choreography, so they go still too. Restored with the rest.
-            if (auto repeater = ctx.repeater.get()) {
-                EnumChildElements(repeater, [&](FrameworkElement child) {
-                    DeanimateButton(ctx, child);
-                    return false;
-                });
-            }
+            DeanimateRunSet(ctx, buttons);
         }
     }
 
     bool instant = instantRequested || ctx.appliedCollapse < 0 ||
                    g_settings.animationMode == AnimationMode::None;
+
+    DIAG_LOG(L"[diag] apply collapse=%d applied=%d instant=%d buttons=%d",
+           (int)collapse, ctx.appliedCollapse, (int)instant,
+           (int)buttons.size());
 
     if (!instant && (collapse ? 1 : 0) != ctx.appliedCollapse) {
         StartAnimation(ctx, std::move(buttons), collapse);
@@ -1210,7 +2114,7 @@ bool ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
     }
 
     bool animateGaps = !instant && !g_unloading &&
-                       g_settings.animationMode == AnimationMode::Spacing &&
+                       g_settings.animationMode == AnimationMode::Slide &&
                        (collapse ? 1 : 0) == ctx.appliedCollapse;
     std::vector<std::pair<FrameworkElement, double>> deferHide;
     SetCollapseState(ctx, buttons, collapse,
@@ -1219,20 +2123,13 @@ bool ApplyToFrame(FrameContext& ctx, bool collapse, bool instantRequested) {
         StartGapCloseAnimation(ctx, buttons, std::move(deferHide));
     } else if (!ctx.animActive) {
         // Steady state: a recycled container can resurface carrying a stale
-        // offset from an earlier run, which reads as jumbled spacing. Sweep.
+        // offset or width from an earlier run. Row only — this runs on every
+        // taskbar event, so it stays shallow; the landing does the deep one.
         if (auto repeater = ctx.repeater.get()) {
-            EnumChildElements(repeater, [](FrameworkElement child) {
-                try {
-                    auto translation = child.Translation();
-                    if (translation.x != 0 || translation.y != 0) {
-                        child.Translation(float3{0, 0, 0});
-                    }
-                } catch (winrt::hresult_error const&) {
-                }
-                return false;
-            });
+            VerifyRowSettled(ctx, repeater, 0);
         }
     }
+    DiagDumpRow(ctx, L"apply-end");
     return true;
 }
 
@@ -1254,19 +2151,24 @@ void OnRenderingTick(void* key) {
                    : 1.0;
     double eased = CubicBezierEase(CurveFor(g_settings.animationCurve), t);
 
+    // Divergence, shared by both animations: an element joining or leaving
+    // the strip means the plan being played back is stale.
+    int childCount = CountStripChildren(*ctx);
+    bool countDiverged = ctx->animChildCount >= 0 && childCount >= 0 &&
+                         childCount != ctx->animChildCount;
+
     if (ctx->animKind == AnimKind::GapClose) {
-        // An element joining or leaving the strip mid-run, or a held
-        // survivor vanishing, is divergence: land the final state instantly
-        // instead of animating a stale plan.
-        int childCount = CountStripChildren(*ctx);
-        if (ctx->animChildCount >= 0 && childCount >= 0 &&
-            childCount != ctx->animChildCount) {
+        // A held survivor vanishing counts too; land instantly either way.
+        if (countDiverged) {
+            DIAG_LOG(L"[diag] gapclose diverge: children %d -> %d",
+                   ctx->animChildCount, childCount);
             StopAnimation(*ctx);
             return;
         }
         try {
             for (auto& button : ctx->animButtons) {
                 if (button.Visibility() != Visibility::Visible) {
+                    DIAG_LOG(L"[diag] gapclose diverge: survivor hidden");
                     StopAnimation(*ctx);
                     return;
                 }
@@ -1302,7 +2204,6 @@ void OnRenderingTick(void* key) {
                     // Running is a genuine launch, not a re-show; let it by.
                     if (button.Visibility() == Visibility::Visible &&
                         !TaskListButton_IsRunning(button)) {
-                        ClearImplicitShowHide(button);
                         button.Visibility(Visibility::Collapsed);
                         repaired = true;
                     }
@@ -1339,8 +2240,8 @@ void OnRenderingTick(void* key) {
         double factor =
             1.0 - CubicBezierEase(CurveFor(g_settings.animationCurve), closeT);
         for (size_t i = 0; i < ctx->animButtons.size(); i++) {
-            ctx->animButtons[i].Translation(
-                float3{(float)(ctx->animGapOffsets[i] * factor), 0, 0});
+            SetSlideX(*ctx, ctx->animButtons[i],
+                      ctx->animGapOffsets[i] * factor);
         }
         return;
     }
@@ -1348,27 +2249,37 @@ void OnRenderingTick(void* key) {
     // Accordion playback. Reality must match the table; an element joining,
     // leaving, or flipping phase off-script kills the run and lands the
     // target instantly.
-    bool diverged = false;
-    int childCount = CountStripChildren(*ctx);
-    if (ctx->animChildCount >= 0 && childCount >= 0 &&
-        childCount != ctx->animChildCount) {
-        diverged = true;
+    bool diverged = countDiverged;
+    if (diverged) {
+        DIAG_LOG(L"[diag] accordion diverge: children %d -> %d",
+               ctx->animChildCount, childCount);
     }
     if (!diverged) {
         try {
             for (auto& entry : ctx->animPlan) {
-                // Collapse hides nothing until the end; reveal's phase two
-                // expects the full set.
-                bool expect = ctx->animSwapped && !ctx->animTargetCollapse
-                                  ? entry.visibleAfter
-                                  : entry.visiblePhase1;
+                // Overflowed throughout: Windows moves it in and out of the
+                // overflow on its own clock, and none of that is off-script.
+                if (!entry.animate) {
+                    continue;
+                }
+                // Neither direction flips Visibility mid-run, so the
+                // phase-one snapshot is the expectation for the whole run.
                 if ((entry.element.Visibility() == Visibility::Visible) !=
-                    expect) {
+                    entry.visiblePhase1) {
+                    try {
+                        DIAG_LOG(L"[diag] accordion diverge: vis flip on %s "
+                               L"expect=%d swapped=%d",
+                               winrt::Windows::UI::Xaml::Automation::AutomationProperties::GetName(entry.element).c_str(),
+                               (int)entry.visiblePhase1,
+                               (int)ctx->animSwapped);
+                    } catch (winrt::hresult_error const&) {
+                    }
                     diverged = true;
                     break;
                 }
             }
         } catch (winrt::hresult_error const&) {
+            DIAG_LOG(L"[diag] accordion diverge: threw");
             diverged = true;
         }
     }
@@ -1391,11 +2302,15 @@ void OnRenderingTick(void* key) {
 
     if (t >= 0.5 && !ctx->animSwapped) {
         ctx->animSwapped = true;
+        DiagDumpStrays(*ctx, L"apex");
         // The apex cut is opacity only, both ways; the layout never moves
         // mid-run. Reveal flips the appearing icons in; collapse flips the
         // disappearing ones out, and their real hides land at the end.
         if (ctx->animTargetCollapse) {
             for (auto& entry : ctx->animPlan) {
+                if (!entry.animate) {
+                    continue;
+                }
                 try {
                     if (entry.visibleBefore && !entry.visibleAfter) {
                         FrameContext::GapHidden held;
@@ -1416,18 +2331,6 @@ void OnRenderingTick(void* key) {
                 }
             }
             ctx->gapHidden.clear();
-            if (ctx->frame.get()) {
-                double width = 0;
-                for (auto& button : ctx->animButtons) {
-                    if (button.Visibility() == Visibility::Visible &&
-                        !TaskListButton_IsRunning(button)) {
-                        width += button.ActualWidth();
-                    }
-                }
-                if (width > 0.5) {
-                    ctx->idleWidth = width;
-                }
-            }
         }
         // The flip can prompt fresh animations while the tick is paused.
         for (auto& button : ctx->animButtons) {
@@ -1436,6 +2339,7 @@ void OnRenderingTick(void* key) {
     }
 
     if (t >= 1.0) {
+        DiagDumpStrays(*ctx, L"run-end");
         if (ctx->animTargetCollapse) {
             // Land the layout off the render clock; the next dispatcher
             // pass commits hides, translations and opacities together.
@@ -1448,31 +2352,19 @@ void OnRenderingTick(void* key) {
         return;
     }
 
-    // Travel comes from the table. Left-aligned adds the fold on top — the
-    // stretch, flipped at the cut, day one's accordion. Centred leaves the
-    // spacing alone: Snappiness instead skips that share of the travel at
-    // the cut, masked by the icon swap.
-    double direction = ctx->animTargetCollapse ? -1.0 : 1.0;
-    double progress = eased;
-    double perGap = 0;
-    if (ctx->animCentered) {
-        double skip = (double)g_settings.animationAmplitudePct / 100.0;
-        progress = eased * (1 - skip) + (ctx->animSwapped ? skip : 0);
-    } else {
-        double foldExtra = direction * ctx->animAmplitude *
-                           (ctx->animSwapped ? 1 - eased : eased);
-        int gaps = (ctx->animSwapped ? ctx->animFoldCountAfter
-                                     : ctx->animFoldCountBefore) -
-                   1;
-        perGap = gaps > 0 ? foldExtra / gaps : 0;
-    }
+    // Every element rides its measured travel on one clock. Snappiness cuts
+    // that share of the journey out at the apex, where the icon swap hides
+    // the jump — the whole animation, for every alignment and icon count.
+    double skip = (double)g_settings.snappinessPct / 100.0;
+    double progress = eased * (1 - skip) + (ctx->animSwapped ? skip : 0);
 
     try {
         for (auto& entry : ctx->animPlan) {
             bool visible = ctx->animSwapped ? entry.visibleAfter
                                             : entry.visibleBefore;
-            if (!visible) {
-                entry.element.Translation(float3{0, 0, 0});
+            // Overflowed icons keep whatever spot the layout gives them.
+            if (!visible || !entry.animate) {
+                SetSlideX(*ctx, entry.element, 0);
                 continue;
             }
             // One continuous expression per direction, no apex switch:
@@ -1482,14 +2374,7 @@ void OnRenderingTick(void* key) {
                 ctx->animTargetCollapse
                     ? (entry.finalX - entry.startX) * progress
                     : (entry.startX - entry.finalX) * (1 - progress);
-            double decoration = 0;
-            if (!ctx->animCentered) {
-                int fold = ctx->animSwapped ? entry.foldAfter
-                                            : entry.foldBefore;
-                decoration = fold >= 0 ? fold * perGap : 0;
-            }
-            entry.element.Translation(
-                float3{(float)(travel + decoration), 0, 0});
+            SetSlideX(*ctx, entry.element, travel);
         }
     } catch (winrt::hresult_error const&) {
     }
@@ -1497,15 +2382,7 @@ void OnRenderingTick(void* key) {
 
 void RestoreFrame(FrameContext& ctx) {
     StopAnimation(ctx);
-
-    for (auto& weak : ctx.lastButtons) {
-        if (auto button = weak.get()) {
-            try {
-                button.Translation(float3{0, 0, 0});
-            } catch (winrt::hresult_error const&) {
-            }
-        }
-    }
+    DetachSlides(ctx);
 
     for (auto& weak : ctx.hiddenByUs) {
         if (auto button = weak.get()) {
@@ -1513,6 +2390,13 @@ void RestoreFrame(FrameContext& ctx) {
         }
     }
     ctx.hiddenByUs.clear();
+    // Nothing this mod hid may outlive it, phantom judgements included.
+    for (auto& weak : ctx.phantomHidden) {
+        if (auto button = weak.get()) {
+            button.Visibility(Visibility::Visible);
+        }
+    }
+    ctx.phantomHidden.clear();
     ReanimateButtons(ctx);
 }
 
@@ -1628,11 +2512,16 @@ void OnTimerTick(void* key) {
     if (ctx->animFinalizePending) {
         FinalizeCollapseRun(*ctx);
     }
+    if (ctx->diagSampleMs > 0 && NowMs() >= ctx->diagSampleMs) {
+        ctx->diagSampleMs = 0;
+        DiagDumpRow(*ctx, L"settled");
+    }
 
     // Watchdog: Rendering stops when the bar is not being composed.
     if (ctx->animActive &&
         NowMs() - ctx->animStartMs >
             (double)g_settings.animationDurationMs * 3.0 + 1000.0) {
+        DIAG_LOG(L"[diag] watchdog fired");
         // Land the target, or the next apply starts the same animation
         // again. Idempotent for a reveal that already landed.
         if (ctx->animKind == AnimKind::Accordion) {
@@ -1664,7 +2553,8 @@ void OnTimerTick(void* key) {
 
     // The timer runs only while something needs a clock; everything else
     // arrives as events. Reveal terms are global: cost, not correctness.
-    bool timing = ctx->animActive || g_emptyHoverSinceTick != 0 ||
+    bool timing = ctx->animActive || ctx->diagSampleMs > 0 ||
+                  g_emptyHoverSinceTick != 0 ||
                   (g_revealed && hoverLike && !g_revealedByStart) ||
                   (hoverLike && g_collapseEnabled && !g_revealed &&
                    g_lastPointerQualified) ||
@@ -1803,7 +2693,141 @@ void StartTimersOnThisThread() {
     }
 }
 
-void WakeAllFramesAsync() {
+void WakeAllFramesAsync(bool skipCurrentThread) {
+    if (g_unloading) {
+        return;
+    }
+
+    // Every reveal flip funnels through here; unload's restore is guarded
+    // out above, so the pre-unload state is what survives.
+    PersistRevealState();
+
+    DWORD threadId = GetCurrentThreadId();
+    std::vector<winrt::Windows::UI::Core::CoreDispatcher> dispatchers;
+    {
+        std::lock_guard<std::mutex> guard(g_framesMutex);
+        for (auto& [key, ctx] : *g_frames) {
+            // Callers that already applied inline skip themselves.
+            if (skipCurrentThread && ctx.threadId == threadId) {
+                continue;
+            }
+            if (ctx.dispatcher) {
+                dispatchers.push_back(ctx.dispatcher);
+            }
+        }
+    }
+
+    for (auto& dispatcher : dispatchers) {
+        PostApply(dispatcher);
+    }
+}
+
+// ---------------------------------------------------------------- diagnostic
+// DIAGNOSTIC BUILD ONLY — strip before submitting. Ctrl+Alt+D dumps every
+// taskbar button's subtree with the properties a stuck highlight would show
+// up in. Changes nothing, so unlike a screenshot or a twirl it does not
+// clear the ghost. One dump holds the stuck button and the healthy ones
+// together, so the difference between them names the element.
+
+void DumpButtonSubtree(FrameworkElement element,
+                       FrameworkElement frame,
+                       int depth,
+                       int maxDepth) {
+    if (!element || depth > maxDepth) {
+        return;
+    }
+
+    try {
+        std::wstring indent((size_t)depth * 2, L' ');
+        auto className = winrt::get_class_name(element);
+        auto name = winrt::Windows::UI::Xaml::Automation::AutomationProperties::
+            GetName(element);
+        double x = -99999;
+        try {
+            x = element.TransformToVisual(frame).TransformPoint(Point{0, 0}).X;
+        } catch (winrt::hresult_error const&) {
+        }
+        auto translation = element.Translation();
+        // RenderTransform is a different channel from Translation, and it is
+        // the one other taskbar mods move icons with.
+        double renderX = 0;
+        try {
+            if (auto transform = element.RenderTransform()) {
+                if (auto single = transform.try_as<Media::TranslateTransform>()) {
+                    renderX = single.X();
+                } else if (auto group =
+                               transform.try_as<Media::TransformGroup>()) {
+                    for (auto const& part : group.Children()) {
+                        if (auto move = part.try_as<Media::TranslateTransform>()) {
+                            renderX += move.X();
+                        }
+                    }
+                }
+            }
+        } catch (winrt::hresult_error const&) {
+        }
+        Wh_Log(L"%s%s [%s] vis=%d op=%.2f w=%.1f h=%.1f x=%.1f tx=%.1f "
+               L"rtx=%.1f maxw=%.1f",
+               indent.c_str(), className.c_str(), name.c_str(),
+               element.Visibility() == Visibility::Visible ? 1 : 0,
+               element.Opacity(), element.ActualWidth(),
+               element.ActualHeight(), x, translation.x, renderX,
+               element.MaxWidth());
+    } catch (winrt::hresult_error const&) {
+        return;
+    }
+
+    EnumChildElements(element, [&](FrameworkElement child) {
+        DumpButtonSubtree(child, frame, depth + 1, maxDepth);
+        return false;
+    });
+}
+
+void DumpHighlightsOnThisThread() {
+    DWORD threadId = GetCurrentThreadId();
+    std::vector<void*> keys;
+    {
+        std::lock_guard<std::mutex> guard(g_framesMutex);
+        for (auto& [key, ctx] : *g_frames) {
+            if (ctx.threadId == threadId) {
+                keys.push_back(key);
+            }
+        }
+    }
+
+    for (void* key : keys) {
+        FrameContext* ctx = GetFrameContext(key);
+        if (!ctx) {
+            continue;
+        }
+        auto frame = ctx->frame.get();
+        auto repeater = ctx->repeater.get();
+        if (!frame || !repeater) {
+            continue;
+        }
+
+        // Where the cursor actually is: a lit plate on a button it is not
+        // over is the anomaly.
+        double cursorX = -1;
+        POINT pt;
+        if (GetCursorPos(&pt)) {
+            try {
+                auto local = frame.TransformToVisual(nullptr);
+                auto origin = local.TransformPoint(Point{0, 0});
+                cursorX = pt.x - origin.X;
+            } catch (winrt::hresult_error const&) {
+            }
+        }
+        Wh_Log(L"=== HIGHLIGHT DUMP cursorX=%.1f ===", cursorX);
+        EnumChildElements(repeater, [&](FrameworkElement child) {
+            DumpButtonSubtree(child, frame, 0, 4);
+            return false;
+        });
+        Wh_Log(L"=== END HIGHLIGHT DUMP ===");
+    }
+}
+
+void RequestHighlightDumpAsync() {
     if (g_unloading) {
         return;
     }
@@ -1819,7 +2843,23 @@ void WakeAllFramesAsync() {
     }
 
     for (auto& dispatcher : dispatchers) {
-        PostApply(dispatcher);
+        // Same lifetime-tied counter as PostApply, so unload still drains.
+        g_pendingWakes++;
+        auto pending =
+            std::shared_ptr<void>(nullptr, [](void*) { g_pendingWakes--; });
+        try {
+            dispatcher.RunAsync(
+                winrt::Windows::UI::Core::CoreDispatcherPriority::Normal,
+                [pending]() {
+                    if (!g_unloading) {
+                        try {
+                            DumpHighlightsOnThisThread();
+                        } catch (...) {
+                        }
+                    }
+                });
+        } catch (winrt::hresult_error const&) {
+        }
     }
 }
 
@@ -2121,7 +3161,7 @@ void HandlePointerMoved(void* pThis, void* pArgs) {
     g_emptyHoverSinceTick = 0;
     ApplyOnThisThreadNow();
     // Other monitors' taskbars have no running timer to notice the flip.
-    WakeAllFramesAsync();
+    WakeAllFramesAsync(true);
 }
 
 int __cdecl TaskbarFrame_OnPointerMoved_Hook(void* pThis, void* pArgs) {
@@ -2218,7 +3258,7 @@ void HandlePointerReleased(void* pThis, void* pArgs) {
     g_emptyHoverSinceTick = 0;
     ApplyOnThisThreadNow();
     // Other monitors' taskbars have no running timer to notice the flip.
-    WakeAllFramesAsync();
+    WakeAllFramesAsync(true);
 }
 
 int __cdecl TaskbarFrame_OnPointerReleased_Hook(void* pThis, void* pArgs) {
@@ -2274,6 +3314,59 @@ void __cdecl TaskListButton_UpdateVisualStates_Hook(void* pThis) {
     if (g_unloading) {
         return;
     }
+    // Ghost guard: right after a collapse lands, the drain can surface a
+    // non-running pinned icon for a frame before the posted apply hides it.
+    // This hook runs inside the drain's own pass — the one spot early
+    // enough to hide it before it renders or opens a gap. Running icons,
+    // parked husks, and everything outside the window pass untouched.
+    try {
+        if (g_collapseEnabled && !g_revealed) {
+            FrameworkElement element = nullptr;
+            FrameKeyFromThis(pThis, &element);
+            // Several frames can share a thread; the button is judged
+            // against its own frame, found by walking up from it.
+            FrameContext* ctx = nullptr;
+            if (element) {
+                std::vector<FrameContext*> candidates;
+                DWORD threadId = GetCurrentThreadId();
+                {
+                    std::lock_guard<std::mutex> guard(g_framesMutex);
+                    for (auto& [key, frameCtx] : *g_frames) {
+                        if (frameCtx.threadId == threadId) {
+                            candidates.push_back(&frameCtx);
+                        }
+                    }
+                }
+                auto node = Media::VisualTreeHelper::GetParent(element)
+                                .try_as<FrameworkElement>();
+                for (int depth = 0; node && !ctx && depth < 12; depth++) {
+                    for (auto* candidate : candidates) {
+                        if (candidate->frame.get() == node) {
+                            ctx = candidate;
+                            break;
+                        }
+                    }
+                    node = Media::VisualTreeHelper::GetParent(node)
+                               .try_as<FrameworkElement>();
+                }
+            }
+            if (ctx && ctx->appliedCollapse == 1 &&
+                NowMs() - ctx->collapseLandedMs < 1000.0) {
+                if (winrt::get_class_name(element) ==
+                        L"Taskbar.TaskListButton" &&
+                    element.Visibility() == Visibility::Visible &&
+                    !TaskListButton_IsRunning(element) &&
+                    !IsParkedOffBar(*ctx, element)) {
+                    DIAG_LOG(L"[diag] ghost hidden on sight");
+                    element.Visibility(Visibility::Collapsed);
+                    if (!TakeFromHiddenSet(ctx->hiddenByUs, element, false)) {
+                        ctx->hiddenByUs.push_back(winrt::make_weak(element));
+                    }
+                }
+            }
+        }
+    } catch (...) {
+    }
     try {
         winrt::Windows::UI::Core::CoreDispatcher dispatcher{nullptr};
         DWORD threadId = GetCurrentThreadId();
@@ -2301,6 +3394,74 @@ void __cdecl TaskListButton_UpdateVisualStates_Hook(void* pThis) {
         }
     } catch (...) {
     }
+}
+
+// DIAG: Windows' own moves on the buttons, timestamped against the mod's
+// phases by the log clock. Log only; every symbol optional. float3 by value
+// travels by pointer on x64, so the hooks take pointers.
+using SharedAnimations_StartItemTranslationAnimation_t =
+    void(__cdecl*)(void* pThis, void** element, float3* from, float3* to);
+SharedAnimations_StartItemTranslationAnimation_t
+    SharedAnimations_StartItemTranslationAnimation_Original;
+void __cdecl SharedAnimations_StartItemTranslationAnimation_Hook(void* pThis,
+                                                                void** element,
+                                                                float3* from,
+                                                                float3* to) {
+    if (g_diagLog.load()) {
+        try {
+            winrt::Windows::UI::Xaml::UIElement target{nullptr};
+            winrt::copy_from_abi(target, *element);
+            DIAG_LOG(L"[diag] win StartItemTranslationAnimation from=%.1f,%.1f "
+                     L"to=%.1f,%.1f %s %s",
+                     from->x, from->y, to->x, to->y,
+                     winrt::get_class_name(target).c_str(),
+                     winrt::Windows::UI::Xaml::Automation::AutomationProperties::
+                         GetName(target)
+                             .c_str());
+        } catch (...) {
+        }
+    }
+    SharedAnimations_StartItemTranslationAnimation_Original(pThis, element,
+                                                            from, to);
+}
+
+using TaskbarFrame_SetRepositionAnimations_t = void(__cdecl*)(void* pThis);
+TaskbarFrame_SetRepositionAnimations_t
+    TaskbarFrame_SetRepositionAnimations_Original;
+void __cdecl TaskbarFrame_SetRepositionAnimations_Hook(void* pThis) {
+    DIAG_LOG(L"[diag] win SetRepositionAnimations");
+    TaskbarFrame_SetRepositionAnimations_Original(pThis);
+}
+
+using TaskListButton_UpdateTransitions_t = void(__cdecl*)(void* pThis,
+                                                          bool enabled,
+                                                          int kind);
+TaskListButton_UpdateTransitions_t TaskListButton_UpdateTransitions_Original;
+void __cdecl TaskListButton_UpdateTransitions_Hook(void* pThis,
+                                                   bool enabled,
+                                                   int kind) {
+    DIAG_LOG(L"[diag] win UpdateTransitions this=%p enabled=%d kind=%d", pThis,
+             (int)enabled, kind);
+    TaskListButton_UpdateTransitions_Original(pThis, enabled, kind);
+}
+
+using TaskListButton_SetTransitionAnimations_t = void(__cdecl*)(void* pThis);
+TaskListButton_SetTransitionAnimations_t
+    TaskListButton_SetTransitionAnimations_Original;
+void __cdecl TaskListButton_SetTransitionAnimations_Hook(void* pThis) {
+    DIAG_LOG(L"[diag] win SetTransitionAnimations this=%p", pThis);
+    TaskListButton_SetTransitionAnimations_Original(pThis);
+}
+
+using TaskListButton_put_TransitionsFrozen_t = int(__cdecl*)(void* pThis,
+                                                             bool frozen);
+TaskListButton_put_TransitionsFrozen_t
+    TaskListButton_put_TransitionsFrozen_Original;
+int __cdecl TaskListButton_put_TransitionsFrozen_Hook(void* pThis,
+                                                      bool frozen) {
+    DIAG_LOG(L"[diag] win TransitionsFrozen abi=%p frozen=%d", pThis,
+             (int)frozen);
+    return TaskListButton_put_TransitionsFrozen_Original(pThis, frozen);
 }
 
 // -------------------------------------------------------------------- hotkey
@@ -2510,6 +3671,12 @@ DWORD WINAPI HotkeyThreadProc(LPVOID param) {
         Wh_Log(L"RegisterHotKey failed, error %u", GetLastError());
     }
 
+    // DIAGNOSTIC BUILD ONLY — strip before submitting.
+    bool dumpRegistered = RegisterHotKey(
+        nullptr, 2, MOD_CONTROL | MOD_ALT | MOD_NOREPEAT, 'D');
+    Wh_Log(L"Highlight dump hotkey Ctrl+Alt+D registered=%d",
+           (int)dumpRegistered);
+
     winrt::com_ptr<IAppVisibility> appVisibility;
     DWORD adviseCookie = 0;
     StartVisibilitySink* sink = nullptr;
@@ -2529,6 +3696,8 @@ DWORD WINAPI HotkeyThreadProc(LPVOID param) {
     while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
         if (msg.message == WM_HOTKEY && msg.wParam == 1) {
             ToggleCollapse();
+        } else if (msg.message == WM_HOTKEY && msg.wParam == 2) {
+            RequestHighlightDumpAsync();
         }
     }
 
@@ -2546,13 +3715,22 @@ DWORD WINAPI HotkeyThreadProc(LPVOID param) {
     if (hotkeyRegistered) {
         UnregisterHotKey(nullptr, 1);
     }
+    if (dumpRegistered) {
+        UnregisterHotKey(nullptr, 2);
+    }
 
     winrt::uninit_apartment();
     return 0;
 }
 
 void StartHotkeyThread() {
-    std::lock_guard<std::mutex> guard(g_hotkeyThreadMutex);
+    // try_lock, never block: this runs from RegisterFrame, i.e. inside a
+    // taskbar layout pass, and a settings save holds this mutex across an
+    // unbounded join. Opportunistic — the next registration retries.
+    std::unique_lock<std::mutex> guard(g_hotkeyThreadMutex, std::try_to_lock);
+    if (!guard.owns_lock()) {
+        return;
+    }
     // The unloading check closes the race with StopHotkeyThread: a start
     // that lost this lock to unload must not spawn into a dying image.
     if (g_hotkeyThread || g_unloading) {
@@ -2776,12 +3954,12 @@ void LoadSettings() {
 
     g_settings.animationDurationMs =
         std::clamp(Wh_GetIntSetting(L"AnimationDurationMs"), 0, 5000);
-    g_settings.animationAmplitudePct =
-        std::clamp(Wh_GetIntSetting(L"AnimationAmplitudePct"), 0, 100);
+    g_settings.snappinessPct =
+        std::clamp(Wh_GetIntSetting(L"SnappinessPct"), 0, 100);
 
     auto mode = WindhawkUtils::StringSetting::make(L"AnimationMode");
-    g_settings.animationMode = wcscmp(mode.get(), L"spacing") == 0
-                                   ? AnimationMode::Spacing
+    g_settings.animationMode = wcscmp(mode.get(), L"slide") == 0
+                                   ? AnimationMode::Slide
                                    : AnimationMode::None;
 
     auto curve = WindhawkUtils::StringSetting::make(L"AnimationCurve");
@@ -2791,6 +3969,9 @@ void LoadSettings() {
     } else if (wcscmp(curve.get(), L"circ") == 0) {
         g_settings.animationCurve = CurveId::Circ;
     }
+
+    g_diagLog = Wh_GetIntSetting(L"DiagLog") != 0;
+    g_diagStray = Wh_GetIntSetting(L"DiagStray") != 0;
 
     g_collapseEnabled = Wh_GetIntSetting(L"Collapsed") != 0;
     g_revealed = false;
@@ -2842,6 +4023,38 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
             &TaskListButton_UpdateVisualStates_Original,
             TaskListButton_UpdateVisualStates_Hook,
         },
+        // DIAG hooks, log only.
+        {
+            {LR"(public: void __cdecl winrt::Taskbar::implementation::SharedAnimations::StartItemTranslationAnimation(struct winrt::Windows::UI::Xaml::UIElement const &,struct winrt::Windows::Foundation::Numerics::float3,struct winrt::Windows::Foundation::Numerics::float3)const )",
+             LR"(public: void __cdecl winrt::Taskbar::implementation::SharedAnimations::StartItemTranslationAnimation(struct winrt::Windows::UI::Xaml::UIElement const &,struct winrt::Windows::Foundation::Numerics::float3,struct winrt::Windows::Foundation::Numerics::float3)const)"},
+            &SharedAnimations_StartItemTranslationAnimation_Original,
+            SharedAnimations_StartItemTranslationAnimation_Hook,
+            true,
+        },
+        {
+            {LR"(private: void __cdecl winrt::Taskbar::implementation::TaskbarFrame::SetRepositionAnimations(void))"},
+            &TaskbarFrame_SetRepositionAnimations_Original,
+            TaskbarFrame_SetRepositionAnimations_Hook,
+            true,
+        },
+        {
+            {LR"(public: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateTransitions(bool,enum winrt::Taskbar::TaskbarButtonTransitionKind))"},
+            &TaskListButton_UpdateTransitions_Original,
+            TaskListButton_UpdateTransitions_Hook,
+            true,
+        },
+        {
+            {LR"(public: void __cdecl winrt::Taskbar::implementation::TaskListButton::SetTransitionAnimations(void))"},
+            &TaskListButton_SetTransitionAnimations_Original,
+            TaskListButton_SetTransitionAnimations_Hook,
+            true,
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListButton,struct winrt::Taskbar::ITaskbarButton>::put_TransitionsFrozen(bool))"},
+            &TaskListButton_put_TransitionsFrozen_Original,
+            TaskListButton_put_TransitionsFrozen_Hook,
+            true,
+        },
     };
 
     if (!WindhawkUtils::HookSymbols(module, symbolHooks,
@@ -2857,6 +4070,14 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
         (int)(TaskbarFrame_OnPointerReleased_Original != nullptr),
         (int)(TaskbarFrame_OnPointerExited_Original != nullptr),
         (int)(TaskbarFrame_MeasureOverride_Original != nullptr));
+    Wh_Log(L"Diag hooks (translate=%d reposition=%d updateTransitions=%d "
+           L"setTransitions=%d frozen=%d)",
+           (int)(SharedAnimations_StartItemTranslationAnimation_Original !=
+                 nullptr),
+           (int)(TaskbarFrame_SetRepositionAnimations_Original != nullptr),
+           (int)(TaskListButton_UpdateTransitions_Original != nullptr),
+           (int)(TaskListButton_SetTransitionAnimations_Original != nullptr),
+           (int)(TaskListButton_put_TransitionsFrozen_Original != nullptr));
     if (!TaskbarFrame_OnPointerReleased_Original) {
         Wh_Log(L"OnPointerReleased hook missing, click reveal will not work");
     }
@@ -2891,6 +4112,10 @@ BOOL Wh_ModInit() {
     Wh_Log(L"Init");
 
     LoadSettings();
+
+    // Sticky reveal from before the last unload or restart.
+    g_revealed = Wh_GetIntValue(L"RevealedState", 0) != 0;
+    g_lastSavedRevealed = g_revealed ? 1 : 0;
 
     if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
         g_taskbarViewDllLoaded = true;
@@ -3025,17 +4250,29 @@ void Wh_ModBeforeUninit() {
             // Signalled on delegate DESTRUCTION, even if dropped uninvoked.
             auto signal = std::shared_ptr<void>(
                 nullptr, [done](void*) { SetEvent(done); });
-            try {
-                dispatcher.RunAsync(
-                    winrt::Windows::UI::Core::CoreDispatcherPriority::High,
-                    [signal]() {
-                        try {
-                            CleanupOnThisThread();
-                        } catch (...) {
-                        }
-                    });
-                queued = true;
-            } catch (winrt::hresult_error const&) {
+            // Bounded retry: a transient failure gets more chances, but a
+            // dispatcher that is permanently shut down must not spin here.
+            // Its thread cannot run timer ticks either, so giving up is safe.
+            for (int attempt = 0; attempt < 5 && !queued; attempt++) {
+                if (attempt && WaitForSingleObject(hThread, 10) ==
+                                   WAIT_OBJECT_0) {
+                    break;
+                }
+                try {
+                    dispatcher.RunAsync(
+                        winrt::Windows::UI::Core::CoreDispatcherPriority::High,
+                        [signal]() {
+                            try {
+                                CleanupOnThisThread();
+                            } catch (...) {
+                            }
+                        });
+                    queued = true;
+                } catch (winrt::hresult_error const&) {
+                }
+            }
+            if (!queued) {
+                Wh_Log(L"Straggler cleanup could not be queued");
             }
         }
         if (queued) {


### PR DESCRIPTION
Adds a new mod: taskbar-collapse-to-running

Hides pinned taskbar icons whose app isn't running, so a taskbar full of pinned
shortcuts collapses down to just what's in use. Icons are only hidden and
unhidden in place, so pinned order is never changed.

Revealing is configurable: left-click the empty part of the taskbar (default),
hover, hover-once-the-cursor-slows ("rest"), a hotkey, or while the Start menu
is open. Windows' own icon reorder slide is stripped and replaced with an
optional spacing-only animation, including an eased gap-close when a running
app exits.

Tested on Windows 11 build 26200, left-aligned taskbar, single monitor.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [X] The submitter, with AI assistance
- - [X] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
