### PR TITLE
Add mod to hide taskbar only on desktop

### DIFF
--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
-// @description     Hides the taskbar on the desktop, shows it for other windows or when you hover near the bottom edge
-// @version         1.0.0
+// @description     Hides the taskbar on the desktop, shows it for other windows or when you hover near the bottom edge.
+// @version         1.1.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         explorer.exe
@@ -13,62 +13,67 @@
 /*
 # Hide Taskbar on Desktop
 
-Hides the Windows taskbar whenever there's nothing else to show (desktop
-focused, or every window minimized), and shows it again immediately when
-any other window is focused.
+Hides the Windows taskbar while the desktop is active and shows it again
+when an application or supported Windows shell UI is active.
 
-You can also peek at the taskbar by moving the mouse to the bottom of the
-screen while on the desktop - the reveal zone matches the taskbar's own
-height (plus a small extra margin you can configure), not just a thin
-strip at the very bottom, so hovering anywhere over where the taskbar
-would be counts. The delay before hiding only applies to that peek: hover
-in, then move away, and it waits a moment before hiding again. Every other
-hide (switching to the desktop, closing or minimizing the last window,
-etc.) hides instantly, no delay.
+### Features
+
+- Hides the taskbar when no normal visible window is active.
+- Shows the taskbar immediately when an application is active.
+- Reveals the taskbar when the mouse enters the bottom area of a monitor.
+- The reveal zone automatically follows the actual taskbar height.
+- Adds a configurable extra hover margin in millimeters.
+- Uses a configurable delay only when hiding after a mouse hover.
+- Hides immediately after minimizing or closing the last application.
+- Keeps the taskbar visible while interacting with taskbar buttons.
+- Supports optional secondary taskbars on additional monitors.
+- Re-checks the desktop state periodically so minimizing the last window
+  does not require an extra desktop click.
+
+### Settings
+
+- Extra hover margin: additional space above the taskbar-height reveal zone.
+- Auto-hide delay after hover: delay before hiding after leaving the reveal zone.
+- Hide secondary taskbars: controls taskbars on additional monitors.
 
 ### Notes
-- Works with a single taskbar, and optionally with secondary taskbars on
-  extra monitors (toggle in the settings).
-- Pressing the Windows key or clicking the Start button still works even
-  while the taskbar is hidden, and will bring the taskbar back, since the
-  Start menu counts as "another window".
-- The "on desktop" check re-verifies itself roughly 10 times a second by
-  checking for any other visible, non-minimized window, rather than
-  depending on a single event. This is what makes minimizing the last
-  window hide the taskbar right away, without needing an extra click.
-- Opening Start, a system tray flyout ("show hidden icons"), or the
-  notification/clock panel keeps the taskbar visible, since those count
-  as "another window" too.
+
+The mod uses a small worker thread with a Windows message queue for
+WinEvent notifications and periodic state checks. The worker is stopped
+and joined before the mod is unloaded.
 */
-// ==/WindhawkModReadme==
+// ==WindhawkModReadme==
 
 // ==WindhawkModSettings==
 /*
 - extraHoverMarginMm: 5
   $name: Extra hover margin (mm)
   $description: >-
-    The reveal zone at the bottom of the screen automatically matches your
-    taskbar's actual height (including your display scaling), so hovering
-    anywhere over where the taskbar would be reveals it. This setting adds
-    a bit of extra margin above that, in millimeters, so you don't need to
-    be pixel-perfect. Default 5mm.
+    Adds extra space above the automatically detected taskbar-height
+    reveal zone. Default is 5 mm.
+
 - autoHideDelayMs: 700
   $name: Auto-hide delay after hover (ms)
   $description: >-
-    How long to wait, after moving the mouse away from the bottom-edge
-    hover zone, before the taskbar hides again. Only applies to that case
-    - other hides (e.g. minimizing the last window) are instant.
-    Default 700ms.
+    How long to wait after the mouse leaves the bottom-edge hover zone
+    before hiding the taskbar. Only applies after a mouse hover reveal.
+    Default is 700 ms.
+
 - hideSecondaryTaskbars: true
   $name: Hide secondary taskbars
   $description: >-
-    Also hide/show taskbars on additional monitors, if you have "Show
-    taskbar on all displays" enabled in Windows
+    Also hide and show taskbars on additional monitors when Windows is
+    configured to show taskbars on all displays.
 */
-// ==/WindhawkModSettings==
+// ==WindhawkModSettings==
 
 #include <windows.h>
 #include <dwmapi.h>
