### PR TITLE
Add Explorer Info Bar+

### DIFF
--- a/mods/explorer-info-bar.wh.cpp
+++ b/mods/explorer-info-bar.wh.cpp
@@ -287,6 +287,9 @@ static HWINEVENTHOOK g_selectionWinEventHook = nullptr;
 static HWINEVENTHOOK g_windowCreateWinEventHook = nullptr;
 static std::atomic<ULONGLONG> g_selectionGeneration{1};
 static std::atomic<ULONGLONG> g_lastPaintWakeTick{0};
+static constexpr ULONGLONG kSelectionWinEventWakeIntervalMs = 200;
+static ULONGLONG g_lastSelectionWinEventWakeTick = 0;
+static UINT_PTR g_selectionWinEventWakeTimer = 0;
 
 static CRITICAL_SECTION g_cacheLock;
 
@@ -1896,10 +1899,127 @@ static void WakeWorkerFromPaint()
     SetEvent(g_workerWakeEvent);
 }
 
+static bool IsWinEventFromTrackedExplorerRoot(HWND hwnd)
+{
+    if (!hwnd)
+        return false;
+
+    const HWND eventRoot = GetAncestor(hwnd, GA_ROOT);
+
+    if (!eventRoot)
+        return false;
+
+    wchar_t rootClassName[64]{};
+
+    if (
+        !GetClassNameW(
+            eventRoot,
+            rootClassName,
+            ARRAYSIZE(rootClassName)
+        ) ||
+        wcscmp(rootClassName, L"CabinetWClass") != 0
+    )
+    {
+        return false;
+    }
+
+    // Copy only HWND values while holding the lock. Root inspection happens
+    // below, after releasing it, because window-manager calls can reenter.
+    std::vector<HWND> trackedWindows;
+    bool snapshotFailed = false;
+
+    AcquireSRWLockShared(&g_subclassLock);
+
+    try
+    {
+        trackedWindows.reserve(g_trackedWindows.size());
+
+        for (const TrackedDirectUiState& state : g_trackedWindows)
+            trackedWindows.push_back(state.hwnd);
+    }
+    catch (...)
+    {
+        snapshotFailed = true;
+    }
+
+    ReleaseSRWLockShared(&g_subclassLock);
+
+    if (snapshotFailed)
+        return false;
+
+    for (HWND trackedWindow : trackedWindows)
+    {
+        if (GetAncestor(trackedWindow, GA_ROOT) == eventRoot)
+            return true;
+    }
+
+    return false;
+}
+
+static void CALLBACK SelectionWinEventWakeTimerProc(
+    HWND,
+    UINT,
+    UINT_PTR timerId,
+    DWORD
+)
+{
+    KillTimer(nullptr, timerId);
+
+    if (g_selectionWinEventWakeTimer == timerId)
+        g_selectionWinEventWakeTimer = 0;
+
+    if (g_unloading.load(std::memory_order_acquire))
+        return;
+
+    g_lastSelectionWinEventWakeTick = GetTickCount64();
+
+    if (g_workerWakeEvent)
+        SetEvent(g_workerWakeEvent);
+}
+
+static void WakeWorkerFromSelectionWinEvent()
+{
+    if (!g_workerWakeEvent)
+        return;
+
+    const ULONGLONG now = GetTickCount64();
+    const ULONGLONG elapsed = now - g_lastSelectionWinEventWakeTick;
+
+    if (
+        !g_lastSelectionWinEventWakeTick ||
+        elapsed >= kSelectionWinEventWakeIntervalMs
+    )
+    {
+        g_lastSelectionWinEventWakeTick = now;
+        SetEvent(g_workerWakeEvent);
+        return;
+    }
+
+    if (g_selectionWinEventWakeTimer)
+        return;
+
+    g_selectionWinEventWakeTimer =
+        SetTimer(
+            nullptr,
+            0,
+            static_cast<UINT>(
+                kSelectionWinEventWakeIntervalMs - elapsed
+            ),
+            SelectionWinEventWakeTimerProc
+        );
+
+    if (!g_selectionWinEventWakeTimer)
+    {
+        // A failed coalescing timer must not leave the final selection stale.
+        g_lastSelectionWinEventWakeTick = now;
+        SetEvent(g_workerWakeEvent);
+    }
+}
+
 static void CALLBACK SelectionWinEventProc(
     HWINEVENTHOOK,
     DWORD event,
-    HWND,
+    HWND hwnd,
     LONG,
     LONG,
     DWORD,
@@ -1911,16 +2031,15 @@ static void CALLBACK SelectionWinEventProc(
         // count change and no EVENT_OBJECT_SELECTION-family notification.
         event < EVENT_OBJECT_FOCUS ||
         event > EVENT_OBJECT_SELECTIONWITHIN ||
-        g_unloading.load(std::memory_order_acquire)
+        g_unloading.load(std::memory_order_acquire) ||
+        !IsWinEventFromTrackedExplorerRoot(hwnd)
     )
     {
         return;
     }
 
     g_selectionGeneration.fetch_add(1, std::memory_order_relaxed);
-
-    if (g_workerWakeEvent)
-        SetEvent(g_workerWakeEvent);
+    WakeWorkerFromSelectionWinEvent();
 }
 
 static void CALLBACK ExplorerObjectCreateWinEventProc(
@@ -2044,6 +2163,12 @@ static DWORD WINAPI SelectionWinEventThreadProc(
 
             break;
         }
+    }
+
+    if (g_selectionWinEventWakeTimer)
+    {
+        KillTimer(nullptr, g_selectionWinEventWakeTimer);
+        g_selectionWinEventWakeTimer = 0;
     }
 
     // Both hooks are installed, pumped and removed by this same owning thread.

--- a/mods/explorer-info-bar.wh.cpp
+++ b/mods/explorer-info-bar.wh.cpp
@@ -1,7 +1,7 @@
 // ==WindhawkMod==
 // @id              explorer-info-bar
 // @name            Explorer Info Bar
-// @description     Adds drive, folder, selection, and file details to File Explorer's bottom info bar.
+// @description     Enhances File Explorer's bottom info bar with drive, content, selection, and single-file details, with customizable styles and colors.
 // @version         1.0.0
 // @author          digART
 // @github          https://github.com/digart11
@@ -18,8 +18,6 @@
 A customizable Windhawk mod that enhances the bottom info bar in Windows 11 File Explorer.
 
 Explorer Info Bar adds useful drive, folder, selection, and single-file information while keeping the native Explorer look and adapting to light, dark, and customized themes.
