### PR TITLE
Update version to 2.2.0 and improve flyout positioning (minor update)

### DIFF
--- a/mods/win7-action-center-recreation.wh.cpp
+++ b/mods/win7-action-center-recreation.wh.cpp
@@ -2,7 +2,7 @@
 // @id             win7-action-center-recreation
 // @name           Windows 7/8.1 Action Center Recreation
 // @description    This mod recreates the Windows 7/8.1 Action Center tray/flyout and restores the classic Security and Maintenance CPL links
-// @version        2.1.0
+// @version        2.2.0
 // @author         babamohammed
 // @github         https://github.com/babamohammed2022
 // @include        explorer.exe
@@ -41,6 +41,7 @@ Windows 8.1 theme
   - The pending-update check reads the standard CBS and Windows Update registry keys that Windows sets when a reboot is required to finish installing updates.
 - **Startup Notification**: After Windows starts, if problems are detected, a balloon notification is shown regardless of cooldown, so you are never left unaware of existing issues after a reboot. The notification is driven by the periodic security check; if the notification area isn't ready yet, a fallback timer waits up to ~2 minutes before giving up.
 - **ESC to Close**: Press Escape to quickly close the flyout window.
+- **Icon-relative placement**: The flyout appears next to the Action Center tray icon on any taskbar edge (bottom, top, left or right) and follows the icon if you drag it to another slot. It is centered on the icon (like the network flyout recreation mod) and falls back to the last known icon position when the icon is hidden in the notification overflow.
 - **Multiple Languages Support**: English, Italian, Spanish, French, Russian, Portuguese, German, Dutch, Polish, Romanian and Turkish are currently supported.
 - **Security and Maintenance CPL Links**: The mod restores the classic side-by-side **Troubleshooting** and **Recovery** entries on the Control Panel *Security and Maintenance* hub page (as on Windows 7/8.1). The labels follow the UI language (EN/IT/ES/FR/RU/PT/DE/NL/PL/RO/TR). Troubleshooting opens the system troubleshooter shell folder while Recovery opens the Recovery applet.
 
@@ -58,12 +59,11 @@ The mod monitors the system's security settings including Firewall, Antivirus, W
 The mod has been tested on Windows 10 1809, Windows 10 21H2 and Windows 11 23H2 and it is compatible with the native Windows 10 taskbar (native on Windows 10 and using ExplorerPatcher or similar methods on Windows 11).
 
 ## Known Limitations
-- **Vertical taskbar (left/right edge)**: Flyout positioning on vertical taskbars 
-  is best-effort as Windows 10's taskbar itself has inconsistent flyout behavior on vertical 
-  taskbars, so perfect placement cannot be guaranteed in all configurations.
+- **Vertical taskbar (left/right edge)**: The flyout is centered on the icon and opens toward the screen center. Windows 10's taskbar itself has inconsistent flyout behavior on vertical taskbars, so perfect placement cannot be guaranteed in all configurations.
 - **Hidden tray icon**: It is recommended to keep the Action Center icon visible 
   in the system tray rather than hidden in the notification overflow. When hidden, 
-  positioning may be less accurate depending on the Windows version.
+  the flyout falls back to the last known icon position, which may be less accurate 
+  depending on the Windows version.
 ## Notes
 
 - The mod runs inside Explorer and works on Windows 10 and 11.
@@ -125,6 +125,7 @@ The mod has been tested on Windows 10 1809, Windows 10 21H2 and Windows 11 23H2 
 */
 // ==/WindhawkModSettings==
 
+// 2.2.0 -> Fixed the position of the flyout
 
 #ifndef UNICODE
 #define UNICODE
@@ -154,8 +155,6 @@ The mod has been tested on Windows 10 1809, Windows 10 21H2 and Windows 11 23H2 
 
 #define FLYOUT_OFFSET 8
 