+
+
+// ============================================================
+// Settings
+// ============================================================
 
 struct {
     int extraHoverMarginMm;
@@ -76,375 +81,1469 @@ struct {
     bool hideSecondaryTaskbars;
 } settings;
 
-HWINEVENTHOOK g_hWinEventHookForeground;
-HANDLE g_hThread;
-DWORD g_threadId;
 
-bool g_taskbarHidden = false;    // current actual visibility state
-bool g_onDesktopState = false;   // true if "nothing else to show" right now
-bool g_shownDueToHover = false;  // taskbar currently shown only because of
-                                  // the bottom-edge hover peek
-ULONGLONG g_hideDeadline = 0;    // tick count when a pending hover-dismiss
-                                  // hide should fire (0 = none pending)
+// ============================================================
+// Global state
+// ============================================================
 
-// Returns true if hwnd is the desktop window: either the classic "Progman"
-// window, or a "WorkerW" that's actually hosting the desktop icons (rather
-// than just being one of the extra wallpaper-helper WorkerW windows).
+HWINEVENTHOOK g_hWinEventHookForeground = nullptr;
+
+HANDLE g_hThread = nullptr;
+HANDLE g_stopEvent = nullptr;
+
+DWORD g_threadId = 0;
+
+bool g_taskbarHidden = false;
+bool g_onDesktopState = false;
+bool g_shownDueToHover = false;
+
+ULONGLONG g_hideDeadline = 0;
+
+
+// ============================================================
+// Desktop detection
+// ============================================================
+
 bool IsDesktopWindow(HWND hwnd) {
-    if (!hwnd) {
+
+    if (!hwnd)
+        return false;
+
+
+    WCHAR className[256] = {};
+
+    if (GetClassNameW(
+            hwnd,
+            className,
+            ARRAYSIZE(className)
+        ) == 0) {
+
         return false;
     }
 
-    WCHAR className[256];
-    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
-        return false;
-    }
 
-    if (wcscmp(className, L"Progman") == 0) {
+    if (wcscmp(
+            className,
+            L"Progman"
+        ) == 0) {
+
         return true;
     }
 
-    if (wcscmp(className, L"WorkerW") == 0) {
-        if (FindWindowExW(hwnd, nullptr, L"SHELLDLL_DefView", nullptr)) {
-            return true;
-        }
+
+    if (wcscmp(
+            className,
+            L"WorkerW"
+        ) == 0) {
+
+        return FindWindowExW(
+                   hwnd,
+                   nullptr,
+                   L"SHELLDLL_DefView",
+                   nullptr
+               ) != nullptr;
     }
+
 
     return false;
 }
 
-bool IsShellChromeClass(const WCHAR* className) {
+
+// ============================================================
+// Explorer / shell window classes
+// ============================================================
+
+bool IsShellChromeClass(
+    const WCHAR* className
+) {
+
     static const WCHAR* kShellClasses[] = {
+
         L"Progman",
         L"WorkerW",
+
         L"Shell_TrayWnd",
         L"Shell_SecondaryTrayWnd",
+
         L"Windows.UI.Core.CoreWindow",
         L"Xaml_WindowedPopupClass",
+
         L"TaskListThumbnailWnd",
         L"SysShadow",
+
         L"tooltips_class32",
         L"MSCTFIME UI",
         L"IME",
     };
 
-    for (const WCHAR* shellClass : kShellClasses) {
-        if (wcscmp(className, shellClass) == 0) {
+
+    for (
+        const WCHAR* shellClass :
+        kShellClasses
+    ) {
+
+        if (wcscmp(
+                className,
+                shellClass
+            ) == 0) {
+
             return true;
         }
     }
 
+
     return false;
 }
 
-BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
-    bool* pFoundOther = (bool*)lParam;
 
-    if (!IsWindowVisible(hwnd) || IsIconic(hwnd)) {
+// ============================================================
+// Find any visible application window
+// ============================================================
+
+BOOL CALLBACK EnumWindowsProc(
+    HWND hwnd,
+    LPARAM lParam
+) {
+
+    bool* pFoundOther =
+        reinterpret_cast<bool*>(lParam);
+
+
+    if (!IsWindowVisible(hwnd) ||
+        IsIconic(hwnd)) {
+
         return TRUE;
     }
 
-    // Skip owned windows (tooltips, dropdowns, small popups, etc.).
-    if (GetWindow(hwnd, GW_OWNER) != nullptr) {
+
+    /*
+        Ignore owned popup windows such as
+        tooltips and dropdowns.
+    */
+
+    if (GetWindow(
+            hwnd,
+            GW_OWNER
+        ) != nullptr) {
+
         return TRUE;
     }
 
-    WCHAR className[256];
-    GetClassNameW(hwnd, className, ARRAYSIZE(className));
 
-    if (IsShellChromeClass(className)) {
+    WCHAR className[256] = {};
+
+
+    /*
+        IMPORTANT:
+        Check GetClassNameW's return value.
+    */
+
+    if (GetClassNameW(
+            hwnd,
+            className,
+            ARRAYSIZE(className)
+        ) == 0) {
+
         return TRUE;
     }
 
-    LONG_PTR exStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
-    if (exStyle & WS_EX_TOOLWINDOW) {
+
+    if (IsShellChromeClass(
+            className
+        )) {
+
         return TRUE;
     }
 
-    // Skip cloaked windows (e.g. UWP apps sitting on another virtual
-    // desktop, which still report as "visible" otherwise).
+
+    LONG_PTR exStyle =
+        GetWindowLongPtrW(
+            hwnd,
+            GWL_EXSTYLE
+        );
+
+
+    if (exStyle &
+        WS_EX_TOOLWINDOW) {
+
+        return TRUE;
+    }
+
+
+    /*
+        Ignore cloaked windows, for example
+        applications on another virtual desktop.
+    */
+
     BOOL cloaked = FALSE;
-    if (SUCCEEDED(DwmGetWindowAttribute(hwnd, DWMWA_CLOAKED, &cloaked,
-                                         sizeof(cloaked))) &&
+
+
+    if (SUCCEEDED(
+            DwmGetWindowAttribute(
+                hwnd,
+                DWMWA_CLOAKED,
+                &cloaked,
+                sizeof(cloaked)
+            )
+        ) &&
         cloaked) {
+
         return TRUE;
     }
 
-    RECT rect;
-    if (GetWindowRect(hwnd, &rect)) {
-        if (rect.right - rect.left <= 0 || rect.bottom - rect.top <= 0) {
-            return TRUE;
-        }
+
+    RECT rect{};
+
+
+    if (!GetWindowRect(
+            hwnd,
+            &rect
+        )) {
+
+        return TRUE;
     }
+
+
+    if (rect.right <= rect.left ||
+        rect.bottom <= rect.top) {
+
+        return TRUE;
+    }
+
 
     *pFoundOther = true;
-    return FALSE;  // found one, no need to keep enumerating
+
+
+    /*
+        We found one valid visible window.
+    */
+
+    return FALSE;
 }
 
-// Checks for any real, non-minimized application window currently visible.
+
 bool AnyOtherVisibleWindowExists() {
+
     bool found = false;
-    EnumWindows(EnumWindowsProc, (LPARAM)&found);
+
+
+    EnumWindows(
+        EnumWindowsProc,
+        reinterpret_cast<LPARAM>(
+            &found
+        )
+    );
+
+
     return found;
 }
 
-bool IsAmbiguousForegroundClass(const WCHAR* className) {
-    // These are the taskbar's own base windows, not a popup on top of it.
-    // The OS sometimes leaves one of these as the "foreground" window by
-    // default (e.g. right after minimizing the last app) without the user
-    // having actually clicked on the taskbar itself, so we can't trust
-    // this alone and fall back to checking for other windows.
-    return wcscmp(className, L"Shell_TrayWnd") == 0 ||
-           wcscmp(className, L"Shell_SecondaryTrayWnd") == 0;
+
+// ============================================================
+// Foreground-window classification
+// ============================================================
+
+bool IsAmbiguousForegroundClass(
+    const WCHAR* className
+) {
+
+    /*
+        The taskbar's base windows can temporarily
+        become the foreground window.
+
+        In that case we use EnumWindows to determine
+        whether another application is actually active.
+    */
+
+    return wcscmp(
+               className,
+               L"Shell_TrayWnd"
+           ) == 0 ||
+
+           wcscmp(
+               className,
+               L"Shell_SecondaryTrayWnd"
+           ) == 0;
 }
 
-// Authoritative check for whether we're in "desktop mode" (hide the
-// taskbar). Trusts a genuinely focused, visible window directly - this
-// includes Start menu, tray icon flyouts, and the notification/clock
-// panel, all of which should keep the taskbar visible. Only falls back to
-// scanning for any other visible window when the foreground window itself
-// is inconclusive (none, minimized, or the taskbar's own base window) -
-// this is what catches minimizing/closing the last real window.
+
+// ============================================================
+// Refresh desktop state
+// ============================================================
+
 void RefreshDesktopState() {
-    HWND fg = GetForegroundWindow();
 
-    if (!fg) {
-        g_onDesktopState = !AnyOtherVisibleWindowExists();
+    HWND foreground =
+        GetForegroundWindow();
+
+
+    /*
+        No foreground window.
+    */
+
+    if (!foreground) {
+
+        g_onDesktopState =
+            !AnyOtherVisibleWindowExists();
+
         return;
     }
 
-    if (IsDesktopWindow(fg)) {
-        g_onDesktopState = true;
+
+    /*
+        Actual desktop window.
+    */
+
+    if (IsDesktopWindow(
+            foreground
+        )) {
+
+        g_onDesktopState =
+            true;
+
         return;
     }
 
-    if (IsIconic(fg)) {
-        g_onDesktopState = !AnyOtherVisibleWindowExists();
+
+    /*
+        Minimized foreground window.
+
+        Check whether another visible application exists.
+    */
+
+    if (IsIconic(
+            foreground
+        )) {
+
+        g_onDesktopState =
+            !AnyOtherVisibleWindowExists();
+
         return;
     }
 
-    WCHAR className[256];
-    if (GetClassNameW(fg, className, ARRAYSIZE(className)) &&
-        IsAmbiguousForegroundClass(className)) {
-        g_onDesktopState = !AnyOtherVisibleWindowExists();
-        return;
+
+    WCHAR className[256] = {};
+
+
+    if (GetClassNameW(
+            foreground,
+            className,
+            ARRAYSIZE(className)
+        ) != 0) {
+
+        if (IsAmbiguousForegroundClass(
+                className
+            )) {
+
+            g_onDesktopState =
+                !AnyOtherVisibleWindowExists();
+
+            return;
+        }
     }
 
-    g_onDesktopState = false;
+
+    /*
+        Any other non-minimized foreground window means
+        we are not on the empty desktop.
+
+        This also covers supported shell UI such as
+        Start and notification panels.
+    */
+
+    g_onDesktopState =
+        false;
 }
 
-void SetTaskbarVisibility(bool show) {
-    HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
+
+// ============================================================
+// Taskbar visibility
+// ============================================================
+
+void SetTaskbarVisibility(
+    bool show
+) {
+
+    HWND hTaskbar =
+        FindWindowW(
+            L"Shell_TrayWnd",
+            nullptr
+        );
+
+
     if (hTaskbar) {
-        ShowWindow(hTaskbar, show ? SW_SHOW : SW_HIDE);
+
+        ShowWindow(
+            hTaskbar,
+            show
+                ? SW_SHOW
+                : SW_HIDE
+        );
     }
 
-    if (settings.hideSecondaryTaskbars) {
-        HWND hSecondary = nullptr;
-        while ((hSecondary = FindWindowExW(nullptr, hSecondary,
-                                            L"Shell_SecondaryTrayWnd",
-                                            nullptr)) != nullptr) {
-            ShowWindow(hSecondary, show ? SW_SHOW : SW_HIDE);
-        }
+
+    if (!settings.hideSecondaryTaskbars)
+        return;
+
+
+    HWND hSecondary = nullptr;
+
+
+    while (
+        (hSecondary =
+            FindWindowExW(
+                nullptr,
+                hSecondary,
+                L"Shell_SecondaryTrayWnd",
+                nullptr
+            )) != nullptr
+    ) {
+
+        ShowWindow(
+            hSecondary,
+            show
+                ? SW_SHOW
+                : SW_HIDE
+        );
     }
 }
 
-// The reveal zone matches the taskbar's own current height (whatever size
-// and display scaling you actually have it set to), plus a configurable
-// extra margin on top. Falls back to a small DPI-scaled default if the
-// taskbar's rect can't be read for some reason.
-int GetHoverZonePx(HWND hTaskbar, UINT dpi) {
-    int marginPx = (int)((double)settings.extraHoverMarginMm / 25.4 * dpi);
 
-    RECT tbRect;
-    if (hTaskbar && GetWindowRect(hTaskbar, &tbRect)) {
-        int taskbarHeight = tbRect.bottom - tbRect.top;
+// ============================================================
+// Hover-zone size
+// ============================================================
+
+int GetHoverZonePx(
+    HWND hTaskbar,
+    UINT dpi
+) {
+
+    /*
+        Convert millimeters to pixels.
+
+        25.4 mm = 1 inch.
+    */
+
+    int marginPx =
+        MulDiv(
+            settings.extraHoverMarginMm,
+            static_cast<int>(dpi),
+            254
+        );
+
+
+    if (marginPx < 0)
+        marginPx = 0;
+
+
+    /*
+        Prefer the actual taskbar height.
+    */
+
+    RECT taskbarRect{};
+
+
+    if (hTaskbar &&
+        GetWindowRect(
+            hTaskbar,
+            &taskbarRect
+        )) {
+
+        int taskbarHeight =
+            taskbarRect.bottom -
+            taskbarRect.top;
+
+
         if (taskbarHeight > 0) {
-            return taskbarHeight + marginPx;
+
+            return taskbarHeight +
+                   marginPx;
         }
     }
 
-    // Fallback: assume a ~48px (at 100% scaling) default taskbar height.
-    int fallbackHeight = (int)(48.0 * dpi / 96.0);
-    return fallbackHeight + marginPx;
+
+    /*
+        Fallback for the short period where
+        Explorer has not created the taskbar yet.
+    */
+
+    int fallbackHeight =
+        MulDiv(
+            48,
+            static_cast<int>(dpi),
+            96
+        );
+
+
+    return fallbackHeight +
+           marginPx;
 }
 
-// True if the cursor is within the taskbar-height-sized zone at the bottom
-// edge of whichever monitor it's currently on.
+
+// ============================================================
+// Find taskbar belonging to a monitor
+// ============================================================
+
+HWND FindTaskbarForMonitor(
+    HMONITOR hMonitor
+) {
+
+    if (!hMonitor)
+        return nullptr;
+
+
+    /*
+        First look for the primary-style taskbar.
+    */
+
+    HWND hTaskbar = nullptr;
+
+
+    while (
+        (hTaskbar =
+            FindWindowExW(
+                nullptr,
+                hTaskbar,
+                L"Shell_TrayWnd",
+                nullptr
+            )) != nullptr
+    ) {
+
+        RECT rect{};
+
+
+        if (!GetWindowRect(
+                hTaskbar,
+                &rect
+            )) {
+
+            continue;
+        }
+
+
+        POINT center{
+            rect.left +
+                (rect.right - rect.left) / 2,
+
+            rect.top +
+                (rect.bottom - rect.top) / 2
+        };
+
+
+        if (
+            MonitorFromPoint(
+                center,
+                MONITOR_DEFAULTTONEAREST
+            ) == hMonitor
+        ) {
+
+            return hTaskbar;
+        }
+    }
+
+
+    /*
+        Then look for secondary taskbars.
+    */
+
+    hTaskbar = nullptr;
+
+
+    while (
+        (hTaskbar =
+            FindWindowExW(
+                nullptr,
+                hTaskbar,
+                L"Shell_SecondaryTrayWnd",
+                nullptr
+            )) != nullptr
+    ) {
+
+        RECT rect{};
+
+
+        if (!GetWindowRect(
+                hTaskbar,
+                &rect
+            )) {
+
+            continue;
+        }
+
+
+        POINT center{
+            rect.left +
+                (rect.right - rect.left) / 2,
+
+            rect.top +
+                (rect.bottom - rect.top) / 2
+        };
+
+
+        if (
+            MonitorFromPoint(
+                center,
+                MONITOR_DEFAULTTONEAREST
+            ) == hMonitor
+        ) {
+
+            return hTaskbar;
+        }
+    }
+
+
+    return nullptr;
+}
+
+
+// ============================================================
+// Bottom-edge detection
+// ============================================================
+
 bool IsCursorNearBottomEdge() {
-    POINT pt;
-    if (!GetCursorPos(&pt)) {
+
+    POINT pt{};
+
+
+    if (!GetCursorPos(
+            &pt
+        )) {
+
         return false;
     }
 
-    HMONITOR hMonitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
-    MONITORINFO mi = {sizeof(mi)};
-    if (!GetMonitorInfoW(hMonitor, &mi)) {
+
+    HMONITOR hMonitor =
+        MonitorFromPoint(
+            pt,
+            MONITOR_DEFAULTTONEAREST
+        );
+
+
+    if (!hMonitor)
+        return false;
+
+
+    MONITORINFO monitorInfo{
+        sizeof(monitorInfo)
+    };
+
+
+    if (!GetMonitorInfoW(
+            hMonitor,
+            &monitorInfo
+        )) {
+
         return false;
     }
 
-    if (pt.x < mi.rcMonitor.left || pt.x > mi.rcMonitor.right) {
+
+    /*
+        RECT.right is an exclusive boundary.
+
+        Therefore >= is used here rather than >.
+    */
+
+    if (
+        pt.x <
+            monitorInfo.rcMonitor.left ||
+
+        pt.x >=
+            monitorInfo.rcMonitor.right
+    ) {
+
         return false;
     }
 
-    HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
-    UINT dpi = hTaskbar ? GetDpiForWindow(hTaskbar) : 96;
 
-    int hotZonePx = GetHoverZonePx(hTaskbar, dpi);
-    if (hotZonePx < 1) {
+    /*
+        Find the taskbar belonging to the monitor
+        where the mouse currently is.
+
+        This fixes the multi-monitor issue where
+        the primary taskbar's height was previously
+        used for every monitor.
+    */
+
+    HWND hTaskbar =
+        FindTaskbarForMonitor(
+            hMonitor
+        );
+
+
+    UINT dpi = 96;
+
+
+    if (hTaskbar) {
+
+        UINT taskbarDpi =
+            GetDpiForWindow(
+                hTaskbar
+            );
+
+
+        if (taskbarDpi != 0)
+            dpi = taskbarDpi;
+    }
+
+
+    int hotZonePx =
+        GetHoverZonePx(
+            hTaskbar,
+            dpi
+        );
+
+
+    if (hotZonePx < 1)
         hotZonePx = 1;
-    }
 
-    return pt.y >= mi.rcMonitor.bottom - hotZonePx;
+
+    return pt.y >=
+               monitorInfo.rcMonitor.bottom -
+                   hotZonePx &&
+
+           pt.y <
+               monitorInfo.rcMonitor.bottom;
 }
 
-// Single place that decides whether the taskbar should be shown or hidden.
-// Only the "hover then move away" case gets a delay; every other hide is
-// instant.
+
+// ============================================================
+// Main taskbar state logic
+// ============================================================
+
 void UpdateTaskbarState() {
-    bool hovering = IsCursorNearBottomEdge();
+
+    bool hovering =
+        IsCursorNearBottomEdge();
+
+
+    /*
+        --------------------------------------------------------
+        APPLICATION / SHELL UI ACTIVE
+        --------------------------------------------------------
+    */
 
     if (!g_onDesktopState) {
-        // A real window is focused: always show, instantly.
+
+        /*
+            A real window is active.
+
+            Always show immediately.
+        */
+
         g_hideDeadline = 0;
+
         g_shownDueToHover = false;
+
+
         if (g_taskbarHidden) {
-            SetTaskbarVisibility(true);
-            g_taskbarHidden = false;
+
+            SetTaskbarVisibility(
+                true
+            );
+
+            g_taskbarHidden =
+                false;
         }
+
+
         return;
     }
 
-    // On desktop.
+
+    /*
+        --------------------------------------------------------
+        DESKTOP + MOUSE IN REVEAL ZONE
+        --------------------------------------------------------
+    */
+
     if (hovering) {
+
         g_hideDeadline = 0;
+
         g_shownDueToHover = true;
+
+
         if (g_taskbarHidden) {
-            SetTaskbarVisibility(true);
-            g_taskbarHidden = false;
+
+            SetTaskbarVisibility(
+                true
+            );
+
+            g_taskbarHidden =
+                false;
         }
+
+
         return;
     }
 
-    // On desktop, not hovering: the taskbar should end up hidden.
+
+    /*
+        --------------------------------------------------------
+        DESKTOP + MOUSE OUTSIDE REVEAL ZONE
+        --------------------------------------------------------
+    */
+
     if (g_taskbarHidden) {
+
         g_hideDeadline = 0;
+
         return;
     }
+
+
+    /*
+        If the taskbar was visible for another reason
+        such as minimizing/closing a window, hide it
+        immediately.
+
+        The hover delay is NOT used here.
+    */
 
     if (!g_shownDueToHover) {
-        // Taskbar was visible for some other reason (a window just got
-        // minimized/closed, or desktop just got focused) - hide instantly.
-        SetTaskbarVisibility(false);
-        g_taskbarHidden = true;
+
+        SetTaskbarVisibility(
+            false
+        );
+
+        g_taskbarHidden =
+            true;
+
         g_hideDeadline = 0;
+
         return;
     }
 
-    // Taskbar was visible because of the hover peek, and the mouse has now
-    // left the zone - this is the only case that gets a grace period.
-    ULONGLONG now = GetTickCount64();
+
+    /*
+        --------------------------------------------------------
+        MOUSE-TRIGGERED HIDE DELAY
+        --------------------------------------------------------
+
+        This is the ONLY situation where the delay applies.
+    */
+
+    ULONGLONG now =
+        GetTickCount64();
+
+
     if (g_hideDeadline == 0) {
-        g_hideDeadline = now + settings.autoHideDelayMs;
-    } else if (now >= g_hideDeadline) {
-        SetTaskbarVisibility(false);
-        g_taskbarHidden = true;
+
+        g_hideDeadline =
+            now +
+            settings.autoHideDelayMs;
+
+    }
+    else if (
+        now >=
+        g_hideDeadline
+    ) {
+
+        SetTaskbarVisibility(
+            false
+        );
+
+        g_taskbarHidden =
+            true;
+
         g_hideDeadline = 0;
-        g_shownDueToHover = false;
+
+        g_shownDueToHover =
+            false;
     }
 }
 
-void CALLBACK WinEventProc(HWINEVENTHOOK hWinEventHook, DWORD event,
-                            HWND hwnd, LONG idObject, LONG idChild,
-                            DWORD idEventThread, DWORD dwmsEventTime) {
-    if (idObject != OBJID_WINDOW || event != EVENT_SYSTEM_FOREGROUND) {
+
+// ============================================================
+// WinEvent callback
+// ============================================================
+
+void CALLBACK WinEventProc(
+    HWINEVENTHOOK hWinEventHook,
+    DWORD event,
+    HWND hwnd,
+    LONG idObject,
+    LONG idChild,
+    DWORD idEventThread,
+    DWORD dwmsEventTime
+) {
+
+    UNREFERENCED_PARAMETER(
+        hWinEventHook
+    );
+
+    UNREFERENCED_PARAMETER(
+        hwnd
+    );
+
+    UNREFERENCED_PARAMETER(
+        idEventThread
+    );
+
+    UNREFERENCED_PARAMETER(
+        dwmsEventTime
+    );
+
+
+    if (
+        event !=
+            EVENT_SYSTEM_FOREGROUND ||
+
+        idObject !=
+            OBJID_WINDOW ||
+
+        idChild !=
+            CHILDID_SELF
+    ) {
+
         return;
     }
 
-    // Quick, instant reaction for the common case (switching to a real
-    // window). The poll timer re-verifies everything ~10x/sec regardless,
-    // which is what reliably catches the minimize/close-last-window case.
+
+    /*
+        Immediately react to foreground changes.
+    */
+
     RefreshDesktopState();
+
     UpdateTaskbarState();
 }
 
-void CALLBACK TimerProc(HWND hwnd, UINT uMsg, UINT_PTR idEvent,
-                         DWORD dwTime) {
+
+// ============================================================
+// Timer callback
+// ============================================================
+
+void CALLBACK TimerProc(
+    HWND hwnd,
+    UINT uMsg,
+    UINT_PTR idEvent,
+    DWORD dwTime
+) {
+
+    UNREFERENCED_PARAMETER(
+        hwnd
+    );
+
+    UNREFERENCED_PARAMETER(
+        uMsg
+    );
+
+    UNREFERENCED_PARAMETER(
+        idEvent
+    );
+
+    UNREFERENCED_PARAMETER(
+        dwTime
+    );
+
+
+    /*
+        Periodic verification catches cases such as:
+
+        - minimizing the last window
+        - closing the last window
+        - Explorer shell transitions
+        - taskbar recreation
+    */
+
     RefreshDesktopState();
+
     UpdateTaskbarState();
 }
 
-// WINEVENT_OUTOFCONTEXT and a polling SetTimer both need a thread that
-// pumps messages, so we spin up a dedicated thread for this instead of
-// relying on whichever thread happens to call Wh_ModInit.
-DWORD WINAPI HookThread(LPVOID param) {
-    g_hWinEventHookForeground = SetWinEventHook(
-        EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND, nullptr,
-        WinEventProc, 0, 0, WINEVENT_OUTOFCONTEXT);
 
-    RefreshDesktopState();
-    UpdateTaskbarState();
+// ============================================================
+// Worker thread
+// ============================================================
 
-    const UINT kPollIntervalMs = 100;
-    UINT_PTR timerId = SetTimer(nullptr, 0, kPollIntervalMs, TimerProc);
+DWORD WINAPI HookThread(
+    LPVOID param
+) {
 
-    MSG msg;
-    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
-        TranslateMessage(&msg);
-        DispatchMessageW(&msg);
+    UNREFERENCED_PARAMETER(
+        param
+    );
+
+
+    /*
+        Force creation of this thread's message queue.
+
+        This is done before the worker starts depending
+        on message delivery.
+    */
+
+    MSG initMsg{};
+
+
+    PeekMessageW(
+        &initMsg,
+        nullptr,
+        WM_USER,
+        WM_USER,
+        PM_NOREMOVE
+    );
+
+
+    /*
+        Install foreground WinEvent hook.
+    */
+
+    g_hWinEventHookForeground =
+        SetWinEventHook(
+            EVENT_SYSTEM_FOREGROUND,
+            EVENT_SYSTEM_FOREGROUND,
+            nullptr,
+            WinEventProc,
+            0,
+            0,
+            WINEVENT_OUTOFCONTEXT
+        );
+
+
+    if (!g_hWinEventHookForeground) {
+
+        Wh_Log(
+            L"SetWinEventHook failed: %lu",
+            GetLastError()
+        );
     }
+
+
+    /*
+        Initial state.
+    */
+
+    RefreshDesktopState();
+
+    UpdateTaskbarState();
+
+
+    /*
+        Poll approximately 10 times per second.
+    */
+
+    const UINT kPollIntervalMs =
+        100;
+
+
+    UINT_PTR timerId =
+        SetTimer(
+            nullptr,
+            0,
+            kPollIntervalMs,
+            TimerProc
+        );
+
+
+    if (!timerId) {
+
+        Wh_Log(
+            L"SetTimer failed: %lu",
+            GetLastError()
+        );
+    }
+
+
+    /*
+        Wait for either:
+
+        - the stop event
+        - Windows messages
+
+        Using an event instead of PostThreadMessage(WM_QUIT)
+        makes shutdown reliable even during early initialization.
+    */
+
+    while (true) {
+
+        DWORD waitResult =
+            MsgWaitForMultipleObjects(
+                1,
+                &g_stopEvent,
+                FALSE,
+                INFINITE,
+                QS_ALLINPUT
+            );
+
+
+        /*
+            Stop requested.
+        */
+
+        if (
+            waitResult ==
+            WAIT_OBJECT_0
+        ) {
+
+            break;
+        }
+
+
+        /*
+            Messages are waiting.
+        */
+
+        if (
+            waitResult ==
+            WAIT_OBJECT_0 + 1
+        ) {
+
+            MSG msg{};
+
+
+            while (
+                PeekMessageW(
+                    &msg,
+                    nullptr,
+                    0,
+                    0,
+                    PM_REMOVE
+                )
+            ) {
+
+                /*
+                    If another component posts WM_QUIT,
+                    stop cleanly.
+                */
+
+                if (
+                    msg.message ==
+                    WM_QUIT
+                ) {
+
+                    SetEvent(
+                        g_stopEvent
+                    );
+
+                    break;
+                }
+
+
+                TranslateMessage(
+                    &msg
+                );
+
+
+                DispatchMessageW(
+                    &msg
+                );
+            }
+
+
+            if (
+                WaitForSingleObject(
+                    g_stopEvent,
+                    0
+                ) ==
+                WAIT_OBJECT_0
+            ) {
+
+                break;
+            }
+
+
+            continue;
+        }
+
+
+        /*
+            Unexpected wait failure.
+        */
+
+        Wh_Log(
+            L"MsgWaitForMultipleObjects failed: %lu",
+            GetLastError()
+        );
+
+        break;
+    }
+
+
+    /*
+        The worker owns these resources, so it cleans them
+        up before the thread exits.
+    */
 
     if (timerId) {
-        KillTimer(nullptr, timerId);
+
+        KillTimer(
+            nullptr,
+            timerId
+        );
     }
+
+
     if (g_hWinEventHookForeground) {
-        UnhookWinEvent(g_hWinEventHookForeground);
-        g_hWinEventHookForeground = nullptr;
+
+        UnhookWinEvent(
+            g_hWinEventHookForeground
+        );
+
+        g_hWinEventHookForeground =
+            nullptr;
     }
+
 
     return 0;
 }
 
+
+// ============================================================
+// Settings
+// ============================================================
+
 void LoadSettings() {
-    settings.extraHoverMarginMm = Wh_GetIntSetting(L"extraHoverMarginMm");
-    settings.autoHideDelayMs = (DWORD)Wh_GetIntSetting(L"autoHideDelayMs");
+
+    settings.extraHoverMarginMm =
+        Wh_GetIntSetting(
+            L"extraHoverMarginMm"
+        );
+
+
+    settings.autoHideDelayMs =
+        static_cast<DWORD>(
+            Wh_GetIntSetting(
+                L"autoHideDelayMs"
+            )
+        );
+
+
     settings.hideSecondaryTaskbars =
-        Wh_GetIntSetting(L"hideSecondaryTaskbars") != 0;
+        Wh_GetIntSetting(
+            L"hideSecondaryTaskbars"
+        ) != 0;
+
+
+    /*
+        Safety limits.
+    */
+
+    if (
+        settings.extraHoverMarginMm <
+        0
+    ) {
+
+        settings.extraHoverMarginMm =
+            0;
+    }
+
+
+    if (
+        settings.extraHoverMarginMm >
+        50
+    ) {
+
+        settings.extraHoverMarginMm =
+            50;
+    }
+
+
+    if (
+        settings.autoHideDelayMs >
+        10000
+    ) {
+
+        settings.autoHideDelayMs =
+            10000;
+    }
 }
 
-// The mod is being initialized, load settings, hook functions, and do other
-// initialization stuff if required.
+
+// ============================================================
+// Windhawk initialization
+// ============================================================
+
 BOOL Wh_ModInit() {
-    Wh_Log(L"Init");
+
+    Wh_Log(
+        L"Init"
+    );
+
 
     LoadSettings();
 
-    g_hThread = CreateThread(nullptr, 0, HookThread, nullptr, 0, &g_threadId);
+
+    /*
+        Manual-reset stop event.
+
+        The worker waits on this event while also
+        processing its message queue.
+    */
+
+    g_stopEvent =
+        CreateEventW(
+            nullptr,
+            TRUE,
+            FALSE,
+            nullptr
+        );
+
+
+    if (!g_stopEvent) {
+
+        Wh_Log(
+            L"CreateEvent failed: %lu",
+            GetLastError()
+        );
+
+        return FALSE;
+    }
+
+
+    /*
+        Start worker thread.
+    */
+
+    g_hThread =
+        CreateThread(
+            nullptr,
+            0,
+            HookThread,
+            nullptr,
+            0,
+            &g_threadId
+        );
+
+
+    if (!g_hThread) {
+
+        Wh_Log(
+            L"CreateThread failed: %lu",
+            GetLastError()
+        );
+
+
+        CloseHandle(
+            g_stopEvent
+        );
+
+
+        g_stopEvent =
+            nullptr;
+
+        g_threadId =
+            0;
+
+
+        return FALSE;
+    }
+
 
     return TRUE;
 }
 
-// The mod is being unloaded, free all allocated resources.
+
+// ============================================================
+// Windhawk uninitialization
+// ============================================================
+
 void Wh_ModUninit() {
-    Wh_Log(L"Uninit");
+
+    Wh_Log(
+        L"Uninit"
+    );
+
+
+    /*
+        Tell the worker to stop.
+    */
+
+    if (g_stopEvent) {
+
+        SetEvent(
+            g_stopEvent
+        );
+    }
+
+
+    /*
+        IMPORTANT:
+
+        Wait until the worker has actually exited before
+        closing its handle or allowing the mod to unload.
+
+        This prevents the worker from executing code from
+        the unloaded mod.
+    */
 
     if (g_hThread) {
-        PostThreadMessageW(g_threadId, WM_QUIT, 0, 0);
-        WaitForSingleObject(g_hThread, 3000);
-        CloseHandle(g_hThread);
-        g_hThread = nullptr;
+
+        WaitForSingleObject(
+            g_hThread,
+            INFINITE
+        );
+
+
+        CloseHandle(
+            g_hThread
+        );
+
+
+        g_hThread =
+            nullptr;
     }
 
-    // Always leave the taskbar visible when the mod is disabled/unloaded.
-    if (g_taskbarHidden) {
-        SetTaskbarVisibility(true);
-        g_taskbarHidden = false;
+
+    g_threadId =
+        0;
+
+
+    if (g_stopEvent) {
+
+        CloseHandle(
+            g_stopEvent
+        );
+
+
+        g_stopEvent =
+            nullptr;
     }
+
+
+    /*
+        Always restore the taskbar when the mod is disabled.
+    */
+
+    SetTaskbarVisibility(
+        true
+    );
+
+
+    g_taskbarHidden =
+        false;
+
+    g_onDesktopState =
+        false;
+
+    g_shownDueToHover =
+        false;
+
+    g_hideDeadline =
+        0;
 }
 
-// The mod settings were changed, reload them.
+
+// ============================================================
+// Settings changed
+// ============================================================
+
 void Wh_ModSettingsChanged() {
-    Wh_Log(L"SettingsChanged");
+
+    Wh_Log(
+        L"SettingsChanged"
+    );
+
 
     LoadSettings();
+
+
+    /*
+        The worker's 100 ms polling cycle will pick up
+        the new settings.
+
+        No cross-thread message or resource manipulation
+        is needed here.
+    */
 }

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -1,0 +1,450 @@
+// ==WindhawkMod==
+// @id              hide-taskbar-only-on-desktop
+// @name            Hide Taskbar Only on Desktop
+// @description     Hides the taskbar on the desktop, shows it for other windows or when you hover near the bottom edge
+// @version         1.0.0
+// @author          Sahil Dashoni
+// @github          https://github.com/Sahil-Dashoni
+// @include         explorer.exe
+// @compilerOptions -ldwmapi
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Hide Taskbar on Desktop
+
+Hides the Windows taskbar whenever there's nothing else to show (desktop
+focused, or every window minimized), and shows it again immediately when
+any other window is focused.
+
+You can also peek at the taskbar by moving the mouse to the bottom of the
+screen while on the desktop - the reveal zone matches the taskbar's own
+height (plus a small extra margin you can configure), not just a thin
+strip at the very bottom, so hovering anywhere over where the taskbar
+would be counts. The delay before hiding only applies to that peek: hover
+in, then move away, and it waits a moment before hiding again. Every other
+hide (switching to the desktop, closing or minimizing the last window,
+etc.) hides instantly, no delay.
+
+### Notes
+- Works with a single taskbar, and optionally with secondary taskbars on
+  extra monitors (toggle in the settings).
+- Pressing the Windows key or clicking the Start button still works even
+  while the taskbar is hidden, and will bring the taskbar back, since the
+  Start menu counts as "another window".
+- The "on desktop" check re-verifies itself roughly 10 times a second by
+  checking for any other visible, non-minimized window, rather than
+  depending on a single event. This is what makes minimizing the last
+  window hide the taskbar right away, without needing an extra click.
+- Opening Start, a system tray flyout ("show hidden icons"), or the
+  notification/clock panel keeps the taskbar visible, since those count
+  as "another window" too.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- extraHoverMarginMm: 5
+  $name: Extra hover margin (mm)
+  $description: >-
+    The reveal zone at the bottom of the screen automatically matches your
+    taskbar's actual height (including your display scaling), so hovering
+    anywhere over where the taskbar would be reveals it. This setting adds
+    a bit of extra margin above that, in millimeters, so you don't need to
+    be pixel-perfect. Default 5mm.
+- autoHideDelayMs: 700
+  $name: Auto-hide delay after hover (ms)
+  $description: >-
+    How long to wait, after moving the mouse away from the bottom-edge
+    hover zone, before the taskbar hides again. Only applies to that case
+    - other hides (e.g. minimizing the last window) are instant.
+    Default 700ms.
+- hideSecondaryTaskbars: true
+  $name: Hide secondary taskbars
+  $description: >-
+    Also hide/show taskbars on additional monitors, if you have "Show
+    taskbar on all displays" enabled in Windows
+*/
+// ==/WindhawkModSettings==
+
+#include <windows.h>
+#include <dwmapi.h>
+
+struct {
+    int extraHoverMarginMm;
+    DWORD autoHideDelayMs;
+    bool hideSecondaryTaskbars;
+} settings;
+
+HWINEVENTHOOK g_hWinEventHookForeground;
+HANDLE g_hThread;
+DWORD g_threadId;
+
+bool g_taskbarHidden = false;    // current actual visibility state
+bool g_onDesktopState = false;   // true if "nothing else to show" right now
+bool g_shownDueToHover = false;  // taskbar currently shown only because of
+                                  // the bottom-edge hover peek
+ULONGLONG g_hideDeadline = 0;    // tick count when a pending hover-dismiss
+                                  // hide should fire (0 = none pending)
+
+// Returns true if hwnd is the desktop window: either the classic "Progman"
+// window, or a "WorkerW" that's actually hosting the desktop icons (rather
+// than just being one of the extra wallpaper-helper WorkerW windows).
+bool IsDesktopWindow(HWND hwnd) {
+    if (!hwnd) {
+        return false;
+    }
+
+    WCHAR className[256];
+    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
+        return false;
+    }
+
+    if (wcscmp(className, L"Progman") == 0) {
+        return true;
+    }
+
+    if (wcscmp(className, L"WorkerW") == 0) {
+        if (FindWindowExW(hwnd, nullptr, L"SHELLDLL_DefView", nullptr)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool IsShellChromeClass(const WCHAR* className) {
+    static const WCHAR* kShellClasses[] = {
+        L"Progman",
+        L"WorkerW",
+        L"Shell_TrayWnd",
+        L"Shell_SecondaryTrayWnd",
+        L"Windows.UI.Core.CoreWindow",
+        L"Xaml_WindowedPopupClass",
+        L"TaskListThumbnailWnd",
+        L"SysShadow",
+        L"tooltips_class32",
+        L"MSCTFIME UI",
+        L"IME",
+    };
+
+    for (const WCHAR* shellClass : kShellClasses) {
+        if (wcscmp(className, shellClass) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
+    bool* pFoundOther = (bool*)lParam;
+
+    if (!IsWindowVisible(hwnd) || IsIconic(hwnd)) {
+        return TRUE;
+    }
+
+    // Skip owned windows (tooltips, dropdowns, small popups, etc.).
+    if (GetWindow(hwnd, GW_OWNER) != nullptr) {
+        return TRUE;
+    }
+
+    WCHAR className[256];
+    GetClassNameW(hwnd, className, ARRAYSIZE(className));
+
+    if (IsShellChromeClass(className)) {
+        return TRUE;
+    }
+
+    LONG_PTR exStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+    if (exStyle & WS_EX_TOOLWINDOW) {
+        return TRUE;
+    }
+
+    // Skip cloaked windows (e.g. UWP apps sitting on another virtual
+    // desktop, which still report as "visible" otherwise).
+    BOOL cloaked = FALSE;
+    if (SUCCEEDED(DwmGetWindowAttribute(hwnd, DWMWA_CLOAKED, &cloaked,
+                                         sizeof(cloaked))) &&
+        cloaked) {
+        return TRUE;
+    }
+
+    RECT rect;
+    if (GetWindowRect(hwnd, &rect)) {
+        if (rect.right - rect.left <= 0 || rect.bottom - rect.top <= 0) {
+            return TRUE;
+        }
+    }
+
+    *pFoundOther = true;
+    return FALSE;  // found one, no need to keep enumerating
+}
+
+// Checks for any real, non-minimized application window currently visible.
+bool AnyOtherVisibleWindowExists() {
+    bool found = false;
+    EnumWindows(EnumWindowsProc, (LPARAM)&found);
+    return found;
+}
+
+bool IsAmbiguousForegroundClass(const WCHAR* className) {
+    // These are the taskbar's own base windows, not a popup on top of it.
+    // The OS sometimes leaves one of these as the "foreground" window by
+    // default (e.g. right after minimizing the last app) without the user
+    // having actually clicked on the taskbar itself, so we can't trust
+    // this alone and fall back to checking for other windows.
+    return wcscmp(className, L"Shell_TrayWnd") == 0 ||
+           wcscmp(className, L"Shell_SecondaryTrayWnd") == 0;
+}
+
+// Authoritative check for whether we're in "desktop mode" (hide the
+// taskbar). Trusts a genuinely focused, visible window directly - this
+// includes Start menu, tray icon flyouts, and the notification/clock
+// panel, all of which should keep the taskbar visible. Only falls back to
+// scanning for any other visible window when the foreground window itself
+// is inconclusive (none, minimized, or the taskbar's own base window) -
+// this is what catches minimizing/closing the last real window.
+void RefreshDesktopState() {
+    HWND fg = GetForegroundWindow();
+
+    if (!fg) {
+        g_onDesktopState = !AnyOtherVisibleWindowExists();
+        return;
+    }
+
+    if (IsDesktopWindow(fg)) {
+        g_onDesktopState = true;
+        return;
+    }
+
+    if (IsIconic(fg)) {
+        g_onDesktopState = !AnyOtherVisibleWindowExists();
+        return;
+    }
+
+    WCHAR className[256];
+    if (GetClassNameW(fg, className, ARRAYSIZE(className)) &&
+        IsAmbiguousForegroundClass(className)) {
+        g_onDesktopState = !AnyOtherVisibleWindowExists();
+        return;
+    }
+
+    g_onDesktopState = false;
+}
+
+void SetTaskbarVisibility(bool show) {
+    HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
+    if (hTaskbar) {
+        ShowWindow(hTaskbar, show ? SW_SHOW : SW_HIDE);
+    }
+
+    if (settings.hideSecondaryTaskbars) {
+        HWND hSecondary = nullptr;
+        while ((hSecondary = FindWindowExW(nullptr, hSecondary,
+                                            L"Shell_SecondaryTrayWnd",
+                                            nullptr)) != nullptr) {
+            ShowWindow(hSecondary, show ? SW_SHOW : SW_HIDE);
+        }
+    }
+}
+
+// The reveal zone matches the taskbar's own current height (whatever size
+// and display scaling you actually have it set to), plus a configurable
+// extra margin on top. Falls back to a small DPI-scaled default if the
+// taskbar's rect can't be read for some reason.
+int GetHoverZonePx(HWND hTaskbar, UINT dpi) {
+    int marginPx = (int)((double)settings.extraHoverMarginMm / 25.4 * dpi);
+
+    RECT tbRect;
+    if (hTaskbar && GetWindowRect(hTaskbar, &tbRect)) {
+        int taskbarHeight = tbRect.bottom - tbRect.top;
+        if (taskbarHeight > 0) {
+            return taskbarHeight + marginPx;
+        }
+    }
+
+    // Fallback: assume a ~48px (at 100% scaling) default taskbar height.
+    int fallbackHeight = (int)(48.0 * dpi / 96.0);
+    return fallbackHeight + marginPx;
+}
+
+// True if the cursor is within the taskbar-height-sized zone at the bottom
+// edge of whichever monitor it's currently on.
+bool IsCursorNearBottomEdge() {
+    POINT pt;
+    if (!GetCursorPos(&pt)) {
+        return false;
+    }
+
+    HMONITOR hMonitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO mi = {sizeof(mi)};
+    if (!GetMonitorInfoW(hMonitor, &mi)) {
+        return false;
+    }
+
+    if (pt.x < mi.rcMonitor.left || pt.x > mi.rcMonitor.right) {
+        return false;
+    }
+
+    HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
+    UINT dpi = hTaskbar ? GetDpiForWindow(hTaskbar) : 96;
+
+    int hotZonePx = GetHoverZonePx(hTaskbar, dpi);
+    if (hotZonePx < 1) {
+        hotZonePx = 1;
+    }
+
+    return pt.y >= mi.rcMonitor.bottom - hotZonePx;
+}
+
+// Single place that decides whether the taskbar should be shown or hidden.
+// Only the "hover then move away" case gets a delay; every other hide is
+// instant.
+void UpdateTaskbarState() {
+    bool hovering = IsCursorNearBottomEdge();
+
+    if (!g_onDesktopState) {
+        // A real window is focused: always show, instantly.
+        g_hideDeadline = 0;
+        g_shownDueToHover = false;
+        if (g_taskbarHidden) {
+            SetTaskbarVisibility(true);
+            g_taskbarHidden = false;
+        }
+        return;
+    }
+
+    // On desktop.
+    if (hovering) {
+        g_hideDeadline = 0;
+        g_shownDueToHover = true;
+        if (g_taskbarHidden) {
+            SetTaskbarVisibility(true);
+            g_taskbarHidden = false;
+        }
+        return;
+    }
+
+    // On desktop, not hovering: the taskbar should end up hidden.
+    if (g_taskbarHidden) {
+        g_hideDeadline = 0;
+        return;
+    }
+
+    if (!g_shownDueToHover) {
+        // Taskbar was visible for some other reason (a window just got
+        // minimized/closed, or desktop just got focused) - hide instantly.
+        SetTaskbarVisibility(false);
+        g_taskbarHidden = true;
+        g_hideDeadline = 0;
+        return;
+    }
+
+    // Taskbar was visible because of the hover peek, and the mouse has now
+    // left the zone - this is the only case that gets a grace period.
+    ULONGLONG now = GetTickCount64();
+    if (g_hideDeadline == 0) {
+        g_hideDeadline = now + settings.autoHideDelayMs;
+    } else if (now >= g_hideDeadline) {
+        SetTaskbarVisibility(false);
+        g_taskbarHidden = true;
+        g_hideDeadline = 0;
+        g_shownDueToHover = false;
+    }
+}
+
+void CALLBACK WinEventProc(HWINEVENTHOOK hWinEventHook, DWORD event,
+                            HWND hwnd, LONG idObject, LONG idChild,
+                            DWORD idEventThread, DWORD dwmsEventTime) {
+    if (idObject != OBJID_WINDOW || event != EVENT_SYSTEM_FOREGROUND) {
+        return;
+    }
+
+    // Quick, instant reaction for the common case (switching to a real
+    // window). The poll timer re-verifies everything ~10x/sec regardless,
+    // which is what reliably catches the minimize/close-last-window case.
+    RefreshDesktopState();
+    UpdateTaskbarState();
+}
+
+void CALLBACK TimerProc(HWND hwnd, UINT uMsg, UINT_PTR idEvent,
+                         DWORD dwTime) {
+    RefreshDesktopState();
+    UpdateTaskbarState();
+}
+
+// WINEVENT_OUTOFCONTEXT and a polling SetTimer both need a thread that
+// pumps messages, so we spin up a dedicated thread for this instead of
+// relying on whichever thread happens to call Wh_ModInit.
+DWORD WINAPI HookThread(LPVOID param) {
+    g_hWinEventHookForeground = SetWinEventHook(
+        EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND, nullptr,
+        WinEventProc, 0, 0, WINEVENT_OUTOFCONTEXT);
+
+    RefreshDesktopState();
+    UpdateTaskbarState();
+
+    const UINT kPollIntervalMs = 100;
+    UINT_PTR timerId = SetTimer(nullptr, 0, kPollIntervalMs, TimerProc);
+
+    MSG msg;
+    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+
+    if (timerId) {
+        KillTimer(nullptr, timerId);
+    }
+    if (g_hWinEventHookForeground) {
+        UnhookWinEvent(g_hWinEventHookForeground);
+        g_hWinEventHookForeground = nullptr;
+    }
+
+    return 0;
+}
+
+void LoadSettings() {
+    settings.extraHoverMarginMm = Wh_GetIntSetting(L"extraHoverMarginMm");
+    settings.autoHideDelayMs = (DWORD)Wh_GetIntSetting(L"autoHideDelayMs");
+    settings.hideSecondaryTaskbars =
+        Wh_GetIntSetting(L"hideSecondaryTaskbars") != 0;
+}
+
+// The mod is being initialized, load settings, hook functions, and do other
+// initialization stuff if required.
+BOOL Wh_ModInit() {
+    Wh_Log(L"Init");
+
+    LoadSettings();
+
+    g_hThread = CreateThread(nullptr, 0, HookThread, nullptr, 0, &g_threadId);
+
+    return TRUE;
+}
+
+// The mod is being unloaded, free all allocated resources.
+void Wh_ModUninit() {
+    Wh_Log(L"Uninit");
+
+    if (g_hThread) {
+        PostThreadMessageW(g_threadId, WM_QUIT, 0, 0);
+        WaitForSingleObject(g_hThread, 3000);
+        CloseHandle(g_hThread);
+        g_hThread = nullptr;
+    }
+
+    // Always leave the taskbar visible when the mod is disabled/unloaded.
+    if (g_taskbarHidden) {
+        SetTaskbarVisibility(true);
+        g_taskbarHidden = false;
+    }
+}
+
+// The mod settings were changed, reload them.
+void Wh_ModSettingsChanged() {
+    Wh_Log(L"SettingsChanged");
+
+    LoadSettings();
+}

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -10,63 +10,73 @@
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
+
 /*
-# Hide Taskbar on Desktop
+
+# Hide Taskbar Only on Desktop
 
 Hides the Windows taskbar while the desktop is active and shows it again
 when an application or supported Windows shell UI is active.
 
-### Features
+## Features
 
-- Hides the taskbar when no normal visible window is active.
-- Shows the taskbar immediately when an application is active.
-- Reveals the taskbar when the mouse enters the bottom area of a monitor.
-- The reveal zone automatically follows the actual taskbar height.
-- Adds a configurable extra hover margin in millimeters.
-- Uses a configurable delay only when hiding after a mouse hover.
+- Hides the taskbar when on the desktop.
+- Shows the taskbar when an application is active.
+- Reveals the taskbar when the mouse enters the bottom-edge hover area.
+- Automatically matches the hover area to the current taskbar height.
+- Supports an additional configurable hover margin.
+- Uses a configurable delay when hiding after mouse hover.
 - Hides immediately after minimizing or closing the last application.
 - Keeps the taskbar visible while interacting with taskbar buttons.
-- Supports optional secondary taskbars on additional monitors.
-- Re-checks the desktop state periodically so minimizing the last window
-  does not require an extra desktop click.
+- Supports secondary taskbars on additional monitors.
 
-### Settings
+## Settings
 
-- Extra hover margin: additional space above the taskbar-height reveal zone.
-- Auto-hide delay after hover: delay before hiding after leaving the reveal zone.
-- Hide secondary taskbars: controls taskbars on additional monitors.
+### Extra hover margin
 
-### Notes
+Adds additional space above the automatically detected taskbar-height
+reveal zone.
 
-The mod uses a small worker thread with a Windows message queue for
-WinEvent notifications and periodic state checks. The worker is stopped
-and joined before the mod is unloaded.
+Default: 5 mm
+
+### Auto-hide delay after hover
+
+Controls how long the taskbar remains visible after the mouse leaves
+the bottom reveal area.
+
+Default: 700 ms
+
+This delay only applies when the taskbar was revealed by mouse hover.
+
+### Hide secondary taskbars
+
+Controls whether taskbars on additional monitors are also hidden.
+
+Default: enabled
+
 */
-// ==WindhawkModReadme==
+
+// ==/WindhawkModReadme==
 
 // ==WindhawkModSettings==
+
 /*
+
 - extraHoverMarginMm: 5
   $name: Extra hover margin (mm)
-  $description: >-
-    Adds extra space above the automatically detected taskbar-height
-    reveal zone. Default is 5 mm.
+  $description: Adds extra space above the automatically detected taskbar-height reveal zone.
 
 - autoHideDelayMs: 700
   $name: Auto-hide delay after hover (ms)
-  $description: >-
-    How long to wait after the mouse leaves the bottom-edge hover zone
-    before hiding the taskbar. Only applies after a mouse hover reveal.
-    Default is 700 ms.
+  $description: How long to wait after the mouse leaves the bottom-edge hover zone before hiding the taskbar.
 
 - hideSecondaryTaskbars: true
   $name: Hide secondary taskbars
-  $description: >-
-    Also hide and show taskbars on additional monitors when Windows is
-    configured to show taskbars on all displays.
-*/
-// ==WindhawkModSettings==
+  $description: Also hide and show taskbars on additional monitors.
 
+*/
+
+// ==/WindhawkModSettings==
 #include <windows.h>
 #include <dwmapi.h>
 


### PR DESCRIPTION
This mod hides the taskbar on the desktop while allowing it to show for other windows or when hovering near the bottom edge. It includes settings for extra hover margin, auto-hide delay, and secondary taskbar visibility.

Features
Hides the taskbar when on the desktop.
Shows the taskbar when an application is active.
Reveals the taskbar when the mouse enters the bottom-edge hover area.
Automatically matches the hover area to the current taskbar height.
Supports an additional configurable hover margin.
Uses a configurable 700 ms delay when hiding after mouse hover.
Hides immediately after minimizing or closing the last application.
Keeps the taskbar visible while interacting with taskbar buttons.
Supports secondary taskbars on additional monitors.
Mod authorship

This mod was created with AI assistance.

The submitter, with AI assistance

ChatGPT

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [x] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
