### PR TITLE
On-Screen Indicator Position 1.2.6

### DIFF
--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Put the volume, brightness and camera on-screen indicators anywhere on the screen, each in its own spot if you like, instead of the three positions Windows offers
-// @version         1.2.5
+// @version         1.2.6
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -266,6 +266,9 @@ std::atomic<Indicator> g_currentIndicator{Indicator::unknown};
 // per placement.
 std::atomic<bool> g_kindUnreliable{false};
 
+// Must match the `position` default in the settings block above.
+constexpr Position kDefaultPosition = Position::topRight;
+
 // Written from Wh_ModSettingsChanged on an arbitrary thread and read on the
 // confirmator's UI thread, so the members are atomic. Each field is still read
 // separately, so a settings change landing mid-placement can put one indicator
@@ -283,6 +286,16 @@ struct {
 } g_settings;
 
 // The position to place the indicator that is being shown right now.
+bool AnyPerIndicator() {
+    for (size_t i = 0; i < (size_t)Indicator::count; i++) {
+        if (g_settings.perIndicator[i].load() != Position::windowsDefault) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 Position CurrentPosition() {
     if (g_kindUnreliable.load()) {
         return g_settings.position.load();
@@ -546,8 +559,8 @@ void LoadSettings() {
     // windowsDefault. Left as windowsDefault it would trip the "nothing to do"
     // check in Wh_ModInit and the mod would sit there doing nothing.
     PCWSTR storedPosition = position.get();
-    g_settings.position = *storedPosition ? PositionFromString(storedPosition)
-                                          : Position::topRight;
+    g_settings.position =
+        *storedPosition ? PositionFromString(storedPosition) : kDefaultPosition;
 
     g_settings.offsetX = Wh_GetIntSetting(L"offsetX");
     g_settings.offsetY = Wh_GetIntSetting(L"offsetY");
@@ -581,13 +594,7 @@ BOOL Wh_ModInit() {
     // Nothing to place and nothing to nudge, so don't load the DLL or install a
     // hook that would only pass the rect straight through. Windhawk reloads the
     // mod after a settings change, so it comes back as soon as there is work.
-    bool anyPerIndicator = false;
-    for (size_t i = 0; i < (size_t)Indicator::count; i++) {
-        if (g_settings.perIndicator[i] != Position::windowsDefault) {
-            anyPerIndicator = true;
-            break;
-        }
-    }
+    bool anyPerIndicator = AnyPerIndicator();
 
     if (g_settings.position == Position::windowsDefault && !anyPerIndicator &&
         !g_settings.offsetX && !g_settings.offsetY) {
@@ -661,8 +668,14 @@ BOOL Wh_ModInit() {
         },
     };
 
-    if (!HookSymbols(g_hardwareConfirmatorModule, symbolHooks,
-                     ARRAYSIZE(symbolHooks))) {
+    // The placement hook is the first entry and is always needed. The eight that
+    // record which kind is being shown only matter when a kind has a spot of its
+    // own, and with the shipped defaults none does, so they aren't installed at
+    // all rather than patching eight entry points to write a value that would be
+    // thrown away.
+    size_t hookCount = anyPerIndicator ? ARRAYSIZE(symbolHooks) : 1;
+
+    if (!HookSymbols(g_hardwareConfirmatorModule, symbolHooks, hookCount)) {
         Wh_Log(L"HookSymbols failed");
         return FALSE;
     }
@@ -671,25 +684,27 @@ BOOL Wh_ModInit() {
     // a null here means that kind would never be recorded and every kind after
     // it would be placed using a stale one. Rather than misplace an indicator,
     // drop to the main position for everything and say so in the log.
-    const void* kindRecorders[] = {
-        (void*)ShowVolumeAsync_Original,
-        (void*)ShowBrightnessAsync_Original,
-        (void*)ShowKeyboardBrightnessAsync_Original,
-        (void*)ShowAirplaneModeOnAsync_Original,
-        (void*)ShowCameraOnAsync_Original,
-        (void*)ShowCameraAccessEnabledAsync_Original,
-        (void*)ShowMicrophoneMutedAsync_Original,
-        (void*)ShowTextAsync_Original,
-    };
+    if (anyPerIndicator) {
+        const void* kindRecorders[] = {
+            (void*)ShowVolumeAsync_Original,
+            (void*)ShowBrightnessAsync_Original,
+            (void*)ShowKeyboardBrightnessAsync_Original,
+            (void*)ShowAirplaneModeOnAsync_Original,
+            (void*)ShowCameraOnAsync_Original,
+            (void*)ShowCameraAccessEnabledAsync_Original,
+            (void*)ShowMicrophoneMutedAsync_Original,
+            (void*)ShowTextAsync_Original,
+        };
 
-    for (const void* recorder : kindRecorders) {
-        if (!recorder) {
-            Wh_Log(
-                L"An indicator entry point didn't resolve, so the position per "
-                L"indicator settings are ignored and everything uses the main "
-                L"position");
-            g_kindUnreliable = true;
-            break;
+        for (const void* recorder : kindRecorders) {
+            if (!recorder) {
+                Wh_Log(
+                    L"An indicator entry point didn't resolve, so the position "
+                    L"per indicator settings are ignored and everything uses "
+                    L"the main position");
+                g_kindUnreliable = true;
+                break;
+            }
         }
     }
 
@@ -698,10 +713,25 @@ BOOL Wh_ModInit() {
 
 void Wh_ModUninit() {
     Wh_Log(L">");
+
+    // The hooks are already gone by this point, so handing back the reference
+    // taken in Wh_ModInit is safe. Without this every enable and disable cycle
+    // leaves one behind.
+    if (g_hardwareConfirmatorModule) {
+        FreeLibrary(g_hardwareConfirmatorModule);
+        g_hardwareConfirmatorModule = nullptr;
+    }
 }
 
-void Wh_ModSettingsChanged() {
+BOOL Wh_ModSettingsChanged(BOOL* bReload) {
     Wh_Log(L">");
 
+    // Whether the kind recorders are installed is decided in Wh_ModInit, so
+    // turning the first override on, or the last one off, needs a reload to
+    // match. Everything else takes effect on the next indicator.
+    bool hadPerIndicator = AnyPerIndicator();
     LoadSettings();
+    *bReload = AnyPerIndicator() != hadPerIndicator;
+
+    return TRUE;
 }

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Place the volume/brightness/camera on-screen indicator anywhere on the screen, not just the three positions Windows offers
-// @version         1.1.4
+// @version         1.2.0
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -44,6 +44,14 @@ The indicator is kept inside the area Windows lays it out in, so an offset that
 would push it past an edge stops at the edge instead of moving off screen. You
 can also leave the position on **Windows default** and use the offsets alone to
 nudge one of the built-in positions.
+
+## A different spot per indicator
+
+Volume, brightness, keyboard brightness, airplane mode, camera, microphone and the
+plain text indicator can each be given their own position. Anything left on **Same
+as the main position** follows the setting above, so you only have to touch the ones
+you want somewhere else. Handy if you want the volume indicator out of the way at the
+bottom but still want the camera one where you will notice it.
 
 ## Choosing a monitor
 
@@ -105,6 +113,102 @@ both target the same function and work out the origin handling.
     setting moves the same distance on a scaled display. The indicator is kept
     inside the area Windows lays it out in, so an offset that would push it past
     an edge stops at the edge instead.
+- perIndicator:
+  - volume: same
+    $name: Volume
+    $options:
+    - same: Same as the main position
+    - topLeft: Top left
+    - topCenter: Top center
+    - topRight: Top right
+    - middleLeft: Middle left
+    - center: Center
+    - middleRight: Middle right
+    - bottomLeft: Bottom left
+    - bottomCenter: Bottom center
+    - bottomRight: Bottom right
+  - brightness: same
+    $name: Brightness
+    $options:
+    - same: Same as the main position
+    - topLeft: Top left
+    - topCenter: Top center
+    - topRight: Top right
+    - middleLeft: Middle left
+    - center: Center
+    - middleRight: Middle right
+    - bottomLeft: Bottom left
+    - bottomCenter: Bottom center
+    - bottomRight: Bottom right
+  - keyboardBrightness: same
+    $name: Keyboard brightness
+    $options:
+    - same: Same as the main position
+    - topLeft: Top left
+    - topCenter: Top center
+    - topRight: Top right
+    - middleLeft: Middle left
+    - center: Center
+    - middleRight: Middle right
+    - bottomLeft: Bottom left
+    - bottomCenter: Bottom center
+    - bottomRight: Bottom right
+  - airplaneMode: same
+    $name: Airplane mode
+    $options:
+    - same: Same as the main position
+    - topLeft: Top left
+    - topCenter: Top center
+    - topRight: Top right
+    - middleLeft: Middle left
+    - center: Center
+    - middleRight: Middle right
+    - bottomLeft: Bottom left
+    - bottomCenter: Bottom center
+    - bottomRight: Bottom right
+  - camera: same
+    $name: Camera
+    $options:
+    - same: Same as the main position
+    - topLeft: Top left
+    - topCenter: Top center
+    - topRight: Top right
+    - middleLeft: Middle left
+    - center: Center
+    - middleRight: Middle right
+    - bottomLeft: Bottom left
+    - bottomCenter: Bottom center
+    - bottomRight: Bottom right
+  - microphone: same
+    $name: Microphone
+    $options:
+    - same: Same as the main position
+    - topLeft: Top left
+    - topCenter: Top center
+    - topRight: Top right
+    - middleLeft: Middle left
+    - center: Center
+    - middleRight: Middle right
+    - bottomLeft: Bottom left
+    - bottomCenter: Bottom center
+    - bottomRight: Bottom right
+  - text: same
+    $name: Other indicators
+    $options:
+    - same: Same as the main position
+    - topLeft: Top left
+    - topCenter: Top center
+    - topRight: Top right
+    - middleLeft: Middle left
+    - center: Center
+    - middleRight: Middle right
+    - bottomLeft: Bottom left
+    - bottomCenter: Bottom center
+    - bottomRight: Bottom right
+  $name: Position per indicator
+  $description: >-
+    Give an individual indicator its own spot. Anything left on Same as the main
+    position follows the Position setting above. The offsets apply to all of them.
 */
 // ==/WindhawkModSettings==
 
@@ -127,6 +231,24 @@ enum class Position {
     bottomRight,
 };
 
+// Which indicator is being shown. Windows has a separate entry point per kind,
+// so the kind is recorded as one is requested and read back when the position is
+// worked out. `same` means the kind has no position of its own.
+enum class Indicator {
+    volume,
+    brightness,
+    keyboardBrightness,
+    airplaneMode,
+    camera,
+    microphone,
+    text,
+    count,
+};
+
+// Only one indicator is on screen at a time, and the entry point runs before the
+// position is worked out, so a single value is enough.
+std::atomic<Indicator> g_currentIndicator{Indicator::text};
+
 // Written from Wh_ModSettingsChanged on an arbitrary thread and read on the
 // confirmator's UI thread, so the members are atomic. Each field is still read
 // separately, so a settings change landing mid-placement can put one indicator
@@ -136,7 +258,21 @@ struct {
     std::atomic<Position> position;
     std::atomic<int> offsetX;
     std::atomic<int> offsetY;
+    // Position::windowsDefault here means "no override", so the main position is
+    // used. The main position keeps its own meaning of leaving Windows' spot be.
+    std::atomic<bool> perIndicatorSet[(size_t)Indicator::count];
+    std::atomic<Position> perIndicator[(size_t)Indicator::count];
 } g_settings;
+
+// The position to place the indicator that is being shown right now.
+Position CurrentPosition() {
+    size_t i = (size_t)g_currentIndicator.load();
+    if (i < (size_t)Indicator::count && g_settings.perIndicatorSet[i].load()) {
+        return g_settings.perIndicator[i].load();
+    }
+
+    return g_settings.position.load();
+}
 
 HMODULE g_hardwareConfirmatorModule;
 
@@ -152,14 +288,18 @@ struct WinrtRect {
 // `rect` comes back from the original function holding the size Windows chose
 // and the position it picked from the built-in setting; only the position is
 // replaced.
-void PlaceInArea(const WinrtRect& area, int offsetX, int offsetY, WinrtRect* rect) {
+void PlaceInArea(const WinrtRect& area,
+                 Position position,
+                 int offsetX,
+                 int offsetY,
+                 WinrtRect* rect) {
     float centerX = (area.Width - rect->Width) / 2;
     float right = area.Width - rect->Width;
 
     float middleY = (area.Height - rect->Height) / 2;
     float bottom = area.Height - rect->Height;
 
-    switch (g_settings.position.load()) {
+    switch (position) {
         case Position::topLeft:
             rect->X = 0;
             rect->Y = 0;
@@ -219,6 +359,70 @@ void PlaceInArea(const WinrtRect& area, int offsetX, int offsetY, WinrtRect* rec
     }
 }
 
+
+// Each kind of indicator has its own entry point on the host, so the kind is
+// recorded as one is asked for and read back when the position is worked out.
+// They are private coroutines returning winrt::fire_and_forget, an empty struct,
+// so the return is passed through as the single byte it occupies. Every one is
+// hooked as optional: if a name stops resolving on some build, that kind just
+// falls back to the main position instead of the mod failing to load.
+
+using ShowVolumeAsync_t = char(WINAPI*)(void* pThis, int value);
+ShowVolumeAsync_t ShowVolumeAsync_Original;
+char WINAPI ShowVolumeAsync_Hook(void* pThis, int value) {
+    g_currentIndicator.store(Indicator::volume);
+    return ShowVolumeAsync_Original(pThis, value);
+}
+
+using ShowBrightnessAsync_t = char(WINAPI*)(void* pThis, int value);
+ShowBrightnessAsync_t ShowBrightnessAsync_Original;
+char WINAPI ShowBrightnessAsync_Hook(void* pThis, int value) {
+    g_currentIndicator.store(Indicator::brightness);
+    return ShowBrightnessAsync_Original(pThis, value);
+}
+
+using ShowKeyboardBrightnessAsync_t = char(WINAPI*)(void* pThis, int value);
+ShowKeyboardBrightnessAsync_t ShowKeyboardBrightnessAsync_Original;
+char WINAPI ShowKeyboardBrightnessAsync_Hook(void* pThis, int value) {
+    g_currentIndicator.store(Indicator::keyboardBrightness);
+    return ShowKeyboardBrightnessAsync_Original(pThis, value);
+}
+
+using ShowAirplaneModeOnAsync_t = char(WINAPI*)(void* pThis, bool value);
+ShowAirplaneModeOnAsync_t ShowAirplaneModeOnAsync_Original;
+char WINAPI ShowAirplaneModeOnAsync_Hook(void* pThis, bool value) {
+    g_currentIndicator.store(Indicator::airplaneMode);
+    return ShowAirplaneModeOnAsync_Original(pThis, value);
+}
+
+using ShowCameraOnAsync_t = char(WINAPI*)(void* pThis, bool value);
+ShowCameraOnAsync_t ShowCameraOnAsync_Original;
+char WINAPI ShowCameraOnAsync_Hook(void* pThis, bool value) {
+    g_currentIndicator.store(Indicator::camera);
+    return ShowCameraOnAsync_Original(pThis, value);
+}
+
+using ShowCameraAccessEnabledAsync_t = char(WINAPI*)(void* pThis, bool value);
+ShowCameraAccessEnabledAsync_t ShowCameraAccessEnabledAsync_Original;
+char WINAPI ShowCameraAccessEnabledAsync_Hook(void* pThis, bool value) {
+    g_currentIndicator.store(Indicator::camera);
+    return ShowCameraAccessEnabledAsync_Original(pThis, value);
+}
+
+using ShowMicrophoneMutedAsync_t = char(WINAPI*)(void* pThis, int value);
+ShowMicrophoneMutedAsync_t ShowMicrophoneMutedAsync_Original;
+char WINAPI ShowMicrophoneMutedAsync_Hook(void* pThis, int value) {
+    g_currentIndicator.store(Indicator::microphone);
+    return ShowMicrophoneMutedAsync_Original(pThis, value);
+}
+
+using ShowTextAsync_t = char(WINAPI*)(void* pThis, void* text, bool value);
+ShowTextAsync_t ShowTextAsync_Original;
+char WINAPI ShowTextAsync_Hook(void* pThis, void* text, bool value) {
+    g_currentIndicator.store(Indicator::text);
+    return ShowTextAsync_Original(pThis, text, value);
+}
+
 using HardwareConfirmatorHost_GetPositionRect_t =
     WinrtRect*(WINAPI*)(void* pThis, WinrtRect* retval, const WinrtRect* rect);
 HardwareConfirmatorHost_GetPositionRect_t
@@ -267,7 +471,8 @@ HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
         pThis, retval, &shiftedRect);
 
     if (result) {
-        PlaceInArea(shiftedRect, offsetSettingX, offsetSettingY, result);
+        PlaceInArea(shiftedRect, CurrentPosition(), offsetSettingX,
+                    offsetSettingY, result);
 
         // Shift the result back.
         result->X += offsetX;
@@ -299,8 +504,8 @@ Position PositionFromString(PCWSTR value) {
     }
 
     // A stale or mistyped stored value would otherwise look like the mod simply
-    // isn't working.
-    if (wcscmp(value, L"windowsDefault") != 0) {
+    // isn't working. "same" is a valid per-indicator value, handled by the caller.
+    if (wcscmp(value, L"windowsDefault") != 0 && wcscmp(value, L"same") != 0) {
         Wh_Log(L"Unknown position \"%s\", using the Windows default", value);
     }
 
@@ -314,6 +519,23 @@ void LoadSettings() {
 
     g_settings.offsetX = Wh_GetIntSetting(L"offsetX");
     g_settings.offsetY = Wh_GetIntSetting(L"offsetY");
+
+    static const PCWSTR kIndicatorSettings[] = {
+        L"perIndicator.volume",       L"perIndicator.brightness",
+        L"perIndicator.keyboardBrightness", L"perIndicator.airplaneMode",
+        L"perIndicator.camera",       L"perIndicator.microphone",
+        L"perIndicator.text",
+    };
+    static_assert(ARRAYSIZE(kIndicatorSettings) == (size_t)Indicator::count);
+
+    for (size_t i = 0; i < ARRAYSIZE(kIndicatorSettings); i++) {
+        WindhawkUtils::StringSetting value =
+            WindhawkUtils::StringSetting::make(kIndicatorSettings[i]);
+        bool isSame = wcscmp(value.get(), L"same") == 0;
+        g_settings.perIndicatorSet[i] = !isSame;
+        g_settings.perIndicator[i] =
+            isSame ? Position::windowsDefault : PositionFromString(value.get());
+    }
 }
 
 BOOL Wh_ModInit() {
@@ -344,6 +566,55 @@ BOOL Wh_ModInit() {
             {LR"(private: struct winrt::Windows::Foundation::Rect __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::GetPositionRect(struct winrt::Windows::Foundation::Rect const &))"},
             &HardwareConfirmatorHost_GetPositionRect_Original,
             HardwareConfirmatorHost_GetPositionRect_Hook,
+        },
+        {
+            {LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowVolumeAsync(int))"},
+            &ShowVolumeAsync_Original,
+            ShowVolumeAsync_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowBrightnessAsync(int))"},
+            &ShowBrightnessAsync_Original,
+            ShowBrightnessAsync_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowKeyboardBrightnessAsync(int))"},
+            &ShowKeyboardBrightnessAsync_Original,
+            ShowKeyboardBrightnessAsync_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowAirplaneModeOnAsync(bool))"},
+            &ShowAirplaneModeOnAsync_Original,
+            ShowAirplaneModeOnAsync_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowCameraOnAsync(bool))"},
+            &ShowCameraOnAsync_Original,
+            ShowCameraOnAsync_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowCameraAccessEnabledAsync(bool))"},
+            &ShowCameraAccessEnabledAsync_Original,
+            ShowCameraAccessEnabledAsync_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowTextAsync(struct winrt::hstring,bool))"},
+            &ShowTextAsync_Original,
+            ShowTextAsync_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowMicrophoneMutedAsync(enum winrt::Windows::Internal::HardwareConfirmator::MicrophoneMuteState))",
+             LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowMicrophoneMutedAsync(enum winrt::HWConfirmatorUI::MicrophoneMuteState))"},
+            &ShowMicrophoneMutedAsync_Original,
+            ShowMicrophoneMutedAsync_Hook,
+            true,  // optional
         },
     };
 

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Place the volume/brightness/camera on-screen indicator anywhere on the screen, not just the three positions Windows offers
-// @version         1.2.0
+// @version         1.2.1
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -505,7 +505,8 @@ Position PositionFromString(PCWSTR value) {
 
     // A stale or mistyped stored value would otherwise look like the mod simply
     // isn't working. "same" is a valid per-indicator value, handled by the caller.
-    if (wcscmp(value, L"windowsDefault") != 0 && wcscmp(value, L"same") != 0) {
+    if (*value && wcscmp(value, L"windowsDefault") != 0 &&
+        wcscmp(value, L"same") != 0) {
         Wh_Log(L"Unknown position \"%s\", using the Windows default", value);
     }
 
@@ -531,10 +532,15 @@ void LoadSettings() {
     for (size_t i = 0; i < ARRAYSIZE(kIndicatorSettings); i++) {
         WindhawkUtils::StringSetting value =
             WindhawkUtils::StringSetting::make(kIndicatorSettings[i]);
-        bool isSame = wcscmp(value.get(), L"same") == 0;
+        // An unset setting reads back empty rather than as the declared
+        // default, so empty has to mean the same thing as "same". Without this
+        // every untouched indicator is pinned to the Windows default and the
+        // main position stops applying to any of them.
+        PCWSTR stored = value.get();
+        bool isSame = !*stored || wcscmp(stored, L"same") == 0;
         g_settings.perIndicatorSet[i] = !isSame;
         g_settings.perIndicator[i] =
-            isSame ? Position::windowsDefault : PositionFromString(value.get());
+            isSame ? Position::windowsDefault : PositionFromString(stored);
     }
 }
 

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Place the volume/brightness/camera on-screen indicator anywhere on the screen, not just the three positions Windows offers
-// @version         1.2.1
+// @version         1.2.2
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -243,11 +243,15 @@ enum class Indicator {
     microphone,
     text,
     count,
+    // Nothing is on screen, or the entry point for whatever is on screen isn't
+    // hooked. Either way there is no kind to look up, so the main position is
+    // used rather than whatever happened to be shown last.
+    unknown,
 };
 
 // Only one indicator is on screen at a time, and the entry point runs before the
 // position is worked out, so a single value is enough.
-std::atomic<Indicator> g_currentIndicator{Indicator::text};
+std::atomic<Indicator> g_currentIndicator{Indicator::unknown};
 
 // Written from Wh_ModSettingsChanged on an arbitrary thread and read on the
 // confirmator's UI thread, so the members are atomic. Each field is still read
@@ -423,6 +427,21 @@ char WINAPI ShowTextAsync_Hook(void* pThis, void* text, bool value) {
     return ShowTextAsync_Original(pThis, text, value);
 }
 
+// Clearing the kind on hide is what makes the fallback above true: without it an
+// unhooked kind would inherit the position of whichever kind was shown last.
+using HideConfirmator_t = void(WINAPI*)(void* pThis);
+HideConfirmator_t HideConfirmator_Original;
+void WINAPI HideConfirmator_Hook(void* pThis) {
+    g_currentIndicator.store(Indicator::unknown);
+    return HideConfirmator_Original(pThis);
+}
+
+HideConfirmator_t HideConfirmatorWithoutAnimation_Original;
+void WINAPI HideConfirmatorWithoutAnimation_Hook(void* pThis) {
+    g_currentIndicator.store(Indicator::unknown);
+    return HideConfirmatorWithoutAnimation_Original(pThis);
+}
+
 using HardwareConfirmatorHost_GetPositionRect_t =
     WinrtRect*(WINAPI*)(void* pThis, WinrtRect* retval, const WinrtRect* rect);
 HardwareConfirmatorHost_GetPositionRect_t
@@ -552,8 +571,16 @@ BOOL Wh_ModInit() {
     // Nothing to place and nothing to nudge, so don't load the DLL or install a
     // hook that would only pass the rect straight through. Windhawk reloads the
     // mod after a settings change, so it comes back as soon as there is work.
-    if (g_settings.position == Position::windowsDefault && !g_settings.offsetX &&
-        !g_settings.offsetY) {
+    bool anyPerIndicator = false;
+    for (size_t i = 0; i < (size_t)Indicator::count; i++) {
+        if (g_settings.perIndicatorSet[i]) {
+            anyPerIndicator = true;
+            break;
+        }
+    }
+
+    if (g_settings.position == Position::windowsDefault && !anyPerIndicator &&
+        !g_settings.offsetX && !g_settings.offsetY) {
         Wh_Log(L"Nothing to do");
         return FALSE;
     }
@@ -572,6 +599,18 @@ BOOL Wh_ModInit() {
             {LR"(private: struct winrt::Windows::Foundation::Rect __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::GetPositionRect(struct winrt::Windows::Foundation::Rect const &))"},
             &HardwareConfirmatorHost_GetPositionRect_Original,
             HardwareConfirmatorHost_GetPositionRect_Hook,
+        },
+        {
+            {LR"(public: void __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::HideConfirmator(void))"},
+            &HideConfirmator_Original,
+            HideConfirmator_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(public: void __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::HideConfirmatorWithoutAnimation(void))"},
+            &HideConfirmatorWithoutAnimation_Original,
+            HideConfirmatorWithoutAnimation_Hook,
+            true,  // optional
         },
         {
             {LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowVolumeAsync(int))"},

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Place the volume/brightness/camera on-screen indicator anywhere on the screen, not just the three positions Windows offers
-// @version         1.2.2
+// @version         1.2.3
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -52,6 +52,11 @@ plain text indicator can each be given their own position. Anything left on **Sa
 as the main position** follows the setting above, so you only have to touch the ones
 you want somewhere else. Handy if you want the volume indicator out of the way at the
 bottom but still want the camera one where you will notice it.
+
+Volume kept at the top left while brightness sits in the middle. Only one of them is
+ever on screen at a time, so this is the same desktop photographed twice:
+
+![Volume top left, brightness center](https://raw.githubusercontent.com/mario0318/windhawk-mods/628f80317652209d3feed54eadf9c329e77b04a7/on-screen-indicator-position/per-indicator.jpg)
 
 ## Choosing a monitor
 
@@ -243,9 +248,8 @@ enum class Indicator {
     microphone,
     text,
     count,
-    // Nothing is on screen, or the entry point for whatever is on screen isn't
-    // hooked. Either way there is no kind to look up, so the main position is
-    // used rather than whatever happened to be shown last.
+    // Nothing has been shown yet, so there is no kind to look up and the main
+    // position is used.
     unknown,
 };
 
@@ -262,20 +266,22 @@ struct {
     std::atomic<Position> position;
     std::atomic<int> offsetX;
     std::atomic<int> offsetY;
-    // Position::windowsDefault here means "no override", so the main position is
-    // used. The main position keeps its own meaning of leaving Windows' spot be.
-    std::atomic<bool> perIndicatorSet[(size_t)Indicator::count];
+    // Position::windowsDefault means "no override", so the main position is used.
+    // It is never offered as a per-indicator choice, which leaves it free to be
+    // the sentinel. The main position keeps its own meaning of leaving Windows'
+    // spot alone.
     std::atomic<Position> perIndicator[(size_t)Indicator::count];
 } g_settings;
 
 // The position to place the indicator that is being shown right now.
 Position CurrentPosition() {
     size_t i = (size_t)g_currentIndicator.load();
-    if (i < (size_t)Indicator::count && g_settings.perIndicatorSet[i].load()) {
-        return g_settings.perIndicator[i].load();
-    }
+    Position perIndicator = i < (size_t)Indicator::count
+                                ? g_settings.perIndicator[i].load()
+                                : Position::windowsDefault;
 
-    return g_settings.position.load();
+    return perIndicator != Position::windowsDefault ? perIndicator
+                                                    : g_settings.position.load();
 }
 
 HMODULE g_hardwareConfirmatorModule;
@@ -368,8 +374,12 @@ void PlaceInArea(const WinrtRect& area,
 // recorded as one is asked for and read back when the position is worked out.
 // They are private coroutines returning winrt::fire_and_forget, an empty struct,
 // so the return is passed through as the single byte it occupies. Every one is
-// hooked as optional: if a name stops resolving on some build, that kind just
-// falls back to the main position instead of the mod failing to load.
+// hooked as optional, so a name that stops resolving on some build costs that one
+// kind rather than the whole mod. Such a kind is placed using whichever kind was
+// recorded before it, or the main position if none has been shown yet. Clearing
+// the record on hide would make that exact, but a hide landing between a show and
+// the placement would then misplace a perfectly normal indicator, which is the
+// worse trade.
 
 using ShowVolumeAsync_t = char(WINAPI*)(void* pThis, int value);
 ShowVolumeAsync_t ShowVolumeAsync_Original;
@@ -425,21 +435,6 @@ ShowTextAsync_t ShowTextAsync_Original;
 char WINAPI ShowTextAsync_Hook(void* pThis, void* text, bool value) {
     g_currentIndicator.store(Indicator::text);
     return ShowTextAsync_Original(pThis, text, value);
-}
-
-// Clearing the kind on hide is what makes the fallback above true: without it an
-// unhooked kind would inherit the position of whichever kind was shown last.
-using HideConfirmator_t = void(WINAPI*)(void* pThis);
-HideConfirmator_t HideConfirmator_Original;
-void WINAPI HideConfirmator_Hook(void* pThis) {
-    g_currentIndicator.store(Indicator::unknown);
-    return HideConfirmator_Original(pThis);
-}
-
-HideConfirmator_t HideConfirmatorWithoutAnimation_Original;
-void WINAPI HideConfirmatorWithoutAnimation_Hook(void* pThis) {
-    g_currentIndicator.store(Indicator::unknown);
-    return HideConfirmatorWithoutAnimation_Original(pThis);
 }
 
 using HardwareConfirmatorHost_GetPositionRect_t =
@@ -540,6 +535,7 @@ void LoadSettings() {
     g_settings.offsetX = Wh_GetIntSetting(L"offsetX");
     g_settings.offsetY = Wh_GetIntSetting(L"offsetY");
 
+
     static const PCWSTR kIndicatorSettings[] = {
         L"perIndicator.volume",       L"perIndicator.brightness",
         L"perIndicator.keyboardBrightness", L"perIndicator.airplaneMode",
@@ -557,7 +553,6 @@ void LoadSettings() {
         // main position stops applying to any of them.
         PCWSTR stored = value.get();
         bool isSame = !*stored || wcscmp(stored, L"same") == 0;
-        g_settings.perIndicatorSet[i] = !isSame;
         g_settings.perIndicator[i] =
             isSame ? Position::windowsDefault : PositionFromString(stored);
     }
@@ -573,7 +568,7 @@ BOOL Wh_ModInit() {
     // mod after a settings change, so it comes back as soon as there is work.
     bool anyPerIndicator = false;
     for (size_t i = 0; i < (size_t)Indicator::count; i++) {
-        if (g_settings.perIndicatorSet[i]) {
+        if (g_settings.perIndicator[i] != Position::windowsDefault) {
             anyPerIndicator = true;
             break;
         }
@@ -599,18 +594,6 @@ BOOL Wh_ModInit() {
             {LR"(private: struct winrt::Windows::Foundation::Rect __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::GetPositionRect(struct winrt::Windows::Foundation::Rect const &))"},
             &HardwareConfirmatorHost_GetPositionRect_Original,
             HardwareConfirmatorHost_GetPositionRect_Hook,
-        },
-        {
-            {LR"(public: void __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::HideConfirmator(void))"},
-            &HideConfirmator_Original,
-            HideConfirmator_Hook,
-            true,  // optional
-        },
-        {
-            {LR"(public: void __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::HideConfirmatorWithoutAnimation(void))"},
-            &HideConfirmatorWithoutAnimation_Original,
-            HideConfirmatorWithoutAnimation_Hook,
-            true,  // optional
         },
         {
             {LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowVolumeAsync(int))"},

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
-// @description     Place the volume/brightness/camera on-screen indicator anywhere on the screen, not just the three positions Windows offers
-// @version         1.2.4
+// @description     Put the volume, brightness and camera on-screen indicators anywhere on the screen, each in its own spot if you like, instead of the three positions Windows offers
+// @version         1.2.5
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -26,7 +26,9 @@ Windows lets you put it in one of three places: top left, top center, or bottom
 center.
 
 This mod replaces that with a full nine-point grid, any corner, any edge center,
-or dead center, plus a pixel offset for fine-tuning.
+or dead center, plus a pixel offset for fine-tuning. Each kind of indicator can
+also be given a spot of its own, so the volume one can sit somewhere different
+from the brightness one.
 
 The brightness indicator moved to the middle of the right edge:
 
@@ -257,6 +259,13 @@ enum class Indicator {
 // position is worked out, so a single value is enough.
 std::atomic<Indicator> g_currentIndicator{Indicator::unknown};
 
+// Set when any of the per-kind entry points didn't resolve. The recorded kind is
+// then meaningless, since an unhooked kind would be placed using whichever kind
+// was recorded before it, so the overrides are ignored for the session and
+// everything uses the main position. Checked once at init rather than guessed at
+// per placement.
+std::atomic<bool> g_kindUnreliable{false};
+
 // Written from Wh_ModSettingsChanged on an arbitrary thread and read on the
 // confirmator's UI thread, so the members are atomic. Each field is still read
 // separately, so a settings change landing mid-placement can put one indicator
@@ -275,6 +284,10 @@ struct {
 
 // The position to place the indicator that is being shown right now.
 Position CurrentPosition() {
+    if (g_kindUnreliable.load()) {
+        return g_settings.position.load();
+    }
+
     size_t i = (size_t)g_currentIndicator.load();
     Position perIndicator = i < (size_t)Indicator::count
                                 ? g_settings.perIndicator[i].load()
@@ -373,12 +386,10 @@ void PlaceInArea(const WinrtRect& area,
 // recorded as one is asked for and read back when the position is worked out.
 // They are private coroutines returning winrt::fire_and_forget, an empty struct,
 // so the return is passed through as the single byte it occupies. Every one is
-// hooked as optional, so a name that stops resolving on some build costs that one
-// kind rather than the whole mod. Such a kind is placed using whichever kind was
-// recorded before it, or the main position if none has been shown yet. Clearing
-// the record on hide would make that exact, but a hide landing between a show and
-// the placement would then misplace a perfectly normal indicator, which is the
-// worse trade.
+// hooked as optional, so a name that stops resolving on some build costs the per
+// indicator feature rather than the whole mod. Wh_ModInit checks afterwards that
+// all eight resolved, and if any didn't it ignores the overrides for the session
+// instead of placing one kind using another kind's spot.
 
 using ShowVolumeAsync_t = char(WINAPI*)(void* pThis, int value);
 ShowVolumeAsync_t ShowVolumeAsync_Original;
@@ -555,14 +566,10 @@ void LoadSettings() {
     for (size_t i = 0; i < ARRAYSIZE(kIndicatorSettings); i++) {
         WindhawkUtils::StringSetting value =
             WindhawkUtils::StringSetting::make(kIndicatorSettings[i]);
-        // An unset setting reads back empty rather than as the declared
-        // default, so empty has to mean the same thing as "same". Without this
-        // every untouched indicator is pinned to the Windows default and the
-        // main position stops applying to any of them.
-        PCWSTR stored = value.get();
-        bool isSame = !*stored || wcscmp(stored, L"same") == 0;
-        g_settings.perIndicator[i] =
-            isSame ? Position::windowsDefault : PositionFromString(stored);
+        // Both "same" and an unset value, which reads back empty, already come
+        // back as windowsDefault and neither is logged as unrecognised. That is
+        // the "no override" sentinel, so the main position applies.
+        g_settings.perIndicator[i] = PositionFromString(value.get());
     }
 }
 
@@ -658,6 +665,32 @@ BOOL Wh_ModInit() {
                      ARRAYSIZE(symbolHooks))) {
         Wh_Log(L"HookSymbols failed");
         return FALSE;
+    }
+
+    // An optional symbol that isn't found leaves its original pointer alone, so
+    // a null here means that kind would never be recorded and every kind after
+    // it would be placed using a stale one. Rather than misplace an indicator,
+    // drop to the main position for everything and say so in the log.
+    const void* kindRecorders[] = {
+        (void*)ShowVolumeAsync_Original,
+        (void*)ShowBrightnessAsync_Original,
+        (void*)ShowKeyboardBrightnessAsync_Original,
+        (void*)ShowAirplaneModeOnAsync_Original,
+        (void*)ShowCameraOnAsync_Original,
+        (void*)ShowCameraAccessEnabledAsync_Original,
+        (void*)ShowMicrophoneMutedAsync_Original,
+        (void*)ShowTextAsync_Original,
+    };
+
+    for (const void* recorder : kindRecorders) {
+        if (!recorder) {
+            Wh_Log(
+                L"An indicator entry point didn't resolve, so the position per "
+                L"indicator settings are ignored and everything uses the main "
+                L"position");
+            g_kindUnreliable = true;
+            break;
+        }
     }
 
     return TRUE;

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Place the volume/brightness/camera on-screen indicator anywhere on the screen, not just the three positions Windows offers
-// @version         1.2.3
+// @version         1.2.4
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -369,7 +369,6 @@ void PlaceInArea(const WinrtRect& area,
     }
 }
 
-
 // Each kind of indicator has its own entry point on the host, so the kind is
 // recorded as one is asked for and read back when the position is worked out.
 // They are private coroutines returning winrt::fire_and_forget, an empty struct,
@@ -530,16 +529,25 @@ Position PositionFromString(PCWSTR value) {
 void LoadSettings() {
     WindhawkUtils::StringSetting position =
         WindhawkUtils::StringSetting::make(L"position");
-    g_settings.position = PositionFromString(position.get());
+    // Same reasoning as the per-indicator settings below. A setting that was
+    // never written reads back empty, which happens to every setting added by an
+    // update, so empty has to mean the default declared in the block rather than
+    // windowsDefault. Left as windowsDefault it would trip the "nothing to do"
+    // check in Wh_ModInit and the mod would sit there doing nothing.
+    PCWSTR storedPosition = position.get();
+    g_settings.position = *storedPosition ? PositionFromString(storedPosition)
+                                          : Position::topRight;
 
     g_settings.offsetX = Wh_GetIntSetting(L"offsetX");
     g_settings.offsetY = Wh_GetIntSetting(L"offsetY");
 
-
     static const PCWSTR kIndicatorSettings[] = {
-        L"perIndicator.volume",       L"perIndicator.brightness",
-        L"perIndicator.keyboardBrightness", L"perIndicator.airplaneMode",
-        L"perIndicator.camera",       L"perIndicator.microphone",
+        L"perIndicator.volume",
+        L"perIndicator.brightness",
+        L"perIndicator.keyboardBrightness",
+        L"perIndicator.airplaneMode",
+        L"perIndicator.camera",
+        L"perIndicator.microphone",
         L"perIndicator.text",
     };
     static_assert(ARRAYSIZE(kIndicatorSettings) == (size_t)Indicator::count);


### PR DESCRIPTION
1.2.0 gives each kind of indicator its own position. volume can sit bottom left while brightness stays top centre and the camera one goes wherever you'll actually notice it. anything left on same as the main position just follows the setting above it.

the host has a separate entry point per kind, ShowVolumeAsync, ShowBrightnessAsync and so on, so the kind gets recorded as one is asked for and read back in GetPositionRect. all of those are hooked optional, so if one stops resolving on a later build that kind falls back to the main position instead of the whole mod refusing to load.

tested on 26200 with volume at top left and brightness at centre, both land where they should. one thing i noticed and can't do anything about from here, switching straight from one kind to another shows the previous one for a frame at the new spot, which looks like the frame being reused and the content swapping a beat later.

## Changelog

If this pull request updates an existing mod, describe the changes below:

* A position per indicator kind, with everything defaulting to the main position
* PlaceInArea takes the position as a parameter rather than reading the global

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