-
-![Explorer Info Bar preview](https://raw.githubusercontent.com/digart11/explorer-info-bar/main/images/explorer-info-bar-preview.png)
 
 ## Features
 
@@ -51,22 +49,18 @@ Explorer Info Bar adds useful drive, folder, selection, and single-file informat
 
 Typical information shown by the mod:
 
-```text
 Drive D: 150.7GB free
 Content: 15 folders / 25 files (77.2MB)
 Selected: 2 folders / 4 files (571KB)
-```
 
 When one file is selected, additional details can appear:
 
-```text
-.jpg (4032×3024)
-.jpeg (6000×4000)
-.mp4 (1920×1080, 01:23:43)
+.jpg (4032&times;3024)
+.jpeg (6000&times;4000)
+.mp4 (1920&times;1080, 01:23:43)
 .mp3 (00:03:47)
 .doc
 .pdf
-```
 */
 // ==/WindhawkModReadme==
 
@@ -135,6 +129,7 @@ When one file is selected, additional details can appear:
 
 
 #include <windows.h>
+#include <windhawk_utils.h>
 #include <shlobj.h>
 #include <shobjidl.h>
 #include <commctrl.h>
@@ -160,10 +155,8 @@ static constexpr int kStatusRowHeight = 24;
 static constexpr ULONGLONG kStatusMarkerLifetimeMs = 250;
 static constexpr DWORD kInitialRefreshDelayMs = 1000;
 static constexpr DWORD kRefreshIntervalMs = 500;
-static constexpr ULONGLONG kContentSafetyRescanMs = 30000;
 static constexpr ULONGLONG kContentFailedRetryMs = 2000;
 static constexpr ULONGLONG kMetadataRetryMs = 5000;
-static constexpr UINT kSubclassRemovalTimeoutMs = 500;
 
 // ============================================================
 // DrawText hook
@@ -286,8 +279,6 @@ struct ModSettings
 static SRWLOCK g_settingsLock = SRWLOCK_INIT;
 static ModSettings g_settings;
 
-static constexpr UINT_PTR kDirectUiSubclassId = 0xE1B029;
-static UINT g_removeDirectUiSubclassMessage = 0;
 static UINT g_refreshDirectUiMessage = 0;
 
 static LRESULT CALLBACK DirectUiSubclassProc(
@@ -295,7 +286,6 @@ static LRESULT CALLBACK DirectUiSubclassProc(
     UINT msg,
     WPARAM wParam,
     LPARAM lParam,
-    UINT_PTR,
     DWORD_PTR
 );
 
@@ -610,39 +600,6 @@ static ModSettings GetSettingsSnapshot()
 // ============================================================
 // Helpers
 // ============================================================
-
-static bool ContainsItemToken(
-    LPCWSTR text,
-    int length
-)
-{
-    if (
-        !text ||
-        length < 4
-    )
-    {
-        return false;
-    }
-
-    for (
-        int i = 0;
-        i <= length - 4;
-        i++
-    )
-    {
-        if (
-            towlower(text[i]) == L'i' &&
-            towlower(text[i + 1]) == L't' &&
-            towlower(text[i + 2]) == L'e' &&
-            towlower(text[i + 3]) == L'm'
-        )
-        {
-            return true;
-        }
-    }
-
-    return false;
-}
 
 enum class ByteFormat
 {
@@ -2504,11 +2461,6 @@ static unsigned ReadCurrentView(
             sameFolder &&
             total != contentCache.itemCount;
 
-        const bool safetyRescanDue =
-            sameFolder &&
-            now - contentCache.lastFullScanTick >=
-                kContentSafetyRescanMs;
-
         const bool retryThrottled =
             folderIdentity ==
                 contentCache.lastAttemptFolderIdentity &&
@@ -2518,8 +2470,7 @@ static unsigned ReadCurrentView(
         if (
             (
                 !sameFolder ||
-                itemCountChanged ||
-                safetyRescanDue
+                itemCountChanged
             ) &&
             !retryThrottled
         )
@@ -2617,11 +2568,19 @@ static unsigned ReadCurrentView(
             selected =
                 static_cast<int>(selectionCount);
 
+            // Avoid hundreds or thousands of cross-apartment shell calls on
+            // large selections. Keep the exact count, but only enumerate
+            // individual selected items up to a conservative cap.
+            constexpr DWORD kMaxDetailedSelectionItems = 256;
+
             const bool enumerateSelection =
-                settings.showSelection ||
+                selectionCount <= kMaxDetailedSelectionItems &&
                 (
-                    settings.singleFileDetails &&
-                    selectionCount == 1
+                    settings.showSelection ||
+                    (
+                        settings.singleFileDetails &&
+                        selectionCount == 1
+                    )
                 );
 
             if (enumerateSelection)
@@ -2807,7 +2766,7 @@ static DWORD WINAPI WorkerThreadProc(
     const HRESULT comHr =
         CoInitializeEx(
             nullptr,
-            COINIT_APARTMENTTHREADED
+            COINIT_MULTITHREADED
         );
 
     Wh_Log(
@@ -2996,6 +2955,38 @@ static bool IsDirectUiWindow(
         cls,
         L"DirectUIHWND"
     ) == 0;
+}
+
+static bool IsExplorerDirectUiTarget(HWND hwnd)
+{
+    if (!IsDirectUiWindow(hwnd))
+        return false;
+
+    HWND current = GetParent(hwnd);
+    bool sawDuiView = false;
+    bool sawShellTab = false;
+
+    while (current)
+    {
+        wchar_t cls[128] = {};
+        if (GetClassNameW(current, cls, ARRAYSIZE(cls)))
+        {
+            if (!sawDuiView && wcscmp(cls, L"DUIViewWndClassName") == 0)
+                sawDuiView = true;
+            else if (sawDuiView && wcscmp(cls, L"ShellTabWindowClass") == 0)
+                sawShellTab = true;
+            else if (sawShellTab && wcscmp(cls, L"CabinetWClass") == 0)
+            {
+                DWORD pid = 0;
+                GetWindowThreadProcessId(current, &pid);
+                return pid == g_pid;
+            }
+        }
+
+        current = GetParent(current);
+    }
+
+    return false;
 }
 
 static bool StatusMarkIsFresh(
@@ -3987,10 +3978,9 @@ static DirectUiSubclassResult EnsureDirectUiSubclass(
     }
 
     if (
-        !SetWindowSubclass(
+        !WindhawkUtils::SetWindowSubclassFromAnyThread(
             hwnd,
             DirectUiSubclassProc,
-            kDirectUiSubclassId,
             0
         )
     )
@@ -4000,7 +3990,7 @@ static DirectUiSubclassResult EnsureDirectUiSubclass(
         );
 
         Wh_Log(
-            L"SetWindowSubclass failed hwnd=%p error=%lu",
+            L"DirectUI subclass install failed hwnd=%p error=%lu",
             hwnd,
             GetLastError()
         );
@@ -4018,10 +4008,9 @@ static DirectUiSubclassResult EnsureDirectUiSubclass(
     }
     catch (...)
     {
-        RemoveWindowSubclass(
+        WindhawkUtils::RemoveWindowSubclassFromAnyThread(
             hwnd,
-            DirectUiSubclassProc,
-            kDirectUiSubclassId
+            DirectUiSubclassProc
         );
 
         ReleaseSRWLockExclusive(
@@ -4069,7 +4058,6 @@ static LRESULT CALLBACK DirectUiSubclassProc(
     UINT msg,
     WPARAM wParam,
     LPARAM lParam,
-    UINT_PTR,
     DWORD_PTR
 )
 {
@@ -4084,65 +4072,8 @@ static LRESULT CALLBACK DirectUiSubclassProc(
         return 0;
     }
 
-    if (
-        g_removeDirectUiSubclassMessage &&
-        msg == g_removeDirectUiSubclassMessage
-    )
-    {
-        const DWORD ownerThread =
-            GetWindowThreadProcessId(
-                hwnd,
-                nullptr
-            );
-
-        const BOOL removed =
-            ownerThread == GetCurrentThreadId() &&
-            RemoveWindowSubclass(
-                hwnd,
-                DirectUiSubclassProc,
-                kDirectUiSubclassId
-            );
-
-        if (removed)
-        {
-            const DWORD shellBrowserCookie =
-                GetShellBrowserCookieSnapshot(hwnd);
-
-            EraseWindowDataCache(hwnd);
-            RevokeShellBrowserCookie(shellBrowserCookie);
-
-            RECT row{};
-
-            if (GetBottomStatusRowRect(hwnd, &row))
-            {
-                RedrawWindow(
-                    hwnd,
-                    &row,
-                    nullptr,
-                    RDW_INVALIDATE |
-                    RDW_ERASE
-                );
-            }
-
-            // Untrack last. If the synchronous removal request times out,
-            // teardown keeps treating this HWND as live until all callback
-            // cleanup has finished.
-            AcquireSRWLockExclusive(&g_subclassLock);
-            UntrackDirectUiWindowLocked(hwnd);
-            ReleaseSRWLockExclusive(&g_subclassLock);
-        }
-
-        return removed ? 1 : 0;
-    }
-
     if (msg == WM_NCDESTROY)
     {
-        RemoveWindowSubclass(
-            hwnd,
-            DirectUiSubclassProc,
-            kDirectUiSubclassId
-        );
-
         const DWORD shellBrowserCookie =
             GetShellBrowserCookieSnapshot(hwnd);
 
@@ -4249,45 +4180,24 @@ static int WINAPI DrawTextW_Hook(
     if (!DrawTextW_Original)
         return 0;
 
-    if (text)
+    // Language-independent marker: Explorer's native information row uses a
+    // distinctive DrawText format. Don't inspect the localized text at all.
+    // The BitBlt hook below performs the decisive validation by mapping this
+    // source rect into the destination DirectUIHWND and requiring it to land
+    // at the bottom of that Explorer view.
+    if (
+        !g_insideFinalPaint &&
+        rect &&
+        format == kNativeStatusTextFormat &&
+        rect->bottom > rect->top &&
+        rect->right > rect->left
+    )
     {
-        int length =
-            count;
-
-        if (length < 0)
-        {
-            length =
-                static_cast<int>(
-                    wcslen(text)
-                );
-        }
-
-        if (
-            length > 0 &&
-            length < 512
-        )
-        {
-            if (
-                format == kNativeStatusTextFormat &&
-                ContainsItemToken(
-                    text,
-                    length
-                )
-            )
-            {
-                g_statusSourceDc =
-                    hdc;
-
-                g_statusMarkTick =
-                    GetTickCount64();
-
-                if (rect)
-                    g_statusRowRect = *rect;
-            }
-        }
+        g_statusSourceDc = hdc;
+        g_statusMarkTick = GetTickCount64();
+        g_statusRowRect = *rect;
     }
 
-    // Important: do not modify the off-screen DirectUI render.
     return DrawTextW_Original(
         hdc,
         text,
@@ -4340,8 +4250,36 @@ static BOOL WINAPI BitBlt_Hook(
             hdcDest
         );
 
-    if (!IsDirectUiWindow(hwnd))
+    if (!IsExplorerDirectUiTarget(hwnd))
         return result;
+
+    // Map the candidate source text rect into destination coordinates and only
+    // accept it when it actually lands on Explorer's bottom information row.
+    RECT client{};
+    if (!GetClientRect(hwnd, &client))
+        return result;
+
+    RECT mappedRow = g_statusRowRect;
+    mappedRow.top = yDest + (g_statusRowRect.top - ySrc);
+    mappedRow.bottom = yDest + (g_statusRowRect.bottom - ySrc);
+    mappedRow.left = xDest + (g_statusRowRect.left - xSrc);
+    mappedRow.right = xDest + (g_statusRowRect.right - xSrc);
+
+    const int rowHeight = mappedRow.bottom - mappedRow.top;
+    const int expectedHeight = ScaleForWindow(hwnd, kStatusRowHeight);
+    const int bottomTolerance = ScaleForWindow(hwnd, 4);
+
+    if (
+        rowHeight < ScaleForWindow(hwnd, 16) ||
+        rowHeight > ScaleForWindow(hwnd, 34) ||
+        std::abs(mappedRow.bottom - client.bottom) > bottomTolerance ||
+        std::abs(rowHeight - expectedHeight) > ScaleForWindow(hwnd, 10)
+    )
+    {
+        return result;
+    }
+
+    g_statusRowRect = mappedRow;
 
     if (
         g_unloading.load(
@@ -4509,20 +4447,12 @@ BOOL Wh_ModInit()
         &g_cacheLock
     );
 
-    g_removeDirectUiSubclassMessage =
-        RegisterWindowMessageW(
-            L"Windhawk_ExplorerInfoBar_RemoveDirectUiSubclass"
-        );
-
     g_refreshDirectUiMessage =
         RegisterWindowMessageW(
             L"Windhawk_ExplorerInfoBar_RefreshDirectUi"
         );
 
-    if (
-        !g_removeDirectUiSubclassMessage ||
-        !g_refreshDirectUiMessage
-    )
+    if (!g_refreshDirectUiMessage)
     {
         Wh_Log(
             L"DirectUI message registration failed error=%lu",
@@ -4761,135 +4691,42 @@ void Wh_ModBeforeUninit()
     if (g_workerThreadId)
         CoCancelCall(g_workerThreadId, 0);
 
-    // A subclass callback points into this module, so unload must not proceed
-    // until every subclass is removed and any timed-out removal callback has
-    // returned to its owning UI thread.
-    ULONGLONG lastWaitLogTick = 0;
+    // Snapshot under the lock, then remove subclasses outside it. The
+    // Windhawk helper handles cross-thread subclass removal without the
+    // custom retry/message/barrier machinery that could previously loop
+    // forever on a hung Explorer UI thread.
+    std::vector<HWND> windows;
 
-    while (true)
+    AcquireSRWLockShared(&g_subclassLock);
+    try
     {
-        HWND hwnd = nullptr;
+        windows.reserve(g_trackedWindows.size());
+        for (const TrackedDirectUiState& state : g_trackedWindows)
+            windows.push_back(state.hwnd);
+    }
+    catch (...)
+    {
+        windows.clear();
+    }
+    ReleaseSRWLockShared(&g_subclassLock);
 
-        AcquireSRWLockShared(&g_subclassLock);
-
-        if (!g_trackedWindows.empty())
-            hwnd = g_trackedWindows.front().hwnd;
-
-        ReleaseSRWLockShared(&g_subclassLock);
-
-        if (!hwnd)
-            break;
-
-        while (true)
+    for (HWND hwnd : windows)
+    {
+        if (hwnd && IsWindow(hwnd))
         {
-            const DWORD ownerThread =
-                GetWindowThreadProcessId(
-                    hwnd,
-                    nullptr
-                );
-
-            if (!ownerThread || !IsWindow(hwnd))
-            {
-                AcquireSRWLockExclusive(&g_subclassLock);
-                const DWORD shellBrowserCookie =
-                    UntrackDirectUiWindowLocked(hwnd);
-                ReleaseSRWLockExclusive(&g_subclassLock);
-
-                EraseWindowDataCache(hwnd);
-                RevokeShellBrowserCookie(shellBrowserCookie);
-                break;
-            }
-
-            DWORD_PTR removalResult = 0;
-            SetLastError(ERROR_SUCCESS);
-
-            const LRESULT sent =
-                SendMessageTimeoutW(
-                    hwnd,
-                    g_removeDirectUiSubclassMessage,
-                    0,
-                    0,
-                    SMTO_ABORTIFHUNG |
-                    SMTO_BLOCK |
-                    SMTO_ERRORONEXIT,
-                    kSubclassRemovalTimeoutMs,
-                    &removalResult
-                );
-
-            if (sent && removalResult == 1)
-            {
-                // SendMessageTimeout returned only after the owner-thread
-                // callback returned, so this HWND is safe to forget.
-                break;
-            }
-
-            bool stillTracked = false;
-
-            AcquireSRWLockShared(&g_subclassLock);
-
-            stillTracked =
-                std::find_if(
-                    g_trackedWindows.begin(),
-                    g_trackedWindows.end(),
-                    [&](const TrackedDirectUiState& value)
-                    {
-                        return value.hwnd == hwnd;
-                    }
-                ) != g_trackedWindows.end();
-
-            ReleaseSRWLockShared(&g_subclassLock);
-
-            if (!stillTracked)
-            {
-                // The removal callback can finish after SendMessageTimeout
-                // gives up. A synchronous no-op message is a UI-thread
-                // barrier: once it returns, that earlier callback has returned.
-                while (IsWindow(hwnd))
-                {
-                    DWORD_PTR barrierResult = 0;
-
-                    const LRESULT barrierSent =
-                        SendMessageTimeoutW(
-                            hwnd,
-                            WM_NULL,
-                            0,
-                            0,
-                            SMTO_ABORTIFHUNG |
-                            SMTO_BLOCK |
-                            SMTO_ERRORONEXIT,
-                            kSubclassRemovalTimeoutMs,
-                            &barrierResult
-                        );
-
-                    if (barrierSent)
-                        break;
-
-                    Sleep(25);
-                }
-
-                break;
-            }
-
-            const ULONGLONG now = GetTickCount64();
-
-            if (
-                lastWaitLogTick == 0 ||
-                now - lastWaitLogTick >= 2000
-            )
-            {
-                Wh_Log(
-                    L"Waiting for DirectUI subclass removal hwnd=%p "
-                    L"ownerTid=%lu error=%lu",
-                    hwnd,
-                    ownerThread,
-                    GetLastError()
-                );
-
-                lastWaitLogTick = now;
-            }
-
-            Sleep(25);
+            WindhawkUtils::RemoveWindowSubclassFromAnyThread(
+                hwnd,
+                DirectUiSubclassProc
+            );
         }
+
+        DWORD shellBrowserCookie = 0;
+        AcquireSRWLockExclusive(&g_subclassLock);
+        shellBrowserCookie = UntrackDirectUiWindowLocked(hwnd);
+        ReleaseSRWLockExclusive(&g_subclassLock);
+
+        EraseWindowDataCache(hwnd);
+        RevokeShellBrowserCookie(shellBrowserCookie);
     }
 
     Wh_Log(L"Explorer Info Bar subclass teardown complete");
@@ -4911,10 +4748,18 @@ void Wh_ModUninit()
     {
         // The cache and COM state must outlive the worker. Wait until the
         // worker has fully stopped before releasing shared resources.
-        WaitForSingleObject(
-            g_workerThread,
-            INFINITE
-        );
+        const DWORD workerWait =
+            WaitForSingleObject(
+                g_workerThread,
+                5000
+            );
+
+        if (workerWait == WAIT_TIMEOUT)
+        {
+            Wh_Log(L"Worker did not stop within 5 seconds; terminating it to avoid blocking mod unload");
+            TerminateThread(g_workerThread, 0);
+            WaitForSingleObject(g_workerThread, 1000);
+        }
 
         CloseHandle(
             g_workerThread

--- a/mods/explorer-info-bar.wh.cpp
+++ b/mods/explorer-info-bar.wh.cpp
@@ -170,6 +170,7 @@ When one file is selected, additional details can appear:
 
 static constexpr DWORD kInitialRefreshDelayMs = 1000;
 static constexpr DWORD kRefreshIntervalMs = 30000;
+static constexpr ULONGLONG kShellBrowserRegistrationRetryMs = 2000;
 static constexpr ULONGLONG kContentFailedRetryMs = 60000;
 static constexpr ULONGLONG kMetadataRetryMs = 5000;
 static constexpr ULONGLONG kStatusRowValidationIntervalMs = 500;
@@ -229,6 +230,7 @@ struct TrackedDirectUiState
     HFONT infoBarFont = nullptr;
     HWND shellTab = nullptr;
     DWORD shellBrowserCookie = 0;
+    ULONGLONG lastShellBrowserRegistrationRetryTick = 0;
     HWND validatedDefView = nullptr;
     bool hasValidatedStatusRow = false;
     RECT validatedStatusRow{};
@@ -361,7 +363,7 @@ struct WindowDataCache
     int selectedFolders = 0;
     ULONGLONG selectedBytes = 0;
     ULONGLONG selectionGeneration = 0;
-    std::wstring contentGroup = L"Loading...";
+    std::wstring contentGroup;
     std::wstring selectionGroup;
     std::wstring driveGroup;
     std::wstring fileDetailsGroup;
@@ -2837,7 +2839,7 @@ static void GetCachedGroups(
     }
     else
     {
-        contentGroup = L"Loading...";
+        contentGroup.clear();
         selectionGroup.clear();
         driveGroup.clear();
         fileDetailsGroup.clear();
@@ -3978,16 +3980,19 @@ static DWORD WINAPI WorkerThreadProc(
     {
         std::vector<WorkerTarget> targetCandidates;
         std::vector<WorkerTarget> targets;
+        std::vector<HWND> registrationRetries;
 
         bool snapshotFailed = false;
+        const ULONGLONG now = GetTickCount64();
 
-        AcquireSRWLockShared(&g_subclassLock);
+        AcquireSRWLockExclusive(&g_subclassLock);
 
         try
         {
             targetCandidates.reserve(g_trackedWindows.size());
+            registrationRetries.reserve(g_trackedWindows.size());
 
-            for (const TrackedDirectUiState& state : g_trackedWindows)
+            for (TrackedDirectUiState& state : g_trackedWindows)
             {
                 if (state.shellBrowserCookie)
                 {
@@ -3997,6 +4002,15 @@ static DWORD WINAPI WorkerThreadProc(
                         state.selectionGeneration
                     });
                 }
+                else if (
+                    !state.lastShellBrowserRegistrationRetryTick ||
+                    now - state.lastShellBrowserRegistrationRetryTick >=
+                        kShellBrowserRegistrationRetryMs
+                )
+                {
+                    registrationRetries.push_back(state.hwnd);
+                    state.lastShellBrowserRegistrationRetryTick = now;
+                }
             }
         }
         catch (...)
@@ -4004,12 +4018,42 @@ static DWORD WINAPI WorkerThreadProc(
             snapshotFailed = true;
         }
 
-        ReleaseSRWLockShared(&g_subclassLock);
+        ReleaseSRWLockExclusive(&g_subclassLock);
 
         if (snapshotFailed)
         {
             Wh_Log(L"Worker target snapshot failed");
             targetCandidates.clear();
+            registrationRetries.clear();
+        }
+
+        for (HWND hwnd : registrationRetries)
+        {
+            if (
+                g_unloading.load(std::memory_order_acquire) ||
+                WaitForSingleObject(g_stopEvent, 0) == WAIT_OBJECT_0
+            )
+            {
+                break;
+            }
+
+            if (
+                g_refreshDirectUiMessage &&
+                !PostMessageW(
+                    hwnd,
+                    g_refreshDirectUiMessage,
+                    0,
+                    0
+                )
+            )
+            {
+                Wh_Log(
+                    L"Shell browser registration retry post failed "
+                    L"hwnd=%p error=%lu",
+                    hwnd,
+                    GetLastError()
+                );
+            }
         }
 
         try
@@ -5732,6 +5776,76 @@ void Wh_ModSettingsChanged()
     RefreshInfoBars();
 }
 
+static void CancelWorkerComCall()
+{
+    if (!g_workerThread || !g_workerThreadId)
+        return;
+
+    const DWORD waitResult =
+        WaitForSingleObject(
+            g_workerThread,
+            0
+        );
+
+    if (waitResult == WAIT_OBJECT_0)
+        return;
+
+    if (waitResult != WAIT_TIMEOUT)
+    {
+        Wh_Log(
+            L"worker cancellation activity check failed "
+            L"result=%lu error=%lu",
+            waitResult,
+            waitResult == WAIT_FAILED ? GetLastError() : ERROR_SUCCESS
+        );
+        return;
+    }
+
+    const HRESULT comHr =
+        CoInitializeEx(
+            nullptr,
+            COINIT_MULTITHREADED
+        );
+
+    const bool shouldUninitialize =
+        comHr == S_OK ||
+        comHr == S_FALSE;
+
+    if (
+        !shouldUninitialize &&
+        comHr != RPC_E_CHANGED_MODE
+    )
+    {
+        Wh_Log(
+            L"worker cancellation COM initialization failed "
+            L"HRESULT=0x%08X",
+            static_cast<unsigned>(comHr)
+        );
+        return;
+    }
+
+    const HRESULT cancelHr =
+        CoCancelCall(
+            g_workerThreadId,
+            0
+        );
+
+    if (shouldUninitialize)
+        CoUninitialize();
+
+    if (
+        cancelHr != S_OK &&
+        cancelHr != RPC_E_CALL_COMPLETE &&
+        cancelHr != RPC_E_CALL_CANCELED
+    )
+    {
+        Wh_Log(
+            L"worker COM-call cancellation failed HRESULT=0x%08X",
+            static_cast<unsigned>(cancelHr)
+        );
+    }
+}
+
 void Wh_ModBeforeUninit()
 {
     g_unloading.store(
@@ -5742,8 +5856,7 @@ void Wh_ModBeforeUninit()
     if (g_stopEvent)
         SetEvent(g_stopEvent);
 
-    if (g_workerThreadId)
-        CoCancelCall(g_workerThreadId, 0);
+    CancelWorkerComCall();
 
     if (g_workerThread)
         CancelSynchronousIo(g_workerThread);
@@ -5828,8 +5941,7 @@ void Wh_ModUninit()
         // Never terminate a thread while it may own COM, CRT or cache locks.
         while (true)
         {
-            if (g_workerThreadId)
-                CoCancelCall(g_workerThreadId, 0);
+            CancelWorkerComCall();
 
             CancelSynchronousIo(g_workerThread);
 

--- a/mods/explorer-info-bar.wh.cpp
+++ b/mods/explorer-info-bar.wh.cpp
@@ -8,7 +8,7 @@
 // @homepage        https://github.com/digart11/explorer-info-bar
 // @license         GPL-3.0-only
 // @include         explorer.exe
-// @compilerOptions -lole32 -lshell32 -luuid -lgdi32 -lcomctl32 -lpropsys
+// @compilerOptions -lole32 -lshell32 -luuid -lgdi32 -lcomctl32 -lpropsys -ladvapi32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -50,6 +50,14 @@ Unlike mods that restore the classic status bar or focus only on metadata, Explo
 - Custom text and panel colors
 - Automatic theme-derived colors by default
 - Works with File Explorer's native status area rather than replacing Explorer itself
+
+## Compatibility / Why this mod is separate
+
+Explorer Info Bar+ uses the native Windows 11 bottom status area; it does not restore or create a classic `msctls_statusbar32`-style status bar. It combines drive, content, and selection information with configurable ordering, styles, colors, literal extension display, and basic image/media metadata in one native-style bar. This is a different presentation and design from Classic Explorer Status Bar and PreVista Explorer Status Bar.
+
+Do not enable Classic Explorer Status Bar or PreVista Explorer Status Bar at the same time as Explorer Info Bar+. Both try to control the same bottom Explorer area and can conflict or overlap.
+
+Explorer Status Bar Metadata overlaps functionally because Explorer Info Bar+ already includes optional single-file metadata. Its metadata functionality is integrated here; no broader incompatibility is implied.
 
 ## Examples
 
@@ -164,6 +172,7 @@ static constexpr DWORD kInitialRefreshDelayMs = 1000;
 static constexpr DWORD kRefreshIntervalMs = 10000;
 static constexpr ULONGLONG kContentFailedRetryMs = 60000;
 static constexpr ULONGLONG kMetadataRetryMs = 5000;
+static constexpr ULONGLONG kStatusRowValidationIntervalMs = 500;
 
 thread_local bool g_insideFinalPaint = false;
 
@@ -214,13 +223,16 @@ struct TrackedDirectUiState
     ULONGLONG selectionGeneration = 1;
     bool hasLayout = false;
     InfoBarLayoutGeometry layout;
-    COLORREF stableRowBackground = CLR_INVALID;
-    COLORREF stableNativeTextColor = CLR_INVALID;
+    COLORREF automaticRowBackground = CLR_INVALID;
+    bool hasSampledNativeRowBackground = false;
+    UINT dpi = 96;
+    HFONT infoBarFont = nullptr;
     HWND shellTab = nullptr;
     DWORD shellBrowserCookie = 0;
     HWND validatedDefView = nullptr;
     bool hasValidatedStatusRow = false;
     RECT validatedStatusRow{};
+    ULONGLONG lastStatusRowValidationTick = 0;
 };
 
 static std::vector<TrackedDirectUiState> g_trackedWindows;
@@ -1276,6 +1288,27 @@ static bool EnsureShellBrowserRegistration(
         return false;
     }
 
+    AcquireSRWLockShared(&g_subclassLock);
+
+    const auto existing =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    const bool alreadyRegistered =
+        existing != g_trackedWindows.end() &&
+        existing->shellBrowserCookie != 0;
+
+    ReleaseSRWLockShared(&g_subclassLock);
+
+    if (alreadyRegistered)
+        return true;
+
     const DWORD ownerThread =
         GetWindowThreadProcessId(
             hwnd,
@@ -1298,28 +1331,6 @@ static bool EnsureShellBrowserRegistration(
 
     if (!shellTab)
         return false;
-
-    AcquireSRWLockShared(&g_subclassLock);
-
-    const auto existing =
-        std::find_if(
-            g_trackedWindows.begin(),
-            g_trackedWindows.end(),
-            [&](const TrackedDirectUiState& value)
-            {
-                return value.hwnd == hwnd;
-            }
-        );
-
-    const bool alreadyRegistered =
-        existing != g_trackedWindows.end() &&
-        existing->shellTab == shellTab &&
-        existing->shellBrowserCookie != 0;
-
-    ReleaseSRWLockShared(&g_subclassLock);
-
-    if (alreadyRegistered)
-        return true;
 
     IShellBrowser* browser =
         TryGetShellBrowserOnOwnerThread(shellTab);
@@ -1405,6 +1416,18 @@ static bool EnsureShellBrowserRegistration(
 // Redraw
 // ============================================================
 
+static int ScaleForDpi(
+    UINT dpi,
+    int value
+)
+{
+    return MulDiv(
+        value,
+        dpi ? static_cast<int>(dpi) : 96,
+        96
+    );
+}
+
 static int ScaleForWindow(
     HWND hwnd,
     int value
@@ -1413,11 +1436,136 @@ static int ScaleForWindow(
     const UINT dpi =
         hwnd ? GetDpiForWindow(hwnd) : 96;
 
-    return MulDiv(
-        value,
-        dpi ? static_cast<int>(dpi) : 96,
-        96
+    return ScaleForDpi(dpi, value);
+}
+
+static HFONT CreateInfoBarFont(UINT dpi)
+{
+    return CreateFontW(
+        -ScaleForDpi(dpi, 12),
+        0,
+        0,
+        0,
+        FW_NORMAL,
+        FALSE,
+        FALSE,
+        FALSE,
+        DEFAULT_CHARSET,
+        OUT_DEFAULT_PRECIS,
+        CLIP_DEFAULT_PRECIS,
+        CLEARTYPE_QUALITY,
+        DEFAULT_PITCH,
+        L"Segoe UI"
     );
+}
+
+static void RefreshTrackedDpiAndFont(HWND hwnd)
+{
+    UINT dpi = hwnd ? GetDpiForWindow(hwnd) : 96;
+
+    if (!dpi)
+        dpi = 96;
+
+    bool needsFont = false;
+
+    AcquireSRWLockShared(&g_subclassLock);
+
+    const auto existing =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    if (
+        existing != g_trackedWindows.end() &&
+        (
+            existing->dpi != dpi ||
+            !existing->infoBarFont
+        )
+    )
+    {
+        needsFont = true;
+    }
+
+    ReleaseSRWLockShared(&g_subclassLock);
+
+    if (!needsFont)
+        return;
+
+    HFONT newFont = CreateInfoBarFont(dpi);
+    HFONT oldFont = nullptr;
+
+    AcquireSRWLockExclusive(&g_subclassLock);
+
+    auto tracked =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    if (
+        tracked != g_trackedWindows.end() &&
+        (
+            tracked->dpi != dpi ||
+            !tracked->infoBarFont
+        )
+    )
+    {
+        oldFont = tracked->infoBarFont;
+        tracked->dpi = dpi;
+        tracked->infoBarFont = newFont;
+        newFont = nullptr;
+    }
+
+    ReleaseSRWLockExclusive(&g_subclassLock);
+
+    if (oldFont)
+        DeleteObject(oldFont);
+
+    if (newFont)
+        DeleteObject(newFont);
+}
+
+static bool GetPaintResources(
+    HWND hwnd,
+    UINT* dpi,
+    HFONT* font
+)
+{
+    if (!dpi || !font)
+        return false;
+
+    bool found = false;
+
+    AcquireSRWLockShared(&g_subclassLock);
+
+    const auto existing =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    if (existing != g_trackedWindows.end())
+    {
+        *dpi = existing->dpi ? existing->dpi : 96;
+        *font = existing->infoBarFont;
+        found = true;
+    }
+
+    ReleaseSRWLockShared(&g_subclassLock);
+    return found;
 }
 
 static HWND FindShellDefViewDescendant(HWND directUi)
@@ -1472,6 +1620,7 @@ static void StoreValidatedStatusRow(
         existing->validatedDefView = row ? defView : nullptr;
         existing->hasValidatedStatusRow = row != nullptr;
         existing->validatedStatusRow = row ? *row : RECT{};
+        existing->lastStatusRowValidationTick = GetTickCount64();
     }
 
     ReleaseSRWLockExclusive(&g_subclassLock);
@@ -1481,6 +1630,17 @@ static bool RefreshValidatedStatusRow(HWND hwnd)
 {
     if (!hwnd || !IsWindow(hwnd))
         return false;
+
+    UINT dpi = 96;
+    HFONT unusedFont = nullptr;
+
+    if (!GetPaintResources(hwnd, &dpi, &unusedFont))
+    {
+        dpi = GetDpiForWindow(hwnd);
+
+        if (!dpi)
+            dpi = 96;
+    }
 
     const HWND defView = FindShellDefViewDescendant(hwnd);
 
@@ -1522,7 +1682,7 @@ static bool RefreshValidatedStatusRow(HWND hwnd)
             valid = false;
     }
 
-    const LONG tolerance = ScaleForWindow(hwnd, 2);
+    const LONG tolerance = ScaleForDpi(dpi, 2);
 
     if (
         valid &&
@@ -1553,7 +1713,7 @@ static bool RefreshValidatedStatusRow(HWND hwnd)
         // Require a small DPI-scaled minimum before treating it as a row.
         if (
             row.bottom - row.top <
-                static_cast<LONG>(ScaleForWindow(hwnd, 8))
+                static_cast<LONG>(ScaleForDpi(dpi, 8))
         )
         {
             valid = false;
@@ -1567,6 +1727,36 @@ static bool RefreshValidatedStatusRow(HWND hwnd)
     );
 
     return valid;
+}
+
+static bool IsStatusRowRevalidationDue(HWND hwnd)
+{
+    ULONGLONG lastValidationTick = 0;
+
+    AcquireSRWLockShared(&g_subclassLock);
+
+    const auto existing =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    if (existing != g_trackedWindows.end())
+    {
+        lastValidationTick =
+            existing->lastStatusRowValidationTick;
+    }
+
+    ReleaseSRWLockShared(&g_subclassLock);
+
+    return
+        !lastValidationTick ||
+        GetTickCount64() - lastValidationTick >=
+            kStatusRowValidationIntervalMs;
 }
 
 static bool GetValidatedStatusRow(
@@ -1692,10 +1882,10 @@ static size_t GetSectionGeometryIndex(
     return 2;
 }
 
-struct StableThemeSnapshot
+struct AutomaticThemeSnapshot
 {
     COLORREF rowBackground = CLR_INVALID;
-    COLORREF nativeTextColor = CLR_INVALID;
+    bool hasSampledNativeRowBackground = false;
 };
 
 static void StoreLayoutGeometry(
@@ -1724,7 +1914,8 @@ static void StoreLayoutGeometry(
 }
 
 static DWORD UntrackDirectUiWindowLocked(
-    HWND hwnd
+    HWND hwnd,
+    HFONT* infoBarFont = nullptr
 )
 {
     DWORD shellBrowserCookie = 0;
@@ -1743,6 +1934,9 @@ static DWORD UntrackDirectUiWindowLocked(
     {
         shellBrowserCookie =
             existing->shellBrowserCookie;
+
+        if (infoBarFont)
+            *infoBarFont = existing->infoBarFont;
 
         g_trackedWindows.erase(existing);
     }
@@ -1775,11 +1969,11 @@ static DWORD GetShellBrowserCookieSnapshot(
     return cookie;
 }
 
-static StableThemeSnapshot GetStableThemeStateSnapshot(
+static AutomaticThemeSnapshot GetAutomaticThemeSnapshot(
     HWND hwnd
 )
 {
-    StableThemeSnapshot result;
+    AutomaticThemeSnapshot result;
 
     AcquireSRWLockShared(&g_subclassLock);
 
@@ -1796,22 +1990,20 @@ static StableThemeSnapshot GetStableThemeStateSnapshot(
     if (existing != g_trackedWindows.end())
     {
         result.rowBackground =
-            existing->stableRowBackground;
+            existing->automaticRowBackground;
 
-        result.nativeTextColor =
-            existing->stableNativeTextColor;
+        result.hasSampledNativeRowBackground =
+            existing->hasSampledNativeRowBackground;
     }
 
     ReleaseSRWLockShared(&g_subclassLock);
     return result;
 }
 
-static void UpdateStableThemeState(
+static void UpdateAutomaticRowBackground(
     HWND hwnd,
     COLORREF rowBackground,
-    bool updateBackground,
-    COLORREF nativeTextColor,
-    bool updateTextColor
+    bool sampledNativeRowBackground
 )
 {
     AcquireSRWLockExclusive(&g_subclassLock);
@@ -1828,11 +2020,32 @@ static void UpdateStableThemeState(
 
     if (existing != g_trackedWindows.end())
     {
-        if (updateBackground)
-            existing->stableRowBackground = rowBackground;
+        existing->automaticRowBackground = rowBackground;
+        existing->hasSampledNativeRowBackground =
+            sampledNativeRowBackground;
+    }
 
-        if (updateTextColor)
-            existing->stableNativeTextColor = nativeTextColor;
+    ReleaseSRWLockExclusive(&g_subclassLock);
+}
+
+static void InvalidateAutomaticTheme(HWND hwnd)
+{
+    AcquireSRWLockExclusive(&g_subclassLock);
+
+    auto existing =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    if (existing != g_trackedWindows.end())
+    {
+        existing->automaticRowBackground = CLR_INVALID;
+        existing->hasSampledNativeRowBackground = false;
     }
 
     ReleaseSRWLockExclusive(&g_subclassLock);
@@ -2789,6 +3002,13 @@ static bool ScanFilesystemDirectory(
     if (IsWorkerStopRequested())
         return false;
 
+    SHELLSTATE state{};
+    SHGetSetSettings(
+        &state,
+        SSF_SHOWALLOBJECTS | SSF_SHOWSUPERHIDDEN,
+        FALSE
+    );
+
     std::wstring searchPath = directoryPath;
 
     if (
@@ -2858,8 +3078,31 @@ static bool ScanFilesystemDirectory(
             wcscmp(findData.cFileName, L"..") != 0
         )
         {
+            const DWORD attributes =
+                findData.dwFileAttributes;
+
+            const bool hidden =
+                (attributes & FILE_ATTRIBUTE_HIDDEN) != 0;
+
+            const bool system =
+                (attributes & FILE_ATTRIBUTE_SYSTEM) != 0;
+
             if (
-                findData.dwFileAttributes &
+                hidden &&
+                (
+                    !state.fShowAllObjects ||
+                    (
+                        system &&
+                        !state.fShowSuperHidden
+                    )
+                )
+            )
+            {
+                goto nextEntry;
+            }
+
+            if (
+                attributes &
                 FILE_ATTRIBUTE_DIRECTORY
             )
             {
@@ -2877,6 +3120,7 @@ static bool ScanFilesystemDirectory(
             }
         }
 
+nextEntry:
         if (FindNextFileW(findHandle, &findData))
             continue;
 
@@ -3816,6 +4060,31 @@ static int MeasureGapWidth(
     return 26;
 }
 
+static COLORREF GetAppThemeFallbackBackground()
+{
+    DWORD appsUseLightTheme = 1;
+    DWORD valueSize = sizeof(appsUseLightTheme);
+
+    const LSTATUS status =
+        RegGetValueW(
+            HKEY_CURRENT_USER,
+            L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+            L"AppsUseLightTheme",
+            RRF_RT_REG_DWORD,
+            nullptr,
+            &appsUseLightTheme,
+            &valueSize
+        );
+
+    const bool useLightTheme =
+        status != ERROR_SUCCESS ||
+        appsUseLightTheme != 0;
+
+    return useLightTheme
+        ? RGB(255, 255, 255)
+        : RGB(32, 32, 32);
+}
+
 static COLORREF PickBackgroundColor(
     HDC hdc,
     HWND hwnd,
@@ -3824,24 +4093,31 @@ static COLORREF PickBackgroundColor(
     int selected
 )
 {
-    // Keep the native unselected status-row background stable per window.
-    // Explorer can temporarily tint the row while items are selected.
-    const StableThemeSnapshot stable =
-        GetStableThemeStateSnapshot(hwnd);
+    AutomaticThemeSnapshot theme =
+        GetAutomaticThemeSnapshot(hwnd);
 
-    if (
-        selected > 0 &&
-        stable.rowBackground != CLR_INVALID
-    )
+    if (theme.hasSampledNativeRowBackground)
     {
-        return stable.rowBackground;
+        return theme.rowBackground;
     }
 
-    COLORREF chosen = CLR_INVALID;
+    if (theme.rowBackground == CLR_INVALID)
+    {
+        theme.rowBackground =
+            GetAppThemeFallbackBackground();
+
+        UpdateAutomaticRowBackground(
+            hwnd,
+            theme.rowBackground,
+            false
+        );
+    }
+
     const int rowWidth = row.right - row.left;
     const int rowHeight = row.bottom - row.top;
 
     if (
+        selected <= 0 &&
         nativePaintRect &&
         rowWidth > 0 &&
         rowHeight > 0
@@ -3871,32 +4147,20 @@ static COLORREF PickBackgroundColor(
 
             if (sample != CLR_INVALID)
             {
-                chosen = sample;
-                break;
+                UpdateAutomaticRowBackground(
+                    hwnd,
+                    sample,
+                    true
+                );
+
+                return sample;
             }
         }
     }
 
-    if (chosen == CLR_INVALID)
-    {
-        if (stable.rowBackground != CLR_INVALID)
-            return stable.rowBackground;
-
-        return GetSysColor(COLOR_WINDOW);
-    }
-
-    if (selected <= 0)
-    {
-        UpdateStableThemeState(
-            hwnd,
-            chosen,
-            true,
-            CLR_INVALID,
-            false
-        );
-    }
-
-    return chosen;
+    // A partial first paint might not expose any safe native pixels. Keep
+    // sampling pending while using the app-theme preference as a safe fallback.
+    return theme.rowBackground;
 }
 
 static void DrawFinalPiece(
@@ -4034,55 +4298,6 @@ static COLORREF GetContrastingTextColor(
         : RGB(232, 232, 232);
 }
 
-static COLORREF PickNativeTextColor(
-    HDC hdc,
-    HWND hwnd,
-    COLORREF background,
-    int selected
-)
-{
-    const StableThemeSnapshot stable =
-        GetStableThemeStateSnapshot(hwnd);
-
-    if (
-        selected > 0 &&
-        stable.nativeTextColor != CLR_INVALID
-    )
-    {
-        return stable.nativeTextColor;
-    }
-
-    COLORREF candidate =
-        GetTextColor(hdc);
-
-    if (
-        candidate == CLR_INVALID ||
-        std::abs(
-            ColorLuminance(candidate) -
-            ColorLuminance(background)
-        ) < 70
-    )
-    {
-        candidate =
-            GetContrastingTextColor(
-                background
-            );
-    }
-
-    if (selected <= 0)
-    {
-        UpdateStableThemeState(
-            hwnd,
-            CLR_INVALID,
-            false,
-            candidate,
-            true
-        );
-    }
-
-    return candidate;
-}
-
 static COLORREF ResolveColor(
     const ColorOverride& colorOverride,
     COLORREF automaticColor
@@ -4102,6 +4317,12 @@ static void PaintFinalInfoBar(
     if (!hdc || !hwnd)
         return;
 
+    UINT dpi = 96;
+    HFONT font = nullptr;
+
+    if (!GetPaintResources(hwnd, &dpi, &font))
+        return;
+
     RECT client{};
 
     if (!GetClientRect(
@@ -4113,12 +4334,21 @@ static void PaintFinalInfoBar(
 
     RECT row{};
 
+    bool hasValidatedRow =
+        GetValidatedStatusRow(hwnd, &row);
+
     if (
-        !RefreshValidatedStatusRow(hwnd) ||
-        !GetValidatedStatusRow(hwnd, &row)
+        !hasValidatedRow ||
+        IsStatusRowRevalidationDue(hwnd)
     )
     {
-        return;
+        if (
+            !RefreshValidatedStatusRow(hwnd) ||
+            !GetValidatedStatusRow(hwnd, &row)
+        )
+        {
+            return;
+        }
     }
 
     RECT coverRow = row;
@@ -4129,10 +4359,10 @@ static void PaintFinalInfoBar(
     coverRow.right =
         std::max(
             coverRow.left,
-            client.right - ScaleForWindow(hwnd, 64)
+            client.right - ScaleForDpi(dpi, 64)
         );
 
-    row.left = ScaleForWindow(hwnd, 6);
+    row.left = ScaleForDpi(dpi, 6);
 
     // Keep the existing conservative content margin without leaving the
     // native status-text area uncovered when the window is narrow.
@@ -4141,8 +4371,8 @@ static void PaintFinalInfoBar(
             row.left,
             std::min(
                 coverRow.right,
-                client.right > ScaleForWindow(hwnd, 220)
-                    ? client.right - ScaleForWindow(hwnd, 220)
+                client.right > ScaleForDpi(dpi, 220)
+                    ? client.right - ScaleForDpi(dpi, 220)
                     : coverRow.right
             )
         );
@@ -4256,25 +4486,6 @@ static void PaintFinalInfoBar(
             hdc
         );
 
-    // Match Explorer's native info-bar font metrics.
-    HFONT font =
-        CreateFontW(
-            -ScaleForWindow(hwnd, 12),
-            0,
-            0,
-            0,
-            FW_NORMAL,
-            FALSE,
-            FALSE,
-            FALSE,
-            DEFAULT_CHARSET,
-            OUT_DEFAULT_PRECIS,
-            CLIP_DEFAULT_PRECIS,
-            CLEARTYPE_QUALITY,
-            DEFAULT_PITCH,
-            L"Segoe UI"
-        );
-
     HFONT oldFont = nullptr;
 
     if (font)
@@ -4289,11 +4500,8 @@ static void PaintFinalInfoBar(
     }
 
     const COLORREF nativeText =
-        PickNativeTextColor(
-            hdc,
-            hwnd,
-            background,
-            selected
+        GetContrastingTextColor(
+            background
         );
 
     const COLORREF textColor =
@@ -4378,7 +4586,7 @@ static void PaintFinalInfoBar(
         };
 
     int x =
-        ScaleForWindow(hwnd, 14);
+        ScaleForDpi(dpi, 14);
 
     bool drew =
         false;
@@ -4464,16 +4672,16 @@ static void PaintFinalInfoBar(
             settings.style == InfoBarStyle::Cards;
 
         const int padX =
-            ScaleForWindow(hwnd, cards ? 10 : 12);
+            ScaleForDpi(dpi, cards ? 10 : 12);
 
         const int gap =
-            ScaleForWindow(hwnd, cards ? 8 : 6);
+            ScaleForDpi(dpi, cards ? 8 : 6);
 
         // Flat panes should begin flush with the left edge.
         // Cards keep a tiny 2 px inset so the rounded border isn't clipped.
         int paneX =
             cards
-                ? row.left + ScaleForWindow(hwnd, 2)
+                ? row.left + ScaleForDpi(dpi, 2)
                 : 0;
 
         auto DrawBox =
@@ -4494,9 +4702,9 @@ static void PaintFinalInfoBar(
 
             RECT box{
                 paneX,
-                row.top + ScaleForWindow(hwnd, cards ? 3 : 1),
+                row.top + ScaleForDpi(dpi, cards ? 3 : 1),
                 paneX + width,
-                row.bottom - ScaleForWindow(hwnd, cards ? 3 : 1)
+                row.bottom - ScaleForDpi(dpi, cards ? 3 : 1)
             };
 
             if (box.right > row.right)
@@ -4532,8 +4740,8 @@ static void PaintFinalInfoBar(
                         box.top,
                         box.right,
                         box.bottom,
-                        ScaleForWindow(hwnd, 6),
-                        ScaleForWindow(hwnd, 6)
+                        ScaleForDpi(dpi, 6),
+                        ScaleForDpi(dpi, 6)
                     );
 
                     SelectObject(hdc, oldPen);
@@ -4646,13 +4854,6 @@ static void PaintFinalInfoBar(
         SelectObject(
             hdc,
             oldFont
-        );
-    }
-
-    if (font)
-    {
-        DeleteObject(
-            font
         );
     }
 
@@ -4832,6 +5033,7 @@ static DirectUiSubclassResult EnsureDirectUiSubclass(
         return DirectUiSubclassResult::Failed;
     }
 
+    RefreshTrackedDpiAndFont(hwnd);
     EnsureWindowDataCache(hwnd);
     EnsureShellBrowserRegistration(hwnd);
 
@@ -4888,12 +5090,13 @@ static LRESULT CALLBACK DirectUiSubclassProc(
     {
         const DWORD shellBrowserCookie =
             GetShellBrowserCookieSnapshot(hwnd);
+        HFONT infoBarFont = nullptr;
 
         EraseWindowDataCache(hwnd);
         RevokeShellBrowserCookie(shellBrowserCookie);
 
         AcquireSRWLockExclusive(&g_subclassLock);
-        UntrackDirectUiWindowLocked(hwnd);
+        UntrackDirectUiWindowLocked(hwnd, &infoBarFont);
         g_installingDirectUiWindows.erase(
             std::remove(
                 g_installingDirectUiWindows.begin(),
@@ -4903,6 +5106,9 @@ static LRESULT CALLBACK DirectUiSubclassProc(
             g_installingDirectUiWindows.end()
         );
         ReleaseSRWLockExclusive(&g_subclassLock);
+
+        if (infoBarFont)
+            DeleteObject(infoBarFont);
 
         return DefSubclassProc(
             hwnd,
@@ -4928,7 +5134,8 @@ static LRESULT CALLBACK DirectUiSubclassProc(
 
     if (
         msg == WM_SIZE ||
-        msg == WM_WINDOWPOSCHANGED
+        msg == WM_WINDOWPOSCHANGED ||
+        msg == WM_DPICHANGED
     )
     {
         const LRESULT result =
@@ -4939,7 +5146,34 @@ static LRESULT CALLBACK DirectUiSubclassProc(
                 lParam
             );
 
+        if (
+            msg == WM_WINDOWPOSCHANGED ||
+            msg == WM_DPICHANGED
+        )
+        {
+            RefreshTrackedDpiAndFont(hwnd);
+        }
+
         RefreshValidatedStatusRow(hwnd);
+        InvalidateInfoBarWindow(hwnd);
+        return result;
+    }
+
+    if (
+        msg == WM_THEMECHANGED ||
+        msg == WM_SETTINGCHANGE ||
+        msg == WM_SYSCOLORCHANGE
+    )
+    {
+        const LRESULT result =
+            DefSubclassProc(
+                hwnd,
+                msg,
+                wParam,
+                lParam
+            );
+
+        InvalidateAutomaticTheme(hwnd);
         InvalidateInfoBarWindow(hwnd);
         return result;
     }
@@ -5361,9 +5595,14 @@ void Wh_ModBeforeUninit()
         }
 
         DWORD shellBrowserCookie = 0;
+        HFONT infoBarFont = nullptr;
         AcquireSRWLockExclusive(&g_subclassLock);
-        shellBrowserCookie = UntrackDirectUiWindowLocked(hwnd);
+        shellBrowserCookie =
+            UntrackDirectUiWindowLocked(hwnd, &infoBarFont);
         ReleaseSRWLockExclusive(&g_subclassLock);
+
+        if (infoBarFont)
+            DeleteObject(infoBarFont);
 
         EraseWindowDataCache(hwnd);
         RevokeShellBrowserCookie(shellBrowserCookie);

--- a/mods/explorer-info-bar.wh.cpp
+++ b/mods/explorer-info-bar.wh.cpp
@@ -160,7 +160,6 @@ When one file is selected, additional details can appear:
 
 #define CWM_GETISHELLBROWSER (WM_USER + 7)
 
-static constexpr int kStatusRowHeight = 24;
 static constexpr DWORD kInitialRefreshDelayMs = 1000;
 static constexpr DWORD kRefreshIntervalMs = 10000;
 static constexpr ULONGLONG kContentFailedRetryMs = 60000;
@@ -219,6 +218,7 @@ struct TrackedDirectUiState
     COLORREF stableNativeTextColor = CLR_INVALID;
     HWND shellTab = nullptr;
     DWORD shellBrowserCookie = 0;
+    HWND validatedDefView = nullptr;
     bool hasValidatedStatusRow = false;
     RECT validatedStatusRow{};
 };
@@ -1382,25 +1382,215 @@ static int ScaleForWindow(
     );
 }
 
-static bool GetBottomStatusRowRect(
+static HWND FindShellDefViewDescendant(HWND directUi)
+{
+    if (!directUi || !IsWindow(directUi))
+        return nullptr;
+
+    // Explorer nests SHELLDLL_DefView below an immediate DirectUI child.
+    // Match only the structural class relationship used by Explorer; window
+    // text is neither queried nor involved in target selection.
+    for (
+        HWND child = FindWindowExW(directUi, nullptr, nullptr, nullptr);
+        child;
+        child = FindWindowExW(directUi, child, nullptr, nullptr)
+    )
+    {
+        HWND defView =
+            FindWindowExW(
+                child,
+                nullptr,
+                L"SHELLDLL_DefView",
+                nullptr
+            );
+
+        if (defView)
+            return defView;
+    }
+
+    return nullptr;
+}
+
+static void StoreValidatedStatusRow(
+    HWND hwnd,
+    HWND defView,
+    const RECT* row
+)
+{
+    AcquireSRWLockExclusive(&g_subclassLock);
+
+    auto existing =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    if (existing != g_trackedWindows.end())
+    {
+        existing->validatedDefView = row ? defView : nullptr;
+        existing->hasValidatedStatusRow = row != nullptr;
+        existing->validatedStatusRow = row ? *row : RECT{};
+    }
+
+    ReleaseSRWLockExclusive(&g_subclassLock);
+}
+
+static bool RefreshValidatedStatusRow(HWND hwnd)
+{
+    if (!hwnd || !IsWindow(hwnd))
+        return false;
+
+    const HWND defView = FindShellDefViewDescendant(hwnd);
+
+    DWORD directUiPid = 0;
+    DWORD defViewPid = 0;
+    const DWORD directUiThread =
+        GetWindowThreadProcessId(hwnd, &directUiPid);
+    const DWORD defViewThread =
+        defView
+            ? GetWindowThreadProcessId(defView, &defViewPid)
+            : 0;
+
+    RECT client{};
+    RECT mappedDefView{};
+
+    bool valid =
+        defView &&
+        IsWindow(defView) &&
+        IsChild(hwnd, defView) &&
+        directUiThread &&
+        defViewThread == directUiThread &&
+        defViewPid == directUiPid &&
+        GetClientRect(hwnd, &client) &&
+        GetWindowRect(defView, &mappedDefView);
+
+    if (valid)
+    {
+        SetLastError(ERROR_SUCCESS);
+
+        const int mapped =
+            MapWindowPoints(
+                nullptr,
+                hwnd,
+                reinterpret_cast<POINT*>(&mappedDefView),
+                2
+            );
+
+        if (!mapped && GetLastError() != ERROR_SUCCESS)
+            valid = false;
+    }
+
+    const LONG tolerance = ScaleForWindow(hwnd, 2);
+
+    if (
+        valid &&
+        (
+            client.right <= client.left ||
+            client.bottom <= client.top ||
+            mappedDefView.right <= mappedDefView.left ||
+            mappedDefView.bottom <= mappedDefView.top ||
+            mappedDefView.left < client.left - tolerance ||
+            mappedDefView.right > client.right + tolerance ||
+            mappedDefView.top < client.top - tolerance ||
+            mappedDefView.bottom <= client.top ||
+            mappedDefView.bottom > client.bottom + tolerance
+        )
+    )
+    {
+        valid = false;
+    }
+
+    RECT row{};
+
+    if (valid)
+    {
+        row = client;
+        row.top = std::min(mappedDefView.bottom, client.bottom);
+
+        // A zero/sliver gap is normal when Explorer's status bar is hidden.
+        // Require a small DPI-scaled minimum before treating it as a row.
+        if (
+            row.bottom - row.top <
+                static_cast<LONG>(ScaleForWindow(hwnd, 8))
+        )
+        {
+            valid = false;
+        }
+    }
+
+    StoreValidatedStatusRow(
+        hwnd,
+        valid ? defView : nullptr,
+        valid ? &row : nullptr
+    );
+
+    return valid;
+}
+
+static bool GetValidatedStatusRow(
     HWND hwnd,
     RECT* row
 )
 {
-    if (!hwnd || !row || !IsWindow(hwnd))
+    if (!row)
         return false;
+
+    HWND defView = nullptr;
+    RECT cachedRow{};
+    bool found = false;
+
+    AcquireSRWLockShared(&g_subclassLock);
+
+    const auto existing =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    if (
+        existing != g_trackedWindows.end() &&
+        existing->hasValidatedStatusRow
+    )
+    {
+        defView = existing->validatedDefView;
+        cachedRow = existing->validatedStatusRow;
+        found = true;
+    }
+
+    ReleaseSRWLockShared(&g_subclassLock);
 
     RECT client{};
 
-    if (!GetClientRect(hwnd, &client))
+    if (
+        !found ||
+        !hwnd ||
+        !IsWindow(hwnd) ||
+        !defView ||
+        !IsWindow(defView) ||
+        !IsChild(hwnd, defView) ||
+        !GetClientRect(hwnd, &client) ||
+        cachedRow.left != client.left ||
+        cachedRow.right != client.right ||
+        cachedRow.bottom != client.bottom ||
+        cachedRow.top < client.top ||
+        cachedRow.top >= cachedRow.bottom
+    )
+    {
+        if (found)
+            StoreValidatedStatusRow(hwnd, nullptr, nullptr);
+
         return false;
+    }
 
-    *row = client;
-    row->top =
-        client.bottom > ScaleForWindow(hwnd, kStatusRowHeight)
-            ? client.bottom - ScaleForWindow(hwnd, kStatusRowHeight)
-            : 0;
-
+    *row = cachedRow;
     return true;
 }
 
@@ -1415,7 +1605,7 @@ static bool InvalidateInfoBarWindow(
 
     RECT row{};
 
-    if (!GetBottomStatusRowRect(hwnd, &row))
+    if (!GetValidatedStatusRow(hwnd, &row))
         return false;
 
     const int clientRight =
@@ -1841,41 +2031,6 @@ static WindowDataCache* FindWindowDataCacheLocked(
         : nullptr;
 }
 
-
-static bool GetValidatedStatusRow(
-    HWND hwnd,
-    RECT* row
-)
-{
-    if (!row)
-        return false;
-
-    bool found = false;
-
-    AcquireSRWLockShared(&g_subclassLock);
-
-    const auto existing =
-        std::find_if(
-            g_trackedWindows.begin(),
-            g_trackedWindows.end(),
-            [&](const TrackedDirectUiState& value)
-            {
-                return value.hwnd == hwnd;
-            }
-        );
-
-    if (
-        existing != g_trackedWindows.end() &&
-        existing->hasValidatedStatusRow
-    )
-    {
-        *row = existing->validatedStatusRow;
-        found = true;
-    }
-
-    ReleaseSRWLockShared(&g_subclassLock);
-    return found;
-}
 
 static void WakeWorkerFromPaint()
 {
@@ -3882,31 +4037,12 @@ static void PaintFinalInfoBar(
 
     RECT row{};
 
-    // Structural attachment doesn't supply a native-copy row rectangle, so
-    // new targets use the geometric fallback below.
-    const bool hasValidatedRow =
-        GetValidatedStatusRow(
-            hwnd,
-            &row
-        );
-
-    // Fall back to Explorer's bottom status-row geometry when no validated
-    // native rect is available.
     if (
-        !hasValidatedRow ||
-        row.bottom <= row.top ||
-        row.top < 0 ||
-        row.bottom >
-            client.bottom + ScaleForWindow(hwnd, 2)
+        !RefreshValidatedStatusRow(hwnd) ||
+        !GetValidatedStatusRow(hwnd, &row)
     )
     {
-        row.top =
-            client.bottom > ScaleForWindow(hwnd, kStatusRowHeight)
-                ? client.bottom - ScaleForWindow(hwnd, kStatusRowHeight)
-                : 0;
-
-        row.bottom =
-            client.bottom;
+        return;
     }
 
     row.left = ScaleForWindow(hwnd, 6);
@@ -4645,7 +4781,10 @@ static LRESULT CALLBACK DirectUiSubclassProc(
     )
     {
         if (!g_unloading.load(std::memory_order_acquire))
+        {
+            RefreshValidatedStatusRow(hwnd);
             InvalidateInfoBarWindow(hwnd);
+        }
 
         return 0;
     }
@@ -4690,6 +4829,24 @@ static LRESULT CALLBACK DirectUiSubclassProc(
             wParam,
             lParam
         );
+    }
+
+    if (
+        msg == WM_SIZE ||
+        msg == WM_WINDOWPOSCHANGED
+    )
+    {
+        const LRESULT result =
+            DefSubclassProc(
+                hwnd,
+                msg,
+                wParam,
+                lParam
+            );
+
+        RefreshValidatedStatusRow(hwnd);
+        InvalidateInfoBarWindow(hwnd);
+        return result;
     }
 
     if (msg == WM_PAINT)
@@ -5094,18 +5251,9 @@ void Wh_ModBeforeUninit()
             // removing the subclass alone leaves those pixels on screen until
             // the next native repaint. Force the status row to repaint now
             // while g_unloading prevents any new overlay from being drawn.
-            RECT client{};
-            if (GetClientRect(hwnd, &client))
+            RECT row{};
+            if (GetValidatedStatusRow(hwnd, &row))
             {
-                RECT row{};
-                row.left = 0;
-                row.right = client.right;
-                row.bottom = client.bottom;
-                row.top = std::max(
-                    0L,
-                    client.bottom - static_cast<LONG>(ScaleForWindow(hwnd, kStatusRowHeight))
-                );
-
                 RedrawWindow(
                     hwnd,
                     &row,

--- a/mods/explorer-info-bar.wh.cpp
+++ b/mods/explorer-info-bar.wh.cpp
@@ -163,7 +163,7 @@ When one file is selected, additional details can appear:
 static constexpr int kStatusRowHeight = 24;
 static constexpr DWORD kInitialRefreshDelayMs = 1000;
 static constexpr DWORD kRefreshIntervalMs = 10000;
-static constexpr ULONGLONG kContentFailedRetryMs = 2000;
+static constexpr ULONGLONG kContentFailedRetryMs = 60000;
 static constexpr ULONGLONG kMetadataRetryMs = 5000;
 
 thread_local bool g_insideFinalPaint = false;
@@ -212,6 +212,7 @@ struct InfoBarLayoutGeometry
 struct TrackedDirectUiState
 {
     HWND hwnd = nullptr;
+    ULONGLONG selectionGeneration = 1;
     bool hasLayout = false;
     InfoBarLayoutGeometry layout;
     COLORREF stableRowBackground = CLR_INVALID;
@@ -285,7 +286,6 @@ static HANDLE g_selectionWinEventThreadReady = nullptr;
 static HANDLE g_selectionWinEventStopEvent = nullptr;
 static HWINEVENTHOOK g_selectionWinEventHook = nullptr;
 static HWINEVENTHOOK g_windowCreateWinEventHook = nullptr;
-static std::atomic<ULONGLONG> g_selectionGeneration{1};
 static std::atomic<ULONGLONG> g_lastPaintWakeTick{0};
 static constexpr ULONGLONG kSelectionWinEventWakeIntervalMs = 200;
 static ULONGLONG g_lastSelectionWinEventWakeTick = 0;
@@ -302,8 +302,10 @@ struct ContentRefreshCache
     int folders = 0;
     ULONGLONG directFileBytes = 0;
     ULONGLONG lastFullScanTick = 0;
-    std::wstring lastAttemptFolderIdentity;
-    ULONGLONG lastScanAttemptTick = 0;
+    bool scanFailed = false;
+    std::wstring failedFolderIdentity;
+    int failedItemCount = -1;
+    ULONGLONG failedScanTick = 0;
 };
 
 struct SingleFileMetadataCache
@@ -1899,10 +1901,40 @@ static void WakeWorkerFromPaint()
     SetEvent(g_workerWakeEvent);
 }
 
-static bool IsWinEventFromTrackedExplorerRoot(HWND hwnd)
+static bool AdvanceSelectionGenerationForWinEvent(HWND hwnd)
 {
     if (!hwnd)
         return false;
+
+    // Resolve the event's tab before taking g_subclassLock. GetParent and
+    // GetClassNameW can call into the window manager and must remain outside
+    // the tracked-state critical section.
+    const HWND eventShellTab =
+        FindAncestorByClass(
+            hwnd,
+            L"ShellTabWindowClass"
+        );
+
+    if (eventShellTab)
+    {
+        bool matched = false;
+
+        AcquireSRWLockExclusive(&g_subclassLock);
+
+        for (TrackedDirectUiState& state : g_trackedWindows)
+        {
+            if (state.shellTab == eventShellTab)
+            {
+                state.selectionGeneration++;
+                matched = true;
+            }
+        }
+
+        ReleaseSRWLockExclusive(&g_subclassLock);
+
+        if (matched)
+            return true;
+    }
 
     const HWND eventRoot = GetAncestor(hwnd, GA_ROOT);
 
@@ -1923,19 +1955,31 @@ static bool IsWinEventFromTrackedExplorerRoot(HWND hwnd)
         return false;
     }
 
-    // Copy only HWND values while holding the lock. Root inspection happens
-    // below, after releasing it, because window-manager calls can reenter.
-    std::vector<HWND> trackedWindows;
+    struct TrackedTabSnapshot
+    {
+        HWND hwnd;
+        HWND shellTab;
+    };
+
+    // If the event HWND couldn't be tied directly to a registered shell tab,
+    // use only a unique visible DirectUI target under the same Explorer root.
+    // This preserves a safe recovery path without dirtying sibling tabs.
+    std::vector<TrackedTabSnapshot> trackedTabs;
     bool snapshotFailed = false;
 
     AcquireSRWLockShared(&g_subclassLock);
 
     try
     {
-        trackedWindows.reserve(g_trackedWindows.size());
+        trackedTabs.reserve(g_trackedWindows.size());
 
         for (const TrackedDirectUiState& state : g_trackedWindows)
-            trackedWindows.push_back(state.hwnd);
+        {
+            trackedTabs.push_back({
+                state.hwnd,
+                state.shellTab
+            });
+        }
     }
     catch (...)
     {
@@ -1947,13 +1991,46 @@ static bool IsWinEventFromTrackedExplorerRoot(HWND hwnd)
     if (snapshotFailed)
         return false;
 
-    for (HWND trackedWindow : trackedWindows)
+    HWND fallbackHwnd = nullptr;
+    HWND fallbackShellTab = nullptr;
+
+    for (const TrackedTabSnapshot& tracked : trackedTabs)
     {
-        if (GetAncestor(trackedWindow, GA_ROOT) == eventRoot)
-            return true;
+        if (
+            IsWindowVisible(tracked.hwnd) &&
+            GetAncestor(tracked.hwnd, GA_ROOT) == eventRoot
+        )
+        {
+            if (fallbackHwnd)
+                return false;
+
+            fallbackHwnd = tracked.hwnd;
+            fallbackShellTab = tracked.shellTab;
+        }
     }
 
-    return false;
+    if (!fallbackHwnd)
+        return false;
+
+    bool matched = false;
+
+    AcquireSRWLockExclusive(&g_subclassLock);
+
+    for (TrackedDirectUiState& state : g_trackedWindows)
+    {
+        if (
+            state.hwnd == fallbackHwnd &&
+            state.shellTab == fallbackShellTab
+        )
+        {
+            state.selectionGeneration++;
+            matched = true;
+            break;
+        }
+    }
+
+    ReleaseSRWLockExclusive(&g_subclassLock);
+    return matched;
 }
 
 static void CALLBACK SelectionWinEventWakeTimerProc(
@@ -2032,13 +2109,12 @@ static void CALLBACK SelectionWinEventProc(
         event < EVENT_OBJECT_FOCUS ||
         event > EVENT_OBJECT_SELECTIONWITHIN ||
         g_unloading.load(std::memory_order_acquire) ||
-        !IsWinEventFromTrackedExplorerRoot(hwnd)
+        !AdvanceSelectionGenerationForWinEvent(hwnd)
     )
     {
         return;
     }
 
-    g_selectionGeneration.fetch_add(1, std::memory_order_relaxed);
     WakeWorkerFromSelectionWinEvent();
 }
 
@@ -2649,7 +2725,8 @@ static std::wstring GetSingleFileDetailsCached(
 
 static unsigned ReadCurrentView(
     HWND hwnd,
-    IShellBrowser* browser
+    IShellBrowser* browser,
+    ULONGLONG selectionGeneration
 )
 {
     if (!hwnd || !browser)
@@ -2822,10 +2899,18 @@ static unsigned ReadCurrentView(
             sameFolder &&
             total != contentCache.itemCount;
 
-        const bool retryThrottled =
-            folderIdentity ==
-                contentCache.lastAttemptFolderIdentity &&
-            now - contentCache.lastScanAttemptTick <
+        const bool sameFailedFolder =
+            contentCache.scanFailed &&
+            !folderIdentity.empty() &&
+            folderIdentity == contentCache.failedFolderIdentity;
+
+        const bool failedItemCountChanged =
+            sameFailedFolder &&
+            total != contentCache.failedItemCount;
+
+        const bool failedRetryDue =
+            sameFailedFolder &&
+            now - contentCache.failedScanTick >=
                 kContentFailedRetryMs;
 
         if (
@@ -2833,12 +2918,13 @@ static unsigned ReadCurrentView(
                 !sameFolder ||
                 itemCountChanged
             ) &&
-            !retryThrottled
+            (
+                !sameFailedFolder ||
+                failedItemCountChanged ||
+                failedRetryDue
+            )
         )
         {
-            contentCache.lastAttemptFolderIdentity = folderIdentity;
-            contentCache.lastScanAttemptTick = now;
-
             int scannedFiles = 0;
             int scannedFolders = 0;
             ULONGLONG scannedBytes = 0;
@@ -2859,8 +2945,19 @@ static unsigned ReadCurrentView(
                 contentCache.folders = scannedFolders;
                 contentCache.directFileBytes = scannedBytes;
                 contentCache.lastFullScanTick = now;
+                contentCache.scanFailed = false;
+                contentCache.failedFolderIdentity.clear();
+                contentCache.failedItemCount = -1;
+                contentCache.failedScanTick = 0;
             }
-
+            else
+            {
+                contentCache.valid = false;
+                contentCache.scanFailed = true;
+                contentCache.failedFolderIdentity = folderIdentity;
+                contentCache.failedItemCount = total;
+                contentCache.failedScanTick = now;
+            }
         }
     }
 
@@ -2869,6 +2966,32 @@ static unsigned ReadCurrentView(
         contentCache.valid &&
         !folderIdentity.empty() &&
         folderIdentity == contentCache.folderIdentity;
+
+    const bool useFailedContentFallback =
+        settings.showContent &&
+        itemCountAvailable &&
+        contentCache.scanFailed &&
+        !folderIdentity.empty() &&
+        folderIdentity == contentCache.failedFolderIdentity &&
+        total == contentCache.failedItemCount;
+
+    if (
+        useFailedContentFallback &&
+        contentOverrideText.empty()
+    )
+    {
+        wchar_t failedContent[128] = {};
+
+        swprintf(
+            failedContent,
+            ARRAYSIZE(failedContent),
+            L"Content: %d item%s",
+            total,
+            total == 1 ? L"" : L"s"
+        );
+
+        contentOverrideText = failedContent;
+    }
 
     if (
         settings.showContent &&
@@ -2902,9 +3025,6 @@ static unsigned ReadCurrentView(
     std::wstring selectionOverrideText;
     std::wstring singleFileDetails = state.fileDetailsGroup;
     bool keepSingleFileMetadataCache = !state.fileDetailsGroup.empty();
-    const ULONGLONG selectionGeneration =
-        g_selectionGeneration.load(std::memory_order_relaxed);
-
     // Always obtain the selection count. Even when the Selected and
     // File Details sections are hidden, the painter uses the count to avoid
     // learning Explorer's temporary selected-row tint as the normal theme.
@@ -3222,10 +3342,12 @@ static DWORD WINAPI WorkerThreadProc(
     {
         HWND hwnd;
         DWORD shellBrowserCookie;
+        ULONGLONG selectionGeneration;
     };
 
     while (true)
     {
+        std::vector<WorkerTarget> targetCandidates;
         std::vector<WorkerTarget> targets;
 
         bool snapshotFailed = false;
@@ -3234,15 +3356,16 @@ static DWORD WINAPI WorkerThreadProc(
 
         try
         {
-            targets.reserve(g_trackedWindows.size());
+            targetCandidates.reserve(g_trackedWindows.size());
 
             for (const TrackedDirectUiState& state : g_trackedWindows)
             {
                 if (state.shellBrowserCookie)
                 {
-                    targets.push_back({
+                    targetCandidates.push_back({
                         state.hwnd,
-                        state.shellBrowserCookie
+                        state.shellBrowserCookie,
+                        state.selectionGeneration
                     });
                 }
             }
@@ -3257,6 +3380,24 @@ static DWORD WINAPI WorkerThreadProc(
         if (snapshotFailed)
         {
             Wh_Log(L"Worker target snapshot failed");
+            targetCandidates.clear();
+        }
+
+        try
+        {
+            targets.reserve(targetCandidates.size());
+
+            for (const WorkerTarget& candidate : targetCandidates)
+            {
+                // Inactive Windows 11 tabs keep their DirectUIHWND tracked,
+                // but a hidden target cannot contribute visible output.
+                if (IsWindowVisible(candidate.hwnd))
+                    targets.push_back(candidate);
+            }
+        }
+        catch (...)
+        {
+            Wh_Log(L"Visible worker target snapshot failed");
             targets.clear();
         }
 
@@ -3285,7 +3426,8 @@ static DWORD WINAPI WorkerThreadProc(
             const unsigned changes =
                 ReadCurrentView(
                     target.hwnd,
-                    browser
+                    browser,
+                    target.selectionGeneration
                 );
 
             browser->Release();
@@ -4898,7 +5040,12 @@ void Wh_ModSettingsChanged()
 
     // Force one detailed selection refresh because visibility/detail settings
     // may have changed even if the Explorer selection itself did not.
-    g_selectionGeneration.fetch_add(1, std::memory_order_relaxed);
+    AcquireSRWLockExclusive(&g_subclassLock);
+
+    for (TrackedDirectUiState& state : g_trackedWindows)
+        state.selectionGeneration++;
+
+    ReleaseSRWLockExclusive(&g_subclassLock);
 
     if (g_workerWakeEvent)
         SetEvent(g_workerWakeEvent);

--- a/mods/explorer-info-bar.wh.cpp
+++ b/mods/explorer-info-bar.wh.cpp
@@ -4096,7 +4096,17 @@ static COLORREF PickBackgroundColor(
     AutomaticThemeSnapshot theme =
         GetAutomaticThemeSnapshot(hwnd);
 
-    if (theme.hasSampledNativeRowBackground)
+    const bool fullRowRepaint =
+        nativePaintRect &&
+        nativePaintRect->left <= row.left &&
+        nativePaintRect->right >= row.right &&
+        nativePaintRect->top <= row.top &&
+        nativePaintRect->bottom >= row.bottom;
+
+    if (
+        theme.hasSampledNativeRowBackground &&
+        !fullRowRepaint
+    )
     {
         return theme.rowBackground;
     }
@@ -5182,7 +5192,6 @@ static LRESULT CALLBACK DirectUiSubclassProc(
     {
         EnsureWindowDataCache(hwnd);
         EnsureShellBrowserRegistration(hwnd);
-        WakeWorkerFromPaint();
 
         RECT updateRect{};
 
@@ -5192,6 +5201,24 @@ static LRESULT CALLBACK DirectUiSubclassProc(
                 &updateRect,
                 FALSE
             );
+
+        RECT row{};
+        RECT intersection{};
+
+        if (
+            !hasUpdateRect ||
+            (
+                GetValidatedStatusRow(hwnd, &row) &&
+                IntersectRect(
+                    &intersection,
+                    &updateRect,
+                    &row
+                )
+            )
+        )
+        {
+            WakeWorkerFromPaint();
+        }
 
         // Let DirectUI finish ALL of its own buffered painting first.
         LRESULT result =

--- a/mods/explorer-info-bar.wh.cpp
+++ b/mods/explorer-info-bar.wh.cpp
@@ -287,11 +287,22 @@ static HANDLE g_selectionWinEventStopEvent = nullptr;
 static HWINEVENTHOOK g_selectionWinEventHook = nullptr;
 static HWINEVENTHOOK g_windowCreateWinEventHook = nullptr;
 static std::atomic<ULONGLONG> g_lastPaintWakeTick{0};
-static constexpr ULONGLONG kSelectionWinEventWakeIntervalMs = 200;
-static ULONGLONG g_lastSelectionWinEventWakeTick = 0;
+static constexpr ULONGLONG kSelectionWinEventDebounceMs = 200;
+static constexpr ULONGLONG kSelectionWinEventMaxLatencyMs = 800;
+static ULONGLONG g_selectionWinEventBurstStartTick = 0;
 static UINT_PTR g_selectionWinEventWakeTimer = 0;
 
 static CRITICAL_SECTION g_cacheLock;
+
+static bool IsWorkerStopRequested()
+{
+    return
+        g_unloading.load(std::memory_order_acquire) ||
+        (
+            g_stopEvent &&
+            WaitForSingleObject(g_stopEvent, 0) == WAIT_OBJECT_0
+        );
+}
 
 struct ContentRefreshCache
 {
@@ -873,7 +884,6 @@ static std::wstring FormatMediaDuration(
 }
 
 static std::wstring BuildSingleFileDetails(
-    IShellItem* item,
     const std::wstring& path,
     bool* transientFailure
 )
@@ -881,7 +891,7 @@ static std::wstring BuildSingleFileDetails(
     if (transientFailure)
         *transientFailure = false;
 
-    if (!item || path.empty())
+    if (path.empty())
         return L"";
 
     const std::wstring extension =
@@ -892,20 +902,48 @@ static std::wstring BuildSingleFileDetails(
             ? L"no extension"
             : extension;
 
-    IShellItem2* item2 = nullptr;
+    if (IsWorkerStopRequested())
+        return result;
+
+    IShellItem* localItem = nullptr;
 
     if (
         FAILED(
-            item->QueryInterface(
-                IID_PPV_ARGS(&item2)
+            SHCreateItemFromParsingName(
+                path.c_str(),
+                nullptr,
+                IID_PPV_ARGS(&localItem)
             )
         ) ||
-        !item2
+        !localItem
     )
     {
         if (transientFailure)
             *transientFailure = true;
 
+        return result;
+    }
+
+    IShellItem2* item2 = nullptr;
+
+    const HRESULT item2Hr =
+        localItem->QueryInterface(
+            IID_PPV_ARGS(&item2)
+        );
+
+    localItem->Release();
+
+    if (FAILED(item2Hr) || !item2)
+    {
+        if (transientFailure)
+            *transientFailure = true;
+
+        return result;
+    }
+
+    if (IsWorkerStopRequested())
+    {
+        item2->Release();
         return result;
     }
 
@@ -1871,14 +1909,27 @@ static void RefreshInfoBarWindow(
             &client
         );
 
+    const int currentControlSafeRight =
+        currentClientAvailable
+            ? std::max(
+                0,
+                static_cast<int>(client.right) -
+                    ScaleForWindow(hwnd, 64)
+            )
+            : -1;
+
     const int currentUsableRight =
         currentClientAvailable
-            ? (
-                client.right > ScaleForWindow(hwnd, 220)
-                    ? static_cast<int>(
-                        client.right - ScaleForWindow(hwnd, 220)
-                    )
-                    : static_cast<int>(client.right)
+            ? std::max(
+                ScaleForWindow(hwnd, 6),
+                std::min(
+                    currentControlSafeRight,
+                    client.right > ScaleForWindow(hwnd, 220)
+                        ? static_cast<int>(
+                            client.right - ScaleForWindow(hwnd, 220)
+                        )
+                        : currentControlSafeRight
+                )
             )
             : -1;
 
@@ -2203,7 +2254,7 @@ static void CALLBACK SelectionWinEventWakeTimerProc(
     if (g_unloading.load(std::memory_order_acquire))
         return;
 
-    g_lastSelectionWinEventWakeTick = GetTickCount64();
+    g_selectionWinEventBurstStartTick = 0;
 
     if (g_workerWakeEvent)
         SetEvent(g_workerWakeEvent);
@@ -2215,35 +2266,49 @@ static void WakeWorkerFromSelectionWinEvent()
         return;
 
     const ULONGLONG now = GetTickCount64();
-    const ULONGLONG elapsed = now - g_lastSelectionWinEventWakeTick;
 
-    if (
-        !g_lastSelectionWinEventWakeTick ||
-        elapsed >= kSelectionWinEventWakeIntervalMs
-    )
+    if (!g_selectionWinEventBurstStartTick)
+        g_selectionWinEventBurstStartTick = now;
+
+    if (g_selectionWinEventWakeTimer)
     {
-        g_lastSelectionWinEventWakeTick = now;
+        KillTimer(nullptr, g_selectionWinEventWakeTimer);
+        g_selectionWinEventWakeTimer = 0;
+    }
+
+    const ULONGLONG burstElapsed =
+        now - g_selectionWinEventBurstStartTick;
+
+    if (burstElapsed >= kSelectionWinEventMaxLatencyMs)
+    {
+        g_selectionWinEventBurstStartTick = 0;
         SetEvent(g_workerWakeEvent);
         return;
     }
 
-    if (g_selectionWinEventWakeTimer)
-        return;
+    const ULONGLONG remainingLatency =
+        kSelectionWinEventMaxLatencyMs - burstElapsed;
+
+    const UINT delay =
+        static_cast<UINT>(
+            std::min(
+                kSelectionWinEventDebounceMs,
+                remainingLatency
+            )
+        );
 
     g_selectionWinEventWakeTimer =
         SetTimer(
             nullptr,
             0,
-            static_cast<UINT>(
-                kSelectionWinEventWakeIntervalMs - elapsed
-            ),
+            delay,
             SelectionWinEventWakeTimerProc
         );
 
     if (!g_selectionWinEventWakeTimer)
     {
-        // A failed coalescing timer must not leave the final selection stale.
-        g_lastSelectionWinEventWakeTick = now;
+        // A failed debounce timer must not leave the final selection stale.
+        g_selectionWinEventBurstStartTick = 0;
         SetEvent(g_workerWakeEvent);
     }
 }
@@ -2721,6 +2786,9 @@ static bool ScanFilesystemDirectory(
         return false;
     }
 
+    if (IsWorkerStopRequested())
+        return false;
+
     std::wstring searchPath = directoryPath;
 
     if (
@@ -2734,6 +2802,9 @@ static bool ScanFilesystemDirectory(
     searchPath += L'*';
 
     WIN32_FIND_DATAW findData{};
+
+    if (IsWorkerStopRequested())
+        return false;
 
     HANDLE findHandle =
         FindFirstFileExW(
@@ -2836,7 +2907,6 @@ static void ClearSingleFileMetadataCache(
 
 static std::wstring GetSingleFileDetailsCached(
     SingleFileMetadataCache* cache,
-    IShellItem* item,
     const std::wstring& path
 )
 {
@@ -2858,7 +2928,6 @@ static std::wstring GetSingleFileDetailsCached(
 
     std::wstring details =
         BuildSingleFileDetails(
-            item,
             path,
             &transientFailure
         );
@@ -3325,7 +3394,6 @@ static unsigned ReadCurrentView(
                                     singleFileDetails =
                                         GetSingleFileDetailsCached(
                                             &metadataCache,
-                                            item,
                                             path
                                         );
                                 }
@@ -3752,6 +3820,7 @@ static COLORREF PickBackgroundColor(
     HDC hdc,
     HWND hwnd,
     const RECT& row,
+    const RECT* nativePaintRect,
     int selected
 )
 {
@@ -3768,36 +3837,43 @@ static COLORREF PickBackgroundColor(
         return stable.rowBackground;
     }
 
-    const int y =
-        row.top +
-        ((row.bottom - row.top) / 2);
-
-    const int samples[] =
-    {
-        ScaleForWindow(hwnd, 420),
-        ScaleForWindow(hwnd, 520),
-        ScaleForWindow(hwnd, 620),
-        ScaleForWindow(hwnd, 720)
-    };
-
     COLORREF chosen = CLR_INVALID;
+    const int rowWidth = row.right - row.left;
+    const int rowHeight = row.bottom - row.top;
 
-    for (int x : samples)
+    if (
+        nativePaintRect &&
+        rowWidth > 0 &&
+        rowHeight > 0
+    )
     {
-        if (x >= row.right)
-            continue;
+        const int y = row.top + (rowHeight / 2);
+        const int sampleNumerators[] = { 9, 8, 7, 6, 5, 4 };
+        const int safetyInset = 1;
 
-        const COLORREF sample =
-            GetPixel(
-                hdc,
-                x,
-                y
-            );
-
-        if (sample != CLR_INVALID)
+        for (int numerator : sampleNumerators)
         {
-            chosen = sample;
-            break;
+            const int x =
+                row.left +
+                (rowWidth * numerator) / 10;
+
+            if (
+                x - safetyInset < nativePaintRect->left ||
+                x + safetyInset >= nativePaintRect->right ||
+                y - safetyInset < nativePaintRect->top ||
+                y + safetyInset >= nativePaintRect->bottom
+            )
+            {
+                continue;
+            }
+
+            const COLORREF sample = GetPixel(hdc, x, y);
+
+            if (sample != CLR_INVALID)
+            {
+                chosen = sample;
+                break;
+            }
         }
     }
 
@@ -3806,7 +3882,7 @@ static COLORREF PickBackgroundColor(
         if (stable.rowBackground != CLR_INVALID)
             return stable.rowBackground;
 
-        chosen = RGB(32, 32, 32);
+        return GetSysColor(COLOR_WINDOW);
     }
 
     if (selected <= 0)
@@ -4045,13 +4121,31 @@ static void PaintFinalInfoBar(
         return;
     }
 
+    RECT coverRow = row;
+
+    // The native controls occupy only the compact area at the far right.
+    // Cover native status text up to that area independently of the wider
+    // content-layout reservation below.
+    coverRow.right =
+        std::max(
+            coverRow.left,
+            client.right - ScaleForWindow(hwnd, 64)
+        );
+
     row.left = ScaleForWindow(hwnd, 6);
 
-    // Preserve Explorer's right-side controls.
+    // Keep the existing conservative content margin without leaving the
+    // native status-text area uncovered when the window is narrow.
     row.right =
-        client.right > ScaleForWindow(hwnd, 220)
-            ? client.right - ScaleForWindow(hwnd, 220)
-            : client.right;
+        std::max(
+            row.left,
+            std::min(
+                coverRow.right,
+                client.right > ScaleForWindow(hwnd, 220)
+                    ? client.right - ScaleForWindow(hwnd, 220)
+                    : coverRow.right
+            )
+        );
 
     std::wstring contentGroup;
     std::wstring selectionGroup;
@@ -4096,7 +4190,7 @@ static void PaintFinalInfoBar(
         return;
 
     RECT paintRect =
-        row;
+        coverRow;
 
     if (
         updateRect &&
@@ -4129,6 +4223,7 @@ static void PaintFinalInfoBar(
             hdc,
             hwnd,
             row,
+            updateRect ? &paintRect : nullptr,
             selected
         );
 
@@ -4141,7 +4236,7 @@ static void PaintFinalInfoBar(
     {
         FillRect(
             hdc,
-            &row,
+            &coverRow,
             brush
         );
 
@@ -5296,15 +5391,46 @@ void Wh_ModUninit()
 
     if (g_workerThread)
     {
-        // CancelSynchronousIo in Wh_ModBeforeUninit interrupts a worker that
-        // is blocked in FindFirstFileExW/FindNextFileW. Never terminate a
-        // thread inside Explorer while it may own COM, CRT or cache locks.
-        CancelSynchronousIo(g_workerThread);
+        // Cancellation can race with the worker entering its next COM or
+        // filesystem call. Retry both mechanisms between bounded waits.
+        // Never terminate a thread while it may own COM, CRT or cache locks.
+        while (true)
+        {
+            if (g_workerThreadId)
+                CoCancelCall(g_workerThreadId, 0);
 
-        WaitForSingleObject(
-            g_workerThread,
-            INFINITE
-        );
+            CancelSynchronousIo(g_workerThread);
+
+            const DWORD waitResult =
+                WaitForSingleObject(
+                    g_workerThread,
+                    500
+                );
+
+            if (waitResult == WAIT_OBJECT_0)
+                break;
+
+            if (waitResult != WAIT_TIMEOUT)
+            {
+                Wh_Log(
+                    L"worker shutdown wait failed result=%lu error=%lu",
+                    waitResult,
+                    GetLastError()
+                );
+
+                DWORD exitCode = STILL_ACTIVE;
+
+                if (
+                    GetExitCodeThread(g_workerThread, &exitCode) &&
+                    exitCode != STILL_ACTIVE
+                )
+                {
+                    break;
+                }
+
+                Sleep(500);
+            }
+        }
 
         CloseHandle(
             g_workerThread

--- a/mods/explorer-info-bar.wh.cpp
+++ b/mods/explorer-info-bar.wh.cpp
@@ -57,7 +57,7 @@ Explorer Info Bar+ uses the native Windows 11 bottom status area; it does not re
 
 Do not enable Classic Explorer Status Bar or PreVista Explorer Status Bar at the same time as Explorer Info Bar+. Both try to control the same bottom Explorer area and can conflict or overlap.
 
-Explorer Status Bar Metadata overlaps functionally because Explorer Info Bar+ already includes optional single-file metadata. Its metadata functionality is integrated here; no broader incompatibility is implied.
+Explorer Info Bar+ paints over the native status-row text, including output from Explorer Status Bar Metadata. Do not enable Explorer Status Bar Metadata at the same time because its output will be covered. When Explorer Status Bar Metadata is not used, Explorer Info Bar+'s optional Single File Details can provide file extension, dimensions, and duration when available.
 
 ## Examples
 
@@ -115,7 +115,7 @@ When one file is selected, additional details can appear:
   $name: Show Selected
   $description: Show information about the current selection.
 
-- singleFileDetails: true
+- singleFileDetails: false
   $name: Show Single File Details
   $description: Show file extension and details when possible.
 
@@ -169,12 +169,11 @@ When one file is selected, additional details can appear:
 #define CWM_GETISHELLBROWSER (WM_USER + 7)
 
 static constexpr DWORD kInitialRefreshDelayMs = 1000;
-static constexpr DWORD kRefreshIntervalMs = 10000;
+static constexpr DWORD kRefreshIntervalMs = 30000;
 static constexpr ULONGLONG kContentFailedRetryMs = 60000;
 static constexpr ULONGLONG kMetadataRetryMs = 5000;
 static constexpr ULONGLONG kStatusRowValidationIntervalMs = 500;
-
-thread_local bool g_insideFinalPaint = false;
+static constexpr ULONGLONG kNativeRowBackgroundSampleIntervalMs = 2000;
 
 static std::atomic<bool> g_unloading{false};
 
@@ -225,6 +224,7 @@ struct TrackedDirectUiState
     InfoBarLayoutGeometry layout;
     COLORREF automaticRowBackground = CLR_INVALID;
     bool hasSampledNativeRowBackground = false;
+    ULONGLONG lastNativeRowBackgroundSampleTick = 0;
     UINT dpi = 96;
     HFONT infoBarFont = nullptr;
     HWND shellTab = nullptr;
@@ -265,7 +265,7 @@ struct ModSettings
     bool showDrive = true;
     bool showContent = true;
     bool showSelection = true;
-    bool singleFileDetails = true;
+    bool singleFileDetails = false;
 };
 
 static SRWLOCK g_settingsLock = SRWLOCK_INIT;
@@ -298,7 +298,6 @@ static HANDLE g_selectionWinEventThreadReady = nullptr;
 static HANDLE g_selectionWinEventStopEvent = nullptr;
 static HWINEVENTHOOK g_selectionWinEventHook = nullptr;
 static HWINEVENTHOOK g_windowCreateWinEventHook = nullptr;
-static std::atomic<ULONGLONG> g_lastPaintWakeTick{0};
 static constexpr ULONGLONG kSelectionWinEventDebounceMs = 200;
 static constexpr ULONGLONG kSelectionWinEventMaxLatencyMs = 800;
 static ULONGLONG g_selectionWinEventBurstStartTick = 0;
@@ -339,6 +338,21 @@ struct SingleFileMetadataCache
     ULONGLONG retryAfterTick = 0;
 };
 
+struct DriveRefreshCache
+{
+    std::wstring path;
+    ULONGLONG freeBytes = 0;
+    ULONGLONG totalBytes = 0;
+    wchar_t driveLetter = L'?';
+    ULONGLONG lastRefreshTick = 0;
+};
+
+struct SingleSelectionRefreshCache
+{
+    std::wstring identity;
+    ULONGLONG lastFilesystemRefreshTick = 0;
+};
+
 struct WindowDataCache
 {
     HWND hwnd = nullptr;
@@ -353,6 +367,10 @@ struct WindowDataCache
     std::wstring fileDetailsGroup;
     ContentRefreshCache contentRefresh;
     SingleFileMetadataCache metadata;
+    DriveRefreshCache driveRefresh;
+    SingleSelectionRefreshCache singleSelectionRefresh;
+    ULONGLONG lastWorkerRefreshTick = 0;
+    ULONGLONG lastPaintWakeTick = 0;
 };
 
 static std::vector<WindowDataCache> g_windowDataCaches;
@@ -1886,6 +1904,7 @@ struct AutomaticThemeSnapshot
 {
     COLORREF rowBackground = CLR_INVALID;
     bool hasSampledNativeRowBackground = false;
+    ULONGLONG lastNativeRowBackgroundSampleTick = 0;
 };
 
 static void StoreLayoutGeometry(
@@ -1994,6 +2013,9 @@ static AutomaticThemeSnapshot GetAutomaticThemeSnapshot(
 
         result.hasSampledNativeRowBackground =
             existing->hasSampledNativeRowBackground;
+
+        result.lastNativeRowBackgroundSampleTick =
+            existing->lastNativeRowBackgroundSampleTick;
     }
 
     ReleaseSRWLockShared(&g_subclassLock);
@@ -2023,6 +2045,12 @@ static void UpdateAutomaticRowBackground(
         existing->automaticRowBackground = rowBackground;
         existing->hasSampledNativeRowBackground =
             sampledNativeRowBackground;
+
+        if (sampledNativeRowBackground)
+        {
+            existing->lastNativeRowBackgroundSampleTick =
+                GetTickCount64();
+        }
     }
 
     ReleaseSRWLockExclusive(&g_subclassLock);
@@ -2296,26 +2324,39 @@ static WindowDataCache* FindWindowDataCacheLocked(
 }
 
 
-static void WakeWorkerFromPaint()
+static void WakeWorkerFromPaint(HWND hwnd)
 {
-    if (!g_workerWakeEvent)
+    if (!hwnd || !g_workerWakeEvent)
         return;
 
     const ULONGLONG now = GetTickCount64();
-    ULONGLONG previous =
-        g_lastPaintWakeTick.load(std::memory_order_relaxed);
+    bool shouldWake = false;
 
-    if (
-        now - previous < 250 ||
-        !g_lastPaintWakeTick.compare_exchange_strong(
-            previous,
-            now,
-            std::memory_order_relaxed
-        )
-    )
+    EnterCriticalSection(&g_cacheLock);
+
+    if (WindowDataCache* cache = FindWindowDataCacheLocked(hwnd))
     {
-        return;
+        const bool dataIsStale =
+            !cache->lastWorkerRefreshTick ||
+            now - cache->lastWorkerRefreshTick >=
+                kRefreshIntervalMs;
+
+        const bool paintWakeIsDue =
+            !cache->lastPaintWakeTick ||
+            now - cache->lastPaintWakeTick >=
+                kRefreshIntervalMs;
+
+        if (dataIsStale && paintWakeIsDue)
+        {
+            cache->lastPaintWakeTick = now;
+            shouldWake = true;
+        }
     }
+
+    LeaveCriticalSection(&g_cacheLock);
+
+    if (!shouldWake)
+        return;
 
     SetEvent(g_workerWakeEvent);
 }
@@ -2823,7 +2864,9 @@ static unsigned UpdateCache(
     const std::wstring& fileDetailsText,
     ULONGLONG selectionGeneration,
     const ContentRefreshCache& contentRefreshCache,
-    const SingleFileMetadataCache& metadataCache
+    const SingleFileMetadataCache& metadataCache,
+    const DriveRefreshCache& driveRefreshCache,
+    const SingleSelectionRefreshCache& singleSelectionRefreshCache
 )
 {
     std::wstring driveText;
@@ -2977,6 +3020,9 @@ static unsigned UpdateCache(
     cache->selectionGeneration = selectionGeneration;
     cache->contentRefresh = contentRefreshCache;
     cache->metadata = metadataCache;
+    cache->driveRefresh = driveRefreshCache;
+    cache->singleSelectionRefresh = singleSelectionRefreshCache;
+    cache->lastWorkerRefreshTick = GetTickCount64();
 
     LeaveCriticalSection(&g_cacheLock);
     return changes;
@@ -3212,6 +3258,12 @@ static unsigned ReadCurrentView(
     SingleFileMetadataCache metadataCache =
         state.metadata;
 
+    DriveRefreshCache driveCache =
+        state.driveRefresh;
+
+    SingleSelectionRefreshCache singleSelectionCache =
+        state.singleSelectionRefresh;
+
     IShellView* shellView = nullptr;
 
     HRESULT hr =
@@ -3285,6 +3337,8 @@ static unsigned ReadCurrentView(
     if (folderIdentity.empty())
         folderIdentity = currentPath;
 
+    const ULONGLONG now = GetTickCount64();
+
     ULONGLONG freeBytes = 0;
     ULONGLONG driveTotalBytes = 0;
     wchar_t driveLetter = L'?';
@@ -3295,26 +3349,49 @@ static unsigned ReadCurrentView(
         currentPath[1] == L':'
     )
     {
-        ULARGE_INTEGER freeAvailable{};
-        ULARGE_INTEGER totalBytes{};
+        const bool drivePathChanged =
+            driveCache.path != currentPath;
 
-        if (
-            GetDiskFreeSpaceExW(
-                currentPath.c_str(),
-                &freeAvailable,
-                &totalBytes,
-                nullptr
-            )
-        )
+        const bool driveRefreshDue =
+            !driveCache.lastRefreshTick ||
+            now - driveCache.lastRefreshTick >=
+                kRefreshIntervalMs;
+
+        if (drivePathChanged || driveRefreshDue)
         {
-            freeBytes = freeAvailable.QuadPart;
-            driveTotalBytes = totalBytes.QuadPart;
+            ULARGE_INTEGER freeAvailable{};
+            ULARGE_INTEGER totalBytes{};
+
+            driveCache.path = currentPath;
+            driveCache.freeBytes = 0;
+            driveCache.totalBytes = 0;
+            driveCache.driveLetter =
+                static_cast<wchar_t>(
+                    towupper(currentPath[0])
+                );
+            driveCache.lastRefreshTick = now;
+
+            if (
+                GetDiskFreeSpaceExW(
+                    currentPath.c_str(),
+                    &freeAvailable,
+                    &totalBytes,
+                    nullptr
+                )
+            )
+            {
+                driveCache.freeBytes = freeAvailable.QuadPart;
+                driveCache.totalBytes = totalBytes.QuadPart;
+            }
         }
 
-        driveLetter =
-            static_cast<wchar_t>(
-                towupper(currentPath[0])
-            );
+        freeBytes = driveCache.freeBytes;
+        driveTotalBytes = driveCache.totalBytes;
+        driveLetter = driveCache.driveLetter;
+    }
+    else if (settings.showDrive)
+    {
+        driveCache = DriveRefreshCache{};
     }
 
     int total = -1;
@@ -3331,8 +3408,6 @@ static unsigned ReadCurrentView(
 
         itemCountAvailable = SUCCEEDED(hr);
     }
-
-    const ULONGLONG now = GetTickCount64();
 
     if (
         settings.showContent &&
@@ -3367,6 +3442,14 @@ static unsigned ReadCurrentView(
             sameFolder &&
             total != contentCache.itemCount;
 
+        const bool periodicFullScanDue =
+            sameFolder &&
+            (
+                !contentCache.lastFullScanTick ||
+                now - contentCache.lastFullScanTick >=
+                    kRefreshIntervalMs
+            );
+
         const bool sameFailedFolder =
             contentCache.scanFailed &&
             !folderIdentity.empty() &&
@@ -3384,7 +3467,8 @@ static unsigned ReadCurrentView(
         if (
             (
                 !sameFolder ||
-                itemCountChanged
+                itemCountChanged ||
+                periodicFullScanDue
             ) &&
             (
                 !sameFailedFolder ||
@@ -3528,9 +3612,9 @@ static unsigned ReadCurrentView(
                 contentCache.folderIdentity != state.contentRefresh.folderIdentity;
 
             // A one-item selection needs an identity-sensitive fallback:
-            // arrowing to another item keeps the count at one. Re-enumerate
-            // that single item on the existing worker refresh cadence so a
-            // missed/failed WinEvent cannot leave size or metadata stale.
+            // arrowing to another item keeps the count at one. Resolve that
+            // item's identity on worker passes, but throttle filesystem reads
+            // when the identity and event generation are unchanged.
             const bool singleSelectionFallback =
                 selectionCount == 1 &&
                 (
@@ -3541,11 +3625,13 @@ static unsigned ReadCurrentView(
             const bool selectionDirty =
                 selectionGeneration != state.selectionGeneration ||
                 selected != state.selected ||
-                folderChanged ||
-                singleSelectionFallback;
+                folderChanged;
 
             const bool enumerateSelection =
-                selectionDirty &&
+                (
+                    selectionDirty ||
+                    singleSelectionFallback
+                ) &&
                 selectionCount <= kMaxDetailedSelectionItems &&
                 (
                     settings.showSelection ||
@@ -3562,6 +3648,7 @@ static unsigned ReadCurrentView(
                 selectedBytes = 0;
                 singleFileDetails.clear();
                 keepSingleFileMetadataCache = false;
+                singleSelectionCache = SingleSelectionRefreshCache{};
             }
 
             if (enumerateSelection)
@@ -3597,24 +3684,99 @@ static unsigned ReadCurrentView(
                         continue;
                     }
 
-                    PWSTR path = nullptr;
+                    std::wstring filesystemPath;
+                    PWSTR rawPath = nullptr;
 
                     if (
                         SUCCEEDED(
                             item->GetDisplayName(
                                 SIGDN_FILESYSPATH,
-                                &path
+                                &rawPath
                             )
                         ) &&
-                        path
+                        rawPath
+                    )
+                    {
+                        filesystemPath = rawPath;
+                        CoTaskMemFree(rawPath);
+                    }
+
+                    std::wstring itemIdentity =
+                        filesystemPath;
+
+                    if (
+                        selectionCount == 1 &&
+                        itemIdentity.empty()
+                    )
+                    {
+                        PWSTR parsingName = nullptr;
+
+                        if (
+                            SUCCEEDED(
+                                item->GetDisplayName(
+                                    SIGDN_DESKTOPABSOLUTEPARSING,
+                                    &parsingName
+                                )
+                            ) &&
+                            parsingName
+                        )
+                        {
+                            itemIdentity = parsingName;
+                            CoTaskMemFree(parsingName);
+                        }
+                    }
+
+                    bool refreshFilesystem =
+                        selectionDirty;
+
+                    if (selectionCount == 1)
+                    {
+                        const bool identityChanged =
+                            itemIdentity != singleSelectionCache.identity;
+
+                        const bool filesystemFallbackDue =
+                            !singleSelectionCache.lastFilesystemRefreshTick ||
+                            now - singleSelectionCache.lastFilesystemRefreshTick >=
+                                kRefreshIntervalMs;
+
+                        refreshFilesystem =
+                            selectionDirty ||
+                            identityChanged ||
+                            filesystemFallbackDue;
+
+                        if (
+                            !selectionDirty &&
+                            refreshFilesystem
+                        )
+                        {
+                            selectedFiles = 0;
+                            selectedFolders = 0;
+                            selectedBytes = 0;
+                            singleFileDetails.clear();
+                            keepSingleFileMetadataCache = false;
+                        }
+
+                        singleSelectionCache.identity =
+                            itemIdentity;
+                    }
+
+                    if (
+                        refreshFilesystem &&
+                        !filesystemPath.empty()
                     )
                     {
                         bool directory = false;
                         ULONGLONG size = 0;
 
+                        if (selectionCount == 1)
+                        {
+                            singleSelectionCache.lastFilesystemRefreshTick =
+                                now;
+                        }
+
                         if (
                             GetFilesystemInfo(
-                                path,
+                                filesystemPath.c_str(),
                                 &directory,
                                 &size
                             )
@@ -3638,13 +3800,11 @@ static unsigned ReadCurrentView(
                                     singleFileDetails =
                                         GetSingleFileDetailsCached(
                                             &metadataCache,
-                                            path
+                                            filesystemPath
                                         );
                                 }
                             }
                         }
-
-                        CoTaskMemFree(path);
                     }
 
                     item->Release();
@@ -3707,7 +3867,9 @@ static unsigned ReadCurrentView(
             singleFileDetails,
             selectionGeneration,
             contentCache,
-            metadataCache
+            metadataCache,
+            driveCache,
+            singleSelectionCache
         );
 
     folderView->Release();
@@ -4103,14 +4265,6 @@ static COLORREF PickBackgroundColor(
         nativePaintRect->top <= row.top &&
         nativePaintRect->bottom >= row.bottom;
 
-    if (
-        theme.hasSampledNativeRowBackground &&
-        !fullRowRepaint
-    )
-    {
-        return theme.rowBackground;
-    }
-
     if (theme.rowBackground == CLR_INVALID)
     {
         theme.rowBackground =
@@ -4121,6 +4275,18 @@ static COLORREF PickBackgroundColor(
             theme.rowBackground,
             false
         );
+    }
+
+    if (!fullRowRepaint)
+        return theme.rowBackground;
+
+    if (
+        theme.hasSampledNativeRowBackground &&
+        GetTickCount64() - theme.lastNativeRowBackgroundSampleTick <
+            kNativeRowBackgroundSampleIntervalMs
+    )
+    {
+        return theme.rowBackground;
     }
 
     const int rowWidth = row.right - row.left;
@@ -5089,6 +5255,8 @@ static LRESULT CALLBACK DirectUiSubclassProc(
     {
         if (!g_unloading.load(std::memory_order_acquire))
         {
+            EnsureWindowDataCache(hwnd);
+            EnsureShellBrowserRegistration(hwnd);
             RefreshValidatedStatusRow(hwnd);
             InvalidateInfoBarWindow(hwnd);
         }
@@ -5164,7 +5332,14 @@ static LRESULT CALLBACK DirectUiSubclassProc(
             RefreshTrackedDpiAndFont(hwnd);
         }
 
-        RefreshValidatedStatusRow(hwnd);
+        if (
+            msg != WM_WINDOWPOSCHANGED ||
+            IsStatusRowRevalidationDue(hwnd)
+        )
+        {
+            RefreshValidatedStatusRow(hwnd);
+        }
+
         InvalidateInfoBarWindow(hwnd);
         return result;
     }
@@ -5190,9 +5365,6 @@ static LRESULT CALLBACK DirectUiSubclassProc(
 
     if (msg == WM_PAINT)
     {
-        EnsureWindowDataCache(hwnd);
-        EnsureShellBrowserRegistration(hwnd);
-
         RECT updateRect{};
 
         const BOOL hasUpdateRect =
@@ -5217,7 +5389,7 @@ static LRESULT CALLBACK DirectUiSubclassProc(
             )
         )
         {
-            WakeWorkerFromPaint();
+            WakeWorkerFromPaint(hwnd);
         }
 
         // Let DirectUI finish ALL of its own buffered painting first.
@@ -5234,9 +5406,6 @@ static LRESULT CALLBACK DirectUiSubclassProc(
 
         if (hdc)
         {
-            g_insideFinalPaint =
-                true;
-
             PaintFinalInfoBar(
                 hdc,
                 hwnd,
@@ -5244,9 +5413,6 @@ static LRESULT CALLBACK DirectUiSubclassProc(
                     ? &updateRect
                     : nullptr
             );
-
-            g_insideFinalPaint =
-                false;
 
             ReleaseDC(
                 hwnd,

--- a/mods/explorer-info-bar.wh.cpp
+++ b/mods/explorer-info-bar.wh.cpp
@@ -1,6 +1,6 @@
 // ==WindhawkMod==
 // @id              explorer-info-bar
-// @name            Explorer Info Bar
+// @name            Explorer Info Bar+
 // @description     Enhances File Explorer's bottom info bar with drive, content, selection, and single-file details, with customizable styles and colors.
 // @version         1.0.0
 // @author          digART
@@ -13,11 +13,17 @@
 
 // ==WindhawkModReadme==
 /*
-# Explorer Info Bar
+# Explorer Info Bar+
 
 A customizable Windhawk mod that enhances the bottom info bar in Windows 11 File Explorer.
 
-Explorer Info Bar adds useful drive, folder, selection, and single-file information while keeping the native Explorer look and adapting to light, dark, and customized themes.
+Explorer Info Bar+ adds drive, folder, selection, literal file-extension, and basic media/image metadata information while keeping the native Explorer look and adapting to light, dark, and customized themes.
+
+Unlike mods that restore the classic status bar or focus only on metadata, Explorer Info Bar+ combines several information groups in one modern, configurable Windows 11 info bar.
+
+## Preview
+
+![Explorer Info Bar+ preview](https://raw.githubusercontent.com/digart11/explorer-info-bar/main/images/explorer-info-bar-preview.png)
 
 ## Features
 
@@ -49,18 +55,22 @@ Explorer Info Bar adds useful drive, folder, selection, and single-file informat
 
 Typical information shown by the mod:
 
+```text
 Drive D: 150.7GB free
 Content: 15 folders / 25 files (77.2MB)
 Selected: 2 folders / 4 files (571KB)
+```
 
 When one file is selected, additional details can appear:
 
-.jpg (4032&times;3024)
-.jpeg (6000&times;4000)
-.mp4 (1920&times;1080, 01:23:43)
+```text
+.jpg (4032×3024)
+.jpeg (6000×4000)
+.mp4 (1920×1080, 01:23:43)
 .mp3 (00:03:47)
 .doc
 .pdf
+```
 */
 // ==/WindhawkModReadme==
 
@@ -154,7 +164,7 @@ static constexpr UINT kNativeStatusTextFormat = 0x00000824;
 static constexpr int kStatusRowHeight = 24;
 static constexpr ULONGLONG kStatusMarkerLifetimeMs = 250;
 static constexpr DWORD kInitialRefreshDelayMs = 1000;
-static constexpr DWORD kRefreshIntervalMs = 500;
+static constexpr DWORD kRefreshIntervalMs = 10000;
 static constexpr ULONGLONG kContentFailedRetryMs = 2000;
 static constexpr ULONGLONG kMetadataRetryMs = 5000;
 
@@ -242,6 +252,8 @@ struct TrackedDirectUiState
     COLORREF stableNativeTextColor = CLR_INVALID;
     HWND shellTab = nullptr;
     DWORD shellBrowserCookie = 0;
+    bool hasValidatedStatusRow = false;
+    RECT validatedStatusRow{};
 };
 
 static std::vector<TrackedDirectUiState> g_trackedWindows;
@@ -299,6 +311,9 @@ static HANDLE g_workerThread = nullptr;
 static DWORD g_workerThreadId = 0;
 static HANDLE g_stopEvent = nullptr;
 static HANDLE g_workerWakeEvent = nullptr;
+static HWINEVENTHOOK g_selectionWinEventHook = nullptr;
+static std::atomic<ULONGLONG> g_selectionGeneration{1};
+static std::atomic<ULONGLONG> g_lastPaintWakeTick{0};
 
 static CRITICAL_SECTION g_cacheLock;
 
@@ -327,6 +342,10 @@ struct WindowDataCache
 {
     HWND hwnd = nullptr;
     int selected = -1;
+    int selectedFiles = 0;
+    int selectedFolders = 0;
+    ULONGLONG selectedBytes = 0;
+    ULONGLONG selectionGeneration = 0;
     std::wstring contentGroup = L"Loading...";
     std::wstring selectionGroup;
     std::wstring driveGroup;
@@ -1844,6 +1863,117 @@ static WindowDataCache* FindWindowDataCacheLocked(
         : nullptr;
 }
 
+
+static bool GetValidatedStatusRow(
+    HWND hwnd,
+    RECT* row
+)
+{
+    if (!row)
+        return false;
+
+    bool found = false;
+
+    AcquireSRWLockShared(&g_subclassLock);
+
+    const auto existing =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    if (
+        existing != g_trackedWindows.end() &&
+        existing->hasValidatedStatusRow
+    )
+    {
+        *row = existing->validatedStatusRow;
+        found = true;
+    }
+
+    ReleaseSRWLockShared(&g_subclassLock);
+    return found;
+}
+
+static void SetValidatedStatusRow(
+    HWND hwnd,
+    const RECT& row
+)
+{
+    AcquireSRWLockExclusive(&g_subclassLock);
+
+    const auto existing =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    if (existing != g_trackedWindows.end())
+    {
+        existing->validatedStatusRow = row;
+        existing->hasValidatedStatusRow = true;
+    }
+
+    ReleaseSRWLockExclusive(&g_subclassLock);
+}
+
+static void WakeWorkerFromPaint()
+{
+    if (!g_workerWakeEvent)
+        return;
+
+    const ULONGLONG now = GetTickCount64();
+    ULONGLONG previous =
+        g_lastPaintWakeTick.load(std::memory_order_relaxed);
+
+    if (
+        now - previous < 250 ||
+        !g_lastPaintWakeTick.compare_exchange_strong(
+            previous,
+            now,
+            std::memory_order_relaxed
+        )
+    )
+    {
+        return;
+    }
+
+    SetEvent(g_workerWakeEvent);
+}
+
+static void CALLBACK SelectionWinEventProc(
+    HWINEVENTHOOK,
+    DWORD event,
+    HWND,
+    LONG,
+    LONG,
+    DWORD,
+    DWORD
+)
+{
+    if (
+        event < EVENT_OBJECT_SELECTION ||
+        event > EVENT_OBJECT_SELECTIONWITHIN ||
+        g_unloading.load(std::memory_order_acquire)
+    )
+    {
+        return;
+    }
+
+    g_selectionGeneration.fetch_add(1, std::memory_order_relaxed);
+
+    if (g_workerWakeEvent)
+        SetEvent(g_workerWakeEvent);
+}
+
 static bool EnsureWindowDataCache(
     HWND hwnd
 )
@@ -1956,6 +2086,7 @@ static unsigned UpdateCache(
     const std::wstring& contentOverrideText,
     const std::wstring& selectionOverrideText,
     const std::wstring& fileDetailsText,
+    ULONGLONG selectionGeneration,
     const ContentRefreshCache& contentRefreshCache,
     const SingleFileMetadataCache& metadataCache
 )
@@ -2105,6 +2236,10 @@ static unsigned UpdateCache(
         cache->fileDetailsGroup = fileDetailsText;
     }
 
+    cache->selectedFiles = selectedFiles;
+    cache->selectedFolders = selectedFolders;
+    cache->selectedBytes = selectedBytes;
+    cache->selectionGeneration = selectionGeneration;
     cache->contentRefresh = contentRefreshCache;
     cache->metadata = metadataCache;
 
@@ -2535,12 +2670,14 @@ static unsigned ReadCurrentView(
             : 0;
 
     int selected = 0;
-    int selectedFiles = 0;
-    int selectedFolders = 0;
-    ULONGLONG selectedBytes = 0;
+    int selectedFiles = state.selectedFiles;
+    int selectedFolders = state.selectedFolders;
+    ULONGLONG selectedBytes = state.selectedBytes;
     std::wstring selectionOverrideText;
-    std::wstring singleFileDetails;
-    bool keepSingleFileMetadataCache = false;
+    std::wstring singleFileDetails = state.fileDetailsGroup;
+    bool keepSingleFileMetadataCache = !state.fileDetailsGroup.empty();
+    const ULONGLONG selectionGeneration =
+        g_selectionGeneration.load(std::memory_order_relaxed);
 
     // Always obtain the selection count. Even when the Selected and
     // File Details sections are hidden, the painter uses the count to avoid
@@ -2573,7 +2710,16 @@ static unsigned ReadCurrentView(
             // individual selected items up to a conservative cap.
             constexpr DWORD kMaxDetailedSelectionItems = 256;
 
+            const bool folderChanged =
+                contentCache.folderIdentity != state.contentRefresh.folderIdentity;
+
+            const bool selectionDirty =
+                selectionGeneration != state.selectionGeneration ||
+                selected != state.selected ||
+                folderChanged;
+
             const bool enumerateSelection =
+                selectionDirty &&
                 selectionCount <= kMaxDetailedSelectionItems &&
                 (
                     settings.showSelection ||
@@ -2582,6 +2728,15 @@ static unsigned ReadCurrentView(
                         selectionCount == 1
                     )
                 );
+
+            if (selectionDirty)
+            {
+                selectedFiles = 0;
+                selectedFolders = 0;
+                selectedBytes = 0;
+                singleFileDetails.clear();
+                keepSingleFileMetadataCache = false;
+            }
 
             if (enumerateSelection)
             {
@@ -2725,6 +2880,7 @@ static unsigned ReadCurrentView(
             contentOverrideText,
             selectionOverrideText,
             singleFileDetails,
+            selectionGeneration,
             contentCache,
             metadataCache
         );
@@ -3347,11 +3503,21 @@ static void PaintFinalInfoBar(
         return;
     }
 
-    RECT row =
-        g_statusRowRect;
+    RECT row{};
 
-    // Fall back to Explorer's bottom status-row height if the native rect is unavailable.
+    // Only use a status-row rect after BitBlt_Hook validated it for this
+    // specific DirectUIHWND. Never paint from an unvalidated thread-local
+    // DrawText candidate.
+    const bool hasValidatedRow =
+        GetValidatedStatusRow(
+            hwnd,
+            &row
+        );
+
+    // Fall back to Explorer's bottom status-row geometry when no validated
+    // native rect is available.
     if (
+        !hasValidatedRow ||
         row.bottom <= row.top ||
         row.top < 0 ||
         row.bottom >
@@ -4110,6 +4276,7 @@ static LRESULT CALLBACK DirectUiSubclassProc(
     {
         EnsureWindowDataCache(hwnd);
         EnsureShellBrowserRegistration(hwnd);
+        WakeWorkerFromPaint();
 
         RECT updateRect{};
 
@@ -4279,7 +4446,7 @@ static BOOL WINAPI BitBlt_Hook(
         return result;
     }
 
-    g_statusRowRect = mappedRow;
+    SetValidatedStatusRow(hwnd, mappedRow);
 
     if (
         g_unloading.load(
@@ -4609,6 +4776,25 @@ BOOL Wh_ModInit()
         return FALSE;
     }
 
+    g_selectionWinEventHook =
+        SetWinEventHook(
+            EVENT_OBJECT_SELECTION,
+            EVENT_OBJECT_SELECTIONWITHIN,
+            nullptr,
+            SelectionWinEventProc,
+            g_pid,
+            0,
+            WINEVENT_OUTOFCONTEXT
+        );
+
+    if (!g_selectionWinEventHook)
+    {
+        Wh_Log(
+            L"selection WinEvent hook failed error=%lu",
+            GetLastError()
+        );
+    }
+
     g_workerThread =
         CreateThread(
             nullptr,
@@ -4621,6 +4807,12 @@ BOOL Wh_ModInit()
 
     if (!g_workerThread)
     {
+        if (g_selectionWinEventHook)
+        {
+            UnhookWinEvent(g_selectionWinEventHook);
+            g_selectionWinEventHook = nullptr;
+        }
+
         Wh_Log(
             L"worker creation failed error=%lu",
             GetLastError()
@@ -4672,6 +4864,10 @@ void Wh_ModSettingsChanged()
 {
     LoadSettings();
 
+    // Force one detailed selection refresh because visibility/detail settings
+    // may have changed even if the Explorer selection itself did not.
+    g_selectionGeneration.fetch_add(1, std::memory_order_relaxed);
+
     if (g_workerWakeEvent)
         SetEvent(g_workerWakeEvent);
 
@@ -4688,8 +4884,17 @@ void Wh_ModBeforeUninit()
     if (g_stopEvent)
         SetEvent(g_stopEvent);
 
+    if (g_selectionWinEventHook)
+    {
+        UnhookWinEvent(g_selectionWinEventHook);
+        g_selectionWinEventHook = nullptr;
+    }
+
     if (g_workerThreadId)
         CoCancelCall(g_workerThreadId, 0);
+
+    if (g_workerThread)
+        CancelSynchronousIo(g_workerThread);
 
     // Snapshot under the lock, then remove subclasses outside it. The
     // Windhawk helper handles cross-thread subclass removal without the
@@ -4698,16 +4903,9 @@ void Wh_ModBeforeUninit()
     std::vector<HWND> windows;
 
     AcquireSRWLockShared(&g_subclassLock);
-    try
-    {
-        windows.reserve(g_trackedWindows.size());
-        for (const TrackedDirectUiState& state : g_trackedWindows)
-            windows.push_back(state.hwnd);
-    }
-    catch (...)
-    {
-        windows.clear();
-    }
+    windows.reserve(g_trackedWindows.size());
+    for (const TrackedDirectUiState& state : g_trackedWindows)
+        windows.push_back(state.hwnd);
     ReleaseSRWLockShared(&g_subclassLock);
 
     for (HWND hwnd : windows)
@@ -4718,6 +4916,33 @@ void Wh_ModBeforeUninit()
                 hwnd,
                 DirectUiSubclassProc
             );
+
+            // The overlay is drawn after Explorer's native buffered paint, so
+            // removing the subclass alone leaves those pixels on screen until
+            // the next native repaint. Force the status row to repaint now
+            // while the GDI hooks are still installed but g_unloading prevents
+            // any new overlay from being drawn.
+            RECT client{};
+            if (GetClientRect(hwnd, &client))
+            {
+                RECT row{};
+                row.left = 0;
+                row.right = client.right;
+                row.bottom = client.bottom;
+                row.top = std::max(
+                    0L,
+                    client.bottom - static_cast<LONG>(ScaleForWindow(hwnd, kStatusRowHeight))
+                );
+
+                RedrawWindow(
+                    hwnd,
+                    &row,
+                    nullptr,
+                    RDW_INVALIDATE |
+                    RDW_ERASE |
+                    RDW_UPDATENOW
+                );
+            }
         }
 
         DWORD shellBrowserCookie = 0;
@@ -4741,25 +4966,17 @@ void Wh_ModUninit()
         );
     }
 
-    if (g_workerThreadId)
-        CoCancelCall(g_workerThreadId, 0);
-
     if (g_workerThread)
     {
-        // The cache and COM state must outlive the worker. Wait until the
-        // worker has fully stopped before releasing shared resources.
-        const DWORD workerWait =
-            WaitForSingleObject(
-                g_workerThread,
-                5000
-            );
+        // CancelSynchronousIo in Wh_ModBeforeUninit interrupts a worker that
+        // is blocked in FindFirstFileExW/FindNextFileW. Never terminate a
+        // thread inside Explorer while it may own COM, CRT or cache locks.
+        CancelSynchronousIo(g_workerThread);
 
-        if (workerWait == WAIT_TIMEOUT)
-        {
-            Wh_Log(L"Worker did not stop within 5 seconds; terminating it to avoid blocking mod unload");
-            TerminateThread(g_workerThread, 0);
-            WaitForSingleObject(g_workerThread, 1000);
-        }
+        WaitForSingleObject(
+            g_workerThread,
+            INFINITE
+        );
 
         CloseHandle(
             g_workerThread

--- a/mods/explorer-info-bar.wh.cpp
+++ b/mods/explorer-info-bar.wh.cpp
@@ -1,0 +1,4953 @@
+// ==WindhawkMod==
+// @id              explorer-info-bar
+// @name            Explorer Info Bar
+// @description     Adds drive, folder, selection, and file details to File Explorer's bottom info bar.
+// @version         1.0.0
+// @author          digART
+// @github          https://github.com/digart11
+// @homepage        https://github.com/digart11/explorer-info-bar
+// @license         GPL-3.0-only
+// @include         explorer.exe
+// @compilerOptions -lole32 -lshell32 -luuid -lgdi32 -lcomctl32 -lpropsys
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Explorer Info Bar
+
+A customizable Windhawk mod that enhances the bottom info bar in Windows 11 File Explorer.
+
+Explorer Info Bar adds useful drive, folder, selection, and single-file information while keeping the native Explorer look and adapting to light, dark, and customized themes.
+
+![Explorer Info Bar preview](https://raw.githubusercontent.com/digart11/explorer-info-bar/main/images/explorer-info-bar-preview.png)
+
+## Features
+
+- Drive free-space information
+- Current folder content summary
+  - Folder count
+  - File count
+  - Immediate file size total
+- Selection information
+  - Selected folders
+  - Selected files
+  - Selected file size
+- Single-file details when available
+  - Real file extension
+  - Image resolution
+  - Video resolution
+  - Media duration
+- Three display styles
+  - Simple
+  - Flat panes
+  - Soft cards
+- Configurable section order
+- Individual section visibility controls
+- Custom text and panel colors
+- Automatic theme-derived colors by default
+- Works with File Explorer's native status area rather than replacing Explorer itself
+
+## Examples
+
+Typical information shown by the mod:
+
+```text
+Drive D: 150.7GB free
+Content: 15 folders / 25 files (77.2MB)
+Selected: 2 folders / 4 files (571KB)
+```
+
+When one file is selected, additional details can appear:
+
+```text
+.jpg (4032×3024)
+.jpeg (6000×4000)
+.mp4 (1920×1080, 01:23:43)
+.mp3 (00:03:47)
+.doc
+.pdf
+```
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- style: simple
+  $name: Style
+  $description: Choose how the info bar sections are displayed.
+  $options:
+    - simple: Simple
+    - panes: Flat panes
+    - cards: Soft cards
+
+- order: drive-content-selection
+  $name: Section order
+  $description: Choose the left-to-right order of Drive, Content and Selected.
+  $options:
+    - drive-content-selection: Drive / Content / Selected
+    - drive-selection-content: Drive / Selected / Content
+    - content-drive-selection: Content / Drive / Selected
+    - content-selection-drive: Content / Selected / Drive
+    - selection-drive-content: Selected / Drive / Content
+    - selection-content-drive: Selected / Content / Drive
+
+- showDrive: true
+  $name: Show Drive
+  $description: Show drive free-space information.
+
+- showContent: true
+  $name: Show Content
+  $description: Show folder and file totals for the current location.
+
+- showSelection: true
+  $name: Show Selected
+  $description: Show information about the current selection.
+
+- singleFileDetails: true
+  $name: Show Single File Details
+  $description: Show file extension and details when possible.
+
+- textColor: auto
+  $name: Text color
+  $description: "Use auto to inherit Explorer, or enter #RRGGBB."
+
+- driveColor: auto
+  $name: Drive panel color
+  $description: "Flat panes/cards only. Use auto to derive from Explorer, or enter #RRGGBB."
+
+- contentColor: auto
+  $name: Content panel color
+  $description: "Flat panes/cards only. Use auto to derive from Explorer, or enter #RRGGBB."
+
+- selectionColor: auto
+  $name: Selected panel color
+  $description: "Flat panes/cards only. Use auto to derive from Explorer, or enter #RRGGBB."
+
+- fileDetailsColor: auto
+  $name: File Details panel color
+  $description: "Flat panes/cards only. Use auto to derive from Explorer, or enter #RRGGBB."
+
+- dividerColor: auto
+  $name: Divider / border color (Soft Cards style only)
+  $description: "Sets the Soft Cards border color. Use auto to derive from Explorer, or enter #RRGGBB."
+*/
+// ==/WindhawkModSettings==
+
+
+#include <windows.h>
+#include <shlobj.h>
+#include <shobjidl.h>
+#include <commctrl.h>
+#include <propkey.h>
+#include <propvarutil.h>
+#include <objidl.h>
+#include <objbase.h>
+
+#include <string>
+#include <array>
+#include <atomic>
+#include <algorithm>
+#include <cwctype>
+#include <cwchar>
+#include <cstdlib>
+#include <vector>
+#include <utility>
+
+#define CWM_GETISHELLBROWSER (WM_USER + 7)
+
+static constexpr UINT kNativeStatusTextFormat = 0x00000824;
+static constexpr int kStatusRowHeight = 24;
+static constexpr ULONGLONG kStatusMarkerLifetimeMs = 250;
+static constexpr DWORD kInitialRefreshDelayMs = 1000;
+static constexpr DWORD kRefreshIntervalMs = 500;
+static constexpr ULONGLONG kContentSafetyRescanMs = 30000;
+static constexpr ULONGLONG kContentFailedRetryMs = 2000;
+static constexpr ULONGLONG kMetadataRetryMs = 5000;
+static constexpr UINT kSubclassRemovalTimeoutMs = 500;
+
+// ============================================================
+// DrawText hook
+// ============================================================
+
+using DrawTextW_t = int (WINAPI*)(
+    HDC,
+    LPCWSTR,
+    int,
+    LPRECT,
+    UINT
+);
+
+static DrawTextW_t DrawTextW_Original = nullptr;
+
+using BitBlt_t = BOOL (WINAPI*)(
+    HDC,
+    int,
+    int,
+    int,
+    int,
+    HDC,
+    int,
+    int,
+    DWORD
+);
+
+static BitBlt_t BitBlt_Original = nullptr;
+
+// Correlate Explorer's buffered status render with the final DirectUIHWND copy.
+thread_local HDC g_statusSourceDc = nullptr;
+thread_local ULONGLONG g_statusMarkTick = 0;
+thread_local RECT g_statusRowRect{};
+thread_local bool g_insideFinalPaint = false;
+
+static std::atomic<bool> g_unloading{false};
+
+static SRWLOCK g_subclassLock = SRWLOCK_INIT;
+
+enum class InfoBarStyle
+{
+    Simple,
+    Panes,
+    Cards
+};
+
+enum class InfoBarSection
+{
+    Drive,
+    Content,
+    Selection
+};
+
+enum CacheChangeFlags : unsigned
+{
+    CacheChangeNone = 0,
+    CacheChangeDrive = 1 << 0,
+    CacheChangeContent = 1 << 1,
+    CacheChangeSelection = 1 << 2,
+    CacheChangeFileDetails = 1 << 3
+};
+
+struct InfoBarLayoutGeometry
+{
+    HWND hwnd = nullptr;
+    std::array<int, 3> sectionLeft{-1, -1, -1};
+    int fileDetailsLeft = -1;
+    int usableRight = -1;
+    InfoBarStyle style = InfoBarStyle::Simple;
+    std::array<InfoBarSection, 3> sectionOrder{};
+    bool showDrive = false;
+    bool showContent = false;
+    bool showSelection = false;
+    bool singleFileDetails = false;
+};
+
+struct TrackedDirectUiState
+{
+    HWND hwnd = nullptr;
+    bool hasLayout = false;
+    InfoBarLayoutGeometry layout;
+    COLORREF stableRowBackground = CLR_INVALID;
+    COLORREF stableNativeTextColor = CLR_INVALID;
+    HWND shellTab = nullptr;
+    DWORD shellBrowserCookie = 0;
+};
+
+static std::vector<TrackedDirectUiState> g_trackedWindows;
+
+struct ColorOverride
+{
+    bool enabled = false;
+    COLORREF value = CLR_INVALID;
+};
+
+struct ModSettings
+{
+    InfoBarStyle style = InfoBarStyle::Simple;
+
+    std::array<InfoBarSection, 3> sectionOrder
+    {
+        InfoBarSection::Drive,
+        InfoBarSection::Content,
+        InfoBarSection::Selection
+    };
+
+    ColorOverride textColor;
+    ColorOverride driveColor;
+    ColorOverride contentColor;
+    ColorOverride selectionColor;
+    ColorOverride fileDetailsColor;
+    ColorOverride dividerColor;
+
+    bool showDrive = true;
+    bool showContent = true;
+    bool showSelection = true;
+    bool singleFileDetails = true;
+};
+
+static SRWLOCK g_settingsLock = SRWLOCK_INIT;
+static ModSettings g_settings;
+
+static constexpr UINT_PTR kDirectUiSubclassId = 0xE1B029;
+static UINT g_removeDirectUiSubclassMessage = 0;
+static UINT g_refreshDirectUiMessage = 0;
+
+static LRESULT CALLBACK DirectUiSubclassProc(
+    HWND hwnd,
+    UINT msg,
+    WPARAM wParam,
+    LPARAM lParam,
+    UINT_PTR,
+    DWORD_PTR
+);
+
+// ============================================================
+// State
+// ============================================================
+
+static DWORD g_pid = 0;
+
+static HANDLE g_workerThread = nullptr;
+static DWORD g_workerThreadId = 0;
+static HANDLE g_stopEvent = nullptr;
+static HANDLE g_workerWakeEvent = nullptr;
+
+static CRITICAL_SECTION g_cacheLock;
+
+struct ContentRefreshCache
+{
+    bool valid = false;
+    std::wstring folderIdentity;
+    int itemCount = -1;
+    int files = 0;
+    int folders = 0;
+    ULONGLONG directFileBytes = 0;
+    ULONGLONG lastFullScanTick = 0;
+    std::wstring lastAttemptFolderIdentity;
+    ULONGLONG lastScanAttemptTick = 0;
+};
+
+struct SingleFileMetadataCache
+{
+    bool valid = false;
+    std::wstring path;
+    std::wstring details;
+    ULONGLONG retryAfterTick = 0;
+};
+
+struct WindowDataCache
+{
+    HWND hwnd = nullptr;
+    int selected = -1;
+    std::wstring contentGroup = L"Loading...";
+    std::wstring selectionGroup;
+    std::wstring driveGroup;
+    std::wstring fileDetailsGroup;
+    ContentRefreshCache contentRefresh;
+    SingleFileMetadataCache metadata;
+};
+
+static std::vector<WindowDataCache> g_windowDataCaches;
+
+
+static std::wstring GetStringSetting(
+    PCWSTR name
+)
+{
+    PCWSTR raw =
+        Wh_GetStringSetting(
+            name
+        );
+
+    std::wstring value =
+        raw ? raw : L"";
+
+    if (raw)
+        Wh_FreeStringSetting(raw);
+
+    return value;
+}
+
+static ColorOverride ParseColorOverride(
+    const std::wstring& value
+)
+{
+    ColorOverride result;
+
+    if (
+        value.empty() ||
+        _wcsicmp(
+            value.c_str(),
+            L"auto"
+        ) == 0
+    )
+    {
+        return result;
+    }
+
+    if (
+        value.length() != 7 ||
+        value[0] != L'#'
+    )
+    {
+        return result;
+    }
+
+    for (size_t i = 1; i < value.length(); i++)
+    {
+        const wchar_t ch = value[i];
+
+        if (!(
+                (ch >= L'0' && ch <= L'9') ||
+                (ch >= L'a' && ch <= L'f') ||
+                (ch >= L'A' && ch <= L'F')
+            ))
+        {
+            return result;
+        }
+    }
+
+    wchar_t* end = nullptr;
+
+    unsigned long rgb =
+        wcstoul(
+            value.c_str() + 1,
+            &end,
+            16
+        );
+
+    if (
+        !end ||
+        *end != L'\0' ||
+        rgb > 0xFFFFFF
+    )
+    {
+        return result;
+    }
+
+    result.enabled = true;
+    result.value =
+        RGB(
+            (rgb >> 16) & 0xFF,
+            (rgb >> 8) & 0xFF,
+            rgb & 0xFF
+        );
+
+    return result;
+}
+
+static std::array<InfoBarSection, 3> ParseSectionOrder(
+    const std::wstring& order
+)
+{
+    if (order == L"drive-selection-content")
+    {
+        return
+        {
+            InfoBarSection::Drive,
+            InfoBarSection::Selection,
+            InfoBarSection::Content
+        };
+    }
+
+    if (order == L"content-drive-selection")
+    {
+        return
+        {
+            InfoBarSection::Content,
+            InfoBarSection::Drive,
+            InfoBarSection::Selection
+        };
+    }
+
+    if (order == L"content-selection-drive")
+    {
+        return
+        {
+            InfoBarSection::Content,
+            InfoBarSection::Selection,
+            InfoBarSection::Drive
+        };
+    }
+
+    if (order == L"selection-drive-content")
+    {
+        return
+        {
+            InfoBarSection::Selection,
+            InfoBarSection::Drive,
+            InfoBarSection::Content
+        };
+    }
+
+    if (order == L"selection-content-drive")
+    {
+        return
+        {
+            InfoBarSection::Selection,
+            InfoBarSection::Content,
+            InfoBarSection::Drive
+        };
+    }
+
+    return
+    {
+        InfoBarSection::Drive,
+        InfoBarSection::Content,
+        InfoBarSection::Selection
+    };
+}
+
+static void LoadSettings()
+{
+    ModSettings settings;
+
+    const std::wstring style =
+        GetStringSetting(
+            L"style"
+        );
+
+    if (style == L"panes")
+        settings.style = InfoBarStyle::Panes;
+    else if (style == L"cards")
+        settings.style = InfoBarStyle::Cards;
+
+    settings.sectionOrder =
+        ParseSectionOrder(
+            GetStringSetting(
+                L"order"
+            )
+        );
+
+    settings.textColor =
+        ParseColorOverride(
+            GetStringSetting(
+                L"textColor"
+            )
+        );
+
+    settings.driveColor =
+        ParseColorOverride(
+            GetStringSetting(
+                L"driveColor"
+            )
+        );
+
+    settings.contentColor =
+        ParseColorOverride(
+            GetStringSetting(
+                L"contentColor"
+            )
+        );
+
+    settings.selectionColor =
+        ParseColorOverride(
+            GetStringSetting(
+                L"selectionColor"
+            )
+        );
+
+    settings.fileDetailsColor =
+        ParseColorOverride(
+            GetStringSetting(
+                L"fileDetailsColor"
+            )
+        );
+
+    settings.dividerColor =
+        ParseColorOverride(
+            GetStringSetting(
+                L"dividerColor"
+            )
+        );
+
+    settings.showDrive =
+        Wh_GetIntSetting(
+            L"showDrive"
+        ) != 0;
+
+    settings.showContent =
+        Wh_GetIntSetting(
+            L"showContent"
+        ) != 0;
+
+    settings.showSelection =
+        Wh_GetIntSetting(
+            L"showSelection"
+        ) != 0;
+
+    settings.singleFileDetails =
+        Wh_GetIntSetting(
+            L"singleFileDetails"
+        ) != 0;
+
+    AcquireSRWLockExclusive(
+        &g_settingsLock
+    );
+
+    g_settings =
+        settings;
+
+    ReleaseSRWLockExclusive(
+        &g_settingsLock
+    );
+}
+
+static ModSettings GetSettingsSnapshot()
+{
+    AcquireSRWLockShared(
+        &g_settingsLock
+    );
+
+    ModSettings settings =
+        g_settings;
+
+    ReleaseSRWLockShared(
+        &g_settingsLock
+    );
+
+    return settings;
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+static bool ContainsItemToken(
+    LPCWSTR text,
+    int length
+)
+{
+    if (
+        !text ||
+        length < 4
+    )
+    {
+        return false;
+    }
+
+    for (
+        int i = 0;
+        i <= length - 4;
+        i++
+    )
+    {
+        if (
+            towlower(text[i]) == L'i' &&
+            towlower(text[i + 1]) == L't' &&
+            towlower(text[i + 2]) == L'e' &&
+            towlower(text[i + 3]) == L'm'
+        )
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+enum class ByteFormat
+{
+    Adaptive,
+    OneDecimal
+};
+
+static std::wstring FormatBytes(
+    ULONGLONG bytes,
+    ByteFormat format = ByteFormat::Adaptive
+)
+{
+    wchar_t buf[64] = {};
+
+    constexpr double KB = 1024.0;
+    constexpr double MB = KB * 1024.0;
+    constexpr double GB = MB * 1024.0;
+    constexpr double TB = GB * 1024.0;
+
+    if (bytes >= static_cast<ULONGLONG>(TB))
+    {
+        swprintf(
+            buf,
+            ARRAYSIZE(buf),
+            format == ByteFormat::OneDecimal
+                ? L"%.1fTB"
+                : L"%.2fTB",
+            static_cast<double>(bytes) / TB
+        );
+    }
+    else if (bytes >= static_cast<ULONGLONG>(GB))
+    {
+        swprintf(
+            buf,
+            ARRAYSIZE(buf),
+            format == ByteFormat::OneDecimal
+                ? L"%.1fGB"
+                : L"%.2fGB",
+            static_cast<double>(bytes) / GB
+        );
+    }
+    else if (bytes >= static_cast<ULONGLONG>(MB))
+    {
+        const double mb =
+            static_cast<double>(bytes) / MB;
+
+        if (format == ByteFormat::OneDecimal)
+        {
+            swprintf(
+                buf,
+                ARRAYSIZE(buf),
+                L"%.1fMB",
+                mb
+            );
+        }
+        else if (mb >= 100.0)
+        {
+            swprintf(
+                buf,
+                ARRAYSIZE(buf),
+                L"%.0fMB",
+                mb
+            );
+        }
+        else
+        {
+            swprintf(
+                buf,
+                ARRAYSIZE(buf),
+                L"%.2fMB",
+                mb
+            );
+        }
+    }
+    else if (bytes >= static_cast<ULONGLONG>(KB))
+    {
+        swprintf(
+            buf,
+            ARRAYSIZE(buf),
+            L"%.0fKB",
+            static_cast<double>(bytes) / KB
+        );
+    }
+    else
+    {
+        swprintf(
+            buf,
+            ARRAYSIZE(buf),
+            L"%lluB",
+            bytes
+        );
+    }
+
+    return buf;
+}
+
+
+static std::wstring GetLiteralExtension(
+    const std::wstring& path
+)
+{
+    const size_t slash =
+        path.find_last_of(
+            L"\\/"
+        );
+
+    const size_t dot =
+        path.find_last_of(
+            L'.'
+        );
+
+    if (
+        dot == std::wstring::npos ||
+        dot + 1 >= path.length() ||
+        (
+            slash != std::wstring::npos &&
+            dot < slash
+        )
+    )
+    {
+        return L"";
+    }
+
+    // Preserve the actual extension, including the dot and original case.
+    return path.substr(
+        dot
+    );
+}
+
+enum class PropertyReadResult
+{
+    Value,
+    Missing,
+    Failed
+};
+
+static PropertyReadResult ReadUInt32Property(
+    IShellItem2* item,
+    REFPROPERTYKEY key,
+    UINT32* value
+)
+{
+    if (!item || !value)
+        return PropertyReadResult::Failed;
+
+    PROPVARIANT property;
+    PropVariantInit(&property);
+
+    HRESULT hr =
+        item->GetProperty(
+            key,
+            &property
+        );
+
+    if (FAILED(hr))
+    {
+        PropVariantClear(&property);
+        return PropertyReadResult::Failed;
+    }
+
+    if (
+        property.vt == VT_EMPTY ||
+        property.vt == VT_NULL
+    )
+    {
+        PropVariantClear(&property);
+        return PropertyReadResult::Missing;
+    }
+
+    ULONG convertedValue = 0;
+    hr =
+        PropVariantToUInt32(
+            property,
+            &convertedValue
+        );
+
+    PropVariantClear(&property);
+
+    if (FAILED(hr))
+        return PropertyReadResult::Missing;
+
+    *value =
+        static_cast<UINT32>(
+            convertedValue
+        );
+
+    return PropertyReadResult::Value;
+}
+
+static PropertyReadResult ReadUInt64Property(
+    IShellItem2* item,
+    REFPROPERTYKEY key,
+    ULONGLONG* value
+)
+{
+    if (!item || !value)
+        return PropertyReadResult::Failed;
+
+    PROPVARIANT property;
+    PropVariantInit(&property);
+
+    HRESULT hr =
+        item->GetProperty(
+            key,
+            &property
+        );
+
+    if (FAILED(hr))
+    {
+        PropVariantClear(&property);
+        return PropertyReadResult::Failed;
+    }
+
+    if (
+        property.vt == VT_EMPTY ||
+        property.vt == VT_NULL
+    )
+    {
+        PropVariantClear(&property);
+        return PropertyReadResult::Missing;
+    }
+
+    hr =
+        PropVariantToUInt64(
+            property,
+            value
+        );
+
+    PropVariantClear(&property);
+
+    return SUCCEEDED(hr)
+        ? PropertyReadResult::Value
+        : PropertyReadResult::Missing;
+}
+
+static std::wstring FormatMediaDuration(
+    ULONGLONG duration100ns
+)
+{
+    if (duration100ns == 0)
+        return L"";
+
+    const ULONGLONG totalSeconds =
+        duration100ns /
+        10000000ULL;
+
+    const ULONGLONG hours =
+        totalSeconds /
+        3600ULL;
+
+    const ULONGLONG minutes =
+        (
+            totalSeconds %
+            3600ULL
+        ) /
+        60ULL;
+
+    const ULONGLONG seconds =
+        totalSeconds %
+        60ULL;
+
+    wchar_t buffer[64] = {};
+
+    swprintf(
+        buffer,
+        ARRAYSIZE(buffer),
+        L"%02llu:%02llu:%02llu",
+        hours,
+        minutes,
+        seconds
+    );
+
+    return buffer;
+}
+
+static std::wstring BuildSingleFileDetails(
+    IShellItem* item,
+    const std::wstring& path,
+    bool* transientFailure
+)
+{
+    if (transientFailure)
+        *transientFailure = false;
+
+    if (!item || path.empty())
+        return L"";
+
+    const std::wstring extension =
+        GetLiteralExtension(path);
+
+    std::wstring result =
+        extension.empty()
+            ? L"no extension"
+            : extension;
+
+    IShellItem2* item2 = nullptr;
+
+    if (
+        FAILED(
+            item->QueryInterface(
+                IID_PPV_ARGS(&item2)
+            )
+        ) ||
+        !item2
+    )
+    {
+        if (transientFailure)
+            *transientFailure = true;
+
+        return result;
+    }
+
+    UINT32 imageWidth = 0;
+    UINT32 imageHeight = 0;
+    UINT32 videoWidth = 0;
+    UINT32 videoHeight = 0;
+    ULONGLONG duration = 0;
+
+    const PropertyReadResult imageWidthResult =
+        ReadUInt32Property(
+            item2,
+            PKEY_Image_HorizontalSize,
+            &imageWidth
+        );
+
+    const PropertyReadResult imageHeightResult =
+        ReadUInt32Property(
+            item2,
+            PKEY_Image_VerticalSize,
+            &imageHeight
+        );
+
+    const PropertyReadResult videoWidthResult =
+        ReadUInt32Property(
+            item2,
+            PKEY_Video_FrameWidth,
+            &videoWidth
+        );
+
+    const PropertyReadResult videoHeightResult =
+        ReadUInt32Property(
+            item2,
+            PKEY_Video_FrameHeight,
+            &videoHeight
+        );
+
+    const PropertyReadResult durationResult =
+        ReadUInt64Property(
+            item2,
+            PKEY_Media_Duration,
+            &duration
+        );
+
+    item2->Release();
+
+    if (transientFailure)
+    {
+        *transientFailure =
+            imageWidthResult == PropertyReadResult::Failed ||
+            imageHeightResult == PropertyReadResult::Failed ||
+            videoWidthResult == PropertyReadResult::Failed ||
+            videoHeightResult == PropertyReadResult::Failed ||
+            durationResult == PropertyReadResult::Failed;
+    }
+
+    UINT32 width = 0;
+    UINT32 height = 0;
+
+    if (
+        videoWidthResult == PropertyReadResult::Value &&
+        videoHeightResult == PropertyReadResult::Value &&
+        videoWidth > 0 &&
+        videoHeight > 0
+    )
+    {
+        width = videoWidth;
+        height = videoHeight;
+    }
+    else if (
+        imageWidthResult == PropertyReadResult::Value &&
+        imageHeightResult == PropertyReadResult::Value &&
+        imageWidth > 0 &&
+        imageHeight > 0
+    )
+    {
+        width = imageWidth;
+        height = imageHeight;
+    }
+
+    const std::wstring durationText =
+        (
+            durationResult == PropertyReadResult::Value &&
+            duration > 0
+        )
+            ? FormatMediaDuration(duration)
+            : L"";
+
+    const bool hasDimensions =
+        width > 0 &&
+        height > 0;
+
+    if (!hasDimensions && durationText.empty())
+        return result;
+
+    result += L" (";
+
+    if (hasDimensions)
+    {
+        wchar_t dimensions[64] = {};
+
+        swprintf(
+            dimensions,
+            ARRAYSIZE(dimensions),
+            L"%u\x00D7%u",
+            width,
+            height
+        );
+
+        result += dimensions;
+    }
+
+    if (!durationText.empty())
+    {
+        if (hasDimensions)
+            result += L", ";
+
+        result += durationText;
+    }
+
+    result += L")";
+    return result;
+}
+
+static bool GetFilesystemInfo(
+    const wchar_t* path,
+    bool* isDirectory,
+    ULONGLONG* fileSize
+)
+{
+    if (!path || !*path)
+        return false;
+
+    WIN32_FILE_ATTRIBUTE_DATA data{};
+
+    if (!GetFileAttributesExW(
+            path,
+            GetFileExInfoStandard,
+            &data))
+    {
+        return false;
+    }
+
+    bool directory =
+        (data.dwFileAttributes &
+         FILE_ATTRIBUTE_DIRECTORY) != 0;
+
+    if (isDirectory)
+        *isDirectory = directory;
+
+    if (fileSize)
+    {
+        if (directory)
+        {
+            *fileSize = 0;
+        }
+        else
+        {
+            *fileSize =
+                (static_cast<ULONGLONG>(
+                    data.nFileSizeHigh
+                ) << 32) |
+                data.nFileSizeLow;
+        }
+    }
+
+    return true;
+}
+
+// ============================================================
+// Explorer window / COM ownership
+// ============================================================
+
+static HWND FindAncestorByClass(
+    HWND hwnd,
+    PCWSTR className
+)
+{
+    for (HWND current = hwnd; current; current = GetParent(current))
+    {
+        wchar_t cls[128] = {};
+
+        if (
+            GetClassNameW(
+                current,
+                cls,
+                ARRAYSIZE(cls)
+            ) &&
+            wcscmp(cls, className) == 0
+        )
+        {
+            return current;
+        }
+    }
+
+    return nullptr;
+}
+
+static IShellBrowser* TryGetShellBrowserOnOwnerThread(
+    HWND shellTab
+)
+{
+    if (!shellTab)
+        return nullptr;
+
+    const DWORD ownerThread =
+        GetWindowThreadProcessId(
+            shellTab,
+            nullptr
+        );
+
+    if (
+        !ownerThread ||
+        ownerThread != GetCurrentThreadId()
+    )
+    {
+        return nullptr;
+    }
+
+    auto* browser =
+        reinterpret_cast<IShellBrowser*>(
+            SendMessageW(
+                shellTab,
+                CWM_GETISHELLBROWSER,
+                0,
+                0
+            )
+        );
+
+    if (browser)
+        browser->AddRef();
+
+    return browser;
+}
+
+static HRESULT CreateGlobalInterfaceTable(
+    IGlobalInterfaceTable** table
+)
+{
+    if (!table)
+        return E_POINTER;
+
+    *table = nullptr;
+
+    return CoCreateInstance(
+        CLSID_StdGlobalInterfaceTable,
+        nullptr,
+        CLSCTX_INPROC_SERVER,
+        IID_PPV_ARGS(table)
+    );
+}
+
+static void RevokeShellBrowserCookie(
+    DWORD cookie
+)
+{
+    if (!cookie)
+        return;
+
+    // Most revocations run on an Explorer UI apartment, but teardown can also
+    // reach this helper after a window has already disappeared. Ensure COM is
+    // available on that fallback thread without changing an existing apartment.
+    const HRESULT initHr =
+        CoInitializeEx(
+            nullptr,
+            COINIT_MULTITHREADED
+        );
+
+    const bool shouldUninitialize =
+        SUCCEEDED(initHr);
+
+    if (
+        FAILED(initHr) &&
+        initHr != RPC_E_CHANGED_MODE
+    )
+    {
+        Wh_Log(
+            L"Shell browser revoke COM setup failed cookie=%lu HRESULT=0x%08X",
+            cookie,
+            static_cast<unsigned>(initHr)
+        );
+        return;
+    }
+
+    IGlobalInterfaceTable* table = nullptr;
+    const HRESULT createHr =
+        CreateGlobalInterfaceTable(&table);
+
+    if (FAILED(createHr) || !table)
+    {
+        Wh_Log(
+            L"Global Interface Table revoke setup failed cookie=%lu HRESULT=0x%08X",
+            cookie,
+            static_cast<unsigned>(createHr)
+        );
+
+        if (shouldUninitialize)
+            CoUninitialize();
+
+        return;
+    }
+
+    const HRESULT revokeHr =
+        table->RevokeInterfaceFromGlobal(cookie);
+
+    table->Release();
+
+    if (shouldUninitialize)
+        CoUninitialize();
+
+    if (FAILED(revokeHr))
+    {
+        Wh_Log(
+            L"Shell browser revoke failed cookie=%lu HRESULT=0x%08X",
+            cookie,
+            static_cast<unsigned>(revokeHr)
+        );
+    }
+}
+
+static bool EnsureShellBrowserRegistration(
+    HWND hwnd
+)
+{
+    if (
+        !hwnd ||
+        g_unloading.load(std::memory_order_acquire)
+    )
+    {
+        return false;
+    }
+
+    const DWORD ownerThread =
+        GetWindowThreadProcessId(
+            hwnd,
+            nullptr
+        );
+
+    if (
+        !ownerThread ||
+        ownerThread != GetCurrentThreadId()
+    )
+    {
+        return false;
+    }
+
+    HWND shellTab =
+        FindAncestorByClass(
+            hwnd,
+            L"ShellTabWindowClass"
+        );
+
+    if (!shellTab)
+        return false;
+
+    AcquireSRWLockShared(&g_subclassLock);
+
+    const auto existing =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    const bool alreadyRegistered =
+        existing != g_trackedWindows.end() &&
+        existing->shellTab == shellTab &&
+        existing->shellBrowserCookie != 0;
+
+    ReleaseSRWLockShared(&g_subclassLock);
+
+    if (alreadyRegistered)
+        return true;
+
+    IShellBrowser* browser =
+        TryGetShellBrowserOnOwnerThread(shellTab);
+
+    if (!browser)
+        return false;
+
+    IGlobalInterfaceTable* table = nullptr;
+    HRESULT hr =
+        CreateGlobalInterfaceTable(&table);
+
+    DWORD newCookie = 0;
+
+    if (SUCCEEDED(hr) && table)
+    {
+        hr =
+            table->RegisterInterfaceInGlobal(
+                browser,
+                IID_IShellBrowser,
+                &newCookie
+            );
+    }
+
+    browser->Release();
+
+    if (table)
+        table->Release();
+
+    if (FAILED(hr) || !newCookie)
+    {
+        Wh_Log(
+            L"Shell browser registration failed hwnd=%p HRESULT=0x%08X",
+            hwnd,
+            static_cast<unsigned>(hr)
+        );
+        return false;
+    }
+
+    DWORD oldCookie = 0;
+    bool stored = false;
+
+    AcquireSRWLockExclusive(&g_subclassLock);
+
+    auto tracked =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    if (
+        tracked != g_trackedWindows.end() &&
+        !g_unloading.load(std::memory_order_acquire)
+    )
+    {
+        oldCookie = tracked->shellBrowserCookie;
+        tracked->shellTab = shellTab;
+        tracked->shellBrowserCookie = newCookie;
+        stored = true;
+    }
+
+    ReleaseSRWLockExclusive(&g_subclassLock);
+
+    if (oldCookie)
+        RevokeShellBrowserCookie(oldCookie);
+
+    if (!stored)
+    {
+        RevokeShellBrowserCookie(newCookie);
+        return false;
+    }
+
+    if (g_workerWakeEvent)
+        SetEvent(g_workerWakeEvent);
+
+    return true;
+}
+
+// ============================================================
+// Redraw
+// ============================================================
+
+static int ScaleForWindow(
+    HWND hwnd,
+    int value
+)
+{
+    const UINT dpi =
+        hwnd ? GetDpiForWindow(hwnd) : 96;
+
+    return MulDiv(
+        value,
+        dpi ? static_cast<int>(dpi) : 96,
+        96
+    );
+}
+
+static bool GetBottomStatusRowRect(
+    HWND hwnd,
+    RECT* row
+)
+{
+    if (!hwnd || !row || !IsWindow(hwnd))
+        return false;
+
+    RECT client{};
+
+    if (!GetClientRect(hwnd, &client))
+        return false;
+
+    *row = client;
+    row->top =
+        client.bottom > ScaleForWindow(hwnd, kStatusRowHeight)
+            ? client.bottom - ScaleForWindow(hwnd, kStatusRowHeight)
+            : 0;
+
+    return true;
+}
+
+static bool InvalidateInfoBarWindow(
+    HWND hwnd,
+    int partialLeft = -1,
+    int partialRight = -1
+)
+{
+    if (!hwnd || !IsWindow(hwnd))
+        return false;
+
+    RECT row{};
+
+    if (!GetBottomStatusRowRect(hwnd, &row))
+        return false;
+
+    const int clientRight =
+        row.right;
+
+    if (
+        partialLeft >= 0 &&
+        partialRight > partialLeft
+    )
+    {
+        row.left =
+            std::min(
+                std::max(partialLeft, 0),
+                clientRight
+            );
+
+        row.right =
+            std::min(
+                partialRight,
+                clientRight
+            );
+
+        if (row.right <= row.left)
+            return false;
+    }
+
+    // Ask DirectUI to repaint only the bottom row.
+    // Our subclass paints our info after DirectUI finishes its own WM_PAINT.
+    return InvalidateRect(
+               hwnd,
+               &row,
+               FALSE
+           ) != FALSE;
+}
+
+static size_t GetSectionGeometryIndex(
+    InfoBarSection section
+)
+{
+    if (section == InfoBarSection::Drive)
+        return 0;
+
+    if (section == InfoBarSection::Content)
+        return 1;
+
+    return 2;
+}
+
+struct StableThemeSnapshot
+{
+    COLORREF rowBackground = CLR_INVALID;
+    COLORREF nativeTextColor = CLR_INVALID;
+};
+
+static void StoreLayoutGeometry(
+    const InfoBarLayoutGeometry& geometry
+)
+{
+    AcquireSRWLockExclusive(&g_subclassLock);
+
+    auto existing =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == geometry.hwnd;
+            }
+        );
+
+    if (existing != g_trackedWindows.end())
+    {
+        existing->layout = geometry;
+        existing->hasLayout = true;
+    }
+
+    ReleaseSRWLockExclusive(&g_subclassLock);
+}
+
+static DWORD UntrackDirectUiWindowLocked(
+    HWND hwnd
+)
+{
+    DWORD shellBrowserCookie = 0;
+
+    const auto existing =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    if (existing != g_trackedWindows.end())
+    {
+        shellBrowserCookie =
+            existing->shellBrowserCookie;
+
+        g_trackedWindows.erase(existing);
+    }
+
+    return shellBrowserCookie;
+}
+
+static DWORD GetShellBrowserCookieSnapshot(
+    HWND hwnd
+)
+{
+    DWORD cookie = 0;
+
+    AcquireSRWLockShared(&g_subclassLock);
+
+    const auto existing =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    if (existing != g_trackedWindows.end())
+        cookie = existing->shellBrowserCookie;
+
+    ReleaseSRWLockShared(&g_subclassLock);
+    return cookie;
+}
+
+static StableThemeSnapshot GetStableThemeStateSnapshot(
+    HWND hwnd
+)
+{
+    StableThemeSnapshot result;
+
+    AcquireSRWLockShared(&g_subclassLock);
+
+    const auto existing =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    if (existing != g_trackedWindows.end())
+    {
+        result.rowBackground =
+            existing->stableRowBackground;
+
+        result.nativeTextColor =
+            existing->stableNativeTextColor;
+    }
+
+    ReleaseSRWLockShared(&g_subclassLock);
+    return result;
+}
+
+static void UpdateStableThemeState(
+    HWND hwnd,
+    COLORREF rowBackground,
+    bool updateBackground,
+    COLORREF nativeTextColor,
+    bool updateTextColor
+)
+{
+    AcquireSRWLockExclusive(&g_subclassLock);
+
+    auto existing =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    if (existing != g_trackedWindows.end())
+    {
+        if (updateBackground)
+            existing->stableRowBackground = rowBackground;
+
+        if (updateTextColor)
+            existing->stableNativeTextColor = nativeTextColor;
+    }
+
+    ReleaseSRWLockExclusive(&g_subclassLock);
+}
+
+static void RefreshInfoBarWindow(
+    HWND hwnd,
+    unsigned changes = CacheChangeNone
+)
+{
+    if (!hwnd || !IsWindow(hwnd))
+        return;
+
+    if (changes == CacheChangeNone)
+    {
+        InvalidateInfoBarWindow(hwnd);
+        return;
+    }
+
+    InfoBarLayoutGeometry geometry;
+    bool hasGeometry = false;
+
+    AcquireSRWLockShared(&g_subclassLock);
+
+    const auto tracked =
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    const bool found =
+        tracked != g_trackedWindows.end();
+
+    if (found)
+    {
+        geometry = tracked->layout;
+        hasGeometry = tracked->hasLayout;
+    }
+
+    ReleaseSRWLockShared(&g_subclassLock);
+
+    if (!found)
+        return;
+
+    const ModSettings settings =
+        GetSettingsSnapshot();
+
+    unsigned visibleChanges = changes;
+
+    if (!settings.showDrive)
+        visibleChanges &= ~CacheChangeDrive;
+
+    if (!settings.showContent)
+        visibleChanges &= ~CacheChangeContent;
+
+    if (!settings.showSelection)
+        visibleChanges &= ~CacheChangeSelection;
+
+    if (!settings.singleFileDetails)
+        visibleChanges &= ~CacheChangeFileDetails;
+
+    if (visibleChanges == CacheChangeNone)
+        return;
+
+    RECT client{};
+
+    const bool currentClientAvailable =
+        GetClientRect(
+            hwnd,
+            &client
+        );
+
+    const int currentUsableRight =
+        currentClientAvailable
+            ? (
+                client.right > ScaleForWindow(hwnd, 220)
+                    ? static_cast<int>(
+                        client.right - ScaleForWindow(hwnd, 220)
+                    )
+                    : static_cast<int>(client.right)
+            )
+            : -1;
+
+    const bool layoutMatchesSettings =
+        hasGeometry &&
+        geometry.style == settings.style &&
+        geometry.sectionOrder == settings.sectionOrder &&
+        geometry.showDrive == settings.showDrive &&
+        geometry.showContent == settings.showContent &&
+        geometry.showSelection == settings.showSelection &&
+        geometry.singleFileDetails == settings.singleFileDetails &&
+        geometry.usableRight == currentUsableRight;
+
+    if (!layoutMatchesSettings)
+    {
+        InvalidateInfoBarWindow(hwnd);
+        return;
+    }
+
+    int partialLeft = -1;
+
+    auto IncludeLeft =
+        [&](int left)
+        {
+            if (left < 0)
+                return false;
+
+            if (
+                partialLeft < 0 ||
+                left < partialLeft
+            )
+            {
+                partialLeft = left;
+            }
+
+            return true;
+        };
+
+    bool geometryComplete = true;
+
+    if (visibleChanges & CacheChangeDrive)
+    {
+        geometryComplete &=
+            IncludeLeft(
+                geometry.sectionLeft[
+                    GetSectionGeometryIndex(
+                        InfoBarSection::Drive
+                    )
+                ]
+            );
+    }
+
+    if (visibleChanges & CacheChangeContent)
+    {
+        geometryComplete &=
+            IncludeLeft(
+                geometry.sectionLeft[
+                    GetSectionGeometryIndex(
+                        InfoBarSection::Content
+                    )
+                ]
+            );
+    }
+
+    if (visibleChanges & CacheChangeSelection)
+    {
+        geometryComplete &=
+            IncludeLeft(
+                geometry.sectionLeft[
+                    GetSectionGeometryIndex(
+                        InfoBarSection::Selection
+                    )
+                ]
+            );
+    }
+
+    if (visibleChanges & CacheChangeFileDetails)
+    {
+        geometryComplete &=
+            IncludeLeft(
+                geometry.fileDetailsLeft
+            );
+    }
+
+    if (
+        !geometryComplete ||
+        partialLeft < 0 ||
+        geometry.usableRight <= partialLeft
+    )
+    {
+        InvalidateInfoBarWindow(hwnd);
+        return;
+    }
+
+    InvalidateInfoBarWindow(
+        hwnd,
+        partialLeft,
+        geometry.usableRight
+    );
+}
+
+static void RefreshInfoBars(
+    unsigned changes = CacheChangeNone
+)
+{
+    std::vector<HWND> windows;
+
+    AcquireSRWLockShared(&g_subclassLock);
+
+    try
+    {
+        windows.reserve(g_trackedWindows.size());
+
+        for (const TrackedDirectUiState& state : g_trackedWindows)
+            windows.push_back(state.hwnd);
+    }
+    catch (...)
+    {
+        ReleaseSRWLockShared(&g_subclassLock);
+        Wh_Log(L"DirectUI refresh snapshot failed");
+        return;
+    }
+
+    ReleaseSRWLockShared(&g_subclassLock);
+
+    for (HWND hwnd : windows)
+        RefreshInfoBarWindow(hwnd, changes);
+}
+
+// ============================================================
+// Cache
+// ============================================================
+
+static WindowDataCache* FindWindowDataCacheLocked(
+    HWND hwnd
+)
+{
+    const auto existing =
+        std::find_if(
+            g_windowDataCaches.begin(),
+            g_windowDataCaches.end(),
+            [&](const WindowDataCache& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        );
+
+    return existing != g_windowDataCaches.end()
+        ? &*existing
+        : nullptr;
+}
+
+static bool EnsureWindowDataCache(
+    HWND hwnd
+)
+{
+    EnterCriticalSection(&g_cacheLock);
+
+    if (FindWindowDataCacheLocked(hwnd))
+    {
+        LeaveCriticalSection(&g_cacheLock);
+        return true;
+    }
+
+    try
+    {
+        WindowDataCache cache;
+        cache.hwnd = hwnd;
+        g_windowDataCaches.push_back(std::move(cache));
+    }
+    catch (...)
+    {
+        LeaveCriticalSection(&g_cacheLock);
+        Wh_Log(L"Window data cache allocation failed hwnd=%p", hwnd);
+        return false;
+    }
+
+    LeaveCriticalSection(&g_cacheLock);
+    return true;
+}
+
+static void EraseWindowDataCache(
+    HWND hwnd
+)
+{
+    EnterCriticalSection(&g_cacheLock);
+
+    g_windowDataCaches.erase(
+        std::remove_if(
+            g_windowDataCaches.begin(),
+            g_windowDataCaches.end(),
+            [&](const WindowDataCache& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        ),
+        g_windowDataCaches.end()
+    );
+
+    LeaveCriticalSection(&g_cacheLock);
+}
+
+static WindowDataCache GetWindowDataCacheSnapshot(
+    HWND hwnd
+)
+{
+    WindowDataCache result;
+    result.hwnd = hwnd;
+
+    EnterCriticalSection(&g_cacheLock);
+
+    if (WindowDataCache* existing = FindWindowDataCacheLocked(hwnd))
+        result = *existing;
+
+    LeaveCriticalSection(&g_cacheLock);
+    return result;
+}
+
+static void GetCachedGroups(
+    HWND hwnd,
+    std::wstring& contentGroup,
+    std::wstring& selectionGroup,
+    std::wstring& driveGroup,
+    std::wstring& fileDetailsGroup,
+    int& selected
+)
+{
+    EnterCriticalSection(&g_cacheLock);
+
+    if (WindowDataCache* cache = FindWindowDataCacheLocked(hwnd))
+    {
+        contentGroup = cache->contentGroup;
+        selectionGroup = cache->selectionGroup;
+        driveGroup = cache->driveGroup;
+        fileDetailsGroup = cache->fileDetailsGroup;
+        selected = cache->selected;
+    }
+    else
+    {
+        contentGroup = L"Loading...";
+        selectionGroup.clear();
+        driveGroup.clear();
+        fileDetailsGroup.clear();
+        selected = 0;
+    }
+
+    LeaveCriticalSection(&g_cacheLock);
+}
+
+static unsigned UpdateCache(
+    HWND hwnd,
+    int files,
+    int folders,
+    int selected,
+    int selectedFiles,
+    int selectedFolders,
+    ULONGLONG directFileBytes,
+    ULONGLONG selectedBytes,
+    ULONGLONG freeBytes,
+    ULONGLONG driveTotalBytes,
+    wchar_t driveLetter,
+    const std::wstring& contentOverrideText,
+    const std::wstring& selectionOverrideText,
+    const std::wstring& fileDetailsText,
+    const ContentRefreshCache& contentRefreshCache,
+    const SingleFileMetadataCache& metadataCache
+)
+{
+    std::wstring driveText;
+
+    if (
+        driveLetter != L'?' &&
+        driveTotalBytes > 0
+    )
+    {
+        wchar_t driveBuf[256] = {};
+
+        swprintf(
+            driveBuf,
+            ARRAYSIZE(driveBuf),
+            L"Drive %c: %s free",
+            driveLetter,
+            FormatBytes(
+                freeBytes,
+                ByteFormat::OneDecimal
+            ).c_str()
+        );
+
+        driveText = driveBuf;
+    }
+
+    std::wstring contentText;
+
+    if (!contentOverrideText.empty())
+    {
+        contentText = contentOverrideText;
+    }
+    else
+    {
+        wchar_t contentBuf[256] = {};
+
+        swprintf(
+            contentBuf,
+            ARRAYSIZE(contentBuf),
+            L"Content: %d folder%s / %d file%s (%s)",
+            folders,
+            folders == 1 ? L"" : L"s",
+            files,
+            files == 1 ? L"" : L"s",
+            FormatBytes(directFileBytes).c_str()
+        );
+
+        contentText = contentBuf;
+    }
+
+    std::wstring selectionText;
+
+    if (selected > 0)
+    {
+        if (!selectionOverrideText.empty())
+        {
+            selectionText = selectionOverrideText;
+        }
+        else
+        {
+            wchar_t selectedBuf[256] = {};
+
+            if (
+                selectedFolders > 0 &&
+                selectedFiles > 0
+            )
+            {
+                swprintf(
+                    selectedBuf,
+                    ARRAYSIZE(selectedBuf),
+                    L"Selected: %d folder%s / %d file%s (%s)",
+                    selectedFolders,
+                    selectedFolders == 1 ? L"" : L"s",
+                    selectedFiles,
+                    selectedFiles == 1 ? L"" : L"s",
+                    FormatBytes(selectedBytes).c_str()
+                );
+            }
+            else if (selectedFolders > 0)
+            {
+                swprintf(
+                    selectedBuf,
+                    ARRAYSIZE(selectedBuf),
+                    L"Selected: %d folder%s",
+                    selectedFolders,
+                    selectedFolders == 1 ? L"" : L"s"
+                );
+            }
+            else
+            {
+                swprintf(
+                    selectedBuf,
+                    ARRAYSIZE(selectedBuf),
+                    L"Selected: %d file%s (%s)",
+                    selectedFiles,
+                    selectedFiles == 1 ? L"" : L"s",
+                    FormatBytes(selectedBytes).c_str()
+                );
+            }
+
+            selectionText = selectedBuf;
+        }
+    }
+
+    unsigned changes = CacheChangeNone;
+
+    EnterCriticalSection(&g_cacheLock);
+
+    WindowDataCache* cache =
+        FindWindowDataCacheLocked(hwnd);
+
+    if (!cache)
+    {
+        // Cache creation belongs to the tracked-window lifecycle. Don't
+        // recreate a cache here if this worker iteration raced with window
+        // destruction and cleanup.
+        LeaveCriticalSection(&g_cacheLock);
+        return CacheChangeNone;
+    }
+
+    if (contentText != cache->contentGroup)
+    {
+        changes |= CacheChangeContent;
+        cache->contentGroup = contentText;
+    }
+
+    if (
+        selectionText != cache->selectionGroup ||
+        selected != cache->selected
+    )
+    {
+        changes |= CacheChangeSelection;
+        cache->selected = selected;
+        cache->selectionGroup = selectionText;
+    }
+
+    if (driveText != cache->driveGroup)
+    {
+        changes |= CacheChangeDrive;
+        cache->driveGroup = driveText;
+    }
+
+    if (fileDetailsText != cache->fileDetailsGroup)
+    {
+        changes |= CacheChangeFileDetails;
+        cache->fileDetailsGroup = fileDetailsText;
+    }
+
+    cache->contentRefresh = contentRefreshCache;
+    cache->metadata = metadataCache;
+
+    LeaveCriticalSection(&g_cacheLock);
+    return changes;
+}
+
+static bool ScanFilesystemDirectory(
+    const std::wstring& directoryPath,
+    int* files,
+    int* folders,
+    ULONGLONG* directFileBytes
+)
+{
+    if (
+        directoryPath.empty() ||
+        !files ||
+        !folders ||
+        !directFileBytes
+    )
+    {
+        return false;
+    }
+
+    std::wstring searchPath = directoryPath;
+
+    if (
+        searchPath.back() != L'\\' &&
+        searchPath.back() != L'/'
+    )
+    {
+        searchPath += L'\\';
+    }
+
+    searchPath += L'*';
+
+    WIN32_FIND_DATAW findData{};
+
+    HANDLE findHandle =
+        FindFirstFileExW(
+            searchPath.c_str(),
+            FindExInfoBasic,
+            &findData,
+            FindExSearchNameMatch,
+            nullptr,
+            FIND_FIRST_EX_LARGE_FETCH
+        );
+
+    if (findHandle == INVALID_HANDLE_VALUE)
+    {
+        const DWORD error = GetLastError();
+
+        if (
+            error == ERROR_FILE_NOT_FOUND ||
+            error == ERROR_NO_MORE_FILES
+        )
+        {
+            *files = 0;
+            *folders = 0;
+            *directFileBytes = 0;
+            return true;
+        }
+
+        return false;
+    }
+
+    int scannedFiles = 0;
+    int scannedFolders = 0;
+    ULONGLONG scannedBytes = 0;
+    bool complete = true;
+
+    while (true)
+    {
+        if (
+            g_unloading.load(std::memory_order_acquire) ||
+            (
+                g_stopEvent &&
+                WaitForSingleObject(g_stopEvent, 0) == WAIT_OBJECT_0
+            )
+        )
+        {
+            complete = false;
+            break;
+        }
+
+        if (
+            wcscmp(findData.cFileName, L".") != 0 &&
+            wcscmp(findData.cFileName, L"..") != 0
+        )
+        {
+            if (
+                findData.dwFileAttributes &
+                FILE_ATTRIBUTE_DIRECTORY
+            )
+            {
+                scannedFolders++;
+            }
+            else
+            {
+                scannedFiles++;
+
+                scannedBytes +=
+                    (static_cast<ULONGLONG>(
+                        findData.nFileSizeHigh
+                    ) << 32) |
+                    findData.nFileSizeLow;
+            }
+        }
+
+        if (FindNextFileW(findHandle, &findData))
+            continue;
+
+        if (GetLastError() != ERROR_NO_MORE_FILES)
+            complete = false;
+
+        break;
+    }
+
+    FindClose(findHandle);
+
+    if (!complete)
+        return false;
+
+    *files = scannedFiles;
+    *folders = scannedFolders;
+    *directFileBytes = scannedBytes;
+    return true;
+}
+
+static void ClearSingleFileMetadataCache(
+    SingleFileMetadataCache* cache
+)
+{
+    if (cache)
+        *cache = SingleFileMetadataCache{};
+}
+
+static std::wstring GetSingleFileDetailsCached(
+    SingleFileMetadataCache* cache,
+    IShellItem* item,
+    const std::wstring& path
+)
+{
+    if (!cache)
+        return L"";
+
+    const ULONGLONG now = GetTickCount64();
+
+    if (path == cache->path)
+    {
+        if (cache->valid)
+            return cache->details;
+
+        if (cache->retryAfterTick > now)
+            return cache->details;
+    }
+
+    bool transientFailure = false;
+
+    std::wstring details =
+        BuildSingleFileDetails(
+            item,
+            path,
+            &transientFailure
+        );
+
+    cache->path = path;
+    cache->details = details;
+    cache->valid = !transientFailure;
+    cache->retryAfterTick =
+        transientFailure
+            ? now + kMetadataRetryMs
+            : 0;
+
+    return details;
+}
+
+// ============================================================
+// Read Explorer state
+// ============================================================
+
+static unsigned ReadCurrentView(
+    HWND hwnd,
+    IShellBrowser* browser
+)
+{
+    if (!hwnd || !browser)
+        return CacheChangeNone;
+
+    const ModSettings settings =
+        GetSettingsSnapshot();
+
+    WindowDataCache state =
+        GetWindowDataCacheSnapshot(hwnd);
+
+    ContentRefreshCache contentCache =
+        state.contentRefresh;
+
+    SingleFileMetadataCache metadataCache =
+        state.metadata;
+
+    IShellView* shellView = nullptr;
+
+    HRESULT hr =
+        browser->QueryActiveShellView(
+            &shellView
+        );
+
+    if (FAILED(hr) || !shellView)
+        return CacheChangeNone;
+
+    IFolderView2* folderView = nullptr;
+
+    hr =
+        shellView->QueryInterface(
+            IID_PPV_ARGS(&folderView)
+        );
+
+    if (FAILED(hr) || !folderView)
+    {
+        shellView->Release();
+        return CacheChangeNone;
+    }
+
+    std::wstring currentPath;
+    std::wstring folderIdentity;
+
+    IShellItem* folderItem = nullptr;
+
+    hr =
+        folderView->GetFolder(
+            IID_PPV_ARGS(&folderItem)
+        );
+
+    if (SUCCEEDED(hr) && folderItem)
+    {
+        PWSTR path = nullptr;
+
+        if (
+            SUCCEEDED(
+                folderItem->GetDisplayName(
+                    SIGDN_FILESYSPATH,
+                    &path
+                )
+            ) &&
+            path
+        )
+        {
+            currentPath = path;
+            CoTaskMemFree(path);
+        }
+
+        PWSTR parsingName = nullptr;
+
+        if (
+            SUCCEEDED(
+                folderItem->GetDisplayName(
+                    SIGDN_DESKTOPABSOLUTEPARSING,
+                    &parsingName
+                )
+            ) &&
+            parsingName
+        )
+        {
+            folderIdentity = parsingName;
+            CoTaskMemFree(parsingName);
+        }
+
+        folderItem->Release();
+    }
+
+    if (folderIdentity.empty())
+        folderIdentity = currentPath;
+
+    ULONGLONG freeBytes = 0;
+    ULONGLONG driveTotalBytes = 0;
+    wchar_t driveLetter = L'?';
+
+    if (
+        settings.showDrive &&
+        currentPath.length() >= 2 &&
+        currentPath[1] == L':'
+    )
+    {
+        ULARGE_INTEGER freeAvailable{};
+        ULARGE_INTEGER totalBytes{};
+
+        if (
+            GetDiskFreeSpaceExW(
+                currentPath.c_str(),
+                &freeAvailable,
+                &totalBytes,
+                nullptr
+            )
+        )
+        {
+            freeBytes = freeAvailable.QuadPart;
+            driveTotalBytes = totalBytes.QuadPart;
+        }
+
+        driveLetter =
+            static_cast<wchar_t>(
+                towupper(currentPath[0])
+            );
+    }
+
+    int total = -1;
+    bool itemCountAvailable = false;
+    std::wstring contentOverrideText;
+
+    if (settings.showContent)
+    {
+        hr =
+            folderView->ItemCount(
+                SVGIO_ALLVIEW,
+                &total
+            );
+
+        itemCountAvailable = SUCCEEDED(hr);
+    }
+
+    const ULONGLONG now = GetTickCount64();
+
+    if (
+        settings.showContent &&
+        itemCountAvailable &&
+        currentPath.empty()
+    )
+    {
+        wchar_t virtualContent[128] = {};
+
+        swprintf(
+            virtualContent,
+            ARRAYSIZE(virtualContent),
+            L"Content: %d item%s",
+            total,
+            total == 1 ? L"" : L"s"
+        );
+
+        contentOverrideText = virtualContent;
+    }
+    else if (
+        settings.showContent &&
+        itemCountAvailable &&
+        !currentPath.empty()
+    )
+    {
+        const bool sameFolder =
+            contentCache.valid &&
+            !folderIdentity.empty() &&
+            folderIdentity == contentCache.folderIdentity;
+
+        const bool itemCountChanged =
+            sameFolder &&
+            total != contentCache.itemCount;
+
+        const bool safetyRescanDue =
+            sameFolder &&
+            now - contentCache.lastFullScanTick >=
+                kContentSafetyRescanMs;
+
+        const bool retryThrottled =
+            folderIdentity ==
+                contentCache.lastAttemptFolderIdentity &&
+            now - contentCache.lastScanAttemptTick <
+                kContentFailedRetryMs;
+
+        if (
+            (
+                !sameFolder ||
+                itemCountChanged ||
+                safetyRescanDue
+            ) &&
+            !retryThrottled
+        )
+        {
+            contentCache.lastAttemptFolderIdentity = folderIdentity;
+            contentCache.lastScanAttemptTick = now;
+
+            int scannedFiles = 0;
+            int scannedFolders = 0;
+            ULONGLONG scannedBytes = 0;
+
+            if (
+                ScanFilesystemDirectory(
+                    currentPath,
+                    &scannedFiles,
+                    &scannedFolders,
+                    &scannedBytes
+                )
+            )
+            {
+                contentCache.valid = true;
+                contentCache.folderIdentity = folderIdentity;
+                contentCache.itemCount = total;
+                contentCache.files = scannedFiles;
+                contentCache.folders = scannedFolders;
+                contentCache.directFileBytes = scannedBytes;
+                contentCache.lastFullScanTick = now;
+            }
+
+        }
+    }
+
+    const bool useCachedContent =
+        settings.showContent &&
+        contentCache.valid &&
+        !folderIdentity.empty() &&
+        folderIdentity == contentCache.folderIdentity;
+
+    if (
+        settings.showContent &&
+        !currentPath.empty() &&
+        !useCachedContent &&
+        contentOverrideText.empty()
+    )
+    {
+        contentOverrideText = L"Content: Loading...";
+    }
+
+    const int files =
+        useCachedContent
+            ? contentCache.files
+            : 0;
+
+    const int folders =
+        useCachedContent
+            ? contentCache.folders
+            : 0;
+
+    const ULONGLONG directFileBytes =
+        useCachedContent
+            ? contentCache.directFileBytes
+            : 0;
+
+    int selected = 0;
+    int selectedFiles = 0;
+    int selectedFolders = 0;
+    ULONGLONG selectedBytes = 0;
+    std::wstring selectionOverrideText;
+    std::wstring singleFileDetails;
+    bool keepSingleFileMetadataCache = false;
+
+    // Always obtain the selection count. Even when the Selected and
+    // File Details sections are hidden, the painter uses the count to avoid
+    // learning Explorer's temporary selected-row tint as the normal theme.
+    IShellItemArray* selection = nullptr;
+
+    hr =
+        folderView->GetSelection(
+            FALSE,
+            &selection
+        );
+
+    if (SUCCEEDED(hr) && selection)
+    {
+        DWORD selectionCount = 0;
+
+        if (
+            SUCCEEDED(
+                selection->GetCount(
+                    &selectionCount
+                )
+            )
+        )
+        {
+            selected =
+                static_cast<int>(selectionCount);
+
+            const bool enumerateSelection =
+                settings.showSelection ||
+                (
+                    settings.singleFileDetails &&
+                    selectionCount == 1
+                );
+
+            if (enumerateSelection)
+            {
+                for (DWORD i = 0; i < selectionCount; i++)
+                {
+                    if (
+                        g_unloading.load(std::memory_order_acquire) ||
+                        (
+                            g_stopEvent &&
+                            WaitForSingleObject(
+                                g_stopEvent,
+                                0
+                            ) == WAIT_OBJECT_0
+                        )
+                    )
+                    {
+                        break;
+                    }
+
+                    IShellItem* item = nullptr;
+
+                    if (
+                        FAILED(
+                            selection->GetItemAt(
+                                i,
+                                &item
+                            )
+                        ) ||
+                        !item
+                    )
+                    {
+                        continue;
+                    }
+
+                    PWSTR path = nullptr;
+
+                    if (
+                        SUCCEEDED(
+                            item->GetDisplayName(
+                                SIGDN_FILESYSPATH,
+                                &path
+                            )
+                        ) &&
+                        path
+                    )
+                    {
+                        bool directory = false;
+                        ULONGLONG size = 0;
+
+                        if (
+                            GetFilesystemInfo(
+                                path,
+                                &directory,
+                                &size
+                            )
+                        )
+                        {
+                            if (directory)
+                            {
+                                selectedFolders++;
+                            }
+                            else
+                            {
+                                selectedFiles++;
+                                selectedBytes += size;
+
+                                if (
+                                    selectionCount == 1 &&
+                                    settings.singleFileDetails
+                                )
+                                {
+                                    keepSingleFileMetadataCache = true;
+                                    singleFileDetails =
+                                        GetSingleFileDetailsCached(
+                                            &metadataCache,
+                                            item,
+                                            path
+                                        );
+                                }
+                            }
+                        }
+
+                        CoTaskMemFree(path);
+                    }
+
+                    item->Release();
+                }
+            }
+        }
+
+        selection->Release();
+    }
+
+    if (!keepSingleFileMetadataCache)
+        ClearSingleFileMetadataCache(&metadataCache);
+
+    if (
+        selected > 0 &&
+        selectedFiles + selectedFolders != selected
+    )
+    {
+        wchar_t virtualSelection[128] = {};
+
+        swprintf(
+            virtualSelection,
+            ARRAYSIZE(virtualSelection),
+            L"Selected: %d item%s",
+            selected,
+            selected == 1 ? L"" : L"s"
+        );
+
+        selectionOverrideText = virtualSelection;
+    }
+
+    if (
+        g_unloading.load(std::memory_order_acquire) ||
+        (
+            g_stopEvent &&
+            WaitForSingleObject(g_stopEvent, 0) == WAIT_OBJECT_0
+        )
+    )
+    {
+        folderView->Release();
+        shellView->Release();
+        return CacheChangeNone;
+    }
+
+    const unsigned changes =
+        UpdateCache(
+            hwnd,
+            files,
+            folders,
+            selected,
+            selectedFiles,
+            selectedFolders,
+            directFileBytes,
+            selectedBytes,
+            freeBytes,
+            driveTotalBytes,
+            driveLetter,
+            contentOverrideText,
+            selectionOverrideText,
+            singleFileDetails,
+            contentCache,
+            metadataCache
+        );
+
+    folderView->Release();
+    shellView->Release();
+    return changes;
+}
+
+// ============================================================
+// Worker
+// ============================================================
+
+static bool WaitForWorkerStop(
+    DWORD timeoutMs
+)
+{
+    HANDLE handles[2] =
+    {
+        g_stopEvent,
+        g_workerWakeEvent
+    };
+
+    const DWORD result =
+        WaitForMultipleObjects(
+            ARRAYSIZE(handles),
+            handles,
+            FALSE,
+            timeoutMs
+        );
+
+    return result == WAIT_OBJECT_0;
+}
+
+static DWORD WINAPI WorkerThreadProc(
+    LPVOID
+)
+{
+    const HRESULT comHr =
+        CoInitializeEx(
+            nullptr,
+            COINIT_APARTMENTTHREADED
+        );
+
+    Wh_Log(
+        L"Explorer Info Bar worker start PID=%lu COM=0x%08X",
+        g_pid,
+        static_cast<unsigned>(comHr)
+    );
+
+    if (FAILED(comHr))
+    {
+        Wh_Log(
+            L"Explorer Info Bar worker COM initialization failed "
+            L"PID=%lu HRESULT=0x%08X",
+            g_pid,
+            static_cast<unsigned>(comHr)
+        );
+        return 0;
+    }
+
+    const bool callCancellationEnabled =
+        SUCCEEDED(
+            CoEnableCallCancellation(nullptr)
+        );
+
+    IGlobalInterfaceTable* table = nullptr;
+    const HRESULT gitHr =
+        CreateGlobalInterfaceTable(&table);
+
+    if (FAILED(gitHr) || !table)
+    {
+        Wh_Log(
+            L"Global Interface Table initialization failed HRESULT=0x%08X",
+            static_cast<unsigned>(gitHr)
+        );
+
+        if (callCancellationEnabled)
+            CoDisableCallCancellation(nullptr);
+
+        CoUninitialize();
+        return 0;
+    }
+
+    if (
+        WaitForWorkerStop(
+            kInitialRefreshDelayMs
+        )
+    )
+    {
+        table->Release();
+
+        if (callCancellationEnabled)
+            CoDisableCallCancellation(nullptr);
+
+        CoUninitialize();
+        return 0;
+    }
+
+    struct WorkerTarget
+    {
+        HWND hwnd;
+        DWORD shellBrowserCookie;
+    };
+
+    while (true)
+    {
+        std::vector<WorkerTarget> targets;
+
+        bool snapshotFailed = false;
+
+        AcquireSRWLockShared(&g_subclassLock);
+
+        try
+        {
+            targets.reserve(g_trackedWindows.size());
+
+            for (const TrackedDirectUiState& state : g_trackedWindows)
+            {
+                if (state.shellBrowserCookie)
+                {
+                    targets.push_back({
+                        state.hwnd,
+                        state.shellBrowserCookie
+                    });
+                }
+            }
+        }
+        catch (...)
+        {
+            snapshotFailed = true;
+        }
+
+        ReleaseSRWLockShared(&g_subclassLock);
+
+        if (snapshotFailed)
+        {
+            Wh_Log(L"Worker target snapshot failed");
+            targets.clear();
+        }
+
+        for (const WorkerTarget& target : targets)
+        {
+            if (
+                g_unloading.load(std::memory_order_acquire) ||
+                WaitForSingleObject(g_stopEvent, 0) == WAIT_OBJECT_0
+            )
+            {
+                break;
+            }
+
+            IShellBrowser* browser = nullptr;
+
+            const HRESULT hr =
+                table->GetInterfaceFromGlobal(
+                    target.shellBrowserCookie,
+                    IID_IShellBrowser,
+                    reinterpret_cast<void**>(&browser)
+                );
+
+            if (FAILED(hr) || !browser)
+                continue;
+
+            const unsigned changes =
+                ReadCurrentView(
+                    target.hwnd,
+                    browser
+                );
+
+            browser->Release();
+
+            if (changes != CacheChangeNone)
+            {
+                RefreshInfoBarWindow(
+                    target.hwnd,
+                    changes
+                );
+            }
+        }
+
+        if (
+            WaitForWorkerStop(
+                kRefreshIntervalMs
+            )
+        )
+        {
+            break;
+        }
+    }
+
+    table->Release();
+
+    if (callCancellationEnabled)
+        CoDisableCallCancellation(nullptr);
+
+    CoUninitialize();
+
+    Wh_Log(
+        L"Explorer Info Bar worker end PID=%lu",
+        g_pid
+    );
+
+    return 0;
+}
+
+// ============================================================
+// Final-paint renderer
+// ============================================================
+
+static bool IsDirectUiWindow(
+    HWND hwnd
+)
+{
+    if (!hwnd)
+        return false;
+
+    wchar_t cls[128] = {};
+
+    if (!GetClassNameW(
+            hwnd,
+            cls,
+            ARRAYSIZE(cls)))
+    {
+        return false;
+    }
+
+    return wcscmp(
+        cls,
+        L"DirectUIHWND"
+    ) == 0;
+}
+
+static bool StatusMarkIsFresh(
+    HDC source
+)
+{
+    if (!g_statusSourceDc)
+        return false;
+
+    ULONGLONG now =
+        GetTickCount64();
+
+    if (
+        now - g_statusMarkTick >
+        kStatusMarkerLifetimeMs
+    )
+    {
+        g_statusSourceDc = nullptr;
+        return false;
+    }
+
+    return source ==
+        g_statusSourceDc;
+}
+
+static int MeasureTextWidth(
+    HDC hdc,
+    const std::wstring& text
+)
+{
+    if (text.empty())
+        return 0;
+
+    SIZE size{};
+
+    if (!GetTextExtentPoint32W(
+            hdc,
+            text.c_str(),
+            static_cast<int>(
+                text.length()
+            ),
+            &size))
+    {
+        return 0;
+    }
+
+    return size.cx;
+}
+
+static int MeasureGapWidth(
+    HDC hdc
+)
+{
+    const wchar_t* gap =
+        L"     ";
+
+    SIZE size{};
+
+    if (
+        GetTextExtentPoint32W(
+            hdc,
+            gap,
+            5,
+            &size
+        )
+    )
+    {
+        return size.cx;
+    }
+
+    return 26;
+}
+
+static COLORREF PickBackgroundColor(
+    HDC hdc,
+    HWND hwnd,
+    const RECT& row,
+    int selected
+)
+{
+    // Keep the native unselected status-row background stable per window.
+    // Explorer can temporarily tint the row while items are selected.
+    const StableThemeSnapshot stable =
+        GetStableThemeStateSnapshot(hwnd);
+
+    if (
+        selected > 0 &&
+        stable.rowBackground != CLR_INVALID
+    )
+    {
+        return stable.rowBackground;
+    }
+
+    const int y =
+        row.top +
+        ((row.bottom - row.top) / 2);
+
+    const int samples[] =
+    {
+        ScaleForWindow(hwnd, 420),
+        ScaleForWindow(hwnd, 520),
+        ScaleForWindow(hwnd, 620),
+        ScaleForWindow(hwnd, 720)
+    };
+
+    COLORREF chosen = CLR_INVALID;
+
+    for (int x : samples)
+    {
+        if (x >= row.right)
+            continue;
+
+        const COLORREF sample =
+            GetPixel(
+                hdc,
+                x,
+                y
+            );
+
+        if (sample != CLR_INVALID)
+        {
+            chosen = sample;
+            break;
+        }
+    }
+
+    if (chosen == CLR_INVALID)
+    {
+        if (stable.rowBackground != CLR_INVALID)
+            return stable.rowBackground;
+
+        chosen = RGB(32, 32, 32);
+    }
+
+    if (selected <= 0)
+    {
+        UpdateStableThemeState(
+            hwnd,
+            chosen,
+            true,
+            CLR_INVALID,
+            false
+        );
+    }
+
+    return chosen;
+}
+
+static void DrawFinalPiece(
+    HDC hdc,
+    int& x,
+    const RECT& row,
+    const std::wstring& text,
+    COLORREF color
+)
+{
+    if (text.empty())
+        return;
+
+    if (x >= row.right)
+    {
+        x = row.right;
+        return;
+    }
+
+    int width =
+        MeasureTextWidth(
+            hdc,
+            text
+        );
+
+    RECT rc =
+        row;
+
+    rc.left =
+        x;
+
+    rc.right =
+        std::min(
+            x + width + 4,
+            static_cast<int>(
+                row.right
+            )
+        );
+
+    SetTextColor(
+        hdc,
+        color
+    );
+
+    DrawTextW_Original(
+        hdc,
+        text.c_str(),
+        -1,
+        &rc,
+        DT_SINGLELINE |
+        DT_VCENTER |
+        DT_NOPREFIX
+    );
+
+    x += width;
+}
+
+static void DrawFinalSeparator(
+    HDC hdc,
+    int& x,
+    const RECT& row,
+    COLORREF color
+)
+{
+    x +=
+        MeasureGapWidth(
+            hdc
+        );
+
+    DrawFinalPiece(
+        hdc,
+        x,
+        row,
+        L"\x00B7",
+        color
+    );
+
+    x +=
+        MeasureGapWidth(
+            hdc
+        );
+}
+
+static int ColorLuminance(
+    COLORREF color
+)
+{
+    return (
+        GetRValue(color) * 30 +
+        GetGValue(color) * 59 +
+        GetBValue(color) * 11
+    ) / 100;
+}
+
+static COLORREF BlendColor(
+    COLORREF base,
+    COLORREF target,
+    int targetPercent
+)
+{
+    targetPercent =
+        std::max(
+            0,
+            std::min(
+                100,
+                targetPercent
+            )
+        );
+
+    const int basePercent =
+        100 - targetPercent;
+
+    return RGB(
+        (
+            GetRValue(base) * basePercent +
+            GetRValue(target) * targetPercent
+        ) / 100,
+        (
+            GetGValue(base) * basePercent +
+            GetGValue(target) * targetPercent
+        ) / 100,
+        (
+            GetBValue(base) * basePercent +
+            GetBValue(target) * targetPercent
+        ) / 100
+    );
+}
+
+static COLORREF GetContrastingTextColor(
+    COLORREF background
+)
+{
+    return ColorLuminance(background) >= 140
+        ? RGB(32, 32, 32)
+        : RGB(232, 232, 232);
+}
+
+static COLORREF PickNativeTextColor(
+    HDC hdc,
+    HWND hwnd,
+    COLORREF background,
+    int selected
+)
+{
+    const StableThemeSnapshot stable =
+        GetStableThemeStateSnapshot(hwnd);
+
+    if (
+        selected > 0 &&
+        stable.nativeTextColor != CLR_INVALID
+    )
+    {
+        return stable.nativeTextColor;
+    }
+
+    COLORREF candidate =
+        GetTextColor(hdc);
+
+    if (
+        candidate == CLR_INVALID ||
+        std::abs(
+            ColorLuminance(candidate) -
+            ColorLuminance(background)
+        ) < 70
+    )
+    {
+        candidate =
+            GetContrastingTextColor(
+                background
+            );
+    }
+
+    if (selected <= 0)
+    {
+        UpdateStableThemeState(
+            hwnd,
+            CLR_INVALID,
+            false,
+            candidate,
+            true
+        );
+    }
+
+    return candidate;
+}
+
+static COLORREF ResolveColor(
+    const ColorOverride& colorOverride,
+    COLORREF automaticColor
+)
+{
+    return colorOverride.enabled
+        ? colorOverride.value
+        : automaticColor;
+}
+
+static void PaintFinalInfoBar(
+    HDC hdc,
+    HWND hwnd,
+    const RECT* updateRect = nullptr
+)
+{
+    if (!hdc || !hwnd)
+        return;
+
+    RECT client{};
+
+    if (!GetClientRect(
+            hwnd,
+            &client))
+    {
+        return;
+    }
+
+    RECT row =
+        g_statusRowRect;
+
+    // Fall back to Explorer's bottom status-row height if the native rect is unavailable.
+    if (
+        row.bottom <= row.top ||
+        row.top < 0 ||
+        row.bottom >
+            client.bottom + ScaleForWindow(hwnd, 2)
+    )
+    {
+        row.top =
+            client.bottom > ScaleForWindow(hwnd, kStatusRowHeight)
+                ? client.bottom - ScaleForWindow(hwnd, kStatusRowHeight)
+                : 0;
+
+        row.bottom =
+            client.bottom;
+    }
+
+    row.left = ScaleForWindow(hwnd, 6);
+
+    // Preserve Explorer's right-side controls.
+    row.right =
+        client.right > ScaleForWindow(hwnd, 220)
+            ? client.right - ScaleForWindow(hwnd, 220)
+            : client.right;
+
+    std::wstring contentGroup;
+    std::wstring selectionGroup;
+    std::wstring driveGroup;
+    std::wstring fileDetailsGroup;
+
+    int selected = 0;
+
+    GetCachedGroups(
+        hwnd,
+        contentGroup,
+        selectionGroup,
+        driveGroup,
+        fileDetailsGroup,
+        selected
+    );
+
+    const ModSettings settings =
+        GetSettingsSnapshot();
+
+    const bool showFileDetails =
+        settings.singleFileDetails &&
+        !fileDetailsGroup.empty();
+
+    const bool hasVisibleContent =
+        (
+            settings.showDrive &&
+            !driveGroup.empty()
+        ) ||
+        (
+            settings.showContent &&
+            !contentGroup.empty()
+        ) ||
+        (
+            settings.showSelection &&
+            !selectionGroup.empty()
+        ) ||
+        showFileDetails;
+
+    // Leave Explorer's native status row untouched when nothing custom is visible.
+    if (!hasVisibleContent)
+        return;
+
+    RECT paintRect =
+        row;
+
+    if (
+        updateRect &&
+        !IntersectRect(
+            &paintRect,
+            &paintRect,
+            updateRect
+        )
+    )
+    {
+        return;
+    }
+
+    const int savedDc =
+        SaveDC(hdc);
+
+    if (!savedDc)
+        return;
+
+    IntersectClipRect(
+        hdc,
+        paintRect.left,
+        paintRect.top,
+        paintRect.right,
+        paintRect.bottom
+    );
+
+    COLORREF background =
+        PickBackgroundColor(
+            hdc,
+            hwnd,
+            row,
+            selected
+        );
+
+    HBRUSH brush =
+        CreateSolidBrush(
+            background
+        );
+
+    if (brush)
+    {
+        FillRect(
+            hdc,
+            &row,
+            brush
+        );
+
+        DeleteObject(
+            brush
+        );
+    }
+
+    int oldBkMode =
+        SetBkMode(
+            hdc,
+            TRANSPARENT
+        );
+
+    COLORREF oldTextColor =
+        GetTextColor(
+            hdc
+        );
+
+    // Match Explorer's native info-bar font metrics.
+    HFONT font =
+        CreateFontW(
+            -ScaleForWindow(hwnd, 12),
+            0,
+            0,
+            0,
+            FW_NORMAL,
+            FALSE,
+            FALSE,
+            FALSE,
+            DEFAULT_CHARSET,
+            OUT_DEFAULT_PRECIS,
+            CLIP_DEFAULT_PRECIS,
+            CLEARTYPE_QUALITY,
+            DEFAULT_PITCH,
+            L"Segoe UI"
+        );
+
+    HFONT oldFont = nullptr;
+
+    if (font)
+    {
+        oldFont =
+            reinterpret_cast<HFONT>(
+                SelectObject(
+                    hdc,
+                    font
+                )
+            );
+    }
+
+    const COLORREF nativeText =
+        PickNativeTextColor(
+            hdc,
+            hwnd,
+            background,
+            selected
+        );
+
+    const COLORREF textColor =
+        ResolveColor(
+            settings.textColor,
+            nativeText
+        );
+
+    // Auto mode must stay visually neutral and theme-compatible.
+    // All three panels use the SAME theme-derived fill by default.
+    // Individual sections differ only when the user explicitly overrides
+    // Drive / Content / Selected colors in settings.
+    const COLORREF automaticPanelColor =
+        BlendColor(
+            background,
+            nativeText,
+            6
+        );
+
+    const COLORREF drivePanelColor =
+        ResolveColor(
+            settings.driveColor,
+            automaticPanelColor
+        );
+
+    const COLORREF contentPanelColor =
+        ResolveColor(
+            settings.contentColor,
+            automaticPanelColor
+        );
+
+    const COLORREF selectionPanelColor =
+        ResolveColor(
+            settings.selectionColor,
+            automaticPanelColor
+        );
+
+    const COLORREF fileDetailsPanelColor =
+        ResolveColor(
+            settings.fileDetailsColor,
+            automaticPanelColor
+        );
+
+    const COLORREF automaticDividerColor =
+        BlendColor(
+            background,
+            nativeText,
+            22
+        );
+
+    // The custom divider/border override intentionally applies only to
+    // Soft Cards. Simple and Flat Panes always derive their structure
+    // from Explorer so changing this setting has no hidden side effects.
+    const COLORREF cardBorderColor =
+        ResolveColor(
+            settings.dividerColor,
+            automaticDividerColor
+        );
+
+    auto GetSectionText =
+        [&](InfoBarSection section) -> const std::wstring&
+        {
+            if (section == InfoBarSection::Drive)
+                return driveGroup;
+
+            if (section == InfoBarSection::Content)
+                return contentGroup;
+
+            return selectionGroup;
+        };
+
+    auto IsSectionEnabled =
+        [&](InfoBarSection section) -> bool
+        {
+            if (section == InfoBarSection::Drive)
+                return settings.showDrive;
+
+            if (section == InfoBarSection::Content)
+                return settings.showContent;
+
+            return settings.showSelection;
+        };
+
+    int x =
+        ScaleForWindow(hwnd, 14);
+
+    bool drew =
+        false;
+
+    InfoBarLayoutGeometry geometry;
+    geometry.hwnd = hwnd;
+    geometry.usableRight = row.right;
+    geometry.style = settings.style;
+    geometry.sectionOrder = settings.sectionOrder;
+    geometry.showDrive = settings.showDrive;
+    geometry.showContent = settings.showContent;
+    geometry.showSelection = settings.showSelection;
+    geometry.singleFileDetails = settings.singleFileDetails;
+
+    if (settings.style == InfoBarStyle::Simple)
+    {
+        for (InfoBarSection section : settings.sectionOrder)
+        {
+            if (!IsSectionEnabled(section))
+                continue;
+
+            geometry.sectionLeft[
+                GetSectionGeometryIndex(section)
+            ] = x;
+
+            const std::wstring& value =
+                GetSectionText(
+                    section
+                );
+
+            if (value.empty())
+                continue;
+
+            if (drew)
+            {
+                DrawFinalSeparator(
+                    hdc,
+                    x,
+                    row,
+                    automaticDividerColor
+                );
+            }
+
+            DrawFinalPiece(
+                hdc,
+                x,
+                row,
+                value,
+                textColor
+            );
+
+            drew =
+                true;
+        }
+
+        geometry.fileDetailsLeft =
+            x;
+
+        if (showFileDetails)
+        {
+            if (drew)
+            {
+                DrawFinalSeparator(
+                    hdc,
+                    x,
+                    row,
+                    automaticDividerColor
+                );
+            }
+
+            DrawFinalPiece(
+                hdc,
+                x,
+                row,
+                fileDetailsGroup,
+                textColor
+            );
+        }
+    }
+    else
+    {
+        const bool cards =
+            settings.style == InfoBarStyle::Cards;
+
+        const int padX =
+            ScaleForWindow(hwnd, cards ? 10 : 12);
+
+        const int gap =
+            ScaleForWindow(hwnd, cards ? 8 : 6);
+
+        // Flat panes should begin flush with the left edge.
+        // Cards keep a tiny 2 px inset so the rounded border isn't clipped.
+        int paneX =
+            cards
+                ? row.left + ScaleForWindow(hwnd, 2)
+                : 0;
+
+        auto DrawBox =
+            [&](const std::wstring& value,
+                COLORREF fill,
+                COLORREF border,
+                COLORREF textColor)
+        {
+            if (value.empty())
+                return;
+
+            int width =
+                MeasureTextWidth(
+                    hdc,
+                    value
+                ) +
+                padX * 2;
+
+            RECT box{
+                paneX,
+                row.top + ScaleForWindow(hwnd, cards ? 3 : 1),
+                paneX + width,
+                row.bottom - ScaleForWindow(hwnd, cards ? 3 : 1)
+            };
+
+            if (box.right > row.right)
+                box.right = row.right;
+
+            if (cards)
+            {
+                HBRUSH fillBrush =
+                    CreateSolidBrush(fill);
+
+                HPEN pen =
+                    CreatePen(
+                        PS_SOLID,
+                        1,
+                        border
+                    );
+
+                if (fillBrush && pen)
+                {
+                    HBRUSH oldBrush =
+                        reinterpret_cast<HBRUSH>(
+                            SelectObject(hdc, fillBrush)
+                        );
+
+                    HPEN oldPen =
+                        reinterpret_cast<HPEN>(
+                            SelectObject(hdc, pen)
+                        );
+
+                    RoundRect(
+                        hdc,
+                        box.left,
+                        box.top,
+                        box.right,
+                        box.bottom,
+                        ScaleForWindow(hwnd, 6),
+                        ScaleForWindow(hwnd, 6)
+                    );
+
+                    SelectObject(hdc, oldPen);
+                    SelectObject(hdc, oldBrush);
+                }
+
+                if (pen)
+                    DeleteObject(pen);
+
+                if (fillBrush)
+                    DeleteObject(fillBrush);
+            }
+            else
+            {
+                HBRUSH fillBrush =
+                    CreateSolidBrush(fill);
+
+                if (fillBrush)
+                {
+                    FillRect(
+                        hdc,
+                        &box,
+                        fillBrush
+                    );
+
+                    DeleteObject(fillBrush);
+                }
+            }
+
+            RECT textRect =
+                box;
+
+            textRect.left += padX;
+            textRect.right -= padX;
+
+            SetTextColor(
+                hdc,
+                textColor
+            );
+
+            DrawTextW_Original(
+                hdc,
+                value.c_str(),
+                -1,
+                &textRect,
+                DT_SINGLELINE |
+                DT_VCENTER |
+                DT_NOPREFIX |
+                DT_END_ELLIPSIS
+            );
+
+            paneX =
+                box.right +
+                gap;
+        };
+
+        for (InfoBarSection section : settings.sectionOrder)
+        {
+            if (!IsSectionEnabled(section))
+                continue;
+
+            geometry.sectionLeft[
+                GetSectionGeometryIndex(section)
+            ] = paneX;
+
+            const std::wstring& value =
+                GetSectionText(
+                    section
+                );
+
+            if (value.empty())
+                continue;
+
+            COLORREF panelColor =
+                contentPanelColor;
+
+            if (section == InfoBarSection::Drive)
+                panelColor = drivePanelColor;
+            else if (section == InfoBarSection::Selection)
+                panelColor = selectionPanelColor;
+
+            DrawBox(
+                value,
+                panelColor,
+                cardBorderColor,
+                textColor
+            );
+        }
+
+        geometry.fileDetailsLeft =
+            paneX;
+
+        if (showFileDetails)
+        {
+            DrawBox(
+                fileDetailsGroup,
+                fileDetailsPanelColor,
+                cardBorderColor,
+                textColor
+            );
+        }
+    }
+
+    StoreLayoutGeometry(
+        geometry
+    );
+
+    if (oldFont)
+    {
+        SelectObject(
+            hdc,
+            oldFont
+        );
+    }
+
+    if (font)
+    {
+        DeleteObject(
+            font
+        );
+    }
+
+    SetTextColor(
+        hdc,
+        oldTextColor
+    );
+
+    SetBkMode(
+        hdc,
+        oldBkMode
+    );
+
+    RestoreDC(
+        hdc,
+        savedDc
+    );
+}
+
+
+enum class DirectUiSubclassResult
+{
+    Failed,
+    AlreadyInstalled,
+    NewlyInstalled
+};
+
+static DirectUiSubclassResult EnsureDirectUiSubclass(
+    HWND hwnd
+)
+{
+    if (
+        !hwnd ||
+        g_unloading.load(
+            std::memory_order_acquire
+        )
+    )
+    {
+        return DirectUiSubclassResult::Failed;
+    }
+
+    DWORD hwndThread =
+        GetWindowThreadProcessId(
+            hwnd,
+            nullptr
+        );
+
+    if (
+        hwndThread !=
+        GetCurrentThreadId()
+    )
+    {
+        Wh_Log(
+            L"DirectUI subclass skipped: wrong thread hwnd=%p hwndTid=%lu currentTid=%lu",
+            hwnd,
+            hwndThread,
+            GetCurrentThreadId()
+        );
+
+        return DirectUiSubclassResult::Failed;
+    }
+
+    AcquireSRWLockExclusive(
+        &g_subclassLock
+    );
+
+    if (
+        g_unloading.load(
+            std::memory_order_acquire
+        )
+    )
+    {
+        ReleaseSRWLockExclusive(
+            &g_subclassLock
+        );
+
+        return DirectUiSubclassResult::Failed;
+    }
+
+    if (
+        std::find_if(
+            g_trackedWindows.begin(),
+            g_trackedWindows.end(),
+            [&](const TrackedDirectUiState& value)
+            {
+                return value.hwnd == hwnd;
+            }
+        ) != g_trackedWindows.end()
+    )
+    {
+        ReleaseSRWLockExclusive(
+            &g_subclassLock
+        );
+
+        return DirectUiSubclassResult::AlreadyInstalled;
+    }
+
+    if (
+        !SetWindowSubclass(
+            hwnd,
+            DirectUiSubclassProc,
+            kDirectUiSubclassId,
+            0
+        )
+    )
+    {
+        ReleaseSRWLockExclusive(
+            &g_subclassLock
+        );
+
+        Wh_Log(
+            L"SetWindowSubclass failed hwnd=%p error=%lu",
+            hwnd,
+            GetLastError()
+        );
+
+        return DirectUiSubclassResult::Failed;
+    }
+
+    try
+    {
+        TrackedDirectUiState state;
+        state.hwnd = hwnd;
+        g_trackedWindows.push_back(
+            std::move(state)
+        );
+    }
+    catch (...)
+    {
+        RemoveWindowSubclass(
+            hwnd,
+            DirectUiSubclassProc,
+            kDirectUiSubclassId
+        );
+
+        ReleaseSRWLockExclusive(
+            &g_subclassLock
+        );
+
+        Wh_Log(
+            L"DirectUI subclass tracking failed hwnd=%p",
+            hwnd
+        );
+
+        return DirectUiSubclassResult::Failed;
+    }
+
+    ReleaseSRWLockExclusive(
+        &g_subclassLock
+    );
+
+    EnsureWindowDataCache(hwnd);
+    EnsureShellBrowserRegistration(hwnd);
+
+    // Run the follow-up invalidation after the native paint that installed us.
+    if (
+        g_refreshDirectUiMessage &&
+        !PostMessageW(
+            hwnd,
+            g_refreshDirectUiMessage,
+            0,
+            0
+        )
+    )
+    {
+        Wh_Log(
+            L"DirectUI initial refresh post failed hwnd=%p error=%lu",
+            hwnd,
+            GetLastError()
+        );
+    }
+
+    return DirectUiSubclassResult::NewlyInstalled;
+}
+
+static LRESULT CALLBACK DirectUiSubclassProc(
+    HWND hwnd,
+    UINT msg,
+    WPARAM wParam,
+    LPARAM lParam,
+    UINT_PTR,
+    DWORD_PTR
+)
+{
+    if (
+        g_refreshDirectUiMessage &&
+        msg == g_refreshDirectUiMessage
+    )
+    {
+        if (!g_unloading.load(std::memory_order_acquire))
+            InvalidateInfoBarWindow(hwnd);
+
+        return 0;
+    }
+
+    if (
+        g_removeDirectUiSubclassMessage &&
+        msg == g_removeDirectUiSubclassMessage
+    )
+    {
+        const DWORD ownerThread =
+            GetWindowThreadProcessId(
+                hwnd,
+                nullptr
+            );
+
+        const BOOL removed =
+            ownerThread == GetCurrentThreadId() &&
+            RemoveWindowSubclass(
+                hwnd,
+                DirectUiSubclassProc,
+                kDirectUiSubclassId
+            );
+
+        if (removed)
+        {
+            const DWORD shellBrowserCookie =
+                GetShellBrowserCookieSnapshot(hwnd);
+
+            EraseWindowDataCache(hwnd);
+            RevokeShellBrowserCookie(shellBrowserCookie);
+
+            RECT row{};
+
+            if (GetBottomStatusRowRect(hwnd, &row))
+            {
+                RedrawWindow(
+                    hwnd,
+                    &row,
+                    nullptr,
+                    RDW_INVALIDATE |
+                    RDW_ERASE
+                );
+            }
+
+            // Untrack last. If the synchronous removal request times out,
+            // teardown keeps treating this HWND as live until all callback
+            // cleanup has finished.
+            AcquireSRWLockExclusive(&g_subclassLock);
+            UntrackDirectUiWindowLocked(hwnd);
+            ReleaseSRWLockExclusive(&g_subclassLock);
+        }
+
+        return removed ? 1 : 0;
+    }
+
+    if (msg == WM_NCDESTROY)
+    {
+        RemoveWindowSubclass(
+            hwnd,
+            DirectUiSubclassProc,
+            kDirectUiSubclassId
+        );
+
+        const DWORD shellBrowserCookie =
+            GetShellBrowserCookieSnapshot(hwnd);
+
+        EraseWindowDataCache(hwnd);
+        RevokeShellBrowserCookie(shellBrowserCookie);
+
+        AcquireSRWLockExclusive(&g_subclassLock);
+        UntrackDirectUiWindowLocked(hwnd);
+        ReleaseSRWLockExclusive(&g_subclassLock);
+
+        return DefSubclassProc(
+            hwnd,
+            msg,
+            wParam,
+            lParam
+        );
+    }
+
+    if (
+        g_unloading.load(
+            std::memory_order_acquire
+        )
+    )
+    {
+        return DefSubclassProc(
+            hwnd,
+            msg,
+            wParam,
+            lParam
+        );
+    }
+
+    if (msg == WM_PAINT)
+    {
+        EnsureWindowDataCache(hwnd);
+        EnsureShellBrowserRegistration(hwnd);
+
+        RECT updateRect{};
+
+        const BOOL hasUpdateRect =
+            GetUpdateRect(
+                hwnd,
+                &updateRect,
+                FALSE
+            );
+
+        // Let DirectUI finish ALL of its own buffered painting first.
+        LRESULT result =
+            DefSubclassProc(
+                hwnd,
+                msg,
+                wParam,
+                lParam
+            );
+
+        HDC hdc =
+            GetDC(hwnd);
+
+        if (hdc)
+        {
+            g_insideFinalPaint =
+                true;
+
+            PaintFinalInfoBar(
+                hdc,
+                hwnd,
+                hasUpdateRect
+                    ? &updateRect
+                    : nullptr
+            );
+
+            g_insideFinalPaint =
+                false;
+
+            ReleaseDC(
+                hwnd,
+                hdc
+            );
+        }
+
+        return result;
+    }
+
+    return DefSubclassProc(
+        hwnd,
+        msg,
+        wParam,
+        lParam
+    );
+}
+
+// ============================================================
+// DrawText marker hook
+// ============================================================
+
+static int WINAPI DrawTextW_Hook(
+    HDC hdc,
+    LPCWSTR text,
+    int count,
+    LPRECT rect,
+    UINT format
+)
+{
+    if (!DrawTextW_Original)
+        return 0;
+
+    if (text)
+    {
+        int length =
+            count;
+
+        if (length < 0)
+        {
+            length =
+                static_cast<int>(
+                    wcslen(text)
+                );
+        }
+
+        if (
+            length > 0 &&
+            length < 512
+        )
+        {
+            if (
+                format == kNativeStatusTextFormat &&
+                ContainsItemToken(
+                    text,
+                    length
+                )
+            )
+            {
+                g_statusSourceDc =
+                    hdc;
+
+                g_statusMarkTick =
+                    GetTickCount64();
+
+                if (rect)
+                    g_statusRowRect = *rect;
+            }
+        }
+    }
+
+    // Important: do not modify the off-screen DirectUI render.
+    return DrawTextW_Original(
+        hdc,
+        text,
+        count,
+        rect,
+        format
+    );
+}
+
+// ============================================================
+// Final DirectUI copy hook
+// ============================================================
+
+static BOOL WINAPI BitBlt_Hook(
+    HDC hdcDest,
+    int xDest,
+    int yDest,
+    int width,
+    int height,
+    HDC hdcSrc,
+    int xSrc,
+    int ySrc,
+    DWORD rop
+)
+{
+    bool relevant =
+        !g_insideFinalPaint &&
+        StatusMarkIsFresh(
+            hdcSrc
+        );
+
+    BOOL result =
+        BitBlt_Original(
+            hdcDest,
+            xDest,
+            yDest,
+            width,
+            height,
+            hdcSrc,
+            xSrc,
+            ySrc,
+            rop
+        );
+
+    if (!relevant)
+        return result;
+
+    HWND hwnd =
+        WindowFromDC(
+            hdcDest
+        );
+
+    if (!IsDirectUiWindow(hwnd))
+        return result;
+
+    if (
+        g_unloading.load(
+            std::memory_order_acquire
+        )
+    )
+    {
+        return result;
+    }
+
+    // This hook runs on DirectUI's UI thread, which is required for subclassing.
+    // Install the subclass here so every future WM_PAINT ends with our row.
+    const DirectUiSubclassResult subclassResult =
+        EnsureDirectUiSubclass(
+            hwnd
+        );
+
+    // The subclass cannot retroactively catch the WM_PAINT that is already
+    // in progress when it is first installed, so finish this current frame
+    // once directly after the relevant BitBlt.
+    if (
+        subclassResult ==
+        DirectUiSubclassResult::NewlyInstalled
+    )
+    {
+        g_insideFinalPaint =
+            true;
+
+        PaintFinalInfoBar(
+            hdcDest,
+            hwnd
+        );
+
+        g_insideFinalPaint =
+            false;
+    }
+
+    return result;
+}
+
+
+// ============================================================
+// Windhawk lifecycle
+// ============================================================
+
+struct ActivateExistingExplorerContext
+{
+    DWORD pid;
+};
+
+static BOOL CALLBACK ActivateDirectUiChildProc(
+    HWND hwnd,
+    LPARAM lParam
+)
+{
+    auto* context =
+        reinterpret_cast<ActivateExistingExplorerContext*>(
+            lParam
+        );
+
+    if (
+        g_unloading.load(std::memory_order_acquire) ||
+        !IsWindowVisible(hwnd)
+    )
+    {
+        return TRUE;
+    }
+
+    DWORD pid = 0;
+
+    GetWindowThreadProcessId(
+        hwnd,
+        &pid
+    );
+
+    if (pid != context->pid)
+        return TRUE;
+
+    wchar_t className[128] = {};
+
+    if (
+        GetClassNameW(
+            hwnd,
+            className,
+            ARRAYSIZE(className)
+        ) &&
+        wcscmp(className, L"DirectUIHWND") == 0
+    )
+    {
+        // The resulting native paint reaches BitBlt_Hook on this window's UI
+        // thread, where the existing correlation safely selects the target.
+        InvalidateInfoBarWindow(hwnd);
+    }
+
+    return TRUE;
+}
+
+static BOOL CALLBACK ActivateExistingExplorerProc(
+    HWND hwnd,
+    LPARAM lParam
+)
+{
+    auto* context =
+        reinterpret_cast<ActivateExistingExplorerContext*>(
+            lParam
+        );
+
+    if (g_unloading.load(std::memory_order_acquire))
+        return FALSE;
+
+    DWORD pid = 0;
+
+    GetWindowThreadProcessId(
+        hwnd,
+        &pid
+    );
+
+    if (
+        pid != context->pid ||
+        !IsWindowVisible(hwnd)
+    )
+    {
+        return TRUE;
+    }
+
+    wchar_t className[128] = {};
+
+    if (
+        !GetClassNameW(
+            hwnd,
+            className,
+            ARRAYSIZE(className)
+        ) ||
+        wcscmp(className, L"CabinetWClass") != 0
+    )
+    {
+        return TRUE;
+    }
+
+    EnumChildWindows(
+        hwnd,
+        ActivateDirectUiChildProc,
+        lParam
+    );
+
+    return TRUE;
+}
+
+BOOL Wh_ModInit()
+{
+    g_unloading.store(
+        false,
+        std::memory_order_release
+    );
+
+    g_pid =
+        GetCurrentProcessId();
+
+    Wh_Log(
+        L"========== Explorer Info Bar INIT PID=%lu ==========",
+        g_pid
+    );
+
+    InitializeCriticalSection(
+        &g_cacheLock
+    );
+
+    g_removeDirectUiSubclassMessage =
+        RegisterWindowMessageW(
+            L"Windhawk_ExplorerInfoBar_RemoveDirectUiSubclass"
+        );
+
+    g_refreshDirectUiMessage =
+        RegisterWindowMessageW(
+            L"Windhawk_ExplorerInfoBar_RefreshDirectUi"
+        );
+
+    if (
+        !g_removeDirectUiSubclassMessage ||
+        !g_refreshDirectUiMessage
+    )
+    {
+        Wh_Log(
+            L"DirectUI message registration failed error=%lu",
+            GetLastError()
+        );
+
+        DeleteCriticalSection(
+            &g_cacheLock
+        );
+
+        return FALSE;
+    }
+
+    LoadSettings();
+
+    HMODULE user32 =
+        GetModuleHandleW(
+            L"user32.dll"
+        );
+
+    HMODULE gdi32 =
+        GetModuleHandleW(
+            L"gdi32.dll"
+        );
+
+    if (!user32 || !gdi32)
+    {
+        Wh_Log(
+            L"required system module not loaded"
+        );
+
+        DeleteCriticalSection(
+            &g_cacheLock
+        );
+
+        return FALSE;
+    }
+
+    void* drawTextTarget =
+        reinterpret_cast<void*>(
+            GetProcAddress(
+                user32,
+                "DrawTextW"
+            )
+        );
+
+    void* bitBltTarget =
+        reinterpret_cast<void*>(
+            GetProcAddress(
+                gdi32,
+                "BitBlt"
+            )
+        );
+
+    if (!drawTextTarget || !bitBltTarget)
+    {
+        Wh_Log(
+            L"required GDI targets not found"
+        );
+
+        DeleteCriticalSection(
+            &g_cacheLock
+        );
+
+        return FALSE;
+    }
+
+    if (
+        !Wh_SetFunctionHook(
+            drawTextTarget,
+            reinterpret_cast<void*>(
+                DrawTextW_Hook
+            ),
+            reinterpret_cast<void**>(
+                &DrawTextW_Original
+            )
+        )
+    )
+    {
+        Wh_Log(
+            L"DrawTextW hook failed"
+        );
+
+        DeleteCriticalSection(
+            &g_cacheLock
+        );
+
+        return FALSE;
+    }
+
+    if (
+        !Wh_SetFunctionHook(
+            bitBltTarget,
+            reinterpret_cast<void*>(
+                BitBlt_Hook
+            ),
+            reinterpret_cast<void**>(
+                &BitBlt_Original
+            )
+        )
+    )
+    {
+        Wh_Log(
+            L"BitBlt hook failed"
+        );
+
+        DeleteCriticalSection(
+            &g_cacheLock
+        );
+
+        return FALSE;
+    }
+
+    g_stopEvent =
+        CreateEventW(
+            nullptr,
+            TRUE,
+            FALSE,
+            nullptr
+        );
+
+    if (!g_stopEvent)
+    {
+        Wh_Log(
+            L"stop event creation failed error=%lu",
+            GetLastError()
+        );
+
+        DeleteCriticalSection(
+            &g_cacheLock
+        );
+
+        return FALSE;
+    }
+
+    g_workerWakeEvent =
+        CreateEventW(
+            nullptr,
+            FALSE,
+            FALSE,
+            nullptr
+        );
+
+    if (!g_workerWakeEvent)
+    {
+        Wh_Log(
+            L"worker wake event creation failed error=%lu",
+            GetLastError()
+        );
+
+        CloseHandle(g_stopEvent);
+        g_stopEvent = nullptr;
+        DeleteCriticalSection(&g_cacheLock);
+        return FALSE;
+    }
+
+    g_workerThread =
+        CreateThread(
+            nullptr,
+            0,
+            WorkerThreadProc,
+            nullptr,
+            0,
+            &g_workerThreadId
+        );
+
+    if (!g_workerThread)
+    {
+        Wh_Log(
+            L"worker creation failed error=%lu",
+            GetLastError()
+        );
+
+        CloseHandle(
+            g_stopEvent
+        );
+
+        g_stopEvent =
+            nullptr;
+
+        CloseHandle(g_workerWakeEvent);
+        g_workerWakeEvent = nullptr;
+        g_workerThreadId = 0;
+
+        DeleteCriticalSection(
+            &g_cacheLock
+        );
+
+        return FALSE;
+    }
+
+    Wh_Log(
+        L"Explorer Info Bar ready"
+    );
+
+    return TRUE;
+}
+
+
+void Wh_ModAfterInit()
+{
+    ActivateExistingExplorerContext context{
+        g_pid
+    };
+
+    EnumWindows(
+        ActivateExistingExplorerProc,
+        reinterpret_cast<LPARAM>(
+            &context
+        )
+    );
+
+}
+
+
+void Wh_ModSettingsChanged()
+{
+    LoadSettings();
+
+    if (g_workerWakeEvent)
+        SetEvent(g_workerWakeEvent);
+
+    RefreshInfoBars();
+}
+
+void Wh_ModBeforeUninit()
+{
+    g_unloading.store(
+        true,
+        std::memory_order_release
+    );
+
+    if (g_stopEvent)
+        SetEvent(g_stopEvent);
+
+    if (g_workerThreadId)
+        CoCancelCall(g_workerThreadId, 0);
+
+    // A subclass callback points into this module, so unload must not proceed
+    // until every subclass is removed and any timed-out removal callback has
+    // returned to its owning UI thread.
+    ULONGLONG lastWaitLogTick = 0;
+
+    while (true)
+    {
+        HWND hwnd = nullptr;
+
+        AcquireSRWLockShared(&g_subclassLock);
+
+        if (!g_trackedWindows.empty())
+            hwnd = g_trackedWindows.front().hwnd;
+
+        ReleaseSRWLockShared(&g_subclassLock);
+
+        if (!hwnd)
+            break;
+
+        while (true)
+        {
+            const DWORD ownerThread =
+                GetWindowThreadProcessId(
+                    hwnd,
+                    nullptr
+                );
+
+            if (!ownerThread || !IsWindow(hwnd))
+            {
+                AcquireSRWLockExclusive(&g_subclassLock);
+                const DWORD shellBrowserCookie =
+                    UntrackDirectUiWindowLocked(hwnd);
+                ReleaseSRWLockExclusive(&g_subclassLock);
+
+                EraseWindowDataCache(hwnd);
+                RevokeShellBrowserCookie(shellBrowserCookie);
+                break;
+            }
+
+            DWORD_PTR removalResult = 0;
+            SetLastError(ERROR_SUCCESS);
+
+            const LRESULT sent =
+                SendMessageTimeoutW(
+                    hwnd,
+                    g_removeDirectUiSubclassMessage,
+                    0,
+                    0,
+                    SMTO_ABORTIFHUNG |
+                    SMTO_BLOCK |
+                    SMTO_ERRORONEXIT,
+                    kSubclassRemovalTimeoutMs,
+                    &removalResult
+                );
+
+            if (sent && removalResult == 1)
+            {
+                // SendMessageTimeout returned only after the owner-thread
+                // callback returned, so this HWND is safe to forget.
+                break;
+            }
+
+            bool stillTracked = false;
+
+            AcquireSRWLockShared(&g_subclassLock);
+
+            stillTracked =
+                std::find_if(
+                    g_trackedWindows.begin(),
+                    g_trackedWindows.end(),
+                    [&](const TrackedDirectUiState& value)
+                    {
+                        return value.hwnd == hwnd;
+                    }
+                ) != g_trackedWindows.end();
+
+            ReleaseSRWLockShared(&g_subclassLock);
+
+            if (!stillTracked)
+            {
+                // The removal callback can finish after SendMessageTimeout
+                // gives up. A synchronous no-op message is a UI-thread
+                // barrier: once it returns, that earlier callback has returned.
+                while (IsWindow(hwnd))
+                {
+                    DWORD_PTR barrierResult = 0;
+
+                    const LRESULT barrierSent =
+                        SendMessageTimeoutW(
+                            hwnd,
+                            WM_NULL,
+                            0,
+                            0,
+                            SMTO_ABORTIFHUNG |
+                            SMTO_BLOCK |
+                            SMTO_ERRORONEXIT,
+                            kSubclassRemovalTimeoutMs,
+                            &barrierResult
+                        );
+
+                    if (barrierSent)
+                        break;
+
+                    Sleep(25);
+                }
+
+                break;
+            }
+
+            const ULONGLONG now = GetTickCount64();
+
+            if (
+                lastWaitLogTick == 0 ||
+                now - lastWaitLogTick >= 2000
+            )
+            {
+                Wh_Log(
+                    L"Waiting for DirectUI subclass removal hwnd=%p "
+                    L"ownerTid=%lu error=%lu",
+                    hwnd,
+                    ownerThread,
+                    GetLastError()
+                );
+
+                lastWaitLogTick = now;
+            }
+
+            Sleep(25);
+        }
+    }
+
+    Wh_Log(L"Explorer Info Bar subclass teardown complete");
+}
+
+void Wh_ModUninit()
+{
+    if (g_stopEvent)
+    {
+        SetEvent(
+            g_stopEvent
+        );
+    }
+
+    if (g_workerThreadId)
+        CoCancelCall(g_workerThreadId, 0);
+
+    if (g_workerThread)
+    {
+        // The cache and COM state must outlive the worker. Wait until the
+        // worker has fully stopped before releasing shared resources.
+        WaitForSingleObject(
+            g_workerThread,
+            INFINITE
+        );
+
+        CloseHandle(
+            g_workerThread
+        );
+
+        g_workerThread =
+            nullptr;
+
+        g_workerThreadId = 0;
+    }
+
+    if (g_stopEvent)
+    {
+        CloseHandle(
+            g_stopEvent
+        );
+
+        g_stopEvent =
+            nullptr;
+    }
+
+    if (g_workerWakeEvent)
+    {
+        CloseHandle(g_workerWakeEvent);
+        g_workerWakeEvent = nullptr;
+    }
+
+    DeleteCriticalSection(
+        &g_cacheLock
+    );
+
+    Wh_Log(
+        L"========== Explorer Info Bar UNINIT PID=%lu ==========",
+        g_pid
+    );
+}

--- a/mods/explorer-info-bar.wh.cpp
+++ b/mods/explorer-info-bar.wh.cpp
@@ -160,46 +160,12 @@ When one file is selected, additional details can appear:
 
 #define CWM_GETISHELLBROWSER (WM_USER + 7)
 
-static constexpr UINT kNativeStatusTextFormat = 0x00000824;
 static constexpr int kStatusRowHeight = 24;
-static constexpr ULONGLONG kStatusMarkerLifetimeMs = 250;
 static constexpr DWORD kInitialRefreshDelayMs = 1000;
 static constexpr DWORD kRefreshIntervalMs = 10000;
 static constexpr ULONGLONG kContentFailedRetryMs = 2000;
 static constexpr ULONGLONG kMetadataRetryMs = 5000;
 
-// ============================================================
-// DrawText hook
-// ============================================================
-
-using DrawTextW_t = int (WINAPI*)(
-    HDC,
-    LPCWSTR,
-    int,
-    LPRECT,
-    UINT
-);
-
-static DrawTextW_t DrawTextW_Original = nullptr;
-
-using BitBlt_t = BOOL (WINAPI*)(
-    HDC,
-    int,
-    int,
-    int,
-    int,
-    HDC,
-    int,
-    int,
-    DWORD
-);
-
-static BitBlt_t BitBlt_Original = nullptr;
-
-// Correlate Explorer's buffered status render with the final DirectUIHWND copy.
-thread_local HDC g_statusSourceDc = nullptr;
-thread_local ULONGLONG g_statusMarkTick = 0;
-thread_local RECT g_statusRowRect{};
 thread_local bool g_insideFinalPaint = false;
 
 static std::atomic<bool> g_unloading{false};
@@ -257,6 +223,7 @@ struct TrackedDirectUiState
 };
 
 static std::vector<TrackedDirectUiState> g_trackedWindows;
+static std::vector<HWND> g_installingDirectUiWindows;
 
 struct ColorOverride
 {
@@ -301,6 +268,8 @@ static LRESULT CALLBACK DirectUiSubclassProc(
     DWORD_PTR
 );
 
+static void TryAttachExplorerDirectUiWindow(HWND hwnd);
+
 // ============================================================
 // State
 // ============================================================
@@ -311,7 +280,11 @@ static HANDLE g_workerThread = nullptr;
 static DWORD g_workerThreadId = 0;
 static HANDLE g_stopEvent = nullptr;
 static HANDLE g_workerWakeEvent = nullptr;
+static HANDLE g_selectionWinEventThread = nullptr;
+static HANDLE g_selectionWinEventThreadReady = nullptr;
+static HANDLE g_selectionWinEventStopEvent = nullptr;
 static HWINEVENTHOOK g_selectionWinEventHook = nullptr;
+static HWINEVENTHOOK g_windowCreateWinEventHook = nullptr;
 static std::atomic<ULONGLONG> g_selectionGeneration{1};
 static std::atomic<ULONGLONG> g_lastPaintWakeTick{0};
 
@@ -1899,32 +1872,6 @@ static bool GetValidatedStatusRow(
     return found;
 }
 
-static void SetValidatedStatusRow(
-    HWND hwnd,
-    const RECT& row
-)
-{
-    AcquireSRWLockExclusive(&g_subclassLock);
-
-    const auto existing =
-        std::find_if(
-            g_trackedWindows.begin(),
-            g_trackedWindows.end(),
-            [&](const TrackedDirectUiState& value)
-            {
-                return value.hwnd == hwnd;
-            }
-        );
-
-    if (existing != g_trackedWindows.end())
-    {
-        existing->validatedStatusRow = row;
-        existing->hasValidatedStatusRow = true;
-    }
-
-    ReleaseSRWLockExclusive(&g_subclassLock);
-}
-
 static void WakeWorkerFromPaint()
 {
     if (!g_workerWakeEvent)
@@ -1960,7 +1907,9 @@ static void CALLBACK SelectionWinEventProc(
 )
 {
     if (
-        event < EVENT_OBJECT_SELECTION ||
+        // A one-item A -> B transition can be focus-only, with no selection
+        // count change and no EVENT_OBJECT_SELECTION-family notification.
+        event < EVENT_OBJECT_FOCUS ||
         event > EVENT_OBJECT_SELECTIONWITHIN ||
         g_unloading.load(std::memory_order_acquire)
     )
@@ -1972,6 +1921,158 @@ static void CALLBACK SelectionWinEventProc(
 
     if (g_workerWakeEvent)
         SetEvent(g_workerWakeEvent);
+}
+
+static void CALLBACK ExplorerObjectCreateWinEventProc(
+    HWINEVENTHOOK,
+    DWORD event,
+    HWND hwnd,
+    LONG idObject,
+    LONG,
+    DWORD,
+    DWORD
+)
+{
+    if (
+        event != EVENT_OBJECT_CREATE ||
+        idObject != OBJID_WINDOW ||
+        !hwnd ||
+        g_unloading.load(std::memory_order_acquire)
+    )
+    {
+        return;
+    }
+
+    TryAttachExplorerDirectUiWindow(hwnd);
+}
+
+static DWORD WINAPI SelectionWinEventThreadProc(
+    LPVOID
+)
+{
+    // WINEVENT_OUTOFCONTEXT callbacks are delivered on the thread that
+    // installed the hook, so this thread owns the hook and its message pump.
+    MSG msg{};
+    PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+
+    g_selectionWinEventHook =
+        SetWinEventHook(
+            EVENT_OBJECT_FOCUS,
+            EVENT_OBJECT_SELECTIONWITHIN,
+            nullptr,
+            SelectionWinEventProc,
+            g_pid,
+            0,
+            WINEVENT_OUTOFCONTEXT
+        );
+
+    if (!g_selectionWinEventHook)
+    {
+        Wh_Log(
+            L"selection WinEvent hook failed error=%lu",
+            GetLastError()
+        );
+    }
+
+    g_windowCreateWinEventHook =
+        SetWinEventHook(
+            EVENT_OBJECT_CREATE,
+            EVENT_OBJECT_CREATE,
+            nullptr,
+            ExplorerObjectCreateWinEventProc,
+            g_pid,
+            0,
+            WINEVENT_OUTOFCONTEXT
+        );
+
+    if (!g_windowCreateWinEventHook)
+    {
+        Wh_Log(
+            L"Explorer window-create WinEvent hook failed error=%lu",
+            GetLastError()
+        );
+    }
+
+    SetEvent(g_selectionWinEventThreadReady);
+
+    if (
+        !g_selectionWinEventHook &&
+        !g_windowCreateWinEventHook
+    )
+    {
+        return 1;
+    }
+
+    bool quit = false;
+
+    while (!quit)
+    {
+        const DWORD waitResult =
+            MsgWaitForMultipleObjectsEx(
+                1,
+                &g_selectionWinEventStopEvent,
+                INFINITE,
+                QS_ALLINPUT,
+                MWMO_INPUTAVAILABLE
+            );
+
+        if (waitResult == WAIT_OBJECT_0)
+        {
+            break;
+        }
+        else if (waitResult == WAIT_OBJECT_0 + 1)
+        {
+            while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
+            {
+                if (msg.message == WM_QUIT)
+                {
+                    quit = true;
+                    break;
+                }
+
+                TranslateMessage(&msg);
+                DispatchMessageW(&msg);
+            }
+        }
+        else
+        {
+            Wh_Log(
+                L"WinEvent helper message wait failed result=%lu error=%lu",
+                waitResult,
+                GetLastError()
+            );
+
+            break;
+        }
+    }
+
+    // Both hooks are installed, pumped and removed by this same owning thread.
+    if (g_windowCreateWinEventHook)
+    {
+        UnhookWinEvent(g_windowCreateWinEventHook);
+        g_windowCreateWinEventHook = nullptr;
+    }
+
+    if (g_selectionWinEventHook)
+    {
+        UnhookWinEvent(g_selectionWinEventHook);
+        g_selectionWinEventHook = nullptr;
+    }
+
+    return 0;
+}
+
+static void StopSelectionWinEventThread()
+{
+    if (g_selectionWinEventThread)
+    {
+        if (g_selectionWinEventStopEvent)
+            SetEvent(g_selectionWinEventStopEvent);
+
+        WaitForSingleObject(g_selectionWinEventThread, INFINITE);
+        CloseHandle(g_selectionWinEventThread);
+        g_selectionWinEventThread = nullptr;
+    }
 }
 
 static bool EnsureWindowDataCache(
@@ -2713,10 +2814,22 @@ static unsigned ReadCurrentView(
             const bool folderChanged =
                 contentCache.folderIdentity != state.contentRefresh.folderIdentity;
 
+            // A one-item selection needs an identity-sensitive fallback:
+            // arrowing to another item keeps the count at one. Re-enumerate
+            // that single item on the existing worker refresh cadence so a
+            // missed/failed WinEvent cannot leave size or metadata stale.
+            const bool singleSelectionFallback =
+                selectionCount == 1 &&
+                (
+                    settings.showSelection ||
+                    settings.singleFileDetails
+                );
+
             const bool selectionDirty =
                 selectionGeneration != state.selectionGeneration ||
                 selected != state.selected ||
-                folderChanged;
+                folderChanged ||
+                singleSelectionFallback;
 
             const bool enumerateSelection =
                 selectionDirty &&
@@ -3118,54 +3231,51 @@ static bool IsExplorerDirectUiTarget(HWND hwnd)
     if (!IsDirectUiWindow(hwnd))
         return false;
 
-    HWND current = GetParent(hwnd);
-    bool sawDuiView = false;
-    bool sawShellTab = false;
-
-    while (current)
-    {
-        wchar_t cls[128] = {};
-        if (GetClassNameW(current, cls, ARRAYSIZE(cls)))
+    const auto hasClass =
+        [](HWND window, PCWSTR expected)
         {
-            if (!sawDuiView && wcscmp(cls, L"DUIViewWndClassName") == 0)
-                sawDuiView = true;
-            else if (sawDuiView && wcscmp(cls, L"ShellTabWindowClass") == 0)
-                sawShellTab = true;
-            else if (sawShellTab && wcscmp(cls, L"CabinetWClass") == 0)
-            {
-                DWORD pid = 0;
-                GetWindowThreadProcessId(current, &pid);
-                return pid == g_pid;
-            }
-        }
+            wchar_t cls[128] = {};
 
-        current = GetParent(current);
-    }
+            return
+                window &&
+                GetClassNameW(window, cls, ARRAYSIZE(cls)) &&
+                wcscmp(cls, expected) == 0;
+        };
 
-    return false;
-}
-
-static bool StatusMarkIsFresh(
-    HDC source
-)
-{
-    if (!g_statusSourceDc)
-        return false;
-
-    ULONGLONG now =
-        GetTickCount64();
+    const HWND duiView = GetParent(hwnd);
+    const HWND shellTab = duiView ? GetParent(duiView) : nullptr;
+    const HWND cabinet = shellTab ? GetParent(shellTab) : nullptr;
 
     if (
-        now - g_statusMarkTick >
-        kStatusMarkerLifetimeMs
+        !hasClass(duiView, L"DUIViewWndClassName") ||
+        !hasClass(shellTab, L"ShellTabWindowClass") ||
+        !hasClass(cabinet, L"CabinetWClass") ||
+        GetAncestor(hwnd, GA_ROOT) != cabinet
     )
     {
-        g_statusSourceDc = nullptr;
         return false;
     }
 
-    return source ==
-        g_statusSourceDc;
+    DWORD targetPid = 0;
+    const DWORD targetThread =
+        GetWindowThreadProcessId(hwnd, &targetPid);
+
+    const auto matchesTargetOwner =
+        [&](HWND window)
+        {
+            DWORD pid = 0;
+
+            return
+                GetWindowThreadProcessId(window, &pid) == targetThread &&
+                pid == targetPid;
+        };
+
+    return
+        targetThread != 0 &&
+        targetPid == g_pid &&
+        matchesTargetOwner(duiView) &&
+        matchesTargetOwner(shellTab) &&
+        matchesTargetOwner(cabinet);
 }
 
 static int MeasureTextWidth(
@@ -3333,7 +3443,7 @@ static void DrawFinalPiece(
         color
     );
 
-    DrawTextW_Original(
+    DrawTextW(
         hdc,
         text.c_str(),
         -1,
@@ -3505,9 +3615,8 @@ static void PaintFinalInfoBar(
 
     RECT row{};
 
-    // Only use a status-row rect after BitBlt_Hook validated it for this
-    // specific DirectUIHWND. Never paint from an unvalidated thread-local
-    // DrawText candidate.
+    // Structural attachment doesn't supply a native-copy row rectangle, so
+    // new targets use the geometric fallback below.
     const bool hasValidatedRow =
         GetValidatedStatusRow(
             hwnd,
@@ -3967,7 +4076,7 @@ static void PaintFinalInfoBar(
                 textColor
             );
 
-            DrawTextW_Original(
+            DrawTextW(
                 hdc,
                 value.c_str(),
                 -1,
@@ -4078,33 +4187,12 @@ static DirectUiSubclassResult EnsureDirectUiSubclass(
 )
 {
     if (
-        !hwnd ||
+        !IsExplorerDirectUiTarget(hwnd) ||
         g_unloading.load(
             std::memory_order_acquire
         )
     )
     {
-        return DirectUiSubclassResult::Failed;
-    }
-
-    DWORD hwndThread =
-        GetWindowThreadProcessId(
-            hwnd,
-            nullptr
-        );
-
-    if (
-        hwndThread !=
-        GetCurrentThreadId()
-    )
-    {
-        Wh_Log(
-            L"DirectUI subclass skipped: wrong thread hwnd=%p hwndTid=%lu currentTid=%lu",
-            hwnd,
-            hwndThread,
-            GetCurrentThreadId()
-        );
-
         return DirectUiSubclassResult::Failed;
     }
 
@@ -4144,6 +4232,33 @@ static DirectUiSubclassResult EnsureDirectUiSubclass(
     }
 
     if (
+        std::find(
+            g_installingDirectUiWindows.begin(),
+            g_installingDirectUiWindows.end(),
+            hwnd
+        ) != g_installingDirectUiWindows.end()
+    )
+    {
+        ReleaseSRWLockExclusive(&g_subclassLock);
+        return DirectUiSubclassResult::AlreadyInstalled;
+    }
+
+    try
+    {
+        g_installingDirectUiWindows.push_back(hwnd);
+    }
+    catch (...)
+    {
+        ReleaseSRWLockExclusive(&g_subclassLock);
+        Wh_Log(L"DirectUI install tracking failed hwnd=%p", hwnd);
+        return DirectUiSubclassResult::Failed;
+    }
+
+    // Never hold g_subclassLock while the utility synchronously marshals the
+    // actual SetWindowSubclass call to the HWND's owning Explorer UI thread.
+    ReleaseSRWLockExclusive(&g_subclassLock);
+
+    if (
         !WindhawkUtils::SetWindowSubclassFromAnyThread(
             hwnd,
             DirectUiSubclassProc,
@@ -4151,9 +4266,16 @@ static DirectUiSubclassResult EnsureDirectUiSubclass(
         )
     )
     {
-        ReleaseSRWLockExclusive(
-            &g_subclassLock
+        AcquireSRWLockExclusive(&g_subclassLock);
+        g_installingDirectUiWindows.erase(
+            std::remove(
+                g_installingDirectUiWindows.begin(),
+                g_installingDirectUiWindows.end(),
+                hwnd
+            ),
+            g_installingDirectUiWindows.end()
         );
+        ReleaseSRWLockExclusive(&g_subclassLock);
 
         Wh_Log(
             L"DirectUI subclass install failed hwnd=%p error=%lu",
@@ -4164,41 +4286,58 @@ static DirectUiSubclassResult EnsureDirectUiSubclass(
         return DirectUiSubclassResult::Failed;
     }
 
-    try
-    {
-        TrackedDirectUiState state;
-        state.hwnd = hwnd;
-        g_trackedWindows.push_back(
-            std::move(state)
+    bool keepInstalled = false;
+    bool trackingFailed = false;
+
+    AcquireSRWLockExclusive(&g_subclassLock);
+
+    const auto installing =
+        std::find(
+            g_installingDirectUiWindows.begin(),
+            g_installingDirectUiWindows.end(),
+            hwnd
         );
+
+    if (
+        installing != g_installingDirectUiWindows.end() &&
+        !g_unloading.load(std::memory_order_acquire)
+    )
+    {
+        try
+        {
+            TrackedDirectUiState state;
+            state.hwnd = hwnd;
+            g_trackedWindows.push_back(std::move(state));
+            keepInstalled = true;
+        }
+        catch (...)
+        {
+            trackingFailed = true;
+        }
     }
-    catch (...)
+
+    if (installing != g_installingDirectUiWindows.end())
+        g_installingDirectUiWindows.erase(installing);
+
+    ReleaseSRWLockExclusive(&g_subclassLock);
+
+    if (!keepInstalled)
     {
         WindhawkUtils::RemoveWindowSubclassFromAnyThread(
             hwnd,
             DirectUiSubclassProc
         );
 
-        ReleaseSRWLockExclusive(
-            &g_subclassLock
-        );
-
-        Wh_Log(
-            L"DirectUI subclass tracking failed hwnd=%p",
-            hwnd
-        );
+        if (trackingFailed)
+            Wh_Log(L"DirectUI subclass tracking failed hwnd=%p", hwnd);
 
         return DirectUiSubclassResult::Failed;
     }
 
-    ReleaseSRWLockExclusive(
-        &g_subclassLock
-    );
-
     EnsureWindowDataCache(hwnd);
     EnsureShellBrowserRegistration(hwnd);
 
-    // Run the follow-up invalidation after the native paint that installed us.
+    // Defer the first invalidation to the DirectUI owning thread.
     if (
         g_refreshDirectUiMessage &&
         !PostMessageW(
@@ -4217,6 +4356,12 @@ static DirectUiSubclassResult EnsureDirectUiSubclass(
     }
 
     return DirectUiSubclassResult::NewlyInstalled;
+}
+
+static void TryAttachExplorerDirectUiWindow(HWND hwnd)
+{
+    if (IsExplorerDirectUiTarget(hwnd))
+        EnsureDirectUiSubclass(hwnd);
 }
 
 static LRESULT CALLBACK DirectUiSubclassProc(
@@ -4248,6 +4393,14 @@ static LRESULT CALLBACK DirectUiSubclassProc(
 
         AcquireSRWLockExclusive(&g_subclassLock);
         UntrackDirectUiWindowLocked(hwnd);
+        g_installingDirectUiWindows.erase(
+            std::remove(
+                g_installingDirectUiWindows.begin(),
+                g_installingDirectUiWindows.end(),
+                hwnd
+            ),
+            g_installingDirectUiWindows.end()
+        );
         ReleaseSRWLockExclusive(&g_subclassLock);
 
         return DefSubclassProc(
@@ -4333,227 +4486,27 @@ static LRESULT CALLBACK DirectUiSubclassProc(
 }
 
 // ============================================================
-// DrawText marker hook
-// ============================================================
-
-static int WINAPI DrawTextW_Hook(
-    HDC hdc,
-    LPCWSTR text,
-    int count,
-    LPRECT rect,
-    UINT format
-)
-{
-    if (!DrawTextW_Original)
-        return 0;
-
-    // Language-independent marker: Explorer's native information row uses a
-    // distinctive DrawText format. Don't inspect the localized text at all.
-    // The BitBlt hook below performs the decisive validation by mapping this
-    // source rect into the destination DirectUIHWND and requiring it to land
-    // at the bottom of that Explorer view.
-    if (
-        !g_insideFinalPaint &&
-        rect &&
-        format == kNativeStatusTextFormat &&
-        rect->bottom > rect->top &&
-        rect->right > rect->left
-    )
-    {
-        g_statusSourceDc = hdc;
-        g_statusMarkTick = GetTickCount64();
-        g_statusRowRect = *rect;
-    }
-
-    return DrawTextW_Original(
-        hdc,
-        text,
-        count,
-        rect,
-        format
-    );
-}
-
-// ============================================================
-// Final DirectUI copy hook
-// ============================================================
-
-static BOOL WINAPI BitBlt_Hook(
-    HDC hdcDest,
-    int xDest,
-    int yDest,
-    int width,
-    int height,
-    HDC hdcSrc,
-    int xSrc,
-    int ySrc,
-    DWORD rop
-)
-{
-    bool relevant =
-        !g_insideFinalPaint &&
-        StatusMarkIsFresh(
-            hdcSrc
-        );
-
-    BOOL result =
-        BitBlt_Original(
-            hdcDest,
-            xDest,
-            yDest,
-            width,
-            height,
-            hdcSrc,
-            xSrc,
-            ySrc,
-            rop
-        );
-
-    if (!relevant)
-        return result;
-
-    HWND hwnd =
-        WindowFromDC(
-            hdcDest
-        );
-
-    if (!IsExplorerDirectUiTarget(hwnd))
-        return result;
-
-    // Map the candidate source text rect into destination coordinates and only
-    // accept it when it actually lands on Explorer's bottom information row.
-    RECT client{};
-    if (!GetClientRect(hwnd, &client))
-        return result;
-
-    RECT mappedRow = g_statusRowRect;
-    mappedRow.top = yDest + (g_statusRowRect.top - ySrc);
-    mappedRow.bottom = yDest + (g_statusRowRect.bottom - ySrc);
-    mappedRow.left = xDest + (g_statusRowRect.left - xSrc);
-    mappedRow.right = xDest + (g_statusRowRect.right - xSrc);
-
-    const int rowHeight = mappedRow.bottom - mappedRow.top;
-    const int expectedHeight = ScaleForWindow(hwnd, kStatusRowHeight);
-    const int bottomTolerance = ScaleForWindow(hwnd, 4);
-
-    if (
-        rowHeight < ScaleForWindow(hwnd, 16) ||
-        rowHeight > ScaleForWindow(hwnd, 34) ||
-        std::abs(mappedRow.bottom - client.bottom) > bottomTolerance ||
-        std::abs(rowHeight - expectedHeight) > ScaleForWindow(hwnd, 10)
-    )
-    {
-        return result;
-    }
-
-    SetValidatedStatusRow(hwnd, mappedRow);
-
-    if (
-        g_unloading.load(
-            std::memory_order_acquire
-        )
-    )
-    {
-        return result;
-    }
-
-    // This hook runs on DirectUI's UI thread, which is required for subclassing.
-    // Install the subclass here so every future WM_PAINT ends with our row.
-    const DirectUiSubclassResult subclassResult =
-        EnsureDirectUiSubclass(
-            hwnd
-        );
-
-    // The subclass cannot retroactively catch the WM_PAINT that is already
-    // in progress when it is first installed, so finish this current frame
-    // once directly after the relevant BitBlt.
-    if (
-        subclassResult ==
-        DirectUiSubclassResult::NewlyInstalled
-    )
-    {
-        g_insideFinalPaint =
-            true;
-
-        PaintFinalInfoBar(
-            hdcDest,
-            hwnd
-        );
-
-        g_insideFinalPaint =
-            false;
-    }
-
-    return result;
-}
-
-
-// ============================================================
 // Windhawk lifecycle
 // ============================================================
 
-struct ActivateExistingExplorerContext
-{
-    DWORD pid;
-};
-
-static BOOL CALLBACK ActivateDirectUiChildProc(
+static BOOL CALLBACK DiscoverDirectUiChildProc(
     HWND hwnd,
-    LPARAM lParam
+    LPARAM
 )
 {
-    auto* context =
-        reinterpret_cast<ActivateExistingExplorerContext*>(
-            lParam
-        );
+    if (g_unloading.load(std::memory_order_acquire))
+        return FALSE;
 
-    if (
-        g_unloading.load(std::memory_order_acquire) ||
-        !IsWindowVisible(hwnd)
-    )
-    {
-        return TRUE;
-    }
-
-    DWORD pid = 0;
-
-    GetWindowThreadProcessId(
-        hwnd,
-        &pid
-    );
-
-    if (pid != context->pid)
-        return TRUE;
-
-    wchar_t className[128] = {};
-
-    if (
-        GetClassNameW(
-            hwnd,
-            className,
-            ARRAYSIZE(className)
-        ) &&
-        wcscmp(className, L"DirectUIHWND") == 0
-    )
-    {
-        // The resulting native paint reaches BitBlt_Hook on this window's UI
-        // thread, where the existing correlation safely selects the target.
-        InvalidateInfoBarWindow(hwnd);
-    }
+    TryAttachExplorerDirectUiWindow(hwnd);
 
     return TRUE;
 }
 
-static BOOL CALLBACK ActivateExistingExplorerProc(
+static BOOL CALLBACK DiscoverExistingExplorerWindowProc(
     HWND hwnd,
-    LPARAM lParam
+    LPARAM
 )
 {
-    auto* context =
-        reinterpret_cast<ActivateExistingExplorerContext*>(
-            lParam
-        );
-
     if (g_unloading.load(std::memory_order_acquire))
         return FALSE;
 
@@ -4565,8 +4518,7 @@ static BOOL CALLBACK ActivateExistingExplorerProc(
     );
 
     if (
-        pid != context->pid ||
-        !IsWindowVisible(hwnd)
+        pid != g_pid
     )
     {
         return TRUE;
@@ -4588,11 +4540,19 @@ static BOOL CALLBACK ActivateExistingExplorerProc(
 
     EnumChildWindows(
         hwnd,
-        ActivateDirectUiChildProc,
-        lParam
+        DiscoverDirectUiChildProc,
+        0
     );
 
     return TRUE;
+}
+
+static void DiscoverExistingExplorerWindows()
+{
+    EnumWindows(
+        DiscoverExistingExplorerWindowProc,
+        0
+    );
 }
 
 BOOL Wh_ModInit()
@@ -4634,104 +4594,6 @@ BOOL Wh_ModInit()
     }
 
     LoadSettings();
-
-    HMODULE user32 =
-        GetModuleHandleW(
-            L"user32.dll"
-        );
-
-    HMODULE gdi32 =
-        GetModuleHandleW(
-            L"gdi32.dll"
-        );
-
-    if (!user32 || !gdi32)
-    {
-        Wh_Log(
-            L"required system module not loaded"
-        );
-
-        DeleteCriticalSection(
-            &g_cacheLock
-        );
-
-        return FALSE;
-    }
-
-    void* drawTextTarget =
-        reinterpret_cast<void*>(
-            GetProcAddress(
-                user32,
-                "DrawTextW"
-            )
-        );
-
-    void* bitBltTarget =
-        reinterpret_cast<void*>(
-            GetProcAddress(
-                gdi32,
-                "BitBlt"
-            )
-        );
-
-    if (!drawTextTarget || !bitBltTarget)
-    {
-        Wh_Log(
-            L"required GDI targets not found"
-        );
-
-        DeleteCriticalSection(
-            &g_cacheLock
-        );
-
-        return FALSE;
-    }
-
-    if (
-        !Wh_SetFunctionHook(
-            drawTextTarget,
-            reinterpret_cast<void*>(
-                DrawTextW_Hook
-            ),
-            reinterpret_cast<void**>(
-                &DrawTextW_Original
-            )
-        )
-    )
-    {
-        Wh_Log(
-            L"DrawTextW hook failed"
-        );
-
-        DeleteCriticalSection(
-            &g_cacheLock
-        );
-
-        return FALSE;
-    }
-
-    if (
-        !Wh_SetFunctionHook(
-            bitBltTarget,
-            reinterpret_cast<void*>(
-                BitBlt_Hook
-            ),
-            reinterpret_cast<void**>(
-                &BitBlt_Original
-            )
-        )
-    )
-    {
-        Wh_Log(
-            L"BitBlt hook failed"
-        );
-
-        DeleteCriticalSection(
-            &g_cacheLock
-        );
-
-        return FALSE;
-    }
 
     g_stopEvent =
         CreateEventW(
@@ -4776,23 +4638,76 @@ BOOL Wh_ModInit()
         return FALSE;
     }
 
-    g_selectionWinEventHook =
-        SetWinEventHook(
-            EVENT_OBJECT_SELECTION,
-            EVENT_OBJECT_SELECTIONWITHIN,
+    g_selectionWinEventThreadReady =
+        CreateEventW(
             nullptr,
-            SelectionWinEventProc,
-            g_pid,
-            0,
-            WINEVENT_OUTOFCONTEXT
+            TRUE,
+            FALSE,
+            nullptr
         );
 
-    if (!g_selectionWinEventHook)
+    g_selectionWinEventStopEvent =
+        CreateEventW(
+            nullptr,
+            TRUE,
+            FALSE,
+            nullptr
+        );
+
+    if (
+        !g_selectionWinEventThreadReady ||
+        !g_selectionWinEventStopEvent
+    )
     {
         Wh_Log(
-            L"selection WinEvent hook failed error=%lu",
+            L"selection WinEvent helper event creation failed error=%lu",
             GetLastError()
         );
+
+        if (g_selectionWinEventThreadReady)
+        {
+            CloseHandle(g_selectionWinEventThreadReady);
+            g_selectionWinEventThreadReady = nullptr;
+        }
+
+        if (g_selectionWinEventStopEvent)
+        {
+            CloseHandle(g_selectionWinEventStopEvent);
+            g_selectionWinEventStopEvent = nullptr;
+        }
+    }
+    else
+    {
+        g_selectionWinEventThread =
+            CreateThread(
+                nullptr,
+                0,
+                SelectionWinEventThreadProc,
+                nullptr,
+                0,
+                nullptr
+            );
+
+        if (!g_selectionWinEventThread)
+        {
+            Wh_Log(
+                L"selection WinEvent helper creation failed error=%lu",
+                GetLastError()
+            );
+
+            CloseHandle(g_selectionWinEventThreadReady);
+            g_selectionWinEventThreadReady = nullptr;
+            CloseHandle(g_selectionWinEventStopEvent);
+            g_selectionWinEventStopEvent = nullptr;
+        }
+        else
+        {
+            // The helper signals only after queue creation and its hook
+            // installation attempt, closing the startup/shutdown race.
+            WaitForSingleObject(g_selectionWinEventThreadReady, INFINITE);
+            CloseHandle(g_selectionWinEventThreadReady);
+            g_selectionWinEventThreadReady = nullptr;
+        }
     }
 
     g_workerThread =
@@ -4807,10 +4722,12 @@ BOOL Wh_ModInit()
 
     if (!g_workerThread)
     {
-        if (g_selectionWinEventHook)
+        StopSelectionWinEventThread();
+
+        if (g_selectionWinEventStopEvent)
         {
-            UnhookWinEvent(g_selectionWinEventHook);
-            g_selectionWinEventHook = nullptr;
+            CloseHandle(g_selectionWinEventStopEvent);
+            g_selectionWinEventStopEvent = nullptr;
         }
 
         Wh_Log(
@@ -4846,17 +4763,7 @@ BOOL Wh_ModInit()
 
 void Wh_ModAfterInit()
 {
-    ActivateExistingExplorerContext context{
-        g_pid
-    };
-
-    EnumWindows(
-        ActivateExistingExplorerProc,
-        reinterpret_cast<LPARAM>(
-            &context
-        )
-    );
-
+    DiscoverExistingExplorerWindows();
 }
 
 
@@ -4883,12 +4790,6 @@ void Wh_ModBeforeUninit()
 
     if (g_stopEvent)
         SetEvent(g_stopEvent);
-
-    if (g_selectionWinEventHook)
-    {
-        UnhookWinEvent(g_selectionWinEventHook);
-        g_selectionWinEventHook = nullptr;
-    }
 
     if (g_workerThreadId)
         CoCancelCall(g_workerThreadId, 0);
@@ -4920,8 +4821,7 @@ void Wh_ModBeforeUninit()
             // The overlay is drawn after Explorer's native buffered paint, so
             // removing the subclass alone leaves those pixels on screen until
             // the next native repaint. Force the status row to repaint now
-            // while the GDI hooks are still installed but g_unloading prevents
-            // any new overlay from being drawn.
+            // while g_unloading prevents any new overlay from being drawn.
             RECT client{};
             if (GetClientRect(hwnd, &client))
             {
@@ -4964,6 +4864,14 @@ void Wh_ModUninit()
         SetEvent(
             g_stopEvent
         );
+    }
+
+    StopSelectionWinEventThread();
+
+    if (g_selectionWinEventStopEvent)
+    {
+        CloseHandle(g_selectionWinEventStopEvent);
+        g_selectionWinEventStopEvent = nullptr;
     }
 
     if (g_workerThread)


### PR DESCRIPTION
Adds a customizable information bar to Windows 11 File Explorer with drive free space, folder/file totals, selection details, and optional single-file metadata.

Explorer Info Bar+ is designed as a broader, modern information bar for the native Windows 11 Explorer bottom area rather than as a restoration of the classic status bar or a metadata-only extension.

It combines several information groups in one configurable overlay:

- Drive free space
- Current folder totals and direct file size
- Selection counts folder,files and selected file size
- Literal file extension, preserving the actual extension as shown on disk
- Basic file metadata such as image/video dimensions and media duration when available

The bar can also be customized with section visibility and order, multiple visual styles, automatic or custom colors, and separate styling for each information group.

This differs from Classic Explorer Status Bar, which restores a classic-style status bar and focuses on traditional status information, and Explorer Status Bar Metadata, which focuses primarily on single-file metadata. Explorer Info Bar+ combines status information, selection information, real file-extension display, and basic metadata into one customizable modern  info bar.

Includes few styles, fully customizable:  Simple, Flat panes, and Soft cards 


<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [x] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