-/* Restituisce il DPI effettivo della finestra tramite GetDpiForWindow (Win10 1607+),
-   con fallback a GetDeviceCaps per compatibilita' con versioni precedenti. */
 static UINT GetWindowDpi(HWND hwnd) {
     typedef UINT (WINAPI *GetDpiForWindow_t)(HWND);
     static auto pfn = (GetDpiForWindow_t)GetProcAddress(
@@ -3789,6 +3788,47 @@ static BOOL GetWorkAreaFromMonitor(HMONITOR hMonitor, RECT* outWorkArea) {
     return FALSE;
 }
 
+/* Restituisce il rettangolo a schermo dell'icona tray del Centro Operativo.
+   Fonte primaria: Shell_NotifyIconGetRect (per GUID) con fallback senza GUID.
+   Se entrambe falliscono, riusa l'ultimo rettangolo valido in cache, cosi' il
+   flyout continua a seguire l'icona anche se questa e' momentaneamente non
+   raggiungibile (es. nascosta nell'overflow). Stesso principio della mod del
+   flyout di connessione: il flyout si adatta alla posizione dell'icona. */
+static BOOL GetTrayIconScreenRect(RECT* outRect) {
+    if (!outRect) return FALSE;
+    SetRectEmpty(outRect);
+
+    if (g_Ctx.hWndMsgHandler && g_Ctx.trayIconAdded) {
+        NOTIFYICONIDENTIFIER nidIcon = { sizeof(NOTIFYICONIDENTIFIER) };
+        nidIcon.hWnd = g_Ctx.hWndMsgHandler;
+        nidIcon.uID = TRAY_ICON_ID;
+        nidIcon.guidItem = TRAY_ICON_GUID;
+        RECT rc = { 0 };
+        HRESULT hr = Shell_NotifyIconGetRect(&nidIcon, &rc);
+        if (hr == S_OK && !IsRectEmpty(&rc)) {
+            *outRect = rc;
+            g_CachedTrayIconRect = rc;
+            return TRUE;
+        }
+        // Fallback senza GUID (usato quando NIM_ADD e' riuscito solo senza GUID)
+        ZeroMemory(&nidIcon.guidItem, sizeof(nidIcon.guidItem));
+        hr = Shell_NotifyIconGetRect(&nidIcon, &rc);
+        if (hr == S_OK && !IsRectEmpty(&rc)) {
+            *outRect = rc;
+            g_CachedTrayIconRect = rc;
+            return TRUE;
+        }
+    }
+
+    // Icona temporaneamente non raggiungibile: riusa l'ultimo rettangolo noto
+    // invece di tornare ad ancorare il flyout al bordo della taskbar.
+    if (!IsRectEmpty(&g_CachedTrayIconRect)) {
+        *outRect = g_CachedTrayIconRect;
+        return TRUE;
+    }
+    return FALSE;
+}
+
 void PositionWindowNearTray(HWND hwnd) {
     // Rileva il DPI effettivo della finestra (non il globale g_dpi che potrebbe
     // essere stantio) e ricalcola le metriche prima di posizionare.
@@ -3798,151 +3838,113 @@ void PositionWindowNearTray(HWND hwnd) {
     { SRWGuard guard(g_Ctx.srwLock, false); activeProblems = g_ActiveProblems; }
     RecalcDpiMetrics(dpi, activeProblems);
 
-    // Determina il bordo della taskbar e il monitor corretto per supporto multimonitor.
-    // CRITICO: usiamo il monitor della taskbar, non quello della finestra (che potrebbe essere a (0,0))
+    int winW = g_ScaledWidth;
+    int winH = g_ScaledHeight;
+
+    // Bordo della taskbar + monitor (solo come fallback, vedi sotto).
     RECT taskbarRect = {};
     HMONITOR hTaskbarMonitor = NULL;
     UINT edge = GetTaskbarEdge(&taskbarRect, &hTaskbarMonitor);
-    
-    // Ottieni l'area di lavoro dal monitor della taskbar (fondamentale per multimonitor)
+
+    // Rettangolo dell'icona: e' la fonte primaria, cosi' il flyout si adatta
+    // alla posizione dell'icona e la segue su qualunque bordo (stesso approccio
+    // della mod del flyout di connessione: il flyout e' centrato sull'icona).
+    RECT rcIcon = {};
+    BOOL haveIcon = GetTrayIconScreenRect(&rcIcon);
+
+    // Monitor: preferisci quello dell'icona, altrimenti quello della taskbar.
+    HMONITOR hMon = NULL;
+    if (haveIcon)
+        hMon = MonitorFromRect(&rcIcon, MONITOR_DEFAULTTONEAREST);
+    if (!hMon)
+        hMon = hTaskbarMonitor;
+    if (!hMon)
+        hMon = MonitorFromWindow(NULL, MONITOR_DEFAULTTOPRIMARY);
+
     RECT rcWork = {};
-    if (!GetWorkAreaFromMonitor(hTaskbarMonitor, &rcWork)) {
-        // Fallback se GetMonitorInfo fallisce
+    if (!GetWorkAreaFromMonitor(hMon, &rcWork))
         SystemParametersInfoW(SPI_GETWORKAREA, 0, &rcWork, 0);
+
+    // Preferisci la geometria dell'icona ad ABM_GETTASKBARPOS: cosi' il flyout
+    // finisce sul lato corretto dell'icona anche con taskbar auto-hide o DPI
+    // misti (identico a quanto fa la mod del flyout di connessione).
+    if (haveIcon) {
+        if (rcIcon.top >= rcWork.bottom - 2)       edge = ABE_BOTTOM;
+        else if (rcIcon.bottom <= rcWork.top + 2)  edge = ABE_TOP;
+        else if (rcIcon.left >= rcWork.right - 2)  edge = ABE_RIGHT;
+        else if (rcIcon.right <= rcWork.left + 2)  edge = ABE_LEFT;
     }
 
-    NOTIFYICONIDENTIFIER nidIcon = { sizeof(NOTIFYICONIDENTIFIER) };
-    nidIcon.hWnd = g_Ctx.hWndMsgHandler; nidIcon.uID = TRAY_ICON_ID; nidIcon.guidItem = TRAY_ICON_GUID;
-    RECT rcIcon = { 0 };
-    HRESULT hrRect = Shell_NotifyIconGetRect(&nidIcon, &rcIcon);
-    Wh_Log(L"PositionWindowNearTray: dpi=%u ScaledSize=%dx%d edge=%u monitor=%p",
-           dpi, g_ScaledWidth, g_ScaledHeight, edge, (void*)hTaskbarMonitor);
-    Wh_Log(L"Shell_NotifyIconGetRect hr=0x%08X rcIcon={%d,%d,%d,%d}",
-           (unsigned)hrRect, rcIcon.left, rcIcon.top, rcIcon.right, rcIcon.bottom);
-    Wh_Log(L"Work area={%d,%d,%d,%d} taskbarRect={%d,%d,%d,%d}",
-           rcWork.left, rcWork.top, rcWork.right, rcWork.bottom,
-           taskbarRect.left, taskbarRect.top, taskbarRect.right, taskbarRect.bottom);
+    const int gap = MulDiv(8, (int)dpi, 96);
 
-    // Usa l'icona tray se disponibile, altrimenti ancona al bordo della taskbar.
-    // Questo assicura che il flyout appaia sullo stesso monitor dell'icona.
-    POINT ptAnchor = { 0 };
-    BOOL useIconPosition = (hrRect == S_OK && 
-                           rcIcon.left != 0 && rcIcon.top != 0 &&
-                           (rcIcon.right - rcIcon.left) > 0 && 
-                           (rcIcon.bottom - rcIcon.top) > 0);
-    
-    if (useIconPosition) {
-        // Posiziona l'anchor vicino all'icona tray (comportamento classico Win7)
+    int x = 0, y = 0;
+    if (haveIcon) {
+        // Centra il flyout sull'icona: orizzontalmente con taskbar in alto/basso,
+        // verticalmente con taskbar laterale (come il flyout di rete).
+        int iconCx = rcIcon.left + (rcIcon.right - rcIcon.left) / 2;
+        int iconCy = rcIcon.top  + (rcIcon.bottom - rcIcon.top) / 2;
         switch (edge) {
-            case ABE_TOP:
-                ptAnchor.x = rcIcon.left;
-                ptAnchor.y = rcIcon.bottom;
-                break;
-            case ABE_LEFT:
-                ptAnchor.x = rcIcon.right;
-                ptAnchor.y = (rcIcon.top + rcIcon.bottom) / 2;
-                break;
-            case ABE_RIGHT:
-                ptAnchor.x = rcIcon.left;
-                ptAnchor.y = (rcIcon.top + rcIcon.bottom) / 2;
-                break;
-            default: // ABE_BOTTOM
-                ptAnchor.x = rcIcon.left;
-                ptAnchor.y = rcIcon.top;
-                break;
+        case ABE_TOP:
+            x = iconCx - winW / 2;
+            y = rcIcon.bottom + gap;
+            break;
+        case ABE_LEFT:
+            x = rcIcon.right + gap;
+            y = iconCy - winH / 2;
+            break;
+        case ABE_RIGHT:
+            x = rcIcon.left - winW - gap;
+            y = iconCy - winH / 2;
+            break;
+        case ABE_BOTTOM:
+        default:
+            x = iconCx - winW / 2;
+            y = rcIcon.top - winH - gap;
+            break;
         }
-        Wh_Log(L"Using tray icon position: anchor={%d,%d}", ptAnchor.x, ptAnchor.y);
     } else {
-        // Fallback: ancora al bordo della taskbar (angolo vicino alla system tray)
-        switch (edge) {
-            case ABE_TOP:
-                ptAnchor.x = taskbarRect.right;
-                ptAnchor.y = taskbarRect.bottom;
-                break;
-            case ABE_LEFT:
-                ptAnchor.x = taskbarRect.right;
-                ptAnchor.y = taskbarRect.bottom;
-                break;
-            case ABE_RIGHT:
-                ptAnchor.x = taskbarRect.left;
-                ptAnchor.y = taskbarRect.bottom;
-                break;
-            default: // ABE_BOTTOM
-                ptAnchor.x = taskbarRect.right;
-                ptAnchor.y = taskbarRect.top;
-                break;
-        }
-        Wh_Log(L"Using taskbar edge position: anchor={%d,%d}", ptAnchor.x, ptAnchor.y);
-    }
-
-    // Flag TPM adattati al bordo: il flyout si apre sempre verso l'interno dello schermo.
-    UINT tpmFlags;
-    switch (edge) {
-        case ABE_TOP:   tpmFlags = TPM_LEFTALIGN  | TPM_TOPALIGN    | TPM_VERTICAL; break;
-        case ABE_LEFT:  tpmFlags = TPM_LEFTALIGN  | TPM_BOTTOMALIGN | TPM_VERTICAL; break;
-        case ABE_RIGHT: tpmFlags = TPM_RIGHTALIGN | TPM_BOTTOMALIGN | TPM_VERTICAL; break;
-        default:        tpmFlags = TPM_LEFTALIGN  | TPM_BOTTOMALIGN | TPM_VERTICAL; break;
-    }
-
-    SIZE szFlyout = { g_ScaledWidth, g_ScaledHeight };
-    RECT rcExclude = taskbarRect;
-    RECT rcResult = { 0 };
-    BOOL bPopup = CalculatePopupWindowPosition(&ptAnchor, &szFlyout, tpmFlags, &rcExclude, &rcResult);
-    Wh_Log(L"CalculatePopupWindowPosition ok=%d tpmFlags=0x%X anchor={%d,%d} rcResult={%d,%d,%d,%d}",
-           bPopup, tpmFlags, ptAnchor.x, ptAnchor.y, rcResult.left, rcResult.top, rcResult.right, rcResult.bottom);
-    
-    if (bPopup) {
-        // Verifica che il risultato sia sul monitor corretto (multimonitor safety check)
-        HMONITOR hResultMonitor = MonitorFromPoint({rcResult.left, rcResult.top}, MONITOR_DEFAULTTONEAREST);
-        if (hResultMonitor != hTaskbarMonitor && hTaskbarMonitor != NULL) {
-            Wh_Log(L"Warning: popup on wrong monitor, using fallback positioning");
-            bPopup = FALSE; // Forza fallback
-        }
-    }
-    
-    if (bPopup) {
-        SetWindowPos(hwnd, HWND_TOPMOST, rcResult.left, rcResult.top, g_ScaledWidth, g_ScaledHeight, SWP_NOACTIVATE);
-    } else {
-        // Fallback manuale per ogni bordo - USA SEMPRE l'area di lavoro del monitor della taskbar
-        int x, y;
+        // Fallback senza icona: ancora al bordo della taskbar (come prima).
         int offsetX = MulDiv(10, (int)dpi, 96);
         int offsetY = MulDiv(6, (int)dpi, 96);
-        
         switch (edge) {
             case ABE_TOP:
-                x = rcWork.right - g_ScaledWidth - offsetX;
+                x = rcWork.right - winW - offsetX;
                 y = taskbarRect.bottom + offsetY;
                 break;
             case ABE_LEFT:
                 x = taskbarRect.right + offsetY;
-                y = rcWork.bottom - g_ScaledHeight - offsetX;
+                y = rcWork.bottom - winH - offsetX;
                 break;
             case ABE_RIGHT:
-                x = taskbarRect.left - g_ScaledWidth - offsetY;
-                y = rcWork.bottom - g_ScaledHeight - offsetX;
+                x = taskbarRect.left - winW - offsetY;
+                y = rcWork.bottom - winH - offsetX;
                 break;
             default: // ABE_BOTTOM
-                x = rcWork.right - g_ScaledWidth - offsetX;
-                y = taskbarRect.top - g_ScaledHeight - offsetY;
+                x = rcWork.right - winW - offsetX;
+                y = taskbarRect.top - winH - offsetY;
                 break;
         }
-        
-        // Multimonitor safety: assicurati che la finestra sia visibile sul monitor
-        // Se x/y sono fuori dal work area, clampali
-        if (x < rcWork.left) x = rcWork.left + offsetX;
-        if (y < rcWork.top) y = rcWork.top + offsetY;
-        if (x + g_ScaledWidth > rcWork.right) x = rcWork.right - g_ScaledWidth - offsetX;
-        if (y + g_ScaledHeight > rcWork.bottom) y = rcWork.bottom - g_ScaledHeight - offsetY;
-        
-        Wh_Log(L"Fallback positioning: pos={%d,%d} workArea={%d,%d,%d,%d}", 
-               x, y, rcWork.left, rcWork.top, rcWork.right, rcWork.bottom);
-        SetWindowPos(hwnd, HWND_TOPMOST, x, y, g_ScaledWidth, g_ScaledHeight, SWP_NOACTIVATE);
     }
 
-    // Applica sempre l'offset bordo taskbar usando il monitor corretto
-    POINT pt = AdjustWindowPosForTaskbar(hwnd);
-    SetWindowPos(hwnd, NULL, pt.x, pt.y, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+    // Clamp dentro l'area di lavoro del monitor dell'icona.
+    if (x + winW > rcWork.right)  x = rcWork.right - winW;
+    if (y + winH > rcWork.bottom) y = rcWork.bottom - winH;
+    if (x < rcWork.left) x = rcWork.left;
+    if (y < rcWork.top)  y = rcWork.top;
+
+    Wh_Log(L"PositionWindowNearTray: dpi=%u size=%dx%d edge=%u icon={%d,%d,%d,%d} pos={%d,%d}",
+           dpi, winW, winH, edge, rcIcon.left, rcIcon.top, rcIcon.right, rcIcon.bottom, x, y);
+
+    SetWindowPos(hwnd, HWND_TOPMOST, x, y, winW, winH, SWP_NOACTIVATE);
+
+    // Solo nel percorso di fallback (senza icona) mantieni la spinta lontano
+    // dalla taskbar; con l'icona il gap e' gia' calcolato sopra.
+    if (!haveIcon) {
+        POINT pt = AdjustWindowPosForTaskbar(hwnd);
+        SetWindowPos(hwnd, NULL, pt.x, pt.y, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+    }
 }
+
 void ToggleFlyout() {
     if (g_Ctx.isUninitializing) return;
 

--- a/mods/win7-action-center-recreation.wh.cpp
+++ b/mods/win7-action-center-recreation.wh.cpp
@@ -68,7 +68,6 @@ The mod has been tested on Windows 10 1809, Windows 10 21H2, Windows 10 22H2, Wi
   in the system tray rather than hidden in the notification overflow. When hidden, 
   the flyout falls back to the last known icon position, which may be less accurate 
   depending on the Windows version.
-- **Atypical taskbar configurations**: In rare cases, uncommon taskbar settings (such as multiple rows or having many tray icons always visible) may cause minor interaction issues. While this is rare, it is typically resolved by restarting Explorer after disabling the mod.
 
 ## Notes
 
@@ -239,6 +238,18 @@ POINT AdjustWindowPosForTaskbar(HWND hWnd)
 #define WM_REFRESH_DATA            (WM_USER + 600)
 #define WM_SECURITY_CHANGED        (WM_USER + 601)
 #define TRAY_ICON_ID               3003
+// Bound on consecutive destructive recoveries (NIM_DELETE + NIM_ADD) driven
+// by the background health timer. A genuine taskbar rebuild is handled by the
+// TaskbarCreated handler, so if the icon still appears unreachable after this
+// many consecutive recovery cycles the shell is in an unexpected state and
+// further delete/re-add cycles would only churn the notification area. The
+// counter resets when the reachability probe succeeds again, and on
+// TaskbarCreated.
+#define TRAY_HEALTH_MAX_RECOVERIES 3
+// Number of consecutive failed reachability probes (one probe every 15 s)
+// required before a destructive recovery is triggered. Probing is
+// non-destructive; only the recovery itself reflows the notification area.
+#define TRAY_HEALTH_PROBE_STRIKES  3
 #define AUTOHIDE_TIMER_ID          2001
 #define NOTIFY_TIMER_ID            2002
 #define REFRESH_TIMER_ID           1001
@@ -1648,9 +1659,27 @@ static RECT g_CachedTrayIconRect = {0}; // Cached tray icon rect for mouse hook
 // activation change), so it just re-shows it instead of closing it: the
 // flyout blinks and clicking the icon can only ever open it (review issue #1).
 static BOOL g_TrayClickWhileFlyoutOpen = FALSE;
+// Tick count captured when the latch above is set. A genuine tray-click
+// gesture delivers ToggleFlyout() on the button-up of the SAME gesture,
+// milliseconds after the button-down. If the latch is older than
+// TRAY_CLICK_LATCH_MAX_AGE_MS it cannot belong to the current click: it was
+// set by some earlier, misread click (e.g. a hit against a stale cached icon
+// rect) and must not be allowed to swallow the current one. The latch is
+// deliberately NOT cleared in HideFlyout(): on a genuine icon click the
+// WA_INACTIVE-induced hide arrives between button-down and button-up, so
+// clearing it there would reintroduce the "icon can only ever open" bug.
+static DWORD g_TrayClickLatchTick = 0;
+#define TRAY_CLICK_LATCH_MAX_AGE_MS 1000UL
 static DWORD g_LastProblemBalloonTick = 0;
 // Require repeated failed reachability probes before destructive tray recovery.
 static UINT g_TrayHealthFailureCount = 0;
+// Number of consecutive destructive recovery cycles (NIM_DELETE + NIM_ADD)
+// performed while the reachability probe keeps failing. Capped at
+// TRAY_HEALTH_MAX_RECOVERIES so a probe that never succeeds on some
+// configuration cannot make the mod churn the notification area forever.
+// Reset to 0 when the reachability probe succeeds again and on TaskbarCreated
+// (deliberately NOT on recovery success, otherwise the cap would never fire).
+static UINT g_TrayRecoveryCycleCount = 0;
 static DWORD g_LastProblemBalloonSignature = 0;
 static int g_LastProblemBalloonState = STATE_GOOD;
 static HHOOK g_hMouseHook = NULL;
@@ -3628,15 +3657,24 @@ void AddTrayIcon() {
 static BOOL IsTrayIconReachable() {
     if (!g_Ctx.trayIconAdded || !g_Ctx.hWndMsgHandler ||
         !IsWindow(g_Ctx.hWndMsgHandler)) return FALSE;
-    NOTIFYICONIDENTIFIER id = { sizeof(id) };
-    id.hWnd = g_Ctx.hWndMsgHandler;
-    id.uID = TRAY_ICON_ID;
-    id.guidItem = TRAY_ICON_GUID;
-    RECT rc = {0};
-    if (Shell_NotifyIconGetRect(&id, &rc) == S_OK) return TRUE;
-    // Fallback without GUID (used when ADD fell back to non-GUID path)
-    ZeroMemory(&id.guidItem, sizeof(id.guidItem));
-    return Shell_NotifyIconGetRect(&id, &rc) == S_OK;
+
+    // Reachability is probed with a non-destructive NIM_MODIFY, not with
+    // Shell_NotifyIconGetRect:
+    //  - Shell_NotifyIconGetRect returns S_FALSE (not a failure) together
+    //    with the rect of the notification-overflow button when the icon is
+    //    hidden in the overflow. The old "!= S_OK means the icon is gone"
+    //    test misread that completely normal state as "icon lost".
+    //  - A failing rect query is not proof the shell lost the icon, while a
+    //    failing NIM_MODIFY is exactly the "the shell no longer knows about
+    //    our icon" signal.
+    // NIM_MODIFY only re-applies the current (unchanged) icon/tooltip, so it
+    // never reflows the notification area the way a recovery NIM_DELETE +
+    // NIM_ADD does. g_nid mirrors the last successful publish, including the
+    // no-GUID fallback variant, so the MODIFY matches how the icon is
+    // actually registered.
+    NOTIFYICONDATAW nid = g_nid;
+    nid.hWnd = g_Ctx.hWndMsgHandler;
+    return Shell_NotifyIconW(NIM_MODIFY, &nid) != FALSE;
 }
 static void ScheduleTrayIconRecovery() {
     if (g_Ctx.isUninitializing || !g_Ctx.hWndMsgHandler ||
@@ -3800,11 +3838,26 @@ static BOOL GetWorkAreaFromMonitor(HMONITOR hMonitor, RECT* outWorkArea) {
 
 /* Restituisce il rettangolo a schermo dell'icona tray del Centro Operativo.
    Fonte primaria: Shell_NotifyIconGetRect (per GUID) con fallback senza GUID.
-   Se entrambe falliscono, riusa l'ultimo rettangolo valido in cache, cosi' il
-   flyout continua a seguire l'icona anche se questa e' momentaneamente non
-   raggiungibile (es. nascosta nell'overflow). Stesso principio della mod del
-   flyout di connessione: il flyout si adatta alla posizione dell'icona. */
-static BOOL GetTrayIconScreenRect(RECT* outRect) {
+
+   allowStale distingue i due casi d'uso:
+   - TRUE (posizionamento del flyout): se il rettangolo "live" non e'
+     disponibile, riusa l'ultimo rettangolo valido in cache, cosi' il flyout
+     resta ancorato vicino all'icona anche quando questa e' nascosta
+     nell'overflow o momentaneamente non raggiungibile. Un rettangolo stantio
+     come ancora di posizionamento e' innocuo.
+   - FALSE (hit-test del mouse hook): un rettangolo stantio e' invece
+     pericoloso, perche' i pixel dove prima stava l'icona possono ora
+     appartenere a un'altra icona. Se la risoluzione live fallisce, la cache
+     viene svuotata (SetRectEmpty) e la funzione restituisce FALSE, cosi'
+     PtInRect() nell'hook fallisce in modo sicuro.
+
+   Nota su Shell_NotifyIconGetRect: S_OK = icona visibile (rc = rettangolo
+   dell'icona); S_FALSE = icona esistente ma nascosta nell'overflow (rc =
+   rettangolo del pulsante overflow, NON la posizione dell'icona); FAILED =
+   errore reale. S_FALSE e' uno stato normale e non va trattato come "icona
+   persa": in quel caso si ricade sulla cache (se allowStale) senza pero'
+   considerare valido il rettangolo del pulsante overflow. */
+static BOOL GetTrayIconScreenRect(RECT* outRect, BOOL allowStale) {
     if (!outRect) return FALSE;
     SetRectEmpty(outRect);
 
@@ -3820,18 +3873,32 @@ static BOOL GetTrayIconScreenRect(RECT* outRect) {
             g_CachedTrayIconRect = rc;
             return TRUE;
         }
-        // Fallback senza GUID (usato quando NIM_ADD e' riuscito solo senza GUID)
-        ZeroMemory(&nidIcon.guidItem, sizeof(nidIcon.guidItem));
-        hr = Shell_NotifyIconGetRect(&nidIcon, &rc);
-        if (hr == S_OK && !IsRectEmpty(&rc)) {
-            *outRect = rc;
-            g_CachedTrayIconRect = rc;
-            return TRUE;
+        // S_FALSE qui significa "icona nascosta nell'overflow": rc contiene
+        // il rettangolo del pulsante overflow, non dell'icona; non usarlo e
+        // non riprovare senza GUID (la shell ha gia' trovato l'icona per GUID).
+        if (hr != S_FALSE) {
+            // Fallback senza GUID (usato quando NIM_ADD e' riuscito solo senza GUID)
+            ZeroMemory(&nidIcon.guidItem, sizeof(nidIcon.guidItem));
+            hr = Shell_NotifyIconGetRect(&nidIcon, &rc);
+            if (hr == S_OK && !IsRectEmpty(&rc)) {
+                *outRect = rc;
+                g_CachedTrayIconRect = rc;
+                return TRUE;
+            }
         }
+        // S_FALSE o FAILED da entrambe le query: nessun rettangolo live.
     }
 
-    // Icona temporaneamente non raggiungibile: riusa l'ultimo rettangolo noto
-    // invece di tornare ad ancorare il flyout al bordo della taskbar.
+    if (!allowStale) {
+        // Hit-test: mai operare su un rettangolo stantio. Svuota la cache
+        // cosi' l'hook non scambia un click su un'altra icona per un click
+        // sulla nostra.
+        SetRectEmpty(&g_CachedTrayIconRect);
+        return FALSE;
+    }
+
+    // Posizionamento: riusa l'ultimo rettangolo noto invece di tornare ad
+    // ancorare il flyout al bordo della taskbar.
     if (!IsRectEmpty(&g_CachedTrayIconRect)) {
         *outRect = g_CachedTrayIconRect;
         return TRUE;
@@ -3859,8 +3926,10 @@ void PositionWindowNearTray(HWND hwnd) {
     // Rettangolo dell'icona: e' la fonte primaria, cosi' il flyout si adatta
     // alla posizione dell'icona e la segue su qualunque bordo (stesso approccio
     // della mod del flyout di connessione: il flyout e' centrato sull'icona).
+    // allowStale=TRUE: per il posizionamento l'ultimo rettangolo noto e'
+    // un'ancora accettabile anche se non piu' attuale (icona nell'overflow).
     RECT rcIcon = {};
-    BOOL haveIcon = GetTrayIconScreenRect(&rcIcon);
+    BOOL haveIcon = GetTrayIconScreenRect(&rcIcon, TRUE);
 
     // Monitor: preferisci quello dell'icona, altrimenti quello della taskbar.
     HMONITOR hMon = NULL;
@@ -3966,10 +4035,20 @@ void ToggleFlyout() {
     // flyout (review issue #1).
     if (g_TrayClickWhileFlyoutOpen) {
         g_TrayClickWhileFlyoutOpen = FALSE;
-        if (g_Ctx.hWndFlyout && IsWindow(g_Ctx.hWndFlyout)) {
-            CloseFlyout(g_Ctx.hWndFlyout);
+        // A genuine gesture delivers this call on the button-up of the same
+        // click that set the latch, i.e. within milliseconds. An older latch
+        // is stale - set by a click that was misread as landing on our icon
+        // (stale hit-test rect) and never consumed because the click actually
+        // went to some other tray icon. Dropping it here prevents it from
+        // swallowing this (real) open request and forcing a double click.
+        if ((DWORD)(GetTickCount() - g_TrayClickLatchTick) <= TRAY_CLICK_LATCH_MAX_AGE_MS) {
+            if (g_Ctx.hWndFlyout && IsWindow(g_Ctx.hWndFlyout)) {
+                CloseFlyout(g_Ctx.hWndFlyout);
+            }
+            return;
         }
-        return;
+        // Stale latch: fall through to the normal toggle logic below so this
+        // click opens/re-shows the flyout as the user expects.
     }
 
     // Dismiss notification popup if showing (Win7 behavior)
@@ -4036,10 +4115,17 @@ void ToggleFlyout() {
 // ============================================================================
 // Mouse Hook (Click Outside) - Versione semplificata
 // ============================================================================
-// Cache the tray icon rect for use in the mouse hook (avoids cross-process call in WH_MOUSE_LL)
+// Refresh the tray icon rect used by the mouse hook hit-test. This MUST use
+// the non-stale variant: the cached rect feeds PtInRect() in the low-level
+// mouse hook, and a stale rect (icon moved into the overflow, tray reflowed
+// because another icon appeared/disappeared) would make the hook misread a
+// click on whatever icon now occupies those coordinates as a click on our
+// icon - latching g_TrayClickWhileFlyoutOpen and eating a later open. If the
+// shell cannot resolve the live rect, GetTrayIconScreenRect() empties the
+// cache so the hit-test fails safe (click closes the flyout).
 static void UpdateCachedTrayIconRect() {
     RECT rc;
-    GetTrayIconScreenRect(&rc);  // updates g_CachedTrayIconRect only when it resolves
+    GetTrayIconScreenRect(&rc, FALSE);  // clears g_CachedTrayIconRect on failure
 }
 
 void InstallClickOutsideHook() {
@@ -4081,9 +4167,12 @@ LRESULT CALLBACK ClickOutsideMouseHookProc(int nCode, WPARAM wParam, LPARAM lPar
                 
                 if (overTrayIcon) {
                     // Latch now, at button-down, before WM_ACTIVATE can hide
-                    // the flyout on this same click (review issue #1).
+                    // the flyout on this same click (review issue #1). The
+                    // timestamp lets ToggleFlyout() drop the latch if it is
+                    // not consumed by the button-up of this same gesture.
                     if (wParam == WM_LBUTTONDOWN) {
                         g_TrayClickWhileFlyoutOpen = TRUE;
+                        g_TrayClickLatchTick = GetTickCount();
                     }
                 } else {
                     // Click outside flyout, not on AC icon, and (either not on taskbar
@@ -4652,6 +4741,10 @@ if (g_pBmpShield16 || g_pBmpShield64 || g_hShieldIcon) {
         // DestroyWindow from the cleanup path (e.g. WM_TRAY_SHUTDOWN) used
         // to leak the keyboard hook.
         RemoveClickOutsideHook();
+        // Drop any pending click latch together with the window: a latch that
+        // outlives the flyout can never belong to an in-flight gesture and
+        // would otherwise risk eating a later open request.
+        g_TrayClickWhileFlyoutOpen = FALSE;
         g_FlyoutClosing = FALSE;
         g_IsHoveringLink = FALSE;
         if (g_Ctx.hWndFlyout == hwnd)
@@ -4872,8 +4965,12 @@ LRESULT CALLBACK TrayMsgHandlerProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM 
         ReleaseProblemBalloonResources();
 
         // Schedule a short delayed recovery instead of racing Shell_NotifyIcon.
+        // The taskbar was rebuilt, so this is a brand-new situation: give the
+        // capped recovery budget back.
         g_Ctx.trayIconAdded = FALSE;
         g_Ctx.trayRetryAttempt = 0;
+        g_TrayRecoveryCycleCount = 0;
+        g_TrayHealthFailureCount = 0;
         KillTimer(hwnd, TRAY_RETRY_TIMER_ID);
         KillTimer(hwnd, TRAY_HEALTH_TIMER_ID);
         SetTimer(hwnd, TRAY_RETRY_TIMER_ID, 300, NULL);
@@ -4939,14 +5036,32 @@ LRESULT CALLBACK TrayMsgHandlerProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM 
             if (!g_Ctx.isUninitializing) {
                 if (IsTrayIconReachable()) {
                     g_TrayHealthFailureCount = 0;
-                } else if (++g_TrayHealthFailureCount >= 3) {
-                    // Shell_NotifyIconGetRect can fail transiently while Explorer
-                    // relays out the notification area. Do not delete/re-add our
-                    // icon on a single probe failure, since NIM_DELETE/NIM_ADD
-                    // needlessly reflows every other tray icon.
-                    Wh_Log(L"Tray reachability failed %u consecutive probes; scheduling recovery", g_TrayHealthFailureCount);
+                    // Reachability restored: allow a fresh set of recoveries
+                    // if the icon ever gets lost again.
+                    g_TrayRecoveryCycleCount = 0;
+                } else if (++g_TrayHealthFailureCount >= TRAY_HEALTH_PROBE_STRIKES) {
+                    UINT failedProbes = g_TrayHealthFailureCount;
                     g_TrayHealthFailureCount = 0;
-                    ScheduleTrayIconRecovery();
+                    if (g_TrayRecoveryCycleCount >= TRAY_HEALTH_MAX_RECOVERIES) {
+                        // Terminal state: recovery NIM_DELETE/NIM_ADD cycles
+                        // reflow the whole notification area, so they are
+                        // capped. If the icon is still unreachable after this
+                        // many consecutive cycles, further churn can only
+                        // make things worse. The genuine "taskbar rebuilt"
+                        // case is covered by the TaskbarCreated handler,
+                        // which resets this counter and starts fresh. The
+                        // (non-destructive) probe keeps running and recovery
+                        // resumes automatically if it starts succeeding.
+                        Wh_Log(L"Tray still unreachable after %u consecutive recovery cycles; "
+                               L"pausing destructive recovery until the taskbar is recreated or the probe succeeds",
+                               g_TrayRecoveryCycleCount);
+                    } else {
+                        ++g_TrayRecoveryCycleCount;
+                        Wh_Log(L"Tray reachability probe (NIM_MODIFY) failed %u consecutive times; "
+                               L"scheduling recovery %u of %u",
+                               failedProbes, g_TrayRecoveryCycleCount, TRAY_HEALTH_MAX_RECOVERIES);
+                        ScheduleTrayIconRecovery();
+                    }
                 }
             }
             return 0;

--- a/mods/win7-action-center-recreation.wh.cpp
+++ b/mods/win7-action-center-recreation.wh.cpp
@@ -14,8 +14,11 @@
 /*
 
 # Windows 7/8.1 Action Center Recreation
+
 This mod recreates the classic Windows 7/8.1 Action Center tray icon and flyout for modern Windows versions.
+
 ## Screenshots
+
 Windows 7 theme
 
 ![Image](https://raw.githubusercontent.com/babamohammed2022/babamohammed2022/main/action.png)
@@ -56,7 +59,7 @@ These are the hotkeys that can be configured in the mod.
 ## How It Works
 
 The mod monitors the system's security settings including Firewall, Antivirus, Windows Update, UAC, Windows Defender and other settings. When an issue is detected, the tray icon changes color and the flyout shows the problem with a clickable link to fix it.
-The mod has been tested on Windows 10 1809, Windows 10 21H2 and Windows 11 23H2 and it is compatible with the native Windows 10 taskbar (native on Windows 10 and using ExplorerPatcher or similar methods on Windows 11).
+The mod has been tested on Windows 10 1809, Windows 10 21H2, Windows 10 22H2, Windows 11 23H2, Windows 11 24H2 and Windows 11 25H2 and it is compatible with the native Windows 10 taskbar (native on Windows 10 and using ExplorerPatcher or similar methods on Windows 11).
 
 ## Known Limitations
 - **Vertical taskbar (left/right edge)**: The flyout is centered on the icon and opens toward the screen center. Windows 10's taskbar itself has inconsistent flyout behavior on vertical taskbars, so perfect placement cannot be guaranteed in all configurations.
@@ -73,6 +76,8 @@ The mod has been tested on Windows 10 1809, Windows 10 21H2 and Windows 11 23H2 
 - Yvor - Testing on Windows 10 21H2 with the Windows 8.1 theme
 - TheWolf - Testing on Windows 11 23H2
 - cips_35 - Testing on Windows 11 25H2 and Turkish Translation
+- pyrates999 - Bug Reporting on Windows 10 22H2
+- m417z - Code review
 - ✮⋆˙ Holly B!!──★ ˙🍓 ̟ ˙✧˖°🪼⋆.ೃ [NURO] - Screenshot of the mod under a Windows 7 theme
 */
 // ==/WindhawkModReadme==

--- a/mods/win7-action-center-recreation.wh.cpp
+++ b/mods/win7-action-center-recreation.wh.cpp
@@ -1649,6 +1649,8 @@ static RECT g_CachedTrayIconRect = {0}; // Cached tray icon rect for mouse hook
 // flyout blinks and clicking the icon can only ever open it (review issue #1).
 static BOOL g_TrayClickWhileFlyoutOpen = FALSE;
 static DWORD g_LastProblemBalloonTick = 0;
+// Require repeated failed reachability probes before destructive tray recovery.
+static UINT g_TrayHealthFailureCount = 0;
 static DWORD g_LastProblemBalloonSignature = 0;
 static int g_LastProblemBalloonState = STATE_GOOD;
 static HHOOK g_hMouseHook = NULL;
@@ -3608,6 +3610,7 @@ static BOOL PublishTrayIcon(BOOL preferAdd) {
     HICON hOldIcon = g_nid.hIcon;
     g_nid = nid;
     g_Ctx.trayIconAdded = TRUE;
+    g_TrayHealthFailureCount = 0;
     if (hOldIcon && hOldIcon != hNewIcon) DestroyIcon(hOldIcon);
     return TRUE;
 }
@@ -4083,41 +4086,6 @@ LRESULT CALLBACK ClickOutsideMouseHookProc(int nCode, WPARAM wParam, LPARAM lPar
                         g_TrayClickWhileFlyoutOpen = TRUE;
                     }
                 } else {
-                    // --- MITIGATION FOR MULTI-ROW SYSTEM TRAY (Windows 10 22h2) ---
-                    // In some configurations with a 2-row taskbar, clicks on the second row
-                    // of the system tray are incorrectly interpreted as "outside clicks"
-                    // and close the flyout, preventing interaction with tray icons.
-                    // This mitigation checks if the click is on the taskbar and, if so,
-                    // keeps the flyout open to allow interaction.
-                    //
-                    // Note: This is a best-effort attempt to mitigate the issue.
-                    // The problem has been reported but could not be reproduced
-                    // in the development environment, so the fix is applied
-                    // conservatively to avoid regressions.
-                    BOOL isOnTaskbar = FALSE;
-                    
-                    try {
-                        APPBARDATA abd = {};
-                        abd.cbSize = sizeof(APPBARDATA);
-                        abd.hWnd = FindWindowW(L"Shell_TrayWnd", NULL);
-                        if (abd.hWnd && SHAppBarMessage(ABM_GETTASKBARPOS, &abd)) {
-                            isOnTaskbar = PtInRect(&abd.rc, pMouse->pt);
-                            if (isOnTaskbar) {
-                                // Click on taskbar but not on AC icon:
-                                // update cache and keep flyout open
-                                UpdateCachedTrayIconRect();
-                                Wh_Log(L"Click on taskbar detected - flyout kept open (mitigation for multi-row tray)");
-                                return CallNextHookEx(g_hMouseHook, nCode, wParam, lParam);
-                            }
-                        }
-                    }
-                    catch (...) {
-                        // Exception occurred while checking taskbar position.
-                        // Fall back to original behavior: close the flyout.
-                        Wh_Log(L"Exception in ClickOutsideMouseHookProc taskbar check");
-                        // Continue to original close behavior below
-                    }
-                    
                     // Click outside flyout, not on AC icon, and (either not on taskbar
                     // or exception occurred during taskbar check) -> close flyout
                     PostMessageW(g_Ctx.hWndFlyout, WM_SAFE_CLOSE, 0, 0);
@@ -4968,8 +4936,19 @@ LRESULT CALLBACK TrayMsgHandlerProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM 
             return 0;
         }
         if (wParam == TRAY_HEALTH_TIMER_ID) {
-            if (!g_Ctx.isUninitializing && !IsTrayIconReachable())
-                ScheduleTrayIconRecovery();
+            if (!g_Ctx.isUninitializing) {
+                if (IsTrayIconReachable()) {
+                    g_TrayHealthFailureCount = 0;
+                } else if (++g_TrayHealthFailureCount >= 3) {
+                    // Shell_NotifyIconGetRect can fail transiently while Explorer
+                    // relays out the notification area. Do not delete/re-add our
+                    // icon on a single probe failure, since NIM_DELETE/NIM_ADD
+                    // needlessly reflows every other tray icon.
+                    Wh_Log(L"Tray reachability failed %u consecutive probes; scheduling recovery", g_TrayHealthFailureCount);
+                    g_TrayHealthFailureCount = 0;
+                    ScheduleTrayIconRecovery();
+                }
+            }
             return 0;
         }
     }
@@ -5017,7 +4996,15 @@ LRESULT CALLBACK TrayMsgHandlerProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM 
 if (trayEvent == NIN_BALLOONUSERCLICK) {
     try {
         RemoveProblemBalloon();
-        // A click must open the flyout
+        // A balloon click must open the flyout. The low-level mouse hook can
+        // have queued WM_SAFE_CLOSE before this notification reaches the tray
+        // window, so do not let the visibility check suppress the open request.
+        // If it is still visible, queue the close first; the subsequent trigger
+        // then re-opens it through the normal ToggleFlyout path.
+        if (g_Ctx.hWndFlyout && IsWindow(g_Ctx.hWndFlyout) &&
+            IsWindowVisible(g_Ctx.hWndFlyout)) {
+            PostMessageW(g_Ctx.hWndFlyout, WM_SAFE_CLOSE, 0, 0);
+        }
         PostMessageW(hwnd, WM_TRIGGER_FLYOUT, 0, 0);
     }
     catch (...) {

--- a/mods/win7-action-center-recreation.wh.cpp
+++ b/mods/win7-action-center-recreation.wh.cpp
@@ -62,11 +62,14 @@ The mod monitors the system's security settings including Firewall, Antivirus, W
 The mod has been tested on Windows 10 1809, Windows 10 21H2, Windows 10 22H2, Windows 11 23H2, Windows 11 24H2 and Windows 11 25H2 and it is compatible with the native Windows 10 taskbar (native on Windows 10 and using ExplorerPatcher or similar methods on Windows 11).
 
 ## Known Limitations
+
 - **Vertical taskbar (left/right edge)**: The flyout is centered on the icon and opens toward the screen center. Windows 10's taskbar itself has inconsistent flyout behavior on vertical taskbars, so perfect placement cannot be guaranteed in all configurations.
 - **Hidden tray icon**: It is recommended to keep the Action Center icon visible 
   in the system tray rather than hidden in the notification overflow. When hidden, 
   the flyout falls back to the last known icon position, which may be less accurate 
   depending on the Windows version.
+- **Atypical taskbar configurations**: In rare cases, uncommon taskbar settings (such as multiple rows or having many tray icons always visible) may cause minor interaction issues. While this is rare, it is typically resolved by restarting Explorer after disabling the mod.
+
 ## Notes
 
 - The mod runs inside Explorer and works on Windows 10 and 11.
@@ -88,19 +91,19 @@ The mod has been tested on Windows 10 1809, Windows 10 21H2, Windows 10 22H2, Wi
   $description: This setting enables rounded edges on the flyout (Windows 7 look). Turn this off for Classic theme or other styles that need square corners.
 - refreshInterval: 5000
   $name: Status check interval (ms)
-  $description: How often the tray icon re-checks security and maintenance (milliseconds). Use at least 1000. Set 0 to check only when Windows reports a change.
+  $description: This setting controls how often the tray icon re-checks security and maintenance (milliseconds). Use at least 1000. Set 0 to check only when Windows reports a change.
 - enableHotkey: false
   $name: Enable hotkeys
-  $description: Turn on keyboard shortcuts for testing (see the options below).
+  $description: This setting turns on keyboard shortcuts for testing (see the options below).
 - enableNotificationSimulation: true
   $name: Test notifications (Ctrl+N)
-  $description: When hotkeys are enabled, Ctrl+N shows a sample balloon and Ctrl+Shift+N clears it. Useful only for testing.
+  $description: This setting enables test notifications. When hotkeys are enabled, Ctrl+N shows a sample balloon and Ctrl+Shift+N clears it. Useful only for testing.
 - privacyMode: false
   $name: Privacy mode
-  $description: Always show the neutral tray icon and hide problems in the flyout. Handy on a shared screen.
+  $description: This setting enables privacy mode to always show the neutral tray icon and hide problems in the flyout. Handy on a shared screen.
 - language: auto
   $name: Language
-  $description: Language for the tray icon, flyout, and balloons. "Auto" follows Windows.
+  $description: This setting controls the language for the tray icon, flyout, and balloons. "Auto" follows Windows.
   $options:
     - auto: Auto (match Windows)
     - en: English
@@ -116,13 +119,13 @@ The mod has been tested on Windows 10 1809, Windows 10 21H2, Windows 10 22H2, Wi
     - tr: Türkçe
 - restoreCplHubLinks: true
   $name: Control Panel links
-  $description: On the Security and Maintenance page, show Troubleshooting and Recovery side by side (classic layout). Turn off if you only want the tray flyout.
+  $description: This setting restores the classic Control Panel links. On the Security and Maintenance page, show Troubleshooting and Recovery side by side (classic layout). Turn off if you only want the tray flyout.
 - useEmbeddedUifile: false
   $name: Control Panel layout fallback
-  $description: Advanced. Only if those Control Panel links do not appear, try an alternate built-in page layout. Leave off in normal use.
+  $description: This setting enables an alternate Control Panel layout. Advanced. Only if those Control Panel links do not appear, try an alternate built-in page layout. Leave off in normal use.
 - theme: auto
   $name: Theme
-  $description: Flyout and notification theme. "Auto" follows the Windows light/dark mode setting.
+  $description: This setting controls the flyout and notification theme. "Auto" follows the Windows light/dark mode setting.
   $options:
     - auto: Auto (follow Windows)
     - light: Light
@@ -130,7 +133,6 @@ The mod has been tested on Windows 10 1809, Windows 10 21H2, Windows 10 22H2, Wi
 */
 // ==/WindhawkModSettings==
 
-// 2.2.0 -> Fixed the position of the flyout
 
 #ifndef UNICODE
 #define UNICODE
@@ -3907,6 +3909,13 @@ void PositionWindowNearTray(HWND hwnd) {
             y = rcIcon.top - winH - gap;
             break;
         }
+
+        // Clamp dentro l'area di lavoro del monitor dell'icona, preservando il margine
+        if (x + winW > rcWork.right  - gap) x = rcWork.right  - winW - gap;
+        if (y + winH > rcWork.bottom - gap) y = rcWork.bottom - winH - gap;
+        if (x < rcWork.left + gap) x = rcWork.left + gap;
+        if (y < rcWork.top  + gap) y = rcWork.top  + gap;
+
     } else {
         // Fallback senza icona: ancora al bordo della taskbar (come prima).
         int offsetX = MulDiv(10, (int)dpi, 96);
@@ -3931,12 +3940,6 @@ void PositionWindowNearTray(HWND hwnd) {
         }
     }
 
-    // Clamp dentro l'area di lavoro del monitor dell'icona.
-    if (x + winW > rcWork.right)  x = rcWork.right - winW;
-    if (y + winH > rcWork.bottom) y = rcWork.bottom - winH;
-    if (x < rcWork.left) x = rcWork.left;
-    if (y < rcWork.top)  y = rcWork.top;
-
     Wh_Log(L"PositionWindowNearTray: dpi=%u size=%dx%d edge=%u icon={%d,%d,%d,%d} pos={%d,%d}",
            dpi, winW, winH, edge, rcIcon.left, rcIcon.top, rcIcon.right, rcIcon.bottom, x, y);
 
@@ -3949,7 +3952,6 @@ void PositionWindowNearTray(HWND hwnd) {
         SetWindowPos(hwnd, NULL, pt.x, pt.y, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
     }
 }
-
 void ToggleFlyout() {
     if (g_Ctx.isUninitializing) return;
 
@@ -4031,16 +4033,10 @@ void ToggleFlyout() {
 // ============================================================================
 // Mouse Hook (Click Outside) - Versione semplificata
 // ============================================================================
-
 // Cache the tray icon rect for use in the mouse hook (avoids cross-process call in WH_MOUSE_LL)
 static void UpdateCachedTrayIconRect() {
-    if (g_Ctx.hWndMsgHandler && g_Ctx.trayIconAdded) {
-        NOTIFYICONIDENTIFIER nidIcon = { sizeof(NOTIFYICONIDENTIFIER) };
-        nidIcon.hWnd = g_Ctx.hWndMsgHandler;
-        nidIcon.uID = TRAY_ICON_ID;
-        nidIcon.guidItem = TRAY_ICON_GUID;
-        Shell_NotifyIconGetRect(&nidIcon, &g_CachedTrayIconRect);
-    }
+    RECT rc;
+    GetTrayIconScreenRect(&rc);  // updates g_CachedTrayIconRect only when it resolves
 }
 
 void InstallClickOutsideHook() {
@@ -4065,7 +4061,6 @@ void RemoveClickOutsideHook() {
 
 
 
-
 LRESULT CALLBACK ClickOutsideMouseHookProc(int nCode, WPARAM wParam, LPARAM lParam) {
     if (g_Ctx.isUninitializing)
         return CallNextHookEx(g_hMouseHook, nCode, wParam, lParam);
@@ -4080,6 +4075,7 @@ LRESULT CALLBACK ClickOutsideMouseHookProc(int nCode, WPARAM wParam, LPARAM lPar
                 // Use cached tray icon rect (updated when flyout opens)
                 // Avoids expensive cross-process Shell_NotifyIconGetRect call in WH_MOUSE_LL
                 BOOL overTrayIcon = PtInRect(&g_CachedTrayIconRect, pMouse->pt);
+                
                 if (overTrayIcon) {
                     // Latch now, at button-down, before WM_ACTIVATE can hide
                     // the flyout on this same click (review issue #1).
@@ -4087,6 +4083,43 @@ LRESULT CALLBACK ClickOutsideMouseHookProc(int nCode, WPARAM wParam, LPARAM lPar
                         g_TrayClickWhileFlyoutOpen = TRUE;
                     }
                 } else {
+                    // --- MITIGATION FOR MULTI-ROW SYSTEM TRAY (Windows 10 22h2) ---
+                    // In some configurations with a 2-row taskbar, clicks on the second row
+                    // of the system tray are incorrectly interpreted as "outside clicks"
+                    // and close the flyout, preventing interaction with tray icons.
+                    // This mitigation checks if the click is on the taskbar and, if so,
+                    // keeps the flyout open to allow interaction.
+                    //
+                    // Note: This is a best-effort attempt to mitigate the issue.
+                    // The problem has been reported but could not be reproduced
+                    // in the development environment, so the fix is applied
+                    // conservatively to avoid regressions.
+                    BOOL isOnTaskbar = FALSE;
+                    
+                    try {
+                        APPBARDATA abd = {};
+                        abd.cbSize = sizeof(APPBARDATA);
+                        abd.hWnd = FindWindowW(L"Shell_TrayWnd", NULL);
+                        if (abd.hWnd && SHAppBarMessage(ABM_GETTASKBARPOS, &abd)) {
+                            isOnTaskbar = PtInRect(&abd.rc, pMouse->pt);
+                            if (isOnTaskbar) {
+                                // Click on taskbar but not on AC icon:
+                                // update cache and keep flyout open
+                                UpdateCachedTrayIconRect();
+                                Wh_Log(L"Click on taskbar detected - flyout kept open (mitigation for multi-row tray)");
+                                return CallNextHookEx(g_hMouseHook, nCode, wParam, lParam);
+                            }
+                        }
+                    }
+                    catch (...) {
+                        // Exception occurred while checking taskbar position.
+                        // Fall back to original behavior: close the flyout.
+                        Wh_Log(L"Exception in ClickOutsideMouseHookProc taskbar check");
+                        // Continue to original close behavior below
+                    }
+                    
+                    // Click outside flyout, not on AC icon, and (either not on taskbar
+                    // or exception occurred during taskbar check) -> close flyout
                     PostMessageW(g_Ctx.hWndFlyout, WM_SAFE_CLOSE, 0, 0);
                 }
             }
@@ -4094,7 +4127,6 @@ LRESULT CALLBACK ClickOutsideMouseHookProc(int nCode, WPARAM wParam, LPARAM lPar
     }
     return CallNextHookEx(g_hMouseHook, nCode, wParam, lParam);
 }
-
 void HideFlyout(HWND hwnd) {
     if (!hwnd || !IsWindow(hwnd)) return;
     RemoveClickOutsideHook();
@@ -4982,16 +5014,17 @@ LRESULT CALLBACK TrayMsgHandlerProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM 
             ReleaseProblemBalloonResources();
             return 0;
         }
-        if (trayEvent == NIN_BALLOONUSERCLICK) {
-            RemoveProblemBalloon();
-            // Il clic deve aprire, non chiudere, il flyout.
-            if (!g_Ctx.hWndFlyout || !IsWindow(g_Ctx.hWndFlyout) ||
-                !IsWindowVisible(g_Ctx.hWndFlyout)) {
-                PostMessageW(hwnd, WM_TRIGGER_FLYOUT, 0, 0);
-            }
-            return 0;
-        }
-
+if (trayEvent == NIN_BALLOONUSERCLICK) {
+    try {
+        RemoveProblemBalloon();
+        // A click must open the flyout
+        PostMessageW(hwnd, WM_TRIGGER_FLYOUT, 0, 0);
+    }
+    catch (...) {
+        Wh_Log(L"Exception in NIN_BALLOONUSERCLICK");
+    }
+    return 0;
+}
         if (trayEvent == WM_LBUTTONUP) { 
             if (g_ProblemBalloonShowing) RemoveProblemBalloon();
             PostMessageW(hwnd, WM_TRIGGER_FLYOUT, 0, 0); 


### PR DESCRIPTION
In reference to the issue https://github.com/ramensoftware/windhawk-mods/issues/5224#issuecomment-5425706301 which I have not been able to replicate completely, this update tries to mitigate this problem by also improving the positioning of the flyout.
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

- Improved the positioning of the flyout
- Mitigated the issue where bottom-row system tray icons became unclickable on multi-row taskbars by ensuring flyout hook checks for taskbar bounds before being closed

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [X] The submitter, with AI assistance
- - [X] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
