### PR TITLE
Add mod to hide taskbar only on desktop

### DIFF
--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -185,27 +185,13 @@ bool IsShellChromeClass(const WCHAR* className) {
         return false;
     }
 
-    static const WCHAR* kShellClasses[] = {
-        L"Progman",
-        L"WorkerW",
-        L"Shell_TrayWnd",
-        L"Shell_SecondaryTrayWnd",
-        L"Windows.UI.Core.CoreWindow",
-        L"Xaml_WindowedPopupClass",
-        L"TaskListThumbnailWnd",
-        L"SysShadow",
-        L"tooltips_class32",
-        L"MSCTFIME UI",
-        L"IME",
-    };
-
-    for (const WCHAR* shellClass : kShellClasses) {
-        if (wcscmp(className, shellClass) == 0) {
-            return true;
-        }
-    }
-
-    return false;
+    return
+        wcscmp(className, L"Windows.UI.Core.CoreWindow") == 0 ||
+        wcscmp(className, L"ApplicationFrameWindow") == 0 ||
+        wcscmp(className, L"Xaml_WindowedPopupClass") == 0 ||
+        wcscmp(className, L"ControlCenterWindow") == 0 ||
+        wcscmp(className, L"TopLevelWindowForOverflowXamlIsland") == 0 ||
+        wcscmp(className, L"NotifyIconOverflowWindow") == 0;
 }
 
 
@@ -439,10 +425,12 @@ bool IsKnownShellUiProcess(const WCHAR* processName) {
     }
 
     return
+        _wcsicmp(processName, L"explorer.exe") == 0 ||
         _wcsicmp(processName, L"StartMenuExperienceHost.exe") == 0 ||
         _wcsicmp(processName, L"ShellExperienceHost.exe") == 0 ||
         _wcsicmp(processName, L"ShellHost.exe") == 0 ||
         _wcsicmp(processName, L"SearchHost.exe") == 0 ||
+        _wcsicmp(processName, L"SearchApp.exe") == 0 ||
         _wcsicmp(processName, L"TextInputHost.exe") == 0;
 }
 

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id hide-taskbar-only-on-desktop
 // @name Hide Taskbar Only on Desktop
 // @description Hides the taskbar when the desktop is active, while showing it for applications and on taskbar hover
-// @version 1.3.0
+// @version 1.4.0
 // @author Sahil Dashoni
 // @github https://github.com/Sahil-Dashoni
 // @include windhawk.exe
@@ -324,6 +324,13 @@ void RefreshDesktopState() {
     if (IsTaskbarWindow(foreground)) {
         if (IsTaskbarForegroundAndUnderCursor(foreground)) {
             g_taskbarIsForeground = true;
+
+            // The taskbar was revealed/kept visible by the user's
+            // interaction with it. Preserve this state so that when the
+            // cursor leaves the taskbar we start the configured hover
+            // delay instead of hiding it immediately.
+            g_shownDueToHover = true;
+
             g_onDesktopState = false;
             return;
         }
@@ -726,7 +733,14 @@ void UpdateTaskbarState() {
      */
     if (!g_onDesktopState) {
         g_hideDeadline = 0;
-        g_shownDueToHover = false;
+
+        // Do not clear g_shownDueToHover while the taskbar itself has
+        // focus. It is needed after the cursor leaves the taskbar so the
+        // configured delay is applied. Clear it for a real application
+        // state, where hiding is never delayed.
+        if (!g_taskbarIsForeground) {
+            g_shownDueToHover = false;
+        }
 
         SetTaskbarVisibility(true);
 

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
-// @id hide-taskbar-only-on-desktop
+// @id hide-taskbar-only-on-desktop-v2
 // @name Hide Taskbar Only on Desktop
-// @description Hides the taskbar when the desktop is active, while showing it for applications and on taskbar hover
-// @version 1.5.0
+// @description Hides the taskbar on desktop while preserving taskbar and Windows shell UI interaction
+// @version 1.7.0
 // @author Sahil Dashoni
 // @github https://github.com/Sahil-Dashoni
 // @include windhawk.exe
@@ -30,7 +30,16 @@ visible whenever an application or shell UI is active.
 - Minimizing or closing the last application hides the taskbar immediately.
 - Keeps the taskbar available while interacting with taskbar buttons.
 - Supports secondary taskbars on additional monitors.
+- Uses independent per-monitor desktop/application state.
+- If an application is open on one monitor while another monitor is
+  showing the desktop, only the desktop monitor's taskbar is hidden.
 - Supports bottom, top, left and right taskbar positions.
+- Keeps the taskbar visible for Windows shell flyouts such as Start,
+  Search, Notifications and Quick Settings.
+- Keeps the taskbar visible while Alt+Tab is open, then uses the same
+  configurable hide delay after Alt+Tab closes.
+- Minimizing the last application clears any previous hover-reveal delay
+  and hides the taskbar immediately on that monitor.
 - Runs as a Windhawk tool instead of being injected into Explorer.
 
 ## Notes
@@ -42,14 +51,20 @@ Because the taskbar is controlled by a separate tool process, an unexpected
 termination of that process while the taskbar is hidden can leave the taskbar
 hidden until Explorer is restarted. Normal disable/unload paths restore it.
 
-If native Windows taskbar auto-hide is enabled, this mod stands down so
-the two mechanisms don't fight each other. If native auto-hide is enabled
-while this mod has hidden the taskbar, the mod restores the taskbar first
-so Windows can take control of it again.
+For predictable behavior, disable Windows' own "Automatically hide the
+taskbar" option while this mod is enabled.
 
 This mod uses only foreground/minimize Windows events for application state
 changes and only uses a short timer while cursor hover handling is actually
 needed. It deliberately avoids system-wide object show/hide/destroy hooks.
+
+On multi-monitor systems, each monitor's taskbar is evaluated independently.
+A normal visible application intersecting a monitor keeps that monitor's
+taskbar visible; a monitor with only the desktop can hide its taskbar.
+
+Windows shell flyouts are treated as temporary shell interaction and keep
+the taskbar visible while they are open. Alt+Tab is likewise treated as an
+active shell interaction.
 
 This mod was created with AI assistance.
 */
@@ -64,10 +79,10 @@ This mod was created with AI assistance.
     dimensions are automatically included. Default is 5 mm.
 
 - autoHideDelayMs: 700
-  $name: Auto-hide delay after hover (ms)
+  $name: Auto-hide delay (ms)
   $description: >-
-    How long the taskbar remains visible after the mouse leaves the
-    hover area. This delay is only used after a hover reveal.
+    How long the taskbar remains visible after a hover reveal or after
+    Alt+Tab closes while no application is active on that monitor.
     Other hides, such as minimizing the last application, are immediate.
 
 - hideSecondaryTaskbars: true
@@ -103,18 +118,27 @@ constexpr UINT kHoverTimerIntervalMs = 200;
 UINT_PTR g_hoverTimerId = 0;
 
 std::atomic<bool> g_refreshPosted{false};
-std::atomic<bool> g_refreshNativeAutoHidePending{false};
-std::atomic<bool> g_nativeAutoHideEnabled{false};
+std::atomic<bool> g_immediateHidePending{false};
 
-bool g_onDesktopState = false;
-// True only while the taskbar itself has foreground focus and the cursor
-// is still over the taskbar. This keeps the hover timer alive after a
-// taskbar click, so moving the cursor away can return to desktop state.
-bool g_taskbarIsForeground = false;
-bool g_shownDueToHover = false;
-ULONGLONG g_hideDeadline = 0;
-
+constexpr size_t kMaxTaskbars = 16;
 constexpr size_t kMaxWinEventHooks = 2;
+
+struct TaskbarState {
+    HWND hwnd = nullptr;
+    HMONITOR monitor = nullptr;
+    RECT monitorRect = {};
+    bool isSecondary = false;
+    bool hasApplication = false;
+    bool taskbarIsForeground = false;
+    bool shellUiForeground = false;
+    bool shownDueToHover = false;
+    bool shownDueToAltTab = false;
+    ULONGLONG hideDeadline = 0;
+};
+
+TaskbarState g_taskbars[kMaxTaskbars] = {};
+size_t g_taskbarCount = 0;
+
 HWINEVENTHOOK g_hWinEventHooks[kMaxWinEventHooks] = {};
 
 
@@ -205,8 +229,24 @@ bool IsTaskbarWindow(HWND hwnd) {
 // Window detection
 // ============================================================
 
+void DiscoverTaskbars();
+
+HWND FindPrimaryTaskbar();
+bool IsTaskbarActuallyHidden(HWND hwnd);
+bool IsShellUiClass(const WCHAR* className);
+
+struct AppMonitorScan {
+    TaskbarState* taskbars;
+    size_t count;
+};
+
 BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
-    bool* pFoundOther = reinterpret_cast<bool*>(lParam);
+    AppMonitorScan* scan =
+        reinterpret_cast<AppMonitorScan*>(lParam);
+
+    if (!scan || !scan->taskbars) {
+        return TRUE;
+    }
 
     if (!IsWindowVisible(hwnd) || IsIconic(hwnd)) {
         return TRUE;
@@ -222,11 +262,15 @@ BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
         return TRUE;
     }
 
-    if (IsShellChromeClass(className)) {
+    if (
+        IsShellChromeClass(className) ||
+        IsShellUiClass(className)
+    ) {
         return TRUE;
     }
 
-    LONG_PTR exStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+    LONG_PTR exStyle =
+        GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
 
     if (exStyle & WS_EX_TOOLWINDOW) {
         return TRUE;
@@ -234,7 +278,8 @@ BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
 
     BOOL cloaked = FALSE;
 
-    if (SUCCEEDED(
+    if (
+        SUCCEEDED(
             DwmGetWindowAttribute(
                 hwnd,
                 DWMWA_CLOAKED,
@@ -242,74 +287,92 @@ BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
                 sizeof(cloaked)
             )
         ) &&
-        cloaked) {
+        cloaked
+    ) {
         return TRUE;
     }
 
-    RECT rect;
+    RECT rect = {};
 
     if (!GetWindowRect(hwnd, &rect)) {
         return TRUE;
     }
 
-    if (rect.right <= rect.left ||
-        rect.bottom <= rect.top) {
+    if (
+        rect.right <= rect.left ||
+        rect.bottom <= rect.top
+    ) {
         return TRUE;
     }
 
-    // Keep legitimate owned application dialogs when they advertise
-    // themselves as application windows.
-    if (GetWindow(hwnd, GW_OWNER) != nullptr &&
-        !(exStyle & WS_EX_APPWINDOW)) {
+    if (
+        GetWindow(hwnd, GW_OWNER) != nullptr &&
+        !(exStyle & WS_EX_APPWINDOW)
+    ) {
         return TRUE;
     }
 
-    *pFoundOther = true;
+    for (size_t i = 0; i < scan->count; ++i) {
+        RECT intersection = {};
 
-    return FALSE;
+        if (
+            IntersectRect(
+                &intersection,
+                &scan->taskbars[i].monitorRect,
+                &rect
+            )
+        ) {
+            scan->taskbars[i].hasApplication = true;
+        }
+    }
+
+    return TRUE;
 }
 
 
-bool AnyOtherVisibleWindowExists() {
-    bool found = false;
+void ScanApplicationWindows() {
+    for (size_t i = 0; i < g_taskbarCount; ++i) {
+        g_taskbars[i].hasApplication = false;
+    }
+
+    if (!g_taskbarCount) {
+        return;
+    }
+
+    AppMonitorScan scan{
+        g_taskbars,
+        g_taskbarCount
+    };
 
     EnumWindows(
         EnumWindowsProc,
-        reinterpret_cast<LPARAM>(&found)
+        reinterpret_cast<LPARAM>(&scan)
     );
-
-    return found;
 }
 
 
 // ============================================================
-// Foreground / desktop state
+// Foreground / taskbar interaction
 // ============================================================
 
-bool IsAmbiguousForegroundClass(const WCHAR* className) {
-    if (!className) {
+bool IsTaskbarForegroundAndUnderCursor(HWND taskbar) {
+    if (!IsTaskbarWindow(taskbar)) {
         return false;
     }
 
-    return wcscmp(className, L"Shell_TrayWnd") == 0 ||
-           wcscmp(className, L"Shell_SecondaryTrayWnd") == 0;
-}
-
-
-bool IsTaskbarForegroundAndUnderCursor(HWND foreground) {
-    if (!IsTaskbarWindow(foreground)) {
+    if (GetForegroundWindow() != taskbar) {
         return false;
     }
 
-    POINT pt;
+    POINT pt = {};
 
     if (!GetCursorPos(&pt)) {
         return false;
     }
 
-    RECT rect;
+    RECT rect = {};
 
-    if (!GetWindowRect(foreground, &rect)) {
+    if (!GetWindowRect(taskbar, &rect)) {
         return false;
     }
 
@@ -317,57 +380,363 @@ bool IsTaskbarForegroundAndUnderCursor(HWND foreground) {
 }
 
 
-void RefreshDesktopState() {
-    HWND foreground = GetForegroundWindow();
-
-    // This flag is transient: it is true only while the taskbar itself
-    // has focus and the cursor is over it. The hover timer uses it to
-    // re-check the state after the cursor leaves the taskbar.
-    g_taskbarIsForeground = false;
-
-    if (!foreground) {
-        g_onDesktopState = !AnyOtherVisibleWindowExists();
-        return;
+bool GetWindowProcessName(HWND hwnd, WCHAR* name, size_t nameCount) {
+    if (!hwnd || !name || nameCount == 0) {
+        return false;
     }
 
-    if (IsTaskbarWindow(foreground)) {
-        if (IsTaskbarForegroundAndUnderCursor(foreground)) {
-            g_taskbarIsForeground = true;
+    DWORD processId = 0;
 
-            g_onDesktopState = false;
-            return;
+    if (!GetWindowThreadProcessId(hwnd, &processId) || !processId) {
+        return false;
+    }
+
+    HANDLE process = OpenProcess(
+        PROCESS_QUERY_LIMITED_INFORMATION,
+        FALSE,
+        processId
+    );
+
+    if (!process) {
+        return false;
+    }
+
+    DWORD size = static_cast<DWORD>(nameCount);
+
+    BOOL result = QueryFullProcessImageNameW(
+        process,
+        0,
+        name,
+        &size
+    );
+
+    CloseHandle(process);
+
+    if (!result || size == 0) {
+        return false;
+    }
+
+    const WCHAR* baseName = wcsrchr(name, L'\\');
+
+    if (baseName) {
+        baseName++;
+        size_t length = wcslen(baseName);
+
+        if (length + 1 <= nameCount) {
+            memmove(name, baseName, (length + 1) * sizeof(WCHAR));
         }
-
-        // The taskbar can remain the foreground window after the user
-        // moves the cursor away. In that situation, treat the desktop
-        // as active if no other application window exists.
-        g_onDesktopState = !AnyOtherVisibleWindowExists();
-        return;
     }
 
-    if (IsDesktopWindow(foreground)) {
-        g_onDesktopState = true;
-        return;
+    return true;
+}
+
+
+bool IsKnownShellUiProcess(const WCHAR* processName) {
+    if (!processName) {
+        return false;
     }
 
-    if (IsIconic(foreground)) {
-        g_onDesktopState = !AnyOtherVisibleWindowExists();
-        return;
+    return
+        _wcsicmp(processName, L"StartMenuExperienceHost.exe") == 0 ||
+        _wcsicmp(processName, L"ShellExperienceHost.exe") == 0 ||
+        _wcsicmp(processName, L"ShellHost.exe") == 0 ||
+        _wcsicmp(processName, L"SearchHost.exe") == 0 ||
+        _wcsicmp(processName, L"TextInputHost.exe") == 0;
+}
+
+
+bool IsShellUiWindow(HWND hwnd) {
+    if (!hwnd || IsTaskbarWindow(hwnd)) {
+        return false;
+    }
+
+    WCHAR processName[MAX_PATH] = {};
+
+    if (!GetWindowProcessName(
+            hwnd,
+            processName,
+            ARRAYSIZE(processName)
+        )) {
+        return false;
+    }
+
+    return IsKnownShellUiProcess(processName);
+}
+
+
+bool IsShellUiClass(const WCHAR* className) {
+    if (!className) {
+        return false;
+    }
+
+    /*
+     * Windows 11 shell flyouts:
+     * - ControlCenterWindow: newer Quick Settings / Notifications hosts.
+     * - Xaml_WindowedPopupClass: XAML popup surfaces used by Start,
+     *   Action Center/flyouts and other shell UI.
+     * - TopLevelWindowForOverflowXamlIsland / NotifyIconOverflowWindow:
+     *   notification/overflow surfaces.
+     * - #32771: the system Alt+Tab switcher window.
+     */
+    return
+        wcscmp(className, L"ControlCenterWindow") == 0 ||
+        wcscmp(className, L"Xaml_WindowedPopupClass") == 0 ||
+        wcscmp(className, L"TopLevelWindowForOverflowXamlIsland") == 0 ||
+        wcscmp(className, L"NotifyIconOverflowWindow") == 0 ||
+        wcscmp(className, L"#32771") == 0;
+}
+
+
+bool IsVisibleShellFlyoutForMonitor(
+    HMONITOR monitor,
+    HWND hwnd
+) {
+    if (!monitor || !hwnd || !IsWindowVisible(hwnd)) {
+        return false;
+    }
+
+    if (IsTaskbarWindow(hwnd)) {
+        return false;
     }
 
     WCHAR className[256] = {};
 
-    if (GetClassNameW(
+    if (
+        GetClassNameW(
+            hwnd,
+            className,
+            ARRAYSIZE(className)
+        ) == 0
+    ) {
+        return false;
+    }
+
+    /*
+     * For an actual visible flyout, use the popup/window class rather than
+     * the owning shell process. ShellExperienceHost and StartMenuExperienceHost
+     * can own other visible windows even when no flyout is open.
+     */
+    if (!IsShellUiClass(className)) {
+        return false;
+    }
+
+    RECT windowRect = {};
+
+    if (!GetWindowRect(hwnd, &windowRect)) {
+        return false;
+    }
+
+    MONITORINFO mi = {};
+    mi.cbSize = sizeof(mi);
+
+    if (!GetMonitorInfoW(monitor, &mi)) {
+        return false;
+    }
+
+    RECT intersection = {};
+
+    return IntersectRect(
+        &intersection,
+        &mi.rcMonitor,
+        &windowRect
+    ) != FALSE;
+}
+
+
+struct ShellFlyoutScan {
+    HMONITOR monitor;
+    bool found;
+};
+
+
+BOOL CALLBACK EnumShellFlyoutProc(
+    HWND hwnd,
+    LPARAM lParam
+) {
+    ShellFlyoutScan* scan =
+        reinterpret_cast<ShellFlyoutScan*>(lParam);
+
+    if (!scan || scan->found) {
+        return FALSE;
+    }
+
+    if (
+        IsVisibleShellFlyoutForMonitor(
+            scan->monitor,
+            hwnd
+        )
+    ) {
+        scan->found = true;
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+
+bool HasVisibleShellFlyout(HMONITOR monitor) {
+    if (!monitor) {
+        return false;
+    }
+
+    ShellFlyoutScan scan = {};
+    scan.monitor = monitor;
+
+    EnumWindows(
+        EnumShellFlyoutProc,
+        reinterpret_cast<LPARAM>(&scan)
+    );
+
+    return scan.found;
+}
+
+
+BOOL CALLBACK EnumAltTabWindowProc(
+    HWND hwnd,
+    LPARAM lParam
+) {
+    bool* found =
+        reinterpret_cast<bool*>(lParam);
+
+    if (!found) {
+        return FALSE;
+    }
+
+    if (!IsWindowVisible(hwnd)) {
+        return TRUE;
+    }
+
+    WCHAR className[128] = {};
+
+    if (
+        GetClassNameW(
+            hwnd,
+            className,
+            ARRAYSIZE(className)
+        ) == 0
+    ) {
+        return TRUE;
+    }
+
+    if (wcscmp(className, L"#32771") == 0) {
+        *found = true;
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+
+bool IsAltTabActive() {
+    /*
+     * Modern Windows versions do not always expose the task switcher
+     * through the legacy #32771 window class. Detect the actual Alt+Tab
+     * shortcut while it is being held, and keep the legacy class check
+     * as a fallback.
+     */
+    bool altTabWindow = false;
+
+    EnumWindows(
+        EnumAltTabWindowProc,
+        reinterpret_cast<LPARAM>(&altTabWindow)
+    );
+
+    if (altTabWindow) {
+        return true;
+    }
+
+    bool altDown =
+        (GetAsyncKeyState(VK_MENU) & 0x8000) != 0;
+
+    bool tabDown =
+        (GetAsyncKeyState(VK_TAB) & 0x8000) != 0;
+
+    return altDown && tabDown;
+}
+
+
+bool IsShellUiForegroundOnMonitor(HMONITOR monitor, HWND foreground) {
+    if (!monitor || !foreground) {
+        return false;
+    }
+
+    WCHAR className[256] = {};
+
+    bool knownClass =
+        GetClassNameW(
             foreground,
             className,
             ARRAYSIZE(className)
-        ) &&
-        IsAmbiguousForegroundClass(className)) {
-        g_onDesktopState = !AnyOtherVisibleWindowExists();
-        return;
+        ) != 0 &&
+        IsShellUiClass(className);
+
+    if (!knownClass && !IsShellUiWindow(foreground)) {
+        return false;
     }
 
-    g_onDesktopState = false;
+    RECT rect = {};
+
+    if (!GetWindowRect(foreground, &rect)) {
+        return false;
+    }
+
+    MONITORINFO mi = {};
+    mi.cbSize = sizeof(mi);
+
+    if (!GetMonitorInfoW(monitor, &mi)) {
+        return false;
+    }
+
+    RECT intersection = {};
+
+    return IntersectRect(
+        &intersection,
+        &mi.rcMonitor,
+        &rect
+    ) != FALSE;
+}
+
+
+void RefreshTaskbarForegroundState() {
+    HWND foreground = GetForegroundWindow();
+
+    for (size_t i = 0; i < g_taskbarCount; ++i) {
+        TaskbarState& taskbar = g_taskbars[i];
+
+        bool foregroundIsTaskbar =
+            foreground == taskbar.hwnd;
+
+        bool cursorOverTaskbar =
+            IsTaskbarForegroundAndUnderCursor(
+                taskbar.hwnd
+            );
+
+        taskbar.taskbarIsForeground =
+            foregroundIsTaskbar;
+
+        taskbar.shellUiForeground =
+            IsShellUiForegroundOnMonitor(
+                taskbar.monitor,
+                foreground
+            );
+
+        if (cursorOverTaskbar) {
+            taskbar.shownDueToHover = true;
+            taskbar.shownDueToAltTab = false;
+            taskbar.hideDeadline = 0;
+        }
+    }
+}
+
+void RefreshPerMonitorState() {
+    /*
+     * Application visibility is determined independently for each monitor.
+     * A window spanning multiple monitors keeps taskbars on all intersected
+     * monitors visible.
+     */
+    DiscoverTaskbars();
+    ScanApplicationWindows();
+    RefreshTaskbarForegroundState();
 }
 
 
@@ -375,22 +744,95 @@ void RefreshDesktopState() {
 // Taskbar discovery
 // ============================================================
 
-HWND FindPrimaryTaskbar() {
-    return FindWindowW(L"Shell_TrayWnd", nullptr);
+bool IsSecondaryTaskbar(HWND hwnd) {
+    if (!hwnd) {
+        return false;
+    }
+
+    WCHAR className[256] = {};
+
+    if (
+        GetClassNameW(
+            hwnd,
+            className,
+            ARRAYSIZE(className)
+        ) == 0
+    ) {
+        return false;
+    }
+
+    return wcscmp(
+        className,
+        L"Shell_SecondaryTrayWnd"
+    ) == 0;
 }
 
 
-HWND FindTaskbarForMonitor(HMONITOR hMonitor) {
-    if (!hMonitor) {
-        return nullptr;
+void DiscoverTaskbars() {
+    TaskbarState oldStates[kMaxTaskbars] = {};
+    size_t oldCount = g_taskbarCount;
+
+    for (size_t i = 0; i < oldCount; ++i) {
+        oldStates[i] = g_taskbars[i];
     }
 
-    HWND primary = FindPrimaryTaskbar();
+    g_taskbarCount = 0;
 
-    if (primary &&
-        MonitorFromWindow(primary, MONITOR_DEFAULTTONULL) == hMonitor) {
-        return primary;
-    }
+    auto addTaskbar = [&](HWND hwnd) {
+        if (!hwnd || g_taskbarCount >= kMaxTaskbars) {
+            return;
+        }
+
+        for (size_t i = 0; i < g_taskbarCount; ++i) {
+            if (g_taskbars[i].hwnd == hwnd) {
+                return;
+            }
+        }
+
+        HMONITOR monitor =
+            MonitorFromWindow(
+                hwnd,
+                MONITOR_DEFAULTTONULL
+            );
+
+        if (!monitor) {
+            return;
+        }
+
+        MONITORINFO mi = {};
+        mi.cbSize = sizeof(mi);
+
+        if (!GetMonitorInfoW(monitor, &mi)) {
+            return;
+        }
+
+        TaskbarState state = {};
+        state.hwnd = hwnd;
+        state.monitor = monitor;
+        state.monitorRect = mi.rcMonitor;
+        state.isSecondary = IsSecondaryTaskbar(hwnd);
+
+        for (size_t i = 0; i < oldCount; ++i) {
+            if (oldStates[i].hwnd == hwnd) {
+                state.shownDueToHover =
+                    oldStates[i].shownDueToHover;
+                state.shownDueToAltTab =
+                    oldStates[i].shownDueToAltTab;
+                state.hideDeadline =
+                    oldStates[i].hideDeadline;
+                break;
+            }
+        }
+
+        g_taskbars[g_taskbarCount++] = state;
+    };
+
+    addTaskbar(
+        FindWindowW(
+            L"Shell_TrayWnd",
+            nullptr
+        )
+    );
 
     HWND secondary = nullptr;
 
@@ -402,48 +844,22 @@ HWND FindTaskbarForMonitor(HMONITOR hMonitor) {
             nullptr
         )) != nullptr
     ) {
-        if (
-            MonitorFromWindow(
-                secondary,
-                MONITOR_DEFAULTTONULL
-            ) == hMonitor
-        ) {
-            return secondary;
-        }
+        addTaskbar(secondary);
     }
-
-    return nullptr;
-}
-
-
-// ============================================================
-// Native Windows auto-hide detection
-// ============================================================
-
-bool QueryNativeTaskbarAutoHide() {
-    APPBARDATA abd = {};
-    abd.cbSize = sizeof(abd);
-
-    UINT_PTR state =
-        SHAppBarMessage(ABM_GETSTATE, &abd);
-
-    return (state & ABS_AUTOHIDE) != 0;
-}
-
-
-void RefreshNativeTaskbarAutoHideState() {
-    bool enabled = QueryNativeTaskbarAutoHide();
-
-    g_nativeAutoHideEnabled.store(
-        enabled,
-        std::memory_order_relaxed
-    );
 }
 
 
 // ============================================================
 // Taskbar visibility
 // ============================================================
+
+HWND FindPrimaryTaskbar() {
+    return FindWindowW(L"Shell_TrayWnd", nullptr);
+}
+
+bool IsTaskbarActuallyHidden(HWND hwnd) {
+    return hwnd != nullptr && IsWindowVisible(hwnd) == FALSE;
+}
 
 void SetWindowVisibilityIfNeeded(HWND hwnd, bool show) {
     if (!hwnd) {
@@ -530,50 +946,15 @@ int MillimetersToPixels(int mm, UINT dpi) {
 }
 
 
-bool IsCursorInTaskbarHoverZone() {
-    POINT pt;
-
-    if (!GetCursorPos(&pt)) {
+bool IsCursorInTaskbarHoverZone(
+    TaskbarState& taskbar
+) {
+    if (!taskbar.hwnd) {
         return false;
     }
-
-    HMONITOR monitor =
-        MonitorFromPoint(
-            pt,
-            MONITOR_DEFAULTTONULL
-        );
-
-    if (!monitor) {
-        return false;
-    }
-
-    HWND taskbar =
-        FindTaskbarForMonitor(monitor);
-
-    if (!taskbar) {
-        return false;
-    }
-
-    WCHAR className[256] = {};
 
     if (
-        GetClassNameW(
-            taskbar,
-            className,
-            ARRAYSIZE(className)
-        ) == 0
-    ) {
-        return false;
-    }
-
-    bool isSecondary =
-        wcscmp(
-            className,
-            L"Shell_SecondaryTrayWnd"
-        ) == 0;
-
-    if (
-        isSecondary &&
+        taskbar.isSecondary &&
         !g_settings.hideSecondaryTaskbars.load(
             std::memory_order_relaxed
         )
@@ -581,9 +962,15 @@ bool IsCursorInTaskbarHoverZone() {
         return false;
     }
 
-    RECT taskbarRect;
+    POINT pt = {};
 
-    if (!GetWindowRect(taskbar, &taskbarRect)) {
+    if (!GetCursorPos(&pt)) {
+        return false;
+    }
+
+    RECT taskbarRect = {};
+
+    if (!GetWindowRect(taskbar.hwnd, &taskbarRect)) {
         return false;
     }
 
@@ -594,9 +981,9 @@ bool IsCursorInTaskbarHoverZone() {
         return false;
     }
 
-    UINT dpi = GetDpiForWindow(taskbar);
+    UINT dpi = GetDpiForWindow(taskbar.hwnd);
 
-    if (dpi == 0) {
+    if (!dpi) {
         dpi = 96;
     }
 
@@ -608,37 +995,23 @@ bool IsCursorInTaskbarHoverZone() {
             dpi
         );
 
-    MONITORINFO mi = {};
-    mi.cbSize = sizeof(mi);
-
-    if (!GetMonitorInfoW(monitor, &mi)) {
-        return false;
-    }
-
     int monitorWidth =
-        mi.rcMonitor.right - mi.rcMonitor.left;
+        taskbar.monitorRect.right -
+        taskbar.monitorRect.left;
 
     int monitorHeight =
-        mi.rcMonitor.bottom - mi.rcMonitor.top;
+        taskbar.monitorRect.bottom -
+        taskbar.monitorRect.top;
 
     int maxMargin =
         monitorWidth < monitorHeight
             ? monitorWidth / 2
             : monitorHeight / 2;
 
-    if (maxMargin < 0) {
-        maxMargin = 0;
-    }
-
     if (marginPx > maxMargin) {
         marginPx = maxMargin;
     }
 
-    /*
-     * The taskbar rectangle itself already identifies the correct edge
-     * and thickness. Inflating it handles bottom, top, left, right and
-     * vertical taskbars without assuming a particular docking position.
-     */
     RECT hoverRect = taskbarRect;
 
     InflateRect(
@@ -702,120 +1075,11 @@ void EnsureHoverTimer(bool needed) {
 // ============================================================
 
 void UpdateTaskbarState() {
-    /*
-     * If native Windows auto-hide is enabled, don't fight it.
-     *
-     * The native setting is cached and refreshed on state-changing
-     * Windows events/settings refreshes, rather than being queried
-     * on every cursor-poll tick.
-     */
-    if (
-        g_nativeAutoHideEnabled.load(
-            std::memory_order_relaxed
-        )
-    ) {
-        g_hideDeadline = 0;
-        g_shownDueToHover = false;
+    if (!g_taskbarCount) {
         StopHoverTimer();
-
-        // Give control back to Windows' native auto-hide implementation.
-        // This is important if native auto-hide was enabled while our
-        // mod had previously hidden the taskbar with SW_HIDE.
-        SetTaskbarVisibility(true);
         return;
     }
 
-    bool hovering = false;
-
-    if (g_onDesktopState) {
-        hovering = IsCursorInTaskbarHoverZone();
-    }
-
-    /*
-     * Application / non-desktop state.
-     */
-    if (!g_onDesktopState) {
-        g_hideDeadline = 0;
-
-        // If the taskbar itself has focus, preserve the hover-reveal state
-        // so leaving the taskbar starts the configured hide delay.
-        //
-        // A real application state clears the hover-reveal state because
-        // the taskbar must remain visible while that application is active.
-        if (g_taskbarIsForeground) {
-            g_shownDueToHover = true;
-        } else {
-            g_shownDueToHover = false;
-        }
-
-        SetTaskbarVisibility(true);
-
-        // If the taskbar itself has focus, keep polling so that moving
-        // the cursor away from it can transition back to desktop state.
-        EnsureHoverTimer(g_taskbarIsForeground);
-
-        return;
-    }
-
-    /*
-     * Desktop + cursor inside hover area.
-     */
-    if (hovering) {
-        g_hideDeadline = 0;
-        g_shownDueToHover = true;
-
-        SetTaskbarVisibility(true);
-        EnsureHoverTimer(true);
-
-        return;
-    }
-
-    /*
-     * Desktop + taskbar is already hidden.
-     *
-     * Do not use a cached hidden flag as the source of truth.
-     * The actual taskbar window visibility is checked here.
-     */
-    if (IsPrimaryTaskbarHidden()) {
-        /*
-         * If secondary hiding was disabled while the primary taskbar
-         * was already hidden, restore the secondary taskbars immediately.
-         */
-        if (
-            !g_settings.hideSecondaryTaskbars.load(
-                std::memory_order_relaxed
-            )
-        ) {
-            SetSecondaryTaskbarsVisibility(true);
-        } else {
-            // Keep secondary taskbars consistent after Explorer recreates them.
-            SetSecondaryTaskbarsVisibility(false);
-        }
-
-        g_hideDeadline = 0;
-        EnsureHoverTimer(true);
-
-        return;
-    }
-
-    /*
-     * Taskbar is visible on the desktop and wasn't revealed by hover.
-     * Hide immediately.
-     */
-    if (!g_shownDueToHover) {
-        SetTaskbarVisibility(false);
-
-        g_hideDeadline = 0;
-        EnsureHoverTimer(true);
-
-        return;
-    }
-
-    /*
-     * The taskbar was revealed by hover and the cursor has now left
-     * the hover zone. This is the only path where the configured delay
-     * is used.
-     */
     ULONGLONG now = GetTickCount64();
 
     DWORD delay =
@@ -823,17 +1087,215 @@ void UpdateTaskbarState() {
             std::memory_order_relaxed
         );
 
-    if (g_hideDeadline == 0) {
-        g_hideDeadline =
-            now + static_cast<ULONGLONG>(delay);
-    } else if (now >= g_hideDeadline) {
-        SetTaskbarVisibility(false);
+    for (size_t i = 0; i < g_taskbarCount; ++i) {
+        TaskbarState& taskbar =
+            g_taskbars[i];
 
-        g_hideDeadline = 0;
-        g_shownDueToHover = false;
+        bool controlled =
+            !taskbar.isSecondary ||
+            g_settings.hideSecondaryTaskbars.load(
+                std::memory_order_relaxed
+            );
+
+        if (!controlled) {
+            taskbar.shownDueToHover = false;
+            taskbar.hideDeadline = 0;
+
+            SetWindowVisibilityIfNeeded(
+                taskbar.hwnd,
+                true
+            );
+
+            continue;
+        }
+
+        bool hovering =
+            IsCursorInTaskbarHoverZone(taskbar);
+
+        bool shellFlyoutOpen =
+            taskbar.shellUiForeground ||
+            HasVisibleShellFlyout(taskbar.monitor);
+
+        bool altTabActive =
+            IsAltTabActive();
+
+        /*
+         * If a normal application is present on this monitor, that
+         * monitor's taskbar remains visible even when another monitor
+         * is on the desktop.
+         */
+        if (taskbar.hasApplication) {
+            taskbar.shownDueToHover = false;
+            taskbar.hideDeadline = 0;
+
+            SetWindowVisibilityIfNeeded(
+                taskbar.hwnd,
+                true
+            );
+
+            continue;
+        }
+
+        /*
+         * Windows shell flyouts (Start, Search, Notifications, Quick
+         * Settings, tray overflow, etc.) and Alt+Tab must keep the
+         * taskbar visible while they are being used.
+         */
+        if (altTabActive) {
+            /*
+             * Alt+Tab is an explicit shell interaction. Keep the taskbar
+             * visible while the switcher is open and remember that this
+             * reveal came from Alt+Tab so the normal hide delay is applied
+             * after Alt+Tab closes.
+             */
+            taskbar.shownDueToAltTab = true;
+            taskbar.hideDeadline = 0;
+
+            SetWindowVisibilityIfNeeded(
+                taskbar.hwnd,
+                true
+            );
+
+            continue;
+        }
+
+        if (shellFlyoutOpen) {
+            taskbar.hideDeadline = 0;
+
+            SetWindowVisibilityIfNeeded(
+                taskbar.hwnd,
+                true
+            );
+
+            continue;
+        }
+
+        /*
+         * Hovering the taskbar reveals it immediately.
+         */
+        if (hovering) {
+            taskbar.shownDueToHover = true;
+            taskbar.shownDueToAltTab = false;
+            taskbar.hideDeadline = 0;
+
+            SetWindowVisibilityIfNeeded(
+                taskbar.hwnd,
+                true
+            );
+
+            continue;
+        }
+
+        /*
+         * A taskbar click/reveal is tracked by shownDueToHover. Once the
+         * cursor leaves the taskbar, the configured delay below is used.
+         * Do not use Shell_TrayWnd being foreground as a permanent
+         * "keep visible" condition, because Explorer may retain that
+         * foreground window after the cursor leaves.
+         *
+         * Keyboard taskbar navigation such as Win+T is handled by the
+         * foreground check only while the actual taskbar is the focused
+         * window and the shell remains active; the hover state is still
+         * what controls mouse-leave hiding.
+         */
+
+        /*
+         * Apply the delay only after a hover/click reveal.
+         */
+        if (
+            taskbar.taskbarIsForeground &&
+            !taskbar.shownDueToHover
+        ) {
+            SetWindowVisibilityIfNeeded(
+                taskbar.hwnd,
+                true
+            );
+
+            continue;
+        }
+
+        if (taskbar.shownDueToAltTab) {
+            /*
+             * Alt+Tab has just closed. Apply the exact same configured delay
+             * used by the hover reveal instead of hiding immediately.
+             */
+            if (!taskbar.hideDeadline) {
+                taskbar.hideDeadline =
+                    now +
+                    static_cast<ULONGLONG>(delay);
+            } else if (now >= taskbar.hideDeadline) {
+                SetWindowVisibilityIfNeeded(
+                    taskbar.hwnd,
+                    false
+                );
+
+                taskbar.hideDeadline = 0;
+                taskbar.shownDueToAltTab = false;
+            }
+
+            continue;
+        }
+
+        if (taskbar.shownDueToHover) {
+            if (!taskbar.hideDeadline) {
+                taskbar.hideDeadline =
+                    now +
+                    static_cast<ULONGLONG>(delay);
+            } else if (now >= taskbar.hideDeadline) {
+                SetWindowVisibilityIfNeeded(
+                    taskbar.hwnd,
+                    false
+                );
+
+                taskbar.hideDeadline = 0;
+                taskbar.shownDueToHover = false;
+            }
+
+            continue;
+        }
+
+        /*
+         * No application and no reveal: hide this monitor's taskbar
+         * immediately.
+         */
+        SetWindowVisibilityIfNeeded(
+            taskbar.hwnd,
+            false
+        );
+
+        taskbar.hideDeadline = 0;
     }
 
-    EnsureHoverTimer(true);
+    bool needTimer = false;
+
+    for (size_t i = 0; i < g_taskbarCount; ++i) {
+        TaskbarState& taskbar =
+            g_taskbars[i];
+
+        bool controlled =
+            !taskbar.isSecondary ||
+            g_settings.hideSecondaryTaskbars.load(
+                std::memory_order_relaxed
+            );
+
+        if (!controlled) {
+            continue;
+        }
+
+        if (
+            taskbar.hasApplication == false ||
+            taskbar.taskbarIsForeground ||
+            taskbar.shellUiForeground ||
+            taskbar.shownDueToHover ||
+            taskbar.shownDueToAltTab ||
+            IsTaskbarActuallyHidden(taskbar.hwnd)
+        ) {
+            needTimer = true;
+            break;
+        }
+    }
+
+    EnsureHoverTimer(needTimer);
 }
 
 
@@ -841,16 +1303,9 @@ void UpdateTaskbarState() {
 // Worker refresh message
 // ============================================================
 
-void RequestStateRefresh(bool refreshNativeAutoHide = false) {
+void RequestStateRefresh() {
     if (!g_threadId) {
         return;
-    }
-
-    if (refreshNativeAutoHide) {
-        g_refreshNativeAutoHidePending.store(
-            true,
-            std::memory_order_release
-        );
     }
 
     bool expected = false;
@@ -902,8 +1357,7 @@ LRESULT CALLBACK SystemMessageWindowProc(
          * Native taskbar auto-hide can be changed from Windows Settings.
          * Re-query it only when this targeted system notification arrives.
          */
-        RefreshNativeTaskbarAutoHideState();
-        RefreshDesktopState();
+        RefreshPerMonitorState();
         UpdateTaskbarState();
         return 0;
 
@@ -912,8 +1366,7 @@ LRESULT CALLBACK SystemMessageWindowProc(
         /*
          * Monitor layout or DPI can change taskbar geometry.
          */
-        RefreshNativeTaskbarAutoHideState();
-        RefreshDesktopState();
+        RefreshPerMonitorState();
         UpdateTaskbarState();
         return 0;
 
@@ -1020,7 +1473,17 @@ void CALLBACK WinEventProc(
      * controls and other transient windows. Avoiding them prevents a
      * synchronous SHAppBarMessage call on every such event.
      */
-    RequestStateRefresh(false);
+    if (
+        event == EVENT_SYSTEM_MINIMIZESTART ||
+        event == EVENT_SYSTEM_MINIMIZEEND
+    ) {
+        g_immediateHidePending.store(
+            true,
+            std::memory_order_release
+        );
+    }
+
+    RequestStateRefresh();
 }
 
 
@@ -1133,8 +1596,7 @@ DWORD WINAPI HookThread(LPVOID) {
     /*
      * Apply the correct initial state after the worker and hooks exist.
      */
-    RefreshNativeTaskbarAutoHideState();
-    RefreshDesktopState();
+        RefreshPerMonitorState();
     UpdateTaskbarState();
 
     MSG msg = {};
@@ -1151,18 +1613,37 @@ DWORD WINAPI HookThread(LPVOID) {
                 std::memory_order_release
             );
 
-            if (
-                g_refreshNativeAutoHidePending.exchange(
+            bool immediateHide =
+                g_immediateHidePending.exchange(
                     false,
                     std::memory_order_acq_rel
-                )
-            ) {
-                RefreshNativeTaskbarAutoHideState();
+                );
+
+            RefreshPerMonitorState();
+
+            if (immediateHide) {
+                for (size_t i = 0; i < g_taskbarCount; ++i) {
+                    if (!g_taskbars[i].hasApplication) {
+                        /*
+                         * A minimize/restore event is an application-state
+                         * transition, not a taskbar hover. Do not let an
+                         * earlier hover reveal delay this hide.
+                         */
+                        g_taskbars[i].shownDueToHover = false;
+                        g_taskbars[i].shownDueToAltTab = false;
+                        g_taskbars[i].hideDeadline = 0;
+
+                        /*
+                         * If Explorer reports Shell_TrayWnd as foreground
+                         * during the transition, it must not keep the
+                         * desktop taskbar visible.
+                         */
+                        g_taskbars[i].taskbarIsForeground = false;
+                    }
+                }
             }
 
-            RefreshDesktopState();
             UpdateTaskbarState();
-
             continue;
         }
 
@@ -1175,7 +1656,7 @@ DWORD WINAPI HookThread(LPVOID) {
              * Cursor movement is the one piece of state that Windows
              * does not provide as a suitable global WinEvent.
              */
-            RefreshDesktopState();
+            RefreshPerMonitorState();
             UpdateTaskbarState();
 
             continue;
@@ -1200,7 +1681,7 @@ DWORD WINAPI HookThread(LPVOID) {
         std::memory_order_release
     );
 
-    g_refreshNativeAutoHidePending.store(
+    g_immediateHidePending.store(
         false,
         std::memory_order_release
     );
@@ -1241,10 +1722,6 @@ void LoadSettings() {
 
     if (margin > 100) {
         margin = 100;
-    }
-
-    if (delay > 60000) {
-        delay = 60000;
     }
 
     g_settings.extraHoverMarginMm.store(
@@ -1384,14 +1861,13 @@ void WhTool_ModSettingsChanged() {
      * Native taskbar auto-hide is a system setting, so refresh it here
      * rather than on every foreground/minimize event.
      */
-    RefreshNativeTaskbarAutoHideState();
-
+    
     /*
      * Apply settings immediately instead of waiting for a timer tick.
      * In particular, this restores secondary taskbars when the setting
      * changes from ON to OFF while the desktop is already active.
      */
-    RequestStateRefresh(false);
+    RequestStateRefresh();
 }
 
 
@@ -1439,11 +1915,6 @@ void WhTool_ModUninit() {
         g_hThread = nullptr;
         g_threadId = 0;
     }
-
-    g_refreshNativeAutoHidePending.store(
-        false,
-        std::memory_order_release
-    );
 
     if (g_hThreadReadyEvent) {
         CloseHandle(g_hThreadReadyEvent);

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -1,293 +1,212 @@
 // ==WindhawkMod==
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
-// @description     Hides the taskbar on the desktop, shows it for other windows or when you hover near the bottom edge.
+// @description     Hides the taskbar when the desktop is active, while showing it for applications and on bottom-edge hover
 // @version         1.1.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
-// @include         explorer.exe
-// @compilerOptions -ldwmapi
+// @include         windhawk.exe
+// @compilerOptions -lshell32 -ldwmapi
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
-
 /*
-
 # Hide Taskbar Only on Desktop
 
-Hides the Windows taskbar while the desktop is active and shows it again
-when an application or supported Windows shell UI is active.
+Hides the Windows taskbar when the desktop is active, while keeping it
+visible whenever an application or shell UI is active.
 
 ## Features
 
-- Hides the taskbar when on the desktop.
-- Shows the taskbar when an application is active.
-- Reveals the taskbar when the mouse enters the bottom-edge hover area.
-- Automatically matches the hover area to the current taskbar height.
-- Supports an additional configurable hover margin.
-- Uses a configurable delay when hiding after mouse hover.
-- Hides immediately after minimizing or closing the last application.
-- Keeps the taskbar visible while interacting with taskbar buttons.
+- Hides the taskbar on the desktop.
+- Shows the taskbar immediately when an application becomes active.
+- Automatically hides the taskbar after minimizing or closing the last
+  application.
+- Reveals the taskbar when the mouse enters the taskbar-sized hover area.
+- The hover area automatically follows the taskbar size and DPI.
+- Adds a configurable extra hover margin in millimeters.
+- Uses a configurable delay after leaving the hover area.
+- The delay is only used for a hover reveal.
+- Minimizing or closing the last application hides the taskbar immediately.
+- Keeps the taskbar available while interacting with taskbar buttons.
 - Supports secondary taskbars on additional monitors.
+- Supports different monitor DPI settings.
+- Supports bottom, top, left and right taskbar positions.
+- Does not inject the mod into Explorer.
 
-## Settings
+## Notes
 
-### Extra hover margin
+This mod intentionally differs from native Windows auto-hide:
+it hides the taskbar window without changing the desktop work area.
 
-Adds additional space above the automatically detected taskbar-height
-reveal zone.
+If native Windows taskbar auto-hide is already enabled, this mod temporarily
+stands down so the two mechanisms don't fight each other.
 
-Default: 5 mm
-
-### Auto-hide delay after hover
-
-Controls how long the taskbar remains visible after the mouse leaves
-the bottom reveal area.
-
-Default: 700 ms
-
-This delay only applies when the taskbar was revealed by mouse hover.
-
-### Hide secondary taskbars
-
-Controls whether taskbars on additional monitors are also hidden.
-
-Default: enabled
-
+This mod was created with AI assistance.
 */
-
 // ==/WindhawkModReadme==
 
 // ==WindhawkModSettings==
-
 /*
-
 - extraHoverMarginMm: 5
   $name: Extra hover margin (mm)
-  $description: Adds extra space above the automatically detected taskbar-height reveal zone.
+  $description: >-
+    Adds extra space around the taskbar reveal area. The taskbar's own
+    dimensions are automatically included. Default is 5 mm.
 
 - autoHideDelayMs: 700
   $name: Auto-hide delay after hover (ms)
-  $description: How long to wait after the mouse leaves the bottom-edge hover zone before hiding the taskbar.
+  $description: >-
+    How long the taskbar remains visible after the mouse leaves the
+    hover area. This delay is only used after a hover reveal.
+    Other hides, such as minimizing the last application, are immediate.
 
 - hideSecondaryTaskbars: true
   $name: Hide secondary taskbars
-  $description: Also hide and show taskbars on additional monitors.
-
+  $description: >-
+    Also hide taskbars on additional monitors. When disabled, secondary
+    taskbars are always restored.
 */
-
 // ==/WindhawkModSettings==
 
 #include <windows.h>
+#include <shellapi.h>
 #include <dwmapi.h>
+#include <atomic>
 
+struct Settings {
+    std::atomic<int> extraHoverMarginMm{5};
+    std::atomic<DWORD> autoHideDelayMs{700};
+    std::atomic<bool> hideSecondaryTaskbars{true};
+};
 
-// ============================================================
-// Settings
-// ============================================================
+Settings g_settings;
 
-struct {
-    int extraHoverMarginMm;
-    DWORD autoHideDelayMs;
-    bool hideSecondaryTaskbars;
-} settings;
+HANDLE g_hThread = nullptr;
+DWORD g_threadId = 0;
 
-
-// ============================================================
-// Global state
-// ============================================================
+HANDLE g_hThreadReadyEvent = nullptr;
 
 HWINEVENTHOOK g_hWinEventHookForeground = nullptr;
 
-HANDLE g_hThread = nullptr;
-HANDLE g_stopEvent = nullptr;
+std::atomic<bool> g_taskbarHidden{false};
 
-DWORD g_threadId = 0;
-
-bool g_taskbarHidden = false;
 bool g_onDesktopState = false;
 bool g_shownDueToHover = false;
-
 ULONGLONG g_hideDeadline = 0;
+
+constexpr UINT WM_APP_REFRESH_STATE = WM_APP + 1;
 
 
 // ============================================================
-// Desktop detection
+// Utility
 // ============================================================
 
 bool IsDesktopWindow(HWND hwnd) {
-
-    if (!hwnd)
-        return false;
-
-
-    WCHAR className[256] = {};
-
-    if (GetClassNameW(
-            hwnd,
-            className,
-            ARRAYSIZE(className)
-        ) == 0) {
-
+    if (!hwnd) {
         return false;
     }
 
+    WCHAR className[256];
 
-    if (wcscmp(
-            className,
-            L"Progman"
-        ) == 0) {
+    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
+        return false;
+    }
 
+    if (wcscmp(className, L"Progman") == 0) {
         return true;
     }
 
-
-    if (wcscmp(
-            className,
-            L"WorkerW"
-        ) == 0) {
-
+    if (wcscmp(className, L"WorkerW") == 0) {
         return FindWindowExW(
-                   hwnd,
-                   nullptr,
-                   L"SHELLDLL_DefView",
-                   nullptr
-               ) != nullptr;
+            hwnd,
+            nullptr,
+            L"SHELLDLL_DefView",
+            nullptr
+        ) != nullptr;
     }
-
 
     return false;
 }
 
 
-// ============================================================
-// Explorer / shell window classes
-// ============================================================
-
-bool IsShellChromeClass(
-    const WCHAR* className
-) {
+bool IsShellChromeClass(const WCHAR* className) {
+    if (!className) {
+        return false;
+    }
 
     static const WCHAR* kShellClasses[] = {
-
         L"Progman",
         L"WorkerW",
-
         L"Shell_TrayWnd",
         L"Shell_SecondaryTrayWnd",
-
         L"Windows.UI.Core.CoreWindow",
         L"Xaml_WindowedPopupClass",
-
         L"TaskListThumbnailWnd",
         L"SysShadow",
-
         L"tooltips_class32",
         L"MSCTFIME UI",
         L"IME",
     };
 
-
-    for (
-        const WCHAR* shellClass :
-        kShellClasses
-    ) {
-
-        if (wcscmp(
-                className,
-                shellClass
-            ) == 0) {
-
+    for (const WCHAR* shellClass : kShellClasses) {
+        if (wcscmp(className, shellClass) == 0) {
             return true;
         }
     }
-
 
     return false;
 }
 
 
+bool IsTaskbarWindow(HWND hwnd) {
+    if (!hwnd) {
+        return false;
+    }
+
+    WCHAR className[256];
+
+    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
+        return false;
+    }
+
+    return wcscmp(className, L"Shell_TrayWnd") == 0 ||
+           wcscmp(className, L"Shell_SecondaryTrayWnd") == 0;
+}
+
+
 // ============================================================
-// Find any visible application window
+// Window detection
 // ============================================================
 
-BOOL CALLBACK EnumWindowsProc(
-    HWND hwnd,
-    LPARAM lParam
-) {
+BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
+    bool* pFoundOther = reinterpret_cast<bool*>(lParam);
 
-    bool* pFoundOther =
-        reinterpret_cast<bool*>(lParam);
-
-
-    if (!IsWindowVisible(hwnd) ||
-        IsIconic(hwnd)) {
-
+    if (!IsWindowVisible(hwnd) || IsIconic(hwnd)) {
         return TRUE;
     }
 
-
-    /*
-        Ignore owned popup windows such as
-        tooltips and dropdowns.
-    */
-
-    if (GetWindow(
-            hwnd,
-            GW_OWNER
-        ) != nullptr) {
-
+    if (IsTaskbarWindow(hwnd)) {
         return TRUE;
     }
 
+    WCHAR className[256];
 
-    WCHAR className[256] = {};
-
-
-    /*
-        IMPORTANT:
-        Check GetClassNameW's return value.
-    */
-
-    if (GetClassNameW(
-            hwnd,
-            className,
-            ARRAYSIZE(className)
-        ) == 0) {
-
+    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
         return TRUE;
     }
 
-
-    if (IsShellChromeClass(
-            className
-        )) {
-
+    if (IsShellChromeClass(className)) {
         return TRUE;
     }
 
+    LONG_PTR exStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
 
-    LONG_PTR exStyle =
-        GetWindowLongPtrW(
-            hwnd,
-            GWL_EXSTYLE
-        );
-
-
-    if (exStyle &
-        WS_EX_TOOLWINDOW) {
-
+    if (exStyle & WS_EX_TOOLWINDOW) {
         return TRUE;
     }
-
-
-    /*
-        Ignore cloaked windows, for example
-        applications on another virtual desktop.
-    */
 
     BOOL cloaked = FALSE;
-
 
     if (SUCCEEDED(
             DwmGetWindowAttribute(
@@ -298,172 +217,192 @@ BOOL CALLBACK EnumWindowsProc(
             )
         ) &&
         cloaked) {
-
         return TRUE;
     }
 
+    RECT rect;
 
-    RECT rect{};
-
-
-    if (!GetWindowRect(
-            hwnd,
-            &rect
-        )) {
-
+    if (!GetWindowRect(hwnd, &rect)) {
         return TRUE;
     }
-
 
     if (rect.right <= rect.left ||
         rect.bottom <= rect.top) {
-
         return TRUE;
     }
 
+    /*
+     * Don't blindly discard every owned window.
+     *
+     * Some applications use owned top-level windows for legitimate
+     * dialogs. Only ignore windows which are clearly tool windows.
+     */
+    if (GetWindow(hwnd, GW_OWNER) != nullptr &&
+        !(exStyle & WS_EX_APPWINDOW)) {
+        return TRUE;
+    }
 
     *pFoundOther = true;
-
-
-    /*
-        We found one valid visible window.
-    */
 
     return FALSE;
 }
 
 
 bool AnyOtherVisibleWindowExists() {
-
     bool found = false;
-
 
     EnumWindows(
         EnumWindowsProc,
-        reinterpret_cast<LPARAM>(
-            &found
-        )
+        reinterpret_cast<LPARAM>(&found)
     );
-
 
     return found;
 }
 
 
 // ============================================================
-// Foreground-window classification
+// Foreground / desktop state
 // ============================================================
 
-bool IsAmbiguousForegroundClass(
-    const WCHAR* className
-) {
+bool IsAmbiguousForegroundClass(const WCHAR* className) {
+    if (!className) {
+        return false;
+    }
 
-    /*
-        The taskbar's base windows can temporarily
-        become the foreground window.
-
-        In that case we use EnumWindows to determine
-        whether another application is actually active.
-    */
-
-    return wcscmp(
-               className,
-               L"Shell_TrayWnd"
-           ) == 0 ||
-
-           wcscmp(
-               className,
-               L"Shell_SecondaryTrayWnd"
-           ) == 0;
+    return wcscmp(className, L"Shell_TrayWnd") == 0 ||
+           wcscmp(className, L"Shell_SecondaryTrayWnd") == 0;
 }
 
 
-// ============================================================
-// Refresh desktop state
-// ============================================================
+bool IsTaskbarForegroundAndUnderCursor(HWND foreground) {
+    if (!IsTaskbarWindow(foreground)) {
+        return false;
+    }
+
+    POINT pt;
+
+    if (!GetCursorPos(&pt)) {
+        return false;
+    }
+
+    RECT rect;
+
+    if (!GetWindowRect(foreground, &rect)) {
+        return false;
+    }
+
+    return PtInRect(&rect, pt) != FALSE;
+}
+
 
 void RefreshDesktopState() {
-
-    HWND foreground =
-        GetForegroundWindow();
-
-
-    /*
-        No foreground window.
-    */
+    HWND foreground = GetForegroundWindow();
 
     if (!foreground) {
-
-        g_onDesktopState =
-            !AnyOtherVisibleWindowExists();
-
+        g_onDesktopState = !AnyOtherVisibleWindowExists();
         return;
     }
-
 
     /*
-        Actual desktop window.
-    */
-
-    if (IsDesktopWindow(
-            foreground
-        )) {
-
-        g_onDesktopState =
-            true;
-
+     * If the taskbar itself is foreground and the mouse is actually
+     * over it, treat the user as interacting with the taskbar.
+     *
+     * This prevents the taskbar from immediately hiding after a
+     * taskbar click while an application is still open.
+     */
+    if (IsTaskbarForegroundAndUnderCursor(foreground)) {
+        g_onDesktopState = false;
         return;
     }
 
-
-    /*
-        Minimized foreground window.
-
-        Check whether another visible application exists.
-    */
-
-    if (IsIconic(
-            foreground
-        )) {
-
-        g_onDesktopState =
-            !AnyOtherVisibleWindowExists();
-
+    if (IsDesktopWindow(foreground)) {
+        g_onDesktopState = true;
         return;
     }
 
+    if (IsIconic(foreground)) {
+        g_onDesktopState = !AnyOtherVisibleWindowExists();
+        return;
+    }
 
-    WCHAR className[256] = {};
-
+    WCHAR className[256];
 
     if (GetClassNameW(
             foreground,
             className,
             ARRAYSIZE(className)
-        ) != 0) {
+        ) &&
+        IsAmbiguousForegroundClass(className)) {
 
-        if (IsAmbiguousForegroundClass(
-                className
-            )) {
+        g_onDesktopState = !AnyOtherVisibleWindowExists();
+        return;
+    }
 
-            g_onDesktopState =
-                !AnyOtherVisibleWindowExists();
+    /*
+     * A normal foreground window means we're not on the desktop.
+     */
+    g_onDesktopState = false;
+}
 
-            return;
+
+// ============================================================
+// Taskbar discovery
+// ============================================================
+
+HWND FindPrimaryTaskbar() {
+    return FindWindowW(L"Shell_TrayWnd", nullptr);
+}
+
+
+HWND FindTaskbarForMonitor(HMONITOR hMonitor) {
+    if (!hMonitor) {
+        return nullptr;
+    }
+
+    HWND primary = FindPrimaryTaskbar();
+
+    if (primary &&
+        MonitorFromWindow(primary, MONITOR_DEFAULTTONULL) ==
+            hMonitor) {
+        return primary;
+    }
+
+    HWND secondary = nullptr;
+
+    while (
+        (secondary = FindWindowExW(
+            nullptr,
+            secondary,
+            L"Shell_SecondaryTrayWnd",
+            nullptr
+        )) != nullptr
+    ) {
+        if (
+            MonitorFromWindow(
+                secondary,
+                MONITOR_DEFAULTTONULL
+            ) == hMonitor
+        ) {
+            return secondary;
         }
     }
 
+    return nullptr;
+}
 
-    /*
-        Any other non-minimized foreground window means
-        we are not on the empty desktop.
 
-        This also covers supported shell UI such as
-        Start and notification panels.
-    */
+// ============================================================
+// Native Windows auto-hide detection
+// ============================================================
 
-    g_onDesktopState =
-        false;
+bool IsNativeTaskbarAutoHideEnabled() {
+    APPBARDATA abd = {};
+    abd.cbSize = sizeof(abd);
+
+    UINT_PTR state =
+        SHAppBarMessage(ABM_GETSTATE, &abd);
+
+    return (state & ABS_AUTOHIDE) != 0;
 }
 
 
@@ -471,503 +410,456 @@ void RefreshDesktopState() {
 // Taskbar visibility
 // ============================================================
 
-void SetTaskbarVisibility(
-    bool show
-) {
+void SetTaskbarVisibility(bool show) {
+    HWND primary = FindPrimaryTaskbar();
 
-    HWND hTaskbar =
-        FindWindowW(
-            L"Shell_TrayWnd",
-            nullptr
-        );
-
-
-    if (hTaskbar) {
-
+    if (primary) {
         ShowWindow(
-            hTaskbar,
-            show
-                ? SW_SHOW
-                : SW_HIDE
+            primary,
+            show ? SW_SHOW : SW_HIDE
         );
     }
 
+    /*
+     * Always restore secondary taskbars when showing.
+     *
+     * This is important when the user changes
+     * hideSecondaryTaskbars from ON to OFF.
+     */
+    bool shouldProcessSecondary =
+        show ||
+        g_settings.hideSecondaryTaskbars.load(
+            std::memory_order_relaxed
+        );
 
-    if (!settings.hideSecondaryTaskbars)
+    if (!shouldProcessSecondary) {
         return;
+    }
 
-
-    HWND hSecondary = nullptr;
-
+    HWND secondary = nullptr;
 
     while (
-        (hSecondary =
-            FindWindowExW(
-                nullptr,
-                hSecondary,
-                L"Shell_SecondaryTrayWnd",
-                nullptr
-            )) != nullptr
+        (secondary = FindWindowExW(
+            nullptr,
+            secondary,
+            L"Shell_SecondaryTrayWnd",
+            nullptr
+        )) != nullptr
     ) {
-
         ShowWindow(
-            hSecondary,
-            show
-                ? SW_SHOW
-                : SW_HIDE
+            secondary,
+            show ? SW_SHOW : SW_HIDE
         );
     }
 }
 
 
 // ============================================================
-// Hover-zone size
+// Hover zone
 // ============================================================
 
-int GetHoverZonePx(
-    HWND hTaskbar,
-    UINT dpi
-) {
-
-    /*
-        Convert millimeters to pixels.
-
-        25.4 mm = 1 inch.
-    */
-
-    int marginPx =
-        MulDiv(
-            settings.extraHoverMarginMm,
-            static_cast<int>(dpi),
-            254
-        );
-
-
-    if (marginPx < 0)
-        marginPx = 0;
-
-
-    /*
-        Prefer the actual taskbar height.
-    */
-
-    RECT taskbarRect{};
-
-
-    if (hTaskbar &&
-        GetWindowRect(
-            hTaskbar,
-            &taskbarRect
-        )) {
-
-        int taskbarHeight =
-            taskbarRect.bottom -
-            taskbarRect.top;
-
-
-        if (taskbarHeight > 0) {
-
-            return taskbarHeight +
-                   marginPx;
-        }
+int MillimetersToPixels(int mm, UINT dpi) {
+    if (mm <= 0) {
+        return 0;
     }
 
-
     /*
-        Fallback for the short period where
-        Explorer has not created the taskbar yet.
-    */
+     * 25.4 mm = 1 inch.
+     *
+     * Clamp the margin to avoid accidentally making the entire
+     * monitor a hover area.
+     */
+    int maxPx = GetSystemMetrics(SM_CYSCREEN) / 2;
 
-    int fallbackHeight =
-        MulDiv(
-            48,
-            static_cast<int>(dpi),
-            96
-        );
+    int px = MulDiv(
+        mm,
+        static_cast<int>(dpi),
+        254
+    );
 
+    if (px < 0) {
+        px = 0;
+    }
 
-    return fallbackHeight +
-           marginPx;
+    if (px > maxPx) {
+        px = maxPx;
+    }
+
+    return px;
 }
 
 
-// ============================================================
-// Find taskbar belonging to a monitor
-// ============================================================
+bool IsCursorInTaskbarHoverZone() {
+    POINT pt;
 
-HWND FindTaskbarForMonitor(
-    HMONITOR hMonitor
-) {
-
-    if (!hMonitor)
-        return nullptr;
-
-
-    /*
-        First look for the primary-style taskbar.
-    */
-
-    HWND hTaskbar = nullptr;
-
-
-    while (
-        (hTaskbar =
-            FindWindowExW(
-                nullptr,
-                hTaskbar,
-                L"Shell_TrayWnd",
-                nullptr
-            )) != nullptr
-    ) {
-
-        RECT rect{};
-
-
-        if (!GetWindowRect(
-                hTaskbar,
-                &rect
-            )) {
-
-            continue;
-        }
-
-
-        POINT center{
-            rect.left +
-                (rect.right - rect.left) / 2,
-
-            rect.top +
-                (rect.bottom - rect.top) / 2
-        };
-
-
-        if (
-            MonitorFromPoint(
-                center,
-                MONITOR_DEFAULTTONEAREST
-            ) == hMonitor
-        ) {
-
-            return hTaskbar;
-        }
-    }
-
-
-    /*
-        Then look for secondary taskbars.
-    */
-
-    hTaskbar = nullptr;
-
-
-    while (
-        (hTaskbar =
-            FindWindowExW(
-                nullptr,
-                hTaskbar,
-                L"Shell_SecondaryTrayWnd",
-                nullptr
-            )) != nullptr
-    ) {
-
-        RECT rect{};
-
-
-        if (!GetWindowRect(
-                hTaskbar,
-                &rect
-            )) {
-
-            continue;
-        }
-
-
-        POINT center{
-            rect.left +
-                (rect.right - rect.left) / 2,
-
-            rect.top +
-                (rect.bottom - rect.top) / 2
-        };
-
-
-        if (
-            MonitorFromPoint(
-                center,
-                MONITOR_DEFAULTTONEAREST
-            ) == hMonitor
-        ) {
-
-            return hTaskbar;
-        }
-    }
-
-
-    return nullptr;
-}
-
-
-// ============================================================
-// Bottom-edge detection
-// ============================================================
-
-bool IsCursorNearBottomEdge() {
-
-    POINT pt{};
-
-
-    if (!GetCursorPos(
-            &pt
-        )) {
-
+    if (!GetCursorPos(&pt)) {
         return false;
     }
 
-
-    HMONITOR hMonitor =
+    HMONITOR monitor =
         MonitorFromPoint(
             pt,
-            MONITOR_DEFAULTTONEAREST
+            MONITOR_DEFAULTTONULL
         );
 
-
-    if (!hMonitor)
-        return false;
-
-
-    MONITORINFO monitorInfo{
-        sizeof(monitorInfo)
-    };
-
-
-    if (!GetMonitorInfoW(
-            hMonitor,
-            &monitorInfo
-        )) {
-
+    if (!monitor) {
         return false;
     }
 
+    HWND taskbar =
+        FindTaskbarForMonitor(monitor);
+
+    if (!taskbar) {
+        return false;
+    }
 
     /*
-        RECT.right is an exclusive boundary.
-
-        Therefore >= is used here rather than >.
-    */
+     * If secondary taskbars are disabled for this mod,
+     * don't use their area as a reveal zone.
+     */
+    WCHAR className[256];
 
     if (
-        pt.x <
-            monitorInfo.rcMonitor.left ||
-
-        pt.x >=
-            monitorInfo.rcMonitor.right
+        GetClassNameW(
+            taskbar,
+            className,
+            ARRAYSIZE(className)
+        ) == 0
     ) {
-
         return false;
     }
 
+    bool isSecondary =
+        wcscmp(
+            className,
+            L"Shell_SecondaryTrayWnd"
+        ) == 0;
 
-    /*
-        Find the taskbar belonging to the monitor
-        where the mouse currently is.
-
-        This fixes the multi-monitor issue where
-        the primary taskbar's height was previously
-        used for every monitor.
-    */
-
-    HWND hTaskbar =
-        FindTaskbarForMonitor(
-            hMonitor
-        );
-
-
-    UINT dpi = 96;
-
-
-    if (hTaskbar) {
-
-        UINT taskbarDpi =
-            GetDpiForWindow(
-                hTaskbar
-            );
-
-
-        if (taskbarDpi != 0)
-            dpi = taskbarDpi;
+    if (
+        isSecondary &&
+        !g_settings.hideSecondaryTaskbars.load(
+            std::memory_order_relaxed
+        )
+    ) {
+        return false;
     }
 
+    RECT taskbarRect;
 
-    int hotZonePx =
-        GetHoverZonePx(
-            hTaskbar,
-            dpi
+    if (!GetWindowRect(taskbar, &taskbarRect)) {
+        return false;
+    }
+
+    if (
+        taskbarRect.right <= taskbarRect.left ||
+        taskbarRect.bottom <= taskbarRect.top
+    ) {
+        return false;
+    }
+
+    UINT dpi = GetDpiForWindow(taskbar);
+
+    if (dpi == 0) {
+        dpi = 96;
+    }
+
+    int marginPx = MillimetersToPixels(
+        g_settings.extraHoverMarginMm.load(
+            std::memory_order_relaxed
+        ),
+        dpi
+    );
+
+    RECT hoverRect = taskbarRect;
+
+    InflateRect(
+        &hoverRect,
+        marginPx,
+        marginPx
+    );
+
+    MONITORINFO mi = {};
+    mi.cbSize = sizeof(mi);
+
+    if (!GetMonitorInfoW(monitor, &mi)) {
+        return false;
+    }
+
+    /*
+     * Keep the reveal area associated with the taskbar edge.
+     *
+     * The normal taskbar rectangle already represents the full
+     * taskbar span, while the thickness determines the hover depth.
+     */
+
+    int monitorWidth =
+        mi.rcMonitor.right - mi.rcMonitor.left;
+
+    int monitorHeight =
+        mi.rcMonitor.bottom - mi.rcMonitor.top;
+
+    int taskbarWidth =
+        taskbarRect.right - taskbarRect.left;
+
+    int taskbarHeight =
+        taskbarRect.bottom - taskbarRect.top;
+
+    /*
+     * Detect the edge on which the taskbar is docked.
+     */
+    int distanceTop =
+        abs(taskbarRect.top - mi.rcMonitor.top);
+
+    int distanceBottom =
+        abs(taskbarRect.bottom - mi.rcMonitor.bottom);
+
+    int distanceLeft =
+        abs(taskbarRect.left - mi.rcMonitor.left);
+
+    int distanceRight =
+        abs(taskbarRect.right - mi.rcMonitor.right);
+
+    int edgeDistance =
+        min(
+            min(distanceTop, distanceBottom),
+            min(distanceLeft, distanceRight)
         );
 
+    /*
+     * If the taskbar is clearly docked to the bottom.
+     */
+    if (
+        edgeDistance == distanceBottom &&
+        taskbarHeight < monitorHeight
+    ) {
+        hoverRect.top =
+            taskbarRect.top - marginPx;
 
-    if (hotZonePx < 1)
-        hotZonePx = 1;
+        hoverRect.bottom =
+            taskbarRect.bottom + marginPx;
 
+        return PtInRect(
+            &hoverRect,
+            pt
+        ) != FALSE;
+    }
 
-    return pt.y >=
-               monitorInfo.rcMonitor.bottom -
-                   hotZonePx &&
+    /*
+     * Top-docked taskbar.
+     */
+    if (
+        edgeDistance == distanceTop &&
+        taskbarHeight < monitorHeight
+    ) {
+        hoverRect.top =
+            taskbarRect.top - marginPx;
 
-           pt.y <
-               monitorInfo.rcMonitor.bottom;
+        hoverRect.bottom =
+            taskbarRect.bottom + marginPx;
+
+        return PtInRect(
+            &hoverRect,
+            pt
+        ) != FALSE;
+    }
+
+    /*
+     * Left-docked taskbar.
+     */
+    if (
+        edgeDistance == distanceLeft &&
+        taskbarWidth < monitorWidth
+    ) {
+        hoverRect.left =
+            taskbarRect.left - marginPx;
+
+        hoverRect.right =
+            taskbarRect.right + marginPx;
+
+        return PtInRect(
+            &hoverRect,
+            pt
+        ) != FALSE;
+    }
+
+    /*
+     * Right-docked taskbar.
+     */
+    if (
+        edgeDistance == distanceRight &&
+        taskbarWidth < monitorWidth
+    ) {
+        hoverRect.left =
+            taskbarRect.left - marginPx;
+
+        hoverRect.right =
+            taskbarRect.right + marginPx;
+
+        return PtInRect(
+            &hoverRect,
+            pt
+        ) != FALSE;
+    }
+
+    return PtInRect(
+        &hoverRect,
+        pt
+    ) != FALSE;
 }
 
 
 // ============================================================
-// Main taskbar state logic
+// State machine
 // ============================================================
 
 void UpdateTaskbarState() {
-
-    bool hovering =
-        IsCursorNearBottomEdge();
-
-
     /*
-        --------------------------------------------------------
-        APPLICATION / SHELL UI ACTIVE
-        --------------------------------------------------------
-    */
+     * If native Windows auto-hide is enabled, don't fight it.
+     */
+    if (IsNativeTaskbarAutoHideEnabled()) {
+        if (g_taskbarHidden.load(
+                std::memory_order_relaxed
+            )) {
 
-    if (!g_onDesktopState) {
+            SetTaskbarVisibility(true);
 
-        /*
-            A real window is active.
-
-            Always show immediately.
-        */
+            g_taskbarHidden.store(
+                false,
+                std::memory_order_relaxed
+            );
+        }
 
         g_hideDeadline = 0;
-
         g_shownDueToHover = false;
 
+        return;
+    }
 
-        if (g_taskbarHidden) {
+    /*
+     * Only calculate the hover zone when the desktop is actually
+     * active. This avoids doing monitor/taskbar geometry work
+     * unnecessarily while an application is focused.
+     */
+    bool hovering = false;
 
-            SetTaskbarVisibility(
-                true
+    if (g_onDesktopState) {
+        hovering = IsCursorInTaskbarHoverZone();
+    }
+
+    /*
+     * Application / non-desktop state.
+     */
+    if (!g_onDesktopState) {
+        g_hideDeadline = 0;
+        g_shownDueToHover = false;
+
+        if (
+            g_taskbarHidden.load(
+                std::memory_order_relaxed
+            )
+        ) {
+            SetTaskbarVisibility(true);
+
+            g_taskbarHidden.store(
+                false,
+                std::memory_order_relaxed
             );
-
-            g_taskbarHidden =
-                false;
         }
-
 
         return;
     }
 
-
     /*
-        --------------------------------------------------------
-        DESKTOP + MOUSE IN REVEAL ZONE
-        --------------------------------------------------------
-    */
-
+     * Desktop + cursor inside hover area.
+     */
     if (hovering) {
-
         g_hideDeadline = 0;
-
         g_shownDueToHover = true;
 
+        if (
+            g_taskbarHidden.load(
+                std::memory_order_relaxed
+            )
+        ) {
+            SetTaskbarVisibility(true);
 
-        if (g_taskbarHidden) {
-
-            SetTaskbarVisibility(
-                true
+            g_taskbarHidden.store(
+                false,
+                std::memory_order_relaxed
             );
-
-            g_taskbarHidden =
-                false;
         }
 
-
         return;
     }
 
-
     /*
-        --------------------------------------------------------
-        DESKTOP + MOUSE OUTSIDE REVEAL ZONE
-        --------------------------------------------------------
-    */
-
-    if (g_taskbarHidden) {
-
+     * Desktop + taskbar already hidden.
+     */
+    if (
+        g_taskbarHidden.load(
+            std::memory_order_relaxed
+        )
+    ) {
         g_hideDeadline = 0;
-
         return;
     }
 
-
     /*
-        If the taskbar was visible for another reason
-        such as minimizing/closing a window, hide it
-        immediately.
-
-        The hover delay is NOT used here.
-    */
-
+     * Taskbar wasn't revealed by hover.
+     *
+     * Therefore this is an ordinary desktop transition and must
+     * hide immediately.
+     */
     if (!g_shownDueToHover) {
+        SetTaskbarVisibility(false);
 
-        SetTaskbarVisibility(
-            false
+        g_taskbarHidden.store(
+            true,
+            std::memory_order_relaxed
         );
 
-        g_taskbarHidden =
-            true;
-
         g_hideDeadline = 0;
 
         return;
     }
 
-
     /*
-        --------------------------------------------------------
-        MOUSE-TRIGGERED HIDE DELAY
-        --------------------------------------------------------
+     * The taskbar was revealed by hover and the cursor has now
+     * left the hover zone.
+     *
+     * This is the ONLY path where the delay is used.
+     */
+    ULONGLONG now = GetTickCount64();
 
-        This is the ONLY situation where the delay applies.
-    */
+    DWORD delay =
+        g_settings.autoHideDelayMs.load(
+            std::memory_order_relaxed
+        );
 
-    ULONGLONG now =
-        GetTickCount64();
-
+    if (delay > 60000) {
+        delay = 60000;
+    }
 
     if (g_hideDeadline == 0) {
-
         g_hideDeadline =
-            now +
-            settings.autoHideDelayMs;
-
+            now + static_cast<ULONGLONG>(delay);
     }
-    else if (
-        now >=
-        g_hideDeadline
-    ) {
+    else if (now >= g_hideDeadline) {
+        SetTaskbarVisibility(false);
 
-        SetTaskbarVisibility(
-            false
+        g_taskbarHidden.store(
+            true,
+            std::memory_order_relaxed
         );
 
-        g_taskbarHidden =
-            true;
-
         g_hideDeadline = 0;
-
-        g_shownDueToHover =
-            false;
+        g_shownDueToHover = false;
     }
 }
 
 
 // ============================================================
-// WinEvent callback
+// WinEvent hook
 // ============================================================
 
 void CALLBACK WinEventProc(
@@ -979,88 +871,21 @@ void CALLBACK WinEventProc(
     DWORD idEventThread,
     DWORD dwmsEventTime
 ) {
-
-    UNREFERENCED_PARAMETER(
-        hWinEventHook
-    );
-
-    UNREFERENCED_PARAMETER(
-        hwnd
-    );
-
-    UNREFERENCED_PARAMETER(
-        idEventThread
-    );
-
-    UNREFERENCED_PARAMETER(
-        dwmsEventTime
-    );
-
-
     if (
-        event !=
-            EVENT_SYSTEM_FOREGROUND ||
-
-        idObject !=
-            OBJID_WINDOW ||
-
-        idChild !=
-            CHILDID_SELF
+        idObject != OBJID_WINDOW ||
+        event != EVENT_SYSTEM_FOREGROUND
     ) {
-
         return;
     }
 
-
     /*
-        Immediately react to foreground changes.
-    */
-
+     * WinEvent callbacks are delivered to the worker's message-loop
+     * thread for OUTOFCONTEXT hooks.
+     *
+     * Refreshing immediately makes application activation feel
+     * instant, while the timer handles minimize/close transitions.
+     */
     RefreshDesktopState();
-
-    UpdateTaskbarState();
-}
-
-
-// ============================================================
-// Timer callback
-// ============================================================
-
-void CALLBACK TimerProc(
-    HWND hwnd,
-    UINT uMsg,
-    UINT_PTR idEvent,
-    DWORD dwTime
-) {
-
-    UNREFERENCED_PARAMETER(
-        hwnd
-    );
-
-    UNREFERENCED_PARAMETER(
-        uMsg
-    );
-
-    UNREFERENCED_PARAMETER(
-        idEvent
-    );
-
-    UNREFERENCED_PARAMETER(
-        dwTime
-    );
-
-
-    /*
-        Periodic verification catches cases such as:
-
-        - minimizing the last window
-        - closing the last window
-        - Explorer shell transitions
-        - taskbar recreation
-    */
-
-    RefreshDesktopState();
-
     UpdateTaskbarState();
 }
 
@@ -1069,37 +894,24 @@ void CALLBACK TimerProc(
 // Worker thread
 // ============================================================
 
-DWORD WINAPI HookThread(
-    LPVOID param
-) {
-
-    UNREFERENCED_PARAMETER(
-        param
-    );
-
-
+DWORD WINAPI HookThread(LPVOID) {
     /*
-        Force creation of this thread's message queue.
-
-        This is done before the worker starts depending
-        on message delivery.
-    */
-
-    MSG initMsg{};
-
+     * Force creation of this thread's USER message queue before
+     * WhTool_ModUninit can attempt PostThreadMessageW.
+     */
+    MSG initialMessage;
 
     PeekMessageW(
-        &initMsg,
+        &initialMessage,
         nullptr,
         WM_USER,
         WM_USER,
         PM_NOREMOVE
     );
 
-
-    /*
-        Install foreground WinEvent hook.
-    */
+    if (g_hThreadReadyEvent) {
+        SetEvent(g_hThreadReadyEvent);
+    }
 
     g_hWinEventHookForeground =
         SetWinEventHook(
@@ -1112,190 +924,95 @@ DWORD WINAPI HookThread(
             WINEVENT_OUTOFCONTEXT
         );
 
-
     if (!g_hWinEventHookForeground) {
-
         Wh_Log(
             L"SetWinEventHook failed: %lu",
             GetLastError()
         );
     }
 
-
     /*
-        Initial state.
-    */
-
+     * Apply the correct initial state immediately.
+     */
     RefreshDesktopState();
-
     UpdateTaskbarState();
 
-
     /*
-        Poll approximately 10 times per second.
-    */
-
-    const UINT kPollIntervalMs =
-        100;
-
+     * 100 ms is retained because the desktop state must react
+     * quickly to minimizing/closing the last application.
+     */
+    constexpr UINT kPollIntervalMs = 100;
 
     UINT_PTR timerId =
         SetTimer(
             nullptr,
             0,
             kPollIntervalMs,
-            TimerProc
+            nullptr
         );
 
-
     if (!timerId) {
-
         Wh_Log(
             L"SetTimer failed: %lu",
             GetLastError()
         );
     }
 
+    MSG msg;
 
-    /*
-        Wait for either:
-
-        - the stop event
-        - Windows messages
-
-        Using an event instead of PostThreadMessage(WM_QUIT)
-        makes shutdown reliable even during early initialization.
-    */
-
-    while (true) {
-
-        DWORD waitResult =
-            MsgWaitForMultipleObjects(
-                1,
-                &g_stopEvent,
-                FALSE,
-                INFINITE,
-                QS_ALLINPUT
-            );
-
-
-        /*
-            Stop requested.
-        */
-
-        if (
-            waitResult ==
-            WAIT_OBJECT_0
-        ) {
-
-            break;
-        }
-
-
-        /*
-            Messages are waiting.
-        */
-
-        if (
-            waitResult ==
-            WAIT_OBJECT_0 + 1
-        ) {
-
-            MSG msg{};
-
-
-            while (
-                PeekMessageW(
-                    &msg,
-                    nullptr,
-                    0,
-                    0,
-                    PM_REMOVE
-                )
-            ) {
-
-                /*
-                    If another component posts WM_QUIT,
-                    stop cleanly.
-                */
-
-                if (
-                    msg.message ==
-                    WM_QUIT
-                ) {
-
-                    SetEvent(
-                        g_stopEvent
-                    );
-
-                    break;
-                }
-
-
-                TranslateMessage(
-                    &msg
-                );
-
-
-                DispatchMessageW(
-                    &msg
-                );
-            }
-
-
-            if (
-                WaitForSingleObject(
-                    g_stopEvent,
-                    0
-                ) ==
-                WAIT_OBJECT_0
-            ) {
-
-                break;
-            }
-
-
+    while (
+        GetMessageW(
+            &msg,
+            nullptr,
+            0,
+            0
+        ) > 0
+    ) {
+        if (msg.message == WM_APP_REFRESH_STATE) {
+            RefreshDesktopState();
+            UpdateTaskbarState();
             continue;
         }
 
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
 
         /*
-            Unexpected wait failure.
-        */
+         * The timer generated by SetTimer(nullptr, ...) produces
+         * WM_TIMER messages.
+         */
+        if (msg.message == WM_TIMER &&
+            msg.wParam == timerId) {
 
-        Wh_Log(
-            L"MsgWaitForMultipleObjects failed: %lu",
-            GetLastError()
-        );
-
-        break;
+            RefreshDesktopState();
+            UpdateTaskbarState();
+        }
     }
 
-
-    /*
-        The worker owns these resources, so it cleans them
-        up before the thread exits.
-    */
-
     if (timerId) {
-
         KillTimer(
             nullptr,
             timerId
         );
     }
 
-
     if (g_hWinEventHookForeground) {
-
         UnhookWinEvent(
             g_hWinEventHookForeground
         );
 
-        g_hWinEventHookForeground =
-            nullptr;
+        g_hWinEventHookForeground = nullptr;
     }
 
+    /*
+     * Always restore the taskbar when the worker exits.
+     */
+    SetTaskbarVisibility(true);
+
+    g_taskbarHidden.store(
+        false,
+        std::memory_order_relaxed
+    );
 
     return 0;
 }
@@ -1306,84 +1023,65 @@ DWORD WINAPI HookThread(
 // ============================================================
 
 void LoadSettings() {
-
-    settings.extraHoverMarginMm =
+    int margin =
         Wh_GetIntSetting(
             L"extraHoverMarginMm"
         );
 
-
-    settings.autoHideDelayMs =
+    DWORD delay =
         static_cast<DWORD>(
             Wh_GetIntSetting(
                 L"autoHideDelayMs"
             )
         );
 
-
-    settings.hideSecondaryTaskbars =
+    bool secondary =
         Wh_GetIntSetting(
             L"hideSecondaryTaskbars"
         ) != 0;
 
-
     /*
-        Safety limits.
-    */
-
-    if (
-        settings.extraHoverMarginMm <
-        0
-    ) {
-
-        settings.extraHoverMarginMm =
-            0;
+     * Prevent pathological values from making the UI unusable.
+     */
+    if (margin < 0) {
+        margin = 0;
     }
 
-
-    if (
-        settings.extraHoverMarginMm >
-        50
-    ) {
-
-        settings.extraHoverMarginMm =
-            50;
+    if (margin > 100) {
+        margin = 100;
     }
 
-
-    if (
-        settings.autoHideDelayMs >
-        10000
-    ) {
-
-        settings.autoHideDelayMs =
-            10000;
+    if (delay > 60000) {
+        delay = 60000;
     }
+
+    g_settings.extraHoverMarginMm.store(
+        margin,
+        std::memory_order_relaxed
+    );
+
+    g_settings.autoHideDelayMs.store(
+        delay,
+        std::memory_order_relaxed
+    );
+
+    g_settings.hideSecondaryTaskbars.store(
+        secondary,
+        std::memory_order_relaxed
+    );
 }
 
 
 // ============================================================
-// Windhawk initialization
+// Tool callbacks
 // ============================================================
 
-BOOL Wh_ModInit() {
-
-    Wh_Log(
-        L"Init"
-    );
-
+BOOL WhTool_ModInit() {
+    Wh_Log(L"Hide Taskbar Only on Desktop: Init");
 
     LoadSettings();
 
-
-    /*
-        Manual-reset stop event.
-
-        The worker waits on this event while also
-        processing its message queue.
-    */
-
-    g_stopEvent =
+    g_hThreadReadyEvent =
         CreateEventW(
             nullptr,
             TRUE,
@@ -1391,9 +1089,7 @@ BOOL Wh_ModInit() {
             nullptr
         );
 
-
-    if (!g_stopEvent) {
-
+    if (!g_hThreadReadyEvent) {
         Wh_Log(
             L"CreateEvent failed: %lu",
             GetLastError()
@@ -1401,11 +1097,6 @@ BOOL Wh_ModInit() {
 
         return FALSE;
     }
-
-
-    /*
-        Start worker thread.
-    */
 
     g_hThread =
         CreateThread(
@@ -1417,144 +1108,454 @@ BOOL Wh_ModInit() {
             &g_threadId
         );
 
-
     if (!g_hThread) {
-
         Wh_Log(
             L"CreateThread failed: %lu",
             GetLastError()
         );
 
-
-        CloseHandle(
-            g_stopEvent
-        );
-
-
-        g_stopEvent =
-            nullptr;
-
-        g_threadId =
-            0;
-
+        CloseHandle(g_hThreadReadyEvent);
+        g_hThreadReadyEvent = nullptr;
 
         return FALSE;
     }
 
-
-    return TRUE;
-}
-
-
-// ============================================================
-// Windhawk uninitialization
-// ============================================================
-
-void Wh_ModUninit() {
-
-    Wh_Log(
-        L"Uninit"
-    );
-
-
     /*
-        Tell the worker to stop.
-    */
-
-    if (g_stopEvent) {
-
-        SetEvent(
-            g_stopEvent
+     * Wait until the worker has created its message queue.
+     * This guarantees that PostThreadMessageW can be used safely
+     * during shutdown.
+     */
+    DWORD result =
+        WaitForSingleObject(
+            g_hThreadReadyEvent,
+            5000
         );
-    }
 
+    CloseHandle(g_hThreadReadyEvent);
+    g_hThreadReadyEvent = nullptr;
 
-    /*
-        IMPORTANT:
+    if (result != WAIT_OBJECT_0) {
+        Wh_Log(
+            L"Worker thread failed to become ready"
+        );
 
-        Wait until the worker has actually exited before
-        closing its handle or allowing the mod to unload.
-
-        This prevents the worker from executing code from
-        the unloaded mod.
-    */
-
-    if (g_hThread) {
+        /*
+         * The worker is still alive. Stop it and wait for it.
+         */
+        while (
+            !PostThreadMessageW(
+                g_threadId,
+                WM_QUIT,
+                0,
+                0
+            )
+        ) {
+            if (
+                WaitForSingleObject(
+                    g_hThread,
+                    100
+                ) != WAIT_TIMEOUT
+            ) {
+                break;
+            }
+        }
 
         WaitForSingleObject(
             g_hThread,
             INFINITE
         );
 
+        CloseHandle(g_hThread);
+        g_hThread = nullptr;
+        g_threadId = 0;
 
-        CloseHandle(
-            g_hThread
-        );
-
-
-        g_hThread =
-            nullptr;
+        return FALSE;
     }
 
-
-    g_threadId =
-        0;
-
-
-    if (g_stopEvent) {
-
-        CloseHandle(
-            g_stopEvent
-        );
+    return TRUE;
+}
 
 
-        g_stopEvent =
-            nullptr;
-    }
-
-
-    /*
-        Always restore the taskbar when the mod is disabled.
-    */
-
-    SetTaskbarVisibility(
-        true
+void WhTool_ModSettingsChanged() {
+    Wh_Log(
+        L"Hide Taskbar Only on Desktop: Settings changed"
     );
 
+    /*
+     * Atomics make this safe even though Windhawk may call
+     * the settings callback from another thread.
+     */
+    LoadSettings();
 
-    g_taskbarHidden =
-        false;
+    /*
+     * The worker will observe the new values on its next
+     * 100 ms update.
+     */
+}
 
-    g_onDesktopState =
-        false;
 
-    g_shownDueToHover =
-        false;
+void WhTool_ModUninit() {
+    Wh_Log(
+        L"Hide Taskbar Only on Desktop: Uninit"
+    );
 
-    g_hideDeadline =
-        0;
+    if (g_hThread) {
+        /*
+         * The worker creates its USER message queue before
+         * signalling g_hThreadReadyEvent, so this should normally
+         * succeed immediately.
+         *
+         * Still retry in case the thread exited between checks.
+         */
+        while (
+            !PostThreadMessageW(
+                g_threadId,
+                WM_QUIT,
+                0,
+                0
+            )
+        ) {
+            if (
+                WaitForSingleObject(
+                    g_hThread,
+                    100
+                ) != WAIT_TIMEOUT
+            ) {
+                break;
+            }
+        }
+
+        /*
+         * IMPORTANT:
+         * Never use a finite timeout here.
+         *
+         * The mod must not be unloaded while HookThread can still
+         * execute code from this module.
+         */
+        WaitForSingleObject(
+            g_hThread,
+            INFINITE
+        );
+
+        CloseHandle(g_hThread);
+
+        g_hThread = nullptr;
+        g_threadId = 0;
+    }
+
+    /*
+     * The worker normally restores the taskbar itself, but do this
+     * again here as a final safety measure.
+     */
+    SetTaskbarVisibility(true);
+
+    g_taskbarHidden.store(
+        false,
+        std::memory_order_relaxed
+    );
 }
 
 
 // ============================================================
-// Settings changed
+// Windhawk Tool Mod launcher
+//
+// IMPORTANT:
+// Keep the official Windhawk launcher section below unchanged.
 // ============================================================
 
-void Wh_ModSettingsChanged() {
+bool g_isToolModProcessLauncher;
+HANDLE g_toolModProcessMutex;
 
-    Wh_Log(
-        L"SettingsChanged"
+void WINAPI EntryPoint_Hook() {
+    Wh_Log(L">");
+    ExitThread(0);
+}
+
+BOOL Wh_ModInit() {
+    DWORD sessionId;
+
+    if (
+        ProcessIdToSessionId(
+            GetCurrentProcessId(),
+            &sessionId
+        ) &&
+        sessionId == 0
+    ) {
+        return FALSE;
+    }
+
+    bool isExcluded = false;
+    bool isToolModProcess = false;
+    bool isCurrentToolModProcess = false;
+
+    int argc;
+
+    LPWSTR* argv =
+        CommandLineToArgvW(
+            GetCommandLine(),
+            &argc
+        );
+
+    if (!argv) {
+        Wh_Log(
+            L"CommandLineToArgvW failed"
+        );
+
+        return FALSE;
+    }
+
+    for (int i = 1; i < argc; i++) {
+        if (
+            wcscmp(argv[i], L"-service") == 0 ||
+            wcscmp(argv[i], L"-service-start") == 0 ||
+            wcscmp(argv[i], L"-service-stop") == 0
+        ) {
+            isExcluded = true;
+            break;
+        }
+    }
+
+    for (int i = 1; i < argc - 1; i++) {
+        if (
+            wcscmp(argv[i], L"-tool-mod") == 0
+        ) {
+            isToolModProcess = true;
+
+            if (
+                wcscmp(
+                    argv[i + 1],
+                    WH_MOD_ID
+                ) == 0
+            ) {
+                isCurrentToolModProcess = true;
+            }
+
+            break;
+        }
+    }
+
+    LocalFree(argv);
+
+    if (isExcluded) {
+        return FALSE;
+    }
+
+    if (isCurrentToolModProcess) {
+        g_toolModProcessMutex =
+            CreateMutexW(
+                nullptr,
+                TRUE,
+                L"windhawk-tool-mod_" WH_MOD_ID
+            );
+
+        if (!g_toolModProcessMutex) {
+            Wh_Log(
+                L"CreateMutex failed"
+            );
+
+            ExitProcess(1);
+        }
+
+        if (
+            GetLastError() ==
+            ERROR_ALREADY_EXISTS
+        ) {
+            Wh_Log(
+                L"Tool mod already running (%s)",
+                WH_MOD_ID
+            );
+
+            ExitProcess(1);
+        }
+
+        if (!WhTool_ModInit()) {
+            ExitProcess(1);
+        }
+
+        IMAGE_DOS_HEADER* dosHeader =
+            reinterpret_cast<IMAGE_DOS_HEADER*>(
+                GetModuleHandle(nullptr)
+            );
+
+        IMAGE_NT_HEADERS* ntHeaders =
+            reinterpret_cast<IMAGE_NT_HEADERS*>(
+                reinterpret_cast<BYTE*>(dosHeader) +
+                dosHeader->e_lfanew
+            );
+
+        DWORD entryPointRVA =
+            ntHeaders->OptionalHeader
+                .AddressOfEntryPoint;
+
+        void* entryPoint =
+            reinterpret_cast<BYTE*>(dosHeader) +
+            entryPointRVA;
+
+        Wh_SetFunctionHook(
+            entryPoint,
+            reinterpret_cast<void*>(
+                EntryPoint_Hook
+            ),
+            nullptr
+        );
+
+        return TRUE;
+    }
+
+    if (isToolModProcess) {
+        return FALSE;
+    }
+
+    g_isToolModProcessLauncher = true;
+
+    return TRUE;
+}
+
+
+void Wh_ModAfterInit() {
+    if (!g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WCHAR currentProcessPath[MAX_PATH];
+
+    switch (
+        GetModuleFileNameW(
+            nullptr,
+            currentProcessPath,
+            ARRAYSIZE(currentProcessPath)
+        )
+    ) {
+        case 0:
+        case ARRAYSIZE(currentProcessPath):
+            Wh_Log(
+                L"GetModuleFileName failed"
+            );
+
+            return;
+    }
+
+    WCHAR commandLine[
+        MAX_PATH +
+        2 +
+        (sizeof(
+            L" -tool-mod \"" WH_MOD_ID "\""
+        ) / sizeof(WCHAR)) -
+        1
+    ];
+
+    swprintf_s(
+        commandLine,
+        L"\"%s\" -tool-mod \"%s\"",
+        currentProcessPath,
+        WH_MOD_ID
     );
 
+    HMODULE kernelModule =
+        GetModuleHandleW(
+            L"kernelbase.dll"
+        );
 
-    LoadSettings();
+    if (!kernelModule) {
+        kernelModule =
+            GetModuleHandleW(
+                L"kernel32.dll"
+            );
+
+        if (!kernelModule) {
+            Wh_Log(
+                L"No kernelbase.dll/kernel32.dll"
+            );
+
+            return;
+        }
+    }
+
+    using CreateProcessInternalW_t =
+        BOOL(WINAPI*)(
+            HANDLE,
+            LPCWSTR,
+            LPWSTR,
+            LPSECURITY_ATTRIBUTES,
+            LPSECURITY_ATTRIBUTES,
+            WINBOOL,
+            DWORD,
+            LPVOID,
+            LPCWSTR,
+            LPSTARTUPINFOW,
+            LPPROCESS_INFORMATION,
+            PHANDLE
+        );
+
+    CreateProcessInternalW_t
+        pCreateProcessInternalW =
+            reinterpret_cast<
+                CreateProcessInternalW_t
+            >(
+                GetProcAddress(
+                    kernelModule,
+                    "CreateProcessInternalW"
+                )
+            );
+
+    if (!pCreateProcessInternalW) {
+        Wh_Log(
+            L"No CreateProcessInternalW"
+        );
+
+        return;
+    }
+
+    STARTUPINFO si{
+        .cb = sizeof(STARTUPINFO),
+        .dwFlags = STARTF_FORCEOFFFEEDBACK,
+    };
+
+    PROCESS_INFORMATION pi{};
+
+    if (
+        !pCreateProcessInternalW(
+            nullptr,
+            currentProcessPath,
+            commandLine,
+            nullptr,
+            nullptr,
+            FALSE,
+            NORMAL_PRIORITY_CLASS,
+            nullptr,
+            nullptr,
+            &si,
+            &pi,
+            nullptr
+        )
+    ) {
+        Wh_Log(
+            L"CreateProcess failed"
+        );
+
+        return;
+    }
+
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+}
 
 
-    /*
-        The worker's 100 ms polling cycle will pick up
-        the new settings.
+void Wh_ModSettingsChanged() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
 
-        No cross-thread message or resource manipulation
-        is needed here.
-    */
+    WhTool_ModSettingsChanged();
+}
+
+
+void Wh_ModUninit() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModUninit();
+
+    ExitProcess(0);
 }

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -12,11 +12,12 @@
 
 // ==WindhawkModReadme==
 /*
+
 # Hide Taskbar Only on Desktop
 
-Hides selected taskbars only while their own display is showing the desktop.
-When an application window is present on that display, the taskbar remains
-visible. Displays are evaluated independently.
+This Windhawk mod hides selected taskbars when their corresponding display is showing only the desktop, and shows them again when an application or relevant Windows shell interaction requires the taskbar.
+
+Each display is evaluated independently. An application being open on one display does not prevent the taskbar on another selected display from hiding when that display is showing only the desktop.
 
 ## Demo
 
@@ -24,164 +25,193 @@ visible. Displays are evaluated independently.
 
 ![Multiple Display](https://raw.githubusercontent.com/Sahil-Dashoni/Hide-Taskbar-Only-on-Desktop-Windhawk-Mod/refs/heads/main/Assets/multiple-display.gif)
 
-Each selected display is evaluated independently. An application can keep one display's taskbar visible while another display remains in the desktop-only state.
-
 ### Single Display
 
 ![Single Display](https://raw.githubusercontent.com/Sahil-Dashoni/Hide-Taskbar-Only-on-Desktop-Windhawk-Mod/refs/heads/main/Assets/single-display.gif)
 
-The taskbar hides when the display returns to the desktop and can be revealed by moving the cursor into the configured bottom-edge area.
+## How It Works
 
-## Behavior
+For each selected display, the mod determines whether there is a visible, non-minimized application window associated with that display.
 
-- A selected taskbar hides only when its display has no visible, non-minimized
-  application window.
-- Maximized windows use Windows' monitor assignment. Normal windows spanning
-  displays count on every display they intersect.
-- Bottom-edge hover reveal can be enabled independently per display.
-- The hover zone is based on the current taskbar height and display DPI, plus
-  the configured extra margin.
-- The hover reveal feature is limited to bottom-docked taskbars.
-- The configured post-hover delay applies to hover dismissal.
-- Relevant Windows shell surfaces such as Start, taskbar popups/overflow,
-  notification/Quick Settings, and supported Alt+Tab surfaces are treated as
-  shell UI rather than normal application windows.
-- Clearing the taskbar selection means no taskbar is hidden.
-- Windows' native taskbar auto-hide setting is not changed.
+When no relevant application window is present, the selected taskbar on that display can be hidden.
 
-## Why this is different from `taskbar-auto-hide-when-maximized`
+When an application becomes active on the display, or when a relevant Windows shell interaction requires the taskbar, it is shown again.
 
-These mods answer different visibility questions.
+The taskbar is hidden directly rather than enabling Windows' native taskbar auto-hide mode. The mod therefore does not intentionally change the Windows desktop work area when hiding the taskbar.
 
-`taskbar-auto-hide-when-maximized` is based on the state of application
-windows, with modes such as `intersected`, `maximized`, and `never`. This mod is
-based on a different predicate: **is this display currently showing only the
-desktop?**
+## Difference from Existing Taskbar Auto-Hide Mods
 
-That means a normal, non-maximized application keeps the selected taskbar
-visible here. The taskbar hides only after the last visible, non-minimized
-application on that display is gone. A maximized window is not required for the
-taskbar to stay visible. Conversely, a completely idle display can hide its
-taskbar even while another display is actively being used.
+This mod shares some concepts with existing taskbar auto-hide projects, but it is focused on a different user-visible behavior and implementation model.
 
-The distinction is therefore the user-visible policy, not merely the mechanism
-used internally:
+**`taskbar-auto-hide-when-maximized`** primarily provides visibility modes based on application-window state, such as maximized or intersected windows. This mod uses a desktop-only predicate: a selected taskbar remains visible whenever its display has a visible, non-minimized application window and hides only when that display has no such application window.
 
-| Scenario | This mod | `taskbar-auto-hide-when-maximized` |
-| --- | --- | --- |
-| Desktop only on a selected display | Hide taskbar | Depends on its selected window-state mode |
-| One normal, non-maximized app visible | Keep taskbar visible | Depends on mode/window state |
-| One display has an app, another is idle | Evaluate each display separately | Uses its own monitor/window-state policy |
-| Goal | Desktop-only taskbar visibility | Auto-hide driven by maximized/intersection state |
+This means the behavior is not limited to maximized, snapped, fullscreen, or taskbar-intersecting windows.
 
-This mod also deliberately leaves Windows' native auto-hide preference alone
-and implements the desktop-only rule directly, including its explicit
-per-display selection and configurable hover-dismiss behavior.
+**`taskbar-auto-hide-per-monitor`** provides per-monitor control over Windows' native taskbar auto-hide behavior. This mod also allows displays to be configured independently, but it directly controls the taskbar window instead of changing Windows' native auto-hide state.
 
-The project remains standalone because its primary purpose is this specific
-desktop-only policy. The existing mod is still the better choice for users who
-want taskbar auto-hide tied to maximized/intersected window state.
+**`taskbar-auto-hide-custom-activation-area`** changes the activation area used by Windows' native taskbar auto-hide behavior. This mod instead performs its own desktop/application-state detection and provides its own configurable bottom-edge hover area.
 
-## Per-display configuration
+The work-area behavior is also different. The mod directly hides the taskbar window without intentionally modifying the Windows desktop work area.
 
-You can independently choose:
+The combination of desktop-only visibility, independent per-display selection, direct taskbar control, custom hover reveal, and shell-interaction handling is the intended focus of this mod.
 
-- Which displays should hide their taskbar when desktop-only.
-- Which displays should allow bottom-edge hover reveal.
+## Per-Display Configuration
 
-Selections use logical display numbers (Display 1, Display 2, and so on) based on
-the currently connected monitors. Windows may internally name the same monitor
-with device identifiers such as `\\.\DISPLAY25`; those internal identifiers are
-not exposed as the selection number.
+The mod supports independent configuration for each display.
 
-The mod tracks monitor identity during the current session so a reconnected
-display that receives a different `DISPLAYn` number can retain its selection
-when the same monitor identity is detected.
+Users can configure:
 
-## Hover reveal
+- Which displays should use desktop-based taskbar hiding
+- Which displays should allow hover reveal
 
-When a selected, bottom-docked taskbar is hidden by the mod, moving the pointer
-into its configured bottom-edge zone reveals it. After leaving the zone, the
-taskbar remains visible for the configured dismissal delay before returning to
-its normal desktop/application state.
+Display selection can target:
 
-Hover tracking is adaptive: it samples more frequently when a configured hover
-zone can matter, uses a slower idle interval otherwise, and backs off further
-when cursor queries repeatedly fail (for example on the secure desktop).
+- All displays
+- Individual displays
 
-## Windows shell interactions
+Display selections use the mod's display-selection entries and stable monitor/device identity tracking. Windows device names such as `\\.\DISPLAY1` are used internally to identify monitors, but these identifiers may differ from the display numbers shown in Windows Display Settings.
 
-The mod distinguishes relevant shell surfaces from ordinary application
-windows. It uses both window classes and the owning process for supported
-Windows shell components, including taskbar popup/overflow surfaces,
-Start/notification/Quick Settings hosts, relevant XAML shell hosts, and known
-Alt+Tab window classes. These surfaces can keep the relevant taskbar visible
-while the user is interacting with the shell.
+The mod tracks monitor/device identity so that a selected display can remain associated with the same detected physical monitor when Windows temporarily changes `DISPLAYn` ordering during the current session.
 
-## Explorer integration and crash recovery
+## Hover Reveal
 
-The main state manager runs in a dedicated `windhawk.exe` process. A small
-Explorer-side hook exists only to prevent the specific secondary-taskbar
-`SW_SHOWNA` transition that caused a visible re-show after the mod had hidden
-the taskbar. It does not alter Explorer's general taskbar behavior.
+For bottom-docked taskbars, the mod provides a configurable bottom-edge hover area.
 
-Each taskbar hidden by the mod is marked with the PID of the owning tool
-process. Explorer caches and checks that process's liveness. If a stale marker
-is detected, the marker is removed and the taskbar is restored through the
-original Explorer `ShowWindow` path. Explorer also performs a stale-marker
-sweep when the Explorer-side component initializes, covering both the primary
-and secondary taskbars.
+When the cursor enters the configured area of a selected display, a taskbar hidden by the mod is revealed.
 
-This means a normal unload restores taskbars, while stale state left by an
-unexpected tool-process termination can be cleaned up without requiring an
-Explorer restart. Taskbars that were never hidden by this mod are not restored
-by the cleanup path.
+When the cursor leaves the hover area, the taskbar remains visible for the configured delay before being hidden again.
 
-## Multi-monitor behavior
+The hover area is calculated using the taskbar's current height and display DPI together with the configured additional margin.
 
-Example with two displays:
+Hover reveal applies only to bottom-docked taskbars. Taskbars docked to the top or sides are not affected by this feature.
 
-1. Display 1 has an application open.
-2. Display 2 shows only the desktop.
-3. The selected taskbar on display 1 stays visible.
+The hover-dismiss delay applies only to hover-based hiding. Other state changes, such as a display becoming desktop-only again, are handled independently.
+
+Cursor tracking uses a dedicated lightweight sampling thread. It uses faster sampling when hover tracking is active and backs off when hover tracking is not needed. The sampler also backs off after repeated cursor-position failures.
+
+## Windows Shell Interactions
+
+The mod accounts for relevant Windows shell surfaces so that the taskbar does not disappear unnecessarily while the user is interacting with Windows.
+
+This includes supported situations involving:
+
+- Start menu
+- Taskbar menus and popups
+- Tray and notification overflow
+- Notification and Quick Settings surfaces
+- Alt+Tab and related task-switching UI
+
+Known shell window classes and the relevant Windows shell processes are considered when identifying these surfaces.
+
+Shell interaction detection is handled separately from the normal application-window check.
+
+## Explorer Integration
+
+The mod includes a small Explorer-side protection for a specific taskbar visibility transition.
+
+When a secondary taskbar has been hidden by the mod, Windows Explorer may independently attempt to show that taskbar using `ShowWindow(..., SW_SHOWNA)`.
+
+The mod blocks that specific transition only while the taskbar is still owned by a running instance of the mod's dedicated tool process.
+
+The protection is intentionally narrow:
+
+- It applies only to the secondary taskbar.
+- It applies only to a taskbar marked as hidden by this mod.
+- It applies only to the `SW_SHOWNA` transition.
+- Other Explorer `ShowWindow` calls are passed through normally.
+
+This prevents a brief secondary-taskbar flash while leaving unrelated Explorer window behavior unchanged.
+
+### Failure Recovery
+
+The taskbar ownership marker contains the process ID of the dedicated tool process that hid the taskbar.
+
+If that process is no longer running, the Explorer-side check removes the stale marker and restores the taskbar through Explorer's normal `ShowWindow` path.
+
+This prevents an unexpected tool-process termination from leaving a taskbar hidden or permanently blocking Explorer from restoring it.
+
+Stale hidden-taskbar state is also checked during Explorer initialization for both primary and secondary taskbars.
+
+## Multi-Monitor Example
+
+Consider a system with two displays:
+
+1. An application is open on display 1.
+2. Display 2 is showing only the desktop.
+3. The selected taskbar on display 1 remains visible.
 4. The selected taskbar on display 2 hides.
-5. Moving to the configured bottom edge of display 2 reveals its taskbar.
-6. Leaving the hover zone starts the configured dismissal delay.
-7. Opening an application on display 2 keeps its taskbar visible.
+5. Moving the cursor into display 2's configured bottom-edge area reveals its taskbar.
+6. After leaving the hover area, the taskbar hides again after the configured delay.
+7. Opening an application on display 2 causes its taskbar to remain visible.
 
-Applications spanning multiple displays count on every display they intersect.
-Maximized windows use Windows' monitor assignment.
+The same logic is applied independently to each selected display.
 
-## Display and taskbar changes
+Applications that span multiple displays are considered for every display they intersect, while maximized windows use the monitor assignment provided by Windows.
 
-Taskbars are rediscovered during reconciliation, so Explorer taskbar recreation
-does not leave the mod tied to an old window handle. State is refreshed for
-relevant taskbar, display, settings, theme, window, and shell visibility
-changes, with a periodic safety poll for missed transitions.
+## Explorer and Display Changes
 
-A display-topology signature resets transient hover state when monitor geometry
-or the connected display set changes.
+The mod refreshes its taskbar and display state when relevant shell or display configuration changes occur.
+
+This allows taskbar state to be rebuilt when:
+
+- Taskbars are recreated
+- Explorer-related state changes
+- The display topology changes
+- Monitors are added or removed
+- Display configuration changes
+- Settings are changed
+
+Taskbars are rediscovered rather than assuming that their window handles remain unchanged.
+
+Display identity is tracked using monitor/device information rather than relying solely on the current `DISPLAYn` ordering.
+
+## Taskbar Ownership
+
+The mod tracks whether a taskbar was actually hidden by the mod.
+
+This prevents the mod from unnecessarily restoring or changing taskbar visibility that it did not cause itself.
+
+Ownership is also associated with the dedicated tool process so that stale ownership can be detected after an unexpected process termination.
+
+When the owning tool process is no longer running, stale ownership can be cleared and the affected taskbar can recover through Explorer's normal visibility path.
+
+## Performance
+
+The full application and display scan runs in the dedicated tool process rather than inside Explorer.
+
+The mod uses:
+
+- A dedicated worker thread for state management
+- A lightweight cursor-sampling thread for hover detection
+- Event-driven refreshes for relevant window and shell changes
+- A periodic safety poll for missed or unusual transitions
+- A one-shot timer for hover dismissal
+
+The Explorer-side hook performs only the narrow visibility check required for secondary-taskbar flash prevention.
+
+Cursor sampling backs off when hover tracking is not needed and also backs off after repeated cursor-position failures.
+
+The periodic safety poll provides a recovery path for missed or unusual transitions. The current implementation uses a fixed short polling interval; this may be optimized further in a future revision.
 
 ## Limitations
 
 - Hover reveal is supported only for bottom-docked taskbars.
-- Display selection currently exposes Display 1 through Display 16.
-- `DISPLAYn` identifiers may differ from the numbering shown in Windows Display
-  Settings and can change after display configuration changes.
-- A taskbar docked to the top or side is not hidden by the desktop-only rule.
-- A display selection that no longer matches any connected display remains
-  configured until the user changes the setting.
-- The mod does not modify Windows' native taskbar auto-hide setting.
+- Windows display device names such as `\\.\DISPLAY1` may differ from the display numbering shown in Windows Display Settings.
+- Display device names can change after display configuration changes.
+- The current display-selection configuration supports up to 16 display entries.
+- The mod intentionally keeps Windows' native taskbar auto-hide setting separate from its own hiding behavior.
+- Windows shell window classes and processes can change between Windows releases, so shell-interaction detection may require updates for future Windows versions.
+- The mod is designed specifically around Windows' Explorer/taskbar behavior and is not intended to be a general-purpose taskbar customization framework.
 
 ## Goal
 
-The goal is a specific visibility rule:
+The goal is not to replace Windows' native taskbar auto-hide or provide a general-purpose taskbar customization framework.
+
+The goal is a specific behavior:
 
 > **Hide the taskbar when its display is showing only the desktop.**
 
-The mod combines that per-display application-state rule with independent
-display selection, shell-interaction handling, taskbar recreation recovery,
-and configurable bottom-edge hover reveal.
+The mod combines independent per-display application-state detection with configurable display selection, stable monitor identity tracking, shell-interaction handling, direct taskbar control, and a configurable bottom-edge hover-reveal area.
 */
 // ==/WindhawkModReadme==
 

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -98,6 +98,7 @@ HANDLE g_hThreadReadyEvent = nullptr;
 
 constexpr UINT WM_APP_REFRESH_STATE = WM_APP + 1;
 constexpr UINT WM_APP_STOP_THREAD = WM_APP + 2;
+constexpr WPARAM kRefreshNativeAutoHide = 1;
 constexpr UINT kHoverTimerIntervalMs = 200;
 
 UINT_PTR g_hoverTimerId = 0;

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -1,63 +1,87 @@
 // ==WindhawkMod==
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
-// @description     Hides the taskbar on the desktop, shows it for other windows or when you hover near the bottom edge
-// @version 2.0.0
+// @description     Hides selected taskbars only while their display is showing the desktop
+// @version         2.1.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
-// @include         explorer.exe
+// @include         windhawk.exe
 // @compilerOptions -ldwmapi
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
 /*
-# Hide Taskbar on Desktop
+# Hide Taskbar Only on Desktop V4
 
-Hides each selected taskbar whenever its own monitor is showing only the
-desktop (or its application windows are all minimized), and shows it again
-when an application or relevant Windows shell UI needs it.
+Hides each selected taskbar when its own display has no visible,
+non-minimized application window, and shows it again when an application or
+relevant Windows shell interaction requires it.
 
-You can also peek at the taskbar by moving the mouse to the bottom of the
-screen while on the desktop - the reveal zone matches the taskbar's own
-height (plus a small extra margin you can configure), not just a thin
-strip at the very bottom, so hovering anywhere over where the taskbar
-would be counts. The hover reveal is selectable per display; select individual displays or All displays. The delay before hiding only applies to that peek: hover
-in, then move away, and it waits a moment before hiding again. Every other
-hide (switching to the desktop, closing or minimizing the last window,
-etc.) hides instantly, no delay.
+V4 is implemented as a Windhawk tool in a dedicated `windhawk.exe` process
+instead of being injected into `explorer.exe`. This avoids one worker copy
+per Explorer process and keeps the state-management code outside the shell.
 
-### Notes
-- Works with a single taskbar, and optionally with secondary taskbars on
-  extra monitors (toggle in the settings).
-- Pressing the Windows key or clicking the Start button still works even
-  while the taskbar is hidden, and will bring the taskbar back, since the
-  Start menu counts as "another window".
-- Each monitor's "on desktop" state re-verifies itself roughly 10 times a
-  second by checking for any other visible, non-minimized window on that
-  monitor, rather than depending on a single event. Maximized windows use
-  Windows' monitor assignment, while normal/spanning windows count on each
-  display they actually intersect. This makes minimizing the last window on
-  one display hide that display's taskbar without affecting another display
-  that still has an application open.
-- Opening Start, the system tray overflow ("show hidden icons"), or the
-  notification/clock panel keeps the corresponding taskbar visible. Real foreground applications also take precedence over a stale desktop
-  scan, including foreground windows that do not expose a normal title or
-  APPWINDOW style.
-- On multi-display setups, the hover zone uses only the taskbar and DPI of
-  the display under the cursor; it never falls back to the primary taskbar.
+### Behavior
+
+- Each display is evaluated independently.
+- A selected taskbar is hidden only while its display has no visible,
+  non-minimized application window.
+- Maximized windows use Windows' monitor assignment. Normal windows that
+  span displays count on every display they actually intersect.
+- Bottom-edge hover reveal is selectable per display. The reveal zone uses
+  the taskbar's actual height and DPI. Hover reveal is intentionally limited
+  to bottom-docked taskbars; non-bottom-docked taskbars are not affected by
+  the hover logic.
+- The configured post-hover delay applies only to hover reveal.
+- Start/taskbar menus, tray overflow, notification/quick-settings surfaces,
+  and Alt+Tab are treated as transient shell interactions.
+- Clearing the "Taskbars to hide on desktop" selection means hide nothing.
+
+### Difference from Existing Taskbar Auto-Hide Mods
+
+**`taskbar-auto-hide-when-maximized`** primarily bases its behavior on
+application-window geometry and maximized state. This mod instead evaluates
+whether each display currently has any visible application window. An
+application can remain open on display 2 while the taskbar on display 1
+hides because display 1 is showing only the desktop.
+
+**`taskbar-auto-hide-per-monitor`** provides explicit per-monitor control
+over native auto-hide. This mod also has per-display selection, but its
+visibility decision is derived automatically from application presence.
+
+**`taskbar-auto-hide-custom-activation-area`** changes the activation area
+for Windows' native auto-hide. This mod directly hides/shows the taskbar
+window and supplies its own hover-reveal behavior.
+
+**`taskbar-fade`** is a broader taskbar customization/fading mod with a
+Smart Idle option. V4 is specifically focused on desktop-only visibility,
+independent per-display application state, and explicit per-display hover
+reveal.
+
+A key difference is the **work-area behavior**: the mod uses
+`ShowWindow(SW_HIDE)` and does not change the Windows desktop work area.
+
+### Process and state model
+
+The mod runs as a dedicated Windhawk tool process. A single worker thread
+owns the mutable runtime state and settings. Window-state WinEvents request
+an immediate reconciliation, while a periodic safety poll handles missed
+or unusual transitions.
+
+Each safety poll performs one display enumeration and one top-level-window
+enumeration. The result is reused for every taskbar.
 */
 // ==/WindhawkModReadme==
 
 // ==WindhawkModSettings==
 /*
-- extraHoverMarginMm: 5
-  $name: Extra hover margin (mm)
+- extraHoverMarginPx: 8
+  $name: Extra hover margin (px)
   $description: >-
     The reveal zone at the bottom of the screen automatically matches your
     taskbar's actual height (including your display scaling), so hovering
     anywhere over where the taskbar would be reveals it. This setting adds
-    a bit of extra margin above that, in millimeters, so you don't need to
-    be pixel-perfect. Default 5mm.
+    a bit of extra margin above that, in pixels, so you don't need to be pixel-perfect. Default 8px.
 - autoHideDelayMs: 700
   $name: Auto-hide delay after hover (ms)
   $description: >-
@@ -118,28 +142,75 @@ etc.) hides instantly, no delay.
 
 #include <windows.h>
 #include <dwmapi.h>
+#include <shellapi.h>
 #include <wchar.h>
+#include <stdint.h>
+
 
 constexpr size_t kMaxMonitorNumbers = 16;
+constexpr size_t kMaxTaskbars = 16;
+
+constexpr UINT WM_APP_REFRESH = WM_APP + 1;
+constexpr UINT WM_APP_SETTINGS = WM_APP + 2;
 
 struct {
-    int extraHoverMarginMm;
+    int extraHoverMarginPx;
     DWORD autoHideDelayMs;
     bool hideAllMonitors;
     bool hideMonitor[kMaxMonitorNumbers + 1];
     bool hoverAllMonitors;
     bool hoverMonitor[kMaxMonitorNumbers + 1];
-} settings = {};
+} g_settings = {};
 
-HWINEVENTHOOK g_hWinEventHookForeground;
-HANDLE g_hThread;
-DWORD g_threadId;
-bool g_shownDueToHover = false;  // taskbar currently shown because of hover
-HMONITOR g_hoverMonitor = nullptr; // monitor whose taskbar was revealed
-ULONGLONG g_hideDeadline = 0;      // pending hover-dismiss deadline
+struct MonitorEntry {
+    HMONITOR monitor;
+    RECT rect;
+    bool primary;
+    wchar_t deviceName[32];
+};
 
-bool IsShellChromeClass(const WCHAR* className) {
-    static const WCHAR* kShellClasses[] = {
+struct MonitorList {
+    MonitorEntry entries[kMaxMonitorNumbers];
+    size_t count;
+};
+
+struct TaskbarMonitorState {
+    HWND hwnd;
+    HMONITOR monitor;
+    int monitorNumber;
+    bool desktopOnly;
+};
+
+struct WindowScanResult {
+    bool applicationOnMonitor[kMaxMonitorNumbers];
+};
+
+HWINEVENTHOOK g_minimizeHook = nullptr;
+HWINEVENTHOOK g_moveHook = nullptr;
+
+HANDLE g_workerThread = nullptr;
+DWORD g_workerThreadId = 0;
+HANDLE g_workerReadyEvent = nullptr;
+
+TaskbarMonitorState g_taskbarStates[kMaxTaskbars] = {};
+size_t g_taskbarStateCount = 0;
+
+bool g_hoverActive = false;
+HMONITOR g_hoverMonitor = nullptr;
+ULONGLONG g_hoverDeadline = 0;
+
+LONG g_refreshPosted = 0;
+
+void LoadSettings();
+
+bool IsShellChromeClass(
+    const WCHAR* className
+) {
+    if (!className) {
+        return false;
+    }
+
+    static const WCHAR* kClasses[] = {
         L"Progman",
         L"WorkerW",
         L"Shell_TrayWnd",
@@ -151,7 +222,7 @@ bool IsShellChromeClass(const WCHAR* className) {
         L"IME",
     };
 
-    for (const WCHAR* shellClass : kShellClasses) {
+    for (const WCHAR* shellClass : kClasses) {
         if (wcscmp(className, shellClass) == 0) {
             return true;
         }
@@ -160,16 +231,14 @@ bool IsShellChromeClass(const WCHAR* className) {
     return false;
 }
 
-bool IsDesktopInfrastructureWindow(HWND hwnd, const WCHAR* className) {
+bool IsDesktopInfrastructureWindow(
+    HWND hwnd,
+    const WCHAR* className
+) {
     if (!hwnd || !className) {
         return false;
     }
 
-    /*
-     * Progman and WorkerW are Explorer's desktop/wallpaper infrastructure.
-     * WorkerW can exist with or without SHELLDLL_DefView, so neither should
-     * ever be classified as an application.
-     */
     if (
         wcscmp(className, L"Progman") == 0 ||
         wcscmp(className, L"WorkerW") == 0
@@ -179,29 +248,292 @@ bool IsDesktopInfrastructureWindow(HWND hwnd, const WCHAR* className) {
 
     HWND shellWindow = GetShellWindow();
 
-    return shellWindow && hwnd == shellWindow;
+    return shellWindow && shellWindow == hwnd;
+}
+
+BOOL CALLBACK CollectMonitorProc(
+    HMONITOR monitor,
+    HDC,
+    LPRECT,
+    LPARAM lParam
+) {
+    MonitorList* list =
+        reinterpret_cast<MonitorList*>(lParam);
+
+    if (!list || list->count >= kMaxMonitorNumbers) {
+        return FALSE;
+    }
+
+    MONITORINFOEXW info = {};
+    info.cbSize = sizeof(info);
+
+    if (!GetMonitorInfoW(monitor, &info)) {
+        return TRUE;
+    }
+
+    MonitorEntry& entry =
+        list->entries[list->count++];
+
+    entry.monitor = monitor;
+    entry.rect = info.rcMonitor;
+    entry.primary =
+        (info.dwFlags & MONITORINFOF_PRIMARY) != 0;
+
+    wcsncpy_s(
+        entry.deviceName,
+        ARRAYSIZE(entry.deviceName),
+        info.szDevice,
+        _TRUNCATE
+    );
+
+    return TRUE;
+}
+
+int GetDisplayDeviceNumber(
+    const wchar_t* deviceName
+) {
+    if (!deviceName) {
+        return 0;
+    }
+
+    constexpr wchar_t kPrefix[] = L"\\\\.\\DISPLAY";
+    constexpr size_t kPrefixLength =
+        ARRAYSIZE(kPrefix) - 1;
+
+    if (
+        wcsncmp(
+            deviceName,
+            kPrefix,
+            kPrefixLength
+        ) != 0
+    ) {
+        return 0;
+    }
+
+    wchar_t* endNumber = nullptr;
+
+    long number =
+        wcstol(
+            deviceName + kPrefixLength,
+            &endNumber,
+            10
+        );
+
+    if (
+        endNumber == deviceName + kPrefixLength ||
+        *endNumber != L'\0' ||
+        number < 1 ||
+        number > static_cast<long>(
+            kMaxMonitorNumbers
+        )
+    ) {
+        return 0;
+    }
+
+    return static_cast<int>(number);
+}
+
+void SortDisplaysForSelection(
+    MonitorList& list
+) {
+    size_t primaryIndex = list.count;
+
+    for (size_t i = 0; i < list.count; ++i) {
+        if (list.entries[i].primary) {
+            primaryIndex = i;
+            break;
+        }
+    }
+
+    if (
+        primaryIndex < list.count &&
+        primaryIndex != 0
+    ) {
+        MonitorEntry primary =
+            list.entries[primaryIndex];
+
+        for (size_t i = primaryIndex; i > 0; --i) {
+            list.entries[i] =
+                list.entries[i - 1];
+        }
+
+        list.entries[0] = primary;
+    }
+
+    for (size_t i = 1; i < list.count; ++i) {
+        size_t best = i;
+
+        int bestNumber =
+            GetDisplayDeviceNumber(
+                list.entries[best].deviceName
+            );
+
+        for (size_t j = i + 1; j < list.count; ++j) {
+            int candidateNumber =
+                GetDisplayDeviceNumber(
+                    list.entries[j].deviceName
+                );
+
+            bool better = false;
+
+            if (
+                candidateNumber > 0 &&
+                bestNumber == 0
+            ) {
+                better = true;
+            } else if (
+                candidateNumber > 0 &&
+                bestNumber > 0 &&
+                candidateNumber < bestNumber
+            ) {
+                better = true;
+            } else if (
+                candidateNumber == 0 &&
+                bestNumber == 0
+            ) {
+                const RECT& a =
+                    list.entries[best].rect;
+                const RECT& b =
+                    list.entries[j].rect;
+
+                better =
+                    b.top < a.top ||
+                    (
+                        b.top == a.top &&
+                        b.left < a.left
+                    );
+            }
+
+            if (better) {
+                best = j;
+                bestNumber = candidateNumber;
+            }
+        }
+
+        if (best != i) {
+            MonitorEntry temp =
+                list.entries[i];
+
+            list.entries[i] =
+                list.entries[best];
+
+            list.entries[best] =
+                temp;
+        }
+    }
+}
+
+MonitorList GetCurrentMonitors() {
+    MonitorList list = {};
+
+    EnumDisplayMonitors(
+        nullptr,
+        nullptr,
+        CollectMonitorProc,
+        reinterpret_cast<LPARAM>(&list)
+    );
+
+    SortDisplaysForSelection(list);
+    return list;
+}
+
+int GetMonitorNumber(
+    const MonitorList& list,
+    HMONITOR monitor
+) {
+    for (size_t i = 0; i < list.count; ++i) {
+        if (list.entries[i].monitor == monitor) {
+            return static_cast<int>(i + 1);
+        }
+    }
+
+    return 0;
+}
+
+bool ShouldHideMonitor(
+    int monitorNumber
+) {
+    if (
+        monitorNumber < 1 ||
+        monitorNumber > static_cast<int>(
+            kMaxMonitorNumbers
+        )
+    ) {
+        return false;
+    }
+
+    return
+        g_settings.hideAllMonitors ||
+        g_settings.hideMonitor[monitorNumber];
+}
+
+bool ShouldRevealOnHover(
+    int monitorNumber
+) {
+    if (
+        monitorNumber < 1 ||
+        monitorNumber > static_cast<int>(
+            kMaxMonitorNumbers
+        )
+    ) {
+        return false;
+    }
+
+    return
+        g_settings.hoverAllMonitors ||
+        g_settings.hoverMonitor[monitorNumber];
+}
+
+bool IsTransientShellWindow(
+    HWND hwnd,
+    const WCHAR* className
+) {
+    if (!hwnd || !className) {
+        return false;
+    }
+
+    // Classic shell popup/menu windows.
+    if (
+        wcscmp(className, L"#32768") == 0 ||
+        wcscmp(className, L"#32771") == 0
+    ) {
+        return true;
+    }
+
+    // Common Windows shell/XAML popup hosts.
+    if (
+        wcscmp(className, L"Xaml_WindowedPopupClass") == 0 ||
+        wcscmp(className, L"Windows.UI.Core.CoreWindow") == 0 ||
+        wcscmp(
+            className,
+            L"TopLevelWindowForOverflowXamlIsland"
+        ) == 0 ||
+        wcscmp(
+            className,
+            L"NotifyIconOverflowWindow"
+        ) == 0 ||
+        wcscmp(
+            className,
+            L"TaskbarOverflowWnd"
+        ) == 0 ||
+        wcscmp(className, L"DirectUIHWND") == 0
+    ) {
+        return true;
+    }
+
+    LONG_PTR exStyle =
+        GetWindowLongPtrW(
+            hwnd,
+            GWL_EXSTYLE
+        );
+
+    // Do not let no-activate transient surfaces make a display look
+    // application-active.
+    return (exStyle & WS_EX_NOACTIVATE) != 0;
 }
 
 
-constexpr size_t kMaxTaskbars = 32;
-
-struct TaskbarMonitorState {
-    HWND hwnd = nullptr;
-    HMONITOR monitor = nullptr;
-    int monitorNumber = 0;
-    bool desktopOnly = true;
-};
-
-TaskbarMonitorState g_taskbarStates[kMaxTaskbars] = {};
-size_t g_taskbarStateCount = 0;
-
-struct MonitorWindowScanContext {
-    HMONITOR monitor;
-    bool found;
-};
-
-
-bool IsLikelyApplicationWindow(
+bool IsApplicationWindowCandidate(
     HWND hwnd,
     const WCHAR* className
 ) {
@@ -215,6 +547,13 @@ bool IsLikelyApplicationWindow(
     }
 
     if (GetWindow(hwnd, GW_OWNER) != nullptr) {
+        return false;
+    }
+
+    if (IsTransientShellWindow(
+            hwnd,
+            className
+        )) {
         return false;
     }
 
@@ -249,860 +588,19 @@ bool IsLikelyApplicationWindow(
             hwnd,
             className
         ) ||
-        IsShellChromeClass(
-            className
-        )
+        IsShellChromeClass(className)
     ) {
         return false;
     }
 
     /*
-     * Do not count a visible, titleless helper surface as an application
-     * unless it explicitly opts into normal app-window treatment.
-     */
-    if (exStyle & WS_EX_APPWINDOW) {
-        return true;
-    }
-
-    return GetWindowTextLengthW(hwnd) > 0;
-}
-
-
-BOOL CALLBACK EnumWindowsForMonitorProc(
-    HWND hwnd,
-    LPARAM lParam
-) {
-    MonitorWindowScanContext* context =
-        reinterpret_cast<MonitorWindowScanContext*>(lParam);
-
-    if (!context || !context->monitor) {
-        return TRUE;
-    }
-
-    WCHAR className[256] = {};
-
-    if (
-        GetClassNameW(
-            hwnd,
-            className,
-            ARRAYSIZE(className)
-        ) == 0
-    ) {
-        return TRUE;
-    }
-
-    if (!IsLikelyApplicationWindow(
-            hwnd,
-            className
-        )) {
-        return TRUE;
-    }
-
-    RECT rect = {};
-
-    if (
-        !GetWindowRect(
-            hwnd,
-            &rect
-        ) ||
-        rect.right <= rect.left ||
-        rect.bottom <= rect.top
-    ) {
-        return TRUE;
-    }
-
-    MONITORINFO targetInfo = {};
-    targetInfo.cbSize = sizeof(targetInfo);
-
-    if (
-        !GetMonitorInfoW(
-            context->monitor,
-            &targetInfo
-        )
-    ) {
-        return TRUE;
-    }
-
-    WINDOWPLACEMENT placement = {};
-    placement.length = sizeof(placement);
-
-    if (
-        GetWindowPlacement(
-            hwnd,
-            &placement
-        ) &&
-        placement.showCmd == SW_SHOWMAXIMIZED
-    ) {
-        HMONITOR windowMonitor =
-            MonitorFromWindow(
-                hwnd,
-                MONITOR_DEFAULTTONEAREST
-            );
-
-        if (
-            windowMonitor ==
-            context->monitor
-        ) {
-            context->found = true;
-            return FALSE;
-        }
-
-        return TRUE;
-    }
-
-    /*
-     * Normal and spanning windows use their actual visible rectangle. This
-     * lets one window legitimately count on more than one display.
-     */
-    RECT intersection = {};
-
-    if (
-        IntersectRect(
-            &intersection,
-            &rect,
-            &targetInfo.rcMonitor
-        )
-    ) {
-        context->found = true;
-        return FALSE;
-    }
-
-    return TRUE;
-}
-
-
-bool HasOtherVisibleWindowOnMonitor(
-    HMONITOR monitor
-) {
-    MonitorWindowScanContext context = {
-        monitor,
-        false
-    };
-
-    EnumWindows(
-        EnumWindowsForMonitorProc,
-        reinterpret_cast<LPARAM>(&context)
-    );
-
-    return context.found;
-}
-
-
-bool IsForegroundApplicationWindow(
-    HWND hwnd,
-    const WCHAR* className
-) {
-    if (
-        !hwnd ||
-        !className ||
-        !IsWindowVisible(hwnd) ||
-        IsIconic(hwnd)
-    ) {
-        return false;
-    }
-
-    if (
-        IsDesktopInfrastructureWindow(
-            hwnd,
-            className
-        ) ||
-        IsShellChromeClass(
-            className
-        )
-    ) {
-        return false;
-    }
-
-    /*
-     * The foreground window is a stronger signal than a background helper
-     * window discovered by EnumWindows. Do not require a title or
-     * WS_EX_APPWINDOW here; this covers shell-integrated applications and
-     * virtual-display/application windows which may be titleless.
-     */
-    BOOL cloaked = FALSE;
-
-    if (
-        SUCCEEDED(
-            DwmGetWindowAttribute(
-                hwnd,
-                DWMWA_CLOAKED,
-                &cloaked,
-                sizeof(cloaked)
-            )
-        ) &&
-        cloaked
-    ) {
-        return false;
-    }
-
-    return true;
-}
-
-
-void RefreshDesktopState() {
-    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-        TaskbarMonitorState& state =
-            g_taskbarStates[i];
-
-        if (!state.monitor) {
-            state.desktopOnly = true;
-            continue;
-        }
-
-        state.desktopOnly =
-            !HasOtherVisibleWindowOnMonitor(
-                state.monitor
-            );
-    }
-
-    /*
-     * The per-monitor scan is the authoritative baseline. A real foreground
-     * application is an additional immediate signal for its own monitor.
-     *
-     * Crucially, Progman/WorkerW are never used for this override because
-     * Windows may associate the desktop foreground window with the primary
-     * display even when the user clicked another display's desktop.
-     */
-    HWND foreground = GetForegroundWindow();
-
-    if (!foreground ||
-        !IsWindowVisible(foreground) ||
-        IsIconic(foreground)) {
-        return;
-    }
-
-    WCHAR className[256] = {};
-
-    if (
-        GetClassNameW(
-            foreground,
-            className,
-            ARRAYSIZE(className)
-        ) == 0
-    ) {
-        return;
-    }
-
-    if (
-        IsDesktopInfrastructureWindow(
-            foreground,
-            className
-        ) ||
-        IsShellChromeClass(
-            className
-        )
-    ) {
-        return;
-    }
-
-    if (!IsForegroundApplicationWindow(
-            foreground,
-            className
-        )) {
-        return;
-    }
-
-    /*
-     * The foreground window is an immediate signal that its display is
-     * active. Prefer the monitor Windows assigns to the window. For unusual
-     * virtual/maximized display geometry, verify that choice against the
-     * actual foreground rectangle and use the monitor with the largest
-     * visible intersection when it differs.
-     */
-    HMONITOR foregroundMonitor =
-        MonitorFromWindow(
-            foreground,
-            MONITOR_DEFAULTTONEAREST
-        );
-
-    /*
-     * Keep the foreground override tied to the monitor Windows assigns to
-     * the foreground window. The per-monitor scan already handles normal
-     * windows that span multiple displays, so there is no need to enumerate
-     * MonitorList here (which would also create a declaration-order
-     * dependency).
-     */
-
-    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-        if (
-            g_taskbarStates[i].monitor ==
-            foregroundMonitor
-        ) {
-            g_taskbarStates[i].desktopOnly = false;
-            break;
-        }
-    }
-}
-
-struct MonitorEntry {
-    HMONITOR monitor;
-    RECT rect;
-    bool primary;
-    wchar_t deviceName[32];
-};
-
-struct MonitorList {
-    MonitorEntry entries[kMaxMonitorNumbers];
-    size_t count;
-};
-
-
-BOOL CALLBACK CollectMonitorProc(
-    HMONITOR monitor,
-    HDC,
-    LPRECT,
-    LPARAM lParam
-) {
-    MonitorList* list =
-        reinterpret_cast<MonitorList*>(lParam);
-
-    if (!list || list->count >= kMaxMonitorNumbers) {
-        return FALSE;
-    }
-
-    MONITORINFOEXW info = {};
-    info.cbSize = sizeof(info);
-
-    if (!GetMonitorInfoW(
-            monitor,
-            &info
-        )) {
-        return TRUE;
-    }
-
-    MonitorEntry& entry =
-        list->entries[list->count++];
-
-    entry.monitor = monitor;
-    entry.rect = info.rcMonitor;
-    entry.primary =
-        (info.dwFlags & MONITORINFOF_PRIMARY) != 0;
-
-    wcsncpy_s(
-        entry.deviceName,
-        ARRAYSIZE(entry.deviceName),
-        info.szDevice,
-        _TRUNCATE
-    );
-
-    return TRUE;
-}
-
-
-int GetDisplayDeviceNumber(
-    const wchar_t* deviceName
-) {
-    if (!deviceName) {
-        return 0;
-    }
-
-    /*
-     * Windows normally exposes the desktop display devices as DISPLAY1,
-     * DISPLAY2, ... . We use that OS-provided identity for numbering instead
-     * of the screen coordinates. This means moving a display left/right in
-     * Windows Display Settings does not change its selected display number.
-     */
-    constexpr wchar_t kPrefix[] = L"\\\\.\\DISPLAY";
-
-    size_t prefixLength =
-        ARRAYSIZE(kPrefix) - 1;
-
-    if (
-        wcsncmp(
-            deviceName,
-            kPrefix,
-            prefixLength
-        ) != 0
-    ) {
-        return 0;
-    }
-
-    wchar_t* endNumber = nullptr;
-
-    long number =
-        wcstol(
-            deviceName + prefixLength,
-            &endNumber,
-            10
-        );
-
-    if (
-        endNumber == deviceName + prefixLength ||
-        *endNumber != L'\0' ||
-        number < 1 ||
-        number > static_cast<long>(
-            kMaxMonitorNumbers
-        )
-    ) {
-        return 0;
-    }
-
-    return static_cast<int>(number);
-}
-
-
-void SortDisplaysForSelection(
-    MonitorList& list
-) {
-    /*
-     * Keep the primary display as Display 1 for the user-facing setting.
-     * For all other displays, prefer Windows' DISPLAYn number. This is much
-     * more stable than sorting by x/y coordinates.
-     *
-     * If Windows gives us an unexpected device name, fall back to the
-     * previous deterministic coordinate ordering.
-     */
-    size_t primaryIndex = list.count;
-
-    for (size_t i = 0; i < list.count; ++i) {
-        if (list.entries[i].primary) {
-            primaryIndex = i;
-            break;
-        }
-    }
-
-    if (
-        primaryIndex < list.count &&
-        primaryIndex != 0
-    ) {
-        MonitorEntry primary =
-            list.entries[primaryIndex];
-
-        for (size_t i = primaryIndex; i > 0; --i) {
-            list.entries[i] =
-                list.entries[i - 1];
-        }
-
-        list.entries[0] = primary;
-    }
-
-    for (size_t i = 1; i < list.count; ++i) {
-        size_t best = i;
-        int bestNumber =
-            GetDisplayDeviceNumber(
-                list.entries[best].deviceName
-            );
-
-        for (size_t j = i + 1; j < list.count; ++j) {
-            int candidateNumber =
-                GetDisplayDeviceNumber(
-                    list.entries[j].deviceName
-                );
-
-            bool candidateIsBetter = false;
-
-            if (
-                candidateNumber > 0 &&
-                bestNumber == 0
-            ) {
-                candidateIsBetter = true;
-            } else if (
-                candidateNumber > 0 &&
-                bestNumber > 0 &&
-                candidateNumber < bestNumber
-            ) {
-                candidateIsBetter = true;
-            } else if (
-                candidateNumber == 0 &&
-                bestNumber == 0
-            ) {
-                const RECT& a =
-                    list.entries[best].rect;
-                const RECT& b =
-                    list.entries[j].rect;
-
-                candidateIsBetter =
-                    b.top < a.top ||
-                    (
-                        b.top == a.top &&
-                        b.left < a.left
-                    );
-            }
-
-            if (candidateIsBetter) {
-                best = j;
-                bestNumber = candidateNumber;
-            }
-        }
-
-        if (best != i) {
-            MonitorEntry temp =
-                list.entries[i];
-
-            list.entries[i] =
-                list.entries[best];
-
-            list.entries[best] =
-                temp;
-        }
-    }
-}
-
-
-MonitorList GetCurrentMonitors() {
-    MonitorList list = {};
-
-    EnumDisplayMonitors(
-        nullptr,
-        nullptr,
-        CollectMonitorProc,
-        reinterpret_cast<LPARAM>(&list)
-    );
-
-    SortDisplaysForSelection(list);
-
-    return list;
-}
-
-
-int GetMonitorNumber(
-    const MonitorList& list,
-    HMONITOR monitor
-) {
-    for (size_t i = 0; i < list.count; ++i) {
-        if (list.entries[i].monitor == monitor) {
-            return static_cast<int>(i + 1);
-        }
-    }
-
-    return 0;
-}
-
-
-bool ShouldHideMonitor(int monitorNumber) {
-    if (
-        monitorNumber < 1 ||
-        monitorNumber > static_cast<int>(kMaxMonitorNumbers)
-    ) {
-        return false;
-    }
-
-    return
-        settings.hideAllMonitors ||
-        settings.hideMonitor[monitorNumber];
-}
-
-bool ShouldRevealOnHover(int monitorNumber) {
-    if (
-        monitorNumber < 1 ||
-        monitorNumber > static_cast<int>(kMaxMonitorNumbers)
-    ) {
-        return false;
-    }
-
-    return
-        settings.hoverAllMonitors ||
-        settings.hoverMonitor[monitorNumber];
-}
-
-
-void RefreshTaskbarMonitorStates() {
-    TaskbarMonitorState oldStates[kMaxTaskbars] = {};
-    size_t oldCount = g_taskbarStateCount;
-
-    MonitorList monitors =
-        GetCurrentMonitors();
-
-    for (size_t i = 0; i < oldCount; ++i) {
-        oldStates[i] = g_taskbarStates[i];
-    }
-
-    g_taskbarStateCount = 0;
-
-    auto addTaskbar = [&](HWND hwnd, bool secondary) {
-        (void)secondary;
-
-        if (
-            !hwnd ||
-            g_taskbarStateCount >= kMaxTaskbars
-        ) {
-            return;
-        }
-
-        RECT taskbarRect = {};
-
-        if (!GetWindowRect(
-                hwnd,
-                &taskbarRect
-            )) {
-            return;
-        }
-
-        // The Shell taskbar HWND is tied to its actual display. Using
-        // MonitorFromWindow() avoids inferring ownership from transient
-        // taskbar geometry, which can be misleading with virtual displays.
-        HMONITOR monitor =
-            MonitorFromWindow(
-                hwnd,
-                MONITOR_DEFAULTTONEAREST
-            );
-
-        if (!monitor) {
-            POINT taskbarCenter = {
-                taskbarRect.left +
-                    (taskbarRect.right - taskbarRect.left) / 2,
-                taskbarRect.top +
-                    (taskbarRect.bottom - taskbarRect.top) / 2
-            };
-
-            monitor =
-                MonitorFromPoint(
-                    taskbarCenter,
-                    MONITOR_DEFAULTTONEAREST
-                );
-        }
-
-        TaskbarMonitorState state = {};
-        state.hwnd = hwnd;
-        state.monitor = monitor;
-        state.monitorNumber =
-            GetMonitorNumber(
-                monitors,
-                monitor
-            );
-
-        for (size_t i = 0; i < oldCount; ++i) {
-            if (oldStates[i].hwnd == hwnd) {
-                state.desktopOnly =
-                    oldStates[i].desktopOnly;
-                break;
-            }
-        }
-
-        g_taskbarStates[g_taskbarStateCount++] = state;
-    };
-
-    addTaskbar(
-        FindWindowW(
-            L"Shell_TrayWnd",
-            nullptr
-        ),
-        false
-    );
-
-    HWND secondary = nullptr;
-
-    while (
-        (secondary = FindWindowExW(
-            nullptr,
-            secondary,
-            L"Shell_SecondaryTrayWnd",
-            nullptr
-        )) != nullptr
-    ) {
-        addTaskbar(
-            secondary,
-            true
-        );
-    }
-}
-
-
-bool IsShellFlyoutWindow(HWND hwnd) {
-    if (
-        !hwnd ||
-        !IsWindow(hwnd) ||
-        !IsWindowVisible(hwnd)
-    ) {
-        return false;
-    }
-
-    WCHAR className[128] = {};
-
-    if (
-        GetClassNameW(
-            hwnd,
-            className,
-            ARRAYSIZE(className)
-        ) == 0
-    ) {
-        return false;
-    }
-
-    /*
-     * These are shell/XAML popup classes used by Windows 11 for taskbar
-     * flyouts such as the notification/calendar and quick-settings surfaces.
-     * The class check is intentionally combined with the Explorer process
-     * check below so an identically named third-party window isn't treated as
-     * shell UI.
-     */
-    bool knownFlyoutClass =
-        wcscmp(
-            className,
-            L"Xaml_WindowedPopupClass"
-        ) == 0 ||
-        wcscmp(
-            className,
-            L"Windows.UI.Core.CoreWindow"
-        ) == 0 ||
-        wcscmp(
-            className,
-            L"TopLevelWindowForOverflowXamlIsland"
-        ) == 0 ||
-        wcscmp(
-            className,
-            L"NotifyIconOverflowWindow"
-        ) == 0;
-
-    if (!knownFlyoutClass) {
-        return false;
-    }
-
-    DWORD processId = 0;
-
-    GetWindowThreadProcessId(
-        hwnd,
-        &processId
-    );
-
-    if (!processId) {
-        return false;
-    }
-
-    HWND taskbar =
-        FindWindowW(
-            L"Shell_TrayWnd",
-            nullptr
-        );
-
-    DWORD taskbarProcessId = 0;
-
-    if (taskbar) {
-        GetWindowThreadProcessId(
-            taskbar,
-            &taskbarProcessId
-        );
-    }
-
-    /*
-     * Use the taskbar's Explorer process as the primary trust boundary.
-     * For secondary taskbars, Explorer is still the owning process, but a
-     * taskbar recreation can briefly leave the primary lookup unavailable.
-     */
-    if (
-        taskbarProcessId != 0 &&
-        processId == taskbarProcessId
-    ) {
-        return true;
-    }
-
-    DWORD explorerProcessId = 0;
-    HWND shellWindow = GetShellWindow();
-
-    if (shellWindow) {
-        GetWindowThreadProcessId(
-            shellWindow,
-            &explorerProcessId
-        );
-    }
-
-    return
-        explorerProcessId != 0 &&
-        processId == explorerProcessId;
-}
-
-
-struct ShellFlyoutScanContext {
-    HMONITOR targetMonitor;
-    bool found;
-};
-
-
-BOOL CALLBACK ShellFlyoutEnumProc(
-    HWND hwnd,
-    LPARAM lParam
-) {
-    ShellFlyoutScanContext* context =
-        reinterpret_cast<ShellFlyoutScanContext*>(lParam);
-
-    if (
-        !context ||
-        !IsShellFlyoutWindow(hwnd)
-    ) {
-        return TRUE;
-    }
-
-    RECT rect = {};
-
-    if (!GetWindowRect(hwnd, &rect)) {
-        return TRUE;
-    }
-
-    POINT center = {
-        rect.left +
-            (rect.right - rect.left) / 2,
-        rect.top +
-            (rect.bottom - rect.top) / 2
-    };
-
-    HMONITOR flyoutMonitor =
-        MonitorFromPoint(
-            center,
-            MONITOR_DEFAULTTONEAREST
-        );
-
-    if (flyoutMonitor == context->targetMonitor) {
-        context->found = true;
-        return FALSE;
-    }
-
-    return TRUE;
-}
-
-
-bool HasVisibleShellFlyoutOnMonitor(
-    HMONITOR monitor
-) {
-    if (!monitor) {
-        return false;
-    }
-
-    ShellFlyoutScanContext context = {
-        monitor,
-        false
-    };
-
-    EnumWindows(
-        ShellFlyoutEnumProc,
-        reinterpret_cast<LPARAM>(&context)
-    );
-
-    return context.found;
-}
-
-
-bool IsAltTabActive() {
-    /*
-     * The legacy Alt+Tab switcher uses #32771. Windows 11's XAML host can
-     * remain present after the switcher closes, so do not treat that host
-     * alone as proof that Alt+Tab is active.
-     */
-    HWND foreground = GetForegroundWindow();
-
-    if (foreground) {
-        WCHAR className[128] = {};
-
-        if (
-            GetClassNameW(
-                foreground,
-                className,
-                ARRAYSIZE(className)
-            ) != 0 &&
-            wcscmp(className, L"#32771") == 0
-        ) {
-            return true;
-        }
-    }
-
-    /*
-     * While the Alt+Tab chord is physically held, keep the taskbar visible
-     * even if the switcher's foreground window is hosted differently.
+     * Background title-less helper surfaces are ignored. A title-less
+     * application becomes covered by the foreground-window path.
      */
     return
-        (GetAsyncKeyState(VK_MENU) & 0x8000) != 0 &&
-        (GetAsyncKeyState(VK_TAB) & 0x8000) != 0;
+        (exStyle & WS_EX_APPWINDOW) != 0 ||
+        GetWindowTextLengthW(hwnd) > 0;
 }
-
 
 bool IsTaskbarPopupClass(
     const WCHAR* className
@@ -1128,80 +626,573 @@ bool IsTaskbarPopupClass(
         ) == 0;
 }
 
-
-bool IsTaskbarPopupOpen(HWND taskbar) {
+bool IsExplorerShellPopup(
+    HWND hwnd,
+    const WCHAR* className,
+    DWORD explorerPid
+) {
     if (
-        !taskbar ||
-        !IsWindow(taskbar)
+        !hwnd ||
+        !className ||
+        !IsWindowVisible(hwnd) ||
+        !IsTaskbarPopupClass(className)
     ) {
         return false;
     }
 
+    DWORD pid = 0;
+
+    GetWindowThreadProcessId(
+        hwnd,
+        &pid
+    );
+
+    if (
+        explorerPid != 0 &&
+        pid == explorerPid
+    ) {
+        return true;
+    }
+
+    HWND shellWindow = GetShellWindow();
+    DWORD shellPid = 0;
+
+    if (shellWindow) {
+        GetWindowThreadProcessId(
+            shellWindow,
+            &shellPid
+        );
+    }
+
+    return
+        shellPid != 0 &&
+        pid == shellPid;
+}
+
+struct ScanContext {
+    const MonitorList* monitors;
+    WindowScanResult* result;
+};
+
+BOOL CALLBACK ScanWindowsWithMonitorsProc(
+    HWND hwnd,
+    LPARAM lParam
+) {
+    ScanContext* context =
+        reinterpret_cast<ScanContext*>(lParam);
+
+    if (
+        !context ||
+        !context->monitors ||
+        !context->result
+    ) {
+        return TRUE;
+    }
+
+    WCHAR className[256] = {};
+
+    if (
+        GetClassNameW(
+            hwnd,
+            className,
+            ARRAYSIZE(className)
+        ) == 0
+    ) {
+        return TRUE;
+    }
+
+    if (!IsApplicationWindowCandidate(
+            hwnd,
+            className
+        )) {
+        return TRUE;
+    }
+
+    RECT rect = {};
+
+    if (
+        !GetWindowRect(
+            hwnd,
+            &rect
+        ) ||
+        rect.right <= rect.left ||
+        rect.bottom <= rect.top
+    ) {
+        return TRUE;
+    }
+
+    WINDOWPLACEMENT placement = {};
+    placement.length = sizeof(placement);
+
+    if (
+        GetWindowPlacement(
+            hwnd,
+            &placement
+        ) &&
+        placement.showCmd == SW_SHOWMAXIMIZED
+    ) {
+        HMONITOR windowMonitor =
+            MonitorFromWindow(
+                hwnd,
+                MONITOR_DEFAULTTONEAREST
+            );
+
+        for (
+            size_t i = 0;
+            i < context->monitors->count;
+            ++i
+        ) {
+            if (
+                context->monitors->entries[i].monitor ==
+                windowMonitor
+            ) {
+                context->result->applicationOnMonitor[i] = true;
+                return TRUE;
+            }
+        }
+
+        return TRUE;
+    }
+
+    for (
+        size_t i = 0;
+        i < context->monitors->count;
+        ++i
+    ) {
+        RECT intersection = {};
+
+        if (
+            IntersectRect(
+                &intersection,
+                &rect,
+                &context->monitors->entries[i].rect
+            )
+        ) {
+            context->result->applicationOnMonitor[i] = true;
+        }
+    }
+
+    return TRUE;
+}
+
+void ScanWindowsOnce(
+    const MonitorList& monitors,
+    WindowScanResult& result
+) {
+    result = {};
+
+    ScanContext context = {
+        &monitors,
+        &result
+    };
+
+    EnumWindows(
+        ScanWindowsWithMonitorsProc,
+        reinterpret_cast<LPARAM>(&context)
+    );
+
+    /*
+     * A title-less foreground application is allowed even when it did not
+     * meet the conservative background candidate rule.
+     */
+    HWND foreground =
+        GetForegroundWindow();
+
+    if (
+        foreground &&
+        IsWindowVisible(foreground) &&
+        !IsIconic(foreground)
+    ) {
+        WCHAR className[256] = {};
+
+        if (
+            GetClassNameW(
+                foreground,
+                className,
+                ARRAYSIZE(className)
+            ) != 0 &&
+            !IsDesktopInfrastructureWindow(
+                foreground,
+                className
+            ) &&
+            !IsShellChromeClass(className)
+        ) {
+            BOOL cloaked = FALSE;
+
+            if (
+                !(
+                    SUCCEEDED(
+                        DwmGetWindowAttribute(
+                            foreground,
+                            DWMWA_CLOAKED,
+                            &cloaked,
+                            sizeof(cloaked)
+                        )
+                    ) &&
+                    cloaked
+                )
+            ) {
+                HMONITOR foregroundMonitor =
+                    MonitorFromWindow(
+                        foreground,
+                        MONITOR_DEFAULTTONEAREST
+                    );
+
+                for (
+                    size_t i = 0;
+                    i < monitors.count;
+                    ++i
+                ) {
+                    if (
+                        monitors.entries[i].monitor ==
+                        foregroundMonitor
+                    ) {
+                        result.applicationOnMonitor[i] = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+void RefreshTaskbarMonitorStates(
+    const MonitorList& monitors
+) {
+    TaskbarMonitorState oldStates[kMaxTaskbars] = {};
+    const size_t oldCount =
+        g_taskbarStateCount;
+
+    for (size_t i = 0; i < oldCount; ++i) {
+        oldStates[i] =
+            g_taskbarStates[i];
+    }
+
+    g_taskbarStateCount = 0;
+
+    auto addTaskbar = [&](HWND hwnd) {
+        if (
+            !hwnd ||
+            g_taskbarStateCount >= kMaxTaskbars
+        ) {
+            return;
+        }
+
+        HMONITOR monitor =
+            MonitorFromWindow(
+                hwnd,
+                MONITOR_DEFAULTTONEAREST
+            );
+
+        TaskbarMonitorState state = {};
+        state.hwnd = hwnd;
+        state.monitor = monitor;
+        state.monitorNumber =
+            GetMonitorNumber(
+                monitors,
+                monitor
+            );
+        state.desktopOnly = true;
+
+        for (size_t i = 0; i < oldCount; ++i) {
+            if (oldStates[i].hwnd == hwnd) {
+                state.desktopOnly =
+                    oldStates[i].desktopOnly;
+                break;
+            }
+        }
+
+        g_taskbarStates[
+            g_taskbarStateCount++
+        ] = state;
+    };
+
+    addTaskbar(
+        FindWindowW(
+            L"Shell_TrayWnd",
+            nullptr
+        )
+    );
+
+    HWND secondary = nullptr;
+
+    while (
+        (secondary = FindWindowExW(
+            nullptr,
+            secondary,
+            L"Shell_SecondaryTrayWnd",
+            nullptr
+        )) != nullptr
+    ) {
+        addTaskbar(secondary);
+    }
+}
+
+void SetTaskbarState(
+    TaskbarMonitorState& state,
+    bool show
+) {
+    if (
+        !state.hwnd ||
+        !IsWindow(state.hwnd)
+    ) {
+        return;
+    }
+
+    const bool visible =
+        IsWindowVisible(state.hwnd) != FALSE;
+
+    if (visible == show) {
+        return;
+    }
+
+    // Only this taskbar HWND is changed. Other displays are handled by their
+    // own TaskbarMonitorState entries.
+    ShowWindow(
+        state.hwnd,
+        show ? SW_SHOW : SW_HIDE
+    );
+}
+
+void ApplyBaseTaskbarState() {
+    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+        TaskbarMonitorState& state =
+            g_taskbarStates[i];
+
+        SetTaskbarState(
+            state,
+            !state.desktopOnly ||
+            !ShouldHideMonitor(
+                state.monitorNumber
+            )
+        );
+    }
+}
+
+int GetHoverZonePx(
+    HWND hTaskbar,
+    UINT dpi
+) {
+    RECT rect = {};
+
+    if (
+        hTaskbar &&
+        GetWindowRect(
+            hTaskbar,
+            &rect
+        )
+    ) {
+        int taskbarHeight =
+            rect.bottom - rect.top;
+
+        if (taskbarHeight > 0) {
+            return
+                taskbarHeight +
+                g_settings.extraHoverMarginPx;
+        }
+    }
+
+    return
+        MulDiv(
+            48,
+            static_cast<int>(dpi),
+            96
+        ) +
+        g_settings.extraHoverMarginPx;
+}
+
+bool IsBottomDockedTaskbar(
+    HWND hTaskbar,
+    HMONITOR monitor
+) {
+    if (!hTaskbar || !monitor) {
+        return false;
+    }
+
+    RECT taskbarRect = {};
+
+    if (!GetWindowRect(
+            hTaskbar,
+            &taskbarRect
+        )) {
+        return false;
+    }
+
+    MONITORINFO mi = {};
+    mi.cbSize = sizeof(mi);
+
+    if (!GetMonitorInfoW(
+            monitor,
+            &mi
+        )) {
+        return false;
+    }
+
+    const LONG tolerance = 4;
+
+    const LONG monitorWidth =
+        mi.rcMonitor.right -
+        mi.rcMonitor.left;
+
+    const LONG monitorHeight =
+        mi.rcMonitor.bottom -
+        mi.rcMonitor.top;
+
+    const LONG taskbarWidth =
+        taskbarRect.right -
+        taskbarRect.left;
+
+    const LONG taskbarHeight =
+        taskbarRect.bottom -
+        taskbarRect.top;
+
+    return
+        taskbarRect.bottom >=
+            mi.rcMonitor.bottom - tolerance &&
+        taskbarRect.top >
+            mi.rcMonitor.top &&
+        taskbarWidth >=
+            monitorWidth / 2 &&
+        taskbarHeight <
+            monitorHeight / 2;
+}
+
+bool IsCursorNearBottomEdge(
+    HWND hTaskbar,
+    HMONITOR cursorMonitor
+) {
+    POINT pt = {};
+
+    if (
+        !hTaskbar ||
+        !cursorMonitor ||
+        !GetCursorPos(&pt)
+    ) {
+        return false;
+    }
+
+    MONITORINFO mi = {};
+    mi.cbSize = sizeof(mi);
+
+    if (!GetMonitorInfoW(
+            cursorMonitor,
+            &mi
+        )) {
+        return false;
+    }
+
+    if (!IsBottomDockedTaskbar(
+            hTaskbar,
+            cursorMonitor
+        )) {
+        return false;
+    }
+
+    UINT dpi =
+        GetDpiForWindow(hTaskbar);
+
+    int hotZonePx =
+        GetHoverZonePx(
+            hTaskbar,
+            dpi
+        );
+
+    if (hotZonePx < 1) {
+        hotZonePx = 1;
+    }
+
+    return
+        pt.y >=
+            mi.rcMonitor.bottom - hotZonePx &&
+        pt.y < mi.rcMonitor.bottom;
+}
+
+HMONITOR GetForegroundShellPopupMonitor() {
+    HWND foreground =
+        GetForegroundWindow();
+
+    if (!foreground) {
+        return nullptr;
+    }
+
+    WCHAR className[128] = {};
+
+    if (
+        GetClassNameW(
+            foreground,
+            className,
+            ARRAYSIZE(className)
+        ) == 0
+    ) {
+        return nullptr;
+    }
+
+    HWND taskbar =
+        FindWindowW(
+            L"Shell_TrayWnd",
+            nullptr
+        );
+
+    DWORD explorerPid = 0;
+
+    if (taskbar) {
+        GetWindowThreadProcessId(
+            taskbar,
+            &explorerPid
+        );
+    }
+
+    if (
+        !IsExplorerShellPopup(
+            foreground,
+            className,
+            explorerPid
+        )
+    ) {
+        return nullptr;
+    }
+
+    return MonitorFromWindow(
+        foreground,
+        MONITOR_DEFAULTTONEAREST
+    );
+}
+
+
+HMONITOR GetCursorPopupMonitor() {
     POINT pt = {};
 
     if (!GetCursorPos(&pt)) {
-        return false;
+        return nullptr;
     }
 
-    HMONITOR taskbarMonitor =
-        MonitorFromWindow(
-            taskbar,
-            MONITOR_DEFAULTTONEAREST
-        );
-
-    HMONITOR cursorMonitor =
-        MonitorFromPoint(
-            pt,
-            MONITOR_DEFAULTTONEAREST
-        );
-
-    if (
-        !taskbarMonitor ||
-        cursorMonitor != taskbarMonitor
-    ) {
-        return false;
-    }
-
-    HWND current = WindowFromPoint(pt);
+    HWND current =
+        WindowFromPoint(pt);
 
     if (!current) {
-        return false;
+        return nullptr;
     }
 
-    HWND root = GetAncestor(
-        current,
-        GA_ROOT
-    );
+    HWND taskbar =
+        FindWindowW(
+            L"Shell_TrayWnd",
+            nullptr
+        );
 
-    if (root) {
-        current = root;
+    DWORD explorerPid = 0;
+
+    if (taskbar) {
+        GetWindowThreadProcessId(
+            taskbar,
+            &explorerPid
+        );
     }
 
-    DWORD taskbarProcessId = 0;
-
-    GetWindowThreadProcessId(
-        taskbar,
-        &taskbarProcessId
-    );
-
-    if (!taskbarProcessId) {
-        return false;
-    }
-
-    /*
-     * A taskbar/Start popup may not become the foreground window. Walk the
-     * window's parent/owner chain from the window under the cursor instead.
-     * This works for normal #32768 menus as well as XAML shell popups.
-     */
     for (
         int depth = 0;
         current && depth < 12;
         ++depth
     ) {
-        if (current == taskbar) {
-            return false;
-        }
-
         WCHAR className[128] = {};
 
         if (
@@ -1209,42 +1200,57 @@ bool IsTaskbarPopupOpen(HWND taskbar) {
                 current,
                 className,
                 ARRAYSIZE(className)
-            ) != 0
+            ) != 0 &&
+            IsExplorerShellPopup(
+                current,
+                className,
+                explorerPid
+            )
         ) {
-            bool popupClass =
-                IsTaskbarPopupClass(
-                    className
-                );
+            RECT rect = {};
 
-            if (
-                popupClass &&
-                IsWindowVisible(current)
-            ) {
-                DWORD popupProcessId = 0;
-
-                GetWindowThreadProcessId(
+            if (GetWindowRect(
                     current,
-                    &popupProcessId
-                );
+                    &rect
+                )) {
+                POINT center = {
+                    rect.left +
+                        (rect.right - rect.left) / 2,
+                    rect.top +
+                        (rect.bottom - rect.top) / 2
+                };
 
-                /*
-                 * Prefer the taskbar's Explorer process. A shell popup from
-                 * one of the known shell UI processes is also accepted.
-                 */
+                HMONITOR popupMonitor =
+                    MonitorFromPoint(
+                        center,
+                        MONITOR_DEFAULTTONEAREST
+                    );
+
+                HMONITOR cursorMonitor =
+                    MonitorFromPoint(
+                        pt,
+                        MONITOR_DEFAULTTONEAREST
+                    );
+
                 if (
-                    popupProcessId == taskbarProcessId
+                    popupMonitor &&
+                    popupMonitor == cursorMonitor
                 ) {
-                    return true;
+                    return popupMonitor;
                 }
 
+                return nullptr;
             }
         }
 
-        HWND parent = GetParent(current);
-        HWND owner = GetWindow(
-            current,
-            GW_OWNER
-        );
+        HWND parent =
+            GetParent(current);
+
+        HWND owner =
+            GetWindow(
+                current,
+                GW_OWNER
+            );
 
         if (
             parent &&
@@ -1261,236 +1267,80 @@ bool IsTaskbarPopupOpen(HWND taskbar) {
         }
     }
 
-    return false;
+    return nullptr;
 }
 
-
-bool IsTaskbarShellPopupForeground(HWND taskbar) {
+bool IsAltTabActive() {
     HWND foreground =
         GetForegroundWindow();
 
-    if (
-        !foreground ||
-        foreground == taskbar
-    ) {
-        return false;
+    if (foreground) {
+        WCHAR className[128] = {};
+
+        if (
+            GetClassNameW(
+                foreground,
+                className,
+                ARRAYSIZE(className)
+            ) != 0 &&
+            wcscmp(
+                className,
+                L"#32771"
+            ) == 0
+        ) {
+            return true;
+        }
     }
-
-    DWORD foregroundThreadId =
-        GetWindowThreadProcessId(
-            foreground,
-            nullptr
-        );
-
-    DWORD taskbarThreadId =
-        GetWindowThreadProcessId(
-            taskbar,
-            nullptr
-        );
-
-    if (
-        !foregroundThreadId ||
-        !taskbarThreadId ||
-        foregroundThreadId != taskbarThreadId
-    ) {
-        return false;
-    }
-
-    WCHAR className[128] = {};
-
-    if (
-        !GetClassNameW(
-            foreground,
-            className,
-            ARRAYSIZE(className)
-        )
-    ) {
-        return false;
-    }
-
-    if (!IsTaskbarPopupClass(className)) {
-        return false;
-    }
-
-    HMONITOR taskbarMonitor =
-        MonitorFromWindow(
-            taskbar,
-            MONITOR_DEFAULTTONEAREST
-        );
-
-    HMONITOR popupMonitor =
-        MonitorFromWindow(
-            foreground,
-            MONITOR_DEFAULTTONEAREST
-        );
-
-    POINT cursorPoint = {};
-    if (!GetCursorPos(&cursorPoint)) {
-        return false;
-    }
-
-    HMONITOR cursorMonitor =
-        MonitorFromPoint(
-            cursorPoint,
-            MONITOR_DEFAULTTONEAREST
-        );
 
     return
-        taskbarMonitor &&
-        popupMonitor &&
-        cursorMonitor &&
-        taskbarMonitor == popupMonitor &&
-        popupMonitor == cursorMonitor;
+        (GetAsyncKeyState(VK_MENU) & 0x8000) != 0 &&
+        (GetAsyncKeyState(VK_TAB) & 0x8000) != 0;
 }
 
+void UpdateTaskbarState() {
+    MonitorList monitors =
+        GetCurrentMonitors();
 
-void SetTaskbarState(
-    TaskbarMonitorState& state,
-    bool show
-) {
-    if (
-        !state.hwnd ||
-        !IsWindow(state.hwnd)
-    ) {
-        return;
-    }
+    RefreshTaskbarMonitorStates(
+        monitors
+    );
 
-    bool visible =
-        IsWindowVisible(state.hwnd) != FALSE;
+    WindowScanResult scan = {};
 
-    if (visible != show) {
-        ShowWindow(
-            state.hwnd,
-            show ? SW_SHOW : SW_HIDE
-        );
-    }
-}
-
-
-void SetTaskbarVisibility(bool show) {
-    HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
-    if (hTaskbar) {
-        ShowWindow(hTaskbar, show ? SW_SHOW : SW_HIDE);
-    }
-
-    HWND hSecondary = nullptr;
-    while (
-        (hSecondary = FindWindowExW(
-            nullptr,
-            hSecondary,
-            L"Shell_SecondaryTrayWnd",
-            nullptr
-        )) != nullptr
-    ) {
-        ShowWindow(
-            hSecondary,
-            show ? SW_SHOW : SW_HIDE
-        );
-    }
-}
-
-// The reveal zone matches the taskbar's own current height (whatever size
-// and display scaling you actually have it set to), plus a configurable
-// extra margin on top. Falls back to a small DPI-scaled default if the
-// taskbar's rect can't be read for some reason.
-int GetHoverZonePx(HWND hTaskbar, UINT dpi) {
-    int marginPx = (int)((double)settings.extraHoverMarginMm / 25.4 * dpi);
-
-    RECT tbRect;
-    if (hTaskbar && GetWindowRect(hTaskbar, &tbRect)) {
-        int taskbarHeight = tbRect.bottom - tbRect.top;
-        if (taskbarHeight > 0) {
-            return taskbarHeight + marginPx;
-        }
-    }
-
-    // Fallback: assume a ~48px (at 100% scaling) default taskbar height.
-    int fallbackHeight = (int)(48.0 * dpi / 96.0);
-    return fallbackHeight + marginPx;
-}
-
-// True if the cursor is within the taskbar-height-sized zone at the bottom
-// edge of whichever monitor it's currently on.
-bool IsCursorNearBottomEdge(HMONITOR cursorMonitor) {
-    POINT pt;
-    if (!GetCursorPos(&pt)) {
-        return false;
-    }
-
-    if (!cursorMonitor) {
-        return false;
-    }
-
-    MONITORINFO mi = {sizeof(mi)};
-
-    if (!GetMonitorInfoW(
-            cursorMonitor,
-            &mi
-        )) {
-        return false;
-    }
-
-    if (
-        pt.x < mi.rcMonitor.left ||
-        pt.x > mi.rcMonitor.right
-    ) {
-        return false;
-    }
-
-    HWND hTaskbar = nullptr;
+    ScanWindowsOnce(
+        monitors,
+        scan
+    );
 
     for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-        if (
-            g_taskbarStates[i].monitor == cursorMonitor &&
-            g_taskbarStates[i].hwnd
+        TaskbarMonitorState& state =
+            g_taskbarStates[i];
+
+        state.desktopOnly = true;
+
+        for (
+            size_t monitorIndex = 0;
+            monitorIndex < monitors.count;
+            ++monitorIndex
         ) {
-            hTaskbar = g_taskbarStates[i].hwnd;
-            break;
+            if (
+                monitors.entries[monitorIndex].monitor ==
+                state.monitor
+            ) {
+                state.desktopOnly =
+                    !scan.applicationOnMonitor[
+                        monitorIndex
+                    ];
+                break;
+            }
         }
     }
 
-    /*
-     * Do not fall back to the primary taskbar for a secondary display.
-     * A primary-taskbar fallback can give the secondary display the wrong
-     * reveal-zone geometry during taskbar transitions.
-     */
-    if (!hTaskbar) {
-        return false;
-    }
-
-    UINT dpi =
-        GetDpiForWindow(hTaskbar);
-
-    int hotZonePx =
-        GetHoverZonePx(
-            hTaskbar,
-            dpi
-        );
-    if (hotZonePx < 1) {
-        hotZonePx = 1;
-    }
-
-    return pt.y >= mi.rcMonitor.bottom - hotZonePx;
-}
-
-// Single place that decides whether the taskbar should be shown or hidden.
-// Only the "hover then move away" case gets a delay; every other hide is
-// instant.
-void UpdateTaskbarState() {
-    RefreshTaskbarMonitorStates();
-
-    /*
-     * Determine the cursor monitor first. Each taskbar is evaluated
-     * independently below; an application on one display must never make
-     * another display's taskbar follow the same desktop state.
-     */
-    int cursorMonitorNumber = 0;
-    HMONITOR cursorMonitor = nullptr;
-
     POINT cursorPoint = {};
-    if (GetCursorPos(&cursorPoint)) {
-        MonitorList monitors = GetCurrentMonitors();
+    HMONITOR cursorMonitor = nullptr;
+    int cursorMonitorNumber = 0;
 
+    if (GetCursorPos(&cursorPoint)) {
         cursorMonitor =
             MonitorFromPoint(
                 cursorPoint,
@@ -1504,65 +1354,65 @@ void UpdateTaskbarState() {
             );
     }
 
-    bool hovering =
-        cursorMonitorNumber != 0 &&
-        ShouldRevealOnHover(cursorMonitorNumber) &&
-        IsCursorNearBottomEdge(cursorMonitor);
+    HWND cursorTaskbar = nullptr;
 
-    /*
-     * Desktop/application state is already calculated independently for each
-     * monitor. Hover only affects the taskbar on the display under the cursor;
-     * all other taskbars retain their own state.
-     */
-    /*
-     * Keep the taskbar visible while a Windows shell flyout is open.
-     * This covers notification/calendar and quick-settings style surfaces
-     * without classifying ordinary application windows as shell UI.
-     */
-    /*
-     * Shell flyouts are local to the display under the cursor for the
-     * interaction model of this mod. Do not globally preempt the state of
-     * unrelated displays.
-     */
-    bool shellFlyoutOpen =
+    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+        if (
+            g_taskbarStates[i].monitor ==
+                cursorMonitor
+        ) {
+            cursorTaskbar =
+                g_taskbarStates[i].hwnd;
+            break;
+        }
+    }
+
+    const bool hovering =
+        cursorTaskbar &&
         cursorMonitor &&
-        HasVisibleShellFlyoutOnMonitor(
+        cursorMonitorNumber != 0 &&
+        ShouldRevealOnHover(
+            cursorMonitorNumber
+        ) &&
+        IsCursorNearBottomEdge(
+            cursorTaskbar,
             cursorMonitor
         );
 
-    if (shellFlyoutOpen) {
-        g_hideDeadline = 0;
-        g_shownDueToHover = false;
+    HMONITOR popupMonitor =
+        GetForegroundShellPopupMonitor();
+
+    if (!popupMonitor) {
+        popupMonitor =
+            GetCursorPopupMonitor();
+    }
+
+    if (popupMonitor) {
+        g_hoverActive = false;
         g_hoverMonitor = nullptr;
+        g_hoverDeadline = 0;
 
         for (size_t i = 0; i < g_taskbarStateCount; ++i) {
             TaskbarMonitorState& state =
                 g_taskbarStates[i];
 
-            bool show =
-                state.monitor == cursorMonitor ||
+            SetTaskbarState(
+                state,
+                state.monitor == popupMonitor ||
                 !state.desktopOnly ||
                 !ShouldHideMonitor(
                     state.monitorNumber
-                );
-
-            SetTaskbarState(
-                state,
-                show
+                )
             );
         }
 
         return;
     }
 
-    /*
-     * Alt+Tab/Task View is another shell interaction where hiding the
-     * taskbar underneath the switcher is undesirable.
-     */
     if (IsAltTabActive()) {
-        g_hideDeadline = 0;
-        g_shownDueToHover = false;
+        g_hoverActive = false;
         g_hoverMonitor = nullptr;
+        g_hoverDeadline = 0;
 
         for (size_t i = 0; i < g_taskbarStateCount; ++i) {
             SetTaskbarState(
@@ -1574,142 +1424,10 @@ void UpdateTaskbarState() {
         return;
     }
 
-    // Check taskbar-owned menus before hover so an actual right-click menu
-    // always wins over the generic bottom-edge hover state.
-    bool taskbarPopupOpen = false;
-
-    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-        if (
-            IsTaskbarPopupOpen(
-                g_taskbarStates[i].hwnd
-            ) ||
-            IsTaskbarShellPopupForeground(
-                g_taskbarStates[i].hwnd
-            )
-        ) {
-            taskbarPopupOpen = true;
-            break;
-        }
-    }
-
-    if (taskbarPopupOpen) {
-        g_hideDeadline = 0;
-        g_shownDueToHover = false;
-        g_hoverMonitor = nullptr;
-
-        /*
-         * Only keep the taskbar whose own popup is active visible.
-         * Other displays continue following their independent state.
-         */
-        for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-            TaskbarMonitorState& state =
-                g_taskbarStates[i];
-
-            bool ownPopup =
-                IsTaskbarPopupOpen(state.hwnd) ||
-                IsTaskbarShellPopupForeground(state.hwnd);
-
-            bool show =
-                ownPopup ||
-                !state.desktopOnly ||
-                !ShouldHideMonitor(
-                    state.monitorNumber
-                );
-
-            SetTaskbarState(
-                state,
-                show
-            );
-        }
-
-        return;
-    }
-
     if (hovering) {
-        g_hideDeadline = 0;
-        g_shownDueToHover = true;
+        g_hoverActive = true;
         g_hoverMonitor = cursorMonitor;
-
-        for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-            TaskbarMonitorState& state =
-                g_taskbarStates[i];
-
-            bool show =
-                !state.desktopOnly ||
-                !ShouldHideMonitor(
-                    state.monitorNumber
-                ) ||
-                state.monitor == g_hoverMonitor;
-
-            SetTaskbarState(
-                state,
-                show
-            );
-        }
-
-        return;
-    }
-
-    if (g_shownDueToHover) {
-        ULONGLONG now = GetTickCount64();
-
-        /*
-         * A hover reveal belongs to one monitor. Crossing to another display
-         * cancels the old monitor's temporary hover ownership immediately.
-         */
-        if (
-            !g_hoverMonitor ||
-            cursorMonitor != g_hoverMonitor
-        ) {
-            for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-                TaskbarMonitorState& state =
-                    g_taskbarStates[i];
-
-                SetTaskbarState(
-                    state,
-                    !state.desktopOnly ||
-                    !ShouldHideMonitor(
-                        state.monitorNumber
-                    )
-                );
-            }
-
-            g_hideDeadline = 0;
-            g_shownDueToHover = false;
-            g_hoverMonitor = nullptr;
-
-            return;
-        }
-
-        if (g_hideDeadline == 0) {
-            g_hideDeadline =
-                now +
-                settings.autoHideDelayMs;
-        }
-
-        if (
-            g_hideDeadline != 0 &&
-            now < g_hideDeadline
-        ) {
-            for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-                TaskbarMonitorState& state =
-                    g_taskbarStates[i];
-
-                bool show =
-                    !state.desktopOnly ||
-                    !ShouldHideMonitor(
-                        state.monitorNumber
-                    ) ||
-                    state.monitor == g_hoverMonitor;
-
-                SetTaskbarState(
-                    state,
-                    show
-                );
-            }
-
-            return;
-        }
+        g_hoverDeadline = 0;
 
         for (size_t i = 0; i < g_taskbarStateCount; ++i) {
             TaskbarMonitorState& state =
@@ -1717,6 +1435,7 @@ void UpdateTaskbarState() {
 
             SetTaskbarState(
                 state,
+                state.monitor == g_hoverMonitor ||
                 !state.desktopOnly ||
                 !ShouldHideMonitor(
                     state.monitorNumber
@@ -1724,132 +1443,258 @@ void UpdateTaskbarState() {
             );
         }
 
-        g_hideDeadline = 0;
-        g_shownDueToHover = false;
-        g_hoverMonitor = nullptr;
         return;
     }
 
-    /*
-     * Each taskbar now follows its own monitor's desktop/application state.
-     * Only selected displays are hidden while they are desktop-only.
-     */
-    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-        TaskbarMonitorState& state =
-            g_taskbarStates[i];
+    if (g_hoverActive) {
+        if (
+            !g_hoverMonitor ||
+            cursorMonitor != g_hoverMonitor
+        ) {
+            g_hoverActive = false;
+            g_hoverMonitor = nullptr;
+            g_hoverDeadline = 0;
 
-        SetTaskbarState(
-            state,
-            !state.desktopOnly ||
-            !ShouldHideMonitor(
-                state.monitorNumber
-            )
+            ApplyBaseTaskbarState();
+            return;
+        }
+
+        const ULONGLONG now =
+            GetTickCount64();
+
+        if (g_hoverDeadline == 0) {
+            g_hoverDeadline =
+                now +
+                g_settings.autoHideDelayMs;
+        }
+
+        if (now < g_hoverDeadline) {
+            for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+                TaskbarMonitorState& state =
+                    g_taskbarStates[i];
+
+                SetTaskbarState(
+                    state,
+                    state.monitor == g_hoverMonitor ||
+                    !state.desktopOnly ||
+                    !ShouldHideMonitor(
+                        state.monitorNumber
+                    )
+                );
+            }
+
+            return;
+        }
+
+        g_hoverActive = false;
+        g_hoverMonitor = nullptr;
+        g_hoverDeadline = 0;
+
+        ApplyBaseTaskbarState();
+        return;
+    }
+
+    ApplyBaseTaskbarState();
+}
+
+void CALLBACK WinEventProc(
+    HWINEVENTHOOK,
+    DWORD event,
+    HWND,
+    LONG,
+    LONG,
+    DWORD,
+    DWORD
+) {
+    if (
+        event != EVENT_SYSTEM_MINIMIZESTART &&
+        event != EVENT_SYSTEM_MINIMIZEEND &&
+        event != EVENT_SYSTEM_MOVESIZEEND
+    ) {
+        return;
+    }
+
+    if (
+        InterlockedExchange(
+            &g_refreshPosted,
+            1
+        ) == 0
+    ) {
+        if (!PostThreadMessageW(
+                g_workerThreadId,
+                WM_APP_REFRESH,
+                0,
+                0
+            )) {
+            InterlockedExchange(
+                &g_refreshPosted,
+                0
+            );
+        }
+    }
+}
+
+DWORD WINAPI WorkerThread(
+    LPVOID
+) {
+    MSG msg = {};
+
+    PeekMessageW(
+        &msg,
+        nullptr,
+        WM_USER,
+        WM_USER,
+        PM_NOREMOVE
+    );
+
+    if (g_workerReadyEvent) {
+        SetEvent(
+            g_workerReadyEvent
         );
     }
-    g_hoverMonitor = nullptr;
-}
 
+    g_minimizeHook =
+        SetWinEventHook(
+            EVENT_SYSTEM_MINIMIZESTART,
+            EVENT_SYSTEM_MINIMIZEEND,
+            nullptr,
+            WinEventProc,
+            0,
+            0,
+            WINEVENT_OUTOFCONTEXT
+        );
 
-void CALLBACK WinEventProc(HWINEVENTHOOK hWinEventHook, DWORD event,
-                            HWND hwnd, LONG idObject, LONG idChild,
-                            DWORD idEventThread, DWORD dwmsEventTime) {
-    if (idObject != OBJID_WINDOW || event != EVENT_SYSTEM_FOREGROUND) {
-        return;
-    }
+    g_moveHook =
+        SetWinEventHook(
+            EVENT_SYSTEM_MOVESIZEEND,
+            EVENT_SYSTEM_MOVESIZEEND,
+            nullptr,
+            WinEventProc,
+            0,
+            0,
+            WINEVENT_OUTOFCONTEXT
+        );
 
-    // Quick, instant reaction for the common case (switching to a real
-    // window). The poll timer re-verifies everything ~10x/sec regardless,
-    // which is what reliably catches the minimize/close-last-window case.
-    RefreshDesktopState();
-    UpdateTaskbarState();
-}
-
-void CALLBACK TimerProc(HWND hwnd, UINT uMsg, UINT_PTR idEvent,
-                         DWORD dwTime) {
-    RefreshDesktopState();
-    UpdateTaskbarState();
-}
-
-// WINEVENT_OUTOFCONTEXT and a polling SetTimer both need a thread that
-// pumps messages, so we spin up a dedicated thread for this instead of
-// relying on whichever thread happens to call Wh_ModInit.
-DWORD WINAPI HookThread(LPVOID param) {
-    g_hWinEventHookForeground = SetWinEventHook(
-        EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND, nullptr,
-        WinEventProc, 0, 0, WINEVENT_OUTOFCONTEXT);
-
-    if (!g_hWinEventHookForeground) {
-        Wh_Log(L"SetWinEventHook(EVENT_SYSTEM_FOREGROUND) failed; using 100 ms polling fallback");
-    }
-
-    RefreshDesktopState();
     UpdateTaskbarState();
 
-    const UINT kPollIntervalMs = 100;
-    UINT_PTR timerId = SetTimer(nullptr, 0, kPollIntervalMs, TimerProc);
+    const UINT kPollIntervalMs = 250;
 
-    MSG msg;
-    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+    UINT_PTR timerId =
+        SetTimer(
+            nullptr,
+            1,
+            kPollIntervalMs,
+            nullptr
+        );
+
+    for (;;) {
+        BOOL result =
+            GetMessageW(
+                &msg,
+                nullptr,
+                0,
+                0
+            );
+
+        if (result <= 0) {
+            break;
+        }
+
+        if (msg.message == WM_TIMER) {
+            UpdateTaskbarState();
+            continue;
+        }
+
+        if (msg.message == WM_APP_REFRESH) {
+            InterlockedExchange(
+                &g_refreshPosted,
+                0
+            );
+
+            UpdateTaskbarState();
+            continue;
+        }
+
+        if (msg.message == WM_APP_SETTINGS) {
+            InterlockedExchange(
+                &g_refreshPosted,
+                0
+            );
+
+            LoadSettings();
+            UpdateTaskbarState();
+            continue;
+        }
+
         TranslateMessage(&msg);
         DispatchMessageW(&msg);
     }
 
     if (timerId) {
-        KillTimer(nullptr, timerId);
+        KillTimer(
+            nullptr,
+            timerId
+        );
     }
-    if (g_hWinEventHookForeground) {
-        UnhookWinEvent(g_hWinEventHookForeground);
-        g_hWinEventHookForeground = nullptr;
+
+    if (g_minimizeHook) {
+        UnhookWinEvent(
+            g_minimizeHook
+        );
+        g_minimizeHook = nullptr;
+    }
+
+    if (g_moveHook) {
+        UnhookWinEvent(
+            g_moveHook
+        );
+        g_moveHook = nullptr;
     }
 
     return 0;
 }
 
 void LoadSettings() {
-    int extraHoverMarginMm =
+    int hoverMargin =
         Wh_GetIntSetting(
-            L"extraHoverMarginMm"
+            L"extraHoverMarginPx"
         );
 
-    if (extraHoverMarginMm < 0) {
-        extraHoverMarginMm = 0;
-    } else if (extraHoverMarginMm > 50) {
-        extraHoverMarginMm = 50;
+    if (hoverMargin < 0) {
+        hoverMargin = 0;
+    } else if (hoverMargin > 200) {
+        hoverMargin = 200;
     }
 
-    settings.extraHoverMarginMm =
-        extraHoverMarginMm;
+    g_settings.extraHoverMarginPx =
+        hoverMargin;
 
-    int autoHideDelayMs =
+    int delay =
         Wh_GetIntSetting(
             L"autoHideDelayMs"
         );
 
-    if (autoHideDelayMs < 0) {
-        autoHideDelayMs = 0;
-    } else if (autoHideDelayMs > 10000) {
-        autoHideDelayMs = 10000;
+    if (delay < 0) {
+        delay = 0;
+    } else if (delay > 10000) {
+        delay = 10000;
     }
 
-    settings.autoHideDelayMs =
-        static_cast<DWORD>(
-            autoHideDelayMs
-        );
+    g_settings.autoHideDelayMs =
+        static_cast<DWORD>(delay);
 
-    settings.hideAllMonitors = false;
+    g_settings.hideAllMonitors = false;
 
     for (
         size_t i = 1;
         i <= kMaxMonitorNumbers;
         ++i
     ) {
-        settings.hideMonitor[i] = false;
-        settings.hoverMonitor[i] = false;
+        g_settings.hideMonitor[i] = false;
+        g_settings.hoverMonitor[i] = false;
     }
 
-    settings.hoverAllMonitors = false;
-
-    bool foundSelection = false;
+    g_settings.hoverAllMonitors = false;
 
     for (
         size_t i = 0;
@@ -1867,15 +1712,8 @@ void LoadSettings() {
             break;
         }
 
-        foundSelection = true;
-
-        if (
-            wcscmp(
-                value,
-                L"all"
-            ) == 0
-        ) {
-            settings.hideAllMonitors = true;
+        if (wcscmp(value, L"all") == 0) {
+            g_settings.hideAllMonitors = true;
         } else if (
             wcsncmp(
                 value,
@@ -1896,23 +1734,19 @@ void LoadSettings() {
                 endNumber &&
                 *endNumber == L'\0' &&
                 number >= 1 &&
-                number <=
-                    static_cast<long>(
-                        kMaxMonitorNumbers
-                    )
+                number <= static_cast<long>(
+                    kMaxMonitorNumbers
+                )
             ) {
-                settings.hideMonitor[number] = true;
+                g_settings.hideMonitor[number] = true;
             }
         }
 
         Wh_FreeStringSetting(value);
     }
 
-    if (!foundSelection) {
-        settings.hideAllMonitors = true;
-    }
+    // Empty selection intentionally means "hide nothing".
 
-    // Empty hover selection intentionally means disabled.
     for (
         size_t i = 0;
         i < kMaxMonitorNumbers;
@@ -1929,13 +1763,8 @@ void LoadSettings() {
             break;
         }
 
-        if (
-            wcscmp(
-                value,
-                L"all"
-            ) == 0
-        ) {
-            settings.hoverAllMonitors = true;
+        if (wcscmp(value, L"all") == 0) {
+            g_settings.hoverAllMonitors = true;
         } else if (
             wcsncmp(
                 value,
@@ -1956,12 +1785,11 @@ void LoadSettings() {
                 endNumber &&
                 *endNumber == L'\0' &&
                 number >= 1 &&
-                number <=
-                    static_cast<long>(
-                        kMaxMonitorNumbers
-                    )
+                number <= static_cast<long>(
+                    kMaxMonitorNumbers
+                )
             ) {
-                settings.hoverMonitor[number] = true;
+                g_settings.hoverMonitor[number] = true;
             }
         }
 
@@ -1969,54 +1797,415 @@ void LoadSettings() {
     }
 }
 
-// The mod is being initialized, load settings, hook functions, and do other
-// initialization stuff if required.
-BOOL Wh_ModInit() {
+BOOL WhTool_ModInit() {
     Wh_Log(L"Init");
 
+    // Load the persisted Windhawk settings before the worker performs its
+    // first state calculation. Without this, g_settings remains zeroed and
+    // ShouldHideMonitor() returns false even when the UI says "All displays".
     LoadSettings();
 
-    g_hThread =
+    g_workerReadyEvent =
+        CreateEventW(
+            nullptr,
+            TRUE,
+            FALSE,
+            nullptr
+        );
+
+    if (!g_workerReadyEvent) {
+        Wh_Log(L"CreateEvent failed");
+        return FALSE;
+    }
+
+    g_workerThread =
         CreateThread(
             nullptr,
             0,
-            HookThread,
+            WorkerThread,
             nullptr,
             0,
-            &g_threadId
+            &g_workerThreadId
         );
 
-    if (!g_hThread) {
+    if (!g_workerThread) {
         Wh_Log(L"CreateThread failed");
+
+        CloseHandle(
+            g_workerReadyEvent
+        );
+
+        g_workerReadyEvent = nullptr;
         return FALSE;
     }
+
+    WaitForSingleObject(
+        g_workerReadyEvent,
+        INFINITE
+    );
 
     return TRUE;
 }
 
-// The mod is being unloaded, free all allocated resources.
-void Wh_ModUninit() {
-    Wh_Log(L"Uninit");
-
-    if (g_hThread) {
-        PostThreadMessageW(g_threadId, WM_QUIT, 0, 0);
-        WaitForSingleObject(g_hThread, 3000);
-        CloseHandle(g_hThread);
-        g_hThread = nullptr;
+void WhTool_ModSettingsChanged() {
+    if (g_workerThread) {
+        PostThreadMessageW(
+            g_workerThreadId,
+            WM_APP_SETTINGS,
+            0,
+            0
+        );
     }
-
-    // Always leave the taskbar visible when the mod is disabled/unloaded.
-    /*
-     * Always restore every taskbar when the mod is unloaded. The state list
-     * may be empty if Explorer recreated the taskbar during shutdown, so also
-     * use the existing direct visibility helper as a fallback.
-     */
-    SetTaskbarVisibility(true);
 }
 
-// The mod settings were changed, reload them.
-void Wh_ModSettingsChanged() {
-    Wh_Log(L"SettingsChanged");
+void WhTool_ModUninit() {
+    Wh_Log(L"Uninit");
 
-    LoadSettings();
+    if (g_workerThread) {
+        WaitForSingleObject(
+            g_workerReadyEvent,
+            INFINITE
+        );
+
+        if (!PostThreadMessageW(
+                g_workerThreadId,
+                WM_QUIT,
+                0,
+                0
+            )) {
+            Wh_Log(
+                L"PostThreadMessageW(WM_QUIT) failed: %lu",
+                GetLastError()
+            );
+        }
+
+        WaitForSingleObject(
+            g_workerThread,
+            INFINITE
+        );
+
+        CloseHandle(
+            g_workerThread
+        );
+
+        g_workerThread = nullptr;
+    }
+
+    if (g_workerReadyEvent) {
+        CloseHandle(
+            g_workerReadyEvent
+        );
+
+        g_workerReadyEvent = nullptr;
+    }
+
+    /*
+     * Restore all currently discoverable taskbars when the tool exits.
+     */
+    HWND taskbar =
+        FindWindowW(
+            L"Shell_TrayWnd",
+            nullptr
+        );
+
+    if (taskbar) {
+        ShowWindow(
+            taskbar,
+            SW_SHOW
+        );
+    }
+
+    HWND secondary = nullptr;
+
+    while (
+        (secondary = FindWindowExW(
+            nullptr,
+            secondary,
+            L"Shell_SecondaryTrayWnd",
+            nullptr
+        )) != nullptr
+    ) {
+        ShowWindow(
+            secondary,
+            SW_SHOW
+        );
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Windhawk tool mod implementation for mods which don't need to inject to other
+// processes or hook other functions. Context:
+// https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process
+//
+// The mod will load and run in a dedicated windhawk.exe process.
+//
+// The launcher below is the documented Windhawk tool-mod boilerplate.
+
+bool g_isToolModProcessLauncher;
+HANDLE g_toolModProcessMutex;
+
+void WINAPI EntryPoint_Hook() {
+    Wh_Log(L">");
+    ExitThread(0);
+}
+
+BOOL Wh_ModInit() {
+    DWORD sessionId;
+
+    if (
+        ProcessIdToSessionId(
+            GetCurrentProcessId(),
+            &sessionId
+        ) &&
+        sessionId == 0
+    ) {
+        return FALSE;
+    }
+
+    bool isExcluded = false;
+    bool isToolModProcess = false;
+    bool isCurrentToolModProcess = false;
+
+    int argc;
+
+    LPWSTR* argv =
+        CommandLineToArgvW(
+            GetCommandLine(),
+            &argc
+        );
+
+    if (!argv) {
+        Wh_Log(L"CommandLineToArgvW failed");
+        return FALSE;
+    }
+
+    for (int i = 1; i < argc; i++) {
+        if (
+            wcscmp(argv[i], L"-service") == 0 ||
+            wcscmp(argv[i], L"-service-start") == 0 ||
+            wcscmp(argv[i], L"-service-stop") == 0
+        ) {
+            isExcluded = true;
+            break;
+        }
+    }
+
+    for (int i = 1; i < argc - 1; i++) {
+        if (
+            wcscmp(argv[i], L"-tool-mod") == 0
+        ) {
+            isToolModProcess = true;
+
+            if (
+                wcscmp(
+                    argv[i + 1],
+                    WH_MOD_ID
+                ) == 0
+            ) {
+                isCurrentToolModProcess = true;
+            }
+
+            break;
+        }
+    }
+
+    LocalFree(argv);
+
+    if (isExcluded) {
+        return FALSE;
+    }
+
+    if (isCurrentToolModProcess) {
+        g_toolModProcessMutex =
+            CreateMutex(
+                nullptr,
+                TRUE,
+                L"windhawk-tool-mod_" WH_MOD_ID
+            );
+
+        if (!g_toolModProcessMutex) {
+            Wh_Log(L"CreateMutex failed");
+            ExitProcess(1);
+        }
+
+        if (GetLastError() == ERROR_ALREADY_EXISTS) {
+            Wh_Log(
+                L"Tool mod already running (%s)",
+                WH_MOD_ID
+            );
+            ExitProcess(1);
+        }
+
+        if (!WhTool_ModInit()) {
+            ExitProcess(1);
+        }
+
+        IMAGE_DOS_HEADER* dosHeader =
+            (IMAGE_DOS_HEADER*)GetModuleHandle(
+                nullptr
+            );
+
+        IMAGE_NT_HEADERS* ntHeaders =
+            (IMAGE_NT_HEADERS*)(
+                (BYTE*)dosHeader +
+                dosHeader->e_lfanew
+            );
+
+        DWORD entryPointRVA =
+            ntHeaders->OptionalHeader.AddressOfEntryPoint;
+
+        void* entryPoint =
+            (BYTE*)dosHeader +
+            entryPointRVA;
+
+        Wh_SetFunctionHook(
+            entryPoint,
+            (void*)EntryPoint_Hook,
+            nullptr
+        );
+
+        return TRUE;
+    }
+
+    if (isToolModProcess) {
+        return FALSE;
+    }
+
+    g_isToolModProcessLauncher = true;
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    if (!g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WCHAR currentProcessPath[MAX_PATH];
+
+    switch (
+        GetModuleFileName(
+            nullptr,
+            currentProcessPath,
+            ARRAYSIZE(currentProcessPath)
+        )
+    ) {
+        case 0:
+        case ARRAYSIZE(currentProcessPath):
+            Wh_Log(
+                L"GetModuleFileName failed"
+            );
+            return;
+    }
+
+    WCHAR commandLine[
+        MAX_PATH +
+        2 +
+        (
+            sizeof(
+                L" -tool-mod \"" WH_MOD_ID "\""
+            ) / sizeof(WCHAR)
+        ) -
+        1
+    ];
+
+    swprintf_s(
+        commandLine,
+        L"\"%s\" -tool-mod \"%s\"",
+        currentProcessPath,
+        WH_MOD_ID
+    );
+
+    HMODULE kernelModule =
+        GetModuleHandle(
+            L"kernelbase.dll"
+        );
+
+    if (!kernelModule) {
+        kernelModule =
+            GetModuleHandle(
+                L"kernel32.dll"
+            );
+
+        if (!kernelModule) {
+            Wh_Log(
+                L"No kernelbase.dll/kernel32.dll"
+            );
+            return;
+        }
+    }
+
+    using CreateProcessInternalW_t = BOOL(WINAPI*)(
+        HANDLE hUserToken,
+        LPCWSTR lpApplicationName,
+        LPWSTR lpCommandLine,
+        LPSECURITY_ATTRIBUTES lpProcessAttributes,
+        LPSECURITY_ATTRIBUTES lpThreadAttributes,
+        WINBOOL bInheritHandles,
+        DWORD dwCreationFlags,
+        LPVOID lpEnvironment,
+        LPCWSTR lpCurrentDirectory,
+        LPSTARTUPINFOW lpStartupInfo,
+        LPPROCESS_INFORMATION lpProcessInformation,
+        PHANDLE hRestrictedUserToken
+    );
+
+    CreateProcessInternalW_t pCreateProcessInternalW =
+        (CreateProcessInternalW_t)GetProcAddress(
+            kernelModule,
+            "CreateProcessInternalW"
+        );
+
+    if (!pCreateProcessInternalW) {
+        Wh_Log(
+            L"No CreateProcessInternalW"
+        );
+        return;
+    }
+
+    STARTUPINFO si{
+        .cb = sizeof(STARTUPINFO),
+        .dwFlags = STARTF_FORCEOFFFEEDBACK,
+    };
+
+    PROCESS_INFORMATION pi;
+
+    if (
+        !pCreateProcessInternalW(
+            nullptr,
+            currentProcessPath,
+            commandLine,
+            nullptr,
+            nullptr,
+            FALSE,
+            NORMAL_PRIORITY_CLASS,
+            nullptr,
+            nullptr,
+            &si,
+            &pi,
+            nullptr
+        )
+    ) {
+        Wh_Log(L"CreateProcess failed");
+        return;
+    }
+
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+}
+
+void Wh_ModSettingsChanged() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModSettingsChanged();
+}
+
+void Wh_ModUninit() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModUninit();
+    ExitProcess(0);
 }

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id hide-taskbar-only-on-desktop
 // @name Hide Taskbar Only on Desktop
 // @description Hides the taskbar on desktop while preserving taskbar and Windows shell UI interaction
-// @version 1.11.0
+// @version 1.11.5
 // @author Sahil Dashoni
 // @github https://github.com/Sahil-Dashoni
 // @include windhawk.exe
@@ -35,7 +35,7 @@ visible whenever an application or shell UI is active.
   showing the desktop, only the desktop monitor's taskbar is hidden.
 - Supports bottom, top, left and right taskbar positions.
 - Keeps the taskbar visible for Windows shell flyouts such as Start,
-  Search, Notifications and Quick Settings.
+  Search, Notifications, Quick Settings and the Start context menu.
 - Keeps the taskbar visible while Alt+Tab is open, then uses the same
   configurable hide delay after Alt+Tab closes.
 - Minimizing the last application clears any previous hover-reveal delay
@@ -129,11 +129,13 @@ struct TaskbarState {
     HWND hwnd = nullptr;
     HMONITOR monitor = nullptr;
     RECT monitorRect = {};
+    RECT taskbarRect = {};
     bool isSecondary = false;
     bool hasApplication = false;
     bool taskbarIsForeground = false;
     bool shellUiForeground = false;
     bool shellFlyoutVisible = false;
+    HWND shellFlyoutHwnd = nullptr;
     bool shownDueToHover = false;
     bool shownDueToAltTab = false;
     ULONGLONG hideDeadline = 0;
@@ -173,12 +175,11 @@ bool IsDesktopWindow(HWND hwnd) {
     }
 
     if (wcscmp(className, L"WorkerW") == 0) {
-        return FindWindowExW(
-            hwnd,
-            nullptr,
-            L"SHELLDLL_DefView",
-            nullptr
-        ) != nullptr;
+        /*
+         * Explorer can keep multiple WorkerW wallpaper windows alive.
+         * They are desktop infrastructure regardless of their children.
+         */
+        return true;
     }
 
     return false;
@@ -226,6 +227,8 @@ bool IsAltTabWindowClass(const WCHAR* className);
 HWND FindPrimaryTaskbar();
 bool IsTaskbarActuallyHidden(HWND hwnd);
 bool IsShellUiClass(const WCHAR* className);
+bool IsCursorOverTaskbarShellPopup(HWND taskbar);
+bool IsForegroundApplicationOnMonitor(HWND foreground, HMONITOR monitor);
 
 bool IsAltTabWindowClass(const WCHAR* className);
 bool GetWindowProcessName(HWND hwnd, WCHAR* name, size_t nameCount);
@@ -235,6 +238,7 @@ bool IsShellUiWindow(HWND hwnd);
 struct AppMonitorScan {
     TaskbarState* taskbars;
     size_t count;
+    HWND shellWindow;
     bool altTabActive;
 };
 
@@ -257,6 +261,10 @@ BOOL CALLBACK EnumWindowsProc(
         return TRUE;
     }
 
+    if (hwnd == scan->shellWindow) {
+        return TRUE;
+    }
+
     /*
      * Explicitly ignore the desktop itself.
      */
@@ -264,6 +272,10 @@ BOOL CALLBACK EnumWindowsProc(
         return TRUE;
     }
 
+    /*
+     * GetShellWindow() is also supplied in scan->shellWindow, but keep the
+     * explicit desktop shell class check as a second line of defense.
+     */
     WCHAR className[256] = {};
 
     if (
@@ -315,6 +327,53 @@ BOOL CALLBACK EnumWindowsProc(
     }
 
     /*
+     * UWP / Store applications such as Calculator and Settings use
+     * ApplicationFrameWindow hosted by ApplicationFrameHost.exe.
+     * Handle this before the generic owner/tool-window filters so the
+     * application's top-level frame is always counted as an application.
+     */
+    if (
+        wcscmp(
+            className,
+            L"ApplicationFrameWindow"
+        ) == 0
+    ) {
+        WCHAR processName[MAX_PATH] = {};
+
+        if (
+            GetWindowProcessName(
+                hwnd,
+                processName,
+                ARRAYSIZE(processName)
+            ) &&
+            _wcsicmp(
+                processName,
+                L"ApplicationFrameHost.exe"
+            ) == 0
+        ) {
+            RECT rect = {};
+
+            if (GetWindowRect(hwnd, &rect)) {
+                for (size_t i = 0; i < scan->count; ++i) {
+                    RECT intersection = {};
+
+                    if (
+                        IntersectRect(
+                            &intersection,
+                            &scan->taskbars[i].monitorRect,
+                            &rect
+                        )
+                    ) {
+                        scan->taskbars[i].hasApplication = true;
+                    }
+                }
+            }
+
+            return TRUE;
+        }
+    }
+
+    /*
      * CoreWindow and XAML popup classes can belong to normal apps too.
      * Only shell-owned instances are treated as shell UI.
      */
@@ -340,10 +399,30 @@ BOOL CALLBACK EnumWindowsProc(
             RECT rect = {};
 
             if (GetWindowRect(hwnd, &rect)) {
+                HWND owner =
+                    GetWindow(
+                        hwnd,
+                        GW_OWNER
+                    );
+
+                bool isContextMenu =
+                    wcscmp(
+                        className,
+                        L"#32768"
+                    ) == 0;
+
                 for (size_t i = 0; i < scan->count; ++i) {
                     RECT intersection = {};
 
+                    bool taskbarOwned =
+                        owner == scan->taskbars[i].hwnd;
+
+                    bool shouldTrack =
+                        !isContextMenu ||
+                        taskbarOwned;
+
                     if (
+                        shouldTrack &&
                         IntersectRect(
                             &intersection,
                             &scan->taskbars[i].monitorRect,
@@ -351,6 +430,7 @@ BOOL CALLBACK EnumWindowsProc(
                         )
                     ) {
                         scan->taskbars[i].shellFlyoutVisible = true;
+                        scan->taskbars[i].shellFlyoutHwnd = hwnd;
                     }
                 }
             }
@@ -427,6 +507,7 @@ void ScanApplicationWindows() {
     for (size_t i = 0; i < g_taskbarCount; ++i) {
         g_taskbars[i].hasApplication = false;
         g_taskbars[i].shellFlyoutVisible = false;
+        g_taskbars[i].shellFlyoutHwnd = nullptr;
     }
 
     g_altTabActive = false;
@@ -438,6 +519,7 @@ void ScanApplicationWindows() {
     AppMonitorScan scan{
         g_taskbars,
         g_taskbarCount,
+        GetShellWindow(),
         false
     };
 
@@ -476,6 +558,233 @@ bool IsTaskbarForegroundAndUnderCursor(HWND taskbar) {
     }
 
     return PtInRect(&rect, pt) != FALSE;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+bool IsCursorOverTaskbarShellPopup(HWND taskbar) {
+    if (!taskbar || !IsTaskbarWindow(taskbar)) {
+        return false;
+    }
+
+    POINT pt = {};
+
+    if (!GetCursorPos(&pt)) {
+        return false;
+    }
+
+    HWND hwnd =
+        WindowFromPoint(pt);
+
+    if (!hwnd) {
+        return false;
+    }
+
+    DWORD taskbarProcessId = 0;
+
+    GetWindowThreadProcessId(
+        taskbar,
+        &taskbarProcessId
+    );
+
+    if (!taskbarProcessId) {
+        return false;
+    }
+
+    /*
+     * Walk the window's parent/owner chain. A Start context menu may be a
+     * standard #32768 menu or a XAML popup and may never become foreground.
+     */
+    HWND current = hwnd;
+
+    for (int depth = 0; current && depth < 12; ++depth) {
+        if (current != taskbar) {
+            WCHAR className[128] = {};
+
+            if (
+                GetClassNameW(
+                    current,
+                    className,
+                    ARRAYSIZE(className)
+                ) != 0
+            ) {
+                bool popupClass =
+                    wcscmp(
+                        className,
+                        L"#32768"
+                    ) == 0 ||
+                    wcscmp(
+                        className,
+                        L"Xaml_WindowedPopupClass"
+                    ) == 0 ||
+                    wcscmp(
+                        className,
+                        L"Windows.UI.Core.CoreWindow"
+                    ) == 0;
+
+                if (
+                    popupClass &&
+                    IsWindowVisible(current)
+                ) {
+                    DWORD popupProcessId = 0;
+
+                    GetWindowThreadProcessId(
+                        current,
+                        &popupProcessId
+                    );
+
+                    if (
+                        popupProcessId == taskbarProcessId
+                    ) {
+                        return true;
+                    }
+
+                    WCHAR processName[MAX_PATH] = {};
+
+                    if (
+                        GetWindowProcessName(
+                            current,
+                            processName,
+                            ARRAYSIZE(processName)
+                        ) &&
+                        IsKnownShellUiProcess(
+                            processName
+                        )
+                    ) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        HWND parent =
+            GetParent(current);
+
+        HWND owner =
+            GetWindow(
+                current,
+                GW_OWNER
+            );
+
+        if (
+            parent &&
+            parent != current
+        ) {
+            current = parent;
+        } else if (
+            owner &&
+            owner != current
+        ) {
+            current = owner;
+        } else {
+            break;
+        }
+    }
+
+    return false;
+}
+
+
+bool IsForegroundApplicationOnMonitor(
+    HWND foreground,
+    HMONITOR monitor
+) {
+    if (!foreground || !monitor) {
+        return false;
+    }
+
+    if (
+        !IsWindowVisible(foreground) ||
+        IsIconic(foreground)
+    ) {
+        return false;
+    }
+
+    if (
+        IsTaskbarWindow(foreground) ||
+        IsDesktopWindow(foreground)
+    ) {
+        return false;
+    }
+
+    WCHAR className[256] = {};
+
+    if (
+        GetClassNameW(
+            foreground,
+            className,
+            ARRAYSIZE(className)
+        ) == 0
+    ) {
+        return false;
+    }
+
+    if (IsAltTabWindowClass(className)) {
+        return false;
+    }
+
+    if (
+        IsShellChromeClass(className) &&
+        IsShellUiWindow(foreground)
+    ) {
+        return false;
+    }
+
+    LONG_PTR exStyle =
+        GetWindowLongPtrW(
+            foreground,
+            GWL_EXSTYLE
+        );
+
+    if (exStyle & WS_EX_TOOLWINDOW) {
+        return false;
+    }
+
+    BOOL cloaked = FALSE;
+
+    if (
+        SUCCEEDED(
+            DwmGetWindowAttribute(
+                foreground,
+                DWMWA_CLOAKED,
+                &cloaked,
+                sizeof(cloaked)
+            )
+        ) &&
+        cloaked
+    ) {
+        return false;
+    }
+
+    RECT rect = {};
+
+    if (!GetWindowRect(foreground, &rect)) {
+        return false;
+    }
+
+    MONITORINFO mi = {};
+    mi.cbSize = sizeof(mi);
+
+    if (!GetMonitorInfoW(monitor, &mi)) {
+        return false;
+    }
+
+    RECT intersection = {};
+
+    return IntersectRect(
+        &intersection,
+        &mi.rcMonitor,
+        &rect
+    ) != FALSE;
 }
 
 
@@ -551,6 +860,27 @@ bool IsShellUiWindow(HWND hwnd) {
         return false;
     }
 
+    WCHAR className[256] = {};
+
+    if (
+        GetClassNameW(
+            hwnd,
+            className,
+            ARRAYSIZE(className)
+        ) == 0
+    ) {
+        return false;
+    }
+
+    /*
+     * Do not classify ordinary explorer.exe windows (or arbitrary shell
+     * process windows) as shell UI. The class must first be one of the
+     * explicitly supported flyout/shell classes.
+     */
+    if (!IsShellUiClass(className)) {
+        return false;
+    }
+
     WCHAR processName[MAX_PATH] = {};
 
     if (!GetWindowProcessName(
@@ -575,7 +905,10 @@ bool IsShellUiClass(const WCHAR* className) {
         wcscmp(className, L"Xaml_WindowedPopupClass") == 0 ||
         wcscmp(className, L"TopLevelWindowForOverflowXamlIsland") == 0 ||
         wcscmp(className, L"NotifyIconOverflowWindow") == 0 ||
-        wcscmp(className, L"Windows.UI.Core.CoreWindow") == 0;
+        wcscmp(className, L"Windows.UI.Core.CoreWindow") == 0 ||
+        wcscmp(className, L"ApplicationFrameWindow") == 0 ||
+        wcscmp(className, L"Windows.UI.Core.CoreComponent") == 0 ||
+        wcscmp(className, L"#32768") == 0;
 }
 
 
@@ -590,103 +923,7 @@ bool IsAltTabWindowClass(const WCHAR* className) {
 }
 
 
-bool IsVisibleShellFlyoutForMonitor(
-    HMONITOR monitor,
-    HWND hwnd
-) {
-    if (!monitor || !hwnd || !IsWindowVisible(hwnd)) {
-        return false;
-    }
 
-    if (IsTaskbarWindow(hwnd)) {
-        return false;
-    }
-
-    WCHAR className[256] = {};
-
-    if (
-        GetClassNameW(
-            hwnd,
-            className,
-            ARRAYSIZE(className)
-        ) == 0
-    ) {
-        return false;
-    }
-
-    if (!IsShellUiClass(className)) {
-        return false;
-    }
-
-    /*
-     * XAML popup classes are used by ordinary applications too.
-     * Require a known Windows shell process before treating one as a
-     * taskbar-preserving shell flyout.
-     */
-    WCHAR processName[MAX_PATH] = {};
-
-    if (
-        !GetWindowProcessName(
-            hwnd,
-            processName,
-            ARRAYSIZE(processName)
-        )
-    ) {
-        return false;
-    }
-
-    bool knownShellProcess =
-        _wcsicmp(processName, L"explorer.exe") == 0 ||
-        IsKnownShellUiProcess(processName);
-
-    if (!knownShellProcess) {
-        return false;
-    }
-
-    BOOL cloaked = FALSE;
-
-    if (
-        SUCCEEDED(
-            DwmGetWindowAttribute(
-                hwnd,
-                DWMWA_CLOAKED,
-                &cloaked,
-                sizeof(cloaked)
-            )
-        ) &&
-        cloaked
-    ) {
-        return false;
-    }
-
-    RECT windowRect = {};
-
-    if (!GetWindowRect(hwnd, &windowRect)) {
-        return false;
-    }
-
-    if (
-        windowRect.right <= windowRect.left ||
-        windowRect.bottom <= windowRect.top
-    ) {
-        return false;
-    }
-
-    MONITORINFO mi = {};
-    mi.cbSize = sizeof(mi);
-
-    if (!GetMonitorInfoW(monitor, &mi)) {
-        return false;
-    }
-
-    RECT intersection = {};
-
-    return IntersectRect(
-        &intersection,
-        &mi.rcMonitor,
-        &windowRect
-    ) != FALSE;
-}
 
 
 bool IsShellUiForegroundOnMonitor(
@@ -711,10 +948,6 @@ bool IsShellUiForegroundOnMonitor(
 
     if (IsAltTabWindowClass(className)) {
         return true;
-    }
-
-    if (!IsShellUiClass(className)) {
-        return false;
     }
 
     if (!IsShellUiWindow(foreground)) {
@@ -859,6 +1092,11 @@ void DiscoverTaskbars() {
         state.monitorRect = mi.rcMonitor;
         state.isSecondary = IsSecondaryTaskbar(hwnd);
 
+        GetWindowRect(
+            hwnd,
+            &state.taskbarRect
+        );
+
         for (size_t i = 0; i < oldCount; ++i) {
             if (oldStates[i].hwnd == hwnd) {
                 state.shownDueToHover =
@@ -867,6 +1105,10 @@ void DiscoverTaskbars() {
                     oldStates[i].shownDueToAltTab;
                 state.hideDeadline =
                     oldStates[i].hideDeadline;
+                state.shellFlyoutVisible =
+                    oldStates[i].shellFlyoutVisible;
+                state.shellFlyoutHwnd =
+                    oldStates[i].shellFlyoutHwnd;
                 break;
             }
         }
@@ -962,15 +1204,7 @@ void SetTaskbarVisibility(bool show) {
 }
 
 
-bool IsPrimaryTaskbarHidden() {
-    HWND primary = FindPrimaryTaskbar();
 
-    if (!primary) {
-        return false;
-    }
-
-    return IsWindowVisible(primary) == FALSE;
-}
 
 
 // ============================================================
@@ -1015,17 +1249,24 @@ bool IsCursorInTaskbarHoverZone(
         return false;
     }
 
-    RECT taskbarRect = {};
-
-    if (!GetWindowRect(taskbar.hwnd, &taskbarRect)) {
-        return false;
-    }
+    RECT taskbarRect = taskbar.taskbarRect;
 
     if (
         taskbarRect.right <= taskbarRect.left ||
         taskbarRect.bottom <= taskbarRect.top
     ) {
-        return false;
+        if (!GetWindowRect(taskbar.hwnd, &taskbarRect)) {
+            return false;
+        }
+
+        if (
+            taskbarRect.right <= taskbarRect.left ||
+            taskbarRect.bottom <= taskbarRect.top
+        ) {
+            return false;
+        }
+
+        taskbar.taskbarRect = taskbarRect;
     }
 
     UINT dpi = GetDpiForWindow(taskbar.hwnd);
@@ -1127,6 +1368,13 @@ void UpdateTaskbarState() {
         return;
     }
 
+    /*
+     * Shell flyouts can close without producing a useful foreground/minimize
+     * event for this tool. Refresh only the foreground shell state here;
+     * application state remains event-driven.
+     */
+    HWND foreground = GetForegroundWindow();
+
     ULONGLONG now = GetTickCount64();
 
     DWORD delay =
@@ -1159,9 +1407,44 @@ void UpdateTaskbarState() {
         bool hovering =
             IsCursorInTaskbarHoverZone(taskbar);
 
+        bool currentShellUi =
+            IsShellUiForegroundOnMonitor(
+                taskbar.monitor,
+                foreground
+            );
+
+        bool foregroundApplication =
+            IsForegroundApplicationOnMonitor(
+                foreground,
+                taskbar.monitor
+            );
+
+        taskbar.shellUiForeground =
+            currentShellUi;
+
+        /*
+         * A Start/taskbar context menu may not become the foreground HWND.
+         * Detect the popup under the cursor without doing a full enumeration.
+         */
+        bool taskbarShellPopup =
+            IsCursorOverTaskbarShellPopup(
+                taskbar.hwnd
+            );
+
+        /*
+         * Shell UI state is allowed to keep the taskbar visible while the
+         * corresponding shell surface is open.
+         */
         bool shellFlyoutOpen =
-            taskbar.shellUiForeground ||
-            taskbar.shellFlyoutVisible;
+            currentShellUi ||
+            taskbarShellPopup ||
+            (
+                taskbar.shellFlyoutVisible &&
+                taskbar.shellFlyoutHwnd &&
+                IsWindowVisible(
+                    taskbar.shellFlyoutHwnd
+                )
+            );
 
         bool altTabActive =
             g_altTabActive;
@@ -1171,8 +1454,13 @@ void UpdateTaskbarState() {
          * monitor's taskbar remains visible even when another monitor
          * is on the desktop.
          */
-        if (taskbar.hasApplication) {
+        if (
+            taskbar.hasApplication ||
+            foregroundApplication
+        ) {
+            taskbar.hasApplication = true;
             taskbar.shownDueToHover = false;
+            taskbar.shownDueToAltTab = false;
             taskbar.hideDeadline = 0;
 
             SetWindowVisibilityIfNeeded(
@@ -1253,15 +1541,31 @@ void UpdateTaskbarState() {
             taskbar.taskbarIsForeground &&
             !taskbar.shownDueToHover
         ) {
-            SetWindowVisibilityIfNeeded(
-                taskbar.hwnd,
-                true
-            );
-
             if (!taskbar.hideDeadline) {
                 taskbar.hideDeadline =
                     now +
                     static_cast<ULONGLONG>(delay);
+            }
+
+            if (now >= taskbar.hideDeadline) {
+                SetWindowVisibilityIfNeeded(
+                    taskbar.hwnd,
+                    false
+                );
+
+                taskbar.hideDeadline = 0;
+
+                /*
+                 * Shell_TrayWnd may remain the foreground HWND briefly
+                 * after it is hidden. Clear the stale cached state so
+                 * the next timer tick doesn't immediately show it again.
+                 */
+                taskbar.taskbarIsForeground = false;
+            } else {
+                SetWindowVisibilityIfNeeded(
+                    taskbar.hwnd,
+                    true
+                );
             }
 
             continue;
@@ -1697,11 +2001,10 @@ DWORD WINAPI HookThread(LPVOID) {
             msg.wParam == g_hoverTimerId
         ) {
             /*
-             * The timer exists only while hover handling is needed.
-             * Cursor movement is the one piece of state that Windows
-             * does not provide as a suitable global WinEvent.
+             * The timer is only for cursor hover and hide deadlines.
+             * Application, shell-flyout and Alt+Tab state is refreshed
+             * by WinEvent/system-notification messages.
              */
-            RefreshPerMonitorState();
             UpdateTaskbarState();
 
             continue;
@@ -1997,7 +2300,13 @@ void WINAPI EntryPoint_Hook() {
 }
 
 BOOL Wh_ModInit() {
-    bool isService = false;
+    DWORD sessionId;
+    if (ProcessIdToSessionId(GetCurrentProcessId(), &sessionId) &&
+        sessionId == 0) {
+        return FALSE;
+    }
+
+    bool isExcluded = false;
     bool isToolModProcess = false;
     bool isCurrentToolModProcess = false;
     int argc;
@@ -2009,8 +2318,10 @@ BOOL Wh_ModInit() {
     }
 
     for (int i = 1; i < argc; i++) {
-        if (wcscmp(argv[i], L"-service") == 0) {
-            isService = true;
+        if (wcscmp(argv[i], L"-service") == 0 ||
+            wcscmp(argv[i], L"-service-start") == 0 ||
+            wcscmp(argv[i], L"-service-stop") == 0) {
+            isExcluded = true;
             break;
         }
     }
@@ -2027,7 +2338,7 @@ BOOL Wh_ModInit() {
 
     LocalFree(argv);
 
-    if (isService) {
+    if (isExcluded) {
         return FALSE;
     }
 

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id hide-taskbar-only-on-desktop
 // @name Hide Taskbar Only on Desktop
 // @description Hides the taskbar when the desktop is active, while showing it for applications and on taskbar hover
-// @version 1.4.0
+// @version 1.5.0
 // @author Sahil Dashoni
 // @github https://github.com/Sahil-Dashoni
 // @include windhawk.exe
@@ -98,12 +98,12 @@ HANDLE g_hThreadReadyEvent = nullptr;
 
 constexpr UINT WM_APP_REFRESH_STATE = WM_APP + 1;
 constexpr UINT WM_APP_STOP_THREAD = WM_APP + 2;
-constexpr WPARAM kRefreshNativeAutoHide = 1;
 constexpr UINT kHoverTimerIntervalMs = 200;
 
 UINT_PTR g_hoverTimerId = 0;
 
 std::atomic<bool> g_refreshPosted{false};
+std::atomic<bool> g_refreshNativeAutoHidePending{false};
 std::atomic<bool> g_nativeAutoHideEnabled{false};
 
 bool g_onDesktopState = false;
@@ -114,7 +114,7 @@ bool g_taskbarIsForeground = false;
 bool g_shownDueToHover = false;
 ULONGLONG g_hideDeadline = 0;
 
-constexpr size_t kMaxWinEventHooks = 3;
+constexpr size_t kMaxWinEventHooks = 2;
 HWINEVENTHOOK g_hWinEventHooks[kMaxWinEventHooks] = {};
 
 
@@ -334,12 +334,6 @@ void RefreshDesktopState() {
         if (IsTaskbarForegroundAndUnderCursor(foreground)) {
             g_taskbarIsForeground = true;
 
-            // The taskbar was revealed/kept visible by the user's
-            // interaction with it. Preserve this state so that when the
-            // cursor leaves the taskbar we start the configured hover
-            // delay instead of hiding it immediately.
-            g_shownDueToHover = true;
-
             g_onDesktopState = false;
             return;
         }
@@ -459,7 +453,7 @@ void SetWindowVisibilityIfNeeded(HWND hwnd, bool show) {
     bool visible = IsWindowVisible(hwnd) != FALSE;
 
     if (visible != show) {
-        ShowWindow(
+        ShowWindowAsync(
             hwnd,
             show ? SW_SHOWNA : SW_HIDE
         );
@@ -743,11 +737,14 @@ void UpdateTaskbarState() {
     if (!g_onDesktopState) {
         g_hideDeadline = 0;
 
-        // Do not clear g_shownDueToHover while the taskbar itself has
-        // focus. It is needed after the cursor leaves the taskbar so the
-        // configured delay is applied. Clear it for a real application
-        // state, where hiding is never delayed.
-        if (!g_taskbarIsForeground) {
+        // If the taskbar itself has focus, preserve the hover-reveal state
+        // so leaving the taskbar starts the configured hide delay.
+        //
+        // A real application state clears the hover-reveal state because
+        // the taskbar must remain visible while that application is active.
+        if (g_taskbarIsForeground) {
+            g_shownDueToHover = true;
+        } else {
             g_shownDueToHover = false;
         }
 
@@ -826,10 +823,6 @@ void UpdateTaskbarState() {
             std::memory_order_relaxed
         );
 
-    if (delay > 60000) {
-        delay = 60000;
-    }
-
     if (g_hideDeadline == 0) {
         g_hideDeadline =
             now + static_cast<ULONGLONG>(delay);
@@ -853,6 +846,13 @@ void RequestStateRefresh(bool refreshNativeAutoHide = false) {
         return;
     }
 
+    if (refreshNativeAutoHide) {
+        g_refreshNativeAutoHidePending.store(
+            true,
+            std::memory_order_release
+        );
+    }
+
     bool expected = false;
 
     if (
@@ -870,7 +870,7 @@ void RequestStateRefresh(bool refreshNativeAutoHide = false) {
         !PostThreadMessageW(
             g_threadId,
             WM_APP_REFRESH_STATE,
-            refreshNativeAutoHide ? kRefreshNativeAutoHide : 0,
+            0,
             0
         )
     ) {
@@ -1151,7 +1151,12 @@ DWORD WINAPI HookThread(LPVOID) {
                 std::memory_order_release
             );
 
-            if (msg.wParam == kRefreshNativeAutoHide) {
+            if (
+                g_refreshNativeAutoHidePending.exchange(
+                    false,
+                    std::memory_order_acq_rel
+                )
+            ) {
                 RefreshNativeTaskbarAutoHideState();
             }
 
@@ -1195,6 +1200,11 @@ DWORD WINAPI HookThread(LPVOID) {
         std::memory_order_release
     );
 
+    g_refreshNativeAutoHidePending.store(
+        false,
+        std::memory_order_release
+    );
+
     return 0;
 }
 
@@ -1209,12 +1219,16 @@ void LoadSettings() {
             L"extraHoverMarginMm"
         );
 
-    DWORD delay =
-        static_cast<DWORD>(
-            Wh_GetIntSetting(
-                L"autoHideDelayMs"
-            )
+    int delay =
+        Wh_GetIntSetting(
+            L"autoHideDelayMs"
         );
+
+    if (delay < 0) {
+        delay = 0;
+    } else if (delay > 60000) {
+        delay = 60000;
+    }
 
     bool secondary =
         Wh_GetIntSetting(
@@ -1239,7 +1253,7 @@ void LoadSettings() {
     );
 
     g_settings.autoHideDelayMs.store(
-        delay,
+        static_cast<DWORD>(delay),
         std::memory_order_relaxed
     );
 
@@ -1425,6 +1439,11 @@ void WhTool_ModUninit() {
         g_hThread = nullptr;
         g_threadId = 0;
     }
+
+    g_refreshNativeAutoHidePending.store(
+        false,
+        std::memory_order_release
+    );
 
     if (g_hThreadReadyEvent) {
         CloseHandle(g_hThreadReadyEvent);

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -38,6 +38,10 @@ visible whenever an application or shell UI is active.
 This mod intentionally differs from native Windows auto-hide:
 it hides the taskbar window without changing the desktop work area.
 
+Because the taskbar is controlled by a separate tool process, an unexpected
+termination of that process while the taskbar is hidden can leave the taskbar
+hidden until Explorer is restarted. Normal disable/unload paths restore it.
+
 If native Windows taskbar auto-hide is enabled, this mod stands down so
 the two mechanisms don't fight each other. If native auto-hide is enabled
 while this mod has hidden the taskbar, the mod restores the taskbar first
@@ -94,8 +98,6 @@ HANDLE g_hThreadReadyEvent = nullptr;
 
 constexpr UINT WM_APP_REFRESH_STATE = WM_APP + 1;
 constexpr UINT WM_APP_STOP_THREAD = WM_APP + 2;
-constexpr WPARAM kRefreshNativeAutoHide = 1;
-
 constexpr UINT kHoverTimerIntervalMs = 200;
 
 UINT_PTR g_hoverTimerId = 0;
@@ -114,6 +116,12 @@ ULONGLONG g_hideDeadline = 0;
 constexpr size_t kMaxWinEventHooks = 3;
 HWINEVENTHOOK g_hWinEventHooks[kMaxWinEventHooks] = {};
 
+
+// Hidden window used to receive setting/display notifications without
+// installing broad system-wide EVENT_OBJECT_* hooks.
+HWND g_hSystemMessageWindow = nullptr;
+const wchar_t kSystemMessageWindowClass[] =
+    L"HideTaskbarOnlyOnDesktop.SystemMessageWindow";
 
 // ============================================================
 // Utility
@@ -452,7 +460,7 @@ void SetWindowVisibilityIfNeeded(HWND hwnd, bool show) {
     if (visible != show) {
         ShowWindow(
             hwnd,
-            show ? SW_SHOW : SW_HIDE
+            show ? SW_SHOWNA : SW_HIDE
         );
     }
 }
@@ -874,6 +882,106 @@ void RequestStateRefresh(bool refreshNativeAutoHide = false) {
 
 
 // ============================================================
+// System notification window
+// ============================================================
+
+LRESULT CALLBACK SystemMessageWindowProc(
+    HWND hwnd,
+    UINT message,
+    WPARAM wParam,
+    LPARAM lParam
+) {
+    UNREFERENCED_PARAMETER(hwnd);
+    UNREFERENCED_PARAMETER(wParam);
+    UNREFERENCED_PARAMETER(lParam);
+
+    switch (message) {
+    case WM_SETTINGCHANGE:
+        /*
+         * Native taskbar auto-hide can be changed from Windows Settings.
+         * Re-query it only when this targeted system notification arrives.
+         */
+        RefreshNativeTaskbarAutoHideState();
+        RefreshDesktopState();
+        UpdateTaskbarState();
+        return 0;
+
+    case WM_DISPLAYCHANGE:
+    case WM_DPICHANGED:
+        /*
+         * Monitor layout or DPI can change taskbar geometry.
+         */
+        RefreshNativeTaskbarAutoHideState();
+        RefreshDesktopState();
+        UpdateTaskbarState();
+        return 0;
+
+    case WM_NCDESTROY:
+        if (g_hSystemMessageWindow == hwnd) {
+            g_hSystemMessageWindow = nullptr;
+        }
+        break;
+    }
+
+    return DefWindowProcW(hwnd, message, wParam, lParam);
+}
+
+
+bool CreateSystemMessageWindow() {
+    WNDCLASSW wc = {};
+    wc.lpfnWndProc = SystemMessageWindowProc;
+    wc.hInstance = GetModuleHandleW(nullptr);
+    wc.lpszClassName = kSystemMessageWindowClass;
+
+    if (!RegisterClassW(&wc)) {
+        DWORD error = GetLastError();
+
+        if (error != ERROR_CLASS_ALREADY_EXISTS) {
+            Wh_Log(
+                L"RegisterClassW failed: %lu",
+                error
+            );
+            return false;
+        }
+    }
+
+    g_hSystemMessageWindow =
+        CreateWindowExW(
+            0,
+            kSystemMessageWindowClass,
+            L"Hide Taskbar Only on Desktop",
+            WS_OVERLAPPED,
+            0,
+            0,
+            0,
+            0,
+            nullptr,
+            nullptr,
+            GetModuleHandleW(nullptr),
+            nullptr
+        );
+
+    if (!g_hSystemMessageWindow) {
+        Wh_Log(
+            L"CreateWindowExW failed: %lu",
+            GetLastError()
+        );
+        return false;
+    }
+
+    return true;
+}
+
+
+void DestroySystemMessageWindow() {
+    if (g_hSystemMessageWindow) {
+        DestroyWindow(g_hSystemMessageWindow);
+        g_hSystemMessageWindow = nullptr;
+    }
+}
+
+
+// ============================================================
 // WinEvent hook
 // ============================================================
 
@@ -911,7 +1019,7 @@ void CALLBACK WinEventProc(
      * controls and other transient windows. Avoiding them prevents a
      * synchronous SHAppBarMessage call on every such event.
      */
-    RequestStateRefresh(event == EVENT_SYSTEM_FOREGROUND);
+    RequestStateRefresh(false);
 }
 
 
@@ -992,6 +1100,8 @@ DWORD WINAPI HookThread(LPVOID) {
     if (g_hThreadReadyEvent) {
         SetEvent(g_hThreadReadyEvent);
     }
+
+    CreateSystemMessageWindow();
 
     /*
      * Only hook events that represent meaningful application-state
@@ -1077,6 +1187,7 @@ DWORD WINAPI HookThread(LPVOID) {
      * Always restore the user's visible taskbars when the tool exits.
      */
     SetTaskbarVisibility(true);
+    DestroySystemMessageWindow();
 
     g_refreshPosted.store(
         false,
@@ -1255,11 +1366,17 @@ void WhTool_ModSettingsChanged() {
     LoadSettings();
 
     /*
+     * Native taskbar auto-hide is a system setting, so refresh it here
+     * rather than on every foreground/minimize event.
+     */
+    RefreshNativeTaskbarAutoHideState();
+
+    /*
      * Apply settings immediately instead of waiting for a timer tick.
      * In particular, this restores secondary taskbars when the setting
      * changes from ON to OFF while the desktop is already active.
      */
-    RequestStateRefresh(true);
+    RequestStateRefresh(false);
 }
 
 
@@ -1509,14 +1626,8 @@ void Wh_ModAfterInit() {
         1
     ];
 
-    /*
-     * MinGW's swprintf_s requires the destination buffer size.
-     * The previous version omitted it, which caused the PR build
-     * to fail on the Windhawk compiler.
-     */
     swprintf_s(
         commandLine,
-        ARRAYSIZE(commandLine),
         L"\"%s\" -tool-mod \"%s\"",
         currentProcessPath,
         WH_MOD_ID

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Hides selected taskbars only while their display is showing the desktop
-// @version         2.3.0
+// @version         3.0.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Hides selected taskbars only while their display is showing the desktop
-// @version         3.5.0
+// @version         3.6.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -51,9 +51,10 @@ per Explorer process and keeps the state-management code outside the shell.
   display-set changes.
 - Native Windows auto-hide state is sampled once per reconciliation and reused
   for the rest of that reconciliation.
-- Cursor movement near the bottom edge is handled through a lightweight
-  low-level mouse hook instead of a dedicated 25 ms sampler
-  thread.
+- Cursor movement near the bottom edge is handled by a dedicated lightweight
+  cursor-sampling thread. It samples only cursor position and posts a refresh
+  when the configured hover-zone state changes, keeping input detection separate
+  from the worker's full window scan.
 - Known taskbar/XAML popup classes are treated as shell surfaces; generic
   `Windows.UI.Core.CoreWindow` windows are no longer rejected solely because of
   their class name, which avoids misclassifying visible UWP application windows.
@@ -103,9 +104,9 @@ or unusual transitions.
 
 Each safety poll performs one display enumeration and one top-level-window
 enumeration. The result is reused for every taskbar. Cursor movement near the
-bottom edge is handled by a cursor `EVENT_OBJECT_LOCATIONCHANGE` WinEvent that
-posts only lightweight state-transition refreshes. Hover dismissal uses a
-one-shot worker timer rather than a fast full-state polling loop.
+bottom edge is handled by a dedicated cursor-sampling thread that posts only
+lightweight state-transition refreshes. Hover dismissal uses a one-shot worker
+timer rather than a fast full-state polling loop.
 */
 // ==/WindhawkModReadme==
 
@@ -156,7 +157,9 @@ one-shot worker timer rather than a fast full-state polling loop.
     Select one or more displays using the Windows `\\.\DISPLAYn` device number.
     These numbers may differ from the display numbers shown in Windows Display
     Settings. Choose All displays to hide every connected display. Use Add to
-    select multiple displays.
+    select multiple displays. When a physical display is reconnected and Windows
+    renumbers DISPLAYn, the mod keeps the selection bound to the same detected
+    monitor device when possible.
   $options:
   - all: All displays
   - monitor1: DISPLAY1
@@ -235,17 +238,25 @@ struct WindowScanResult {
 HWINEVENTHOOK g_foregroundHook = nullptr;
 HWINEVENTHOOK g_minimizeHook = nullptr;
 HWINEVENTHOOK g_moveHook = nullptr;
-HHOOK g_mouseHook = nullptr;
 HWINEVENTHOOK g_taskbarShowHook = nullptr;
 DWORD g_taskbarShowHookProcessId = 0;
 
 HANDLE g_workerThread = nullptr;
 DWORD g_workerThreadId = 0;
 HANDLE g_workerReadyEvent = nullptr;
+HANDLE g_cursorThread = nullptr;
+HANDLE g_cursorStopEvent = nullptr;
 
-HMONITOR g_lastCursorTriggerMonitor = nullptr;
-bool g_lastCursorInTriggerBand = false;
-bool g_lastCursorInExactHoverZone = false;
+struct CursorHoverSnapshot {
+    HMONITOR monitor;
+    RECT monitorRect;
+    int hotZonePx;
+    bool enabled;
+};
+
+CursorHoverSnapshot g_cursorHoverSnapshots[kMaxTaskbars] = {};
+size_t g_cursorHoverSnapshotCount = 0;
+SRWLOCK g_cursorHoverSnapshotLock = SRWLOCK_INIT;
 
 constexpr wchar_t kHiddenByModProperty[] =
     L"Windhawk.HideTaskbarOnlyOnDesktop.HiddenByMod";
@@ -616,6 +627,12 @@ BOOL CALLBACK CollectMonitorProc(
         ARRAYSIZE(entry.deviceName),
         info.szDevice,
         _TRUNCATE
+    );
+
+    GetStableMonitorDeviceId(
+        entry.deviceName,
+        entry.stableDeviceId,
+        ARRAYSIZE(entry.stableDeviceId)
     );
 
     return TRUE;
@@ -1568,13 +1585,126 @@ bool IsCursorNearBottomEdge(
     );
 }
 
+void UpdateCursorHoverSnapshot() {
+    CursorHoverSnapshot snapshots[kMaxTaskbars] = {};
+    size_t snapshotCount = 0;
+
+    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+        if (snapshotCount >= kMaxTaskbars) {
+            break;
+        }
+
+        const TaskbarMonitorState& state =
+            g_taskbarStates[i];
+
+        CursorHoverSnapshot& snapshot =
+            snapshots[snapshotCount++];
+
+        snapshot.monitor = state.monitor;
+        snapshot.enabled =
+            ShouldRevealOnHover(state) &&
+            IsBottomDockedTaskbar(
+                state.hwnd,
+                state.monitor
+            );
+
+        MONITORINFO mi = {};
+        mi.cbSize = sizeof(mi);
+
+        if (
+            !snapshot.monitor ||
+            !GetMonitorInfoW(
+                snapshot.monitor,
+                &mi
+            )
+        ) {
+            snapshot.enabled = false;
+            continue;
+        }
+
+        snapshot.monitorRect = mi.rcMonitor;
+
+        UINT dpi =
+            GetDpiForWindow(state.hwnd);
+
+        if (dpi == 0) {
+            dpi = 96;
+        }
+
+        snapshot.hotZonePx =
+            GetHoverZonePx(
+                state.hwnd,
+                dpi
+            );
+
+        if (snapshot.hotZonePx < 1) {
+            snapshot.hotZonePx = 1;
+        }
+    }
+
+    AcquireSRWLockExclusive(
+        &g_cursorHoverSnapshotLock
+    );
+
+    for (size_t i = 0; i < snapshotCount; ++i) {
+        g_cursorHoverSnapshots[i] =
+            snapshots[i];
+    }
+
+    g_cursorHoverSnapshotCount = snapshotCount;
+
+    ReleaseSRWLockExclusive(
+        &g_cursorHoverSnapshotLock
+    );
+}
+
+bool IsCursorInConfiguredHoverZoneAtSnapshot(
+    POINT pt,
+    HMONITOR cursorMonitor
+) {
+    if (!cursorMonitor) {
+        return false;
+    }
+
+    AcquireSRWLockShared(
+        &g_cursorHoverSnapshotLock
+    );
+
+    bool result = false;
+
+    for (
+        size_t i = 0;
+        i < g_cursorHoverSnapshotCount;
+        ++i
+    ) {
+        const CursorHoverSnapshot& snapshot =
+            g_cursorHoverSnapshots[i];
+
+        if (
+            !snapshot.enabled ||
+            snapshot.monitor != cursorMonitor
+        ) {
+            continue;
+        }
+
+        result =
+            pt.y >=
+                snapshot.monitorRect.bottom -
+                snapshot.hotZonePx &&
+            pt.y < snapshot.monitorRect.bottom;
+        break;
+    }
+
+    ReleaseSRWLockShared(
+        &g_cursorHoverSnapshotLock
+    );
+
+    return result;
+}
+
 void UpdateTaskbarState() {
     MonitorList monitors =
         GetCurrentMonitors();
-
-    BindConfiguredMonitorSelections(
-        monitors
-    );
 
     ULONGLONG topologySignature =
         HashDisplayTopology(monitors);
@@ -1584,6 +1714,11 @@ void UpdateTaskbarState() {
         topologySignature != g_displayTopologySignature
     ) {
         ClearStableMonitorDeviceIdCache();
+
+        // Rebuild the monitor list after clearing the cache so every current
+        // monitor gets a fresh stable device identity before selection binding.
+        monitors = GetCurrentMonitors();
+        topologySignature = HashDisplayTopology(monitors);
 
         // A display add/remove, arrangement change, or geometry/DPI transition
         // can invalidate the current hover monitor. Reconcile from the base
@@ -1596,9 +1731,15 @@ void UpdateTaskbarState() {
 
     g_displayTopologySignature = topologySignature;
 
+    BindConfiguredMonitorSelections(
+        monitors
+    );
+
     RefreshTaskbarMonitorStates(
         monitors
     );
+
+    UpdateCursorHoverSnapshot();
 
     // ABM_GETSTATE reports the native auto-hide setting globally. Sample it
     // once per reconciliation and reuse the result for every taskbar.
@@ -1923,36 +2064,10 @@ bool IsCursorInConfiguredHoverZone() {
             MONITOR_DEFAULTTONEAREST
         );
 
-    if (!cursorMonitor) {
-        return false;
-    }
-
-    TaskbarMonitorState* cursorState = nullptr;
-
-    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-        if (
-            g_taskbarStates[i].monitor ==
-            cursorMonitor
-        ) {
-            cursorState =
-                &g_taskbarStates[i];
-            break;
-        }
-    }
-
-    if (
-        !cursorState ||
-        !ShouldRevealOnHover(*cursorState)
-    ) {
-        return false;
-    }
-
-    return
-        cursorState->hwnd &&
-        IsCursorNearBottomEdge(
-            cursorState->hwnd,
-            cursorMonitor
-        );
+    return IsCursorInConfiguredHoverZoneAtPoint(
+        pt,
+        cursorMonitor
+    );
 }
 
 
@@ -1993,93 +2108,52 @@ void PostRefresh() {
     }
 }
 
-bool IsCursorInBottomTriggerBand(POINT pt, HMONITOR monitor) {
-    if (!monitor) {
-        return false;
-    }
+DWORD WINAPI CursorSamplingThread(LPVOID) {
+    bool lastHoverZone = false;
+    HMONITOR lastMonitor = nullptr;
 
-    MONITORINFO mi = {};
-    mi.cbSize = sizeof(mi);
+    for (;;) {
+        DWORD waitResult =
+            WaitForSingleObject(
+                g_cursorStopEvent,
+                25
+            );
 
-    if (!GetMonitorInfoW(monitor, &mi)) {
-        return false;
-    }
+        if (waitResult == WAIT_OBJECT_0) {
+            break;
+        }
 
-    // This is only a lightweight trigger band. The worker performs the exact
-    // taskbar-height/DPI hover-zone check before changing visibility. Keeping
-    // this callback lightweight avoids putting window scanning on the cursor
-    // movement event path.
-    constexpr LONG kCursorTriggerBandPx = 256;
+        POINT pt = {};
 
-    return
-        pt.y >= mi.rcMonitor.bottom - kCursorTriggerBandPx &&
-        pt.y < mi.rcMonitor.bottom;
-}
+        if (!GetCursorPos(&pt)) {
+            continue;
+        }
 
+        HMONITOR monitor =
+            MonitorFromPoint(
+                pt,
+                MONITOR_DEFAULTTONEAREST
+            );
 
-LRESULT CALLBACK LowLevelMouseProc(
-    int nCode,
-    WPARAM wParam,
-    LPARAM lParam
-) {
-    if (nCode == HC_ACTION && wParam == WM_MOUSEMOVE) {
-        const MSLLHOOKSTRUCT* mouse =
-            reinterpret_cast<const MSLLHOOKSTRUCT*>(lParam);
+        const bool hoverZone =
+            IsCursorInConfiguredHoverZoneAtSnapshot(
+                pt,
+                monitor
+            );
 
-        if (mouse) {
-            HMONITOR monitor =
-                MonitorFromPoint(
-                    mouse->pt,
-                    MONITOR_DEFAULTTONEAREST
-                );
+        const bool changed =
+            hoverZone != lastHoverZone ||
+            (hoverZone && monitor != lastMonitor);
 
-            const bool inBand =
-                IsCursorInBottomTriggerBand(
-                    mouse->pt,
-                    monitor
-                );
+        lastHoverZone = hoverZone;
+        lastMonitor = monitor;
 
-            const bool exactHoverZone =
-                inBand &&
-                IsCursorInConfiguredHoverZoneAtPoint(
-                    mouse->pt,
-                    monitor
-                );
-
-            const bool monitorChanged =
-                inBand && monitor != g_lastCursorTriggerMonitor;
-
-            const bool bandChanged =
-                inBand != g_lastCursorInTriggerBand;
-
-            const bool exactZoneChanged =
-                exactHoverZone != g_lastCursorInExactHoverZone;
-
-            g_lastCursorTriggerMonitor = monitor;
-            g_lastCursorInTriggerBand = inBand;
-            g_lastCursorInExactHoverZone = exactHoverZone;
-
-            // The broad trigger band prevents refreshes for normal mouse
-            // movement. A separate exact-zone edge catches the moment the
-            // cursor actually reaches the configured taskbar reveal area,
-            // avoiding the old 1-second safety-poll latency. This only changes
-            // the reveal trigger; the existing hover-dismiss delay is untouched.
-            if (
-                monitorChanged ||
-                bandChanged ||
-                exactZoneChanged
-            ) {
-                PostRefresh();
-            }
+        if (changed) {
+            PostRefresh();
         }
     }
 
-    return CallNextHookEx(
-        g_mouseHook,
-        nCode,
-        wParam,
-        lParam
-    );
+    return 0;
 }
 
 void CALLBACK WinEventProc(
@@ -2325,12 +2399,6 @@ DWORD WINAPI WorkerThread(
         );
     }
 
-    if (g_workerReadyEvent) {
-        SetEvent(
-            g_workerReadyEvent
-        );
-    }
-
     g_foregroundHook =
         SetWinEventHook(
             EVENT_SYSTEM_FOREGROUND,
@@ -2364,24 +2432,14 @@ DWORD WINAPI WorkerThread(
             WINEVENT_OUTOFCONTEXT
         );
 
-    g_mouseHook =
-        SetWindowsHookExW(
-            WH_MOUSE_LL,
-            LowLevelMouseProc,
-            GetModuleHandleW(nullptr),
-            0
-        );
-
-    if (!g_mouseHook) {
-        Wh_Log(L"SetWindowsHookExW(WH_MOUSE_LL) failed: %lu", GetLastError());
-    }
-
-    g_lastCursorTriggerMonitor = nullptr;
-    g_lastCursorInTriggerBand = false;
-    g_lastCursorInExactHoverZone = false;
-
     EnsureTaskbarShowHook();
     UpdateTaskbarState();
+
+    if (g_workerReadyEvent) {
+        SetEvent(
+            g_workerReadyEvent
+        );
+    }
 
     UINT_PTR timerId =
         SetTimer(
@@ -2405,7 +2463,7 @@ DWORD WINAPI WorkerThread(
         }
 
         if (msg.message == WM_TIMER) {
-            if (msg.hwnd == g_workerMessageWindow) {
+            if (msg.hwnd && msg.hwnd == g_workerMessageWindow) {
                 DispatchMessageW(&msg);
                 continue;
             }
@@ -2459,10 +2517,6 @@ DWORD WINAPI WorkerThread(
     SafeUnhookWinEvent(g_foregroundHook);
     SafeUnhookWinEvent(g_minimizeHook);
     SafeUnhookWinEvent(g_moveHook);
-    if (g_mouseHook) {
-        UnhookWindowsHookEx(g_mouseHook);
-        g_mouseHook = nullptr;
-    }
     SafeUnhookWinEvent(g_taskbarShowHook);
     g_taskbarShowHookProcessId = 0;
 
@@ -2661,6 +2715,40 @@ BOOL WhTool_ModInit() {
         INFINITE
     );
 
+    g_cursorStopEvent =
+        CreateEventW(
+            nullptr,
+            TRUE,
+            FALSE,
+            nullptr
+        );
+
+    if (!g_cursorStopEvent) {
+        Wh_Log(
+            L"CreateEvent for cursor sampler failed: %lu",
+            GetLastError()
+        );
+        return TRUE;
+    }
+
+    g_cursorThread =
+        CreateThread(
+            nullptr,
+            0,
+            CursorSamplingThread,
+            nullptr,
+            0,
+            nullptr
+        );
+
+    if (!g_cursorThread) {
+        Wh_Log(
+            L"CreateThread for cursor sampler failed: %lu",
+            GetLastError()
+        );
+        SafeCloseHandle(g_cursorStopEvent);
+    }
+
     return TRUE;
 }
 
@@ -2767,6 +2855,25 @@ bool WaitForThreadWithTimeout(
 
 void WhTool_ModUninit() {
     Wh_Log(L"Uninit");
+
+    if (g_cursorStopEvent) {
+        SetEvent(g_cursorStopEvent);
+    }
+
+    if (g_cursorThread) {
+        if (!WaitForThreadWithTimeout(
+                g_cursorThread,
+                3000,
+                L"cursor sampler"
+            )) {
+            RestoreAllTaskbars();
+            ExitProcess(1);
+        }
+
+        SafeCloseHandle(g_cursorThread);
+    }
+
+    SafeCloseHandle(g_cursorStopEvent);
 
     if (g_workerThread) {
         DWORD readyResult =

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id hide-taskbar-only-on-desktop
 // @name Hide Taskbar Only on Desktop
 // @description Hides the taskbar on desktop while preserving taskbar and Windows shell UI interaction
-// @version 1.11.5
+// @version 1.13.0
 // @author Sahil Dashoni
 // @github https://github.com/Sahil-Dashoni
 // @include windhawk.exe
@@ -121,9 +121,11 @@ UINT_PTR g_hoverTimerId = 0;
 
 std::atomic<bool> g_refreshPosted{false};
 std::atomic<bool> g_immediateHidePending{false};
+ULONGLONG g_lastApplicationScanTick = 0;
+constexpr ULONGLONG kApplicationRescanIntervalMs = 1000;
 
 constexpr size_t kMaxTaskbars = 16;
-constexpr size_t kMaxWinEventHooks = 2;
+constexpr size_t kMaxWinEventHooks = 3;
 
 struct TaskbarState {
     HWND hwnd = nullptr;
@@ -152,6 +154,7 @@ HWINEVENTHOOK g_hWinEventHooks[kMaxWinEventHooks] = {};
 // Hidden window used to receive setting/display notifications without
 // installing broad system-wide EVENT_OBJECT_* hooks.
 HWND g_hSystemMessageWindow = nullptr;
+UINT g_taskbarCreatedMsg = 0;
 const wchar_t kSystemMessageWindowClass[] =
     L"HideTaskbarOnlyOnDesktop.SystemMessageWindow";
 
@@ -220,6 +223,14 @@ bool IsTaskbarWindow(HWND hwnd) {
 // Window detection
 // ============================================================
 
+struct ForegroundInfo {
+    HWND hwnd = nullptr;
+    WCHAR className[256] = {};
+    WCHAR processName[MAX_PATH] = {};
+    bool classValid = false;
+    bool processValid = false;
+};
+
 void DiscoverTaskbars();
 bool IsAltTabWindowClass(const WCHAR* className);
 
@@ -228,9 +239,14 @@ HWND FindPrimaryTaskbar();
 bool IsTaskbarActuallyHidden(HWND hwnd);
 bool IsShellUiClass(const WCHAR* className);
 bool IsCursorOverTaskbarShellPopup(HWND taskbar);
-bool IsForegroundApplicationOnMonitor(HWND foreground, HMONITOR monitor);
-
-bool IsAltTabWindowClass(const WCHAR* className);
+bool IsShellUiForegroundOnMonitor(
+    HMONITOR monitor,
+    const ForegroundInfo& info
+);
+bool IsForegroundApplicationOnMonitor(
+    const ForegroundInfo& info,
+    HMONITOR monitor
+);
 bool GetWindowProcessName(HWND hwnd, WCHAR* name, size_t nameCount);
 bool IsKnownShellUiProcess(const WCHAR* processName);
 bool IsShellUiWindow(HWND hwnd);
@@ -695,53 +711,46 @@ bool IsCursorOverTaskbarShellPopup(HWND taskbar) {
 
 
 bool IsForegroundApplicationOnMonitor(
-    HWND foreground,
+    const ForegroundInfo& info,
     HMONITOR monitor
 ) {
-    if (!foreground || !monitor) {
-        return false;
-    }
-
     if (
-        !IsWindowVisible(foreground) ||
-        IsIconic(foreground)
+        !monitor ||
+        !info.hwnd ||
+        !info.classValid
     ) {
         return false;
     }
 
     if (
-        IsTaskbarWindow(foreground) ||
-        IsDesktopWindow(foreground)
+        !IsWindowVisible(info.hwnd) ||
+        IsIconic(info.hwnd)
     ) {
         return false;
     }
 
-    WCHAR className[256] = {};
-
     if (
-        GetClassNameW(
-            foreground,
-            className,
-            ARRAYSIZE(className)
-        ) == 0
+        IsTaskbarWindow(info.hwnd) ||
+        IsDesktopWindow(info.hwnd)
     ) {
         return false;
     }
 
-    if (IsAltTabWindowClass(className)) {
+    if (IsAltTabWindowClass(info.className)) {
         return false;
     }
 
     if (
-        IsShellChromeClass(className) &&
-        IsShellUiWindow(foreground)
+        info.processValid &&
+        IsShellChromeClass(info.className) &&
+        IsKnownShellUiProcess(info.processName)
     ) {
         return false;
     }
 
     LONG_PTR exStyle =
         GetWindowLongPtrW(
-            foreground,
+            info.hwnd,
             GWL_EXSTYLE
         );
 
@@ -754,7 +763,7 @@ bool IsForegroundApplicationOnMonitor(
     if (
         SUCCEEDED(
             DwmGetWindowAttribute(
-                foreground,
+                info.hwnd,
                 DWMWA_CLOAKED,
                 &cloaked,
                 sizeof(cloaked)
@@ -767,7 +776,7 @@ bool IsForegroundApplicationOnMonitor(
 
     RECT rect = {};
 
-    if (!GetWindowRect(foreground, &rect)) {
+    if (!GetWindowRect(info.hwnd, &rect)) {
         return false;
     }
 
@@ -906,7 +915,6 @@ bool IsShellUiClass(const WCHAR* className) {
         wcscmp(className, L"TopLevelWindowForOverflowXamlIsland") == 0 ||
         wcscmp(className, L"NotifyIconOverflowWindow") == 0 ||
         wcscmp(className, L"Windows.UI.Core.CoreWindow") == 0 ||
-        wcscmp(className, L"ApplicationFrameWindow") == 0 ||
         wcscmp(className, L"Windows.UI.Core.CoreComponent") == 0 ||
         wcscmp(className, L"#32768") == 0;
 }
@@ -926,37 +934,66 @@ bool IsAltTabWindowClass(const WCHAR* className) {
 
 
 
-bool IsShellUiForegroundOnMonitor(
-    HMONITOR monitor,
-    HWND foreground
-) {
-    if (!monitor || !foreground) {
-        return false;
+
+
+ForegroundInfo GetForegroundInfo(HWND hwnd) {
+    ForegroundInfo info = {};
+    info.hwnd = hwnd;
+
+    if (!hwnd) {
+        return info;
     }
 
-    WCHAR className[256] = {};
-
-    if (
+    info.classValid =
         GetClassNameW(
-            foreground,
-            className,
-            ARRAYSIZE(className)
-        ) == 0
+            hwnd,
+            info.className,
+            ARRAYSIZE(info.className)
+        ) != 0;
+
+    if (info.classValid) {
+        info.processValid =
+            GetWindowProcessName(
+                hwnd,
+                info.processName,
+                ARRAYSIZE(info.processName)
+            );
+    }
+
+    return info;
+}
+
+
+
+
+
+bool IsShellUiForegroundOnMonitor(
+    HMONITOR monitor,
+    const ForegroundInfo& info
+) {
+    if (
+        !monitor ||
+        !info.hwnd ||
+        !info.classValid
     ) {
         return false;
     }
 
-    if (IsAltTabWindowClass(className)) {
+    if (IsAltTabWindowClass(info.className)) {
         return true;
     }
 
-    if (!IsShellUiWindow(foreground)) {
+    if (
+        !info.processValid ||
+        !IsShellUiClass(info.className) ||
+        !IsKnownShellUiProcess(info.processName)
+    ) {
         return false;
     }
 
     RECT rect = {};
 
-    if (!GetWindowRect(foreground, &rect)) {
+    if (!GetWindowRect(info.hwnd, &rect)) {
         return false;
     }
 
@@ -979,6 +1016,8 @@ bool IsShellUiForegroundOnMonitor(
 
 void RefreshTaskbarForegroundState() {
     HWND foreground = GetForegroundWindow();
+    ForegroundInfo foregroundInfo =
+        GetForegroundInfo(foreground);
 
     for (size_t i = 0; i < g_taskbarCount; ++i) {
         TaskbarState& taskbar = g_taskbars[i];
@@ -997,7 +1036,7 @@ void RefreshTaskbarForegroundState() {
         taskbar.shellUiForeground =
             IsShellUiForegroundOnMonitor(
                 taskbar.monitor,
-                foreground
+                foregroundInfo
             );
 
         if (cursorOverTaskbar) {
@@ -1016,6 +1055,7 @@ void RefreshPerMonitorState() {
      */
     DiscoverTaskbars();
     ScanApplicationWindows();
+    g_lastApplicationScanTick = GetTickCount64();
     RefreshTaskbarForegroundState();
 }
 
@@ -1373,12 +1413,33 @@ void UpdateTaskbarState() {
      * event for this tool. Refresh only the foreground shell state here;
      * application state remains event-driven.
      */
-    HWND foreground = GetForegroundWindow();
-
     ULONGLONG now = GetTickCount64();
+
+    /*
+     * Some background window closes/appearances do not change the
+     * foreground window. Reconcile application state once per second,
+     * rather than doing a full EnumWindows scan every 200 ms.
+     */
+    if (
+        g_lastApplicationScanTick == 0 ||
+        now - g_lastApplicationScanTick >=
+            kApplicationRescanIntervalMs
+    ) {
+        ScanApplicationWindows();
+        g_lastApplicationScanTick = now;
+    }
+
+    HWND foreground = GetForegroundWindow();
+    ForegroundInfo foregroundInfo =
+        GetForegroundInfo(foreground);
 
     DWORD delay =
         g_settings.autoHideDelayMs.load(
+            std::memory_order_relaxed
+        );
+
+    bool hideSecondaryTaskbars =
+        g_settings.hideSecondaryTaskbars.load(
             std::memory_order_relaxed
         );
 
@@ -1410,12 +1471,12 @@ void UpdateTaskbarState() {
         bool currentShellUi =
             IsShellUiForegroundOnMonitor(
                 taskbar.monitor,
-                foreground
+                foregroundInfo
             );
 
         bool foregroundApplication =
             IsForegroundApplicationOnMonitor(
-                foreground,
+                foregroundInfo,
                 taskbar.monitor
             );
 
@@ -1426,10 +1487,14 @@ void UpdateTaskbarState() {
          * A Start/taskbar context menu may not become the foreground HWND.
          * Detect the popup under the cursor without doing a full enumeration.
          */
-        bool taskbarShellPopup =
-            IsCursorOverTaskbarShellPopup(
-                taskbar.hwnd
-            );
+        bool taskbarShellPopup = false;
+
+        if (hovering) {
+            taskbarShellPopup =
+                IsCursorOverTaskbarShellPopup(
+                    taskbar.hwnd
+                );
+        }
 
         /*
          * Shell UI state is allowed to keep the taskbar visible while the
@@ -1708,6 +1773,14 @@ LRESULT CALLBACK SystemMessageWindowProc(
     UNREFERENCED_PARAMETER(wParam);
     UNREFERENCED_PARAMETER(lParam);
 
+    if (
+        g_taskbarCreatedMsg &&
+        message == g_taskbarCreatedMsg
+    ) {
+        RequestStateRefresh();
+        return 0;
+    }
+
     switch (message) {
     case WM_SETTINGCHANGE:
     case WM_DISPLAYCHANGE:
@@ -1731,6 +1804,16 @@ LRESULT CALLBACK SystemMessageWindowProc(
 
 
 bool CreateSystemMessageWindow() {
+    g_taskbarCreatedMsg =
+        RegisterWindowMessageW(L"TaskbarCreated");
+
+    if (!g_taskbarCreatedMsg) {
+        Wh_Log(
+            L"RegisterWindowMessageW(TaskbarCreated) failed: %lu",
+            GetLastError()
+        );
+    }
+
     WNDCLASSW wc = {};
     wc.lpfnWndProc = SystemMessageWindowProc;
     wc.hInstance = GetModuleHandleW(nullptr);
@@ -1781,6 +1864,8 @@ void DestroySystemMessageWindow() {
         DestroyWindow(g_hSystemMessageWindow);
         g_hSystemMessageWindow = nullptr;
     }
+
+    g_taskbarCreatedMsg = 0;
 }
 
 
@@ -1792,7 +1877,8 @@ bool IsRelevantWinEvent(DWORD event) {
     return
         event == EVENT_SYSTEM_FOREGROUND ||
         event == EVENT_SYSTEM_MINIMIZESTART ||
-        event == EVENT_SYSTEM_MINIMIZEEND;
+        event == EVENT_SYSTEM_MINIMIZEEND ||
+        event == EVENT_SYSTEM_MOVESIZEEND;
 }
 
 
@@ -1862,7 +1948,8 @@ bool InstallWinEventHookFor(
 
     if (!g_hWinEventHooks[index]) {
         Wh_Log(
-            L"SetWinEventHook(%lu, %lu) failed: %lu",
+            L"SetWinEventHook(index=%zu, %lu, %lu) failed: %lu",
+            index,
             eventMin,
             eventMax,
             GetLastError()
@@ -1914,7 +2001,9 @@ DWORD WINAPI HookThread(LPVOID) {
         SetEvent(g_hThreadReadyEvent);
     }
 
-    CreateSystemMessageWindow();
+    if (!CreateSystemMessageWindow()) {
+        Wh_Log(L"CreateSystemMessageWindow failed");
+    }
 
     /*
      * Only hook events that represent meaningful application-state
@@ -1936,6 +2025,12 @@ DWORD WINAPI HookThread(LPVOID) {
         1
     );
 
+    hookOk &= InstallWinEventHookFor(
+        EVENT_SYSTEM_MOVESIZEEND,
+        EVENT_SYSTEM_MOVESIZEEND,
+        2
+    );
+
     if (!hookOk) {
         Wh_Log(
             L"One or more WinEvent hooks failed"
@@ -1945,7 +2040,7 @@ DWORD WINAPI HookThread(LPVOID) {
     /*
      * Apply the correct initial state after the worker and hooks exist.
      */
-        RefreshPerMonitorState();
+    RefreshPerMonitorState();
     UpdateTaskbarState();
 
     MSG msg = {};
@@ -2205,11 +2300,6 @@ void WhTool_ModSettingsChanged() {
 
     LoadSettings();
 
-    /*
-     * Native taskbar auto-hide is a system setting, so refresh it here
-     * rather than on every foreground/minimize event.
-     */
-    
     /*
      * Apply settings immediately instead of waiting for a timer tick.
      * In particular, this restores secondary taskbars when the setting

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Hides selected taskbars only while their display is showing the desktop
-// @version         2.2.0
+// @version         2.3.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -11,13 +11,13 @@
 
 // ==WindhawkModReadme==
 /*
-# Hide Taskbar Only on Desktop V4
+# Hide Taskbar Only on Desktop
 
 Hides each selected taskbar when its own display has no visible,
 non-minimized application window, and shows it again when an application or
 relevant Windows shell interaction requires it.
 
-V4 is implemented as a Windhawk tool in a dedicated `windhawk.exe` process
+The mod is implemented as a Windhawk tool in a dedicated `windhawk.exe` process
 instead of being injected into `explorer.exe`. This avoids one worker copy
 per Explorer process and keeps the state-management code outside the shell.
 
@@ -37,7 +37,7 @@ per Explorer process and keeps the state-management code outside the shell.
   and Alt+Tab are treated as transient shell interactions.
 - Clearing the "Taskbars to hide on desktop" selection means hide nothing.
 
-### Difference from Existing Taskbar Auto-Hide Mods
+### Why this is a separate mod
 
 **`taskbar-auto-hide-when-maximized`** primarily bases its behavior on
 application-window geometry and maximized state. This mod instead evaluates
@@ -54,7 +54,7 @@ for Windows' native auto-hide. This mod directly hides/shows the taskbar
 window and supplies its own hover-reveal behavior.
 
 **`taskbar-fade`** is a broader taskbar customization/fading mod with a
-Smart Idle option. V4 is specifically focused on desktop-only visibility,
+Smart Idle option. This mod is specifically focused on desktop-only visibility,
 independent per-display application state, and explicit per-display hover
 reveal.
 
@@ -97,7 +97,7 @@ enumeration. The result is reused for every taskbar.
     more individual displays.
   $options:
   - all: All displays
-  - monitor1: Display 1 (primary)
+  - monitor1: Display 1
   - monitor2: Display 2
   - monitor3: Display 3
   - monitor4: Display 4
@@ -116,12 +116,12 @@ enumeration. The result is reused for every taskbar.
 - hideOnMonitors: ["all"]
   $name: Taskbars to hide on desktop
   $description: >-
-    Select one or more displays. Display 1 is the primary display.
+    Select one or more displays using the Windows Display number.
     Choose All displays to hide every connected display. Use Add to select
     multiple displays.
   $options:
   - all: All displays
-  - monitor1: Display 1 (primary)
+  - monitor1: Display 1
   - monitor2: Display 2
   - monitor3: Display 3
   - monitor4: Display 4
@@ -144,7 +144,6 @@ enumeration. The result is reused for every taskbar.
 #include <dwmapi.h>
 #include <shellapi.h>
 #include <wchar.h>
-#include <stdint.h>
 
 
 constexpr size_t kMaxMonitorNumbers = 16;
@@ -165,7 +164,6 @@ struct {
 struct MonitorEntry {
     HMONITOR monitor;
     RECT rect;
-    bool primary;
     wchar_t deviceName[32];
 };
 
@@ -189,6 +187,8 @@ HWINEVENTHOOK g_foregroundHook = nullptr;
 HWINEVENTHOOK g_minimizeHook = nullptr;
 HWINEVENTHOOK g_moveHook = nullptr;
 HWINEVENTHOOK g_taskbarShowHook = nullptr;
+DWORD g_taskbarShowHookProcessId = 0;
+HHOOK g_mouseHook = nullptr;
 
 HANDLE g_workerThread = nullptr;
 DWORD g_workerThreadId = 0;
@@ -278,9 +278,6 @@ BOOL CALLBACK CollectMonitorProc(
 
     entry.monitor = monitor;
     entry.rect = info.rcMonitor;
-    entry.primary =
-        (info.dwFlags & MONITORINFOF_PRIMARY) != 0;
-
     wcsncpy_s(
         entry.deviceName,
         ARRAYSIZE(entry.deviceName),
@@ -335,96 +332,6 @@ int GetDisplayDeviceNumber(
     return static_cast<int>(number);
 }
 
-void SortDisplaysForSelection(
-    MonitorList& list
-) {
-    size_t primaryIndex = list.count;
-
-    for (size_t i = 0; i < list.count; ++i) {
-        if (list.entries[i].primary) {
-            primaryIndex = i;
-            break;
-        }
-    }
-
-    if (
-        primaryIndex < list.count &&
-        primaryIndex != 0
-    ) {
-        MonitorEntry primary =
-            list.entries[primaryIndex];
-
-        for (size_t i = primaryIndex; i > 0; --i) {
-            list.entries[i] =
-                list.entries[i - 1];
-        }
-
-        list.entries[0] = primary;
-    }
-
-    for (size_t i = 1; i < list.count; ++i) {
-        size_t best = i;
-
-        int bestNumber =
-            GetDisplayDeviceNumber(
-                list.entries[best].deviceName
-            );
-
-        for (size_t j = i + 1; j < list.count; ++j) {
-            int candidateNumber =
-                GetDisplayDeviceNumber(
-                    list.entries[j].deviceName
-                );
-
-            bool better = false;
-
-            if (
-                candidateNumber > 0 &&
-                bestNumber == 0
-            ) {
-                better = true;
-            } else if (
-                candidateNumber > 0 &&
-                bestNumber > 0 &&
-                candidateNumber < bestNumber
-            ) {
-                better = true;
-            } else if (
-                candidateNumber == 0 &&
-                bestNumber == 0
-            ) {
-                const RECT& a =
-                    list.entries[best].rect;
-                const RECT& b =
-                    list.entries[j].rect;
-
-                better =
-                    b.top < a.top ||
-                    (
-                        b.top == a.top &&
-                        b.left < a.left
-                    );
-            }
-
-            if (better) {
-                best = j;
-                bestNumber = candidateNumber;
-            }
-        }
-
-        if (best != i) {
-            MonitorEntry temp =
-                list.entries[i];
-
-            list.entries[i] =
-                list.entries[best];
-
-            list.entries[best] =
-                temp;
-        }
-    }
-}
-
 MonitorList GetCurrentMonitors() {
     MonitorList list = {};
 
@@ -435,7 +342,6 @@ MonitorList GetCurrentMonitors() {
         reinterpret_cast<LPARAM>(&list)
     );
 
-    SortDisplaysForSelection(list);
     return list;
 }
 
@@ -445,12 +351,16 @@ int GetMonitorNumber(
 ) {
     for (size_t i = 0; i < list.count; ++i) {
         if (list.entries[i].monitor == monitor) {
-            return static_cast<int>(i + 1);
+            return GetDisplayDeviceNumber(
+                list.entries[i].deviceName
+            );
         }
     }
 
     return 0;
 }
+
+bool IsBottomDockedTaskbar(HWND hTaskbar, HMONITOR monitor);
 
 bool ShouldHideMonitor(
     int monitorNumber
@@ -517,8 +427,7 @@ bool IsTransientShellWindow(
         wcscmp(
             className,
             L"TaskbarOverflowWnd"
-        ) == 0 ||
-        wcscmp(className, L"DirectUIHWND") == 0
+        ) == 0
     ) {
         return true;
     }
@@ -930,6 +839,34 @@ void RefreshTaskbarMonitorStates(
     }
 }
 
+bool IsNativeAutoHideEnabled(HWND taskbar) {
+    if (!taskbar || !IsWindow(taskbar)) {
+        return false;
+    }
+
+    APPBARDATA data = {};
+    data.cbSize = sizeof(data);
+    data.hWnd = taskbar;
+
+    return (SHAppBarMessage(ABM_GETSTATE, &data) & ABS_AUTOHIDE) != 0;
+}
+
+
+bool ShouldHideTaskbar(
+    const TaskbarMonitorState& state
+) {
+    return
+        state.hwnd &&
+        state.monitor &&
+        ShouldHideMonitor(state.monitorNumber) &&
+        IsBottomDockedTaskbar(
+            state.hwnd,
+            state.monitor
+        ) &&
+        !IsNativeAutoHideEnabled(state.hwnd);
+}
+
+
 void SetTaskbarState(
     TaskbarMonitorState& state,
     bool show
@@ -1105,163 +1042,92 @@ bool IsCursorNearBottomEdge(
         pt.y < mi.rcMonitor.bottom;
 }
 
-HMONITOR GetForegroundShellPopupMonitor() {
-    HWND foreground =
-        GetForegroundWindow();
+struct TaskbarPopupScanContext {
+    DWORD taskbarProcessId;
+    HMONITOR monitor;
+    bool found;
+};
 
-    if (!foreground) {
-        return nullptr;
+BOOL CALLBACK FindTaskbarPopupProc(HWND hwnd, LPARAM lParam) {
+    TaskbarPopupScanContext* context =
+        reinterpret_cast<TaskbarPopupScanContext*>(lParam);
+
+    if (!context || context->found || !IsWindowVisible(hwnd)) {
+        return TRUE;
+    }
+
+    DWORD processId = 0;
+    GetWindowThreadProcessId(hwnd, &processId);
+
+    if (processId != context->taskbarProcessId) {
+        return TRUE;
     }
 
     WCHAR className[128] = {};
-
-    if (
-        GetClassNameW(
-            foreground,
+    if (!GetClassNameW(
+            hwnd,
             className,
-            ARRAYSIZE(className)
-        ) == 0
-    ) {
-        return nullptr;
+            ARRAYSIZE(className))) {
+        return TRUE;
     }
 
-    HWND taskbar =
-        FindWindowW(
-            L"Shell_TrayWnd",
-            nullptr
-        );
-
-    DWORD explorerPid = 0;
-
-    if (taskbar) {
-        GetWindowThreadProcessId(
-            taskbar,
-            &explorerPid
-        );
+    if (!IsTaskbarPopupClass(className)) {
+        return TRUE;
     }
 
-    if (
-        !IsExplorerShellPopup(
-            foreground,
-            className,
-            explorerPid
-        )
-    ) {
-        return nullptr;
+    RECT rect = {};
+    if (!GetWindowRect(hwnd, &rect)) {
+        return TRUE;
     }
 
-    return MonitorFromWindow(
-        foreground,
-        MONITOR_DEFAULTTONEAREST
-    );
+    POINT center = {
+        rect.left + (rect.right - rect.left) / 2,
+        rect.top + (rect.bottom - rect.top) / 2
+    };
+
+    if (MonitorFromPoint(
+            center,
+            MONITOR_DEFAULTTONEAREST) == context->monitor) {
+        context->found = true;
+        return FALSE;
+    }
+
+    return TRUE;
 }
 
-
-HMONITOR GetCursorPopupMonitor() {
-    POINT pt = {};
-
-    if (!GetCursorPos(&pt)) {
-        return nullptr;
+bool IsTaskbarContextMenuOpen(
+    HWND taskbar,
+    HMONITOR monitor) {
+    if (!taskbar || !monitor || !IsWindow(taskbar)) {
+        return false;
     }
 
-    HWND current =
-        WindowFromPoint(pt);
+    DWORD processId = 0;
+    GetWindowThreadProcessId(taskbar, &processId);
 
-    if (!current) {
-        return nullptr;
+    if (!processId) {
+        return false;
     }
 
-    HWND taskbar =
-        FindWindowW(
-            L"Shell_TrayWnd",
-            nullptr
-        );
+    TaskbarPopupScanContext context = {
+        processId,
+        monitor,
+        false
+    };
 
-    DWORD explorerPid = 0;
+    EnumWindows(
+        FindTaskbarPopupProc,
+        reinterpret_cast<LPARAM>(&context));
 
-    if (taskbar) {
-        GetWindowThreadProcessId(
-            taskbar,
-            &explorerPid
-        );
-    }
+    return context.found;
+}
 
-    for (
-        int depth = 0;
-        current && depth < 12;
-        ++depth
-    ) {
-        WCHAR className[128] = {};
-
-        if (
-            GetClassNameW(
-                current,
-                className,
-                ARRAYSIZE(className)
-            ) != 0 &&
-            IsExplorerShellPopup(
-                current,
-                className,
-                explorerPid
-            )
-        ) {
-            RECT rect = {};
-
-            if (GetWindowRect(
-                    current,
-                    &rect
-                )) {
-                POINT center = {
-                    rect.left +
-                        (rect.right - rect.left) / 2,
-                    rect.top +
-                        (rect.bottom - rect.top) / 2
-                };
-
-                HMONITOR popupMonitor =
-                    MonitorFromPoint(
-                        center,
-                        MONITOR_DEFAULTTONEAREST
-                    );
-
-                HMONITOR cursorMonitor =
-                    MonitorFromPoint(
-                        pt,
-                        MONITOR_DEFAULTTONEAREST
-                    );
-
-                if (
-                    popupMonitor &&
-                    popupMonitor == cursorMonitor
-                ) {
-                    return popupMonitor;
-                }
-
-                return nullptr;
-            }
-        }
-
-        HWND parent =
-            GetParent(current);
-
-        HWND owner =
-            GetWindow(
-                current,
-                GW_OWNER
-            );
-
-        if (
-            parent &&
-            parent != current
-        ) {
-            current = parent;
-        } else if (
-            owner &&
-            owner != current
-        ) {
-            current = owner;
-        } else {
-            break;
+HMONITOR GetTaskbarPopupMonitor() {
+    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+        if (IsTaskbarContextMenuOpen(
+                g_taskbarStates[i].hwnd,
+                g_taskbarStates[i].monitor)) {
+            return g_taskbarStates[i].monitor;
         }
     }
 
@@ -1269,30 +1135,22 @@ HMONITOR GetCursorPopupMonitor() {
 }
 
 bool IsAltTabActive() {
-    HWND foreground =
-        GetForegroundWindow();
+    HWND foreground = GetForegroundWindow();
+    if (!foreground || !IsWindowVisible(foreground)) {
+        return false;
+    }
 
-    if (foreground) {
-        WCHAR className[128] = {};
-
-        if (
-            GetClassNameW(
-                foreground,
-                className,
-                ARRAYSIZE(className)
-            ) != 0 &&
-            wcscmp(
-                className,
-                L"#32771"
-            ) == 0
-        ) {
-            return true;
-        }
+    WCHAR className[128] = {};
+    if (!GetClassNameW(
+            foreground,
+            className,
+            ARRAYSIZE(className))) {
+        return false;
     }
 
     return
-        (GetAsyncKeyState(VK_MENU) & 0x8000) != 0 &&
-        (GetAsyncKeyState(VK_TAB) & 0x8000) != 0;
+        wcscmp(className, L"TaskSwitcherWnd") == 0 ||
+        wcscmp(className, L"MultitaskingViewFrame") == 0;
 }
 
 void UpdateTaskbarState() {
@@ -1377,13 +1235,11 @@ void UpdateTaskbarState() {
             cursorMonitor
         );
 
+    // Keep the taskbar visible for an open shell context menu/overflow
+    // surface even after the cursor leaves the popup. This prevents the
+    // desktop-only hide logic from hiding the taskbar while its menu is open.
     HMONITOR popupMonitor =
-        GetForegroundShellPopupMonitor();
-
-    if (!popupMonitor) {
-        popupMonitor =
-            GetCursorPopupMonitor();
-    }
+        GetTaskbarPopupMonitor();
 
     if (popupMonitor) {
         g_hoverActive = false;
@@ -1398,9 +1254,7 @@ void UpdateTaskbarState() {
                 state,
                 state.monitor == popupMonitor ||
                 !state.desktopOnly ||
-                !ShouldHideMonitor(
-                    state.monitorNumber
-                )
+                !ShouldHideTaskbar(state)
             );
         }
 
@@ -1413,9 +1267,13 @@ void UpdateTaskbarState() {
         g_hoverDeadline = 0;
 
         for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+            TaskbarMonitorState& state =
+                g_taskbarStates[i];
+
             SetTaskbarState(
-                g_taskbarStates[i],
-                true
+                state,
+                !state.desktopOnly ||
+                !ShouldHideTaskbar(state)
             );
         }
 
@@ -1435,9 +1293,7 @@ void UpdateTaskbarState() {
                 state,
                 state.monitor == g_hoverMonitor ||
                 !state.desktopOnly ||
-                !ShouldHideMonitor(
-                    state.monitorNumber
-                )
+                !ShouldHideTaskbar(state)
             );
         }
 
@@ -1574,6 +1430,77 @@ bool IsCursorInConfiguredHoverZone() {
 }
 
 
+void PostRefresh() {
+    if (
+        InterlockedExchange(
+            &g_refreshPosted,
+            1
+        ) != 0
+    ) {
+        return;
+    }
+
+    if (!PostThreadMessageW(
+            g_workerThreadId,
+            WM_APP_REFRESH,
+            0,
+            0
+        )) {
+        InterlockedExchange(
+            &g_refreshPosted,
+            0
+        );
+    }
+}
+
+
+LRESULT CALLBACK LowLevelMouseProc(
+    int code,
+    WPARAM message,
+    LPARAM lParam
+) {
+    if (
+        code == HC_ACTION &&
+        message == WM_MOUSEMOVE
+    ) {
+        const MSLLHOOKSTRUCT* mouse =
+            reinterpret_cast<const MSLLHOOKSTRUCT*>(lParam);
+
+        if (mouse) {
+            HMONITOR monitor =
+                MonitorFromPoint(
+                    mouse->pt,
+                    MONITOR_DEFAULTTONEAREST
+                );
+
+            MONITORINFO mi = {};
+            mi.cbSize = sizeof(mi);
+
+            if (
+                monitor &&
+                GetMonitorInfoW(
+                    monitor,
+                    &mi
+                ) &&
+                mouse->pt.y >=
+                    mi.rcMonitor.bottom - 256 &&
+                mouse->pt.y <
+                    mi.rcMonitor.bottom
+            ) {
+                PostRefresh();
+            }
+        }
+    }
+
+    return CallNextHookEx(
+        g_mouseHook,
+        code,
+        message,
+        lParam
+    );
+}
+
+
 void CALLBACK WinEventProc(
     HWINEVENTHOOK,
     DWORD event,
@@ -1639,24 +1566,65 @@ void CALLBACK WinEventProc(
         return;
     }
 
-    if (
-        InterlockedExchange(
-            &g_refreshPosted,
-            1
-        ) == 0
-    ) {
-        if (!PostThreadMessageW(
-                g_workerThreadId,
-                WM_APP_REFRESH,
-                0,
-                0
-            )) {
-            InterlockedExchange(
-                &g_refreshPosted,
-                0
-            );
+    PostRefresh();
+}
+
+
+void EnsureTaskbarShowHook() {
+    HWND taskbar =
+        FindWindowW(
+            L"Shell_TrayWnd",
+            nullptr
+        );
+
+    DWORD explorerPid = 0;
+    if (taskbar) {
+        GetWindowThreadProcessId(
+            taskbar,
+            &explorerPid
+        );
+    }
+
+    if (explorerPid == g_taskbarShowHookProcessId) {
+        return;
+    }
+
+    if (g_taskbarShowHook) {
+        UnhookWinEvent(g_taskbarShowHook);
+        g_taskbarShowHook = nullptr;
+        g_taskbarShowHookProcessId = 0;
+    }
+
+    if (explorerPid) {
+        g_taskbarShowHook = SetWinEventHook(
+            EVENT_OBJECT_SHOW,
+            EVENT_OBJECT_SHOW,
+            nullptr,
+            WinEventProc,
+            explorerPid,
+            0,
+            WINEVENT_OUTOFCONTEXT
+        );
+
+        if (g_taskbarShowHook) {
+            g_taskbarShowHookProcessId = explorerPid;
         }
     }
+}
+
+
+bool HasHiddenTaskbar() {
+    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+        if (
+            g_taskbarStates[i].hwnd &&
+            !IsWindowVisible(g_taskbarStates[i].hwnd) &&
+            ShouldHideTaskbar(g_taskbarStates[i])
+        ) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 
@@ -1712,26 +1680,32 @@ DWORD WINAPI WorkerThread(
             WINEVENT_OUTOFCONTEXT
         );
 
-    g_taskbarShowHook =
-        SetWinEventHook(
-            EVENT_OBJECT_SHOW,
-            EVENT_OBJECT_SHOW,
-            nullptr,
-            WinEventProc,
-            0,
-            0,
-            WINEVENT_OUTOFCONTEXT
-        );
-
+    EnsureTaskbarShowHook();
     UpdateTaskbarState();
 
-    const UINT kPollIntervalMs = 250;
+    const UINT kIdlePollIntervalMs = 1000;
+    const UINT kHiddenPollIntervalMs = 250;
+    const UINT kHoverPollIntervalMs = 50;
+
+    g_mouseHook =
+        SetWindowsHookExW(
+            WH_MOUSE_LL,
+            LowLevelMouseProc,
+            nullptr,
+            0
+        );
+
+    if (!g_mouseHook) {
+        Wh_Log(
+            L"SetWindowsHookExW(WH_MOUSE_LL) failed; timer remains fallback"
+        );
+    }
 
     UINT_PTR timerId =
         SetTimer(
             nullptr,
             1,
-            kPollIntervalMs,
+            kIdlePollIntervalMs,
             nullptr
         );
 
@@ -1749,7 +1723,22 @@ DWORD WINAPI WorkerThread(
         }
 
         if (msg.message == WM_TIMER) {
+            EnsureTaskbarShowHook();
             UpdateTaskbarState();
+
+            if (timerId) {
+                SetTimer(
+                    nullptr,
+                    timerId,
+                    g_hoverActive
+                        ? kHoverPollIntervalMs
+                        : HasHiddenTaskbar()
+                            ? kHiddenPollIntervalMs
+                            : kIdlePollIntervalMs,
+                    nullptr
+                );
+            }
+
             continue;
         }
 
@@ -1759,23 +1748,61 @@ DWORD WINAPI WorkerThread(
                 0
             );
 
+            EnsureTaskbarShowHook();
             UpdateTaskbarState();
+
+            if (timerId) {
+                SetTimer(
+                    nullptr,
+                    timerId,
+                    g_hoverActive
+                        ? kHoverPollIntervalMs
+                        : HasHiddenTaskbar()
+                            ? kHiddenPollIntervalMs
+                            : kIdlePollIntervalMs,
+                    nullptr
+                );
+            }
+
             continue;
         }
 
         if (msg.message == WM_APP_SETTINGS) {
-            InterlockedExchange(
-                &g_refreshPosted,
-                0
-            );
-
             LoadSettings();
+            EnsureTaskbarShowHook();
             UpdateTaskbarState();
+
+            if (timerId) {
+                SetTimer(
+                    nullptr,
+                    timerId,
+                    g_hoverActive
+                        ? kHoverPollIntervalMs
+                        : HasHiddenTaskbar()
+                            ? kHiddenPollIntervalMs
+                            : kIdlePollIntervalMs,
+                    nullptr
+                );
+            }
+
             continue;
         }
 
         TranslateMessage(&msg);
         DispatchMessageW(&msg);
+
+        if (timerId) {
+            SetTimer(
+                nullptr,
+                timerId,
+                g_hoverActive
+                    ? kHoverPollIntervalMs
+                    : HasHiddenTaskbar()
+                        ? kHiddenPollIntervalMs
+                        : kIdlePollIntervalMs,
+                nullptr
+            );
+        }
     }
 
     if (timerId) {
@@ -1811,6 +1838,14 @@ DWORD WINAPI WorkerThread(
             g_taskbarShowHook
         );
         g_taskbarShowHook = nullptr;
+        g_taskbarShowHookProcessId = 0;
+    }
+
+    if (g_mouseHook) {
+        UnhookWindowsHookEx(
+            g_mouseHook
+        );
+        g_mouseHook = nullptr;
     }
 
     return 0;

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -1,0 +1,1560 @@
+// ==WindhawkMod==
+// @id              hide-taskbar-only-on-desktop
+// @name            Hide Taskbar Only on Desktop
+// @description     Hides the taskbar on the desktop, shows it for other windows or when you hover near the bottom edge.
+// @version         1.1.0
+// @author          Sahil Dashoni
+// @github          https://github.com/Sahil-Dashoni
+// @include         explorer.exe
+// @compilerOptions -ldwmapi
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+
+/*
+
+# Hide Taskbar Only on Desktop
+
+Hides the Windows taskbar while the desktop is active and shows it again
+when an application or supported Windows shell UI is active.
+
+## Features
+
+- Hides the taskbar when on the desktop.
+- Shows the taskbar when an application is active.
+- Reveals the taskbar when the mouse enters the bottom-edge hover area.
+- Automatically matches the hover area to the current taskbar height.
+- Supports an additional configurable hover margin.
+- Uses a configurable delay when hiding after mouse hover.
+- Hides immediately after minimizing or closing the last application.
+- Keeps the taskbar visible while interacting with taskbar buttons.
+- Supports secondary taskbars on additional monitors.
+
+## Settings
+
+### Extra hover margin
+
+Adds additional space above the automatically detected taskbar-height
+reveal zone.
+
+Default: 5 mm
+
+### Auto-hide delay after hover
+
+Controls how long the taskbar remains visible after the mouse leaves
+the bottom reveal area.
+
+Default: 700 ms
+
+This delay only applies when the taskbar was revealed by mouse hover.
+
+### Hide secondary taskbars
+
+Controls whether taskbars on additional monitors are also hidden.
+
+Default: enabled
+
+*/
+
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+
+/*
+
+- extraHoverMarginMm: 5
+  $name: Extra hover margin (mm)
+  $description: Adds extra space above the automatically detected taskbar-height reveal zone.
+
+- autoHideDelayMs: 700
+  $name: Auto-hide delay after hover (ms)
+  $description: How long to wait after the mouse leaves the bottom-edge hover zone before hiding the taskbar.
+
+- hideSecondaryTaskbars: true
+  $name: Hide secondary taskbars
+  $description: Also hide and show taskbars on additional monitors.
+
+*/
+
+// ==/WindhawkModSettings==
+
+#include <windows.h>
+#include <dwmapi.h>
+
+
+// ============================================================
+// Settings
+// ============================================================
+
+struct {
+    int extraHoverMarginMm;
+    DWORD autoHideDelayMs;
+    bool hideSecondaryTaskbars;
+} settings;
+
+
+// ============================================================
+// Global state
+// ============================================================
+
+HWINEVENTHOOK g_hWinEventHookForeground = nullptr;
+
+HANDLE g_hThread = nullptr;
+HANDLE g_stopEvent = nullptr;
+
+DWORD g_threadId = 0;
+
+bool g_taskbarHidden = false;
+bool g_onDesktopState = false;
+bool g_shownDueToHover = false;
+
+ULONGLONG g_hideDeadline = 0;
+
+
+// ============================================================
+// Desktop detection
+// ============================================================
+
+bool IsDesktopWindow(HWND hwnd) {
+
+    if (!hwnd)
+        return false;
+
+
+    WCHAR className[256] = {};
+
+    if (GetClassNameW(
+            hwnd,
+            className,
+            ARRAYSIZE(className)
+        ) == 0) {
+
+        return false;
+    }
+
+
+    if (wcscmp(
+            className,
+            L"Progman"
+        ) == 0) {
+
+        return true;
+    }
+
+
+    if (wcscmp(
+            className,
+            L"WorkerW"
+        ) == 0) {
+
+        return FindWindowExW(
+                   hwnd,
+                   nullptr,
+                   L"SHELLDLL_DefView",
+                   nullptr
+               ) != nullptr;
+    }
+
+
+    return false;
+}
+
+
+// ============================================================
+// Explorer / shell window classes
+// ============================================================
+
+bool IsShellChromeClass(
+    const WCHAR* className
+) {
+
+    static const WCHAR* kShellClasses[] = {
+
+        L"Progman",
+        L"WorkerW",
+
+        L"Shell_TrayWnd",
+        L"Shell_SecondaryTrayWnd",
+
+        L"Windows.UI.Core.CoreWindow",
+        L"Xaml_WindowedPopupClass",
+
+        L"TaskListThumbnailWnd",
+        L"SysShadow",
+
+        L"tooltips_class32",
+        L"MSCTFIME UI",
+        L"IME",
+    };
+
+
+    for (
+        const WCHAR* shellClass :
+        kShellClasses
+    ) {
+
+        if (wcscmp(
+                className,
+                shellClass
+            ) == 0) {
+
+            return true;
+        }
+    }
+
+
+    return false;
+}
+
+
+// ============================================================
+// Find any visible application window
+// ============================================================
+
+BOOL CALLBACK EnumWindowsProc(
+    HWND hwnd,
+    LPARAM lParam
+) {
+
+    bool* pFoundOther =
+        reinterpret_cast<bool*>(lParam);
+
+
+    if (!IsWindowVisible(hwnd) ||
+        IsIconic(hwnd)) {
+
+        return TRUE;
+    }
+
+
+    /*
+        Ignore owned popup windows such as
+        tooltips and dropdowns.
+    */
+
+    if (GetWindow(
+            hwnd,
+            GW_OWNER
+        ) != nullptr) {
+
+        return TRUE;
+    }
+
+
+    WCHAR className[256] = {};
+
+
+    /*
+        IMPORTANT:
+        Check GetClassNameW's return value.
+    */
+
+    if (GetClassNameW(
+            hwnd,
+            className,
+            ARRAYSIZE(className)
+        ) == 0) {
+
+        return TRUE;
+    }
+
+
+    if (IsShellChromeClass(
+            className
+        )) {
+
+        return TRUE;
+    }
+
+
+    LONG_PTR exStyle =
+        GetWindowLongPtrW(
+            hwnd,
+            GWL_EXSTYLE
+        );
+
+
+    if (exStyle &
+        WS_EX_TOOLWINDOW) {
+
+        return TRUE;
+    }
+
+
+    /*
+        Ignore cloaked windows, for example
+        applications on another virtual desktop.
+    */
+
+    BOOL cloaked = FALSE;
+
+
+    if (SUCCEEDED(
+            DwmGetWindowAttribute(
+                hwnd,
+                DWMWA_CLOAKED,
+                &cloaked,
+                sizeof(cloaked)
+            )
+        ) &&
+        cloaked) {
+
+        return TRUE;
+    }
+
+
+    RECT rect{};
+
+
+    if (!GetWindowRect(
+            hwnd,
+            &rect
+        )) {
+
+        return TRUE;
+    }
+
+
+    if (rect.right <= rect.left ||
+        rect.bottom <= rect.top) {
+
+        return TRUE;
+    }
+
+
+    *pFoundOther = true;
+
+
+    /*
+        We found one valid visible window.
+    */
+
+    return FALSE;
+}
+
+
+bool AnyOtherVisibleWindowExists() {
+
+    bool found = false;
+
+
+    EnumWindows(
+        EnumWindowsProc,
+        reinterpret_cast<LPARAM>(
+            &found
+        )
+    );
+
+
+    return found;
+}
+
+
+// ============================================================
+// Foreground-window classification
+// ============================================================
+
+bool IsAmbiguousForegroundClass(
+    const WCHAR* className
+) {
+
+    /*
+        The taskbar's base windows can temporarily
+        become the foreground window.
+
+        In that case we use EnumWindows to determine
+        whether another application is actually active.
+    */
+
+    return wcscmp(
+               className,
+               L"Shell_TrayWnd"
+           ) == 0 ||
+
+           wcscmp(
+               className,
+               L"Shell_SecondaryTrayWnd"
+           ) == 0;
+}
+
+
+// ============================================================
+// Refresh desktop state
+// ============================================================
+
+void RefreshDesktopState() {
+
+    HWND foreground =
+        GetForegroundWindow();
+
+
+    /*
+        No foreground window.
+    */
+
+    if (!foreground) {
+
+        g_onDesktopState =
+            !AnyOtherVisibleWindowExists();
+
+        return;
+    }
+
+
+    /*
+        Actual desktop window.
+    */
+
+    if (IsDesktopWindow(
+            foreground
+        )) {
+
+        g_onDesktopState =
+            true;
+
+        return;
+    }
+
+
+    /*
+        Minimized foreground window.
+
+        Check whether another visible application exists.
+    */
+
+    if (IsIconic(
+            foreground
+        )) {
+
+        g_onDesktopState =
+            !AnyOtherVisibleWindowExists();
+
+        return;
+    }
+
+
+    WCHAR className[256] = {};
+
+
+    if (GetClassNameW(
+            foreground,
+            className,
+            ARRAYSIZE(className)
+        ) != 0) {
+
+        if (IsAmbiguousForegroundClass(
+                className
+            )) {
+
+            g_onDesktopState =
+                !AnyOtherVisibleWindowExists();
+
+            return;
+        }
+    }
+
+
+    /*
+        Any other non-minimized foreground window means
+        we are not on the empty desktop.
+
+        This also covers supported shell UI such as
+        Start and notification panels.
+    */
+
+    g_onDesktopState =
+        false;
+}
+
+
+// ============================================================
+// Taskbar visibility
+// ============================================================
+
+void SetTaskbarVisibility(
+    bool show
+) {
+
+    HWND hTaskbar =
+        FindWindowW(
+            L"Shell_TrayWnd",
+            nullptr
+        );
+
+
+    if (hTaskbar) {
+
+        ShowWindow(
+            hTaskbar,
+            show
+                ? SW_SHOW
+                : SW_HIDE
+        );
+    }
+
+
+    if (!settings.hideSecondaryTaskbars)
+        return;
+
+
+    HWND hSecondary = nullptr;
+
+
+    while (
+        (hSecondary =
+            FindWindowExW(
+                nullptr,
+                hSecondary,
+                L"Shell_SecondaryTrayWnd",
+                nullptr
+            )) != nullptr
+    ) {
+
+        ShowWindow(
+            hSecondary,
+            show
+                ? SW_SHOW
+                : SW_HIDE
+        );
+    }
+}
+
+
+// ============================================================
+// Hover-zone size
+// ============================================================
+
+int GetHoverZonePx(
+    HWND hTaskbar,
+    UINT dpi
+) {
+
+    /*
+        Convert millimeters to pixels.
+
+        25.4 mm = 1 inch.
+    */
+
+    int marginPx =
+        MulDiv(
+            settings.extraHoverMarginMm,
+            static_cast<int>(dpi),
+            254
+        );
+
+
+    if (marginPx < 0)
+        marginPx = 0;
+
+
+    /*
+        Prefer the actual taskbar height.
+    */
+
+    RECT taskbarRect{};
+
+
+    if (hTaskbar &&
+        GetWindowRect(
+            hTaskbar,
+            &taskbarRect
+        )) {
+
+        int taskbarHeight =
+            taskbarRect.bottom -
+            taskbarRect.top;
+
+
+        if (taskbarHeight > 0) {
+
+            return taskbarHeight +
+                   marginPx;
+        }
+    }
+
+
+    /*
+        Fallback for the short period where
+        Explorer has not created the taskbar yet.
+    */
+
+    int fallbackHeight =
+        MulDiv(
+            48,
+            static_cast<int>(dpi),
+            96
+        );
+
+
+    return fallbackHeight +
+           marginPx;
+}
+
+
+// ============================================================
+// Find taskbar belonging to a monitor
+// ============================================================
+
+HWND FindTaskbarForMonitor(
+    HMONITOR hMonitor
+) {
+
+    if (!hMonitor)
+        return nullptr;
+
+
+    /*
+        First look for the primary-style taskbar.
+    */
+
+    HWND hTaskbar = nullptr;
+
+
+    while (
+        (hTaskbar =
+            FindWindowExW(
+                nullptr,
+                hTaskbar,
+                L"Shell_TrayWnd",
+                nullptr
+            )) != nullptr
+    ) {
+
+        RECT rect{};
+
+
+        if (!GetWindowRect(
+                hTaskbar,
+                &rect
+            )) {
+
+            continue;
+        }
+
+
+        POINT center{
+            rect.left +
+                (rect.right - rect.left) / 2,
+
+            rect.top +
+                (rect.bottom - rect.top) / 2
+        };
+
+
+        if (
+            MonitorFromPoint(
+                center,
+                MONITOR_DEFAULTTONEAREST
+            ) == hMonitor
+        ) {
+
+            return hTaskbar;
+        }
+    }
+
+
+    /*
+        Then look for secondary taskbars.
+    */
+
+    hTaskbar = nullptr;
+
+
+    while (
+        (hTaskbar =
+            FindWindowExW(
+                nullptr,
+                hTaskbar,
+                L"Shell_SecondaryTrayWnd",
+                nullptr
+            )) != nullptr
+    ) {
+
+        RECT rect{};
+
+
+        if (!GetWindowRect(
+                hTaskbar,
+                &rect
+            )) {
+
+            continue;
+        }
+
+
+        POINT center{
+            rect.left +
+                (rect.right - rect.left) / 2,
+
+            rect.top +
+                (rect.bottom - rect.top) / 2
+        };
+
+
+        if (
+            MonitorFromPoint(
+                center,
+                MONITOR_DEFAULTTONEAREST
+            ) == hMonitor
+        ) {
+
+            return hTaskbar;
+        }
+    }
+
+
+    return nullptr;
+}
+
+
+// ============================================================
+// Bottom-edge detection
+// ============================================================
+
+bool IsCursorNearBottomEdge() {
+
+    POINT pt{};
+
+
+    if (!GetCursorPos(
+            &pt
+        )) {
+
+        return false;
+    }
+
+
+    HMONITOR hMonitor =
+        MonitorFromPoint(
+            pt,
+            MONITOR_DEFAULTTONEAREST
+        );
+
+
+    if (!hMonitor)
+        return false;
+
+
+    MONITORINFO monitorInfo{
+        sizeof(monitorInfo)
+    };
+
+
+    if (!GetMonitorInfoW(
+            hMonitor,
+            &monitorInfo
+        )) {
+
+        return false;
+    }
+
+
+    /*
+        RECT.right is an exclusive boundary.
+
+        Therefore >= is used here rather than >.
+    */
+
+    if (
+        pt.x <
+            monitorInfo.rcMonitor.left ||
+
+        pt.x >=
+            monitorInfo.rcMonitor.right
+    ) {
+
+        return false;
+    }
+
+
+    /*
+        Find the taskbar belonging to the monitor
+        where the mouse currently is.
+
+        This fixes the multi-monitor issue where
+        the primary taskbar's height was previously
+        used for every monitor.
+    */
+
+    HWND hTaskbar =
+        FindTaskbarForMonitor(
+            hMonitor
+        );
+
+
+    UINT dpi = 96;
+
+
+    if (hTaskbar) {
+
+        UINT taskbarDpi =
+            GetDpiForWindow(
+                hTaskbar
+            );
+
+
+        if (taskbarDpi != 0)
+            dpi = taskbarDpi;
+    }
+
+
+    int hotZonePx =
+        GetHoverZonePx(
+            hTaskbar,
+            dpi
+        );
+
+
+    if (hotZonePx < 1)
+        hotZonePx = 1;
+
+
+    return pt.y >=
+               monitorInfo.rcMonitor.bottom -
+                   hotZonePx &&
+
+           pt.y <
+               monitorInfo.rcMonitor.bottom;
+}
+
+
+// ============================================================
+// Main taskbar state logic
+// ============================================================
+
+void UpdateTaskbarState() {
+
+    bool hovering =
+        IsCursorNearBottomEdge();
+
+
+    /*
+        --------------------------------------------------------
+        APPLICATION / SHELL UI ACTIVE
+        --------------------------------------------------------
+    */
+
+    if (!g_onDesktopState) {
+
+        /*
+            A real window is active.
+
+            Always show immediately.
+        */
+
+        g_hideDeadline = 0;
+
+        g_shownDueToHover = false;
+
+
+        if (g_taskbarHidden) {
+
+            SetTaskbarVisibility(
+                true
+            );
+
+            g_taskbarHidden =
+                false;
+        }
+
+
+        return;
+    }
+
+
+    /*
+        --------------------------------------------------------
+        DESKTOP + MOUSE IN REVEAL ZONE
+        --------------------------------------------------------
+    */
+
+    if (hovering) {
+
+        g_hideDeadline = 0;
+
+        g_shownDueToHover = true;
+
+
+        if (g_taskbarHidden) {
+
+            SetTaskbarVisibility(
+                true
+            );
+
+            g_taskbarHidden =
+                false;
+        }
+
+
+        return;
+    }
+
+
+    /*
+        --------------------------------------------------------
+        DESKTOP + MOUSE OUTSIDE REVEAL ZONE
+        --------------------------------------------------------
+    */
+
+    if (g_taskbarHidden) {
+
+        g_hideDeadline = 0;
+
+        return;
+    }
+
+
+    /*
+        If the taskbar was visible for another reason
+        such as minimizing/closing a window, hide it
+        immediately.
+
+        The hover delay is NOT used here.
+    */
+
+    if (!g_shownDueToHover) {
+
+        SetTaskbarVisibility(
+            false
+        );
+
+        g_taskbarHidden =
+            true;
+
+        g_hideDeadline = 0;
+
+        return;
+    }
+
+
+    /*
+        --------------------------------------------------------
+        MOUSE-TRIGGERED HIDE DELAY
+        --------------------------------------------------------
+
+        This is the ONLY situation where the delay applies.
+    */
+
+    ULONGLONG now =
+        GetTickCount64();
+
+
+    if (g_hideDeadline == 0) {
+
+        g_hideDeadline =
+            now +
+            settings.autoHideDelayMs;
+
+    }
+    else if (
+        now >=
+        g_hideDeadline
+    ) {
+
+        SetTaskbarVisibility(
+            false
+        );
+
+        g_taskbarHidden =
+            true;
+
+        g_hideDeadline = 0;
+
+        g_shownDueToHover =
+            false;
+    }
+}
+
+
+// ============================================================
+// WinEvent callback
+// ============================================================
+
+void CALLBACK WinEventProc(
+    HWINEVENTHOOK hWinEventHook,
+    DWORD event,
+    HWND hwnd,
+    LONG idObject,
+    LONG idChild,
+    DWORD idEventThread,
+    DWORD dwmsEventTime
+) {
+
+    UNREFERENCED_PARAMETER(
+        hWinEventHook
+    );
+
+    UNREFERENCED_PARAMETER(
+        hwnd
+    );
+
+    UNREFERENCED_PARAMETER(
+        idEventThread
+    );
+
+    UNREFERENCED_PARAMETER(
+        dwmsEventTime
+    );
+
+
+    if (
+        event !=
+            EVENT_SYSTEM_FOREGROUND ||
+
+        idObject !=
+            OBJID_WINDOW ||
+
+        idChild !=
+            CHILDID_SELF
+    ) {
+
+        return;
+    }
+
+
+    /*
+        Immediately react to foreground changes.
+    */
+
+    RefreshDesktopState();
+
+    UpdateTaskbarState();
+}
+
+
+// ============================================================
+// Timer callback
+// ============================================================
+
+void CALLBACK TimerProc(
+    HWND hwnd,
+    UINT uMsg,
+    UINT_PTR idEvent,
+    DWORD dwTime
+) {
+
+    UNREFERENCED_PARAMETER(
+        hwnd
+    );
+
+    UNREFERENCED_PARAMETER(
+        uMsg
+    );
+
+    UNREFERENCED_PARAMETER(
+        idEvent
+    );
+
+    UNREFERENCED_PARAMETER(
+        dwTime
+    );
+
+
+    /*
+        Periodic verification catches cases such as:
+
+        - minimizing the last window
+        - closing the last window
+        - Explorer shell transitions
+        - taskbar recreation
+    */
+
+    RefreshDesktopState();
+
+    UpdateTaskbarState();
+}
+
+
+// ============================================================
+// Worker thread
+// ============================================================
+
+DWORD WINAPI HookThread(
+    LPVOID param
+) {
+
+    UNREFERENCED_PARAMETER(
+        param
+    );
+
+
+    /*
+        Force creation of this thread's message queue.
+
+        This is done before the worker starts depending
+        on message delivery.
+    */
+
+    MSG initMsg{};
+
+
+    PeekMessageW(
+        &initMsg,
+        nullptr,
+        WM_USER,
+        WM_USER,
+        PM_NOREMOVE
+    );
+
+
+    /*
+        Install foreground WinEvent hook.
+    */
+
+    g_hWinEventHookForeground =
+        SetWinEventHook(
+            EVENT_SYSTEM_FOREGROUND,
+            EVENT_SYSTEM_FOREGROUND,
+            nullptr,
+            WinEventProc,
+            0,
+            0,
+            WINEVENT_OUTOFCONTEXT
+        );
+
+
+    if (!g_hWinEventHookForeground) {
+
+        Wh_Log(
+            L"SetWinEventHook failed: %lu",
+            GetLastError()
+        );
+    }
+
+
+    /*
+        Initial state.
+    */
+
+    RefreshDesktopState();
+
+    UpdateTaskbarState();
+
+
+    /*
+        Poll approximately 10 times per second.
+    */
+
+    const UINT kPollIntervalMs =
+        100;
+
+
+    UINT_PTR timerId =
+        SetTimer(
+            nullptr,
+            0,
+            kPollIntervalMs,
+            TimerProc
+        );
+
+
+    if (!timerId) {
+
+        Wh_Log(
+            L"SetTimer failed: %lu",
+            GetLastError()
+        );
+    }
+
+
+    /*
+        Wait for either:
+
+        - the stop event
+        - Windows messages
+
+        Using an event instead of PostThreadMessage(WM_QUIT)
+        makes shutdown reliable even during early initialization.
+    */
+
+    while (true) {
+
+        DWORD waitResult =
+            MsgWaitForMultipleObjects(
+                1,
+                &g_stopEvent,
+                FALSE,
+                INFINITE,
+                QS_ALLINPUT
+            );
+
+
+        /*
+            Stop requested.
+        */
+
+        if (
+            waitResult ==
+            WAIT_OBJECT_0
+        ) {
+
+            break;
+        }
+
+
+        /*
+            Messages are waiting.
+        */
+
+        if (
+            waitResult ==
+            WAIT_OBJECT_0 + 1
+        ) {
+
+            MSG msg{};
+
+
+            while (
+                PeekMessageW(
+                    &msg,
+                    nullptr,
+                    0,
+                    0,
+                    PM_REMOVE
+                )
+            ) {
+
+                /*
+                    If another component posts WM_QUIT,
+                    stop cleanly.
+                */
+
+                if (
+                    msg.message ==
+                    WM_QUIT
+                ) {
+
+                    SetEvent(
+                        g_stopEvent
+                    );
+
+                    break;
+                }
+
+
+                TranslateMessage(
+                    &msg
+                );
+
+
+                DispatchMessageW(
+                    &msg
+                );
+            }
+
+
+            if (
+                WaitForSingleObject(
+                    g_stopEvent,
+                    0
+                ) ==
+                WAIT_OBJECT_0
+            ) {
+
+                break;
+            }
+
+
+            continue;
+        }
+
+
+        /*
+            Unexpected wait failure.
+        */
+
+        Wh_Log(
+            L"MsgWaitForMultipleObjects failed: %lu",
+            GetLastError()
+        );
+
+        break;
+    }
+
+
+    /*
+        The worker owns these resources, so it cleans them
+        up before the thread exits.
+    */
+
+    if (timerId) {
+
+        KillTimer(
+            nullptr,
+            timerId
+        );
+    }
+
+
+    if (g_hWinEventHookForeground) {
+
+        UnhookWinEvent(
+            g_hWinEventHookForeground
+        );
+
+        g_hWinEventHookForeground =
+            nullptr;
+    }
+
+
+    return 0;
+}
+
+
+// ============================================================
+// Settings
+// ============================================================
+
+void LoadSettings() {
+
+    settings.extraHoverMarginMm =
+        Wh_GetIntSetting(
+            L"extraHoverMarginMm"
+        );
+
+
+    settings.autoHideDelayMs =
+        static_cast<DWORD>(
+            Wh_GetIntSetting(
+                L"autoHideDelayMs"
+            )
+        );
+
+
+    settings.hideSecondaryTaskbars =
+        Wh_GetIntSetting(
+            L"hideSecondaryTaskbars"
+        ) != 0;
+
+
+    /*
+        Safety limits.
+    */
+
+    if (
+        settings.extraHoverMarginMm <
+        0
+    ) {
+
+        settings.extraHoverMarginMm =
+            0;
+    }
+
+
+    if (
+        settings.extraHoverMarginMm >
+        50
+    ) {
+
+        settings.extraHoverMarginMm =
+            50;
+    }
+
+
+    if (
+        settings.autoHideDelayMs >
+        10000
+    ) {
+
+        settings.autoHideDelayMs =
+            10000;
+    }
+}
+
+
+// ============================================================
+// Windhawk initialization
+// ============================================================
+
+BOOL Wh_ModInit() {
+
+    Wh_Log(
+        L"Init"
+    );
+
+
+    LoadSettings();
+
+
+    /*
+        Manual-reset stop event.
+
+        The worker waits on this event while also
+        processing its message queue.
+    */
+
+    g_stopEvent =
+        CreateEventW(
+            nullptr,
+            TRUE,
+            FALSE,
+            nullptr
+        );
+
+
+    if (!g_stopEvent) {
+
+        Wh_Log(
+            L"CreateEvent failed: %lu",
+            GetLastError()
+        );
+
+        return FALSE;
+    }
+
+
+    /*
+        Start worker thread.
+    */
+
+    g_hThread =
+        CreateThread(
+            nullptr,
+            0,
+            HookThread,
+            nullptr,
+            0,
+            &g_threadId
+        );
+
+
+    if (!g_hThread) {
+
+        Wh_Log(
+            L"CreateThread failed: %lu",
+            GetLastError()
+        );
+
+
+        CloseHandle(
+            g_stopEvent
+        );
+
+
+        g_stopEvent =
+            nullptr;
+
+        g_threadId =
+            0;
+
+
+        return FALSE;
+    }
+
+
+    return TRUE;
+}
+
+
+// ============================================================
+// Windhawk uninitialization
+// ============================================================
+
+void Wh_ModUninit() {
+
+    Wh_Log(
+        L"Uninit"
+    );
+
+
+    /*
+        Tell the worker to stop.
+    */
+
+    if (g_stopEvent) {
+
+        SetEvent(
+            g_stopEvent
+        );
+    }
+
+
+    /*
+        IMPORTANT:
+
+        Wait until the worker has actually exited before
+        closing its handle or allowing the mod to unload.
+
+        This prevents the worker from executing code from
+        the unloaded mod.
+    */
+
+    if (g_hThread) {
+
+        WaitForSingleObject(
+            g_hThread,
+            INFINITE
+        );
+
+
+        CloseHandle(
+            g_hThread
+        );
+
+
+        g_hThread =
+            nullptr;
+    }
+
+
+    g_threadId =
+        0;
+
+
+    if (g_stopEvent) {
+
+        CloseHandle(
+            g_stopEvent
+        );
+
+
+        g_stopEvent =
+            nullptr;
+    }
+
+
+    /*
+        Always restore the taskbar when the mod is disabled.
+    */
+
+    SetTaskbarVisibility(
+        true
+    );
+
+
+    g_taskbarHidden =
+        false;
+
+    g_onDesktopState =
+        false;
+
+    g_shownDueToHover =
+        false;
+
+    g_hideDeadline =
+        0;
+}
+
+
+// ============================================================
+// Settings changed
+// ============================================================
+
+void Wh_ModSettingsChanged() {
+
+    Wh_Log(
+        L"SettingsChanged"
+    );
+
+
+    LoadSettings();
+
+
+    /*
+        The worker's 100 ms polling cycle will pick up
+        the new settings.
+
+        No cross-thread message or resource manipulation
+        is needed here.
+    */
+}

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,10 +2,11 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Hides selected taskbars only while their display is showing the desktop
-// @version         3.6.0
+// @version         3.5.5
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
+// @include         explorer.exe
 // @compilerOptions -ldwmapi
 // ==/WindhawkMod==
 
@@ -17,9 +18,11 @@ Hides each selected taskbar when its own display has no visible,
 non-minimized application window, and shows it again when an application or
 relevant Windows shell interaction requires it.
 
-The mod is implemented as a Windhawk tool in a dedicated `windhawk.exe` process
-instead of being injected into `explorer.exe`. This avoids one worker copy
-per Explorer process and keeps the state-management code outside the shell.
+The mod uses a dedicated `windhawk.exe` process as its state manager instead of
+running the full state-management logic inside `explorer.exe`. A small
+Explorer-side hook is used only to prevent the specific secondary-taskbar
+`SW_SHOWNA` transition that Explorer can issue after this mod has hidden that
+taskbar.
 
 ### Behavior
 
@@ -97,8 +100,8 @@ already recreated a taskbar, restarting Explorer may still be required.
 
 ### Process and state model
 
-The mod runs as a dedicated Windhawk tool process. A single worker thread
-owns the mutable runtime state and settings. Window-state WinEvents request
+The mod runs its mutable state and settings in a dedicated Windhawk tool process.
+A minimal Explorer-side hook handles one shell visibility operation. Window-state WinEvents request
 an immediate reconciliation, while a periodic safety poll handles missed
 or unusual transitions.
 
@@ -260,6 +263,127 @@ SRWLOCK g_cursorHoverSnapshotLock = SRWLOCK_INIT;
 
 constexpr wchar_t kHiddenByModProperty[] =
     L"Windhawk.HideTaskbarOnlyOnDesktop.HiddenByMod";
+
+// Explorer-side protection for the secondary-taskbar shell transition.
+// The dedicated tool process remains authoritative for taskbar state. Explorer
+// only consults the per-window property and blocks SW_SHOWNA for an explicitly
+// hidden secondary taskbar.
+using ShowWindow_t = BOOL (WINAPI*)(HWND, int);
+
+ShowWindow_t g_explorerShowWindowOriginal = nullptr;
+void* g_explorerShowWindowTarget = nullptr;
+bool g_isExplorerProcess = false;
+
+bool IsExplorerSecondaryTaskbar(HWND hwnd) {
+    if (!hwnd) {
+        return false;
+    }
+
+    WCHAR className[128] = {};
+
+    if (
+        GetClassNameW(
+            hwnd,
+            className,
+            ARRAYSIZE(className)
+        ) == 0
+    ) {
+        return false;
+    }
+
+    return wcscmp(
+        className,
+        L"Shell_SecondaryTrayWnd"
+    ) == 0;
+}
+
+bool IsSecondaryTaskbarHiddenByMod(HWND hwnd) {
+    return
+        IsExplorerSecondaryTaskbar(hwnd) &&
+        GetPropW(
+            hwnd,
+            kHiddenByModProperty
+        ) != nullptr;
+}
+
+BOOL WINAPI ExplorerShowWindowHook(
+    HWND hwnd,
+    int nCmdShow
+) {
+    if (
+        nCmdShow == SW_SHOWNA &&
+        IsSecondaryTaskbarHiddenByMod(hwnd)
+    ) {
+        return FALSE;
+    }
+
+    return g_explorerShowWindowOriginal(
+        hwnd,
+        nCmdShow
+    );
+}
+
+bool InstallExplorerVisibilityHook() {
+    HMODULE user32 =
+        GetModuleHandleW(L"user32.dll");
+
+    if (!user32) {
+        Wh_Log(
+            L"GetModuleHandleW(user32.dll) failed: %lu",
+            GetLastError()
+        );
+        return false;
+    }
+
+    g_explorerShowWindowTarget =
+        reinterpret_cast<void*>(
+            GetProcAddress(
+                user32,
+                "ShowWindow"
+            )
+        );
+
+    if (!g_explorerShowWindowTarget) {
+        Wh_Log(
+            L"GetProcAddress(ShowWindow) failed: %lu",
+            GetLastError()
+        );
+        return false;
+    }
+
+    if (
+        Wh_SetFunctionHook(
+            g_explorerShowWindowTarget,
+            reinterpret_cast<void*>(ExplorerShowWindowHook),
+            reinterpret_cast<void**>(&g_explorerShowWindowOriginal)
+        ) == FALSE
+    ) {
+        Wh_Log(
+            L"Failed to hook Explorer ShowWindow"
+        );
+        g_explorerShowWindowTarget = nullptr;
+        return false;
+    }
+
+    return true;
+}
+
+void UninstallExplorerVisibilityHook() {
+    if (g_explorerShowWindowTarget) {
+        if (
+            Wh_RemoveFunctionHook(
+                g_explorerShowWindowTarget
+            ) == FALSE
+        ) {
+            Wh_Log(
+                L"Failed to remove Explorer ShowWindow hook"
+            );
+        }
+
+        g_explorerShowWindowTarget = nullptr;
+        g_explorerShowWindowOriginal = nullptr;
+    }
+}
 
 HWND g_workerMessageWindow = nullptr;
 ATOM g_workerWindowClassAtom = 0;
@@ -3008,8 +3132,43 @@ BOOL Wh_ModInit() {
 
     LocalFree(argv);
 
+    WCHAR modulePath[MAX_PATH] = {};
+    DWORD moduleLength =
+        GetModuleFileNameW(
+            nullptr,
+            modulePath,
+            ARRAYSIZE(modulePath)
+        );
+
+    if (
+        moduleLength == 0 ||
+        moduleLength >= ARRAYSIZE(modulePath)
+    ) {
+        Wh_Log(
+            L"GetModuleFileNameW failed: %lu",
+            GetLastError()
+        );
+        return FALSE;
+    }
+
+    const WCHAR* moduleName =
+        wcsrchr(modulePath, L'\\');
+
+    moduleName = moduleName
+        ? moduleName + 1
+        : modulePath;
+
+    g_isExplorerProcess =
+        _wcsicmp(moduleName, L"explorer.exe") == 0;
+
     if (isExcluded) {
         return FALSE;
+    }
+
+    if (g_isExplorerProcess) {
+        return InstallExplorerVisibilityHook()
+            ? TRUE
+            : FALSE;
     }
 
     if (isCurrentToolModProcess) {
@@ -3348,7 +3507,7 @@ void Wh_ModAfterInit() {
 }
 
 void Wh_ModSettingsChanged() {
-    if (g_isToolModProcessLauncher) {
+    if (g_isToolModProcessLauncher || g_isExplorerProcess) {
         return;
     }
 
@@ -3356,6 +3515,11 @@ void Wh_ModSettingsChanged() {
 }
 
 void Wh_ModUninit() {
+    if (g_isExplorerProcess) {
+        UninstallExplorerVisibilityHook();
+        return;
+    }
+
     if (g_isToolModProcessLauncher) {
         StopLauncherWatchdog();
         return;

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -1,11 +1,11 @@
 // ==WindhawkMod==
-// @id              hide-taskbar-only-on-desktop
-// @name            Hide Taskbar Only on Desktop
-// @description     Hides the taskbar when the desktop is active, while showing it for applications and on taskbar hover
-// @version         1.2.0
-// @author          Sahil Dashoni
-// @github          https://github.com/Sahil-Dashoni
-// @include         windhawk.exe
+// @id hide-taskbar-only-on-desktop
+// @name Hide Taskbar Only on Desktop
+// @description Hides the taskbar when the desktop is active, while showing it for applications and on taskbar hover
+// @version 1.3.0
+// @author Sahil Dashoni
+// @github https://github.com/Sahil-Dashoni
+// @include windhawk.exe
 // @compilerOptions -lshell32 -ldwmapi
 // ==/WindhawkMod==
 
@@ -39,10 +39,13 @@ This mod intentionally differs from native Windows auto-hide:
 it hides the taskbar window without changing the desktop work area.
 
 If native Windows taskbar auto-hide is enabled, this mod stands down so
-the two mechanisms don't fight each other.
+the two mechanisms don't fight each other. If native auto-hide is enabled
+while this mod has hidden the taskbar, the mod restores the taskbar first
+so Windows can take control of it again.
 
-This mod uses Windows events for application/window state changes and
-only uses a short timer while cursor hover handling is actually needed.
+This mod uses only foreground/minimize Windows events for application state
+changes and only uses a short timer while cursor hover handling is actually
+needed. It deliberately avoids system-wide object show/hide/destroy hooks.
 
 This mod was created with AI assistance.
 */
@@ -91,6 +94,7 @@ HANDLE g_hThreadReadyEvent = nullptr;
 
 constexpr UINT WM_APP_REFRESH_STATE = WM_APP + 1;
 constexpr UINT WM_APP_STOP_THREAD = WM_APP + 2;
+constexpr WPARAM kRefreshNativeAutoHide = 1;
 
 constexpr UINT kHoverTimerIntervalMs = 200;
 
@@ -103,7 +107,7 @@ bool g_onDesktopState = false;
 bool g_shownDueToHover = false;
 ULONGLONG g_hideDeadline = 0;
 
-constexpr size_t kMaxWinEventHooks = 6;
+constexpr size_t kMaxWinEventHooks = 3;
 HWINEVENTHOOK g_hWinEventHooks[kMaxWinEventHooks] = {};
 
 
@@ -685,6 +689,11 @@ void UpdateTaskbarState() {
         g_hideDeadline = 0;
         g_shownDueToHover = false;
         StopHoverTimer();
+
+        // Give control back to Windows' native auto-hide implementation.
+        // This is important if native auto-hide was enabled while our
+        // mod had previously hidden the taskbar with SW_HIDE.
+        SetTaskbarVisibility(true);
         return;
     }
 
@@ -795,7 +804,7 @@ void UpdateTaskbarState() {
 // Worker refresh message
 // ============================================================
 
-void RequestStateRefresh() {
+void RequestStateRefresh(bool refreshNativeAutoHide = false) {
     if (!g_threadId) {
         return;
     }
@@ -817,7 +826,7 @@ void RequestStateRefresh() {
         !PostThreadMessageW(
             g_threadId,
             WM_APP_REFRESH_STATE,
-            0,
+            refreshNativeAutoHide ? kRefreshNativeAutoHide : 0,
             0
         )
     ) {
@@ -837,17 +846,14 @@ bool IsRelevantWinEvent(DWORD event) {
     return
         event == EVENT_SYSTEM_FOREGROUND ||
         event == EVENT_SYSTEM_MINIMIZESTART ||
-        event == EVENT_SYSTEM_MINIMIZEEND ||
-        event == EVENT_OBJECT_SHOW ||
-        event == EVENT_OBJECT_HIDE ||
-        event == EVENT_OBJECT_DESTROY;
+        event == EVENT_SYSTEM_MINIMIZEEND;
 }
 
 
 void CALLBACK WinEventProc(
     HWINEVENTHOOK,
     DWORD event,
-    HWND hwnd,
+    HWND,
     LONG idObject,
     LONG idChild,
     DWORD,
@@ -861,22 +867,16 @@ void CALLBACK WinEventProc(
         return;
     }
 
-    if (!hwnd) {
-        RequestStateRefresh();
-        return;
-    }
-
     /*
-     * Foreground/minimize transitions are always relevant.
+     * Foreground changes are the main state transition we care about.
+     * Minimize start/end are needed for the last-application case.
      *
-     * Object show/hide/destroy events are also useful for:
-     * - the last application being closed,
-     * - Explorer recreating the taskbar,
-     * - native taskbar auto-hide changes.
-     *
-     * They are debounced into a single refresh message.
+     * We deliberately do not hook EVENT_OBJECT_SHOW/HIDE/DESTROY here.
+     * Those events are system-wide and can fire for menus, tooltips,
+     * controls and other transient windows. Avoiding them prevents a
+     * synchronous SHAppBarMessage call on every such event.
      */
-    RequestStateRefresh();
+    RequestStateRefresh(event == EVENT_SYSTEM_FOREGROUND);
 }
 
 
@@ -959,8 +959,10 @@ DWORD WINAPI HookThread(LPVOID) {
     }
 
     /*
-     * Install only the events needed to track foreground/application
-     * state and taskbar/window lifetime changes.
+     * Only hook events that represent meaningful application-state
+     * transitions. In particular, do not hook EVENT_OBJECT_SHOW/HIDE/
+     * DESTROY because those are generated system-wide for large numbers
+     * of transient windows and controls.
      */
     bool hookOk = true;
 
@@ -972,32 +974,8 @@ DWORD WINAPI HookThread(LPVOID) {
 
     hookOk &= InstallWinEventHookFor(
         EVENT_SYSTEM_MINIMIZESTART,
-        EVENT_SYSTEM_MINIMIZESTART,
+        EVENT_SYSTEM_MINIMIZEEND,
         1
-    );
-
-    hookOk &= InstallWinEventHookFor(
-        EVENT_SYSTEM_MINIMIZEEND,
-        EVENT_SYSTEM_MINIMIZEEND,
-        2
-    );
-
-    hookOk &= InstallWinEventHookFor(
-        EVENT_OBJECT_SHOW,
-        EVENT_OBJECT_SHOW,
-        3
-    );
-
-    hookOk &= InstallWinEventHookFor(
-        EVENT_OBJECT_HIDE,
-        EVENT_OBJECT_HIDE,
-        4
-    );
-
-    hookOk &= InstallWinEventHookFor(
-        EVENT_OBJECT_DESTROY,
-        EVENT_OBJECT_DESTROY,
-        5
     );
 
     if (!hookOk) {
@@ -1027,7 +1005,10 @@ DWORD WINAPI HookThread(LPVOID) {
                 std::memory_order_release
             );
 
-            RefreshNativeTaskbarAutoHideState();
+            if (msg.wParam == kRefreshNativeAutoHide) {
+                RefreshNativeTaskbarAutoHideState();
+            }
+
             RefreshDesktopState();
             UpdateTaskbarState();
 
@@ -1243,7 +1224,7 @@ void WhTool_ModSettingsChanged() {
      * In particular, this restores secondary taskbars when the setting
      * changes from ON to OFF while the desktop is already active.
      */
-    RequestStateRefresh();
+    RequestStateRefresh(true);
 }
 
 

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -1,5 +1,5 @@
 // ==WindhawkMod==
-// @id hide-taskbar-only-on-desktop-v2
+// @id hide-taskbar-only-on-desktop
 // @name Hide Taskbar Only on Desktop
 // @description Hides the taskbar on desktop while preserving taskbar and Windows shell UI interaction
 // @version 1.7.0

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Hides selected taskbars only while their display is showing the desktop
-// @version         3.0.0
+// @version         3.1.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -93,50 +93,52 @@ enumeration. The result is reused for every taskbar.
   $name: Reveal taskbar on bottom-edge hover
   $description: >-
     Select the displays where bottom-edge hovering should reveal the taskbar.
-    Select All displays to enable it everywhere, or replace it with one or
-    more individual displays.
+    The display options use Windows `\\.\DISPLAYn` device numbers, which may
+    differ from the numbers shown in Windows Display Settings. Select All
+    displays to enable it everywhere, or replace it with individual displays.
   $options:
   - all: All displays
-  - monitor1: Display 1
-  - monitor2: Display 2
-  - monitor3: Display 3
-  - monitor4: Display 4
-  - monitor5: Display 5
-  - monitor6: Display 6
-  - monitor7: Display 7
-  - monitor8: Display 8
-  - monitor9: Display 9
-  - monitor10: Display 10
-  - monitor11: Display 11
-  - monitor12: Display 12
-  - monitor13: Display 13
-  - monitor14: Display 14
-  - monitor15: Display 15
-  - monitor16: Display 16
+  - monitor1: DISPLAY1
+  - monitor2: DISPLAY2
+  - monitor3: DISPLAY3
+  - monitor4: DISPLAY4
+  - monitor5: DISPLAY5
+  - monitor6: DISPLAY6
+  - monitor7: DISPLAY7
+  - monitor8: DISPLAY8
+  - monitor9: DISPLAY9
+  - monitor10: DISPLAY10
+  - monitor11: DISPLAY11
+  - monitor12: DISPLAY12
+  - monitor13: DISPLAY13
+  - monitor14: DISPLAY14
+  - monitor15: DISPLAY15
+  - monitor16: DISPLAY16
 - hideOnMonitors: ["all"]
   $name: Taskbars to hide on desktop
   $description: >-
-    Select one or more displays using the Windows Display number.
-    Choose All displays to hide every connected display. Use Add to select
-    multiple displays.
+    Select one or more displays using the Windows `\\.\DISPLAYn` device number.
+    These numbers may differ from the display numbers shown in Windows Display
+    Settings. Choose All displays to hide every connected display. Use Add to
+    select multiple displays.
   $options:
   - all: All displays
-  - monitor1: Display 1
-  - monitor2: Display 2
-  - monitor3: Display 3
-  - monitor4: Display 4
-  - monitor5: Display 5
-  - monitor6: Display 6
-  - monitor7: Display 7
-  - monitor8: Display 8
-  - monitor9: Display 9
-  - monitor10: Display 10
-  - monitor11: Display 11
-  - monitor12: Display 12
-  - monitor13: Display 13
-  - monitor14: Display 14
-  - monitor15: Display 15
-  - monitor16: Display 16
+  - monitor1: DISPLAY1
+  - monitor2: DISPLAY2
+  - monitor3: DISPLAY3
+  - monitor4: DISPLAY4
+  - monitor5: DISPLAY5
+  - monitor6: DISPLAY6
+  - monitor7: DISPLAY7
+  - monitor8: DISPLAY8
+  - monitor9: DISPLAY9
+  - monitor10: DISPLAY10
+  - monitor11: DISPLAY11
+  - monitor12: DISPLAY12
+  - monitor13: DISPLAY13
+  - monitor14: DISPLAY14
+  - monitor15: DISPLAY15
+  - monitor16: DISPLAY16
 */
 // ==/WindhawkModSettings==
 
@@ -181,6 +183,7 @@ struct TaskbarMonitorState {
 
 struct WindowScanResult {
     bool applicationOnMonitor[kMaxMonitorNumbers];
+    bool taskbarPopupOnMonitor[kMaxMonitorNumbers];
 };
 
 HWINEVENTHOOK g_foregroundHook = nullptr;
@@ -188,11 +191,12 @@ HWINEVENTHOOK g_minimizeHook = nullptr;
 HWINEVENTHOOK g_moveHook = nullptr;
 HWINEVENTHOOK g_taskbarShowHook = nullptr;
 DWORD g_taskbarShowHookProcessId = 0;
-HHOOK g_mouseHook = nullptr;
 
 HANDLE g_workerThread = nullptr;
 DWORD g_workerThreadId = 0;
 HANDLE g_workerReadyEvent = nullptr;
+HANDLE g_cursorThread = nullptr;
+HANDLE g_cursorStopEvent = nullptr;
 
 TaskbarMonitorState g_taskbarStates[kMaxTaskbars] = {};
 size_t g_taskbarStateCount = 0;
@@ -204,6 +208,7 @@ ULONGLONG g_hoverDeadline = 0;
 LONG g_refreshPosted = 0;
 
 void LoadSettings();
+void WhTool_ModUninit();
 
 bool IsShellChromeClass(
     const WCHAR* className
@@ -365,6 +370,10 @@ bool IsBottomDockedTaskbar(HWND hTaskbar, HMONITOR monitor);
 bool ShouldHideMonitor(
     int monitorNumber
 ) {
+    if (g_settings.hideAllMonitors) {
+        return true;
+    }
+
     if (
         monitorNumber < 1 ||
         monitorNumber > static_cast<int>(
@@ -374,14 +383,16 @@ bool ShouldHideMonitor(
         return false;
     }
 
-    return
-        g_settings.hideAllMonitors ||
-        g_settings.hideMonitor[monitorNumber];
+    return g_settings.hideMonitor[monitorNumber];
 }
 
 bool ShouldRevealOnHover(
     int monitorNumber
 ) {
+    if (g_settings.hoverAllMonitors) {
+        return true;
+    }
+
     if (
         monitorNumber < 1 ||
         monitorNumber > static_cast<int>(
@@ -391,9 +402,7 @@ bool ShouldRevealOnHover(
         return false;
     }
 
-    return
-        g_settings.hoverAllMonitors ||
-        g_settings.hoverMonitor[monitorNumber];
+    return g_settings.hoverMonitor[monitorNumber];
 }
 
 bool IsTransientShellWindow(
@@ -583,6 +592,7 @@ bool IsExplorerShellPopup(
 struct ScanContext {
     const MonitorList* monitors;
     WindowScanResult* result;
+    DWORD explorerPid;
 };
 
 BOOL CALLBACK ScanWindowsWithMonitorsProc(
@@ -610,6 +620,43 @@ BOOL CALLBACK ScanWindowsWithMonitorsProc(
         ) == 0
     ) {
         return TRUE;
+    }
+
+    if (IsExplorerShellPopup(
+            hwnd,
+            className,
+            context->explorerPid
+        )) {
+        RECT popupRect = {};
+
+        if (GetWindowRect(hwnd, &popupRect)) {
+            POINT center = {
+                popupRect.left +
+                    (popupRect.right - popupRect.left) / 2,
+                popupRect.top +
+                    (popupRect.bottom - popupRect.top) / 2
+            };
+
+            HMONITOR popupMonitor =
+                MonitorFromPoint(
+                    center,
+                    MONITOR_DEFAULTTONEAREST
+                );
+
+            for (
+                size_t i = 0;
+                i < context->monitors->count;
+                ++i
+            ) {
+                if (
+                    context->monitors->entries[i].monitor ==
+                    popupMonitor
+                ) {
+                    context->result->taskbarPopupOnMonitor[i] = true;
+                    break;
+                }
+            }
+        }
     }
 
     if (!IsApplicationWindowCandidate(
@@ -692,9 +739,24 @@ void ScanWindowsOnce(
 ) {
     result = {};
 
+    DWORD explorerPid = 0;
+    HWND primaryTaskbar =
+        FindWindowW(
+            L"Shell_TrayWnd",
+            nullptr
+        );
+
+    if (primaryTaskbar) {
+        GetWindowThreadProcessId(
+            primaryTaskbar,
+            &explorerPid
+        );
+    }
+
     ScanContext context = {
         &monitors,
-        &result
+        &result,
+        explorerPid
     };
 
     EnumWindows(
@@ -897,9 +959,7 @@ void ApplyBaseTaskbarState() {
         SetTaskbarState(
             state,
             !state.desktopOnly ||
-            !ShouldHideMonitor(
-                state.monitorNumber
-            )
+            !ShouldHideTaskbar(state)
         );
     }
 }
@@ -1026,6 +1086,10 @@ bool IsCursorNearBottomEdge(
     UINT dpi =
         GetDpiForWindow(hTaskbar);
 
+    if (dpi == 0) {
+        dpi = 96;
+    }
+
     int hotZonePx =
         GetHoverZonePx(
             hTaskbar,
@@ -1040,98 +1104,6 @@ bool IsCursorNearBottomEdge(
         pt.y >=
             mi.rcMonitor.bottom - hotZonePx &&
         pt.y < mi.rcMonitor.bottom;
-}
-
-struct TaskbarPopupScanContext {
-    DWORD taskbarProcessId;
-    HMONITOR monitor;
-    bool found;
-};
-
-BOOL CALLBACK FindTaskbarPopupProc(HWND hwnd, LPARAM lParam) {
-    TaskbarPopupScanContext* context =
-        reinterpret_cast<TaskbarPopupScanContext*>(lParam);
-
-    if (!context || context->found || !IsWindowVisible(hwnd)) {
-        return TRUE;
-    }
-
-    DWORD processId = 0;
-    GetWindowThreadProcessId(hwnd, &processId);
-
-    if (processId != context->taskbarProcessId) {
-        return TRUE;
-    }
-
-    WCHAR className[128] = {};
-    if (!GetClassNameW(
-            hwnd,
-            className,
-            ARRAYSIZE(className))) {
-        return TRUE;
-    }
-
-    if (!IsTaskbarPopupClass(className)) {
-        return TRUE;
-    }
-
-    RECT rect = {};
-    if (!GetWindowRect(hwnd, &rect)) {
-        return TRUE;
-    }
-
-    POINT center = {
-        rect.left + (rect.right - rect.left) / 2,
-        rect.top + (rect.bottom - rect.top) / 2
-    };
-
-    if (MonitorFromPoint(
-            center,
-            MONITOR_DEFAULTTONEAREST) == context->monitor) {
-        context->found = true;
-        return FALSE;
-    }
-
-    return TRUE;
-}
-
-bool IsTaskbarContextMenuOpen(
-    HWND taskbar,
-    HMONITOR monitor) {
-    if (!taskbar || !monitor || !IsWindow(taskbar)) {
-        return false;
-    }
-
-    DWORD processId = 0;
-    GetWindowThreadProcessId(taskbar, &processId);
-
-    if (!processId) {
-        return false;
-    }
-
-    TaskbarPopupScanContext context = {
-        processId,
-        monitor,
-        false
-    };
-
-    EnumWindows(
-        FindTaskbarPopupProc,
-        reinterpret_cast<LPARAM>(&context));
-
-    return context.found;
-}
-
-HMONITOR GetTaskbarPopupMonitor() {
-    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-        if (IsTaskbarContextMenuOpen(
-                g_taskbarStates[i].hwnd,
-                g_taskbarStates[i].monitor)) {
-            return g_taskbarStates[i].monitor;
-        }
-    }
-
-    return nullptr;
 }
 
 bool IsAltTabActive() {
@@ -1226,7 +1198,6 @@ void UpdateTaskbarState() {
     const bool hovering =
         cursorTaskbar &&
         cursorMonitor &&
-        cursorMonitorNumber != 0 &&
         ShouldRevealOnHover(
             cursorMonitorNumber
         ) &&
@@ -1236,10 +1207,22 @@ void UpdateTaskbarState() {
         );
 
     // Keep the taskbar visible for an open shell context menu/overflow
-    // surface even after the cursor leaves the popup. This prevents the
-    // desktop-only hide logic from hiding the taskbar while its menu is open.
-    HMONITOR popupMonitor =
-        GetTaskbarPopupMonitor();
+    // surface even after the cursor leaves the popup. Popup state was collected
+    // during the main EnumWindows pass above, so no second full enumeration is
+    // needed here.
+    HMONITOR popupMonitor = nullptr;
+
+    for (
+        size_t monitorIndex = 0;
+        monitorIndex < monitors.count;
+        ++monitorIndex
+    ) {
+        if (scan.taskbarPopupOnMonitor[monitorIndex]) {
+            popupMonitor =
+                monitors.entries[monitorIndex].monitor;
+            break;
+        }
+    }
 
     if (popupMonitor) {
         g_hoverActive = false;
@@ -1331,9 +1314,7 @@ void UpdateTaskbarState() {
                     state,
                     state.monitor == g_hoverMonitor ||
                     !state.desktopOnly ||
-                    !ShouldHideMonitor(
-                        state.monitorNumber
-                    )
+                    !ShouldHideTaskbar(state)
                 );
             }
 
@@ -1453,51 +1434,75 @@ void PostRefresh() {
     }
 }
 
+bool IsCursorInBottomTriggerBand(POINT pt, HMONITOR monitor) {
+    if (!monitor) {
+        return false;
+    }
 
-LRESULT CALLBACK LowLevelMouseProc(
-    int code,
-    WPARAM message,
-    LPARAM lParam
-) {
-    if (
-        code == HC_ACTION &&
-        message == WM_MOUSEMOVE
-    ) {
-        const MSLLHOOKSTRUCT* mouse =
-            reinterpret_cast<const MSLLHOOKSTRUCT*>(lParam);
+    MONITORINFO mi = {};
+    mi.cbSize = sizeof(mi);
 
-        if (mouse) {
-            HMONITOR monitor =
+    if (!GetMonitorInfoW(monitor, &mi)) {
+        return false;
+    }
+
+    // This is only a lightweight trigger band. The worker performs the exact
+    // taskbar-height/DPI hover-zone check before changing visibility. Keeping
+    // this sampler separate from the worker avoids putting window scanning on
+    // the system input hook path.
+    constexpr LONG kCursorTriggerBandPx = 256;
+
+    return
+        pt.y >= mi.rcMonitor.bottom - kCursorTriggerBandPx &&
+        pt.y < mi.rcMonitor.bottom;
+}
+
+DWORD WINAPI CursorSamplingThread(LPVOID) {
+    HMONITOR lastMonitor = nullptr;
+    bool lastInBand = false;
+
+    for (;;) {
+        DWORD waitResult =
+            WaitForSingleObject(
+                g_cursorStopEvent,
+                25
+            );
+
+        if (waitResult == WAIT_OBJECT_0) {
+            break;
+        }
+
+        POINT pt = {};
+        HMONITOR monitor = nullptr;
+        bool inBand = false;
+
+        if (GetCursorPos(&pt)) {
+            monitor =
                 MonitorFromPoint(
-                    mouse->pt,
+                    pt,
                     MONITOR_DEFAULTTONEAREST
                 );
 
-            MONITORINFO mi = {};
-            mi.cbSize = sizeof(mi);
+            inBand =
+                IsCursorInBottomTriggerBand(
+                    pt,
+                    monitor
+                );
+        }
 
-            if (
-                monitor &&
-                GetMonitorInfoW(
-                    monitor,
-                    &mi
-                ) &&
-                mouse->pt.y >=
-                    mi.rcMonitor.bottom - 256 &&
-                mouse->pt.y <
-                    mi.rcMonitor.bottom
-            ) {
-                PostRefresh();
-            }
+        const bool hoverTriggerChanged =
+            inBand != lastInBand ||
+            (inBand && monitor != lastMonitor);
+
+        lastMonitor = monitor;
+        lastInBand = inBand;
+
+        if (hoverTriggerChanged) {
+            PostRefresh();
         }
     }
 
-    return CallNextHookEx(
-        g_mouseHook,
-        code,
-        message,
-        lParam
-    );
+    return 0;
 }
 
 
@@ -1536,25 +1541,7 @@ void CALLBACK WinEventProc(
             return;
         }
 
-        if (
-            InterlockedExchange(
-                &g_refreshPosted,
-                1
-            ) == 0
-        ) {
-            if (!PostThreadMessageW(
-                    g_workerThreadId,
-                    WM_APP_REFRESH,
-                    0,
-                    0
-                )) {
-                InterlockedExchange(
-                    &g_refreshPosted,
-                    0
-                );
-            }
-        }
-
+        PostRefresh();
         return;
     }
 
@@ -1686,20 +1673,6 @@ DWORD WINAPI WorkerThread(
     const UINT kIdlePollIntervalMs = 1000;
     const UINT kHiddenPollIntervalMs = 250;
     const UINT kHoverPollIntervalMs = 50;
-
-    g_mouseHook =
-        SetWindowsHookExW(
-            WH_MOUSE_LL,
-            LowLevelMouseProc,
-            nullptr,
-            0
-        );
-
-    if (!g_mouseHook) {
-        Wh_Log(
-            L"SetWindowsHookExW(WH_MOUSE_LL) failed; timer remains fallback"
-        );
-    }
 
     UINT_PTR timerId =
         SetTimer(
@@ -1841,13 +1814,6 @@ DWORD WINAPI WorkerThread(
         g_taskbarShowHookProcessId = 0;
     }
 
-    if (g_mouseHook) {
-        UnhookWindowsHookEx(
-            g_mouseHook
-        );
-        g_mouseHook = nullptr;
-    }
-
     return 0;
 }
 
@@ -1943,6 +1909,8 @@ void LoadSettings() {
     }
 
     // Empty selection intentionally means "hide nothing".
+    // "All displays" is handled independently of DISPLAYn parsing so it still
+    // applies if Windows reports an unexpected device-number format.
 
     for (
         size_t i = 0;
@@ -2041,6 +2009,38 @@ BOOL WhTool_ModInit() {
         INFINITE
     );
 
+    g_cursorStopEvent =
+        CreateEventW(
+            nullptr,
+            TRUE,
+            FALSE,
+            nullptr
+        );
+
+    if (!g_cursorStopEvent) {
+        Wh_Log(L"CreateEvent for cursor sampler failed");
+        WhTool_ModUninit();
+        return FALSE;
+    }
+
+    g_cursorThread =
+        CreateThread(
+            nullptr,
+            0,
+            CursorSamplingThread,
+            nullptr,
+            0,
+            nullptr
+        );
+
+    if (!g_cursorThread) {
+        Wh_Log(L"CreateThread for cursor sampler failed");
+        CloseHandle(g_cursorStopEvent);
+        g_cursorStopEvent = nullptr;
+        WhTool_ModUninit();
+        return FALSE;
+    }
+
     return TRUE;
 }
 
@@ -2057,6 +2057,25 @@ void WhTool_ModSettingsChanged() {
 
 void WhTool_ModUninit() {
     Wh_Log(L"Uninit");
+
+    if (g_cursorStopEvent) {
+        SetEvent(g_cursorStopEvent);
+    }
+
+    if (g_cursorThread) {
+        WaitForSingleObject(
+            g_cursorThread,
+            INFINITE
+        );
+
+        CloseHandle(g_cursorThread);
+        g_cursorThread = nullptr;
+    }
+
+    if (g_cursorStopEvent) {
+        CloseHandle(g_cursorStopEvent);
+        g_cursorStopEvent = nullptr;
+    }
 
     if (g_workerThread) {
         WaitForSingleObject(

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -104,6 +104,10 @@ std::atomic<bool> g_refreshPosted{false};
 std::atomic<bool> g_nativeAutoHideEnabled{false};
 
 bool g_onDesktopState = false;
+// True only while the taskbar itself has foreground focus and the cursor
+// is still over the taskbar. This keeps the hover timer alive after a
+// taskbar click, so moving the cursor away can return to desktop state.
+bool g_taskbarIsForeground = false;
 bool g_shownDueToHover = false;
 ULONGLONG g_hideDeadline = 0;
 
@@ -307,13 +311,27 @@ bool IsTaskbarForegroundAndUnderCursor(HWND foreground) {
 void RefreshDesktopState() {
     HWND foreground = GetForegroundWindow();
 
+    // This flag is transient: it is true only while the taskbar itself
+    // has focus and the cursor is over it. The hover timer uses it to
+    // re-check the state after the cursor leaves the taskbar.
+    g_taskbarIsForeground = false;
+
     if (!foreground) {
         g_onDesktopState = !AnyOtherVisibleWindowExists();
         return;
     }
 
-    if (IsTaskbarForegroundAndUnderCursor(foreground)) {
-        g_onDesktopState = false;
+    if (IsTaskbarWindow(foreground)) {
+        if (IsTaskbarForegroundAndUnderCursor(foreground)) {
+            g_taskbarIsForeground = true;
+            g_onDesktopState = false;
+            return;
+        }
+
+        // The taskbar can remain the foreground window after the user
+        // moves the cursor away. In that situation, treat the desktop
+        // as active if no other application window exists.
+        g_onDesktopState = !AnyOtherVisibleWindowExists();
         return;
     }
 
@@ -711,7 +729,10 @@ void UpdateTaskbarState() {
         g_shownDueToHover = false;
 
         SetTaskbarVisibility(true);
-        StopHoverTimer();
+
+        // If the taskbar itself has focus, keep polling so that moving
+        // the cursor away from it can transition back to desktop state.
+        EnsureHoverTimer(g_taskbarIsForeground);
 
         return;
     }

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id hide-taskbar-only-on-desktop
 // @name Hide Taskbar Only on Desktop
 // @description Hides the taskbar on desktop while preserving taskbar and Windows shell UI interaction
-// @version 1.7.0
+// @version 1.9.0
 // @author Sahil Dashoni
 // @github https://github.com/Sahil-Dashoni
 // @include windhawk.exe
@@ -26,7 +26,7 @@ visible whenever an application or shell UI is active.
 - Uses the taskbar's actual rectangle and per-monitor DPI.
 - Adds a configurable extra hover margin in millimeters.
 - Uses a configurable delay after leaving the hover area.
-- The delay is only used after a hover reveal.
+- The delay is used after a hover reveal and after Alt+Tab closes.
 - Minimizing or closing the last application hides the taskbar immediately.
 - Keeps the taskbar available while interacting with taskbar buttons.
 - Supports secondary taskbars on additional monitors.
@@ -54,9 +54,9 @@ hidden until Explorer is restarted. Normal disable/unload paths restore it.
 For predictable behavior, disable Windows' own "Automatically hide the
 taskbar" option while this mod is enabled.
 
-This mod uses only foreground/minimize Windows events for application state
-changes and only uses a short timer while cursor hover handling is actually
-needed. It deliberately avoids system-wide object show/hide/destroy hooks.
+This mod uses foreground/minimize Windows events for application state
+changes and a timer for cursor/hover and hide-delay handling. It deliberately
+avoids system-wide object show/hide/destroy hooks.
 
 On multi-monitor systems, each monitor's taskbar is evaluated independently.
 A normal visible application intersecting a monitor keeps that monitor's
@@ -98,6 +98,8 @@ This mod was created with AI assistance.
 #include <dwmapi.h>
 #include <atomic>
 #include <stdio.h>
+#include <string.h>
+#include <wchar.h>
 
 struct Settings {
     std::atomic<int> extraHoverMarginMm{5};
@@ -152,33 +154,6 @@ const wchar_t kSystemMessageWindowClass[] =
 // Utility
 // ============================================================
 
-bool IsDesktopWindow(HWND hwnd) {
-    if (!hwnd) {
-        return false;
-    }
-
-    WCHAR className[256] = {};
-
-    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
-        return false;
-    }
-
-    if (wcscmp(className, L"Progman") == 0) {
-        return true;
-    }
-
-    if (wcscmp(className, L"WorkerW") == 0) {
-        return FindWindowExW(
-            hwnd,
-            nullptr,
-            L"SHELLDLL_DefView",
-            nullptr
-        ) != nullptr;
-    }
-
-    return false;
-}
-
 
 bool IsShellChromeClass(const WCHAR* className) {
     if (!className) {
@@ -231,7 +206,6 @@ bool IsTaskbarWindow(HWND hwnd) {
 
 void DiscoverTaskbars();
 
-HWND FindPrimaryTaskbar();
 bool IsTaskbarActuallyHidden(HWND hwnd);
 bool IsShellUiClass(const WCHAR* className);
 
@@ -276,22 +250,6 @@ BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
         return TRUE;
     }
 
-    BOOL cloaked = FALSE;
-
-    if (
-        SUCCEEDED(
-            DwmGetWindowAttribute(
-                hwnd,
-                DWMWA_CLOAKED,
-                &cloaked,
-                sizeof(cloaked)
-            )
-        ) &&
-        cloaked
-    ) {
-        return TRUE;
-    }
-
     RECT rect = {};
 
     if (!GetWindowRect(hwnd, &rect)) {
@@ -308,6 +266,26 @@ BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
     if (
         GetWindow(hwnd, GW_OWNER) != nullptr &&
         !(exStyle & WS_EX_APPWINDOW)
+    ) {
+        return TRUE;
+    }
+
+    /*
+     * DWM cloaking is relatively expensive, so query it only after the
+     * cheaper visibility/style/geometry checks.
+     */
+    BOOL cloaked = FALSE;
+
+    if (
+        SUCCEEDED(
+            DwmGetWindowAttribute(
+                hwnd,
+                DWMWA_CLOAKED,
+                &cloaked,
+                sizeof(cloaked)
+            )
+        ) &&
+        cloaked
     ) {
         return TRUE;
     }
@@ -523,6 +501,29 @@ bool IsVisibleShellFlyoutForMonitor(
     RECT windowRect = {};
 
     if (!GetWindowRect(hwnd, &windowRect)) {
+        return false;
+    }
+
+    if (
+        windowRect.right <= windowRect.left ||
+        windowRect.bottom <= windowRect.top
+    ) {
+        return false;
+    }
+
+    BOOL cloaked = FALSE;
+
+    if (
+        SUCCEEDED(
+            DwmGetWindowAttribute(
+                hwnd,
+                DWMWA_CLOAKED,
+                &cloaked,
+                sizeof(cloaked)
+            )
+        ) &&
+        cloaked
+    ) {
         return false;
     }
 
@@ -915,16 +916,6 @@ void SetTaskbarVisibility(bool show) {
 }
 
 
-bool IsPrimaryTaskbarHidden() {
-    HWND primary = FindPrimaryTaskbar();
-
-    if (!primary) {
-        return false;
-    }
-
-    return IsWindowVisible(primary) == FALSE;
-}
-
 
 // ============================================================
 // Hover zone
@@ -1087,6 +1078,12 @@ void UpdateTaskbarState() {
             std::memory_order_relaxed
         );
 
+    /*
+     * Alt+Tab is global, so detect it once per state update rather than once
+     * for every taskbar.
+     */
+    bool altTabActive = IsAltTabActive();
+
     for (size_t i = 0; i < g_taskbarCount; ++i) {
         TaskbarState& taskbar =
             g_taskbars[i];
@@ -1112,13 +1109,6 @@ void UpdateTaskbarState() {
         bool hovering =
             IsCursorInTaskbarHoverZone(taskbar);
 
-        bool shellFlyoutOpen =
-            taskbar.shellUiForeground ||
-            HasVisibleShellFlyout(taskbar.monitor);
-
-        bool altTabActive =
-            IsAltTabActive();
-
         /*
          * If a normal application is present on this monitor, that
          * monitor's taskbar remains visible even when another monitor
@@ -1126,6 +1116,7 @@ void UpdateTaskbarState() {
          */
         if (taskbar.hasApplication) {
             taskbar.shownDueToHover = false;
+            taskbar.shownDueToAltTab = false;
             taskbar.hideDeadline = 0;
 
             SetWindowVisibilityIfNeeded(
@@ -1135,6 +1126,10 @@ void UpdateTaskbarState() {
 
             continue;
         }
+
+        bool shellFlyoutOpen =
+            taskbar.shellUiForeground ||
+            HasVisibleShellFlyout(taskbar.monitor);
 
         /*
          * Windows shell flyouts (Start, Search, Notifications, Quick
@@ -1353,10 +1348,6 @@ LRESULT CALLBACK SystemMessageWindowProc(
 
     switch (message) {
     case WM_SETTINGCHANGE:
-        /*
-         * Native taskbar auto-hide can be changed from Windows Settings.
-         * Re-query it only when this targeted system notification arrives.
-         */
         RefreshPerMonitorState();
         UpdateTaskbarState();
         return 0;

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -171,14 +171,6 @@ or the connected display set changes.
   configured until the user changes the setting.
 - The mod does not modify Windows' native taskbar auto-hide setting.
 
-## Demo
-
-A real recording is recommended here for the repository submission: show a
-selected taskbar hiding when its display becomes desktop-only, revealing when
-the pointer reaches the bottom edge, and hiding again after the dismissal
-delay. Do not use a generated or illustrative image in place of a real
-recording.
-
 ## Goal
 
 The goal is a specific visibility rule:

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Hides selected taskbars only while their display is showing the desktop
-// @version         3.4.0
+// @version         3.5.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -42,7 +42,7 @@ per Explorer process and keeps the state-management code outside the shell.
 
 - The tool re-discovers primary and secondary taskbars during every reconciliation,
   so Explorer taskbar recreation is picked up automatically.
-- A message-only worker window reacts to `TaskbarCreated`, display-configuration,
+- A hidden top-level worker window reacts to `TaskbarCreated`, display-configuration,
   settings, and theme changes instead of waiting for the next safety-poll tick.
 - Selected `DISPLAYn` entries are bound to the display's monitor device identity
   during the current Windows session, so a dock/reconnect that renumbers
@@ -51,9 +51,16 @@ per Explorer process and keeps the state-management code outside the shell.
   display-set changes.
 - Native Windows auto-hide state is sampled once per reconciliation and reused
   for the rest of that reconciliation.
+- Cursor movement near the bottom edge is handled through a lightweight
+  low-level mouse hook instead of a dedicated 25 ms sampler
+  thread.
 - Known taskbar/XAML popup classes are treated as shell surfaces; generic
   `Windows.UI.Core.CoreWindow` windows are no longer rejected solely because of
   their class name, which avoids misclassifying visible UWP application windows.
+- The mod records which taskbars it actually hid, so reconciliation does not
+  restore taskbars that were hidden by another mechanism.
+- The launcher watchdog restores only taskbars marked by this mod after an
+  unexpected tool-process exit.
 
 ### How this differs from related taskbar mods
 
@@ -81,10 +88,11 @@ A key implementation difference is the **work-area behavior**: the mod uses
 `ShowWindow(SW_HIDE)` and does not change the Windows desktop work area.
 
 The launcher keeps a lightweight watchdog for the dedicated tool process. If the
-tool exits unexpectedly while a taskbar is hidden, the watchdog re-shows the
-currently discoverable primary and secondary taskbars. A normal mod unload also
-restores taskbars. If Explorer itself is unresponsive or has already recreated a
-taskbar, restarting Explorer may still be required.
+tool exits unexpectedly while a taskbar hidden by this mod is still marked, the
+watchdog re-shows those currently discoverable taskbars. It does not restore
+taskbars hidden by other mechanisms. A normal mod unload also restores only
+windows marked as hidden by this mod. If Explorer itself is unresponsive or has
+already recreated a taskbar, restarting Explorer may still be required.
 
 ### Process and state model
 
@@ -94,10 +102,10 @@ an immediate reconciliation, while a periodic safety poll handles missed
 or unusual transitions.
 
 Each safety poll performs one display enumeration and one top-level-window
-enumeration. The result is reused for every taskbar. Hover reveal uses a gated
-cursor sampler only while a hidden taskbar can actually be revealed, and its
-post-hover delay expires through a one-shot worker timer rather than a fast
-full-state polling loop.
+enumeration. The result is reused for every taskbar. Cursor movement near the
+bottom edge is handled by a cursor `EVENT_OBJECT_LOCATIONCHANGE` WinEvent that
+posts only lightweight state-transition refreshes. Hover dismissal uses a
+one-shot worker timer rather than a fast full-state polling loop.
 */
 // ==/WindhawkModReadme==
 
@@ -211,6 +219,7 @@ struct TaskbarMonitorState {
     int monitorNumber;
     wchar_t stableDeviceId[256];
     bool desktopOnly;
+    bool hiddenByMod;
 };
 
 struct MonitorSelectionBinding {
@@ -226,15 +235,20 @@ struct WindowScanResult {
 HWINEVENTHOOK g_foregroundHook = nullptr;
 HWINEVENTHOOK g_minimizeHook = nullptr;
 HWINEVENTHOOK g_moveHook = nullptr;
+HHOOK g_mouseHook = nullptr;
 HWINEVENTHOOK g_taskbarShowHook = nullptr;
 DWORD g_taskbarShowHookProcessId = 0;
 
 HANDLE g_workerThread = nullptr;
 DWORD g_workerThreadId = 0;
 HANDLE g_workerReadyEvent = nullptr;
-HANDLE g_cursorThread = nullptr;
-HANDLE g_cursorStopEvent = nullptr;
-HANDLE g_cursorWakeEvent = nullptr;
+
+HMONITOR g_lastCursorTriggerMonitor = nullptr;
+bool g_lastCursorInTriggerBand = false;
+bool g_lastCursorInExactHoverZone = false;
+
+constexpr wchar_t kHiddenByModProperty[] =
+    L"Windhawk.HideTaskbarOnlyOnDesktop.HiddenByMod";
 
 HWND g_workerMessageWindow = nullptr;
 ATOM g_workerWindowClassAtom = 0;
@@ -255,11 +269,8 @@ HMONITOR g_hoverMonitor = nullptr;
 ULONGLONG g_hoverDeadline = 0;
 
 LONG g_refreshPosted = 0;
-LONG g_cursorSamplingEnabled = 0;
-
 void LoadSettings();
 void WhTool_ModUninit();
-void UpdateCursorSamplingState();
 void ArmHoverExpireTimer();
 void CancelHoverExpireTimer();
 
@@ -311,50 +322,19 @@ bool IsDesktopInfrastructureWindow(
     return shellWindow && shellWindow == hwnd;
 }
 
-bool GetStableMonitorDeviceId(
-    const wchar_t* deviceName,
-    wchar_t* output,
-    size_t outputCount
-);
+struct StableMonitorDeviceCacheEntry {
+    bool valid;
+    wchar_t deviceName[32];
+    wchar_t stableDeviceId[256];
+};
 
-BOOL CALLBACK CollectMonitorProc(
-    HMONITOR monitor,
-    HDC,
-    LPRECT,
-    LPARAM lParam
-) {
-    MonitorList* list =
-        reinterpret_cast<MonitorList*>(lParam);
+StableMonitorDeviceCacheEntry
+    g_stableMonitorDeviceCache[kMaxMonitorNumbers] = {};
 
-    if (!list || list->count >= kMaxMonitorNumbers) {
-        return FALSE;
+void ClearStableMonitorDeviceIdCache() {
+    for (auto& entry : g_stableMonitorDeviceCache) {
+        entry = {};
     }
-
-    MONITORINFOEXW info = {};
-    info.cbSize = sizeof(info);
-
-    if (!GetMonitorInfoW(monitor, &info)) {
-        return TRUE;
-    }
-
-    MonitorEntry& entry =
-        list->entries[list->count++];
-
-    entry.monitor = monitor;
-    entry.rect = info.rcMonitor;
-    wcsncpy_s(
-        entry.deviceName,
-        ARRAYSIZE(entry.deviceName),
-        info.szDevice,
-        _TRUNCATE
-    );
-    GetStableMonitorDeviceId(
-        entry.deviceName,
-        entry.stableDeviceId,
-        ARRAYSIZE(entry.stableDeviceId)
-    );
-
-    return TRUE;
 }
 
 bool GetStableMonitorDeviceId(
@@ -372,6 +352,25 @@ bool GetStableMonitorDeviceId(
 
     output[0] = L'\0';
 
+    for (const auto& entry : g_stableMonitorDeviceCache) {
+        if (
+            entry.valid &&
+            wcscmp(
+                entry.deviceName,
+                deviceName
+            ) == 0
+        ) {
+            wcsncpy_s(
+                output,
+                outputCount,
+                entry.stableDeviceId,
+                _TRUNCATE
+            );
+            return output[0] != L'\0';
+        }
+    }
+
+    wchar_t stableDeviceId[256] = {};
     DISPLAY_DEVICEW adapter = {};
     adapter.cb = sizeof(adapter);
 
@@ -409,28 +408,57 @@ bool GetStableMonitorDeviceId(
             monitor.DeviceID[0] != L'\0'
         ) {
             wcsncpy_s(
-                output,
-                outputCount,
+                stableDeviceId,
+                ARRAYSIZE(stableDeviceId),
                 monitor.DeviceID,
                 _TRUNCATE
             );
-            return output[0] != L'\0';
-        }
-
-        if (adapter.DeviceID[0] != L'\0') {
+        } else if (adapter.DeviceID[0] != L'\0') {
             wcsncpy_s(
-                output,
-                outputCount,
+                stableDeviceId,
+                ARRAYSIZE(stableDeviceId),
                 adapter.DeviceID,
                 _TRUNCATE
             );
-            return output[0] != L'\0';
         }
 
+        break;
+    }
+
+    if (stableDeviceId[0] == L'\0') {
         return false;
     }
 
-    return false;
+    for (auto& entry : g_stableMonitorDeviceCache) {
+        if (!entry.valid) {
+            entry.valid = true;
+
+            wcsncpy_s(
+                entry.deviceName,
+                ARRAYSIZE(entry.deviceName),
+                deviceName,
+                _TRUNCATE
+            );
+
+            wcsncpy_s(
+                entry.stableDeviceId,
+                ARRAYSIZE(entry.stableDeviceId),
+                stableDeviceId,
+                _TRUNCATE
+            );
+
+            break;
+        }
+    }
+
+    wcsncpy_s(
+        output,
+        outputCount,
+        stableDeviceId,
+        _TRUNCATE
+    );
+
+    return output[0] != L'\0';
 }
 
 int GetDisplayDeviceNumber(
@@ -556,6 +584,41 @@ void BindConfiguredMonitorSelections(
             g_hoverMonitorBindings
         );
     }
+}
+
+BOOL CALLBACK CollectMonitorProc(
+    HMONITOR monitor,
+    HDC,
+    LPRECT,
+    LPARAM lParam
+) {
+    MonitorList* list =
+        reinterpret_cast<MonitorList*>(lParam);
+
+    if (!list || list->count >= kMaxMonitorNumbers) {
+        return FALSE;
+    }
+
+    MONITORINFOEXW info = {};
+    info.cbSize = sizeof(info);
+
+    if (!GetMonitorInfoW(monitor, &info)) {
+        return TRUE;
+    }
+
+    MonitorEntry& entry =
+        list->entries[list->count++];
+
+    entry.monitor = monitor;
+    entry.rect = info.rcMonitor;
+    wcsncpy_s(
+        entry.deviceName,
+        ARRAYSIZE(entry.deviceName),
+        info.szDevice,
+        _TRUNCATE
+    );
+
+    return TRUE;
 }
 
 MonitorList GetCurrentMonitors() {
@@ -1182,11 +1245,19 @@ void RefreshTaskbarMonitorStates(
         }
 
         state.desktopOnly = true;
+        state.hiddenByMod =
+            GetPropW(
+                hwnd,
+                kHiddenByModProperty
+            ) != nullptr;
 
         for (size_t i = 0; i < oldCount; ++i) {
             if (oldStates[i].hwnd == hwnd) {
                 state.desktopOnly =
                     oldStates[i].desktopOnly;
+                state.hiddenByMod =
+                    oldStates[i].hiddenByMod ||
+                    state.hiddenByMod;
                 break;
             }
         }
@@ -1250,19 +1321,66 @@ void SetTaskbarState(
         return;
     }
 
-    bool visible =
-        IsWindowVisible(state.hwnd) != FALSE;
+    if (show) {
+        if (!state.hiddenByMod) {
+            return;
+        }
 
-    if (visible != show) {
-        // Keep the visibility transition synchronous. Explorer can immediately
+        // Keep normal state transitions synchronous. Explorer can immediately
         // re-show a taskbar while processing shell/minimize transitions; using
         // ShowWindowAsync here can leave several SHOW/HIDE requests queued and
-        // cause a visible flicker loop. The worker is already serialized, so a
-        // synchronous transition gives us the stable state machine behavior.
+        // cause a visible flicker loop.
         ShowWindow(
             state.hwnd,
-            show ? SW_SHOW : SW_HIDE
+            SW_SHOW
         );
+
+        if (IsWindowVisible(state.hwnd)) {
+            RemovePropW(
+                state.hwnd,
+                kHiddenByModProperty
+            );
+            state.hiddenByMod = false;
+        }
+
+        return;
+    }
+
+    if (!IsWindowVisible(state.hwnd)) {
+        state.hiddenByMod =
+            state.hiddenByMod ||
+            GetPropW(
+                state.hwnd,
+                kHiddenByModProperty
+            ) != nullptr;
+        return;
+    }
+
+    if (!SetPropW(
+            state.hwnd,
+            kHiddenByModProperty,
+            reinterpret_cast<HANDLE>(1)
+        )) {
+        Wh_Log(
+            L"SetPropW failed for taskbar 0x%p: %lu",
+            state.hwnd,
+            GetLastError()
+        );
+    }
+
+    ShowWindow(
+        state.hwnd,
+        SW_HIDE
+    );
+
+    if (!IsWindowVisible(state.hwnd)) {
+        state.hiddenByMod = true;
+    } else {
+        RemovePropW(
+            state.hwnd,
+            kHiddenByModProperty
+        );
+        state.hiddenByMod = false;
     }
 }
 
@@ -1271,8 +1389,8 @@ bool IsTaskbarHiddenByMod(
 ) {
     return
         state.hwnd &&
-        !IsWindowVisible(state.hwnd) &&
-        ShouldHideTaskbar(state);
+        state.hiddenByMod &&
+        !IsWindowVisible(state.hwnd);
 }
 
 void ApplyBaseTaskbarState() {
@@ -1384,17 +1502,12 @@ bool IsBottomDockedTaskbar(
             monitorHeight / 2;
 }
 
-bool IsCursorNearBottomEdge(
+bool IsPointNearBottomEdge(
     HWND hTaskbar,
-    HMONITOR cursorMonitor
+    HMONITOR cursorMonitor,
+    POINT pt
 ) {
-    POINT pt = {};
-
-    if (
-        !hTaskbar ||
-        !cursorMonitor ||
-        !GetCursorPos(&pt)
-    ) {
+    if (!hTaskbar || !cursorMonitor) {
         return false;
     }
 
@@ -1438,6 +1551,23 @@ bool IsCursorNearBottomEdge(
         pt.y < mi.rcMonitor.bottom;
 }
 
+bool IsCursorNearBottomEdge(
+    HWND hTaskbar,
+    HMONITOR cursorMonitor
+) {
+    POINT pt = {};
+
+    if (!GetCursorPos(&pt)) {
+        return false;
+    }
+
+    return IsPointNearBottomEdge(
+        hTaskbar,
+        cursorMonitor,
+        pt
+    );
+}
+
 void UpdateTaskbarState() {
     MonitorList monitors =
         GetCurrentMonitors();
@@ -1453,6 +1583,8 @@ void UpdateTaskbarState() {
         g_displayTopologySignature != 0 &&
         topologySignature != g_displayTopologySignature
     ) {
+        ClearStableMonitorDeviceIdCache();
+
         // A display add/remove, arrangement change, or geometry/DPI transition
         // can invalidate the current hover monitor. Reconcile from the base
         // state instead of carrying old hover state across the transition.
@@ -1615,7 +1747,6 @@ void UpdateTaskbarState() {
             );
         }
 
-        UpdateCursorSamplingState();
         return;
     }
 
@@ -1637,7 +1768,6 @@ void UpdateTaskbarState() {
             );
         }
 
-        UpdateCursorSamplingState();
         return;
     }
 
@@ -1652,8 +1782,7 @@ void UpdateTaskbarState() {
             CancelHoverExpireTimer();
 
             ApplyBaseTaskbarState();
-            UpdateCursorSamplingState();
-            return;
+                return;
         }
 
         const ULONGLONG now =
@@ -1680,8 +1809,7 @@ void UpdateTaskbarState() {
                 );
             }
 
-            UpdateCursorSamplingState();
-            return;
+                return;
         }
 
         g_hoverActive = false;
@@ -1691,41 +1819,10 @@ void UpdateTaskbarState() {
         CancelHoverExpireTimer();
 
         ApplyBaseTaskbarState();
-        UpdateCursorSamplingState();
         return;
     }
 
     ApplyBaseTaskbarState();
-    UpdateCursorSamplingState();
-}
-
-void UpdateCursorSamplingState() {
-    bool shouldSample = g_hoverActive;
-
-    if (!shouldSample) {
-        for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-            const TaskbarMonitorState& state =
-                g_taskbarStates[i];
-
-            if (
-                IsTaskbarHiddenByMod(state) &&
-                ShouldRevealOnHover(state)
-            ) {
-                shouldSample = true;
-                break;
-            }
-        }
-    }
-
-    LONG oldValue =
-        InterlockedExchange(
-            &g_cursorSamplingEnabled,
-            shouldSample ? 1 : 0
-        );
-
-    if (shouldSample && oldValue == 0 && g_cursorWakeEvent) {
-        SetEvent(g_cursorWakeEvent);
-    }
 }
 
 void ArmHoverExpireTimer() {
@@ -1777,6 +1874,42 @@ bool IsTaskbarWindow(HWND hwnd) {
         wcscmp(className, L"Shell_SecondaryTrayWnd") == 0;
 }
 
+bool IsCursorInConfiguredHoverZoneAtPoint(
+    POINT pt,
+    HMONITOR cursorMonitor
+) {
+    if (!cursorMonitor) {
+        return false;
+    }
+
+    TaskbarMonitorState* cursorState = nullptr;
+
+    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+        if (
+            g_taskbarStates[i].monitor ==
+            cursorMonitor
+        ) {
+            cursorState = &g_taskbarStates[i];
+            break;
+        }
+    }
+
+    if (
+        !cursorState ||
+        !ShouldRevealOnHover(*cursorState)
+    ) {
+        return false;
+    }
+
+    return
+        cursorState->hwnd &&
+        IsPointNearBottomEdge(
+            cursorState->hwnd,
+            cursorMonitor,
+            pt
+        );
+}
+
 bool IsCursorInConfiguredHoverZone() {
     POINT pt = {};
 
@@ -1793,9 +1926,6 @@ bool IsCursorInConfiguredHoverZone() {
     if (!cursorMonitor) {
         return false;
     }
-
-    MonitorList monitors =
-        GetCurrentMonitors();
 
     TaskbarMonitorState* cursorState = nullptr;
 
@@ -1877,8 +2007,8 @@ bool IsCursorInBottomTriggerBand(POINT pt, HMONITOR monitor) {
 
     // This is only a lightweight trigger band. The worker performs the exact
     // taskbar-height/DPI hover-zone check before changing visibility. Keeping
-    // this sampler separate from the worker avoids putting window scanning on
-    // the system input hook path.
+    // this callback lightweight avoids putting window scanning on the cursor
+    // movement event path.
     constexpr LONG kCursorTriggerBandPx = 256;
 
     return
@@ -1886,93 +2016,71 @@ bool IsCursorInBottomTriggerBand(POINT pt, HMONITOR monitor) {
         pt.y < mi.rcMonitor.bottom;
 }
 
-DWORD WINAPI CursorSamplingThread(LPVOID) {
-    HMONITOR lastMonitor = nullptr;
-    bool lastInBand = false;
 
-    HANDLE waitHandles[2] = {
-        g_cursorStopEvent,
-        g_cursorWakeEvent
-    };
+LRESULT CALLBACK LowLevelMouseProc(
+    int nCode,
+    WPARAM wParam,
+    LPARAM lParam
+) {
+    if (nCode == HC_ACTION && wParam == WM_MOUSEMOVE) {
+        const MSLLHOOKSTRUCT* mouse =
+            reinterpret_cast<const MSLLHOOKSTRUCT*>(lParam);
 
-    for (;;) {
-        if (
-            InterlockedCompareExchange(
-                &g_cursorSamplingEnabled,
-                0,
-                0
-            ) == 0
-        ) {
-            DWORD waitResult =
-                WaitForMultipleObjects(
-                    ARRAYSIZE(waitHandles),
-                    waitHandles,
-                    FALSE,
-                    INFINITE
-                );
-
-            if (waitResult == WAIT_OBJECT_0) {
-                break;
-            }
-
-            lastMonitor = nullptr;
-            lastInBand = false;
-            continue;
-        }
-
-        DWORD waitResult =
-            WaitForSingleObject(
-                g_cursorStopEvent,
-                25
-            );
-
-        if (waitResult == WAIT_OBJECT_0) {
-            break;
-        }
-
-        if (
-            InterlockedCompareExchange(
-                &g_cursorSamplingEnabled,
-                0,
-                0
-            ) == 0
-        ) {
-            continue;
-        }
-
-        POINT pt = {};
-        HMONITOR monitor = nullptr;
-        bool inBand = false;
-
-        if (GetCursorPos(&pt)) {
-            monitor =
+        if (mouse) {
+            HMONITOR monitor =
                 MonitorFromPoint(
-                    pt,
+                    mouse->pt,
                     MONITOR_DEFAULTTONEAREST
                 );
 
-            inBand =
+            const bool inBand =
                 IsCursorInBottomTriggerBand(
-                    pt,
+                    mouse->pt,
                     monitor
                 );
-        }
 
-        const bool hoverTriggerChanged =
-            inBand != lastInBand ||
-            (inBand && monitor != lastMonitor);
+            const bool exactHoverZone =
+                inBand &&
+                IsCursorInConfiguredHoverZoneAtPoint(
+                    mouse->pt,
+                    monitor
+                );
 
-        lastMonitor = monitor;
-        lastInBand = inBand;
+            const bool monitorChanged =
+                inBand && monitor != g_lastCursorTriggerMonitor;
 
-        if (hoverTriggerChanged) {
-            PostRefresh();
+            const bool bandChanged =
+                inBand != g_lastCursorInTriggerBand;
+
+            const bool exactZoneChanged =
+                exactHoverZone != g_lastCursorInExactHoverZone;
+
+            g_lastCursorTriggerMonitor = monitor;
+            g_lastCursorInTriggerBand = inBand;
+            g_lastCursorInExactHoverZone = exactHoverZone;
+
+            // The broad trigger band prevents refreshes for normal mouse
+            // movement. A separate exact-zone edge catches the moment the
+            // cursor actually reaches the configured taskbar reveal area,
+            // avoiding the old 1-second safety-poll latency. This only changes
+            // the reveal trigger; the existing hover-dismiss delay is untouched.
+            if (
+                monitorChanged ||
+                bandChanged ||
+                exactZoneChanged
+            ) {
+                PostRefresh();
+            }
         }
     }
 
-    return 0;
+    return CallNextHookEx(
+        g_mouseHook,
+        nCode,
+        wParam,
+        lParam
+    );
 }
-
 
 void CALLBACK WinEventProc(
     HWINEVENTHOOK,
@@ -2065,20 +2173,6 @@ void EnsureTaskbarShowHook() {
 }
 
 
-bool HasHiddenTaskbar() {
-    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-        if (
-            g_taskbarStates[i].hwnd &&
-            !IsWindowVisible(g_taskbarStates[i].hwnd) &&
-            ShouldHideTaskbar(g_taskbarStates[i])
-        ) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 
 LRESULT CALLBACK WorkerMessageWindowProc(
     HWND hwnd,
@@ -2138,25 +2232,24 @@ bool CreateWorkerMessageWindow() {
         RegisterClassExW(&wc);
 
     if (!g_workerWindowClassAtom) {
-        if (GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
-            Wh_Log(L"RegisterClassExW failed: %lu", GetLastError());
-            return false;
-        }
-
-        g_workerWindowClassAtom = 1;
+        Wh_Log(
+            L"RegisterClassExW failed: %lu",
+            GetLastError()
+        );
+        return false;
     }
 
     g_workerMessageWindow =
         CreateWindowExW(
-            0,
+            WS_EX_TOOLWINDOW,
             kClassName,
+            L"",
+            WS_POPUP,
+            0,
+            0,
+            0,
+            0,
             nullptr,
-            0,
-            0,
-            0,
-            0,
-            0,
-            HWND_MESSAGE,
             nullptr,
             instance,
             nullptr
@@ -2165,12 +2258,11 @@ bool CreateWorkerMessageWindow() {
     if (!g_workerMessageWindow) {
         Wh_Log(L"CreateWindowExW(message window) failed: %lu", GetLastError());
 
-        if (g_workerWindowClassAtom == 1) {
-            g_workerWindowClassAtom = 0;
-        } else {
-            UnregisterClassW(kClassName, instance);
-            g_workerWindowClassAtom = 0;
-        }
+        UnregisterClassW(
+            kClassName,
+            instance
+        );
+        g_workerWindowClassAtom = 0;
 
         return false;
     }
@@ -2204,15 +2296,12 @@ void UpdateSafetyTimer(UINT_PTR timerId) {
         return;
     }
 
-    const UINT kIdlePollIntervalMs = 1000;
-    const UINT kHiddenPollIntervalMs = 250;
+    constexpr UINT kSafetyPollIntervalMs = 1000;
 
     SetTimer(
         nullptr,
         timerId,
-        HasHiddenTaskbar()
-            ? kHiddenPollIntervalMs
-            : kIdlePollIntervalMs,
+        kSafetyPollIntervalMs,
         nullptr
     );
 }
@@ -2230,7 +2319,11 @@ DWORD WINAPI WorkerThread(
         PM_NOREMOVE
     );
 
-    CreateWorkerMessageWindow();
+    if (!CreateWorkerMessageWindow()) {
+        Wh_Log(
+            L"CreateWorkerMessageWindow failed; continuing with WinEvent/safety-poll handling"
+        );
+    }
 
     if (g_workerReadyEvent) {
         SetEvent(
@@ -2271,6 +2364,22 @@ DWORD WINAPI WorkerThread(
             WINEVENT_OUTOFCONTEXT
         );
 
+    g_mouseHook =
+        SetWindowsHookExW(
+            WH_MOUSE_LL,
+            LowLevelMouseProc,
+            GetModuleHandleW(nullptr),
+            0
+        );
+
+    if (!g_mouseHook) {
+        Wh_Log(L"SetWindowsHookExW(WH_MOUSE_LL) failed: %lu", GetLastError());
+    }
+
+    g_lastCursorTriggerMonitor = nullptr;
+    g_lastCursorInTriggerBand = false;
+    g_lastCursorInExactHoverZone = false;
+
     EnsureTaskbarShowHook();
     UpdateTaskbarState();
 
@@ -2296,9 +2405,13 @@ DWORD WINAPI WorkerThread(
         }
 
         if (msg.message == WM_TIMER) {
+            if (msg.hwnd == g_workerMessageWindow) {
+                DispatchMessageW(&msg);
+                continue;
+            }
+
             EnsureTaskbarShowHook();
             UpdateTaskbarState();
-
             UpdateSafetyTimer(timerId);
 
             continue;
@@ -2346,6 +2459,10 @@ DWORD WINAPI WorkerThread(
     SafeUnhookWinEvent(g_foregroundHook);
     SafeUnhookWinEvent(g_minimizeHook);
     SafeUnhookWinEvent(g_moveHook);
+    if (g_mouseHook) {
+        UnhookWindowsHookEx(g_mouseHook);
+        g_mouseHook = nullptr;
+    }
     SafeUnhookWinEvent(g_taskbarShowHook);
     g_taskbarShowHookProcessId = 0;
 
@@ -2544,51 +2661,6 @@ BOOL WhTool_ModInit() {
         INFINITE
     );
 
-    g_cursorStopEvent =
-        CreateEventW(
-            nullptr,
-            TRUE,
-            FALSE,
-            nullptr
-        );
-
-    if (!g_cursorStopEvent) {
-        Wh_Log(L"CreateEvent for cursor sampler failed");
-        WhTool_ModUninit();
-        return FALSE;
-    }
-
-    g_cursorWakeEvent =
-        CreateEventW(
-            nullptr,
-            FALSE,
-            FALSE,
-            nullptr
-        );
-
-    if (!g_cursorWakeEvent) {
-        Wh_Log(L"CreateEvent for cursor sampler wake failed");
-        WhTool_ModUninit();
-        return FALSE;
-    }
-
-    g_cursorThread =
-        CreateThread(
-            nullptr,
-            0,
-            CursorSamplingThread,
-            nullptr,
-            0,
-            nullptr
-        );
-
-    if (!g_cursorThread) {
-        Wh_Log(L"CreateThread for cursor sampler failed");
-        SafeCloseHandle(g_cursorStopEvent);
-        WhTool_ModUninit();
-        return FALSE;
-    }
-
     return TRUE;
 }
 
@@ -2604,18 +2676,40 @@ void WhTool_ModSettingsChanged() {
 }
 
 void RestoreAllTaskbars() {
-    HWND taskbar =
+    auto restoreTaskbarIfMarked = [](HWND hwnd) {
+        if (
+            !hwnd ||
+            !IsWindow(hwnd) ||
+            !GetPropW(
+                hwnd,
+                kHiddenByModProperty
+            )
+        ) {
+            return;
+        }
+
+        /*
+         * Teardown/recovery is intentionally asynchronous. This path can run
+         * from the launcher watchdog, where blocking on Explorer's UI thread
+         * could otherwise hang Windhawk itself.
+         */
+        ShowWindowAsync(
+            hwnd,
+            SW_SHOW
+        );
+
+        RemovePropW(
+            hwnd,
+            kHiddenByModProperty
+        );
+    };
+
+    restoreTaskbarIfMarked(
         FindWindowW(
             L"Shell_TrayWnd",
             nullptr
-        );
-
-    if (taskbar) {
-        ShowWindow(
-            taskbar,
-            SW_SHOW
-        );
-    }
+        )
+    );
 
     HWND secondary = nullptr;
 
@@ -2627,10 +2721,7 @@ void RestoreAllTaskbars() {
             nullptr
         )) != nullptr
     ) {
-        ShowWindow(
-            secondary,
-            SW_SHOW
-        );
+        restoreTaskbarIfMarked(secondary);
     }
 }
 
@@ -2667,43 +2758,15 @@ bool WaitForThreadWithTimeout(
     }
 
     /*
-     * This function is used only by the dedicated tool process. Do not return
-     * while a worker may still execute mod code, because that could unload the
-     * module underneath the thread. The launcher watchdog restores taskbars
-     * after this process exits.
+     * The caller must restore any taskbars hidden by this mod and terminate the
+     * dedicated process immediately if a worker remains stuck. Returning here
+     * is safe only because the caller handles that termination.
      */
-    ExitProcess(1);
     return false;
 }
 
 void WhTool_ModUninit() {
     Wh_Log(L"Uninit");
-
-    if (g_cursorStopEvent) {
-        SetEvent(g_cursorStopEvent);
-    }
-
-    if (g_cursorWakeEvent) {
-        SetEvent(g_cursorWakeEvent);
-    }
-
-    if (g_cursorThread) {
-        WaitForThreadWithTimeout(
-            g_cursorThread,
-            3000,
-            L"cursor sampler"
-        );
-
-        SafeCloseHandle(g_cursorThread);
-    }
-
-    if (g_cursorStopEvent) {
-        SafeCloseHandle(g_cursorStopEvent);
-    }
-
-    if (g_cursorWakeEvent) {
-        SafeCloseHandle(g_cursorWakeEvent);
-    }
 
     if (g_workerThread) {
         DWORD readyResult =
@@ -2733,11 +2796,14 @@ void WhTool_ModUninit() {
             );
         }
 
-        WaitForThreadWithTimeout(
-            g_workerThread,
-            5000,
-            L"worker"
-        );
+        if (!WaitForThreadWithTimeout(
+                g_workerThread,
+                5000,
+                L"worker"
+            )) {
+            RestoreAllTaskbars();
+            ExitProcess(1);
+        }
 
         SafeCloseHandle(g_workerThread);
     }
@@ -2899,6 +2965,50 @@ BOOL Wh_ModInit() {
     return TRUE;
 }
 
+bool IsAnotherToolModInstanceRunning() {
+    HANDLE mutex =
+        OpenMutexW(
+            SYNCHRONIZE,
+            FALSE,
+            L"windhawk-tool-mod_" WH_MOD_ID
+        );
+
+    if (!mutex) {
+        return false;
+    }
+
+    DWORD result =
+        WaitForSingleObject(
+            mutex,
+            0
+        );
+
+    if (
+        result == WAIT_OBJECT_0 ||
+        result == WAIT_ABANDONED
+    ) {
+        ReleaseMutex(mutex);
+        CloseHandle(mutex);
+        return false;
+    }
+
+    if (result == WAIT_TIMEOUT) {
+        CloseHandle(mutex);
+        return true;
+    }
+
+    Wh_Log(
+        L"Could not determine tool-process mutex owner: %lu",
+        GetLastError()
+    );
+
+    CloseHandle(mutex);
+
+    // When ownership cannot be determined, do not disturb a potentially
+    // running tool instance.
+    return true;
+}
+
 DWORD WINAPI ToolModWatchdogThread(LPVOID) {
     HANDLE waitHandles[2] = {
         g_launcherWatchdogStopEvent,
@@ -2919,10 +3029,16 @@ DWORD WINAPI ToolModWatchdogThread(LPVOID) {
          * or completed a normal shutdown, make sure Explorer taskbars are not
          * left hidden.
          */
-        Wh_Log(
-            L"Tool process exited; restoring taskbars"
-        );
-        RestoreAllTaskbars();
+        if (IsAnotherToolModInstanceRunning()) {
+            Wh_Log(
+                L"Tool process exited, but another tool instance is still running; not restoring taskbars"
+            );
+        } else {
+            Wh_Log(
+                L"Tool process exited; restoring taskbars hidden by this mod"
+            );
+            RestoreAllTaskbars();
+        }
     }
 
     return 0;

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -1,4 +1,4 @@
-
+// ==WindhawkMod==
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Hides the taskbar when the desktop is active, while showing it for applications and on taskbar hover

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Hides selected taskbars only while their display is showing the desktop
-// @version         3.1.0
+// @version         3.4.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -37,29 +37,54 @@ per Explorer process and keeps the state-management code outside the shell.
   and Alt+Tab are treated as transient shell interactions.
 - Clearing the "Taskbars to hide on desktop" selection means hide nothing.
 
-### Why this is a separate mod
 
-**`taskbar-auto-hide-when-maximized`** primarily bases its behavior on
-application-window geometry and maximized state. This mod instead evaluates
-whether each display currently has any visible application window. An
-application can remain open on display 2 while the taskbar on display 1
-hides because display 1 is showing only the desktop.
+### Robustness
 
-**`taskbar-auto-hide-per-monitor`** provides explicit per-monitor control
-over native auto-hide. This mod also has per-display selection, but its
-visibility decision is derived automatically from application presence.
+- The tool re-discovers primary and secondary taskbars during every reconciliation,
+  so Explorer taskbar recreation is picked up automatically.
+- A message-only worker window reacts to `TaskbarCreated`, display-configuration,
+  settings, and theme changes instead of waiting for the next safety-poll tick.
+- Selected `DISPLAYn` entries are bound to the display's monitor device identity
+  during the current Windows session, so a dock/reconnect that renumbers
+  `DISPLAYn` can keep the selection attached to the same physical display.
+- A display-topology signature resets stale hover state after monitor geometry or
+  display-set changes.
+- Native Windows auto-hide state is sampled once per reconciliation and reused
+  for the rest of that reconciliation.
+- Known taskbar/XAML popup classes are treated as shell surfaces; generic
+  `Windows.UI.Core.CoreWindow` windows are no longer rejected solely because of
+  their class name, which avoids misclassifying visible UWP application windows.
 
-**`taskbar-auto-hide-custom-activation-area`** changes the activation area
-for Windows' native auto-hide. This mod directly hides/shows the taskbar
-window and supplies its own hover-reveal behavior.
+### How this differs from related taskbar mods
 
-**`taskbar-fade`** is a broader taskbar customization/fading mod with a
-Smart Idle option. This mod is specifically focused on desktop-only visibility,
-independent per-display application state, and explicit per-display hover
-reveal.
+This mod overlaps with existing per-monitor taskbar mods in that each display
+is evaluated independently. The key behavioral difference from
+**`taskbar-auto-hide-when-maximized`** is the predicate used for hiding: this
+mod keeps a selected taskbar visible whenever its display has any visible,
+non-minimized application window, and hides it only when that display has no
+such window. It is therefore not limited to maximized, snapped, fullscreen,
+or taskbar-intersecting application states.
 
-A key difference is the **work-area behavior**: the mod uses
+**`taskbar-auto-hide-per-monitor`** provides explicit per-monitor control over
+Windows' native auto-hide. This mod instead derives visibility from application
+presence and directly controls the taskbar window.
+
+**`taskbar-auto-hide-custom-activation-area`** changes the activation area for
+Windows' native auto-hide. This mod supplies its own bottom-edge hover reveal
+while leaving the normal desktop work area unchanged.
+
+**`taskbar-fade`** is a broader taskbar customization/fading mod with a Smart
+Idle option. This mod is specifically focused on desktop-only visibility and
+its associated per-display application-state rule.
+
+A key implementation difference is the **work-area behavior**: the mod uses
 `ShowWindow(SW_HIDE)` and does not change the Windows desktop work area.
+
+The launcher keeps a lightweight watchdog for the dedicated tool process. If the
+tool exits unexpectedly while a taskbar is hidden, the watchdog re-shows the
+currently discoverable primary and secondary taskbars. A normal mod unload also
+restores taskbars. If Explorer itself is unresponsive or has already recreated a
+taskbar, restarting Explorer may still be required.
 
 ### Process and state model
 
@@ -69,7 +94,10 @@ an immediate reconciliation, while a periodic safety poll handles missed
 or unusual transitions.
 
 Each safety poll performs one display enumeration and one top-level-window
-enumeration. The result is reused for every taskbar.
+enumeration. The result is reused for every taskbar. Hover reveal uses a gated
+cursor sampler only while a hidden taskbar can actually be revealed, and its
+post-hover delay expires through a one-shot worker timer rather than a fast
+full-state polling loop.
 */
 // ==/WindhawkModReadme==
 
@@ -153,6 +181,8 @@ constexpr size_t kMaxTaskbars = 16;
 
 constexpr UINT WM_APP_REFRESH = WM_APP + 1;
 constexpr UINT WM_APP_SETTINGS = WM_APP + 2;
+constexpr UINT_PTR kSafetyTimerId = 1;
+constexpr UINT_PTR kHoverExpireTimerId = 2;
 
 struct {
     int extraHoverMarginPx;
@@ -167,6 +197,7 @@ struct MonitorEntry {
     HMONITOR monitor;
     RECT rect;
     wchar_t deviceName[32];
+    wchar_t stableDeviceId[256];
 };
 
 struct MonitorList {
@@ -178,7 +209,13 @@ struct TaskbarMonitorState {
     HWND hwnd;
     HMONITOR monitor;
     int monitorNumber;
+    wchar_t stableDeviceId[256];
     bool desktopOnly;
+};
+
+struct MonitorSelectionBinding {
+    bool configured;
+    wchar_t stableDeviceId[256];
 };
 
 struct WindowScanResult {
@@ -197,18 +234,34 @@ DWORD g_workerThreadId = 0;
 HANDLE g_workerReadyEvent = nullptr;
 HANDLE g_cursorThread = nullptr;
 HANDLE g_cursorStopEvent = nullptr;
+HANDLE g_cursorWakeEvent = nullptr;
+
+HWND g_workerMessageWindow = nullptr;
+ATOM g_workerWindowClassAtom = 0;
+UINT g_taskbarCreatedMessage = 0;
+ULONGLONG g_displayTopologySignature = 0;
 
 TaskbarMonitorState g_taskbarStates[kMaxTaskbars] = {};
 size_t g_taskbarStateCount = 0;
+bool g_nativeAutoHideEnabled = false;
+
+MonitorSelectionBinding
+    g_hideMonitorBindings[kMaxMonitorNumbers + 1] = {};
+MonitorSelectionBinding
+    g_hoverMonitorBindings[kMaxMonitorNumbers + 1] = {};
 
 bool g_hoverActive = false;
 HMONITOR g_hoverMonitor = nullptr;
 ULONGLONG g_hoverDeadline = 0;
 
 LONG g_refreshPosted = 0;
+LONG g_cursorSamplingEnabled = 0;
 
 void LoadSettings();
 void WhTool_ModUninit();
+void UpdateCursorSamplingState();
+void ArmHoverExpireTimer();
+void CancelHoverExpireTimer();
 
 bool IsShellChromeClass(
     const WCHAR* className
@@ -258,6 +311,12 @@ bool IsDesktopInfrastructureWindow(
     return shellWindow && shellWindow == hwnd;
 }
 
+bool GetStableMonitorDeviceId(
+    const wchar_t* deviceName,
+    wchar_t* output,
+    size_t outputCount
+);
+
 BOOL CALLBACK CollectMonitorProc(
     HMONITOR monitor,
     HDC,
@@ -289,8 +348,89 @@ BOOL CALLBACK CollectMonitorProc(
         info.szDevice,
         _TRUNCATE
     );
+    GetStableMonitorDeviceId(
+        entry.deviceName,
+        entry.stableDeviceId,
+        ARRAYSIZE(entry.stableDeviceId)
+    );
 
     return TRUE;
+}
+
+bool GetStableMonitorDeviceId(
+    const wchar_t* deviceName,
+    wchar_t* output,
+    size_t outputCount
+) {
+    if (
+        !deviceName ||
+        !output ||
+        outputCount == 0
+    ) {
+        return false;
+    }
+
+    output[0] = L'\0';
+
+    DISPLAY_DEVICEW adapter = {};
+    adapter.cb = sizeof(adapter);
+
+    for (
+        DWORD adapterIndex = 0;
+        EnumDisplayDevicesW(
+            nullptr,
+            adapterIndex,
+            &adapter,
+            0
+        );
+        ++adapterIndex
+    ) {
+        if (
+            wcscmp(
+                adapter.DeviceName,
+                deviceName
+            ) != 0
+        ) {
+            adapter = {};
+            adapter.cb = sizeof(adapter);
+            continue;
+        }
+
+        DISPLAY_DEVICEW monitor = {};
+        monitor.cb = sizeof(monitor);
+
+        if (
+            EnumDisplayDevicesW(
+                adapter.DeviceName,
+                0,
+                &monitor,
+                0
+            ) &&
+            monitor.DeviceID[0] != L'\0'
+        ) {
+            wcsncpy_s(
+                output,
+                outputCount,
+                monitor.DeviceID,
+                _TRUNCATE
+            );
+            return output[0] != L'\0';
+        }
+
+        if (adapter.DeviceID[0] != L'\0') {
+            wcsncpy_s(
+                output,
+                outputCount,
+                adapter.DeviceID,
+                _TRUNCATE
+            );
+            return output[0] != L'\0';
+        }
+
+        return false;
+    }
+
+    return false;
 }
 
 int GetDisplayDeviceNumber(
@@ -331,10 +471,91 @@ int GetDisplayDeviceNumber(
             kMaxMonitorNumbers
         )
     ) {
+        Wh_Log(
+            L"Unsupported display device number for %s: %ld (supported range: 1-%d)",
+            deviceName,
+            number,
+            static_cast<int>(kMaxMonitorNumbers)
+        );
         return 0;
     }
 
     return static_cast<int>(number);
+}
+
+void ResetMonitorSelectionBindings() {
+    for (
+        size_t i = 0;
+        i <= kMaxMonitorNumbers;
+        ++i
+    ) {
+        g_hideMonitorBindings[i] = {};
+        g_hoverMonitorBindings[i] = {};
+    }
+}
+
+void BindSelectionIdentity(
+    int configuredNumber,
+    const MonitorList& monitors,
+    const bool* selected,
+    MonitorSelectionBinding* bindings
+) {
+    if (
+        configuredNumber < 1 ||
+        configuredNumber > static_cast<int>(kMaxMonitorNumbers) ||
+        !selected ||
+        !bindings ||
+        !selected[configuredNumber] ||
+        bindings[configuredNumber].configured
+    ) {
+        return;
+    }
+
+    for (size_t i = 0; i < monitors.count; ++i) {
+        if (
+            GetDisplayDeviceNumber(
+                monitors.entries[i].deviceName
+            ) == configuredNumber
+        ) {
+            if (monitors.entries[i].stableDeviceId[0] != L'\0') {
+                bindings[configuredNumber].configured = true;
+                wcsncpy_s(
+                    bindings[configuredNumber].stableDeviceId,
+                    ARRAYSIZE(
+                        bindings[configuredNumber].stableDeviceId
+                    ),
+                    monitors.entries[i].stableDeviceId,
+                    _TRUNCATE
+                );
+            }
+
+            return;
+        }
+    }
+}
+
+void BindConfiguredMonitorSelections(
+    const MonitorList& monitors
+) {
+    for (
+        int configuredNumber = 1;
+        configuredNumber <= static_cast<int>(kMaxMonitorNumbers);
+        ++configuredNumber
+    ) {
+        BindSelectionIdentity(
+            configuredNumber,
+            monitors,
+            g_settings.hideMonitor,
+            g_hideMonitorBindings
+        );
+
+        BindSelectionIdentity(
+            configuredNumber,
+            monitors,
+            g_settings.hoverMonitor,
+            g_hoverMonitorBindings
+        );
+    }
 }
 
 MonitorList GetCurrentMonitors() {
@@ -348,6 +569,47 @@ MonitorList GetCurrentMonitors() {
     );
 
     return list;
+}
+
+ULONGLONG HashDisplayTopology(
+    const MonitorList& monitors
+) {
+    // FNV-1a style hash over monitor device names and geometry. The signature
+    // is only used to detect that the topology changed, not as a stable ID.
+    ULONGLONG hash = 1469598103934665603ull;
+
+    auto mixByte = [&](unsigned char value) {
+        hash ^= value;
+        hash *= 1099511628211ull;
+    };
+
+    auto mixInt = [&](LONG value) {
+        unsigned long v = static_cast<unsigned long>(value);
+        for (int shift = 0; shift < 32; shift += 8) {
+            mixByte(static_cast<unsigned char>((v >> shift) & 0xff));
+        }
+    };
+
+    mixInt(static_cast<LONG>(monitors.count));
+
+    for (size_t i = 0; i < monitors.count; ++i) {
+        const MonitorEntry& entry = monitors.entries[i];
+
+        mixInt(entry.rect.left);
+        mixInt(entry.rect.top);
+        mixInt(entry.rect.right);
+        mixInt(entry.rect.bottom);
+
+        for (const wchar_t* pName = entry.deviceName; *pName; ++pName) {
+            wchar_t ch = *pName;
+            mixByte(static_cast<unsigned char>(ch & 0xff));
+            mixByte(static_cast<unsigned char>((ch >> 8) & 0xff));
+        }
+
+        mixByte(0);
+    }
+
+    return hash;
 }
 
 int GetMonitorNumber(
@@ -367,42 +629,85 @@ int GetMonitorNumber(
 
 bool IsBottomDockedTaskbar(HWND hTaskbar, HMONITOR monitor);
 
+bool StableDeviceIdsMatch(
+    const wchar_t* left,
+    const wchar_t* right
+) {
+    return
+        left &&
+        right &&
+        left[0] != L'\0' &&
+        right[0] != L'\0' &&
+        wcscmp(left, right) == 0;
+}
+
+bool IsMonitorSelected(
+    int monitorNumber,
+    const wchar_t* stableDeviceId,
+    const bool* selected,
+    const MonitorSelectionBinding* bindings
+) {
+    if (!selected || !bindings) {
+        return false;
+    }
+
+    if (
+        monitorNumber >= 1 &&
+        monitorNumber <= static_cast<int>(kMaxMonitorNumbers) &&
+        selected[monitorNumber] &&
+        !bindings[monitorNumber].configured
+    ) {
+        return true;
+    }
+
+    for (
+        int configuredNumber = 1;
+        configuredNumber <= static_cast<int>(kMaxMonitorNumbers);
+        ++configuredNumber
+    ) {
+        if (
+            selected[configuredNumber] &&
+            bindings[configuredNumber].configured &&
+            StableDeviceIdsMatch(
+                stableDeviceId,
+                bindings[configuredNumber].stableDeviceId
+            )
+        ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool ShouldHideMonitor(
-    int monitorNumber
+    const TaskbarMonitorState& state
 ) {
     if (g_settings.hideAllMonitors) {
         return true;
     }
 
-    if (
-        monitorNumber < 1 ||
-        monitorNumber > static_cast<int>(
-            kMaxMonitorNumbers
-        )
-    ) {
-        return false;
-    }
-
-    return g_settings.hideMonitor[monitorNumber];
+    return IsMonitorSelected(
+        state.monitorNumber,
+        state.stableDeviceId,
+        g_settings.hideMonitor,
+        g_hideMonitorBindings
+    );
 }
 
 bool ShouldRevealOnHover(
-    int monitorNumber
+    const TaskbarMonitorState& state
 ) {
     if (g_settings.hoverAllMonitors) {
         return true;
     }
 
-    if (
-        monitorNumber < 1 ||
-        monitorNumber > static_cast<int>(
-            kMaxMonitorNumbers
-        )
-    ) {
-        return false;
-    }
-
-    return g_settings.hoverMonitor[monitorNumber];
+    return IsMonitorSelected(
+        state.monitorNumber,
+        state.stableDeviceId,
+        g_settings.hoverMonitor,
+        g_hoverMonitorBindings
+    );
 }
 
 bool IsTransientShellWindow(
@@ -424,11 +729,7 @@ bool IsTransientShellWindow(
     // Common Windows shell/XAML popup hosts.
     if (
         wcscmp(className, L"Xaml_WindowedPopupClass") == 0 ||
-        wcscmp(className, L"Windows.UI.Core.CoreWindow") == 0 ||
-        wcscmp(
-            className,
-            L"TopLevelWindowForOverflowXamlIsland"
-        ) == 0 ||
+        wcscmp(className, L"TopLevelWindowForOverflowXamlIsland") == 0 ||
         wcscmp(
             className,
             L"NotifyIconOverflowWindow"
@@ -466,7 +767,16 @@ bool IsApplicationWindowCandidate(
         return false;
     }
 
-    if (GetWindow(hwnd, GW_OWNER) != nullptr) {
+    LONG_PTR exStyle =
+        GetWindowLongPtrW(
+            hwnd,
+            GWL_EXSTYLE
+        );
+
+    if (
+        GetWindow(hwnd, GW_OWNER) != nullptr &&
+        !(exStyle & WS_EX_APPWINDOW)
+    ) {
         return false;
     }
 
@@ -476,12 +786,6 @@ bool IsApplicationWindowCandidate(
         )) {
         return false;
     }
-
-    LONG_PTR exStyle =
-        GetWindowLongPtrW(
-            hwnd,
-            GWL_EXSTYLE
-        );
 
     if (exStyle & WS_EX_TOOLWINDOW) {
         return false;
@@ -630,30 +934,22 @@ BOOL CALLBACK ScanWindowsWithMonitorsProc(
         RECT popupRect = {};
 
         if (GetWindowRect(hwnd, &popupRect)) {
-            POINT center = {
-                popupRect.left +
-                    (popupRect.right - popupRect.left) / 2,
-                popupRect.top +
-                    (popupRect.bottom - popupRect.top) / 2
-            };
-
-            HMONITOR popupMonitor =
-                MonitorFromPoint(
-                    center,
-                    MONITOR_DEFAULTTONEAREST
-                );
-
+            // Mark every display intersected by the popup rather than using
+            // its center point. This handles shell surfaces that straddle
+            // monitor boundaries and avoids arbitrarily selecting one display.
             for (
                 size_t i = 0;
                 i < context->monitors->count;
                 ++i
             ) {
-                if (
-                    context->monitors->entries[i].monitor ==
-                    popupMonitor
-                ) {
+                RECT intersection = {};
+
+                if (IntersectRect(
+                        &intersection,
+                        &popupRect,
+                        &context->monitors->entries[i].rect
+                    )) {
                     context->result->taskbarPopupOnMonitor[i] = true;
-                    break;
                 }
             }
         }
@@ -865,6 +1161,26 @@ void RefreshTaskbarMonitorStates(
                 monitors,
                 monitor
             );
+
+        for (
+            size_t monitorIndex = 0;
+            monitorIndex < monitors.count;
+            ++monitorIndex
+        ) {
+            if (
+                monitors.entries[monitorIndex].monitor ==
+                monitor
+            ) {
+                wcsncpy_s(
+                    state.stableDeviceId,
+                    ARRAYSIZE(state.stableDeviceId),
+                    monitors.entries[monitorIndex].stableDeviceId,
+                    _TRUNCATE
+                );
+                break;
+            }
+        }
+
         state.desktopOnly = true;
 
         for (size_t i = 0; i < oldCount; ++i) {
@@ -901,18 +1217,12 @@ void RefreshTaskbarMonitorStates(
     }
 }
 
-bool IsNativeAutoHideEnabled(HWND taskbar) {
-    if (!taskbar || !IsWindow(taskbar)) {
-        return false;
-    }
-
+bool IsNativeAutoHideEnabled() {
     APPBARDATA data = {};
     data.cbSize = sizeof(data);
-    data.hWnd = taskbar;
 
     return (SHAppBarMessage(ABM_GETSTATE, &data) & ABS_AUTOHIDE) != 0;
 }
-
 
 bool ShouldHideTaskbar(
     const TaskbarMonitorState& state
@@ -920,12 +1230,12 @@ bool ShouldHideTaskbar(
     return
         state.hwnd &&
         state.monitor &&
-        ShouldHideMonitor(state.monitorNumber) &&
+        ShouldHideMonitor(state) &&
         IsBottomDockedTaskbar(
             state.hwnd,
             state.monitor
         ) &&
-        !IsNativeAutoHideEnabled(state.hwnd);
+        !g_nativeAutoHideEnabled;
 }
 
 
@@ -944,11 +1254,25 @@ void SetTaskbarState(
         IsWindowVisible(state.hwnd) != FALSE;
 
     if (visible != show) {
+        // Keep the visibility transition synchronous. Explorer can immediately
+        // re-show a taskbar while processing shell/minimize transitions; using
+        // ShowWindowAsync here can leave several SHOW/HIDE requests queued and
+        // cause a visible flicker loop. The worker is already serialized, so a
+        // synchronous transition gives us the stable state machine behavior.
         ShowWindow(
             state.hwnd,
             show ? SW_SHOW : SW_HIDE
         );
     }
+}
+
+bool IsTaskbarHiddenByMod(
+    const TaskbarMonitorState& state
+) {
+    return
+        state.hwnd &&
+        !IsWindowVisible(state.hwnd) &&
+        ShouldHideTaskbar(state);
 }
 
 void ApplyBaseTaskbarState() {
@@ -983,7 +1307,11 @@ int GetHoverZonePx(
         if (taskbarHeight > 0) {
             return
                 taskbarHeight +
-                g_settings.extraHoverMarginPx;
+                MulDiv(
+                    g_settings.extraHoverMarginPx,
+                    static_cast<int>(dpi),
+                    96
+                );
         }
     }
 
@@ -993,7 +1321,11 @@ int GetHoverZonePx(
             static_cast<int>(dpi),
             96
         ) +
-        g_settings.extraHoverMarginPx;
+        MulDiv(
+            g_settings.extraHoverMarginPx,
+            static_cast<int>(dpi),
+            96
+        );
 }
 
 bool IsBottomDockedTaskbar(
@@ -1106,32 +1438,40 @@ bool IsCursorNearBottomEdge(
         pt.y < mi.rcMonitor.bottom;
 }
 
-bool IsAltTabActive() {
-    HWND foreground = GetForegroundWindow();
-    if (!foreground || !IsWindowVisible(foreground)) {
-        return false;
-    }
-
-    WCHAR className[128] = {};
-    if (!GetClassNameW(
-            foreground,
-            className,
-            ARRAYSIZE(className))) {
-        return false;
-    }
-
-    return
-        wcscmp(className, L"TaskSwitcherWnd") == 0 ||
-        wcscmp(className, L"MultitaskingViewFrame") == 0;
-}
-
 void UpdateTaskbarState() {
     MonitorList monitors =
         GetCurrentMonitors();
 
+    BindConfiguredMonitorSelections(
+        monitors
+    );
+
+    ULONGLONG topologySignature =
+        HashDisplayTopology(monitors);
+
+    if (
+        g_displayTopologySignature != 0 &&
+        topologySignature != g_displayTopologySignature
+    ) {
+        // A display add/remove, arrangement change, or geometry/DPI transition
+        // can invalidate the current hover monitor. Reconcile from the base
+        // state instead of carrying old hover state across the transition.
+        g_hoverActive = false;
+        g_hoverMonitor = nullptr;
+        g_hoverDeadline = 0;
+        CancelHoverExpireTimer();
+    }
+
+    g_displayTopologySignature = topologySignature;
+
     RefreshTaskbarMonitorStates(
         monitors
     );
+
+    // ABM_GETSTATE reports the native auto-hide setting globally. Sample it
+    // once per reconciliation and reuse the result for every taskbar.
+    g_nativeAutoHideEnabled =
+        IsNativeAutoHideEnabled();
 
     WindowScanResult scan = {};
 
@@ -1166,7 +1506,6 @@ void UpdateTaskbarState() {
 
     POINT cursorPoint = {};
     HMONITOR cursorMonitor = nullptr;
-    int cursorMonitorNumber = 0;
 
     if (GetCursorPos(&cursorPoint)) {
         cursorMonitor =
@@ -1175,14 +1514,10 @@ void UpdateTaskbarState() {
                 MONITOR_DEFAULTTONEAREST
             );
 
-        cursorMonitorNumber =
-            GetMonitorNumber(
-                monitors,
-                cursorMonitor
-            );
     }
 
     HWND cursorTaskbar = nullptr;
+    bool cursorTaskbarHiddenByMod = false;
 
     for (size_t i = 0; i < g_taskbarStateCount; ++i) {
         if (
@@ -1191,75 +1526,96 @@ void UpdateTaskbarState() {
         ) {
             cursorTaskbar =
                 g_taskbarStates[i].hwnd;
+            cursorTaskbarHiddenByMod =
+                IsTaskbarHiddenByMod(g_taskbarStates[i]);
             break;
         }
     }
 
-    const bool hovering =
+    bool cursorHoverConfigured = false;
+
+    for (
+        size_t i = 0;
+        i < g_taskbarStateCount;
+        ++i
+    ) {
+        if (
+            g_taskbarStates[i].monitor ==
+            cursorMonitor
+        ) {
+            cursorHoverConfigured =
+                ShouldRevealOnHover(
+                    g_taskbarStates[i]
+                );
+            break;
+        }
+    }
+
+    const bool cursorInHoverZone =
         cursorTaskbar &&
         cursorMonitor &&
-        ShouldRevealOnHover(
-            cursorMonitorNumber
-        ) &&
+        cursorHoverConfigured &&
         IsCursorNearBottomEdge(
             cursorTaskbar,
             cursorMonitor
+        );
+
+    const bool hovering =
+        cursorInHoverZone &&
+        (
+            cursorTaskbarHiddenByMod ||
+            (g_hoverActive && g_hoverMonitor == cursorMonitor)
         );
 
     // Keep the taskbar visible for an open shell context menu/overflow
     // surface even after the cursor leaves the popup. Popup state was collected
     // during the main EnumWindows pass above, so no second full enumeration is
     // needed here.
-    HMONITOR popupMonitor = nullptr;
+    bool popupPresent = false;
 
-    for (
-        size_t monitorIndex = 0;
-        monitorIndex < monitors.count;
-        ++monitorIndex
-    ) {
+    for (size_t monitorIndex = 0;
+         monitorIndex < monitors.count;
+         ++monitorIndex) {
         if (scan.taskbarPopupOnMonitor[monitorIndex]) {
-            popupMonitor =
-                monitors.entries[monitorIndex].monitor;
+            popupPresent = true;
             break;
         }
     }
 
-    if (popupMonitor) {
+    if (popupPresent) {
         g_hoverActive = false;
         g_hoverMonitor = nullptr;
         g_hoverDeadline = 0;
+        CancelHoverExpireTimer();
 
         for (size_t i = 0; i < g_taskbarStateCount; ++i) {
             TaskbarMonitorState& state =
                 g_taskbarStates[i];
 
+            bool popupOnThisMonitor = false;
+
+            for (size_t monitorIndex = 0;
+                 monitorIndex < monitors.count;
+                 ++monitorIndex) {
+                if (
+                    monitors.entries[monitorIndex].monitor ==
+                        state.monitor &&
+                    scan.taskbarPopupOnMonitor[monitorIndex]
+                ) {
+                    popupOnThisMonitor = true;
+                    break;
+                }
+            }
+
             SetTaskbarState(
                 state,
-                state.monitor == popupMonitor ||
+                popupOnThisMonitor ||
                 !state.desktopOnly ||
                 !ShouldHideTaskbar(state)
             );
         }
 
-        return;
-    }
-
-    if (IsAltTabActive()) {
-        g_hoverActive = false;
-        g_hoverMonitor = nullptr;
-        g_hoverDeadline = 0;
-
-        for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-            TaskbarMonitorState& state =
-                g_taskbarStates[i];
-
-            SetTaskbarState(
-                state,
-                !state.desktopOnly ||
-                !ShouldHideTaskbar(state)
-            );
-        }
-
+        UpdateCursorSamplingState();
         return;
     }
 
@@ -1267,6 +1623,7 @@ void UpdateTaskbarState() {
         g_hoverActive = true;
         g_hoverMonitor = cursorMonitor;
         g_hoverDeadline = 0;
+        CancelHoverExpireTimer();
 
         for (size_t i = 0; i < g_taskbarStateCount; ++i) {
             TaskbarMonitorState& state =
@@ -1280,6 +1637,7 @@ void UpdateTaskbarState() {
             );
         }
 
+        UpdateCursorSamplingState();
         return;
     }
 
@@ -1291,8 +1649,10 @@ void UpdateTaskbarState() {
             g_hoverActive = false;
             g_hoverMonitor = nullptr;
             g_hoverDeadline = 0;
+            CancelHoverExpireTimer();
 
             ApplyBaseTaskbarState();
+            UpdateCursorSamplingState();
             return;
         }
 
@@ -1303,6 +1663,8 @@ void UpdateTaskbarState() {
             g_hoverDeadline =
                 now +
                 g_settings.autoHideDelayMs;
+
+            ArmHoverExpireTimer();
         }
 
         if (now < g_hoverDeadline) {
@@ -1318,6 +1680,7 @@ void UpdateTaskbarState() {
                 );
             }
 
+            UpdateCursorSamplingState();
             return;
         }
 
@@ -1325,11 +1688,71 @@ void UpdateTaskbarState() {
         g_hoverMonitor = nullptr;
         g_hoverDeadline = 0;
 
+        CancelHoverExpireTimer();
+
         ApplyBaseTaskbarState();
+        UpdateCursorSamplingState();
         return;
     }
 
     ApplyBaseTaskbarState();
+    UpdateCursorSamplingState();
+}
+
+void UpdateCursorSamplingState() {
+    bool shouldSample = g_hoverActive;
+
+    if (!shouldSample) {
+        for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+            const TaskbarMonitorState& state =
+                g_taskbarStates[i];
+
+            if (
+                IsTaskbarHiddenByMod(state) &&
+                ShouldRevealOnHover(state)
+            ) {
+                shouldSample = true;
+                break;
+            }
+        }
+    }
+
+    LONG oldValue =
+        InterlockedExchange(
+            &g_cursorSamplingEnabled,
+            shouldSample ? 1 : 0
+        );
+
+    if (shouldSample && oldValue == 0 && g_cursorWakeEvent) {
+        SetEvent(g_cursorWakeEvent);
+    }
+}
+
+void ArmHoverExpireTimer() {
+    if (!g_workerMessageWindow) {
+        return;
+    }
+
+    UINT delay =
+        g_settings.autoHideDelayMs == 0
+            ? 1
+            : g_settings.autoHideDelayMs;
+
+    SetTimer(
+        g_workerMessageWindow,
+        kHoverExpireTimerId,
+        delay,
+        nullptr
+    );
+}
+
+void CancelHoverExpireTimer() {
+    if (g_workerMessageWindow) {
+        KillTimer(
+            g_workerMessageWindow,
+            kHoverExpireTimerId
+        );
+    }
 }
 
 bool IsTaskbarWindow(HWND hwnd) {
@@ -1374,42 +1797,48 @@ bool IsCursorInConfiguredHoverZone() {
     MonitorList monitors =
         GetCurrentMonitors();
 
-    const int monitorNumber =
-        GetMonitorNumber(
-            monitors,
-            cursorMonitor
-        );
-
-    if (
-        monitorNumber == 0 ||
-        !ShouldRevealOnHover(
-            monitorNumber
-        )
-    ) {
-        return false;
-    }
-
-    HWND taskbar = nullptr;
+    TaskbarMonitorState* cursorState = nullptr;
 
     for (size_t i = 0; i < g_taskbarStateCount; ++i) {
         if (
             g_taskbarStates[i].monitor ==
             cursorMonitor
         ) {
-            taskbar =
-                g_taskbarStates[i].hwnd;
+            cursorState =
+                &g_taskbarStates[i];
             break;
         }
     }
 
+    if (
+        !cursorState ||
+        !ShouldRevealOnHover(*cursorState)
+    ) {
+        return false;
+    }
+
     return
-        taskbar &&
+        cursorState->hwnd &&
         IsCursorNearBottomEdge(
-            taskbar,
+            cursorState->hwnd,
             cursorMonitor
         );
 }
 
+
+void SafeUnhookWinEvent(HWINEVENTHOOK& hook) {
+    if (hook) {
+        UnhookWinEvent(hook);
+        hook = nullptr;
+    }
+}
+
+void SafeCloseHandle(HANDLE& handle) {
+    if (handle) {
+        CloseHandle(handle);
+        handle = nullptr;
+    }
+}
 
 void PostRefresh() {
     if (
@@ -1461,7 +1890,36 @@ DWORD WINAPI CursorSamplingThread(LPVOID) {
     HMONITOR lastMonitor = nullptr;
     bool lastInBand = false;
 
+    HANDLE waitHandles[2] = {
+        g_cursorStopEvent,
+        g_cursorWakeEvent
+    };
+
     for (;;) {
+        if (
+            InterlockedCompareExchange(
+                &g_cursorSamplingEnabled,
+                0,
+                0
+            ) == 0
+        ) {
+            DWORD waitResult =
+                WaitForMultipleObjects(
+                    ARRAYSIZE(waitHandles),
+                    waitHandles,
+                    FALSE,
+                    INFINITE
+                );
+
+            if (waitResult == WAIT_OBJECT_0) {
+                break;
+            }
+
+            lastMonitor = nullptr;
+            lastInBand = false;
+            continue;
+        }
+
         DWORD waitResult =
             WaitForSingleObject(
                 g_cursorStopEvent,
@@ -1470,6 +1928,16 @@ DWORD WINAPI CursorSamplingThread(LPVOID) {
 
         if (waitResult == WAIT_OBJECT_0) {
             break;
+        }
+
+        if (
+            InterlockedCompareExchange(
+                &g_cursorSamplingEnabled,
+                0,
+                0
+            ) == 0
+        ) {
+            continue;
         }
 
         POINT pt = {};
@@ -1576,11 +2044,8 @@ void EnsureTaskbarShowHook() {
         return;
     }
 
-    if (g_taskbarShowHook) {
-        UnhookWinEvent(g_taskbarShowHook);
-        g_taskbarShowHook = nullptr;
-        g_taskbarShowHookProcessId = 0;
-    }
+    SafeUnhookWinEvent(g_taskbarShowHook);
+    g_taskbarShowHookProcessId = 0;
 
     if (explorerPid) {
         g_taskbarShowHook = SetWinEventHook(
@@ -1615,6 +2080,143 @@ bool HasHiddenTaskbar() {
 }
 
 
+LRESULT CALLBACK WorkerMessageWindowProc(
+    HWND hwnd,
+    UINT message,
+    WPARAM wParam,
+    LPARAM lParam
+) {
+    if (
+        message == WM_TIMER &&
+        wParam == kHoverExpireTimerId
+    ) {
+        KillTimer(hwnd, kHoverExpireTimerId);
+        PostRefresh();
+        return 0;
+    }
+
+    if (
+        message == g_taskbarCreatedMessage ||
+        message == WM_DISPLAYCHANGE ||
+        message == WM_SETTINGCHANGE ||
+        message == WM_THEMECHANGED
+    ) {
+        PostRefresh();
+        return 0;
+    }
+
+    return DefWindowProcW(
+        hwnd,
+        message,
+        wParam,
+        lParam
+    );
+}
+
+bool CreateWorkerMessageWindow() {
+    g_taskbarCreatedMessage =
+        RegisterWindowMessageW(L"TaskbarCreated");
+
+    if (!g_taskbarCreatedMessage) {
+        Wh_Log(L"RegisterWindowMessage(TaskbarCreated) failed: %lu", GetLastError());
+        return false;
+    }
+
+    const wchar_t* kClassName =
+        L"WindhawkHideTaskbarOnlyOnDesktopMessageWindow";
+
+    HINSTANCE instance =
+        GetModuleHandleW(nullptr);
+
+    WNDCLASSEXW wc = {};
+    wc.cbSize = sizeof(wc);
+    wc.hInstance = instance;
+    wc.lpfnWndProc = WorkerMessageWindowProc;
+    wc.lpszClassName = kClassName;
+
+    g_workerWindowClassAtom =
+        RegisterClassExW(&wc);
+
+    if (!g_workerWindowClassAtom) {
+        if (GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
+            Wh_Log(L"RegisterClassExW failed: %lu", GetLastError());
+            return false;
+        }
+
+        g_workerWindowClassAtom = 1;
+    }
+
+    g_workerMessageWindow =
+        CreateWindowExW(
+            0,
+            kClassName,
+            nullptr,
+            0,
+            0,
+            0,
+            0,
+            0,
+            HWND_MESSAGE,
+            nullptr,
+            instance,
+            nullptr
+        );
+
+    if (!g_workerMessageWindow) {
+        Wh_Log(L"CreateWindowExW(message window) failed: %lu", GetLastError());
+
+        if (g_workerWindowClassAtom == 1) {
+            g_workerWindowClassAtom = 0;
+        } else {
+            UnregisterClassW(kClassName, instance);
+            g_workerWindowClassAtom = 0;
+        }
+
+        return false;
+    }
+
+    return true;
+}
+
+void DestroyWorkerMessageWindow() {
+    if (g_workerMessageWindow) {
+        DestroyWindow(g_workerMessageWindow);
+        g_workerMessageWindow = nullptr;
+    }
+
+    if (g_workerWindowClassAtom) {
+        const wchar_t* kClassName =
+            L"WindhawkHideTaskbarOnlyOnDesktopMessageWindow";
+
+        UnregisterClassW(
+            kClassName,
+            GetModuleHandleW(nullptr)
+        );
+
+        g_workerWindowClassAtom = 0;
+    }
+
+    g_taskbarCreatedMessage = 0;
+}
+
+void UpdateSafetyTimer(UINT_PTR timerId) {
+    if (!timerId) {
+        return;
+    }
+
+    const UINT kIdlePollIntervalMs = 1000;
+    const UINT kHiddenPollIntervalMs = 250;
+
+    SetTimer(
+        nullptr,
+        timerId,
+        HasHiddenTaskbar()
+            ? kHiddenPollIntervalMs
+            : kIdlePollIntervalMs,
+        nullptr
+    );
+}
+
 DWORD WINAPI WorkerThread(
     LPVOID
 ) {
@@ -1627,6 +2229,8 @@ DWORD WINAPI WorkerThread(
         WM_USER,
         PM_NOREMOVE
     );
+
+    CreateWorkerMessageWindow();
 
     if (g_workerReadyEvent) {
         SetEvent(
@@ -1670,15 +2274,11 @@ DWORD WINAPI WorkerThread(
     EnsureTaskbarShowHook();
     UpdateTaskbarState();
 
-    const UINT kIdlePollIntervalMs = 1000;
-    const UINT kHiddenPollIntervalMs = 250;
-    const UINT kHoverPollIntervalMs = 50;
-
     UINT_PTR timerId =
         SetTimer(
             nullptr,
-            1,
-            kIdlePollIntervalMs,
+            kSafetyTimerId,
+            1000,
             nullptr
         );
 
@@ -1699,18 +2299,7 @@ DWORD WINAPI WorkerThread(
             EnsureTaskbarShowHook();
             UpdateTaskbarState();
 
-            if (timerId) {
-                SetTimer(
-                    nullptr,
-                    timerId,
-                    g_hoverActive
-                        ? kHoverPollIntervalMs
-                        : HasHiddenTaskbar()
-                            ? kHiddenPollIntervalMs
-                            : kIdlePollIntervalMs,
-                    nullptr
-                );
-            }
+            UpdateSafetyTimer(timerId);
 
             continue;
         }
@@ -1724,18 +2313,7 @@ DWORD WINAPI WorkerThread(
             EnsureTaskbarShowHook();
             UpdateTaskbarState();
 
-            if (timerId) {
-                SetTimer(
-                    nullptr,
-                    timerId,
-                    g_hoverActive
-                        ? kHoverPollIntervalMs
-                        : HasHiddenTaskbar()
-                            ? kHiddenPollIntervalMs
-                            : kIdlePollIntervalMs,
-                    nullptr
-                );
-            }
+            UpdateSafetyTimer(timerId);
 
             continue;
         }
@@ -1745,18 +2323,7 @@ DWORD WINAPI WorkerThread(
             EnsureTaskbarShowHook();
             UpdateTaskbarState();
 
-            if (timerId) {
-                SetTimer(
-                    nullptr,
-                    timerId,
-                    g_hoverActive
-                        ? kHoverPollIntervalMs
-                        : HasHiddenTaskbar()
-                            ? kHiddenPollIntervalMs
-                            : kIdlePollIntervalMs,
-                    nullptr
-                );
-            }
+            UpdateSafetyTimer(timerId);
 
             continue;
         }
@@ -1764,18 +2331,7 @@ DWORD WINAPI WorkerThread(
         TranslateMessage(&msg);
         DispatchMessageW(&msg);
 
-        if (timerId) {
-            SetTimer(
-                nullptr,
-                timerId,
-                g_hoverActive
-                    ? kHoverPollIntervalMs
-                    : HasHiddenTaskbar()
-                        ? kHiddenPollIntervalMs
-                        : kIdlePollIntervalMs,
-                nullptr
-            );
-        }
+        UpdateSafetyTimer(timerId);
     }
 
     if (timerId) {
@@ -1785,39 +2341,22 @@ DWORD WINAPI WorkerThread(
         );
     }
 
-    if (g_foregroundHook) {
-        UnhookWinEvent(
-            g_foregroundHook
-        );
-        g_foregroundHook = nullptr;
-    }
+    CancelHoverExpireTimer();
 
-    if (g_minimizeHook) {
-        UnhookWinEvent(
-            g_minimizeHook
-        );
-        g_minimizeHook = nullptr;
-    }
+    SafeUnhookWinEvent(g_foregroundHook);
+    SafeUnhookWinEvent(g_minimizeHook);
+    SafeUnhookWinEvent(g_moveHook);
+    SafeUnhookWinEvent(g_taskbarShowHook);
+    g_taskbarShowHookProcessId = 0;
 
-    if (g_moveHook) {
-        UnhookWinEvent(
-            g_moveHook
-        );
-        g_moveHook = nullptr;
-    }
-
-    if (g_taskbarShowHook) {
-        UnhookWinEvent(
-            g_taskbarShowHook
-        );
-        g_taskbarShowHook = nullptr;
-        g_taskbarShowHookProcessId = 0;
-    }
+    DestroyWorkerMessageWindow();
 
     return 0;
 }
 
 void LoadSettings() {
+    ResetMonitorSelectionBindings();
+
     int hoverMargin =
         Wh_GetIntSetting(
             L"extraHoverMarginPx"
@@ -1996,11 +2535,7 @@ BOOL WhTool_ModInit() {
     if (!g_workerThread) {
         Wh_Log(L"CreateThread failed");
 
-        CloseHandle(
-            g_workerReadyEvent
-        );
-
-        g_workerReadyEvent = nullptr;
+        SafeCloseHandle(g_workerReadyEvent);
         return FALSE;
     }
 
@@ -2023,6 +2558,20 @@ BOOL WhTool_ModInit() {
         return FALSE;
     }
 
+    g_cursorWakeEvent =
+        CreateEventW(
+            nullptr,
+            FALSE,
+            FALSE,
+            nullptr
+        );
+
+    if (!g_cursorWakeEvent) {
+        Wh_Log(L"CreateEvent for cursor sampler wake failed");
+        WhTool_ModUninit();
+        return FALSE;
+    }
+
     g_cursorThread =
         CreateThread(
             nullptr,
@@ -2035,8 +2584,7 @@ BOOL WhTool_ModInit() {
 
     if (!g_cursorThread) {
         Wh_Log(L"CreateThread for cursor sampler failed");
-        CloseHandle(g_cursorStopEvent);
-        g_cursorStopEvent = nullptr;
+        SafeCloseHandle(g_cursorStopEvent);
         WhTool_ModUninit();
         return FALSE;
     }
@@ -2055,69 +2603,7 @@ void WhTool_ModSettingsChanged() {
     }
 }
 
-void WhTool_ModUninit() {
-    Wh_Log(L"Uninit");
-
-    if (g_cursorStopEvent) {
-        SetEvent(g_cursorStopEvent);
-    }
-
-    if (g_cursorThread) {
-        WaitForSingleObject(
-            g_cursorThread,
-            INFINITE
-        );
-
-        CloseHandle(g_cursorThread);
-        g_cursorThread = nullptr;
-    }
-
-    if (g_cursorStopEvent) {
-        CloseHandle(g_cursorStopEvent);
-        g_cursorStopEvent = nullptr;
-    }
-
-    if (g_workerThread) {
-        WaitForSingleObject(
-            g_workerReadyEvent,
-            INFINITE
-        );
-
-        if (!PostThreadMessageW(
-                g_workerThreadId,
-                WM_QUIT,
-                0,
-                0
-            )) {
-            Wh_Log(
-                L"PostThreadMessageW(WM_QUIT) failed: %lu",
-                GetLastError()
-            );
-        }
-
-        WaitForSingleObject(
-            g_workerThread,
-            INFINITE
-        );
-
-        CloseHandle(
-            g_workerThread
-        );
-
-        g_workerThread = nullptr;
-    }
-
-    if (g_workerReadyEvent) {
-        CloseHandle(
-            g_workerReadyEvent
-        );
-
-        g_workerReadyEvent = nullptr;
-    }
-
-    /*
-     * Restore all currently discoverable taskbars when the tool exits.
-     */
+void RestoreAllTaskbars() {
     HWND taskbar =
         FindWindowW(
             L"Shell_TrayWnd",
@@ -2148,6 +2634,124 @@ void WhTool_ModUninit() {
     }
 }
 
+bool WaitForThreadWithTimeout(
+    HANDLE thread,
+    DWORD timeoutMs,
+    const wchar_t* threadName
+) {
+    if (!thread) {
+        return true;
+    }
+
+    DWORD result =
+        WaitForSingleObject(
+            thread,
+            timeoutMs
+        );
+
+    if (result == WAIT_OBJECT_0) {
+        return true;
+    }
+
+    if (result == WAIT_TIMEOUT) {
+        Wh_Log(
+            L"Timed out waiting for %s thread shutdown; terminating the dedicated tool process",
+            threadName ? threadName : L"worker"
+        );
+    } else {
+        Wh_Log(
+            L"Wait for %s thread failed: %lu; terminating the dedicated tool process",
+            threadName ? threadName : L"worker",
+            GetLastError()
+        );
+    }
+
+    /*
+     * This function is used only by the dedicated tool process. Do not return
+     * while a worker may still execute mod code, because that could unload the
+     * module underneath the thread. The launcher watchdog restores taskbars
+     * after this process exits.
+     */
+    ExitProcess(1);
+    return false;
+}
+
+void WhTool_ModUninit() {
+    Wh_Log(L"Uninit");
+
+    if (g_cursorStopEvent) {
+        SetEvent(g_cursorStopEvent);
+    }
+
+    if (g_cursorWakeEvent) {
+        SetEvent(g_cursorWakeEvent);
+    }
+
+    if (g_cursorThread) {
+        WaitForThreadWithTimeout(
+            g_cursorThread,
+            3000,
+            L"cursor sampler"
+        );
+
+        SafeCloseHandle(g_cursorThread);
+    }
+
+    if (g_cursorStopEvent) {
+        SafeCloseHandle(g_cursorStopEvent);
+    }
+
+    if (g_cursorWakeEvent) {
+        SafeCloseHandle(g_cursorWakeEvent);
+    }
+
+    if (g_workerThread) {
+        DWORD readyResult =
+            WaitForSingleObject(
+                g_workerReadyEvent,
+                1000
+            );
+
+        if (readyResult != WAIT_OBJECT_0) {
+            Wh_Log(
+                L"Worker ready wait during shutdown did not complete: %lu",
+                readyResult == WAIT_TIMEOUT
+                    ? ERROR_TIMEOUT
+                    : GetLastError()
+            );
+        }
+
+        if (!PostThreadMessageW(
+                g_workerThreadId,
+                WM_QUIT,
+                0,
+                0
+            )) {
+            Wh_Log(
+                L"PostThreadMessageW(WM_QUIT) failed: %lu",
+                GetLastError()
+            );
+        }
+
+        WaitForThreadWithTimeout(
+            g_workerThread,
+            5000,
+            L"worker"
+        );
+
+        SafeCloseHandle(g_workerThread);
+    }
+
+    if (g_workerReadyEvent) {
+        SafeCloseHandle(g_workerReadyEvent);
+    }
+
+    /*
+     * Restore all currently discoverable taskbars when the tool exits.
+     */
+    RestoreAllTaskbars();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Windhawk tool mod implementation for mods which don't need to inject to other
 // processes or hook other functions. Context:
@@ -2159,6 +2763,10 @@ void WhTool_ModUninit() {
 
 bool g_isToolModProcessLauncher;
 HANDLE g_toolModProcessMutex;
+
+HANDLE g_launcherWatchdogThread = nullptr;
+HANDLE g_launcherWatchdogStopEvent = nullptr;
+HANDLE g_toolModChildProcess = nullptr;
 
 void WINAPI EntryPoint_Hook() {
     Wh_Log(L">");
@@ -2291,6 +2899,68 @@ BOOL Wh_ModInit() {
     return TRUE;
 }
 
+DWORD WINAPI ToolModWatchdogThread(LPVOID) {
+    HANDLE waitHandles[2] = {
+        g_launcherWatchdogStopEvent,
+        g_toolModChildProcess
+    };
+
+    DWORD result =
+        WaitForMultipleObjects(
+            ARRAYSIZE(waitHandles),
+            waitHandles,
+            FALSE,
+            INFINITE
+        );
+
+    if (result == WAIT_OBJECT_0 + 1) {
+        /*
+         * The dedicated tool process ended. Whether it crashed, was killed,
+         * or completed a normal shutdown, make sure Explorer taskbars are not
+         * left hidden.
+         */
+        Wh_Log(
+            L"Tool process exited; restoring taskbars"
+        );
+        RestoreAllTaskbars();
+    }
+
+    return 0;
+}
+
+void StopLauncherWatchdog() {
+    if (g_launcherWatchdogStopEvent) {
+        SetEvent(
+            g_launcherWatchdogStopEvent
+        );
+    }
+
+    if (g_launcherWatchdogThread) {
+        WaitForSingleObject(
+            g_launcherWatchdogThread,
+            INFINITE
+        );
+        CloseHandle(
+            g_launcherWatchdogThread
+        );
+        g_launcherWatchdogThread = nullptr;
+    }
+
+    if (g_launcherWatchdogStopEvent) {
+        CloseHandle(
+            g_launcherWatchdogStopEvent
+        );
+        g_launcherWatchdogStopEvent = nullptr;
+    }
+
+    if (g_toolModChildProcess) {
+        CloseHandle(
+            g_toolModChildProcess
+        );
+        g_toolModChildProcess = nullptr;
+    }
+}
+
 void Wh_ModAfterInit() {
     if (!g_isToolModProcessLauncher) {
         return;
@@ -2405,7 +3075,52 @@ void Wh_ModAfterInit() {
         return;
     }
 
-    CloseHandle(pi.hProcess);
+    g_toolModChildProcess = pi.hProcess;
+
+    g_launcherWatchdogStopEvent =
+        CreateEventW(
+            nullptr,
+            TRUE,
+            FALSE,
+            nullptr
+        );
+
+    if (!g_launcherWatchdogStopEvent) {
+        Wh_Log(
+            L"CreateEvent for launcher watchdog failed: %lu",
+            GetLastError()
+        );
+        CloseHandle(pi.hProcess);
+        g_toolModChildProcess = nullptr;
+        CloseHandle(pi.hThread);
+        return;
+    }
+
+    g_launcherWatchdogThread =
+        CreateThread(
+            nullptr,
+            0,
+            ToolModWatchdogThread,
+            nullptr,
+            0,
+            nullptr
+        );
+
+    if (!g_launcherWatchdogThread) {
+        Wh_Log(
+            L"CreateThread for launcher watchdog failed: %lu",
+            GetLastError()
+        );
+        CloseHandle(
+            g_launcherWatchdogStopEvent
+        );
+        g_launcherWatchdogStopEvent = nullptr;
+        CloseHandle(pi.hProcess);
+        g_toolModChildProcess = nullptr;
+        CloseHandle(pi.hThread);
+        return;
+    }
+
     CloseHandle(pi.hThread);
 }
 
@@ -2419,6 +3134,7 @@ void Wh_ModSettingsChanged() {
 
 void Wh_ModUninit() {
     if (g_isToolModProcessLauncher) {
+        StopLauncherWatchdog();
         return;
     }
 

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -1,8 +1,8 @@
-// ==WindhawkMod==
+
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
-// @description     Hides the taskbar when the desktop is active, while showing it for applications and on bottom-edge hover
-// @version         1.1.0
+// @description     Hides the taskbar when the desktop is active, while showing it for applications and on taskbar hover
+// @version         1.2.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -19,28 +19,30 @@ visible whenever an application or shell UI is active.
 ## Features
 
 - Hides the taskbar on the desktop.
-- Shows the taskbar immediately when an application becomes active.
-- Automatically hides the taskbar after minimizing or closing the last
-  application.
+- Shows the taskbar when an application becomes active.
+- Automatically hides the taskbar after minimizing or closing the last application.
 - Reveals the taskbar when the mouse enters the taskbar-sized hover area.
-- The hover area automatically follows the taskbar size and DPI.
+- The hover area follows the taskbar on the cursor's monitor.
+- Uses the taskbar's actual rectangle and per-monitor DPI.
 - Adds a configurable extra hover margin in millimeters.
 - Uses a configurable delay after leaving the hover area.
-- The delay is only used for a hover reveal.
+- The delay is only used after a hover reveal.
 - Minimizing or closing the last application hides the taskbar immediately.
 - Keeps the taskbar available while interacting with taskbar buttons.
 - Supports secondary taskbars on additional monitors.
-- Supports different monitor DPI settings.
 - Supports bottom, top, left and right taskbar positions.
-- Does not inject the mod into Explorer.
+- Runs as a Windhawk tool instead of being injected into Explorer.
 
 ## Notes
 
 This mod intentionally differs from native Windows auto-hide:
 it hides the taskbar window without changing the desktop work area.
 
-If native Windows taskbar auto-hide is already enabled, this mod temporarily
-stands down so the two mechanisms don't fight each other.
+If native Windows taskbar auto-hide is enabled, this mod stands down so
+the two mechanisms don't fight each other.
+
+This mod uses Windows events for application/window state changes and
+only uses a short timer while cursor hover handling is actually needed.
 
 This mod was created with AI assistance.
 */
@@ -73,7 +75,6 @@ This mod was created with AI assistance.
 #include <shellapi.h>
 #include <dwmapi.h>
 #include <atomic>
-#include <algorithm>
 #include <stdio.h>
 
 struct Settings {
@@ -86,18 +87,24 @@ Settings g_settings;
 
 HANDLE g_hThread = nullptr;
 DWORD g_threadId = 0;
-
 HANDLE g_hThreadReadyEvent = nullptr;
 
-HWINEVENTHOOK g_hWinEventHookForeground = nullptr;
+constexpr UINT WM_APP_REFRESH_STATE = WM_APP + 1;
+constexpr UINT WM_APP_STOP_THREAD = WM_APP + 2;
 
-std::atomic<bool> g_taskbarHidden{false};
+constexpr UINT kHoverTimerIntervalMs = 200;
+
+UINT_PTR g_hoverTimerId = 0;
+
+std::atomic<bool> g_refreshPosted{false};
+std::atomic<bool> g_nativeAutoHideEnabled{false};
 
 bool g_onDesktopState = false;
 bool g_shownDueToHover = false;
 ULONGLONG g_hideDeadline = 0;
 
-constexpr UINT WM_APP_REFRESH_STATE = WM_APP + 1;
+constexpr size_t kMaxWinEventHooks = 6;
+HWINEVENTHOOK g_hWinEventHooks[kMaxWinEventHooks] = {};
 
 
 // ============================================================
@@ -109,7 +116,7 @@ bool IsDesktopWindow(HWND hwnd) {
         return false;
     }
 
-    WCHAR className[256];
+    WCHAR className[256] = {};
 
     if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
         return false;
@@ -166,7 +173,7 @@ bool IsTaskbarWindow(HWND hwnd) {
         return false;
     }
 
-    WCHAR className[256];
+    WCHAR className[256] = {};
 
     if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
         return false;
@@ -192,7 +199,7 @@ BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
         return TRUE;
     }
 
-    WCHAR className[256];
+    WCHAR className[256] = {};
 
     if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
         return TRUE;
@@ -233,12 +240,8 @@ BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
         return TRUE;
     }
 
-    /*
-     * Don't blindly discard every owned window.
-     *
-     * Some applications use owned top-level windows for legitimate
-     * dialogs. Only ignore windows which are clearly tool windows.
-     */
+    // Keep legitimate owned application dialogs when they advertise
+    // themselves as application windows.
     if (GetWindow(hwnd, GW_OWNER) != nullptr &&
         !(exStyle & WS_EX_APPWINDOW)) {
         return TRUE;
@@ -305,13 +308,6 @@ void RefreshDesktopState() {
         return;
     }
 
-    /*
-     * If the taskbar itself is foreground and the mouse is actually
-     * over it, treat the user as interacting with the taskbar.
-     *
-     * This prevents the taskbar from immediately hiding after a
-     * taskbar click while an application is still open.
-     */
     if (IsTaskbarForegroundAndUnderCursor(foreground)) {
         g_onDesktopState = false;
         return;
@@ -327,7 +323,7 @@ void RefreshDesktopState() {
         return;
     }
 
-    WCHAR className[256];
+    WCHAR className[256] = {};
 
     if (GetClassNameW(
             foreground,
@@ -335,14 +331,10 @@ void RefreshDesktopState() {
             ARRAYSIZE(className)
         ) &&
         IsAmbiguousForegroundClass(className)) {
-
         g_onDesktopState = !AnyOtherVisibleWindowExists();
         return;
     }
 
-    /*
-     * A normal foreground window means we're not on the desktop.
-     */
     g_onDesktopState = false;
 }
 
@@ -364,8 +356,7 @@ HWND FindTaskbarForMonitor(HMONITOR hMonitor) {
     HWND primary = FindPrimaryTaskbar();
 
     if (primary &&
-        MonitorFromWindow(primary, MONITOR_DEFAULTTONULL) ==
-            hMonitor) {
+        MonitorFromWindow(primary, MONITOR_DEFAULTTONULL) == hMonitor) {
         return primary;
     }
 
@@ -397,7 +388,7 @@ HWND FindTaskbarForMonitor(HMONITOR hMonitor) {
 // Native Windows auto-hide detection
 // ============================================================
 
-bool IsNativeTaskbarAutoHideEnabled() {
+bool QueryNativeTaskbarAutoHide() {
     APPBARDATA abd = {};
     abd.cbSize = sizeof(abd);
 
@@ -408,36 +399,37 @@ bool IsNativeTaskbarAutoHideEnabled() {
 }
 
 
+void RefreshNativeTaskbarAutoHideState() {
+    bool enabled = QueryNativeTaskbarAutoHide();
+
+    g_nativeAutoHideEnabled.store(
+        enabled,
+        std::memory_order_relaxed
+    );
+}
+
+
 // ============================================================
 // Taskbar visibility
 // ============================================================
 
-void SetTaskbarVisibility(bool show) {
-    HWND primary = FindPrimaryTaskbar();
-
-    if (primary) {
-        ShowWindow(
-            primary,
-            show ? SW_SHOW : SW_HIDE
-        );
-    }
-
-    /*
-     * Always restore secondary taskbars when showing.
-     *
-     * This is important when the user changes
-     * hideSecondaryTaskbars from ON to OFF.
-     */
-    bool shouldProcessSecondary =
-        show ||
-        g_settings.hideSecondaryTaskbars.load(
-            std::memory_order_relaxed
-        );
-
-    if (!shouldProcessSecondary) {
+void SetWindowVisibilityIfNeeded(HWND hwnd, bool show) {
+    if (!hwnd) {
         return;
     }
 
+    bool visible = IsWindowVisible(hwnd) != FALSE;
+
+    if (visible != show) {
+        ShowWindow(
+            hwnd,
+            show ? SW_SHOW : SW_HIDE
+        );
+    }
+}
+
+
+void SetSecondaryTaskbarsVisibility(bool show) {
     HWND secondary = nullptr;
 
     while (
@@ -448,11 +440,41 @@ void SetTaskbarVisibility(bool show) {
             nullptr
         )) != nullptr
     ) {
-        ShowWindow(
-            secondary,
-            show ? SW_SHOW : SW_HIDE
-        );
+        SetWindowVisibilityIfNeeded(secondary, show);
     }
+}
+
+
+void SetTaskbarVisibility(bool show) {
+    HWND primary = FindPrimaryTaskbar();
+
+    if (primary) {
+        SetWindowVisibilityIfNeeded(primary, show);
+    }
+
+    bool hideSecondary =
+        g_settings.hideSecondaryTaskbars.load(
+            std::memory_order_relaxed
+        );
+
+    // When the setting is disabled, secondary taskbars must be restored
+    // even while the primary taskbar is hidden on the desktop.
+    if (show || hideSecondary) {
+        SetSecondaryTaskbarsVisibility(show);
+    } else {
+        SetSecondaryTaskbarsVisibility(true);
+    }
+}
+
+
+bool IsPrimaryTaskbarHidden() {
+    HWND primary = FindPrimaryTaskbar();
+
+    if (!primary) {
+        return false;
+    }
+
+    return IsWindowVisible(primary) == FALSE;
 }
 
 
@@ -461,33 +483,18 @@ void SetTaskbarVisibility(bool show) {
 // ============================================================
 
 int MillimetersToPixels(int mm, UINT dpi) {
-    if (mm <= 0) {
+    if (mm <= 0 || dpi == 0) {
         return 0;
     }
 
-    /*
-     * 25.4 mm = 1 inch.
-     *
-     * Clamp the margin to avoid accidentally making the entire
-     * monitor a hover area.
-     */
-    int maxPx = GetSystemMetrics(SM_CYSCREEN) / 2;
-
-    int px = MulDiv(
-        mm,
+    // px = mm * dpi / 25.4
+    // Using integer arithmetic:
+    // px = mm * 10 * dpi / 254
+    return MulDiv(
+        mm * 10,
         static_cast<int>(dpi),
         254
     );
-
-    if (px < 0) {
-        px = 0;
-    }
-
-    if (px > maxPx) {
-        px = maxPx;
-    }
-
-    return px;
 }
 
 
@@ -515,11 +522,7 @@ bool IsCursorInTaskbarHoverZone() {
         return false;
     }
 
-    /*
-     * If secondary taskbars are disabled for this mod,
-     * don't use their area as a reveal zone.
-     */
-    WCHAR className[256];
+    WCHAR className[256] = {};
 
     if (
         GetClassNameW(
@@ -565,20 +568,13 @@ bool IsCursorInTaskbarHoverZone() {
         dpi = 96;
     }
 
-    int marginPx = MillimetersToPixels(
-        g_settings.extraHoverMarginMm.load(
-            std::memory_order_relaxed
-        ),
-        dpi
-    );
-
-    RECT hoverRect = taskbarRect;
-
-    InflateRect(
-        &hoverRect,
-        marginPx,
-        marginPx
-    );
+    int marginPx =
+        MillimetersToPixels(
+            g_settings.extraHoverMarginMm.load(
+                std::memory_order_relaxed
+            ),
+            dpi
+        );
 
     MONITORINFO mi = {};
     mi.cbSize = sizeof(mi);
@@ -587,126 +583,85 @@ bool IsCursorInTaskbarHoverZone() {
         return false;
     }
 
-    /*
-     * Keep the reveal area associated with the taskbar edge.
-     *
-     * The normal taskbar rectangle already represents the full
-     * taskbar span, while the thickness determines the hover depth.
-     */
-
     int monitorWidth =
         mi.rcMonitor.right - mi.rcMonitor.left;
 
     int monitorHeight =
         mi.rcMonitor.bottom - mi.rcMonitor.top;
 
-    int taskbarWidth =
-        taskbarRect.right - taskbarRect.left;
+    int maxMargin =
+        monitorWidth < monitorHeight
+            ? monitorWidth / 2
+            : monitorHeight / 2;
 
-    int taskbarHeight =
-        taskbarRect.bottom - taskbarRect.top;
+    if (maxMargin < 0) {
+        maxMargin = 0;
+    }
+
+    if (marginPx > maxMargin) {
+        marginPx = maxMargin;
+    }
 
     /*
-     * Detect the edge on which the taskbar is docked.
+     * The taskbar rectangle itself already identifies the correct edge
+     * and thickness. Inflating it handles bottom, top, left, right and
+     * vertical taskbars without assuming a particular docking position.
      */
-    int distanceTop =
-        abs(taskbarRect.top - mi.rcMonitor.top);
+    RECT hoverRect = taskbarRect;
 
-    int distanceBottom =
-        abs(taskbarRect.bottom - mi.rcMonitor.bottom);
-
-    int distanceLeft =
-        abs(taskbarRect.left - mi.rcMonitor.left);
-
-    int distanceRight =
-        abs(taskbarRect.right - mi.rcMonitor.right);
-
-    int edgeDistance =
-    std::min(
-        std::min(distanceTop, distanceBottom),
-        std::min(distanceLeft, distanceRight)
+    InflateRect(
+        &hoverRect,
+        marginPx,
+        marginPx
     );
-
-    /*
-     * If the taskbar is clearly docked to the bottom.
-     */
-    if (
-        edgeDistance == distanceBottom &&
-        taskbarHeight < monitorHeight
-    ) {
-        hoverRect.top =
-            taskbarRect.top - marginPx;
-
-        hoverRect.bottom =
-            taskbarRect.bottom + marginPx;
-
-        return PtInRect(
-            &hoverRect,
-            pt
-        ) != FALSE;
-    }
-
-    /*
-     * Top-docked taskbar.
-     */
-    if (
-        edgeDistance == distanceTop &&
-        taskbarHeight < monitorHeight
-    ) {
-        hoverRect.top =
-            taskbarRect.top - marginPx;
-
-        hoverRect.bottom =
-            taskbarRect.bottom + marginPx;
-
-        return PtInRect(
-            &hoverRect,
-            pt
-        ) != FALSE;
-    }
-
-    /*
-     * Left-docked taskbar.
-     */
-    if (
-        edgeDistance == distanceLeft &&
-        taskbarWidth < monitorWidth
-    ) {
-        hoverRect.left =
-            taskbarRect.left - marginPx;
-
-        hoverRect.right =
-            taskbarRect.right + marginPx;
-
-        return PtInRect(
-            &hoverRect,
-            pt
-        ) != FALSE;
-    }
-
-    /*
-     * Right-docked taskbar.
-     */
-    if (
-        edgeDistance == distanceRight &&
-        taskbarWidth < monitorWidth
-    ) {
-        hoverRect.left =
-            taskbarRect.left - marginPx;
-
-        hoverRect.right =
-            taskbarRect.right + marginPx;
-
-        return PtInRect(
-            &hoverRect,
-            pt
-        ) != FALSE;
-    }
 
     return PtInRect(
         &hoverRect,
         pt
     ) != FALSE;
+}
+
+
+// ============================================================
+// Timer management
+// ============================================================
+
+void StopHoverTimer() {
+    if (g_hoverTimerId) {
+        KillTimer(
+            nullptr,
+            g_hoverTimerId
+        );
+
+        g_hoverTimerId = 0;
+    }
+}
+
+
+void EnsureHoverTimer(bool needed) {
+    if (!needed) {
+        StopHoverTimer();
+        return;
+    }
+
+    if (g_hoverTimerId) {
+        return;
+    }
+
+    g_hoverTimerId =
+        SetTimer(
+            nullptr,
+            0,
+            kHoverTimerIntervalMs,
+            nullptr
+        );
+
+    if (!g_hoverTimerId) {
+        Wh_Log(
+            L"SetTimer failed: %lu",
+            GetLastError()
+        );
+    }
 }
 
 
@@ -717,31 +672,22 @@ bool IsCursorInTaskbarHoverZone() {
 void UpdateTaskbarState() {
     /*
      * If native Windows auto-hide is enabled, don't fight it.
+     *
+     * The native setting is cached and refreshed on state-changing
+     * Windows events/settings refreshes, rather than being queried
+     * on every cursor-poll tick.
      */
-    if (IsNativeTaskbarAutoHideEnabled()) {
-        if (g_taskbarHidden.load(
-                std::memory_order_relaxed
-            )) {
-
-            SetTaskbarVisibility(true);
-
-            g_taskbarHidden.store(
-                false,
-                std::memory_order_relaxed
-            );
-        }
-
+    if (
+        g_nativeAutoHideEnabled.load(
+            std::memory_order_relaxed
+        )
+    ) {
         g_hideDeadline = 0;
         g_shownDueToHover = false;
-
+        StopHoverTimer();
         return;
     }
 
-    /*
-     * Only calculate the hover zone when the desktop is actually
-     * active. This avoids doing monitor/taskbar geometry work
-     * unnecessarily while an application is focused.
-     */
     bool hovering = false;
 
     if (g_onDesktopState) {
@@ -755,18 +701,8 @@ void UpdateTaskbarState() {
         g_hideDeadline = 0;
         g_shownDueToHover = false;
 
-        if (
-            g_taskbarHidden.load(
-                std::memory_order_relaxed
-            )
-        ) {
-            SetTaskbarVisibility(true);
-
-            g_taskbarHidden.store(
-                false,
-                std::memory_order_relaxed
-            );
-        }
+        SetTaskbarVisibility(true);
+        StopHoverTimer();
 
         return;
     }
@@ -778,58 +714,57 @@ void UpdateTaskbarState() {
         g_hideDeadline = 0;
         g_shownDueToHover = true;
 
+        SetTaskbarVisibility(true);
+        EnsureHoverTimer(true);
+
+        return;
+    }
+
+    /*
+     * Desktop + taskbar is already hidden.
+     *
+     * Do not use a cached hidden flag as the source of truth.
+     * The actual taskbar window visibility is checked here.
+     */
+    if (IsPrimaryTaskbarHidden()) {
+        /*
+         * If secondary hiding was disabled while the primary taskbar
+         * was already hidden, restore the secondary taskbars immediately.
+         */
         if (
-            g_taskbarHidden.load(
+            !g_settings.hideSecondaryTaskbars.load(
                 std::memory_order_relaxed
             )
         ) {
-            SetTaskbarVisibility(true);
-
-            g_taskbarHidden.store(
-                false,
-                std::memory_order_relaxed
-            );
+            SetSecondaryTaskbarsVisibility(true);
+        } else {
+            // Keep secondary taskbars consistent after Explorer recreates them.
+            SetSecondaryTaskbarsVisibility(false);
         }
 
-        return;
-    }
-
-    /*
-     * Desktop + taskbar already hidden.
-     */
-    if (
-        g_taskbarHidden.load(
-            std::memory_order_relaxed
-        )
-    ) {
         g_hideDeadline = 0;
+        EnsureHoverTimer(true);
+
         return;
     }
 
     /*
-     * Taskbar wasn't revealed by hover.
-     *
-     * Therefore this is an ordinary desktop transition and must
-     * hide immediately.
+     * Taskbar is visible on the desktop and wasn't revealed by hover.
+     * Hide immediately.
      */
     if (!g_shownDueToHover) {
         SetTaskbarVisibility(false);
 
-        g_taskbarHidden.store(
-            true,
-            std::memory_order_relaxed
-        );
-
         g_hideDeadline = 0;
+        EnsureHoverTimer(true);
 
         return;
     }
 
     /*
-     * The taskbar was revealed by hover and the cursor has now
-     * left the hover zone.
-     *
-     * This is the ONLY path where the delay is used.
+     * The taskbar was revealed by hover and the cursor has now left
+     * the hover zone. This is the only path where the configured delay
+     * is used.
      */
     ULONGLONG now = GetTickCount64();
 
@@ -845,17 +780,51 @@ void UpdateTaskbarState() {
     if (g_hideDeadline == 0) {
         g_hideDeadline =
             now + static_cast<ULONGLONG>(delay);
-    }
-    else if (now >= g_hideDeadline) {
+    } else if (now >= g_hideDeadline) {
         SetTaskbarVisibility(false);
-
-        g_taskbarHidden.store(
-            true,
-            std::memory_order_relaxed
-        );
 
         g_hideDeadline = 0;
         g_shownDueToHover = false;
+    }
+
+    EnsureHoverTimer(true);
+}
+
+
+// ============================================================
+// Worker refresh message
+// ============================================================
+
+void RequestStateRefresh() {
+    if (!g_threadId) {
+        return;
+    }
+
+    bool expected = false;
+
+    if (
+        !g_refreshPosted.compare_exchange_strong(
+            expected,
+            true,
+            std::memory_order_acq_rel,
+            std::memory_order_relaxed
+        )
+    ) {
+        return;
+    }
+
+    if (
+        !PostThreadMessageW(
+            g_threadId,
+            WM_APP_REFRESH_STATE,
+            0,
+            0
+        )
+    ) {
+        g_refreshPosted.store(
+            false,
+            std::memory_order_release
+        );
     }
 }
 
@@ -864,31 +833,50 @@ void UpdateTaskbarState() {
 // WinEvent hook
 // ============================================================
 
+bool IsRelevantWinEvent(DWORD event) {
+    return
+        event == EVENT_SYSTEM_FOREGROUND ||
+        event == EVENT_SYSTEM_MINIMIZESTART ||
+        event == EVENT_SYSTEM_MINIMIZEEND ||
+        event == EVENT_OBJECT_SHOW ||
+        event == EVENT_OBJECT_HIDE ||
+        event == EVENT_OBJECT_DESTROY;
+}
+
+
 void CALLBACK WinEventProc(
-    HWINEVENTHOOK hWinEventHook,
+    HWINEVENTHOOK,
     DWORD event,
     HWND hwnd,
     LONG idObject,
     LONG idChild,
-    DWORD idEventThread,
-    DWORD dwmsEventTime
+    DWORD,
+    DWORD
 ) {
     if (
         idObject != OBJID_WINDOW ||
-        event != EVENT_SYSTEM_FOREGROUND
+        idChild != CHILDID_SELF ||
+        !IsRelevantWinEvent(event)
     ) {
         return;
     }
 
+    if (!hwnd) {
+        RequestStateRefresh();
+        return;
+    }
+
     /*
-     * WinEvent callbacks are delivered to the worker's message-loop
-     * thread for OUTOFCONTEXT hooks.
+     * Foreground/minimize transitions are always relevant.
      *
-     * Refreshing immediately makes application activation feel
-     * instant, while the timer handles minimize/close transitions.
+     * Object show/hide/destroy events are also useful for:
+     * - the last application being closed,
+     * - Explorer recreating the taskbar,
+     * - native taskbar auto-hide changes.
+     *
+     * They are debounced into a single refresh message.
      */
-    RefreshDesktopState();
-    UpdateTaskbarState();
+    RequestStateRefresh();
 }
 
 
@@ -896,12 +884,67 @@ void CALLBACK WinEventProc(
 // Worker thread
 // ============================================================
 
+bool InstallWinEventHookFor(
+    DWORD eventMin,
+    DWORD eventMax,
+    size_t index
+) {
+    if (index >= kMaxWinEventHooks) {
+        return false;
+    }
+
+    g_hWinEventHooks[index] =
+        SetWinEventHook(
+            eventMin,
+            eventMax,
+            nullptr,
+            WinEventProc,
+            0,
+            0,
+            WINEVENT_OUTOFCONTEXT
+        );
+
+    if (!g_hWinEventHooks[index]) {
+        Wh_Log(
+            L"SetWinEventHook(%lu, %lu) failed: %lu",
+            eventMin,
+            eventMax,
+            GetLastError()
+        );
+
+        return false;
+    }
+
+    return true;
+}
+
+
+void UninstallWinEventHooks() {
+    for (size_t i = 0; i < kMaxWinEventHooks; i++) {
+        if (g_hWinEventHooks[i]) {
+            UnhookWinEvent(
+                g_hWinEventHooks[i]
+            );
+
+            g_hWinEventHooks[i] = nullptr;
+        }
+    }
+}
+
+
 DWORD WINAPI HookThread(LPVOID) {
     /*
-     * Force creation of this thread's USER message queue before
-     * WhTool_ModUninit can attempt PostThreadMessageW.
+     * Use real physical screen coordinates for mixed-DPI monitors.
      */
-    MSG initialMessage;
+    SetThreadDpiAwarenessContext(
+        DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+    );
+
+    /*
+     * Force creation of this thread's USER message queue before
+     * signalling readiness. This makes PostThreadMessageW safe.
+     */
+    MSG initialMessage = {};
 
     PeekMessageW(
         &initialMessage,
@@ -915,105 +958,113 @@ DWORD WINAPI HookThread(LPVOID) {
         SetEvent(g_hThreadReadyEvent);
     }
 
-    g_hWinEventHookForeground =
-        SetWinEventHook(
-            EVENT_SYSTEM_FOREGROUND,
-            EVENT_SYSTEM_FOREGROUND,
-            nullptr,
-            WinEventProc,
-            0,
-            0,
-            WINEVENT_OUTOFCONTEXT
-        );
+    /*
+     * Install only the events needed to track foreground/application
+     * state and taskbar/window lifetime changes.
+     */
+    bool hookOk = true;
 
-    if (!g_hWinEventHookForeground) {
+    hookOk &= InstallWinEventHookFor(
+        EVENT_SYSTEM_FOREGROUND,
+        EVENT_SYSTEM_FOREGROUND,
+        0
+    );
+
+    hookOk &= InstallWinEventHookFor(
+        EVENT_SYSTEM_MINIMIZESTART,
+        EVENT_SYSTEM_MINIMIZESTART,
+        1
+    );
+
+    hookOk &= InstallWinEventHookFor(
+        EVENT_SYSTEM_MINIMIZEEND,
+        EVENT_SYSTEM_MINIMIZEEND,
+        2
+    );
+
+    hookOk &= InstallWinEventHookFor(
+        EVENT_OBJECT_SHOW,
+        EVENT_OBJECT_SHOW,
+        3
+    );
+
+    hookOk &= InstallWinEventHookFor(
+        EVENT_OBJECT_HIDE,
+        EVENT_OBJECT_HIDE,
+        4
+    );
+
+    hookOk &= InstallWinEventHookFor(
+        EVENT_OBJECT_DESTROY,
+        EVENT_OBJECT_DESTROY,
+        5
+    );
+
+    if (!hookOk) {
         Wh_Log(
-            L"SetWinEventHook failed: %lu",
-            GetLastError()
+            L"One or more WinEvent hooks failed"
         );
     }
 
     /*
-     * Apply the correct initial state immediately.
+     * Apply the correct initial state after the worker and hooks exist.
      */
+    RefreshNativeTaskbarAutoHideState();
     RefreshDesktopState();
     UpdateTaskbarState();
 
-    /*
-     * 100 ms is retained because the desktop state must react
-     * quickly to minimizing/closing the last application.
-     */
-    constexpr UINT kPollIntervalMs = 100;
+    MSG msg = {};
 
-    UINT_PTR timerId =
-        SetTimer(
-            nullptr,
-            0,
-            kPollIntervalMs,
-            nullptr
-        );
+    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+        if (msg.message == WM_APP_STOP_THREAD) {
+            PostQuitMessage(0);
+            continue;
+        }
 
-    if (!timerId) {
-        Wh_Log(
-            L"SetTimer failed: %lu",
-            GetLastError()
-        );
-    }
-
-    MSG msg;
-
-    while (
-        GetMessageW(
-            &msg,
-            nullptr,
-            0,
-            0
-        ) > 0
-    ) {
         if (msg.message == WM_APP_REFRESH_STATE) {
+            g_refreshPosted.store(
+                false,
+                std::memory_order_release
+            );
+
+            RefreshNativeTaskbarAutoHideState();
             RefreshDesktopState();
             UpdateTaskbarState();
+
+            continue;
+        }
+
+        if (
+            msg.message == WM_TIMER &&
+            msg.wParam == g_hoverTimerId
+        ) {
+            /*
+             * The timer exists only while hover handling is needed.
+             * Cursor movement is the one piece of state that Windows
+             * does not provide as a suitable global WinEvent.
+             */
+            RefreshDesktopState();
+            UpdateTaskbarState();
+
             continue;
         }
 
         TranslateMessage(&msg);
         DispatchMessageW(&msg);
-
-        /*
-         * The timer generated by SetTimer(nullptr, ...) produces
-         * WM_TIMER messages.
-         */
-        if (msg.message == WM_TIMER &&
-            msg.wParam == timerId) {
-
-            RefreshDesktopState();
-            UpdateTaskbarState();
-        }
     }
 
-    if (timerId) {
-        KillTimer(
-            nullptr,
-            timerId
-        );
-    }
+    StopHoverTimer();
 
-    if (g_hWinEventHookForeground) {
-        UnhookWinEvent(
-            g_hWinEventHookForeground
-        );
-
-        g_hWinEventHookForeground = nullptr;
-    }
+    UninstallWinEventHooks();
 
     /*
-     * Always restore the taskbar when the worker exits.
+     * Always restore the user's visible taskbars when the tool exits.
      */
     SetTaskbarVisibility(true);
 
-    g_taskbarHidden.store(
+    g_refreshPosted.store(
         false,
-        std::memory_order_relaxed
+        std::memory_order_release
     );
 
     return 0;
@@ -1042,9 +1093,6 @@ void LoadSettings() {
             L"hideSecondaryTaskbars"
         ) != 0;
 
-    /*
-     * Prevent pathological values from making the UI unusable.
-     */
     if (margin < 0) {
         margin = 0;
     }
@@ -1079,7 +1127,9 @@ void LoadSettings() {
 // ============================================================
 
 BOOL WhTool_ModInit() {
-    Wh_Log(L"Hide Taskbar Only on Desktop: Init");
+    Wh_Log(
+        L"Hide Taskbar Only on Desktop: Init"
+    );
 
     LoadSettings();
 
@@ -1124,8 +1174,10 @@ BOOL WhTool_ModInit() {
 
     /*
      * Wait until the worker has created its message queue.
-     * This guarantees that PostThreadMessageW can be used safely
-     * during shutdown.
+     *
+     * The event handle remains valid until the worker is joined.
+     * This avoids a race where the worker could call SetEvent on a
+     * handle that the init thread already closed after a timeout.
      */
     DWORD result =
         WaitForSingleObject(
@@ -1133,21 +1185,19 @@ BOOL WhTool_ModInit() {
             5000
         );
 
-    CloseHandle(g_hThreadReadyEvent);
-    g_hThreadReadyEvent = nullptr;
-
     if (result != WAIT_OBJECT_0) {
         Wh_Log(
             L"Worker thread failed to become ready"
         );
 
         /*
-         * The worker is still alive. Stop it and wait for it.
+         * Ask the worker to stop using the same message queue that
+         * will later be used for normal refresh requests.
          */
         while (
             !PostThreadMessageW(
                 g_threadId,
-                WM_QUIT,
+                WM_APP_STOP_THREAD,
                 0,
                 0
             )
@@ -1171,6 +1221,9 @@ BOOL WhTool_ModInit() {
         g_hThread = nullptr;
         g_threadId = 0;
 
+        CloseHandle(g_hThreadReadyEvent);
+        g_hThreadReadyEvent = nullptr;
+
         return FALSE;
     }
 
@@ -1183,16 +1236,14 @@ void WhTool_ModSettingsChanged() {
         L"Hide Taskbar Only on Desktop: Settings changed"
     );
 
-    /*
-     * Atomics make this safe even though Windhawk may call
-     * the settings callback from another thread.
-     */
     LoadSettings();
 
     /*
-     * The worker will observe the new values on its next
-     * 100 ms update.
+     * Apply settings immediately instead of waiting for a timer tick.
+     * In particular, this restores secondary taskbars when the setting
+     * changes from ON to OFF while the desktop is already active.
      */
+    RequestStateRefresh();
 }
 
 
@@ -1203,16 +1254,14 @@ void WhTool_ModUninit() {
 
     if (g_hThread) {
         /*
-         * The worker creates its USER message queue before
-         * signalling g_hThreadReadyEvent, so this should normally
-         * succeed immediately.
-         *
-         * Still retry in case the thread exited between checks.
+         * Never unload the mod while the worker could still execute
+         * code from it. Use an application message which converts to
+         * PostQuitMessage on the worker thread.
          */
         while (
             !PostThreadMessageW(
                 g_threadId,
-                WM_QUIT,
+                WM_APP_STOP_THREAD,
                 0,
                 0
             )
@@ -1229,10 +1278,8 @@ void WhTool_ModUninit() {
 
         /*
          * IMPORTANT:
-         * Never use a finite timeout here.
-         *
-         * The mod must not be unloaded while HookThread can still
-         * execute code from this module.
+         * No finite timeout here. The module must remain mapped until
+         * the worker has completely stopped and removed its hooks.
          */
         WaitForSingleObject(
             g_hThread,
@@ -1245,16 +1292,16 @@ void WhTool_ModUninit() {
         g_threadId = 0;
     }
 
+    if (g_hThreadReadyEvent) {
+        CloseHandle(g_hThreadReadyEvent);
+        g_hThreadReadyEvent = nullptr;
+    }
+
     /*
-     * The worker normally restores the taskbar itself, but do this
-     * again here as a final safety measure.
+     * Final restoration in case the worker exited through an unusual
+     * path. ShowWindow on an already-visible taskbar is harmless.
      */
     SetTaskbarVisibility(true);
-
-    g_taskbarHidden.store(
-        false,
-        std::memory_order_relaxed
-    );
 }
 
 
@@ -1446,8 +1493,14 @@ void Wh_ModAfterInit() {
         1
     ];
 
+    /*
+     * MinGW's swprintf_s requires the destination buffer size.
+     * The previous version omitted it, which caused the PR build
+     * to fail on the Windhawk compiler.
+     */
     swprintf_s(
         commandLine,
+        ARRAYSIZE(commandLine),
         L"\"%s\" -tool-mod \"%s\"",
         currentProcessPath,
         WH_MOD_ID
@@ -1484,7 +1537,7 @@ void Wh_ModAfterInit() {
             DWORD,
             LPVOID,
             LPCWSTR,
-            LPSTARTUPINFOW,
+            LPSTARTUPINFO,
             LPPROCESS_INFORMATION,
             PHANDLE
         );
@@ -1508,12 +1561,11 @@ void Wh_ModAfterInit() {
         return;
     }
 
-    STARTUPINFO si{
-        .cb = sizeof(STARTUPINFO),
-        .dwFlags = STARTF_FORCEOFFFEEDBACK,
-    };
+    STARTUPINFO si = {};
+    si.cb = sizeof(STARTUPINFO);
+    si.dwFlags = STARTF_FORCEOFFFEEDBACK;
 
-    PROCESS_INFORMATION pi{};
+    PROCESS_INFORMATION pi = {};
 
     if (
         !pCreateProcessInternalW(
@@ -1532,7 +1584,8 @@ void Wh_ModAfterInit() {
         )
     ) {
         Wh_Log(
-            L"CreateProcess failed"
+            L"CreateProcess failed: %lu",
+            GetLastError()
         );
 
         return;

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Hides selected taskbars only while their display is showing the desktop
-// @version         4.1.0
+// @version         4.5.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -89,8 +89,10 @@ You can independently choose:
 - Which displays should hide their taskbar when desktop-only.
 - Which displays should allow bottom-edge hover reveal.
 
-Selections use Windows display device names such as `\\.\DISPLAY1`. These
-identifiers may differ from the numbers shown in Windows Display Settings.
+Selections use logical display numbers (Display 1, Display 2, and so on) based on
+the currently connected monitors. Windows may internally name the same monitor
+with device identifiers such as `\\.\DISPLAY25`; those internal identifiers are
+not exposed as the selection number.
 
 The mod tracks monitor identity during the current session so a reconnected
 display that receives a different `DISPLAYn` number can retain its selection
@@ -163,7 +165,7 @@ or the connected display set changes.
 ## Limitations
 
 - Hover reveal is supported only for bottom-docked taskbars.
-- Display selection currently exposes `DISPLAY1` through `DISPLAY16`.
+- Display selection currently exposes Display 1 through Display 16.
 - `DISPLAYn` identifiers may differ from the numbering shown in Windows Display
   Settings and can change after display configuration changes.
 - A taskbar docked to the top or side is not hidden by the desktop-only rule.
@@ -203,31 +205,33 @@ and configurable bottom-edge hover reveal.
   $name: Reveal taskbar on bottom-edge hover
   $description: >-
     Select the displays where bottom-edge hovering should reveal the taskbar.
-    The display options use Windows `\\.\DISPLAYn` device numbers, which may
-    differ from the numbers shown in Windows Display Settings. Select All
-    displays to enable it everywhere, or replace it with individual displays.
+    Select the displays by their current logical number (Display 1, Display 2, and
+    so on). Internal Windows device identifiers can differ and are not used for
+    the selection number. Select All displays to enable it everywhere, or replace
+    it with individual displays.
   $options:
   - all: All displays
-  - monitor1: DISPLAY1
-  - monitor2: DISPLAY2
-  - monitor3: DISPLAY3
-  - monitor4: DISPLAY4
-  - monitor5: DISPLAY5
-  - monitor6: DISPLAY6
-  - monitor7: DISPLAY7
-  - monitor8: DISPLAY8
-  - monitor9: DISPLAY9
-  - monitor10: DISPLAY10
-  - monitor11: DISPLAY11
-  - monitor12: DISPLAY12
-  - monitor13: DISPLAY13
-  - monitor14: DISPLAY14
-  - monitor15: DISPLAY15
-  - monitor16: DISPLAY16
+  - monitor1: Display 1
+  - monitor2: Display 2
+  - monitor3: Display 3
+  - monitor4: Display 4
+  - monitor5: Display 5
+  - monitor6: Display 6
+  - monitor7: Display 7
+  - monitor8: Display 8
+  - monitor9: Display 9
+  - monitor10: Display 10
+  - monitor11: Display 11
+  - monitor12: Display 12
+  - monitor13: Display 13
+  - monitor14: Display 14
+  - monitor15: Display 15
+  - monitor16: Display 16
 - hideOnMonitors: ["all"]
   $name: Taskbars to hide on desktop
   $description: >-
-    Select one or more displays using the Windows `\\.\DISPLAYn` device number.
+    Select one or more displays using their current logical display number. Internal
+    Windows `\\.\DISPLAYn` identifiers are not used for the selection number.
     These numbers may differ from the display numbers shown in Windows Display
     Settings. Choose All displays to hide every connected display. Only
     bottom-docked taskbars participate in desktop-based hiding. Use Add to
@@ -236,22 +240,22 @@ and configurable bottom-edge hover reveal.
     monitor device when possible.
   $options:
   - all: All displays
-  - monitor1: DISPLAY1
-  - monitor2: DISPLAY2
-  - monitor3: DISPLAY3
-  - monitor4: DISPLAY4
-  - monitor5: DISPLAY5
-  - monitor6: DISPLAY6
-  - monitor7: DISPLAY7
-  - monitor8: DISPLAY8
-  - monitor9: DISPLAY9
-  - monitor10: DISPLAY10
-  - monitor11: DISPLAY11
-  - monitor12: DISPLAY12
-  - monitor13: DISPLAY13
-  - monitor14: DISPLAY14
-  - monitor15: DISPLAY15
-  - monitor16: DISPLAY16
+  - monitor1: Display 1
+  - monitor2: Display 2
+  - monitor3: Display 3
+  - monitor4: Display 4
+  - monitor5: Display 5
+  - monitor6: Display 6
+  - monitor7: Display 7
+  - monitor8: Display 8
+  - monitor9: Display 9
+  - monitor10: Display 10
+  - monitor11: Display 11
+  - monitor12: Display 12
+  - monitor13: Display 13
+  - monitor14: Display 14
+  - monitor15: Display 15
+  - monitor16: Display 16
 */
 // ==/WindhawkModSettings==
 
@@ -458,7 +462,11 @@ void RecoverStaleHiddenTaskbar(HWND hwnd) {
     }
 
     if (g_explorerShowWindowOriginal) {
-        g_explorerShowWindowOriginal(hwnd, SW_SHOW);
+        RemovePropW(
+            hwnd,
+            kHiddenByModProperty
+        );
+        g_explorerShowWindowOriginal(hwnd, SW_SHOWNA);
     }
 }
 
@@ -485,7 +493,11 @@ BOOL WINAPI ExplorerShowWindowHook(HWND hwnd, int nCmdShow) {
             const bool ownerAlive = IsHiddenTaskbarOwnerAlive(hwnd);
 
             if (!ownerAlive && g_explorerShowWindowOriginal) {
-                return g_explorerShowWindowOriginal(hwnd, SW_SHOW);
+                RemovePropW(
+                    hwnd,
+                    kHiddenByModProperty
+                );
+                return g_explorerShowWindowOriginal(hwnd, SW_SHOWNA);
             }
 
             if (ownerAlive && IsExplorerSecondaryTaskbar(hwnd)) {
@@ -731,56 +743,6 @@ bool GetStableMonitorDeviceId(
     return output[0] != L'\0';
 }
 
-int GetDisplayDeviceNumber(
-    const wchar_t* deviceName
-) {
-    if (!deviceName) {
-        return 0;
-    }
-
-    constexpr wchar_t kPrefix[] = L"\\\\.\\DISPLAY";
-    constexpr size_t kPrefixLength =
-        ARRAYSIZE(kPrefix) - 1;
-
-    if (
-        wcsncmp(
-            deviceName,
-            kPrefix,
-            kPrefixLength
-        ) != 0
-    ) {
-        return 0;
-    }
-
-    wchar_t* endNumber = nullptr;
-
-    long number =
-        wcstol(
-            deviceName + kPrefixLength,
-            &endNumber,
-            10
-        );
-
-    if (
-        endNumber == deviceName + kPrefixLength ||
-        *endNumber != L'\0' ||
-        number < 1 ||
-        number > static_cast<long>(
-            kMaxMonitorNumbers
-        )
-    ) {
-        Wh_Log(
-            L"Unsupported display device number for %s: %ld (supported range: 1-%d)",
-            deviceName,
-            number,
-            static_cast<int>(kMaxMonitorNumbers)
-        );
-        return 0;
-    }
-
-    return static_cast<int>(number);
-}
-
 void ResetMonitorSelectionBindings() {
     for (
         size_t i = 0;
@@ -810,11 +772,11 @@ void BindSelectionIdentity(
     }
 
     for (size_t i = 0; i < monitors.count; ++i) {
-        if (
-            GetDisplayDeviceNumber(
-                monitors.entries[i].deviceName
-            ) == configuredNumber
-        ) {
+        // Settings use the logical order of the currently connected
+        // monitors rather than the Windows DISPLAYn device identifier.
+        // This keeps "Display 2" usable even when Windows happens to name
+        // that monitor DISPLAY25, DISPLAY9, or another non-sequential value.
+        if (static_cast<int>(i + 1) == configuredNumber) {
             if (monitors.entries[i].stableDeviceId[0] != L'\0') {
                 bindings[configuredNumber].configured = true;
                 wcsncpy_s(
@@ -907,6 +869,49 @@ MonitorList GetCurrentMonitors() {
         reinterpret_cast<LPARAM>(&list)
     );
 
+    // Give the settings UI a deterministic, user-friendly numbering: the
+    // primary display is Display 1, followed by the remaining active displays
+    // ordered by their Windows device name. The actual device number is only
+    // an internal identifier and is never used as the selection index.
+    for (size_t i = 1; i < list.count; ++i) {
+        MonitorEntry key = list.entries[i];
+        MONITORINFO miKey = {};
+        miKey.cbSize = sizeof(miKey);
+        const bool keyPrimary =
+            key.monitor &&
+            GetMonitorInfoW(key.monitor, &miKey) &&
+            (miKey.dwFlags & MONITORINFOF_PRIMARY) != 0;
+
+        size_t j = i;
+        while (j > 0) {
+            MONITORINFO miPrev = {};
+            miPrev.cbSize = sizeof(miPrev);
+            const bool prevPrimary =
+                list.entries[j - 1].monitor &&
+                GetMonitorInfoW(list.entries[j - 1].monitor, &miPrev) &&
+                (miPrev.dwFlags & MONITORINFOF_PRIMARY) != 0;
+
+            bool shouldMoveBefore = false;
+            if (keyPrimary != prevPrimary) {
+                shouldMoveBefore = keyPrimary;
+            } else {
+                shouldMoveBefore =
+                    wcscmp(
+                        key.deviceName,
+                        list.entries[j - 1].deviceName
+                    ) < 0;
+            }
+
+            if (!shouldMoveBefore) {
+                break;
+            }
+
+            list.entries[j] = list.entries[j - 1];
+            --j;
+        }
+        list.entries[j] = key;
+    }
+
     return list;
 }
 
@@ -957,9 +962,9 @@ int GetMonitorNumber(
 ) {
     for (size_t i = 0; i < list.count; ++i) {
         if (list.entries[i].monitor == monitor) {
-            return GetDisplayDeviceNumber(
-                list.entries[i].deviceName
-            );
+            // The settings UI is intentionally based on the logical monitor
+            // order, not the internal Windows DISPLAYn device identifier.
+            return static_cast<int>(i + 1);
         }
     }
 
@@ -1703,21 +1708,34 @@ void SetTaskbarState(
             return;
         }
 
-        // Keep normal state transitions synchronous. Explorer can immediately
-        // re-show a taskbar while processing shell/minimize transitions; using
-        // ShowWindowAsync here can leave several SHOW/HIDE requests queued and
-        // cause a visible flicker loop.
+        // Clear our ownership marker before showing so Explorer is never left
+        // with a hidden taskbar that still looks owned by this mod. Keep the
+        // normal transition synchronous so Explorer cannot queue a stale SHOW
+        // behind our state reconciliation.
+        RemovePropW(
+            state.hwnd,
+            kHiddenByModProperty
+        );
+
         ShowWindow(
             state.hwnd,
-            SW_SHOW
+            SW_SHOWNA
         );
 
         if (IsWindowVisible(state.hwnd)) {
-            RemovePropW(
-                state.hwnd,
-                kHiddenByModProperty
-            );
             state.hiddenByMod = false;
+        } else {
+            // Restore the marker if the show operation did not make the taskbar
+            // visible. This keeps ownership explicit rather than leaving a
+            // silently hidden, unowned taskbar behind.
+            SetPropW(
+                state.hwnd,
+                kHiddenByModProperty,
+                reinterpret_cast<HANDLE>(
+                    static_cast<ULONG_PTR>(GetCurrentProcessId())
+                )
+            );
+            state.hiddenByMod = true;
         }
 
         return;
@@ -1763,6 +1781,108 @@ void SetTaskbarState(
         );
         state.hiddenByMod = false;
     }
+}
+
+struct CursorShellSurfaceContext {
+    POINT point;
+    HMONITOR monitor;
+    bool found;
+};
+
+BOOL CALLBACK FindShellSurfaceAtCursorProc(
+    HWND hwnd,
+    LPARAM lParam
+) {
+    auto* context =
+        reinterpret_cast<CursorShellSurfaceContext*>(lParam);
+
+    if (!context || context->found || !IsWindowVisible(hwnd)) {
+        return context && context->found ? FALSE : TRUE;
+    }
+
+    WCHAR className[256] = {};
+    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
+        return TRUE;
+    }
+
+    if (!IsTaskbarPopupClass(className)) {
+        return TRUE;
+    }
+
+    RECT rect = {};
+    if (!GetWindowRect(hwnd, &rect) ||
+        !PtInRect(&rect, context->point)) {
+        return TRUE;
+    }
+
+    context->found = true;
+    context->monitor =
+        MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+    return FALSE;
+}
+
+struct VisibleShellPopupContext {
+    HMONITOR monitor;
+    bool found;
+};
+
+BOOL CALLBACK FindVisibleShellPopupOnMonitorProc(
+    HWND hwnd,
+    LPARAM lParam
+) {
+    auto* context =
+        reinterpret_cast<VisibleShellPopupContext*>(lParam);
+
+    if (!context || context->found || !IsWindowVisible(hwnd)) {
+        return context && context->found ? FALSE : TRUE;
+    }
+
+    WCHAR className[256] = {};
+    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
+        return TRUE;
+    }
+
+    if (!IsTaskbarPopupClass(className) ||
+        IsShellChromeClass(className) ||
+        IsDesktopInfrastructureWindow(hwnd, className)) {
+        return TRUE;
+    }
+
+    RECT rect = {};
+    if (!GetWindowRect(hwnd, &rect)) {
+        return TRUE;
+    }
+
+    MONITORINFO mi = {};
+    mi.cbSize = sizeof(mi);
+    if (!context->monitor ||
+        !GetMonitorInfoW(context->monitor, &mi)) {
+        return TRUE;
+    }
+
+    RECT intersection = {};
+    if (IntersectRect(&intersection, &rect, &mi.rcMonitor)) {
+        context->found = true;
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+bool IsVisibleShellPopupOnMonitor(HMONITOR monitor) {
+    if (!monitor) {
+        return false;
+    }
+
+    VisibleShellPopupContext context = {};
+    context.monitor = monitor;
+
+    EnumWindows(
+        FindVisibleShellPopupOnMonitorProc,
+        reinterpret_cast<LPARAM>(&context)
+    );
+
+    return context.found;
 }
 
 void ApplyBaseTaskbarState() {
@@ -1951,7 +2071,8 @@ void UpdateCursorHoverSnapshot() {
 
         const TaskbarMonitorState& state = g_taskbarStates[i];
 
-        if (!ShouldRevealOnHover(state) ||
+        if (!state.hiddenByMod ||
+            !ShouldRevealOnHover(state) ||
             !IsBottomDockedTaskbar(state.hwnd, state.monitor)) {
             continue;
         }
@@ -2075,8 +2196,6 @@ void UpdateTaskbarState() {
         monitors
     );
 
-    UpdateCursorHoverSnapshot();
-
     // ABM_GETSTATE reports the native auto-hide setting globally. Sample it
     // once per reconciliation and reuse the result for every taskbar.
     g_nativeAutoHideEnabled =
@@ -2157,26 +2276,6 @@ void UpdateTaskbarState() {
     const bool hovering =
         cursorInHoverZone;
 
-    auto shellSurfaceOnMonitor =
-        [&](HMONITOR monitor) {
-            for (
-                size_t monitorIndex = 0;
-                monitorIndex < monitors.count;
-                ++monitorIndex
-            ) {
-                if (
-                    monitors.entries[monitorIndex].monitor ==
-                    monitor
-                ) {
-                    return scan.shellSurfaceOnMonitor[
-                        monitorIndex
-                    ];
-                }
-            }
-
-            return false;
-        };
-
     if (hovering) {
         g_hoverActive = true;
         g_hoverMonitor = cursorMonitor;
@@ -2190,12 +2289,14 @@ void UpdateTaskbarState() {
             SetTaskbarState(
                 state,
                 state.monitor == g_hoverMonitor ||
-                shellSurfaceOnMonitor(state.monitor) ||
                 !state.desktopOnly ||
                 !ShouldHideTaskbar(state)
             );
         }
 
+        // Snapshot the state after visibility reconciliation. The cursor sampler
+        // must see the taskbars that are actually hidden by the mod.
+        UpdateCursorHoverSnapshot();
         return;
     }
 
@@ -2219,12 +2320,43 @@ void UpdateTaskbarState() {
                 SetTaskbarState(
                     state,
                     state.monitor == g_hoverMonitor ||
-                    shellSurfaceOnMonitor(state.monitor) ||
                     !state.desktopOnly ||
                     !ShouldHideTaskbar(state)
                 );
             }
 
+            UpdateCursorHoverSnapshot();
+            return;
+        }
+
+        bool shellPopupPresent = false;
+        for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+            TaskbarMonitorState& state = g_taskbarStates[i];
+            if (IsVisibleShellPopupOnMonitor(state.monitor)) {
+                shellPopupPresent = true;
+                break;
+            }
+        }
+
+        if (shellPopupPresent) {
+            // Keep the revealed taskbar visible while a shell popup/context
+            // menu is still open, even when the cursor has moved outside the
+            // popup. The popup itself is what keeps the interaction alive.
+            for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+                TaskbarMonitorState& state =
+                    g_taskbarStates[i];
+
+                SetTaskbarState(
+                    state,
+                    !state.desktopOnly ||
+                    !ShouldHideTaskbar(state) ||
+                    IsVisibleShellPopupOnMonitor(state.monitor)
+                );
+            }
+
+            g_hoverDeadline = now + 100;
+            ArmHoverExpireTimer();
+            UpdateCursorHoverSnapshot();
             return;
         }
 
@@ -2235,6 +2367,7 @@ void UpdateTaskbarState() {
         CancelHoverExpireTimer();
 
         ApplyBaseTaskbarState();
+        UpdateCursorHoverSnapshot();
         return;
     }
 
@@ -2244,11 +2377,12 @@ void UpdateTaskbarState() {
 
         SetTaskbarState(
             state,
-            shellSurfaceOnMonitor(state.monitor) ||
             !state.desktopOnly ||
             !ShouldHideTaskbar(state)
         );
     }
+
+    UpdateCursorHoverSnapshot();
 }
 
 void ArmHoverExpireTimer() {
@@ -2415,6 +2549,10 @@ bool HasEnabledHoverSnapshot() {
 }
 
 DWORD WINAPI CursorSamplingThread(LPVOID) {
+    SetThreadDpiAwarenessContext(
+        DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+    );
+
     bool lastHoverZone = false;
     HMONITOR lastMonitor = nullptr;
     int cursorPositionFailures = 0;
@@ -2569,7 +2707,6 @@ void EnsureTaskbarShowHook() {
 }
 
 
-
 LRESULT CALLBACK WorkerMessageWindowProc(
     HWND hwnd,
     UINT message,
@@ -2687,24 +2824,13 @@ void DestroyWorkerMessageWindow() {
     g_taskbarCreatedMessage = 0;
 }
 
-void UpdateSafetyTimer(UINT_PTR timerId) {
-    if (!timerId) {
-        return;
-    }
-
-    constexpr UINT kSafetyPollIntervalMs = 1000;
-
-    SetTimer(
-        nullptr,
-        timerId,
-        kSafetyPollIntervalMs,
-        nullptr
-    );
-}
-
 DWORD WINAPI WorkerThread(
     LPVOID
 ) {
+    SetThreadDpiAwarenessContext(
+        DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+    );
+
     MSG msg = {};
 
     PeekMessageW(
@@ -2763,11 +2889,15 @@ DWORD WINAPI WorkerThread(
     EnsureTaskbarShowHook();
     UpdateTaskbarState();
 
+    // Keep a true periodic safety poll. It is only a fallback for shell/window
+    // transitions that do not produce a usable accessibility event. Refresh
+    // events never re-arm this timer, so frequent events cannot postpone it.
+    constexpr UINT kSafetyPollIntervalMs = 250;
     UINT_PTR timerId =
         SetTimer(
             nullptr,
             kSafetyTimerId,
-            1000,
+            kSafetyPollIntervalMs,
             nullptr
         );
 
@@ -2792,12 +2922,14 @@ DWORD WINAPI WorkerThread(
 
             EnsureTaskbarShowHook();
             UpdateTaskbarState();
-            UpdateSafetyTimer(timerId);
 
             continue;
         }
 
         if (msg.message == WM_APP_REFRESH) {
+            // Clear before processing. A new event that arrives during the
+            // reconciliation can then set the flag again instead of being
+            // silently coalesced into the refresh already in progress.
             InterlockedExchange(
                 &g_refreshPosted,
                 0
@@ -2806,7 +2938,13 @@ DWORD WINAPI WorkerThread(
             EnsureTaskbarShowHook();
             UpdateTaskbarState();
 
-            UpdateSafetyTimer(timerId);
+            // Do not lose a refresh posted while UpdateTaskbarState() ran.
+            if (InterlockedExchange(
+                    &g_refreshPosted,
+                    0
+                ) != 0) {
+                PostRefresh();
+            }
 
             continue;
         }
@@ -2816,7 +2954,6 @@ DWORD WINAPI WorkerThread(
             EnsureTaskbarShowHook();
             UpdateTaskbarState();
 
-            UpdateSafetyTimer(timerId);
 
             continue;
         }
@@ -2824,7 +2961,6 @@ DWORD WINAPI WorkerThread(
         TranslateMessage(&msg);
         DispatchMessageW(&msg);
 
-        UpdateSafetyTimer(timerId);
     }
 
     if (timerId) {
@@ -3119,20 +3255,28 @@ void RestoreAllTaskbars() {
             return;
         }
 
-        /*
-         * Teardown/recovery is intentionally asynchronous. This path can run
-         * during tool shutdown, where blocking on Explorer's UI thread
-         * could otherwise hang Windhawk itself.
-         */
-        ShowWindowAsync(
-            hwnd,
-            SW_SHOW
-        );
-
+        // Remove ownership before the restore request so Explorer cannot treat
+        // its own SHOW path as an attempt to violate the mod's hidden state.
         RemovePropW(
             hwnd,
             kHiddenByModProperty
         );
+
+        // Teardown must not wait on Explorer's UI thread.
+        if (!ShowWindowAsync(
+                hwnd,
+                SW_SHOWNA
+            )) {
+            // Keep explicit ownership if the asynchronous restore request could
+            // not be queued.
+            SetPropW(
+                hwnd,
+                kHiddenByModProperty,
+                reinterpret_cast<HANDLE>(
+                    static_cast<ULONG_PTR>(GetCurrentProcessId())
+                )
+            );
+        }
     };
 
     restoreTaskbarIfMarked(

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -73,6 +73,8 @@ This mod was created with AI assistance.
 #include <shellapi.h>
 #include <dwmapi.h>
 #include <atomic>
+#include <algorithm>
+#include <stdio.h>
 
 struct Settings {
     std::atomic<int> extraHoverMarginMm{5};
@@ -620,10 +622,10 @@ bool IsCursorInTaskbarHoverZone() {
         abs(taskbarRect.right - mi.rcMonitor.right);
 
     int edgeDistance =
-        min(
-            min(distanceTop, distanceBottom),
-            min(distanceLeft, distanceRight)
-        );
+    std::min(
+        std::min(distanceTop, distanceBottom),
+        std::min(distanceLeft, distanceRight)
+    );
 
     /*
      * If the taskbar is clearly docked to the bottom.

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id hide-taskbar-only-on-desktop
 // @name Hide Taskbar Only on Desktop
 // @description Hides the taskbar on desktop while preserving taskbar and Windows shell UI interaction
-// @version 1.10.0
+// @version 1.11.0
 // @author Sahil Dashoni
 // @github https://github.com/Sahil-Dashoni
 // @include windhawk.exe
@@ -98,6 +98,8 @@ This mod was created with AI assistance.
 #include <dwmapi.h>
 #include <atomic>
 #include <stdio.h>
+#include <string.h>
+#include <wchar.h>
 
 struct Settings {
     std::atomic<int> extraHoverMarginMm{5};
@@ -131,6 +133,7 @@ struct TaskbarState {
     bool hasApplication = false;
     bool taskbarIsForeground = false;
     bool shellUiForeground = false;
+    bool shellFlyoutVisible = false;
     bool shownDueToHover = false;
     bool shownDueToAltTab = false;
     ULONGLONG hideDeadline = 0;
@@ -138,6 +141,8 @@ struct TaskbarState {
 
 TaskbarState g_taskbars[kMaxTaskbars] = {};
 size_t g_taskbarCount = 0;
+
+bool g_altTabActive = false;
 
 HWINEVENTHOOK g_hWinEventHooks[kMaxWinEventHooks] = {};
 
@@ -187,7 +192,6 @@ bool IsShellChromeClass(const WCHAR* className) {
 
     return
         wcscmp(className, L"Windows.UI.Core.CoreWindow") == 0 ||
-        wcscmp(className, L"ApplicationFrameWindow") == 0 ||
         wcscmp(className, L"Xaml_WindowedPopupClass") == 0 ||
         wcscmp(className, L"ControlCenterWindow") == 0 ||
         wcscmp(className, L"TopLevelWindowForOverflowXamlIsland") == 0 ||
@@ -223,12 +227,21 @@ HWND FindPrimaryTaskbar();
 bool IsTaskbarActuallyHidden(HWND hwnd);
 bool IsShellUiClass(const WCHAR* className);
 
+bool IsAltTabWindowClass(const WCHAR* className);
+bool GetWindowProcessName(HWND hwnd, WCHAR* name, size_t nameCount);
+bool IsKnownShellUiProcess(const WCHAR* processName);
+bool IsShellUiWindow(HWND hwnd);
+
 struct AppMonitorScan {
     TaskbarState* taskbars;
     size_t count;
+    bool altTabActive;
 };
 
-BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
+BOOL CALLBACK EnumWindowsProc(
+    HWND hwnd,
+    LPARAM lParam
+) {
     AppMonitorScan* scan =
         reinterpret_cast<AppMonitorScan*>(lParam);
 
@@ -244,16 +257,105 @@ BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
         return TRUE;
     }
 
-    WCHAR className[256] = {};
-
-    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
+    /*
+     * Explicitly ignore the desktop itself.
+     */
+    if (IsDesktopWindow(hwnd)) {
         return TRUE;
     }
 
+    WCHAR className[256] = {};
+
     if (
-        IsShellChromeClass(className) ||
-        IsShellUiClass(className)
+        GetClassNameW(
+            hwnd,
+            className,
+            ARRAYSIZE(className)
+        ) == 0
     ) {
+        return TRUE;
+    }
+
+    /*
+     * Detect the Alt+Tab switcher in this same EnumWindows pass.
+     */
+    if (IsAltTabWindowClass(className)) {
+        if (
+            wcscmp(
+                className,
+                L"XamlExplorerHostIslandWindow"
+            ) == 0
+        ) {
+            WCHAR processName[MAX_PATH] = {};
+
+            if (
+                GetWindowProcessName(
+                    hwnd,
+                    processName,
+                    ARRAYSIZE(processName)
+                ) &&
+                (
+                    _wcsicmp(
+                        processName,
+                        L"explorer.exe"
+                    ) == 0 ||
+                    _wcsicmp(
+                        processName,
+                        L"ShellExperienceHost.exe"
+                    ) == 0
+                )
+            ) {
+                scan->altTabActive = true;
+            }
+        } else {
+            scan->altTabActive = true;
+        }
+
+        return TRUE;
+    }
+
+    /*
+     * CoreWindow and XAML popup classes can belong to normal apps too.
+     * Only shell-owned instances are treated as shell UI.
+     */
+    if (
+        IsShellChromeClass(className) &&
+        IsShellUiWindow(hwnd)
+    ) {
+        BOOL cloaked = FALSE;
+
+        if (
+            !(
+                SUCCEEDED(
+                    DwmGetWindowAttribute(
+                        hwnd,
+                        DWMWA_CLOAKED,
+                        &cloaked,
+                        sizeof(cloaked)
+                    )
+                ) &&
+                cloaked
+            )
+        ) {
+            RECT rect = {};
+
+            if (GetWindowRect(hwnd, &rect)) {
+                for (size_t i = 0; i < scan->count; ++i) {
+                    RECT intersection = {};
+
+                    if (
+                        IntersectRect(
+                            &intersection,
+                            &scan->taskbars[i].monitorRect,
+                            &rect
+                        )
+                    ) {
+                        scan->taskbars[i].shellFlyoutVisible = true;
+                    }
+                }
+            }
+        }
+
         return TRUE;
     }
 
@@ -261,22 +363,6 @@ BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
         GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
 
     if (exStyle & WS_EX_TOOLWINDOW) {
-        return TRUE;
-    }
-
-    BOOL cloaked = FALSE;
-
-    if (
-        SUCCEEDED(
-            DwmGetWindowAttribute(
-                hwnd,
-                DWMWA_CLOAKED,
-                &cloaked,
-                sizeof(cloaked)
-            )
-        ) &&
-        cloaked
-    ) {
         return TRUE;
     }
 
@@ -296,6 +382,25 @@ BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
     if (
         GetWindow(hwnd, GW_OWNER) != nullptr &&
         !(exStyle & WS_EX_APPWINDOW)
+    ) {
+        return TRUE;
+    }
+
+    /*
+     * DWM is deliberately queried after the cheaper filters.
+     */
+    BOOL cloaked = FALSE;
+
+    if (
+        SUCCEEDED(
+            DwmGetWindowAttribute(
+                hwnd,
+                DWMWA_CLOAKED,
+                &cloaked,
+                sizeof(cloaked)
+            )
+        ) &&
+        cloaked
     ) {
         return TRUE;
     }
@@ -321,7 +426,10 @@ BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
 void ScanApplicationWindows() {
     for (size_t i = 0; i < g_taskbarCount; ++i) {
         g_taskbars[i].hasApplication = false;
+        g_taskbars[i].shellFlyoutVisible = false;
     }
+
+    g_altTabActive = false;
 
     if (!g_taskbarCount) {
         return;
@@ -329,13 +437,16 @@ void ScanApplicationWindows() {
 
     AppMonitorScan scan{
         g_taskbars,
-        g_taskbarCount
+        g_taskbarCount,
+        false
     };
 
     EnumWindows(
         EnumWindowsProc,
         reinterpret_cast<LPARAM>(&scan)
     );
+
+    g_altTabActive = scan.altTabActive;
 }
 
 
@@ -575,158 +686,6 @@ bool IsVisibleShellFlyoutForMonitor(
         &mi.rcMonitor,
         &windowRect
     ) != FALSE;
-}
-
-
-struct ShellFlyoutScan {
-    HMONITOR monitor;
-    bool found;
-};
-
-
-BOOL CALLBACK EnumShellFlyoutProc(
-    HWND hwnd,
-    LPARAM lParam
-) {
-    ShellFlyoutScan* scan =
-        reinterpret_cast<ShellFlyoutScan*>(lParam);
-
-    if (!scan || scan->found) {
-        return FALSE;
-    }
-
-    if (
-        IsVisibleShellFlyoutForMonitor(
-            scan->monitor,
-            hwnd
-        )
-    ) {
-        scan->found = true;
-        return FALSE;
-    }
-
-    return TRUE;
-}
-
-
-bool HasVisibleShellFlyout(HMONITOR monitor) {
-    if (!monitor) {
-        return false;
-    }
-
-    ShellFlyoutScan scan = {};
-    scan.monitor = monitor;
-
-    EnumWindows(
-        EnumShellFlyoutProc,
-        reinterpret_cast<LPARAM>(&scan)
-    );
-
-    return scan.found;
-}
-
-
-BOOL CALLBACK EnumAltTabWindowProc(
-    HWND hwnd,
-    LPARAM lParam
-) {
-    bool* found =
-        reinterpret_cast<bool*>(lParam);
-
-    if (!found || !IsWindowVisible(hwnd)) {
-        return TRUE;
-    }
-
-    WCHAR className[128] = {};
-
-    if (
-        GetClassNameW(
-            hwnd,
-            className,
-            ARRAYSIZE(className)
-        ) == 0 ||
-        !IsAltTabWindowClass(className)
-    ) {
-        return TRUE;
-    }
-
-    /*
-     * The modern Windows 11 switcher uses
-     * XamlExplorerHostIslandWindow. Restrict it to the shell processes
-     * that actually host the task switcher.
-     */
-    if (
-        wcscmp(
-            className,
-            L"XamlExplorerHostIslandWindow"
-        ) == 0
-    ) {
-        WCHAR processName[MAX_PATH] = {};
-
-        if (
-            !GetWindowProcessName(
-                hwnd,
-                processName,
-                ARRAYSIZE(processName)
-            )
-        ) {
-            return TRUE;
-        }
-
-        if (
-            _wcsicmp(processName, L"explorer.exe") != 0 &&
-            _wcsicmp(processName, L"ShellExperienceHost.exe") != 0
-        ) {
-            return TRUE;
-        }
-    }
-
-    BOOL cloaked = FALSE;
-
-    if (
-        SUCCEEDED(
-            DwmGetWindowAttribute(
-                hwnd,
-                DWMWA_CLOAKED,
-                &cloaked,
-                sizeof(cloaked)
-            )
-        ) &&
-        cloaked
-    ) {
-        return TRUE;
-    }
-
-    *found = true;
-    return FALSE;
-}
-
-
-bool IsAltTabActive() {
-    /*
-     * Modern Windows versions do not always expose the task switcher
-     * through the legacy #32771 window class. Detect the actual Alt+Tab
-     * shortcut while it is being held, and keep the legacy class check
-     * as a fallback.
-     */
-    bool altTabWindow = false;
-
-    EnumWindows(
-        EnumAltTabWindowProc,
-        reinterpret_cast<LPARAM>(&altTabWindow)
-    );
-
-    if (altTabWindow) {
-        return true;
-    }
-
-    bool altDown =
-        (GetAsyncKeyState(VK_MENU) & 0x8000) != 0;
-
-    bool tabDown =
-        (GetAsyncKeyState(VK_TAB) & 0x8000) != 0;
-
-    return altDown && tabDown;
 }
 
 
@@ -1202,10 +1161,10 @@ void UpdateTaskbarState() {
 
         bool shellFlyoutOpen =
             taskbar.shellUiForeground ||
-            HasVisibleShellFlyout(taskbar.monitor);
+            taskbar.shellFlyoutVisible;
 
         bool altTabActive =
-            IsAltTabActive();
+            g_altTabActive;
 
         /*
          * If a normal application is present on this monitor, that
@@ -1298,6 +1257,12 @@ void UpdateTaskbarState() {
                 taskbar.hwnd,
                 true
             );
+
+            if (!taskbar.hideDeadline) {
+                taskbar.hideDeadline =
+                    now +
+                    static_cast<ULONGLONG>(delay);
+            }
 
             continue;
         }
@@ -1441,21 +1406,13 @@ LRESULT CALLBACK SystemMessageWindowProc(
 
     switch (message) {
     case WM_SETTINGCHANGE:
-        /*
-         * Native taskbar auto-hide can be changed from Windows Settings.
-         * Re-query it only when this targeted system notification arrives.
-         */
-        RefreshPerMonitorState();
-        UpdateTaskbarState();
-        return 0;
-
     case WM_DISPLAYCHANGE:
     case WM_DPICHANGED:
         /*
-         * Monitor layout or DPI can change taskbar geometry.
+         * Queue the state refresh on the worker thread rather than doing
+         * a complete EnumWindows sweep synchronously in this callback.
          */
-        RefreshPerMonitorState();
-        UpdateTaskbarState();
+        RequestStateRefresh();
         return 0;
 
     case WM_NCDESTROY:
@@ -2017,12 +1974,19 @@ void WhTool_ModUninit() {
 }
 
 
-// ============================================================
-// Windhawk Tool Mod launcher
+////////////////////////////////////////////////////////////////////////////////
+// Windhawk tool mod implementation for mods which don't need to inject to other
+// processes or hook other functions. Context:
+// https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process
 //
-// IMPORTANT:
-// Keep the official Windhawk launcher section below unchanged.
-// ============================================================
+// The mod will load and run in a dedicated windhawk.exe process.
+//
+// Paste the code below as part of the mod code, and use these callbacks:
+// * WhTool_ModInit
+// * WhTool_ModSettingsChanged
+// * WhTool_ModUninit
+//
+// Currently, other callbacks are not supported.
 
 bool g_isToolModProcessLauncher;
 HANDLE g_toolModProcessMutex;
@@ -2033,99 +1997,51 @@ void WINAPI EntryPoint_Hook() {
 }
 
 BOOL Wh_ModInit() {
-    DWORD sessionId;
-
-    if (
-        ProcessIdToSessionId(
-            GetCurrentProcessId(),
-            &sessionId
-        ) &&
-        sessionId == 0
-    ) {
-        return FALSE;
-    }
-
-    bool isExcluded = false;
+    bool isService = false;
     bool isToolModProcess = false;
     bool isCurrentToolModProcess = false;
-
     int argc;
-
-    LPWSTR* argv =
-        CommandLineToArgvW(
-            GetCommandLine(),
-            &argc
-        );
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);
 
     if (!argv) {
-        Wh_Log(
-            L"CommandLineToArgvW failed"
-        );
-
+        Wh_Log(L"CommandLineToArgvW failed");
         return FALSE;
     }
 
     for (int i = 1; i < argc; i++) {
-        if (
-            wcscmp(argv[i], L"-service") == 0 ||
-            wcscmp(argv[i], L"-service-start") == 0 ||
-            wcscmp(argv[i], L"-service-stop") == 0
-        ) {
-            isExcluded = true;
+        if (wcscmp(argv[i], L"-service") == 0) {
+            isService = true;
             break;
         }
     }
 
     for (int i = 1; i < argc - 1; i++) {
-        if (
-            wcscmp(argv[i], L"-tool-mod") == 0
-        ) {
+        if (wcscmp(argv[i], L"-tool-mod") == 0) {
             isToolModProcess = true;
-
-            if (
-                wcscmp(
-                    argv[i + 1],
-                    WH_MOD_ID
-                ) == 0
-            ) {
+            if (wcscmp(argv[i + 1], WH_MOD_ID) == 0) {
                 isCurrentToolModProcess = true;
             }
-
             break;
         }
     }
 
     LocalFree(argv);
 
-    if (isExcluded) {
+    if (isService) {
         return FALSE;
     }
 
     if (isCurrentToolModProcess) {
         g_toolModProcessMutex =
-            CreateMutexW(
-                nullptr,
-                TRUE,
-                L"windhawk-tool-mod_" WH_MOD_ID
-            );
+            CreateMutex(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
 
         if (!g_toolModProcessMutex) {
-            Wh_Log(
-                L"CreateMutex failed"
-            );
-
+            Wh_Log(L"CreateMutex failed");
             ExitProcess(1);
         }
 
-        if (
-            GetLastError() ==
-            ERROR_ALREADY_EXISTS
-        ) {
-            Wh_Log(
-                L"Tool mod already running (%s)",
-                WH_MOD_ID
-            );
-
+        if (GetLastError() == ERROR_ALREADY_EXISTS) {
+            Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
             ExitProcess(1);
         }
 
@@ -2134,32 +2050,14 @@ BOOL Wh_ModInit() {
         }
 
         IMAGE_DOS_HEADER* dosHeader =
-            reinterpret_cast<IMAGE_DOS_HEADER*>(
-                GetModuleHandle(nullptr)
-            );
-
+            (IMAGE_DOS_HEADER*)GetModuleHandle(nullptr);
         IMAGE_NT_HEADERS* ntHeaders =
-            reinterpret_cast<IMAGE_NT_HEADERS*>(
-                reinterpret_cast<BYTE*>(dosHeader) +
-                dosHeader->e_lfanew
-            );
+            (IMAGE_NT_HEADERS*)((BYTE*)dosHeader + dosHeader->e_lfanew);
 
-        DWORD entryPointRVA =
-            ntHeaders->OptionalHeader
-                .AddressOfEntryPoint;
+        DWORD entryPointRVA = ntHeaders->OptionalHeader.AddressOfEntryPoint;
+        void* entryPoint = (BYTE*)dosHeader + entryPointRVA;
 
-        void* entryPoint =
-            reinterpret_cast<BYTE*>(dosHeader) +
-            entryPointRVA;
-
-        Wh_SetFunctionHook(
-            entryPoint,
-            reinterpret_cast<void*>(
-                EntryPoint_Hook
-            ),
-            nullptr
-        );
-
+        Wh_SetFunctionHook(entryPoint, (void*)EntryPoint_Hook, nullptr);
         return TRUE;
     }
 
@@ -2168,10 +2066,8 @@ BOOL Wh_ModInit() {
     }
 
     g_isToolModProcessLauncher = true;
-
     return TRUE;
 }
-
 
 void Wh_ModAfterInit() {
     if (!g_isToolModProcessLauncher) {
@@ -2179,128 +2075,60 @@ void Wh_ModAfterInit() {
     }
 
     WCHAR currentProcessPath[MAX_PATH];
-
-    switch (
-        GetModuleFileNameW(
-            nullptr,
-            currentProcessPath,
-            ARRAYSIZE(currentProcessPath)
-        )
-    ) {
+    switch (GetModuleFileName(nullptr, currentProcessPath,
+                              ARRAYSIZE(currentProcessPath))) {
         case 0:
         case ARRAYSIZE(currentProcessPath):
-            Wh_Log(
-                L"GetModuleFileName failed"
-            );
-
+            Wh_Log(L"GetModuleFileName failed");
             return;
     }
 
-    WCHAR commandLine[
-        MAX_PATH +
-        2 +
-        (sizeof(
-            L" -tool-mod \"" WH_MOD_ID "\""
-        ) / sizeof(WCHAR)) -
-        1
-    ];
+    WCHAR
+    commandLine[MAX_PATH + 2 +
+                (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
+    swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
+               WH_MOD_ID);
 
-    swprintf_s(
-        commandLine,
-        L"\"%s\" -tool-mod \"%s\"",
-        currentProcessPath,
-        WH_MOD_ID
-    );
-
-    HMODULE kernelModule =
-        GetModuleHandleW(
-            L"kernelbase.dll"
-        );
-
+    HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
     if (!kernelModule) {
-        kernelModule =
-            GetModuleHandleW(
-                L"kernel32.dll"
-            );
-
+        kernelModule = GetModuleHandle(L"kernel32.dll");
         if (!kernelModule) {
-            Wh_Log(
-                L"No kernelbase.dll/kernel32.dll"
-            );
-
+            Wh_Log(L"No kernelbase.dll/kernel32.dll");
             return;
         }
     }
 
-    using CreateProcessInternalW_t =
-        BOOL(WINAPI*)(
-            HANDLE,
-            LPCWSTR,
-            LPWSTR,
-            LPSECURITY_ATTRIBUTES,
-            LPSECURITY_ATTRIBUTES,
-            WINBOOL,
-            DWORD,
-            LPVOID,
-            LPCWSTR,
-            LPSTARTUPINFO,
-            LPPROCESS_INFORMATION,
-            PHANDLE
-        );
-
-    CreateProcessInternalW_t
-        pCreateProcessInternalW =
-            reinterpret_cast<
-                CreateProcessInternalW_t
-            >(
-                GetProcAddress(
-                    kernelModule,
-                    "CreateProcessInternalW"
-                )
-            );
-
+    using CreateProcessInternalW_t = BOOL(WINAPI*)(
+        HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
+        LPSECURITY_ATTRIBUTES lpProcessAttributes,
+        LPSECURITY_ATTRIBUTES lpThreadAttributes, WINBOOL bInheritHandles,
+        DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory,
+        LPSTARTUPINFOW lpStartupInfo,
+        LPPROCESS_INFORMATION lpProcessInformation,
+        PHANDLE hRestrictedUserToken);
+    CreateProcessInternalW_t pCreateProcessInternalW =
+        (CreateProcessInternalW_t)GetProcAddress(kernelModule,
+                                                 "CreateProcessInternalW");
     if (!pCreateProcessInternalW) {
-        Wh_Log(
-            L"No CreateProcessInternalW"
-        );
-
+        Wh_Log(L"No CreateProcessInternalW");
         return;
     }
 
-    STARTUPINFO si = {};
-    si.cb = sizeof(STARTUPINFO);
-    si.dwFlags = STARTF_FORCEOFFFEEDBACK;
-
-    PROCESS_INFORMATION pi = {};
-
-    if (
-        !pCreateProcessInternalW(
-            nullptr,
-            currentProcessPath,
-            commandLine,
-            nullptr,
-            nullptr,
-            FALSE,
-            NORMAL_PRIORITY_CLASS,
-            nullptr,
-            nullptr,
-            &si,
-            &pi,
-            nullptr
-        )
-    ) {
-        Wh_Log(
-            L"CreateProcess failed: %lu",
-            GetLastError()
-        );
-
+    STARTUPINFO si{
+        .cb = sizeof(STARTUPINFO),
+        .dwFlags = STARTF_FORCEOFFFEEDBACK,
+    };
+    PROCESS_INFORMATION pi;
+    if (!pCreateProcessInternalW(nullptr, currentProcessPath, commandLine,
+                                 nullptr, nullptr, FALSE, NORMAL_PRIORITY_CLASS,
+                                 nullptr, nullptr, &si, &pi, nullptr)) {
+        Wh_Log(L"CreateProcess failed");
         return;
     }
 
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
 }
-
 
 void Wh_ModSettingsChanged() {
     if (g_isToolModProcessLauncher) {
@@ -2310,13 +2138,11 @@ void Wh_ModSettingsChanged() {
     WhTool_ModSettingsChanged();
 }
 
-
 void Wh_ModUninit() {
     if (g_isToolModProcessLauncher) {
         return;
     }
 
     WhTool_ModUninit();
-
     ExitProcess(0);
 }

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Hides selected taskbars only while their display is showing the desktop
-// @version         4.5.0
+// @version         4.6.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -124,13 +124,13 @@ This prevents a brief secondary-taskbar flash while leaving unrelated Explorer w
 
 ### Failure Recovery
 
-The taskbar ownership marker contains the process ID of the dedicated tool process that hid the taskbar.
+The taskbar ownership marker contains the process ID and creation time of the dedicated tool process that hid the taskbar.
 
 If that process is no longer running, the Explorer-side check removes the stale marker and restores the taskbar through Explorer's normal `ShowWindow` path.
 
 This prevents an unexpected tool-process termination from leaving a taskbar hidden or permanently blocking Explorer from restoring it.
 
-Stale hidden-taskbar state is also checked during Explorer initialization for both primary and secondary taskbars.
+Stale hidden-taskbar state is also checked during Explorer initialization and by a low-frequency Explorer-side recovery check for both primary and secondary taskbars.
 
 ## Multi-Monitor Example
 
@@ -187,7 +187,7 @@ The mod uses:
 - A periodic safety poll for missed or unusual transitions
 - A one-shot timer for hover dismissal
 
-The Explorer-side hook performs only the narrow visibility check required for secondary-taskbar flash prevention.
+The Explorer-side hook performs only the narrow visibility check required for secondary-taskbar flash prevention. A separate low-frequency Explorer recovery thread only checks for stale mod-owned taskbar state and does not participate in normal taskbar visibility decisions.
 
 Cursor sampling backs off when hover tracking is not needed and also backs off after repeated cursor-position failures.
 
@@ -341,7 +341,6 @@ struct MonitorSelectionBinding {
 
 struct WindowScanResult {
     bool applicationOnMonitor[kMaxMonitorNumbers];
-    bool shellSurfaceOnMonitor[kMaxMonitorNumbers];
 };
 
 HWINEVENTHOOK g_foregroundHook = nullptr;
@@ -369,6 +368,10 @@ SRWLOCK g_cursorHoverSnapshotLock = SRWLOCK_INIT;
 
 constexpr wchar_t kHiddenByModProperty[] =
     L"Windhawk.HideTaskbarOnlyOnDesktop.HiddenByMod";
+constexpr wchar_t kHiddenByModCreationTimeLowProperty[] =
+    L"Windhawk.HideTaskbarOnlyOnDesktop.HiddenByMod.CreationTimeLow";
+constexpr wchar_t kHiddenByModCreationTimeHighProperty[] =
+    L"Windhawk.HideTaskbarOnlyOnDesktop.HiddenByMod.CreationTimeHigh";
 
 // Explorer-side protection for the secondary-taskbar shell transition.
 // The dedicated tool process remains authoritative for taskbar state. Explorer
@@ -380,7 +383,36 @@ bool g_isExplorerProcess = false;
 
 DWORD g_hiddenTaskbarOwnerPid = 0;
 HANDLE g_hiddenTaskbarOwnerProcess = nullptr;
+FILETIME g_hiddenTaskbarOwnerCreationTime = {};
+HANDLE g_explorerRecoveryThread = nullptr;
+HANDLE g_explorerRecoveryStopEvent = nullptr;
 SRWLOCK g_hiddenTaskbarOwnerCacheLock = SRWLOCK_INIT;
+
+bool GetProcessCreationTime(
+    HANDLE process,
+    FILETIME* creationTime
+) {
+    if (!process || !creationTime) {
+        return false;
+    }
+
+    FILETIME exitTime = {};
+    FILETIME kernelTime = {};
+    FILETIME userTime = {};
+
+    return GetProcessTimes(
+        process,
+        creationTime,
+        &exitTime,
+        &kernelTime,
+        &userTime
+    ) != FALSE;
+}
+
+void RecoverStaleHiddenTaskbars();
+bool SetHiddenTaskbarOwnershipMarker(HWND hwnd);
+void RemoveHiddenTaskbarOwnershipMarker(HWND hwnd);
+void RestoreHiddenTaskbarOwnershipMarker(HWND hwnd);
 
 void ResetHiddenTaskbarOwnerCache() {
     AcquireSRWLockExclusive(
@@ -395,6 +427,7 @@ void ResetHiddenTaskbarOwnerCache() {
     }
 
     g_hiddenTaskbarOwnerPid = 0;
+    g_hiddenTaskbarOwnerCreationTime = {};
 
     ReleaseSRWLockExclusive(
         &g_hiddenTaskbarOwnerCacheLock
@@ -436,17 +469,33 @@ bool IsHiddenTaskbarOwnerAlive(HWND hwnd) {
     }
 
     HANDLE marker = GetPropW(hwnd, kHiddenByModProperty);
-
     if (!marker) {
         return false;
     }
 
     DWORD ownerPid = static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(marker));
 
+    const bool hasCreationTime =
+        GetPropW(hwnd, kHiddenByModCreationTimeLowProperty) != nullptr &&
+        GetPropW(hwnd, kHiddenByModCreationTimeHighProperty) != nullptr;
+
+    FILETIME markerCreationTime = {};
+    markerCreationTime.dwLowDateTime =
+        static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(
+            GetPropW(hwnd, kHiddenByModCreationTimeLowProperty)));
+    markerCreationTime.dwHighDateTime =
+        static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(
+            GetPropW(hwnd, kHiddenByModCreationTimeHighProperty)));
+
+
     if (!ownerPid) {
         RemovePropW(hwnd, kHiddenByModProperty);
+        RemovePropW(hwnd, kHiddenByModCreationTimeLowProperty);
+        RemovePropW(hwnd, kHiddenByModCreationTimeHighProperty);
         return false;
     }
+
+    bool ownerAlive = false;
 
     AcquireSRWLockExclusive(&g_hiddenTaskbarOwnerCacheLock);
 
@@ -457,16 +506,47 @@ bool IsHiddenTaskbarOwnerAlive(HWND hwnd) {
         }
 
         g_hiddenTaskbarOwnerPid = ownerPid;
+        g_hiddenTaskbarOwnerCreationTime = {};
         g_hiddenTaskbarOwnerProcess =
-            OpenProcess(SYNCHRONIZE, FALSE, ownerPid);
+            OpenProcess(
+                SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION,
+                FALSE,
+                ownerPid
+            );
+
+        if (g_hiddenTaskbarOwnerProcess) {
+            GetProcessCreationTime(
+                g_hiddenTaskbarOwnerProcess,
+                &g_hiddenTaskbarOwnerCreationTime
+            );
+        }
     }
 
-    bool ownerAlive =
+    ownerAlive =
         g_hiddenTaskbarOwnerProcess &&
         WaitForSingleObject(g_hiddenTaskbarOwnerProcess, 0) == WAIT_TIMEOUT;
 
+    if (ownerAlive && !hasCreationTime) {
+        // Markers created by older versions contained only a PID. Treat them
+        // as stale once this version is running so a reused PID cannot inherit
+        // hidden-taskbar ownership accidentally. The tool process will rebuild
+        // the marker if the taskbar still needs to remain hidden.
+        ownerAlive = false;
+    } else if (
+        ownerAlive &&
+        CompareFileTime(
+            &markerCreationTime,
+            &g_hiddenTaskbarOwnerCreationTime
+        ) != 0
+    ) {
+        ownerAlive = false;
+    }
+
+
     if (!ownerAlive) {
         RemovePropW(hwnd, kHiddenByModProperty);
+        RemovePropW(hwnd, kHiddenByModCreationTimeLowProperty);
+        RemovePropW(hwnd, kHiddenByModCreationTimeHighProperty);
 
         if (g_hiddenTaskbarOwnerProcess) {
             CloseHandle(g_hiddenTaskbarOwnerProcess);
@@ -474,6 +554,7 @@ bool IsHiddenTaskbarOwnerAlive(HWND hwnd) {
         }
 
         g_hiddenTaskbarOwnerPid = 0;
+        g_hiddenTaskbarOwnerCreationTime = {};
     }
 
     ReleaseSRWLockExclusive(&g_hiddenTaskbarOwnerCacheLock);
@@ -481,21 +562,21 @@ bool IsHiddenTaskbarOwnerAlive(HWND hwnd) {
     return ownerAlive;
 }
 
+
 void RecoverStaleHiddenTaskbar(HWND hwnd) {
     if (!IsExplorerTaskbar(hwnd) ||
         !GetPropW(hwnd, kHiddenByModProperty)) {
         return;
     }
 
+
     if (IsHiddenTaskbarOwnerAlive(hwnd)) {
         return;
     }
 
+
     if (g_explorerShowWindowOriginal) {
-        RemovePropW(
-            hwnd,
-            kHiddenByModProperty
-        );
+        RemoveHiddenTaskbarOwnershipMarker(hwnd);
         g_explorerShowWindowOriginal(hwnd, SW_SHOWNA);
     }
 }
@@ -514,6 +595,72 @@ void RecoverStaleHiddenTaskbars() {
     }
 }
 
+DWORD WINAPI ExplorerRecoveryThread(LPVOID) {
+    constexpr DWORD kRecoveryCheckIntervalMs = 1000;
+
+    for (;;) {
+        DWORD result = WaitForSingleObject(
+            g_explorerRecoveryStopEvent,
+            kRecoveryCheckIntervalMs
+        );
+
+        if (result != WAIT_TIMEOUT) {
+            break;
+        }
+
+        RecoverStaleHiddenTaskbars();
+    }
+
+    return 0;
+}
+
+bool StartExplorerRecoveryThread() {
+    g_explorerRecoveryStopEvent =
+        CreateEventW(nullptr, TRUE, FALSE, nullptr);
+
+    if (!g_explorerRecoveryStopEvent) {
+        Wh_Log(L"CreateEventW(explorer recovery) failed: %lu", GetLastError());
+        return false;
+    }
+
+    g_explorerRecoveryThread = CreateThread(
+        nullptr,
+        0,
+        ExplorerRecoveryThread,
+        nullptr,
+        0,
+        nullptr
+    );
+
+    if (!g_explorerRecoveryThread) {
+        Wh_Log(L"CreateThread(explorer recovery) failed: %lu", GetLastError());
+        CloseHandle(g_explorerRecoveryStopEvent);
+        g_explorerRecoveryStopEvent = nullptr;
+        return false;
+    }
+
+    return true;
+}
+
+void StopExplorerRecoveryThread() {
+    if (g_explorerRecoveryStopEvent) {
+        SetEvent(g_explorerRecoveryStopEvent);
+    }
+
+    if (g_explorerRecoveryThread) {
+        // The thread is executing code from the injected module, so it must be
+        // fully stopped before Explorer unloads the mod.
+        WaitForSingleObject(g_explorerRecoveryThread, INFINITE);
+        CloseHandle(g_explorerRecoveryThread);
+        g_explorerRecoveryThread = nullptr;
+    }
+
+    if (g_explorerRecoveryStopEvent) {
+        CloseHandle(g_explorerRecoveryStopEvent);
+        g_explorerRecoveryStopEvent = nullptr;
+    }
+}
+
 BOOL WINAPI ExplorerShowWindowHook(HWND hwnd, int nCmdShow) {
     if (nCmdShow == SW_SHOWNA && IsExplorerTaskbar(hwnd)) {
         const bool marked =
@@ -523,10 +670,7 @@ BOOL WINAPI ExplorerShowWindowHook(HWND hwnd, int nCmdShow) {
             const bool ownerAlive = IsHiddenTaskbarOwnerAlive(hwnd);
 
             if (!ownerAlive && g_explorerShowWindowOriginal) {
-                RemovePropW(
-                    hwnd,
-                    kHiddenByModProperty
-                );
+                RemoveHiddenTaskbarOwnershipMarker(hwnd);
                 return g_explorerShowWindowOriginal(hwnd, SW_SHOWNA);
             }
 
@@ -540,6 +684,7 @@ BOOL WINAPI ExplorerShowWindowHook(HWND hwnd, int nCmdShow) {
 }
 
 bool InstallExplorerVisibilityHook() {
+
     if (
         !WindhawkUtils::SetFunctionHook(
             ShowWindow,
@@ -1302,16 +1447,6 @@ bool IsShellSurfaceWindow(
     return false;
 }
 
-bool IsTransientShellWindow(
-    HWND hwnd,
-    const WCHAR* className
-) {
-    return IsShellSurfaceWindow(
-        hwnd,
-        className
-    );
-}
-
 bool IsApplicationWindowCandidate(
     HWND hwnd,
     const WCHAR* className
@@ -1341,7 +1476,7 @@ bool IsApplicationWindowCandidate(
         return false;
     }
 
-    if (IsTransientShellWindow(
+    if (IsShellSurfaceWindow(
             hwnd,
             className
         )) {
@@ -1415,34 +1550,6 @@ BOOL CALLBACK ScanWindowsWithMonitorsProc(
         ) == 0
     ) {
         return TRUE;
-    }
-
-    if (IsShellSurfaceWindow(
-            hwnd,
-            className
-        )) {
-        RECT popupRect = {};
-
-        if (GetWindowRect(hwnd, &popupRect)) {
-            // Mark every display intersected by the popup rather than using
-            // its center point. This handles shell surfaces that straddle
-            // monitor boundaries and avoids arbitrarily selecting one display.
-            for (
-                size_t i = 0;
-                i < context->monitors->count;
-                ++i
-            ) {
-                RECT intersection = {};
-
-                if (IntersectRect(
-                        &intersection,
-                        &popupRect,
-                        &context->monitors->entries[i].rect
-                    )) {
-                    context->result->shellSurfaceOnMonitor[i] = true;
-                }
-            }
-        }
     }
 
     if (!IsApplicationWindowCandidate(
@@ -1722,6 +1829,78 @@ bool ShouldHideTaskbar(
 }
 
 
+bool SetHiddenTaskbarOwnershipMarker(HWND hwnd) {
+    if (!hwnd) {
+        return false;
+    }
+
+    FILETIME creationTime = {};
+    if (!GetProcessCreationTime(
+            GetCurrentProcess(),
+            &creationTime
+        )) {
+        Wh_Log(L"GetProcessTimes(current process) failed: %lu", GetLastError());
+        return SetPropW(
+            hwnd,
+            kHiddenByModProperty,
+            reinterpret_cast<HANDLE>(
+                static_cast<ULONG_PTR>(GetCurrentProcessId())
+            )
+        ) != FALSE;
+    }
+
+    const bool pidSet = SetPropW(
+        hwnd,
+        kHiddenByModProperty,
+        reinterpret_cast<HANDLE>(
+            static_cast<ULONG_PTR>(GetCurrentProcessId())
+        )
+    ) != FALSE;
+
+    const bool lowSet = SetPropW(
+        hwnd,
+        kHiddenByModCreationTimeLowProperty,
+        reinterpret_cast<HANDLE>(
+            static_cast<ULONG_PTR>(creationTime.dwLowDateTime)
+        )
+    ) != FALSE;
+
+    const bool highSet = SetPropW(
+        hwnd,
+        kHiddenByModCreationTimeHighProperty,
+        reinterpret_cast<HANDLE>(
+            static_cast<ULONG_PTR>(creationTime.dwHighDateTime)
+        )
+    ) != FALSE;
+
+    if (!pidSet || !lowSet || !highSet) {
+        Wh_Log(L"Set hidden taskbar ownership metadata failed for 0x%p: %lu",
+               hwnd, GetLastError());
+        RemovePropW(hwnd, kHiddenByModCreationTimeLowProperty);
+        RemovePropW(hwnd, kHiddenByModCreationTimeHighProperty);
+    }
+
+    return pidSet;
+}
+
+void RemoveHiddenTaskbarOwnershipMarker(HWND hwnd) {
+    if (!hwnd) {
+        return;
+    }
+
+    RemovePropW(hwnd, kHiddenByModProperty);
+    RemovePropW(hwnd, kHiddenByModCreationTimeLowProperty);
+    RemovePropW(hwnd, kHiddenByModCreationTimeHighProperty);
+}
+
+void RestoreHiddenTaskbarOwnershipMarker(HWND hwnd) {
+    if (!hwnd) {
+        return;
+    }
+
+    SetHiddenTaskbarOwnershipMarker(hwnd);
+}
+
 void SetTaskbarState(
     TaskbarMonitorState& state,
     bool show
@@ -1742,10 +1921,7 @@ void SetTaskbarState(
         // with a hidden taskbar that still looks owned by this mod. Keep the
         // normal transition synchronous so Explorer cannot queue a stale SHOW
         // behind our state reconciliation.
-        RemovePropW(
-            state.hwnd,
-            kHiddenByModProperty
-        );
+        RemoveHiddenTaskbarOwnershipMarker(state.hwnd);
 
         ShowWindow(
             state.hwnd,
@@ -1758,13 +1934,7 @@ void SetTaskbarState(
             // Restore the marker if the show operation did not make the taskbar
             // visible. This keeps ownership explicit rather than leaving a
             // silently hidden, unowned taskbar behind.
-            SetPropW(
-                state.hwnd,
-                kHiddenByModProperty,
-                reinterpret_cast<HANDLE>(
-                    static_cast<ULONG_PTR>(GetCurrentProcessId())
-                )
-            );
+            RestoreHiddenTaskbarOwnershipMarker(state.hwnd);
             state.hiddenByMod = true;
         }
 
@@ -1781,17 +1951,9 @@ void SetTaskbarState(
         return;
     }
 
-    if (!SetPropW(
-            state.hwnd,
-            kHiddenByModProperty,
-            reinterpret_cast<HANDLE>(
-                static_cast<ULONG_PTR>(
-                    GetCurrentProcessId()
-                )
-            )
-        )) {
+    if (!SetHiddenTaskbarOwnershipMarker(state.hwnd)) {
         Wh_Log(
-            L"SetPropW failed for taskbar 0x%p: %lu",
+            L"Set hidden taskbar ownership marker failed for 0x%p: %lu",
             state.hwnd,
             GetLastError()
         );
@@ -1805,50 +1967,9 @@ void SetTaskbarState(
     if (!IsWindowVisible(state.hwnd)) {
         state.hiddenByMod = true;
     } else {
-        RemovePropW(
-            state.hwnd,
-            kHiddenByModProperty
-        );
+        RemoveHiddenTaskbarOwnershipMarker(state.hwnd);
         state.hiddenByMod = false;
     }
-}
-
-struct CursorShellSurfaceContext {
-    POINT point;
-    HMONITOR monitor;
-    bool found;
-};
-
-BOOL CALLBACK FindShellSurfaceAtCursorProc(
-    HWND hwnd,
-    LPARAM lParam
-) {
-    auto* context =
-        reinterpret_cast<CursorShellSurfaceContext*>(lParam);
-
-    if (!context || context->found || !IsWindowVisible(hwnd)) {
-        return context && context->found ? FALSE : TRUE;
-    }
-
-    WCHAR className[256] = {};
-    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
-        return TRUE;
-    }
-
-    if (!IsTaskbarPopupClass(className)) {
-        return TRUE;
-    }
-
-    RECT rect = {};
-    if (!GetWindowRect(hwnd, &rect) ||
-        !PtInRect(&rect, context->point)) {
-        return TRUE;
-    }
-
-    context->found = true;
-    context->monitor =
-        MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-    return FALSE;
 }
 
 struct VisibleShellPopupContext {
@@ -2190,6 +2311,7 @@ bool IsCursorInConfiguredHoverZoneAtSnapshot(
 }
 
 void UpdateTaskbarState() {
+
     MonitorList monitors =
         GetCurrentMonitors();
 
@@ -2217,6 +2339,9 @@ void UpdateTaskbarState() {
     }
 
     g_displayTopologySignature = topologySignature;
+
+    for (size_t i = 0; i < monitors.count; ++i) {
+    }
 
     BindConfiguredMonitorSelections(
         monitors
@@ -2260,6 +2385,7 @@ void UpdateTaskbarState() {
                 break;
             }
         }
+
     }
 
     POINT cursorPoint = {};
@@ -2305,6 +2431,7 @@ void UpdateTaskbarState() {
 
     const bool hovering =
         cursorInHoverZone;
+
 
     if (hovering) {
         g_hoverActive = true;
@@ -2685,6 +2812,11 @@ void CALLBACK WinEventProc(
         return;
     }
 
+    if (event == EVENT_SYSTEM_FOREGROUND) {
+        PostRefresh();
+        return;
+    }
+
     if (
         event != EVENT_SYSTEM_MINIMIZESTART &&
         event != EVENT_SYSTEM_MINIMIZEEND &&
@@ -2716,6 +2848,7 @@ void EnsureTaskbarShowHook() {
         return;
     }
 
+
     SafeUnhookWinEvent(g_taskbarShowHook);
     g_taskbarShowHookProcessId = 0;
 
@@ -2732,6 +2865,7 @@ void EnsureTaskbarShowHook() {
 
         if (g_taskbarShowHook) {
             g_taskbarShowHookProcessId = explorerPid;
+        } else {
         }
     }
 }
@@ -2905,6 +3039,7 @@ DWORD WINAPI WorkerThread(
             WINEVENT_OUTOFCONTEXT
         );
 
+
     g_moveHook =
         SetWinEventHook(
             EVENT_SYSTEM_MOVESIZEEND,
@@ -2930,6 +3065,7 @@ DWORD WINAPI WorkerThread(
             kSafetyPollIntervalMs,
             nullptr
         );
+
 
     for (;;) {
         BOOL result =
@@ -3287,10 +3423,7 @@ void RestoreAllTaskbars() {
 
         // Remove ownership before the restore request so Explorer cannot treat
         // its own SHOW path as an attempt to violate the mod's hidden state.
-        RemovePropW(
-            hwnd,
-            kHiddenByModProperty
-        );
+        RemoveHiddenTaskbarOwnershipMarker(hwnd);
 
         // Teardown must not wait on Explorer's UI thread.
         if (!ShowWindowAsync(
@@ -3299,13 +3432,7 @@ void RestoreAllTaskbars() {
             )) {
             // Keep explicit ownership if the asynchronous restore request could
             // not be queued.
-            SetPropW(
-                hwnd,
-                kHiddenByModProperty,
-                reinterpret_cast<HANDLE>(
-                    static_cast<ULONG_PTR>(GetCurrentProcessId())
-                )
-            );
+            SetHiddenTaskbarOwnershipMarker(hwnd);
         }
     };
 
@@ -3535,6 +3662,7 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
+
     if (isCurrentToolModProcess) {
         g_toolModProcessMutex =
             CreateMutex(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
@@ -3592,6 +3720,7 @@ void Wh_ModAfterInit() {
     swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
                WH_MOD_ID);
 
+
     HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
     if (!kernelModule) {
         kernelModule = GetModuleHandle(L"kernel32.dll");
@@ -3629,6 +3758,7 @@ void Wh_ModAfterInit() {
         return;
     }
 
+
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
 }
@@ -3662,7 +3792,18 @@ BOOL Wh_ModInit() {
             return FALSE;
         }
 
+        Wh_Log(
+    L"Explorer init: original=%p",
+    g_explorerShowWindowOriginal
+);
+
         RecoverStaleHiddenTaskbars();
+        StartExplorerRecoveryThread();
+
+        Wh_Log(
+    L"Explorer init: original=%p",
+    g_explorerShowWindowOriginal
+);
         return TRUE;
     }
 
@@ -3687,6 +3828,7 @@ void Wh_ModSettingsChanged() {
 
 void Wh_ModUninit() {
     if (g_isExplorerProcess) {
+        StopExplorerRecoveryThread();
         ResetHiddenTaskbarOwnerCache();
         return;
     }

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Hides selected taskbars only while their display is showing the desktop
-// @version         2.1.0
+// @version         2.2.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -185,8 +185,10 @@ struct WindowScanResult {
     bool applicationOnMonitor[kMaxMonitorNumbers];
 };
 
+HWINEVENTHOOK g_foregroundHook = nullptr;
 HWINEVENTHOOK g_minimizeHook = nullptr;
 HWINEVENTHOOK g_moveHook = nullptr;
+HWINEVENTHOOK g_taskbarShowHook = nullptr;
 
 HANDLE g_workerThread = nullptr;
 DWORD g_workerThreadId = 0;
@@ -939,19 +941,15 @@ void SetTaskbarState(
         return;
     }
 
-    const bool visible =
+    bool visible =
         IsWindowVisible(state.hwnd) != FALSE;
 
-    if (visible == show) {
-        return;
+    if (visible != show) {
+        ShowWindow(
+            state.hwnd,
+            show ? SW_SHOW : SW_HIDE
+        );
     }
-
-    // Only this taskbar HWND is changed. Other displays are handled by their
-    // own TaskbarMonitorState entries.
-    ShowWindow(
-        state.hwnd,
-        show ? SW_SHOW : SW_HIDE
-    );
 }
 
 void ApplyBaseTaskbarState() {
@@ -1497,15 +1495,142 @@ void UpdateTaskbarState() {
     ApplyBaseTaskbarState();
 }
 
+bool IsTaskbarWindow(HWND hwnd) {
+    if (!hwnd || !IsWindow(hwnd)) {
+        return false;
+    }
+
+    WCHAR className[128] = {};
+
+    if (
+        GetClassNameW(
+            hwnd,
+            className,
+            ARRAYSIZE(className)
+        ) == 0
+    ) {
+        return false;
+    }
+
+    return
+        wcscmp(className, L"Shell_TrayWnd") == 0 ||
+        wcscmp(className, L"Shell_SecondaryTrayWnd") == 0;
+}
+
+bool IsCursorInConfiguredHoverZone() {
+    POINT pt = {};
+
+    if (!GetCursorPos(&pt)) {
+        return false;
+    }
+
+    HMONITOR cursorMonitor =
+        MonitorFromPoint(
+            pt,
+            MONITOR_DEFAULTTONEAREST
+        );
+
+    if (!cursorMonitor) {
+        return false;
+    }
+
+    MonitorList monitors =
+        GetCurrentMonitors();
+
+    const int monitorNumber =
+        GetMonitorNumber(
+            monitors,
+            cursorMonitor
+        );
+
+    if (
+        monitorNumber == 0 ||
+        !ShouldRevealOnHover(
+            monitorNumber
+        )
+    ) {
+        return false;
+    }
+
+    HWND taskbar = nullptr;
+
+    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+        if (
+            g_taskbarStates[i].monitor ==
+            cursorMonitor
+        ) {
+            taskbar =
+                g_taskbarStates[i].hwnd;
+            break;
+        }
+    }
+
+    return
+        taskbar &&
+        IsCursorNearBottomEdge(
+            taskbar,
+            cursorMonitor
+        );
+}
+
+
 void CALLBACK WinEventProc(
     HWINEVENTHOOK,
     DWORD event,
-    HWND,
-    LONG,
+    HWND hwnd,
+    LONG idObject,
     LONG,
     DWORD,
     DWORD
 ) {
+    /*
+     * Explorer can re-show a secondary taskbar while the user interacts with
+     * the primary taskbar or other shell UI. Handle only SHOW for the exact
+     * taskbar window classes. The callback never changes Explorer windows
+     * directly; it only schedules the serialized worker update. We intentionally
+     * do not watch HIDE.
+     */
+    if (
+        event == EVENT_OBJECT_SHOW &&
+        idObject == OBJID_WINDOW &&
+        IsTaskbarWindow(hwnd)
+    ) {
+        /*
+         * While the cursor is already inside the configured hover zone,
+         * Explorer may emit SHOW for more than one taskbar during the same
+         * shell transition. The worker's hover calculation is authoritative,
+         * so don't enqueue an additional refresh that can immediately undo
+         * and repeat the hover visibility transition.
+         *
+         * Outside the hover zone the narrow SHOW hook is retained so an
+         * Explorer re-show is reconciled promptly.
+         */
+        if (IsCursorInConfiguredHoverZone()) {
+            return;
+        }
+
+        if (
+            InterlockedExchange(
+                &g_refreshPosted,
+                1
+            ) == 0
+        ) {
+            if (!PostThreadMessageW(
+                    g_workerThreadId,
+                    WM_APP_REFRESH,
+                    0,
+                    0
+                )) {
+                InterlockedExchange(
+                    &g_refreshPosted,
+                    0
+                );
+            }
+        }
+
+        return;
+    }
+
     if (
         event != EVENT_SYSTEM_MINIMIZESTART &&
         event != EVENT_SYSTEM_MINIMIZEEND &&
@@ -1534,6 +1659,7 @@ void CALLBACK WinEventProc(
     }
 }
 
+
 DWORD WINAPI WorkerThread(
     LPVOID
 ) {
@@ -1553,6 +1679,17 @@ DWORD WINAPI WorkerThread(
         );
     }
 
+    g_foregroundHook =
+        SetWinEventHook(
+            EVENT_SYSTEM_FOREGROUND,
+            EVENT_SYSTEM_FOREGROUND,
+            nullptr,
+            WinEventProc,
+            0,
+            0,
+            WINEVENT_OUTOFCONTEXT
+        );
+
     g_minimizeHook =
         SetWinEventHook(
             EVENT_SYSTEM_MINIMIZESTART,
@@ -1568,6 +1705,17 @@ DWORD WINAPI WorkerThread(
         SetWinEventHook(
             EVENT_SYSTEM_MOVESIZEEND,
             EVENT_SYSTEM_MOVESIZEEND,
+            nullptr,
+            WinEventProc,
+            0,
+            0,
+            WINEVENT_OUTOFCONTEXT
+        );
+
+    g_taskbarShowHook =
+        SetWinEventHook(
+            EVENT_OBJECT_SHOW,
+            EVENT_OBJECT_SHOW,
             nullptr,
             WinEventProc,
             0,
@@ -1637,6 +1785,13 @@ DWORD WINAPI WorkerThread(
         );
     }
 
+    if (g_foregroundHook) {
+        UnhookWinEvent(
+            g_foregroundHook
+        );
+        g_foregroundHook = nullptr;
+    }
+
     if (g_minimizeHook) {
         UnhookWinEvent(
             g_minimizeHook
@@ -1649,6 +1804,13 @@ DWORD WINAPI WorkerThread(
             g_moveHook
         );
         g_moveHook = nullptr;
+    }
+
+    if (g_taskbarShowHook) {
+        UnhookWinEvent(
+            g_taskbarShowHook
+        );
+        g_taskbarShowHook = nullptr;
     }
 
     return 0;

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Hides selected taskbars only while their display is showing the desktop
-// @version         4.0.0
+// @version         4.1.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -14,149 +14,180 @@
 /*
 # Hide Taskbar Only on Desktop
 
-Hides each selected taskbar when its own display has no visible,
-non-minimized application window, and shows it again when an application or
-relevant Windows shell interaction requires the taskbar.
+Hides selected taskbars only while their own display is showing the desktop.
+When an application window is present on that display, the taskbar remains
+visible. Displays are evaluated independently.
 
-Each display is evaluated independently. An application being open on one
-display does not prevent the taskbar on another selected display from hiding.
+## Demo
 
-### Behavior
+### Multiple Displays
 
-- Each display is evaluated independently.
-- A selected taskbar is hidden only while its display has no visible,
-  non-minimized application window.
-- Maximized windows use Windows' monitor assignment. Normal windows that span
-  displays count on every display they actually intersect.
-- Bottom-edge hover reveal can be configured per display. The reveal zone is
-  based on the taskbar's actual height and display DPI plus the configured
-  extra margin.
-- Hover reveal is limited to bottom-docked taskbars.
-- The configured post-hover delay applies only to hover dismissal.
-- Relevant Windows shell surfaces, including Start, taskbar popups/overflow,
-  notification/quick-settings surfaces, and Alt+Tab, are treated as transient
-  shell UI rather than ordinary application windows.
-- Clearing the "Taskbars to hide on desktop" selection means hide nothing.
-- Windows' native taskbar auto-hide setting is left unchanged.
+![Multiple Display](https://raw.githubusercontent.com/Sahil-Dashoni/Hide-Taskbar-Only-on-Desktop-Windhawk-Mod/refs/heads/main/Assets/multiple-display.gif)
 
-### Why this is a separate behavior
+Each selected display is evaluated independently. An application can keep one display's taskbar visible while another display remains in the desktop-only state.
 
-This mod is focused on a specific visibility rule:
+### Single Display
 
-> **Hide a selected taskbar whenever its display is showing only the desktop.**
+![Single Display](https://raw.githubusercontent.com/Sahil-Dashoni/Hide-Taskbar-Only-on-Desktop-Windhawk-Mod/refs/heads/main/Assets/single-display.gif)
 
-An ordinary non-maximized application keeps the taskbar visible on its display,
-while a display with no visible application can have its selected taskbar
-hidden.
+The taskbar hides when the display returns to the desktop and can be revealed by moving the cursor into the configured bottom-edge area.
 
-Compared with **`taskbar-auto-hide-when-maximized`**, the distinction is the
-predicate and the interaction model. That mod is centered around window-state
-modes such as maximized/intersected behavior; this mod is centered around
-whether an application is present on each display and directly controls the
-taskbar window.
+## Behavior
 
-Compared with mods that configure Windows' native taskbar auto-hide, this mod
-does not enable or rewrite that setting. It directly hides the taskbar and
-leaves the normal desktop work area unchanged.
+- A selected taskbar hides only when its display has no visible, non-minimized
+  application window.
+- Maximized windows use Windows' monitor assignment. Normal windows spanning
+  displays count on every display they intersect.
+- Bottom-edge hover reveal can be enabled independently per display.
+- The hover zone is based on the current taskbar height and display DPI, plus
+  the configured extra margin.
+- The hover reveal feature is limited to bottom-docked taskbars.
+- The configured post-hover delay applies to hover dismissal.
+- Relevant Windows shell surfaces such as Start, taskbar popups/overflow,
+  notification/Quick Settings, and supported Alt+Tab surfaces are treated as
+  shell UI rather than normal application windows.
+- Clearing the taskbar selection means no taskbar is hidden.
+- Windows' native taskbar auto-hide setting is not changed.
 
-### Per-display configuration
+## Why this is different from `taskbar-auto-hide-when-maximized`
 
-Users can independently choose:
+These mods answer different visibility questions.
 
-- Which displays should hide their taskbar on desktop-only displays.
+`taskbar-auto-hide-when-maximized` is based on the state of application
+windows, with modes such as `intersected`, `maximized`, and `never`. This mod is
+based on a different predicate: **is this display currently showing only the
+desktop?**
+
+That means a normal, non-maximized application keeps the selected taskbar
+visible here. The taskbar hides only after the last visible, non-minimized
+application on that display is gone. A maximized window is not required for the
+taskbar to stay visible. Conversely, a completely idle display can hide its
+taskbar even while another display is actively being used.
+
+The distinction is therefore the user-visible policy, not merely the mechanism
+used internally:
+
+| Scenario | This mod | `taskbar-auto-hide-when-maximized` |
+| --- | --- | --- |
+| Desktop only on a selected display | Hide taskbar | Depends on its selected window-state mode |
+| One normal, non-maximized app visible | Keep taskbar visible | Depends on mode/window state |
+| One display has an app, another is idle | Evaluate each display separately | Uses its own monitor/window-state policy |
+| Goal | Desktop-only taskbar visibility | Auto-hide driven by maximized/intersection state |
+
+This mod also deliberately leaves Windows' native auto-hide preference alone
+and implements the desktop-only rule directly, including its explicit
+per-display selection and configurable hover-dismiss behavior.
+
+The project remains standalone because its primary purpose is this specific
+desktop-only policy. The existing mod is still the better choice for users who
+want taskbar auto-hide tied to maximized/intersected window state.
+
+## Per-display configuration
+
+You can independently choose:
+
+- Which displays should hide their taskbar when desktop-only.
 - Which displays should allow bottom-edge hover reveal.
 
 Selections use Windows display device names such as `\\.\DISPLAY1`. These
-identifiers may differ from the display numbers shown in Windows Display
-Settings.
+identifiers may differ from the numbers shown in Windows Display Settings.
 
-The mod tracks monitor/device identity during the current session so a
-reconnected display that receives a different `DISPLAYn` number can keep its
-selection when the same monitor identity is detected.
+The mod tracks monitor identity during the current session so a reconnected
+display that receives a different `DISPLAYn` number can retain its selection
+when the same monitor identity is detected.
 
-### Hover reveal
+## Hover reveal
 
-For a bottom-docked taskbar, moving the pointer into the configured
-bottom-edge zone reveals a taskbar hidden by the mod.
+When a selected, bottom-docked taskbar is hidden by the mod, moving the pointer
+into its configured bottom-edge zone reveals it. After leaving the zone, the
+taskbar remains visible for the configured dismissal delay before returning to
+its normal desktop/application state.
 
-After leaving the zone, the taskbar remains visible for the configured delay
-before returning to its normal desktop/application state.
+Hover tracking is adaptive: it samples more frequently when a configured hover
+zone can matter, uses a slower idle interval otherwise, and backs off further
+when cursor queries repeatedly fail (for example on the secure desktop).
 
-The hover zone uses the taskbar's current height and display DPI together with
-the configured extra margin. Top- and side-docked taskbars are not affected by
-hover reveal.
+## Windows shell interactions
 
-### Windows shell interactions
+The mod distinguishes relevant shell surfaces from ordinary application
+windows. It uses both window classes and the owning process for supported
+Windows shell components, including taskbar popup/overflow surfaces,
+Start/notification/Quick Settings hosts, relevant XAML shell hosts, and known
+Alt+Tab window classes. These surfaces can keep the relevant taskbar visible
+while the user is interacting with the shell.
 
-The mod distinguishes known shell surfaces from normal application windows.
-This includes taskbar popup/overflow windows, relevant XAML shell hosts,
-Start/notification/quick-settings surfaces hosted by Windows shell processes,
-and known Alt+Tab window classes.
-
-These surfaces can keep the relevant taskbar visible while the user is
-interacting with the shell.
-
-### Explorer integration and recovery
+## Explorer integration and crash recovery
 
 The main state manager runs in a dedicated `windhawk.exe` process. A small
-Explorer-side hook is used only to stop a specific `SW_SHOWNA` operation from
-re-showing a secondary taskbar immediately after the mod hid it.
+Explorer-side hook exists only to prevent the specific secondary-taskbar
+`SW_SHOWNA` transition that caused a visible re-show after the mod had hidden
+the taskbar. It does not alter Explorer's general taskbar behavior.
 
-The taskbar marker stores the owning tool-process ID rather than a constant
-value. The Explorer-side hook verifies that the owning process is still alive.
-If the owner has exited, the stale marker is removed and the normal Explorer
-operation is allowed to continue.
+Each taskbar hidden by the mod is marked with the PID of the owning tool
+process. Explorer caches and checks that process's liveness. If a stale marker
+is detected, the marker is removed and the taskbar is restored through the
+original Explorer `ShowWindow` path. Explorer also performs a stale-marker
+sweep when the Explorer-side component initializes, covering both the primary
+and secondary taskbars.
 
-The mod also records which taskbars it actually hid, so it does not restore
-taskbars hidden by unrelated mechanisms.
+This means a normal unload restores taskbars, while stale state left by an
+unexpected tool-process termination can be cleaned up without requiring an
+Explorer restart. Taskbars that were never hidden by this mod are not restored
+by the cleanup path.
 
-### Multi-monitor behavior
+## Multi-monitor behavior
 
-Consider two displays:
+Example with two displays:
 
 1. Display 1 has an application open.
 2. Display 2 shows only the desktop.
-3. A selected taskbar on display 1 stays visible.
-4. A selected taskbar on display 2 hides.
-5. Hovering the configured bottom edge of display 2 reveals its taskbar.
+3. The selected taskbar on display 1 stays visible.
+4. The selected taskbar on display 2 hides.
+5. Moving to the configured bottom edge of display 2 reveals its taskbar.
 6. Leaving the hover zone starts the configured dismissal delay.
 7. Opening an application on display 2 keeps its taskbar visible.
 
-Applications that span multiple displays count on every display they intersect.
-Maximized windows use the monitor assignment provided by Windows.
+Applications spanning multiple displays count on every display they intersect.
+Maximized windows use Windows' monitor assignment.
 
-### Display and taskbar changes
+## Display and taskbar changes
 
-Taskbars are rediscovered during reconciliation so Explorer taskbar recreation
-does not leave the mod tied to an old window handle.
+Taskbars are rediscovered during reconciliation, so Explorer taskbar recreation
+does not leave the mod tied to an old window handle. State is refreshed for
+relevant taskbar, display, settings, theme, window, and shell visibility
+changes, with a periodic safety poll for missed transitions.
 
-The state is refreshed for relevant taskbar, display, settings, theme, window,
-and shell visibility changes, with a periodic safety poll for missed
-transitions.
+A display-topology signature resets transient hover state when monitor geometry
+or the connected display set changes.
 
-A display-topology signature resets transient hover state when monitor
-geometry or the connected display set changes.
-
-### Limitations
+## Limitations
 
 - Hover reveal is supported only for bottom-docked taskbars.
 - Display selection currently exposes `DISPLAY1` through `DISPLAY16`.
 - `DISPLAYn` identifiers may differ from the numbering shown in Windows Display
-  Settings and may change after display configuration changes.
+  Settings and can change after display configuration changes.
+- A taskbar docked to the top or side is not hidden by the desktop-only rule.
+- A display selection that no longer matches any connected display remains
+  configured until the user changes the setting.
 - The mod does not modify Windows' native taskbar auto-hide setting.
-- The mod is focused specifically on desktop-only taskbar visibility rather
-  than being a general-purpose taskbar customization framework.
 
-### Goal
+## Demo
 
-The goal is a specific taskbar visibility rule:
+A real recording is recommended here for the repository submission: show a
+selected taskbar hiding when its display becomes desktop-only, revealing when
+the pointer reaches the bottom edge, and hiding again after the dismissal
+delay. Do not use a generated or illustrative image in place of a real
+recording.
+
+## Goal
+
+The goal is a specific visibility rule:
 
 > **Hide the taskbar when its display is showing only the desktop.**
 
 The mod combines that per-display application-state rule with independent
 display selection, shell-interaction handling, taskbar recreation recovery,
 and configurable bottom-edge hover reveal.
-
 */
 // ==/WindhawkModReadme==
 
@@ -344,6 +375,21 @@ void ResetHiddenTaskbarOwnerCache() {
     );
 }
 
+bool IsExplorerTaskbar(HWND hwnd) {
+    if (!hwnd) {
+        return false;
+    }
+
+    WCHAR className[128] = {};
+
+    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
+        return false;
+    }
+
+    return wcscmp(className, L"Shell_TrayWnd") == 0 ||
+           wcscmp(className, L"Shell_SecondaryTrayWnd") == 0;
+}
+
 bool IsExplorerSecondaryTaskbar(HWND hwnd) {
     if (!hwnd) {
         return false;
@@ -351,116 +397,112 @@ bool IsExplorerSecondaryTaskbar(HWND hwnd) {
 
     WCHAR className[128] = {};
 
-    if (
-        GetClassNameW(
-            hwnd,
-            className,
-            ARRAYSIZE(className)
-        ) == 0
-    ) {
+    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
         return false;
     }
 
-    return wcscmp(
-        className,
-        L"Shell_SecondaryTrayWnd"
-    ) == 0;
+    return wcscmp(className, L"Shell_SecondaryTrayWnd") == 0;
 }
 
-bool IsSecondaryTaskbarHiddenByMod(HWND hwnd) {
-    if (!IsExplorerSecondaryTaskbar(hwnd)) {
+bool IsHiddenTaskbarOwnerAlive(HWND hwnd) {
+    if (!IsExplorerTaskbar(hwnd)) {
         return false;
     }
 
-    HANDLE marker =
-        GetPropW(
-            hwnd,
-            kHiddenByModProperty
-        );
+    HANDLE marker = GetPropW(hwnd, kHiddenByModProperty);
 
     if (!marker) {
         return false;
     }
 
-    DWORD ownerPid =
-        static_cast<DWORD>(
-            reinterpret_cast<ULONG_PTR>(marker)
-        );
+    DWORD ownerPid = static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(marker));
 
     if (!ownerPid) {
-        RemovePropW(
-            hwnd,
-            kHiddenByModProperty
-        );
+        RemovePropW(hwnd, kHiddenByModProperty);
         return false;
     }
 
-    AcquireSRWLockExclusive(
-        &g_hiddenTaskbarOwnerCacheLock
-    );
+    AcquireSRWLockExclusive(&g_hiddenTaskbarOwnerCacheLock);
 
     if (ownerPid != g_hiddenTaskbarOwnerPid) {
         if (g_hiddenTaskbarOwnerProcess) {
-            CloseHandle(
-                g_hiddenTaskbarOwnerProcess
-            );
+            CloseHandle(g_hiddenTaskbarOwnerProcess);
             g_hiddenTaskbarOwnerProcess = nullptr;
         }
 
         g_hiddenTaskbarOwnerPid = ownerPid;
         g_hiddenTaskbarOwnerProcess =
-            OpenProcess(
-                SYNCHRONIZE,
-                FALSE,
-                ownerPid
-            );
+            OpenProcess(SYNCHRONIZE, FALSE, ownerPid);
     }
 
     bool ownerAlive =
         g_hiddenTaskbarOwnerProcess &&
-        WaitForSingleObject(
-            g_hiddenTaskbarOwnerProcess,
-            0
-        ) == WAIT_TIMEOUT;
+        WaitForSingleObject(g_hiddenTaskbarOwnerProcess, 0) == WAIT_TIMEOUT;
 
     if (!ownerAlive) {
-        RemovePropW(
-            hwnd,
-            kHiddenByModProperty
-        );
+        RemovePropW(hwnd, kHiddenByModProperty);
 
         if (g_hiddenTaskbarOwnerProcess) {
-            CloseHandle(
-                g_hiddenTaskbarOwnerProcess
-            );
+            CloseHandle(g_hiddenTaskbarOwnerProcess);
             g_hiddenTaskbarOwnerProcess = nullptr;
         }
 
         g_hiddenTaskbarOwnerPid = 0;
     }
 
-    ReleaseSRWLockExclusive(
-        &g_hiddenTaskbarOwnerCacheLock
-    );
+    ReleaseSRWLockExclusive(&g_hiddenTaskbarOwnerCacheLock);
 
     return ownerAlive;
 }
 
-BOOL WINAPI ExplorerShowWindowHook(
-    HWND hwnd,
-    int nCmdShow
-) {
-    if (
-        nCmdShow == SW_SHOWNA &&
-        IsSecondaryTaskbarHiddenByMod(hwnd)
-    ) {
-        return FALSE;
+void RecoverStaleHiddenTaskbar(HWND hwnd) {
+    if (!IsExplorerTaskbar(hwnd) ||
+        !GetPropW(hwnd, kHiddenByModProperty)) {
+        return;
     }
 
-    return g_explorerShowWindowOriginal(
-        hwnd,
-        nCmdShow
-    );
+    if (IsHiddenTaskbarOwnerAlive(hwnd)) {
+        return;
+    }
+
+    if (g_explorerShowWindowOriginal) {
+        g_explorerShowWindowOriginal(hwnd, SW_SHOW);
+    }
+}
+
+void RecoverStaleHiddenTaskbars() {
+    RecoverStaleHiddenTaskbar(FindWindowW(L"Shell_TrayWnd", nullptr));
+
+    HWND secondary = nullptr;
+
+    while ((secondary = FindWindowExW(
+                nullptr,
+                secondary,
+                L"Shell_SecondaryTrayWnd",
+                nullptr)) != nullptr) {
+        RecoverStaleHiddenTaskbar(secondary);
+    }
+}
+
+BOOL WINAPI ExplorerShowWindowHook(HWND hwnd, int nCmdShow) {
+    if (nCmdShow == SW_SHOWNA && IsExplorerTaskbar(hwnd)) {
+        const bool marked =
+            GetPropW(hwnd, kHiddenByModProperty) != nullptr;
+
+        if (marked) {
+            const bool ownerAlive = IsHiddenTaskbarOwnerAlive(hwnd);
+
+            if (!ownerAlive && g_explorerShowWindowOriginal) {
+                return g_explorerShowWindowOriginal(hwnd, SW_SHOW);
+            }
+
+            if (ownerAlive && IsExplorerSecondaryTaskbar(hwnd)) {
+                return FALSE;
+            }
+        }
+    }
+
+    return g_explorerShowWindowOriginal(hwnd, nCmdShow);
 }
 
 bool InstallExplorerVisibilityHook() {
@@ -1915,68 +1957,49 @@ void UpdateCursorHoverSnapshot() {
             break;
         }
 
-        const TaskbarMonitorState& state =
-            g_taskbarStates[i];
+        const TaskbarMonitorState& state = g_taskbarStates[i];
 
-        CursorHoverSnapshot& snapshot =
-            snapshots[snapshotCount++];
+        if (!ShouldRevealOnHover(state) ||
+            !IsBottomDockedTaskbar(state.hwnd, state.monitor)) {
+            continue;
+        }
 
+        CursorHoverSnapshot& snapshot = snapshots[snapshotCount++];
         snapshot.monitor = state.monitor;
-        snapshot.enabled =
-            ShouldRevealOnHover(state) &&
-            IsBottomDockedTaskbar(
-                state.hwnd,
-                state.monitor
-            );
+        snapshot.enabled = true;
 
         MONITORINFO mi = {};
         mi.cbSize = sizeof(mi);
 
-        if (
-            !snapshot.monitor ||
-            !GetMonitorInfoW(
-                snapshot.monitor,
-                &mi
-            )
-        ) {
-            snapshot.enabled = false;
+        if (!snapshot.monitor || !GetMonitorInfoW(snapshot.monitor, &mi)) {
+            --snapshotCount;
             continue;
         }
 
         snapshot.monitorRect = mi.rcMonitor;
 
-        UINT dpi =
-            GetDpiForWindow(state.hwnd);
+        UINT dpi = GetDpiForWindow(state.hwnd);
 
         if (dpi == 0) {
             dpi = 96;
         }
 
-        snapshot.hotZonePx =
-            GetHoverZonePx(
-                state.hwnd,
-                dpi
-            );
+        snapshot.hotZonePx = GetHoverZonePx(state.hwnd, dpi);
 
         if (snapshot.hotZonePx < 1) {
             snapshot.hotZonePx = 1;
         }
     }
 
-    AcquireSRWLockExclusive(
-        &g_cursorHoverSnapshotLock
-    );
+    AcquireSRWLockExclusive(&g_cursorHoverSnapshotLock);
 
     for (size_t i = 0; i < snapshotCount; ++i) {
-        g_cursorHoverSnapshots[i] =
-            snapshots[i];
+        g_cursorHoverSnapshots[i] = snapshots[i];
     }
 
     g_cursorHoverSnapshotCount = snapshotCount;
 
-    ReleaseSRWLockExclusive(
-        &g_cursorHoverSnapshotLock
-    );
+    ReleaseSRWLockExclusive(&g_cursorHoverSnapshotLock);
 }
 
 bool IsCursorInConfiguredHoverZoneAtSnapshot(
@@ -2383,8 +2406,14 @@ bool HasEnabledHoverSnapshot() {
         &g_cursorHoverSnapshotLock
     );
 
-    bool result =
-        g_cursorHoverSnapshotCount != 0;
+    bool result = false;
+
+    for (size_t i = 0; i < g_cursorHoverSnapshotCount; ++i) {
+        if (g_cursorHoverSnapshots[i].enabled) {
+            result = true;
+            break;
+        }
+    }
 
     ReleaseSRWLockShared(
         &g_cursorHoverSnapshotLock
@@ -3299,6 +3328,12 @@ void WINAPI EntryPoint_Hook() {
 }
 
 BOOL Wh_ModInit() {
+    DWORD sessionId;
+    if (ProcessIdToSessionId(GetCurrentProcessId(), &sessionId) &&
+        sessionId == 0) {
+        return FALSE;
+    }
+
     bool isService = false;
     bool isToolModProcess = false;
     bool isCurrentToolModProcess = false;
@@ -3310,7 +3345,9 @@ BOOL Wh_ModInit() {
     }
 
     for (int i = 1; i < argc; i++) {
-        if (wcscmp(argv[i], L"-service") == 0) {
+        if (wcscmp(argv[i], L"-service") == 0 ||
+            wcscmp(argv[i], L"-service-start") == 0 ||
+            wcscmp(argv[i], L"-service-stop") == 0) {
             isService = true;
             break;
         }
@@ -3455,9 +3492,12 @@ void Wh_ModUninit() {
 BOOL Wh_ModInit() {
     if (IsCurrentProcessExplorer()) {
         g_isExplorerProcess = true;
-        return InstallExplorerVisibilityHook()
-            ? TRUE
-            : FALSE;
+        if (!InstallExplorerVisibilityHook()) {
+            return FALSE;
+        }
+
+        RecoverStaleHiddenTaskbars();
+        return TRUE;
     }
 
     return WindhawkToolModLauncher_Wh_ModInit();

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Hides selected taskbars only while their display is showing the desktop
-// @version         3.5.5
+// @version         4.0.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -16,100 +16,147 @@
 
 Hides each selected taskbar when its own display has no visible,
 non-minimized application window, and shows it again when an application or
-relevant Windows shell interaction requires it.
+relevant Windows shell interaction requires the taskbar.
 
-The mod uses a dedicated `windhawk.exe` process as its state manager instead of
-running the full state-management logic inside `explorer.exe`. A small
-Explorer-side hook is used only to prevent the specific secondary-taskbar
-`SW_SHOWNA` transition that Explorer can issue after this mod has hidden that
-taskbar.
+Each display is evaluated independently. An application being open on one
+display does not prevent the taskbar on another selected display from hiding.
 
 ### Behavior
 
 - Each display is evaluated independently.
 - A selected taskbar is hidden only while its display has no visible,
   non-minimized application window.
-- Maximized windows use Windows' monitor assignment. Normal windows that
-  span displays count on every display they actually intersect.
-- Bottom-edge hover reveal is selectable per display. The reveal zone uses
-  the taskbar's actual height and DPI. Hover reveal is intentionally limited
-  to bottom-docked taskbars; non-bottom-docked taskbars are not affected by
-  the hover logic.
-- The configured post-hover delay applies only to hover reveal.
-- Start/taskbar menus, tray overflow, notification/quick-settings surfaces,
-  and Alt+Tab are treated as transient shell interactions.
+- Maximized windows use Windows' monitor assignment. Normal windows that span
+  displays count on every display they actually intersect.
+- Bottom-edge hover reveal can be configured per display. The reveal zone is
+  based on the taskbar's actual height and display DPI plus the configured
+  extra margin.
+- Hover reveal is limited to bottom-docked taskbars.
+- The configured post-hover delay applies only to hover dismissal.
+- Relevant Windows shell surfaces, including Start, taskbar popups/overflow,
+  notification/quick-settings surfaces, and Alt+Tab, are treated as transient
+  shell UI rather than ordinary application windows.
 - Clearing the "Taskbars to hide on desktop" selection means hide nothing.
+- Windows' native taskbar auto-hide setting is left unchanged.
 
+### Why this is a separate behavior
 
-### Robustness
+This mod is focused on a specific visibility rule:
 
-- The tool re-discovers primary and secondary taskbars during every reconciliation,
-  so Explorer taskbar recreation is picked up automatically.
-- A hidden top-level worker window reacts to `TaskbarCreated`, display-configuration,
-  settings, and theme changes instead of waiting for the next safety-poll tick.
-- Selected `DISPLAYn` entries are bound to the display's monitor device identity
-  during the current Windows session, so a dock/reconnect that renumbers
-  `DISPLAYn` can keep the selection attached to the same physical display.
-- A display-topology signature resets stale hover state after monitor geometry or
-  display-set changes.
-- Native Windows auto-hide state is sampled once per reconciliation and reused
-  for the rest of that reconciliation.
-- Cursor movement near the bottom edge is handled by a dedicated lightweight
-  cursor-sampling thread. It samples only cursor position and posts a refresh
-  when the configured hover-zone state changes, keeping input detection separate
-  from the worker's full window scan.
-- Known taskbar/XAML popup classes are treated as shell surfaces; generic
-  `Windows.UI.Core.CoreWindow` windows are no longer rejected solely because of
-  their class name, which avoids misclassifying visible UWP application windows.
-- The mod records which taskbars it actually hid, so reconciliation does not
-  restore taskbars that were hidden by another mechanism.
-- The launcher watchdog restores only taskbars marked by this mod after an
-  unexpected tool-process exit.
+> **Hide a selected taskbar whenever its display is showing only the desktop.**
 
-### How this differs from related taskbar mods
+An ordinary non-maximized application keeps the taskbar visible on its display,
+while a display with no visible application can have its selected taskbar
+hidden.
 
-This mod overlaps with existing per-monitor taskbar mods in that each display
-is evaluated independently. The key behavioral difference from
-**`taskbar-auto-hide-when-maximized`** is the predicate used for hiding: this
-mod keeps a selected taskbar visible whenever its display has any visible,
-non-minimized application window, and hides it only when that display has no
-such window. It is therefore not limited to maximized, snapped, fullscreen,
-or taskbar-intersecting application states.
+Compared with **`taskbar-auto-hide-when-maximized`**, the distinction is the
+predicate and the interaction model. That mod is centered around window-state
+modes such as maximized/intersected behavior; this mod is centered around
+whether an application is present on each display and directly controls the
+taskbar window.
 
-**`taskbar-auto-hide-per-monitor`** provides explicit per-monitor control over
-Windows' native auto-hide. This mod instead derives visibility from application
-presence and directly controls the taskbar window.
+Compared with mods that configure Windows' native taskbar auto-hide, this mod
+does not enable or rewrite that setting. It directly hides the taskbar and
+leaves the normal desktop work area unchanged.
 
-**`taskbar-auto-hide-custom-activation-area`** changes the activation area for
-Windows' native auto-hide. This mod supplies its own bottom-edge hover reveal
-while leaving the normal desktop work area unchanged.
+### Per-display configuration
 
-**`taskbar-fade`** is a broader taskbar customization/fading mod with a Smart
-Idle option. This mod is specifically focused on desktop-only visibility and
-its associated per-display application-state rule.
+Users can independently choose:
 
-A key implementation difference is the **work-area behavior**: the mod uses
-`ShowWindow(SW_HIDE)` and does not change the Windows desktop work area.
+- Which displays should hide their taskbar on desktop-only displays.
+- Which displays should allow bottom-edge hover reveal.
 
-The launcher keeps a lightweight watchdog for the dedicated tool process. If the
-tool exits unexpectedly while a taskbar hidden by this mod is still marked, the
-watchdog re-shows those currently discoverable taskbars. It does not restore
-taskbars hidden by other mechanisms. A normal mod unload also restores only
-windows marked as hidden by this mod. If Explorer itself is unresponsive or has
-already recreated a taskbar, restarting Explorer may still be required.
+Selections use Windows display device names such as `\\.\DISPLAY1`. These
+identifiers may differ from the display numbers shown in Windows Display
+Settings.
 
-### Process and state model
+The mod tracks monitor/device identity during the current session so a
+reconnected display that receives a different `DISPLAYn` number can keep its
+selection when the same monitor identity is detected.
 
-The mod runs its mutable state and settings in a dedicated Windhawk tool process.
-A minimal Explorer-side hook handles one shell visibility operation. Window-state WinEvents request
-an immediate reconciliation, while a periodic safety poll handles missed
-or unusual transitions.
+### Hover reveal
 
-Each safety poll performs one display enumeration and one top-level-window
-enumeration. The result is reused for every taskbar. Cursor movement near the
-bottom edge is handled by a dedicated cursor-sampling thread that posts only
-lightweight state-transition refreshes. Hover dismissal uses a one-shot worker
-timer rather than a fast full-state polling loop.
+For a bottom-docked taskbar, moving the pointer into the configured
+bottom-edge zone reveals a taskbar hidden by the mod.
+
+After leaving the zone, the taskbar remains visible for the configured delay
+before returning to its normal desktop/application state.
+
+The hover zone uses the taskbar's current height and display DPI together with
+the configured extra margin. Top- and side-docked taskbars are not affected by
+hover reveal.
+
+### Windows shell interactions
+
+The mod distinguishes known shell surfaces from normal application windows.
+This includes taskbar popup/overflow windows, relevant XAML shell hosts,
+Start/notification/quick-settings surfaces hosted by Windows shell processes,
+and known Alt+Tab window classes.
+
+These surfaces can keep the relevant taskbar visible while the user is
+interacting with the shell.
+
+### Explorer integration and recovery
+
+The main state manager runs in a dedicated `windhawk.exe` process. A small
+Explorer-side hook is used only to stop a specific `SW_SHOWNA` operation from
+re-showing a secondary taskbar immediately after the mod hid it.
+
+The taskbar marker stores the owning tool-process ID rather than a constant
+value. The Explorer-side hook verifies that the owning process is still alive.
+If the owner has exited, the stale marker is removed and the normal Explorer
+operation is allowed to continue.
+
+The mod also records which taskbars it actually hid, so it does not restore
+taskbars hidden by unrelated mechanisms.
+
+### Multi-monitor behavior
+
+Consider two displays:
+
+1. Display 1 has an application open.
+2. Display 2 shows only the desktop.
+3. A selected taskbar on display 1 stays visible.
+4. A selected taskbar on display 2 hides.
+5. Hovering the configured bottom edge of display 2 reveals its taskbar.
+6. Leaving the hover zone starts the configured dismissal delay.
+7. Opening an application on display 2 keeps its taskbar visible.
+
+Applications that span multiple displays count on every display they intersect.
+Maximized windows use the monitor assignment provided by Windows.
+
+### Display and taskbar changes
+
+Taskbars are rediscovered during reconciliation so Explorer taskbar recreation
+does not leave the mod tied to an old window handle.
+
+The state is refreshed for relevant taskbar, display, settings, theme, window,
+and shell visibility changes, with a periodic safety poll for missed
+transitions.
+
+A display-topology signature resets transient hover state when monitor
+geometry or the connected display set changes.
+
+### Limitations
+
+- Hover reveal is supported only for bottom-docked taskbars.
+- Display selection currently exposes `DISPLAY1` through `DISPLAY16`.
+- `DISPLAYn` identifiers may differ from the numbering shown in Windows Display
+  Settings and may change after display configuration changes.
+- The mod does not modify Windows' native taskbar auto-hide setting.
+- The mod is focused specifically on desktop-only taskbar visibility rather
+  than being a general-purpose taskbar customization framework.
+
+### Goal
+
+The goal is a specific taskbar visibility rule:
+
+> **Hide the taskbar when its display is showing only the desktop.**
+
+The mod combines that per-display application-state rule with independent
+display selection, shell-interaction handling, taskbar recreation recovery,
+and configurable bottom-edge hover reveal.
+
 */
 // ==/WindhawkModReadme==
 
@@ -159,7 +206,8 @@ timer rather than a fast full-state polling loop.
   $description: >-
     Select one or more displays using the Windows `\\.\DISPLAYn` device number.
     These numbers may differ from the display numbers shown in Windows Display
-    Settings. Choose All displays to hide every connected display. Use Add to
+    Settings. Choose All displays to hide every connected display. Only
+    bottom-docked taskbars participate in desktop-based hiding. Use Add to
     select multiple displays. When a physical display is reconnected and Windows
     renumbers DISPLAYn, the mod keeps the selection bound to the same detected
     monitor device when possible.
@@ -187,6 +235,7 @@ timer rather than a fast full-state polling loop.
 #include <windows.h>
 #include <dwmapi.h>
 #include <shellapi.h>
+#include <windhawk_utils.h>
 #include <wchar.h>
 
 
@@ -235,7 +284,7 @@ struct MonitorSelectionBinding {
 
 struct WindowScanResult {
     bool applicationOnMonitor[kMaxMonitorNumbers];
-    bool taskbarPopupOnMonitor[kMaxMonitorNumbers];
+    bool shellSurfaceOnMonitor[kMaxMonitorNumbers];
 };
 
 HWINEVENTHOOK g_foregroundHook = nullptr;
@@ -267,12 +316,33 @@ constexpr wchar_t kHiddenByModProperty[] =
 // Explorer-side protection for the secondary-taskbar shell transition.
 // The dedicated tool process remains authoritative for taskbar state. Explorer
 // only consults the per-window property and blocks SW_SHOWNA for an explicitly
-// hidden secondary taskbar.
-using ShowWindow_t = BOOL (WINAPI*)(HWND, int);
-
+// hidden secondary taskbar while its owning tool process is still alive.
+using ShowWindow_t = decltype(&ShowWindow);
 ShowWindow_t g_explorerShowWindowOriginal = nullptr;
-void* g_explorerShowWindowTarget = nullptr;
 bool g_isExplorerProcess = false;
+
+DWORD g_hiddenTaskbarOwnerPid = 0;
+HANDLE g_hiddenTaskbarOwnerProcess = nullptr;
+SRWLOCK g_hiddenTaskbarOwnerCacheLock = SRWLOCK_INIT;
+
+void ResetHiddenTaskbarOwnerCache() {
+    AcquireSRWLockExclusive(
+        &g_hiddenTaskbarOwnerCacheLock
+    );
+
+    if (g_hiddenTaskbarOwnerProcess) {
+        CloseHandle(
+            g_hiddenTaskbarOwnerProcess
+        );
+        g_hiddenTaskbarOwnerProcess = nullptr;
+    }
+
+    g_hiddenTaskbarOwnerPid = 0;
+
+    ReleaseSRWLockExclusive(
+        &g_hiddenTaskbarOwnerCacheLock
+    );
+}
 
 bool IsExplorerSecondaryTaskbar(HWND hwnd) {
     if (!hwnd) {
@@ -298,12 +368,82 @@ bool IsExplorerSecondaryTaskbar(HWND hwnd) {
 }
 
 bool IsSecondaryTaskbarHiddenByMod(HWND hwnd) {
-    return
-        IsExplorerSecondaryTaskbar(hwnd) &&
+    if (!IsExplorerSecondaryTaskbar(hwnd)) {
+        return false;
+    }
+
+    HANDLE marker =
         GetPropW(
             hwnd,
             kHiddenByModProperty
-        ) != nullptr;
+        );
+
+    if (!marker) {
+        return false;
+    }
+
+    DWORD ownerPid =
+        static_cast<DWORD>(
+            reinterpret_cast<ULONG_PTR>(marker)
+        );
+
+    if (!ownerPid) {
+        RemovePropW(
+            hwnd,
+            kHiddenByModProperty
+        );
+        return false;
+    }
+
+    AcquireSRWLockExclusive(
+        &g_hiddenTaskbarOwnerCacheLock
+    );
+
+    if (ownerPid != g_hiddenTaskbarOwnerPid) {
+        if (g_hiddenTaskbarOwnerProcess) {
+            CloseHandle(
+                g_hiddenTaskbarOwnerProcess
+            );
+            g_hiddenTaskbarOwnerProcess = nullptr;
+        }
+
+        g_hiddenTaskbarOwnerPid = ownerPid;
+        g_hiddenTaskbarOwnerProcess =
+            OpenProcess(
+                SYNCHRONIZE,
+                FALSE,
+                ownerPid
+            );
+    }
+
+    bool ownerAlive =
+        g_hiddenTaskbarOwnerProcess &&
+        WaitForSingleObject(
+            g_hiddenTaskbarOwnerProcess,
+            0
+        ) == WAIT_TIMEOUT;
+
+    if (!ownerAlive) {
+        RemovePropW(
+            hwnd,
+            kHiddenByModProperty
+        );
+
+        if (g_hiddenTaskbarOwnerProcess) {
+            CloseHandle(
+                g_hiddenTaskbarOwnerProcess
+            );
+            g_hiddenTaskbarOwnerProcess = nullptr;
+        }
+
+        g_hiddenTaskbarOwnerPid = 0;
+    }
+
+    ReleaseSRWLockExclusive(
+        &g_hiddenTaskbarOwnerCacheLock
+    );
+
+    return ownerAlive;
 }
 
 BOOL WINAPI ExplorerShowWindowHook(
@@ -324,65 +464,20 @@ BOOL WINAPI ExplorerShowWindowHook(
 }
 
 bool InstallExplorerVisibilityHook() {
-    HMODULE user32 =
-        GetModuleHandleW(L"user32.dll");
-
-    if (!user32) {
-        Wh_Log(
-            L"GetModuleHandleW(user32.dll) failed: %lu",
-            GetLastError()
-        );
-        return false;
-    }
-
-    g_explorerShowWindowTarget =
-        reinterpret_cast<void*>(
-            GetProcAddress(
-                user32,
-                "ShowWindow"
-            )
-        );
-
-    if (!g_explorerShowWindowTarget) {
-        Wh_Log(
-            L"GetProcAddress(ShowWindow) failed: %lu",
-            GetLastError()
-        );
-        return false;
-    }
-
     if (
-        Wh_SetFunctionHook(
-            g_explorerShowWindowTarget,
-            reinterpret_cast<void*>(ExplorerShowWindowHook),
-            reinterpret_cast<void**>(&g_explorerShowWindowOriginal)
-        ) == FALSE
+        !WindhawkUtils::SetFunctionHook(
+            ShowWindow,
+            ExplorerShowWindowHook,
+            &g_explorerShowWindowOriginal
+        )
     ) {
         Wh_Log(
             L"Failed to hook Explorer ShowWindow"
         );
-        g_explorerShowWindowTarget = nullptr;
         return false;
     }
 
     return true;
-}
-
-void UninstallExplorerVisibilityHook() {
-    if (g_explorerShowWindowTarget) {
-        if (
-            Wh_RemoveFunctionHook(
-                g_explorerShowWindowTarget
-            ) == FALSE
-        ) {
-            Wh_Log(
-                L"Failed to remove Explorer ShowWindow hook"
-            );
-        }
-
-        g_explorerShowWindowTarget = nullptr;
-        g_explorerShowWindowOriginal = nullptr;
-    }
 }
 
 HWND g_workerMessageWindow = nullptr;
@@ -408,6 +503,12 @@ void LoadSettings();
 void WhTool_ModUninit();
 void ArmHoverExpireTimer();
 void CancelHoverExpireTimer();
+void RestoreAllTaskbars();
+bool WaitForThreadWithTimeout(
+    HANDLE thread,
+    DWORD timeoutMs,
+    const wchar_t* threadName
+);
 
 bool IsShellChromeClass(
     const WCHAR* className
@@ -914,49 +1015,233 @@ bool ShouldRevealOnHover(
     );
 }
 
+bool GetWindowProcessImageName(
+    DWORD pid,
+    wchar_t* output,
+    size_t outputCount
+) {
+    if (!pid || !output || outputCount == 0) {
+        return false;
+    }
+
+    output[0] = L'\0';
+
+    HANDLE process =
+        OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION,
+            FALSE,
+            pid
+        );
+
+    if (!process) {
+        return false;
+    }
+
+    DWORD size =
+        static_cast<DWORD>(
+            outputCount
+        );
+
+    BOOL result =
+        QueryFullProcessImageNameW(
+            process,
+            0,
+            output,
+            &size
+        );
+
+    CloseHandle(process);
+
+    return result && output[0] != L'\0';
+}
+
+bool IsKnownShellProcess(DWORD pid) {
+    wchar_t imagePath[MAX_PATH] = {};
+
+    if (!GetWindowProcessImageName(
+            pid,
+            imagePath,
+            ARRAYSIZE(imagePath)
+        )) {
+        return false;
+    }
+
+    const wchar_t* baseName =
+        wcsrchr(
+            imagePath,
+            L'\\'
+        );
+
+    baseName =
+        baseName
+            ? baseName + 1
+            : imagePath;
+
+    return
+        _wcsicmp(
+            baseName,
+            L"StartMenuExperienceHost.exe"
+        ) == 0 ||
+        _wcsicmp(
+            baseName,
+            L"ShellExperienceHost.exe"
+        ) == 0 ||
+        _wcsicmp(
+            baseName,
+            L"ShellHost.exe"
+        ) == 0;
+}
+
+bool IsExplorerProcess(DWORD pid) {
+    wchar_t imagePath[MAX_PATH] = {};
+
+    if (!GetWindowProcessImageName(
+            pid,
+            imagePath,
+            ARRAYSIZE(imagePath)
+        )) {
+        return false;
+    }
+
+    const wchar_t* baseName =
+        wcsrchr(
+            imagePath,
+            L'\\'
+        );
+
+    baseName =
+        baseName
+            ? baseName + 1
+            : imagePath;
+
+    return _wcsicmp(
+        baseName,
+        L"explorer.exe"
+    ) == 0;
+}
+
+bool IsTaskbarPopupClass(
+    const WCHAR* className
+) {
+    if (!className) {
+        return false;
+    }
+
+    static const WCHAR* kClasses[] = {
+        L"#32768",
+        L"#32771",
+        L"Xaml_WindowedPopupClass",
+        L"TopLevelWindowForOverflowXamlIsland",
+        L"NotifyIconOverflowWindow",
+        L"TaskbarOverflowWnd",
+    };
+
+    for (const WCHAR* shellClass : kClasses) {
+        if (wcscmp(className, shellClass) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool IsAltTabClass(
+    const WCHAR* className
+) {
+    if (!className) {
+        return false;
+    }
+
+    static const WCHAR* kClasses[] = {
+        L"MultitaskingViewFrame",
+        L"TaskSwitcherWnd",
+        L"TaskSwitcherOverlayWnd",
+        L"ForegroundStaging",
+    };
+
+    for (const WCHAR* shellClass : kClasses) {
+        if (wcscmp(className, shellClass) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool IsShellSurfaceWindow(
+    HWND hwnd,
+    const WCHAR* className
+) {
+    if (
+        !hwnd ||
+        !className ||
+        !IsWindowVisible(hwnd)
+    ) {
+        return false;
+    }
+
+    DWORD pid = 0;
+
+    GetWindowThreadProcessId(
+        hwnd,
+        &pid
+    );
+
+    if (IsTaskbarPopupClass(className)) {
+        return true;
+    }
+
+    if (
+        IsAltTabClass(className) &&
+        (
+            IsExplorerProcess(pid) ||
+            IsKnownShellProcess(pid)
+        )
+    ) {
+        return true;
+    }
+
+    // Windows 11 uses XAML host windows for several shell surfaces,
+    // including Start and Alt+Tab variants. Limit this class to Explorer
+    // and the known Windows shell processes.
+    if (
+        wcscmp(
+            className,
+            L"XamlExplorerHostIslandWindow"
+        ) == 0 &&
+        (
+            IsExplorerProcess(pid) ||
+            IsKnownShellProcess(pid)
+        )
+    ) {
+        return true;
+    }
+
+    // Start, notification center and quick settings can expose
+    // Windows.UI.Core.CoreWindow instances from their dedicated
+    // Windows shell processes.
+    if (
+        wcscmp(
+            className,
+            L"Windows.UI.Core.CoreWindow"
+        ) == 0 &&
+        IsKnownShellProcess(pid)
+    ) {
+        return true;
+    }
+
+    return false;
+}
+
 bool IsTransientShellWindow(
     HWND hwnd,
     const WCHAR* className
 ) {
-    if (!hwnd || !className) {
-        return false;
-    }
-
-    // Classic shell popup/menu windows.
-    if (
-        wcscmp(className, L"#32768") == 0 ||
-        wcscmp(className, L"#32771") == 0
-    ) {
-        return true;
-    }
-
-    // Common Windows shell/XAML popup hosts.
-    if (
-        wcscmp(className, L"Xaml_WindowedPopupClass") == 0 ||
-        wcscmp(className, L"TopLevelWindowForOverflowXamlIsland") == 0 ||
-        wcscmp(
-            className,
-            L"NotifyIconOverflowWindow"
-        ) == 0 ||
-        wcscmp(
-            className,
-            L"TaskbarOverflowWnd"
-        ) == 0
-    ) {
-        return true;
-    }
-
-    LONG_PTR exStyle =
-        GetWindowLongPtrW(
-            hwnd,
-            GWL_EXSTYLE
-        );
-
-    // Do not let no-activate transient surfaces make a display look
-    // application-active.
-    return (exStyle & WS_EX_NOACTIVATE) != 0;
+    return IsShellSurfaceWindow(
+        hwnd,
+        className
+    );
 }
-
 
 bool IsApplicationWindowCandidate(
     HWND hwnd,
@@ -978,7 +1263,10 @@ bool IsApplicationWindowCandidate(
         );
 
     if (
-        GetWindow(hwnd, GW_OWNER) != nullptr &&
+        GetWindow(
+            hwnd,
+            GW_OWNER
+        ) != nullptr &&
         !(exStyle & WS_EX_APPWINDOW)
     ) {
         return false;
@@ -1021,86 +1309,16 @@ bool IsApplicationWindowCandidate(
         return false;
     }
 
-    /*
-     * Background title-less helper surfaces are ignored. A title-less
-     * application becomes covered by the foreground-window path.
-     */
+    // Background title-less helper surfaces are ignored. A title-less
+    // application becomes covered by the foreground-window path.
     return
         (exStyle & WS_EX_APPWINDOW) != 0 ||
         GetWindowTextLengthW(hwnd) > 0;
 }
 
-bool IsTaskbarPopupClass(
-    const WCHAR* className
-) {
-    if (!className) {
-        return false;
-    }
-
-    return
-        wcscmp(className, L"#32768") == 0 ||
-        wcscmp(className, L"Xaml_WindowedPopupClass") == 0 ||
-        wcscmp(
-            className,
-            L"TopLevelWindowForOverflowXamlIsland"
-        ) == 0 ||
-        wcscmp(
-            className,
-            L"NotifyIconOverflowWindow"
-        ) == 0 ||
-        wcscmp(
-            className,
-            L"TaskbarOverflowWnd"
-        ) == 0;
-}
-
-bool IsExplorerShellPopup(
-    HWND hwnd,
-    const WCHAR* className,
-    DWORD explorerPid
-) {
-    if (
-        !hwnd ||
-        !className ||
-        !IsWindowVisible(hwnd) ||
-        !IsTaskbarPopupClass(className)
-    ) {
-        return false;
-    }
-
-    DWORD pid = 0;
-
-    GetWindowThreadProcessId(
-        hwnd,
-        &pid
-    );
-
-    if (
-        explorerPid != 0 &&
-        pid == explorerPid
-    ) {
-        return true;
-    }
-
-    HWND shellWindow = GetShellWindow();
-    DWORD shellPid = 0;
-
-    if (shellWindow) {
-        GetWindowThreadProcessId(
-            shellWindow,
-            &shellPid
-        );
-    }
-
-    return
-        shellPid != 0 &&
-        pid == shellPid;
-}
-
 struct ScanContext {
     const MonitorList* monitors;
     WindowScanResult* result;
-    DWORD explorerPid;
 };
 
 BOOL CALLBACK ScanWindowsWithMonitorsProc(
@@ -1130,10 +1348,9 @@ BOOL CALLBACK ScanWindowsWithMonitorsProc(
         return TRUE;
     }
 
-    if (IsExplorerShellPopup(
+    if (IsShellSurfaceWindow(
             hwnd,
-            className,
-            context->explorerPid
+            className
         )) {
         RECT popupRect = {};
 
@@ -1153,7 +1370,7 @@ BOOL CALLBACK ScanWindowsWithMonitorsProc(
                         &popupRect,
                         &context->monitors->entries[i].rect
                     )) {
-                    context->result->taskbarPopupOnMonitor[i] = true;
+                    context->result->shellSurfaceOnMonitor[i] = true;
                 }
             }
         }
@@ -1239,24 +1456,9 @@ void ScanWindowsOnce(
 ) {
     result = {};
 
-    DWORD explorerPid = 0;
-    HWND primaryTaskbar =
-        FindWindowW(
-            L"Shell_TrayWnd",
-            nullptr
-        );
-
-    if (primaryTaskbar) {
-        GetWindowThreadProcessId(
-            primaryTaskbar,
-            &explorerPid
-        );
-    }
-
     ScanContext context = {
         &monitors,
-        &result,
-        explorerPid
+        &result
     };
 
     EnumWindows(
@@ -1500,7 +1702,11 @@ void SetTaskbarState(
     if (!SetPropW(
             state.hwnd,
             kHiddenByModProperty,
-            reinterpret_cast<HANDLE>(1)
+            reinterpret_cast<HANDLE>(
+                static_cast<ULONG_PTR>(
+                    GetCurrentProcessId()
+                )
+            )
         )) {
         Wh_Log(
             L"SetPropW failed for taskbar 0x%p: %lu",
@@ -1523,15 +1729,6 @@ void SetTaskbarState(
         );
         state.hiddenByMod = false;
     }
-}
-
-bool IsTaskbarHiddenByMod(
-    const TaskbarMonitorState& state
-) {
-    return
-        state.hwnd &&
-        state.hiddenByMod &&
-        !IsWindowVisible(state.hwnd);
 }
 
 void ApplyBaseTaskbarState() {
@@ -1914,38 +2111,23 @@ void UpdateTaskbarState() {
     }
 
     HWND cursorTaskbar = nullptr;
-    bool cursorTaskbarHiddenByMod = false;
+    bool cursorHoverConfigured = false;
 
     for (size_t i = 0; i < g_taskbarStateCount; ++i) {
         if (
-            g_taskbarStates[i].monitor ==
-                cursorMonitor
-        ) {
-            cursorTaskbar =
-                g_taskbarStates[i].hwnd;
-            cursorTaskbarHiddenByMod =
-                IsTaskbarHiddenByMod(g_taskbarStates[i]);
-            break;
-        }
-    }
-
-    bool cursorHoverConfigured = false;
-
-    for (
-        size_t i = 0;
-        i < g_taskbarStateCount;
-        ++i
-    ) {
-        if (
-            g_taskbarStates[i].monitor ==
+            g_taskbarStates[i].monitor !=
             cursorMonitor
         ) {
-            cursorHoverConfigured =
-                ShouldRevealOnHover(
-                    g_taskbarStates[i]
-                );
-            break;
+            continue;
         }
+
+        cursorTaskbar =
+            g_taskbarStates[i].hwnd;
+        cursorHoverConfigured =
+            ShouldRevealOnHover(
+                g_taskbarStates[i]
+            );
+        break;
     }
 
     const bool cursorInHoverZone =
@@ -1958,62 +2140,27 @@ void UpdateTaskbarState() {
         );
 
     const bool hovering =
-        cursorInHoverZone &&
-        (
-            cursorTaskbarHiddenByMod ||
-            (g_hoverActive && g_hoverMonitor == cursorMonitor)
-        );
+        cursorInHoverZone;
 
-    // Keep the taskbar visible for an open shell context menu/overflow
-    // surface even after the cursor leaves the popup. Popup state was collected
-    // during the main EnumWindows pass above, so no second full enumeration is
-    // needed here.
-    bool popupPresent = false;
-
-    for (size_t monitorIndex = 0;
-         monitorIndex < monitors.count;
-         ++monitorIndex) {
-        if (scan.taskbarPopupOnMonitor[monitorIndex]) {
-            popupPresent = true;
-            break;
-        }
-    }
-
-    if (popupPresent) {
-        g_hoverActive = false;
-        g_hoverMonitor = nullptr;
-        g_hoverDeadline = 0;
-        CancelHoverExpireTimer();
-
-        for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-            TaskbarMonitorState& state =
-                g_taskbarStates[i];
-
-            bool popupOnThisMonitor = false;
-
-            for (size_t monitorIndex = 0;
-                 monitorIndex < monitors.count;
-                 ++monitorIndex) {
+    auto shellSurfaceOnMonitor =
+        [&](HMONITOR monitor) {
+            for (
+                size_t monitorIndex = 0;
+                monitorIndex < monitors.count;
+                ++monitorIndex
+            ) {
                 if (
                     monitors.entries[monitorIndex].monitor ==
-                        state.monitor &&
-                    scan.taskbarPopupOnMonitor[monitorIndex]
+                    monitor
                 ) {
-                    popupOnThisMonitor = true;
-                    break;
+                    return scan.shellSurfaceOnMonitor[
+                        monitorIndex
+                    ];
                 }
             }
 
-            SetTaskbarState(
-                state,
-                popupOnThisMonitor ||
-                !state.desktopOnly ||
-                !ShouldHideTaskbar(state)
-            );
-        }
-
-        return;
-    }
+            return false;
+        };
 
     if (hovering) {
         g_hoverActive = true;
@@ -2028,6 +2175,7 @@ void UpdateTaskbarState() {
             SetTaskbarState(
                 state,
                 state.monitor == g_hoverMonitor ||
+                shellSurfaceOnMonitor(state.monitor) ||
                 !state.desktopOnly ||
                 !ShouldHideTaskbar(state)
             );
@@ -2037,19 +2185,6 @@ void UpdateTaskbarState() {
     }
 
     if (g_hoverActive) {
-        if (
-            !g_hoverMonitor ||
-            cursorMonitor != g_hoverMonitor
-        ) {
-            g_hoverActive = false;
-            g_hoverMonitor = nullptr;
-            g_hoverDeadline = 0;
-            CancelHoverExpireTimer();
-
-            ApplyBaseTaskbarState();
-                return;
-        }
-
         const ULONGLONG now =
             GetTickCount64();
 
@@ -2069,12 +2204,13 @@ void UpdateTaskbarState() {
                 SetTaskbarState(
                     state,
                     state.monitor == g_hoverMonitor ||
+                    shellSurfaceOnMonitor(state.monitor) ||
                     !state.desktopOnly ||
                     !ShouldHideTaskbar(state)
                 );
             }
 
-                return;
+            return;
         }
 
         g_hoverActive = false;
@@ -2087,7 +2223,17 @@ void UpdateTaskbarState() {
         return;
     }
 
-    ApplyBaseTaskbarState();
+    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+        TaskbarMonitorState& state =
+            g_taskbarStates[i];
+
+        SetTaskbarState(
+            state,
+            shellSurfaceOnMonitor(state.monitor) ||
+            !state.desktopOnly ||
+            !ShouldHideTaskbar(state)
+        );
+    }
 }
 
 void ArmHoverExpireTimer() {
@@ -2232,15 +2378,43 @@ void PostRefresh() {
     }
 }
 
+bool HasEnabledHoverSnapshot() {
+    AcquireSRWLockShared(
+        &g_cursorHoverSnapshotLock
+    );
+
+    bool result =
+        g_cursorHoverSnapshotCount != 0;
+
+    ReleaseSRWLockShared(
+        &g_cursorHoverSnapshotLock
+    );
+
+    return result;
+}
+
 DWORD WINAPI CursorSamplingThread(LPVOID) {
     bool lastHoverZone = false;
     HMONITOR lastMonitor = nullptr;
+    int cursorPositionFailures = 0;
 
     for (;;) {
+        const bool hoverTrackingActive =
+            HasEnabledHoverSnapshot();
+
+        DWORD waitMs =
+            hoverTrackingActive
+                ? 25
+                : 100;
+
+        if (cursorPositionFailures >= 3) {
+            waitMs = 1000;
+        }
+
         DWORD waitResult =
             WaitForSingleObject(
                 g_cursorStopEvent,
-                25
+                waitMs
             );
 
         if (waitResult == WAIT_OBJECT_0) {
@@ -2250,8 +2424,11 @@ DWORD WINAPI CursorSamplingThread(LPVOID) {
         POINT pt = {};
 
         if (!GetCursorPos(&pt)) {
+            ++cursorPositionFailures;
             continue;
         }
+
+        cursorPositionFailures = 0;
 
         HMONITOR monitor =
             MonitorFromPoint(
@@ -2517,6 +2694,12 @@ DWORD WINAPI WorkerThread(
         PM_NOREMOVE
     );
 
+    if (g_workerReadyEvent) {
+        SetEvent(
+            g_workerReadyEvent
+        );
+    }
+
     if (!CreateWorkerMessageWindow()) {
         Wh_Log(
             L"CreateWorkerMessageWindow failed; continuing with WinEvent/safety-poll handling"
@@ -2558,12 +2741,6 @@ DWORD WINAPI WorkerThread(
 
     EnsureTaskbarShowHook();
     UpdateTaskbarState();
-
-    if (g_workerReadyEvent) {
-        SetEvent(
-            g_workerReadyEvent
-        );
-    }
 
     UINT_PTR timerId =
         SetTimer(
@@ -2698,14 +2875,13 @@ void LoadSettings() {
         i < kMaxMonitorNumbers;
         ++i
     ) {
-        PCWSTR value =
-            Wh_GetStringSetting(
+        auto value =
+            WindhawkUtils::StringSetting::make(
                 L"hideOnMonitors[%d]",
                 static_cast<int>(i)
             );
 
-        if (!value || !*value) {
-            Wh_FreeStringSetting(value);
+        if (!*value) {
             break;
         }
 
@@ -2739,7 +2915,6 @@ void LoadSettings() {
             }
         }
 
-        Wh_FreeStringSetting(value);
     }
 
     // Empty selection intentionally means "hide nothing".
@@ -2751,14 +2926,13 @@ void LoadSettings() {
         i < kMaxMonitorNumbers;
         ++i
     ) {
-        PCWSTR value =
-            Wh_GetStringSetting(
+        auto value =
+            WindhawkUtils::StringSetting::make(
                 L"hoverRevealOnMonitors[%d]",
                 static_cast<int>(i)
             );
 
-        if (!value || !*value) {
-            Wh_FreeStringSetting(value);
+        if (!*value) {
             break;
         }
 
@@ -2792,7 +2966,6 @@ void LoadSettings() {
             }
         }
 
-        Wh_FreeStringSetting(value);
     }
 }
 
@@ -2834,10 +3007,35 @@ BOOL WhTool_ModInit() {
         return FALSE;
     }
 
-    WaitForSingleObject(
-        g_workerReadyEvent,
-        INFINITE
-    );
+    DWORD readyResult =
+        WaitForSingleObject(
+            g_workerReadyEvent,
+            5000
+        );
+
+    if (readyResult != WAIT_OBJECT_0) {
+        Wh_Log(
+            L"Worker startup wait failed: %lu",
+            readyResult == WAIT_TIMEOUT
+                ? ERROR_TIMEOUT
+                : GetLastError()
+        );
+
+        RestoreAllTaskbars();
+
+        if (!WaitForThreadWithTimeout(
+                g_workerThread,
+                5000,
+                L"worker"
+            )) {
+            ExitProcess(1);
+        }
+
+        SafeCloseHandle(g_workerThread);
+        SafeCloseHandle(g_workerReadyEvent);
+
+        return FALSE;
+    }
 
     g_cursorStopEvent =
         CreateEventW(
@@ -2902,7 +3100,7 @@ void RestoreAllTaskbars() {
 
         /*
          * Teardown/recovery is intentionally asynchronous. This path can run
-         * from the launcher watchdog, where blocking on Explorer's UI thread
+         * during tool shutdown, where blocking on Explorer's UI thread
          * could otherwise hang Windhawk itself.
          */
         ShowWindowAsync(
@@ -3000,21 +3198,6 @@ void WhTool_ModUninit() {
     SafeCloseHandle(g_cursorStopEvent);
 
     if (g_workerThread) {
-        DWORD readyResult =
-            WaitForSingleObject(
-                g_workerReadyEvent,
-                1000
-            );
-
-        if (readyResult != WAIT_OBJECT_0) {
-            Wh_Log(
-                L"Worker ready wait during shutdown did not complete: %lu",
-                readyResult == WAIT_TIMEOUT
-                    ? ERROR_TIMEOUT
-                    : GetLastError()
-            );
-        }
-
         if (!PostThreadMessageW(
                 g_workerThreadId,
                 WM_QUIT,
@@ -3050,90 +3233,14 @@ void WhTool_ModUninit() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Windhawk tool mod implementation for mods which don't need to inject to other
-// processes or hook other functions. Context:
-// https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process
-//
-// The mod will load and run in a dedicated windhawk.exe process.
-//
-// The launcher below is the documented Windhawk tool-mod boilerplate.
+// Explorer is a special target for this hybrid mod. The standard tool-mod
+// launcher is kept below as the documented Windhawk boilerplate; the Explorer
+// branch wraps around it without changing the tool-process logic.
 
-bool g_isToolModProcessLauncher;
-HANDLE g_toolModProcessMutex;
-
-HANDLE g_launcherWatchdogThread = nullptr;
-HANDLE g_launcherWatchdogStopEvent = nullptr;
-HANDLE g_toolModChildProcess = nullptr;
-
-void WINAPI EntryPoint_Hook() {
-    Wh_Log(L">");
-    ExitThread(0);
-}
-
-BOOL Wh_ModInit() {
-    DWORD sessionId;
-
-    if (
-        ProcessIdToSessionId(
-            GetCurrentProcessId(),
-            &sessionId
-        ) &&
-        sessionId == 0
-    ) {
-        return FALSE;
-    }
-
-    bool isExcluded = false;
-    bool isToolModProcess = false;
-    bool isCurrentToolModProcess = false;
-
-    int argc;
-
-    LPWSTR* argv =
-        CommandLineToArgvW(
-            GetCommandLine(),
-            &argc
-        );
-
-    if (!argv) {
-        Wh_Log(L"CommandLineToArgvW failed");
-        return FALSE;
-    }
-
-    for (int i = 1; i < argc; i++) {
-        if (
-            wcscmp(argv[i], L"-service") == 0 ||
-            wcscmp(argv[i], L"-service-start") == 0 ||
-            wcscmp(argv[i], L"-service-stop") == 0
-        ) {
-            isExcluded = true;
-            break;
-        }
-    }
-
-    for (int i = 1; i < argc - 1; i++) {
-        if (
-            wcscmp(argv[i], L"-tool-mod") == 0
-        ) {
-            isToolModProcess = true;
-
-            if (
-                wcscmp(
-                    argv[i + 1],
-                    WH_MOD_ID
-                ) == 0
-            ) {
-                isCurrentToolModProcess = true;
-            }
-
-            break;
-        }
-    }
-
-    LocalFree(argv);
-
+bool IsCurrentProcessExplorer() {
     WCHAR modulePath[MAX_PATH] = {};
-    DWORD moduleLength =
+
+    DWORD length =
         GetModuleFileNameW(
             nullptr,
             modulePath,
@@ -3141,54 +3248,100 @@ BOOL Wh_ModInit() {
         );
 
     if (
-        moduleLength == 0 ||
-        moduleLength >= ARRAYSIZE(modulePath)
+        length == 0 ||
+        length >= ARRAYSIZE(modulePath)
     ) {
-        Wh_Log(
-            L"GetModuleFileNameW failed: %lu",
-            GetLastError()
-        );
-        return FALSE;
+        return false;
     }
 
     const WCHAR* moduleName =
-        wcsrchr(modulePath, L'\\');
+        wcsrchr(
+            modulePath,
+            L'\\'
+        );
 
-    moduleName = moduleName
-        ? moduleName + 1
-        : modulePath;
+    moduleName =
+        moduleName
+            ? moduleName + 1
+            : modulePath;
 
-    g_isExplorerProcess =
-        _wcsicmp(moduleName, L"explorer.exe") == 0;
+    return _wcsicmp(
+        moduleName,
+        L"explorer.exe"
+    ) == 0;
+}
 
-    if (isExcluded) {
+#define Wh_ModInit WindhawkToolModLauncher_Wh_ModInit
+#define Wh_ModAfterInit WindhawkToolModLauncher_Wh_ModAfterInit
+#define Wh_ModSettingsChanged WindhawkToolModLauncher_Wh_ModSettingsChanged
+#define Wh_ModUninit WindhawkToolModLauncher_Wh_ModUninit
+
+////////////////////////////////////////////////////////////////////////////////
+// Windhawk tool mod implementation for mods which don't need to inject to other
+// processes or hook other functions. Context:
+// https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process
+//
+// The mod will load and run in a dedicated windhawk.exe process.
+//
+// Paste the code below as part of the mod code, and use these callbacks:
+// * WhTool_ModInit
+// * WhTool_ModSettingsChanged
+// * WhTool_ModUninit
+//
+// Currently, other callbacks are not supported.
+
+bool g_isToolModProcessLauncher;
+HANDLE g_toolModProcessMutex;
+
+void WINAPI EntryPoint_Hook() {
+    Wh_Log(L">");
+    ExitThread(0);
+}
+
+BOOL Wh_ModInit() {
+    bool isService = false;
+    bool isToolModProcess = false;
+    bool isCurrentToolModProcess = false;
+    int argc;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);
+    if (!argv) {
+        Wh_Log(L"CommandLineToArgvW failed");
         return FALSE;
     }
 
-    if (g_isExplorerProcess) {
-        return InstallExplorerVisibilityHook()
-            ? TRUE
-            : FALSE;
+    for (int i = 1; i < argc; i++) {
+        if (wcscmp(argv[i], L"-service") == 0) {
+            isService = true;
+            break;
+        }
+    }
+
+    for (int i = 1; i < argc - 1; i++) {
+        if (wcscmp(argv[i], L"-tool-mod") == 0) {
+            isToolModProcess = true;
+            if (wcscmp(argv[i + 1], WH_MOD_ID) == 0) {
+                isCurrentToolModProcess = true;
+            }
+            break;
+        }
+    }
+
+    LocalFree(argv);
+
+    if (isService) {
+        return FALSE;
     }
 
     if (isCurrentToolModProcess) {
         g_toolModProcessMutex =
-            CreateMutex(
-                nullptr,
-                TRUE,
-                L"windhawk-tool-mod_" WH_MOD_ID
-            );
-
+            CreateMutex(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
         if (!g_toolModProcessMutex) {
             Wh_Log(L"CreateMutex failed");
             ExitProcess(1);
         }
 
         if (GetLastError() == ERROR_ALREADY_EXISTS) {
-            Wh_Log(
-                L"Tool mod already running (%s)",
-                WH_MOD_ID
-            );
+            Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
             ExitProcess(1);
         }
 
@@ -3197,29 +3350,14 @@ BOOL Wh_ModInit() {
         }
 
         IMAGE_DOS_HEADER* dosHeader =
-            (IMAGE_DOS_HEADER*)GetModuleHandle(
-                nullptr
-            );
-
+            (IMAGE_DOS_HEADER*)GetModuleHandle(nullptr);
         IMAGE_NT_HEADERS* ntHeaders =
-            (IMAGE_NT_HEADERS*)(
-                (BYTE*)dosHeader +
-                dosHeader->e_lfanew
-            );
+            (IMAGE_NT_HEADERS*)((BYTE*)dosHeader + dosHeader->e_lfanew);
 
-        DWORD entryPointRVA =
-            ntHeaders->OptionalHeader.AddressOfEntryPoint;
+        DWORD entryPointRVA = ntHeaders->OptionalHeader.AddressOfEntryPoint;
+        void* entryPoint = (BYTE*)dosHeader + entryPointRVA;
 
-        void* entryPoint =
-            (BYTE*)dosHeader +
-            entryPointRVA;
-
-        Wh_SetFunctionHook(
-            entryPoint,
-            (void*)EntryPoint_Hook,
-            nullptr
-        );
-
+        Wh_SetFunctionHook(entryPoint, (void*)EntryPoint_Hook, nullptr);
         return TRUE;
     }
 
@@ -3231,202 +3369,48 @@ BOOL Wh_ModInit() {
     return TRUE;
 }
 
-bool IsAnotherToolModInstanceRunning() {
-    HANDLE mutex =
-        OpenMutexW(
-            SYNCHRONIZE,
-            FALSE,
-            L"windhawk-tool-mod_" WH_MOD_ID
-        );
-
-    if (!mutex) {
-        return false;
-    }
-
-    DWORD result =
-        WaitForSingleObject(
-            mutex,
-            0
-        );
-
-    if (
-        result == WAIT_OBJECT_0 ||
-        result == WAIT_ABANDONED
-    ) {
-        ReleaseMutex(mutex);
-        CloseHandle(mutex);
-        return false;
-    }
-
-    if (result == WAIT_TIMEOUT) {
-        CloseHandle(mutex);
-        return true;
-    }
-
-    Wh_Log(
-        L"Could not determine tool-process mutex owner: %lu",
-        GetLastError()
-    );
-
-    CloseHandle(mutex);
-
-    // When ownership cannot be determined, do not disturb a potentially
-    // running tool instance.
-    return true;
-}
-
-DWORD WINAPI ToolModWatchdogThread(LPVOID) {
-    HANDLE waitHandles[2] = {
-        g_launcherWatchdogStopEvent,
-        g_toolModChildProcess
-    };
-
-    DWORD result =
-        WaitForMultipleObjects(
-            ARRAYSIZE(waitHandles),
-            waitHandles,
-            FALSE,
-            INFINITE
-        );
-
-    if (result == WAIT_OBJECT_0 + 1) {
-        /*
-         * The dedicated tool process ended. Whether it crashed, was killed,
-         * or completed a normal shutdown, make sure Explorer taskbars are not
-         * left hidden.
-         */
-        if (IsAnotherToolModInstanceRunning()) {
-            Wh_Log(
-                L"Tool process exited, but another tool instance is still running; not restoring taskbars"
-            );
-        } else {
-            Wh_Log(
-                L"Tool process exited; restoring taskbars hidden by this mod"
-            );
-            RestoreAllTaskbars();
-        }
-    }
-
-    return 0;
-}
-
-void StopLauncherWatchdog() {
-    if (g_launcherWatchdogStopEvent) {
-        SetEvent(
-            g_launcherWatchdogStopEvent
-        );
-    }
-
-    if (g_launcherWatchdogThread) {
-        WaitForSingleObject(
-            g_launcherWatchdogThread,
-            INFINITE
-        );
-        CloseHandle(
-            g_launcherWatchdogThread
-        );
-        g_launcherWatchdogThread = nullptr;
-    }
-
-    if (g_launcherWatchdogStopEvent) {
-        CloseHandle(
-            g_launcherWatchdogStopEvent
-        );
-        g_launcherWatchdogStopEvent = nullptr;
-    }
-
-    if (g_toolModChildProcess) {
-        CloseHandle(
-            g_toolModChildProcess
-        );
-        g_toolModChildProcess = nullptr;
-    }
-}
-
 void Wh_ModAfterInit() {
     if (!g_isToolModProcessLauncher) {
         return;
     }
 
     WCHAR currentProcessPath[MAX_PATH];
-
-    switch (
-        GetModuleFileName(
-            nullptr,
-            currentProcessPath,
-            ARRAYSIZE(currentProcessPath)
-        )
-    ) {
+    switch (GetModuleFileName(nullptr, currentProcessPath,
+                              ARRAYSIZE(currentProcessPath))) {
         case 0:
         case ARRAYSIZE(currentProcessPath):
-            Wh_Log(
-                L"GetModuleFileName failed"
-            );
+            Wh_Log(L"GetModuleFileName failed");
             return;
     }
 
-    WCHAR commandLine[
-        MAX_PATH +
-        2 +
-        (
-            sizeof(
-                L" -tool-mod \"" WH_MOD_ID "\""
-            ) / sizeof(WCHAR)
-        ) -
-        1
-    ];
+    WCHAR
+    commandLine[MAX_PATH + 2 +
+                (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
+    swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
+               WH_MOD_ID);
 
-    swprintf_s(
-        commandLine,
-        L"\"%s\" -tool-mod \"%s\"",
-        currentProcessPath,
-        WH_MOD_ID
-    );
-
-    HMODULE kernelModule =
-        GetModuleHandle(
-            L"kernelbase.dll"
-        );
-
+    HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
     if (!kernelModule) {
-        kernelModule =
-            GetModuleHandle(
-                L"kernel32.dll"
-            );
-
+        kernelModule = GetModuleHandle(L"kernel32.dll");
         if (!kernelModule) {
-            Wh_Log(
-                L"No kernelbase.dll/kernel32.dll"
-            );
+            Wh_Log(L"No kernelbase.dll/kernel32.dll");
             return;
         }
     }
 
     using CreateProcessInternalW_t = BOOL(WINAPI*)(
-        HANDLE hUserToken,
-        LPCWSTR lpApplicationName,
-        LPWSTR lpCommandLine,
+        HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
         LPSECURITY_ATTRIBUTES lpProcessAttributes,
-        LPSECURITY_ATTRIBUTES lpThreadAttributes,
-        WINBOOL bInheritHandles,
-        DWORD dwCreationFlags,
-        LPVOID lpEnvironment,
-        LPCWSTR lpCurrentDirectory,
+        LPSECURITY_ATTRIBUTES lpThreadAttributes, WINBOOL bInheritHandles,
+        DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory,
         LPSTARTUPINFOW lpStartupInfo,
         LPPROCESS_INFORMATION lpProcessInformation,
-        PHANDLE hRestrictedUserToken
-    );
-
+        PHANDLE hRestrictedUserToken);
     CreateProcessInternalW_t pCreateProcessInternalW =
-        (CreateProcessInternalW_t)GetProcAddress(
-            kernelModule,
-            "CreateProcessInternalW"
-        );
-
+        (CreateProcessInternalW_t)GetProcAddress(kernelModule,
+                                                 "CreateProcessInternalW");
     if (!pCreateProcessInternalW) {
-        Wh_Log(
-            L"No CreateProcessInternalW"
-        );
+        Wh_Log(L"No CreateProcessInternalW");
         return;
     }
 
@@ -3434,80 +3418,20 @@ void Wh_ModAfterInit() {
         .cb = sizeof(STARTUPINFO),
         .dwFlags = STARTF_FORCEOFFFEEDBACK,
     };
-
     PROCESS_INFORMATION pi;
-
-    if (
-        !pCreateProcessInternalW(
-            nullptr,
-            currentProcessPath,
-            commandLine,
-            nullptr,
-            nullptr,
-            FALSE,
-            NORMAL_PRIORITY_CLASS,
-            nullptr,
-            nullptr,
-            &si,
-            &pi,
-            nullptr
-        )
-    ) {
+    if (!pCreateProcessInternalW(nullptr, currentProcessPath, commandLine,
+                                 nullptr, nullptr, FALSE, NORMAL_PRIORITY_CLASS,
+                                 nullptr, nullptr, &si, &pi, nullptr)) {
         Wh_Log(L"CreateProcess failed");
         return;
     }
 
-    g_toolModChildProcess = pi.hProcess;
-
-    g_launcherWatchdogStopEvent =
-        CreateEventW(
-            nullptr,
-            TRUE,
-            FALSE,
-            nullptr
-        );
-
-    if (!g_launcherWatchdogStopEvent) {
-        Wh_Log(
-            L"CreateEvent for launcher watchdog failed: %lu",
-            GetLastError()
-        );
-        CloseHandle(pi.hProcess);
-        g_toolModChildProcess = nullptr;
-        CloseHandle(pi.hThread);
-        return;
-    }
-
-    g_launcherWatchdogThread =
-        CreateThread(
-            nullptr,
-            0,
-            ToolModWatchdogThread,
-            nullptr,
-            0,
-            nullptr
-        );
-
-    if (!g_launcherWatchdogThread) {
-        Wh_Log(
-            L"CreateThread for launcher watchdog failed: %lu",
-            GetLastError()
-        );
-        CloseHandle(
-            g_launcherWatchdogStopEvent
-        );
-        g_launcherWatchdogStopEvent = nullptr;
-        CloseHandle(pi.hProcess);
-        g_toolModChildProcess = nullptr;
-        CloseHandle(pi.hThread);
-        return;
-    }
-
+    CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
 }
 
 void Wh_ModSettingsChanged() {
-    if (g_isToolModProcessLauncher || g_isExplorerProcess) {
+    if (g_isToolModProcessLauncher) {
         return;
     }
 
@@ -3515,16 +3439,52 @@ void Wh_ModSettingsChanged() {
 }
 
 void Wh_ModUninit() {
-    if (g_isExplorerProcess) {
-        UninstallExplorerVisibilityHook();
-        return;
-    }
-
     if (g_isToolModProcessLauncher) {
-        StopLauncherWatchdog();
         return;
     }
 
     WhTool_ModUninit();
     ExitProcess(0);
 }
+
+#undef Wh_ModInit
+#undef Wh_ModAfterInit
+#undef Wh_ModSettingsChanged
+#undef Wh_ModUninit
+
+BOOL Wh_ModInit() {
+    if (IsCurrentProcessExplorer()) {
+        g_isExplorerProcess = true;
+        return InstallExplorerVisibilityHook()
+            ? TRUE
+            : FALSE;
+    }
+
+    return WindhawkToolModLauncher_Wh_ModInit();
+}
+
+void Wh_ModAfterInit() {
+    if (g_isExplorerProcess) {
+        return;
+    }
+
+    WindhawkToolModLauncher_Wh_ModAfterInit();
+}
+
+void Wh_ModSettingsChanged() {
+    if (g_isExplorerProcess) {
+        return;
+    }
+
+    WindhawkToolModLauncher_Wh_ModSettingsChanged();
+}
+
+void Wh_ModUninit() {
+    if (g_isExplorerProcess) {
+        ResetHiddenTaskbarOwnerCache();
+        return;
+    }
+
+    WindhawkToolModLauncher_Wh_ModUninit();
+}
+

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id hide-taskbar-only-on-desktop
 // @name Hide Taskbar Only on Desktop
 // @description Hides the taskbar on desktop while preserving taskbar and Windows shell UI interaction
-// @version 1.9.0
+// @version 1.10.0
 // @author Sahil Dashoni
 // @github https://github.com/Sahil-Dashoni
 // @include windhawk.exe
@@ -26,7 +26,7 @@ visible whenever an application or shell UI is active.
 - Uses the taskbar's actual rectangle and per-monitor DPI.
 - Adds a configurable extra hover margin in millimeters.
 - Uses a configurable delay after leaving the hover area.
-- The delay is used after a hover reveal and after Alt+Tab closes.
+- The delay is only used after a hover reveal.
 - Minimizing or closing the last application hides the taskbar immediately.
 - Keeps the taskbar available while interacting with taskbar buttons.
 - Supports secondary taskbars on additional monitors.
@@ -54,9 +54,9 @@ hidden until Explorer is restarted. Normal disable/unload paths restore it.
 For predictable behavior, disable Windows' own "Automatically hide the
 taskbar" option while this mod is enabled.
 
-This mod uses foreground/minimize Windows events for application state
-changes and a timer for cursor/hover and hide-delay handling. It deliberately
-avoids system-wide object show/hide/destroy hooks.
+This mod uses only foreground/minimize Windows events for application state
+changes and only uses a short timer while cursor hover handling is actually
+needed. It deliberately avoids system-wide object show/hide/destroy hooks.
 
 On multi-monitor systems, each monitor's taskbar is evaluated independently.
 A normal visible application intersecting a monitor keeps that monitor's
@@ -98,8 +98,6 @@ This mod was created with AI assistance.
 #include <dwmapi.h>
 #include <atomic>
 #include <stdio.h>
-#include <string.h>
-#include <wchar.h>
 
 struct Settings {
     std::atomic<int> extraHoverMarginMm{5};
@@ -154,6 +152,33 @@ const wchar_t kSystemMessageWindowClass[] =
 // Utility
 // ============================================================
 
+bool IsDesktopWindow(HWND hwnd) {
+    if (!hwnd) {
+        return false;
+    }
+
+    WCHAR className[256] = {};
+
+    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
+        return false;
+    }
+
+    if (wcscmp(className, L"Progman") == 0) {
+        return true;
+    }
+
+    if (wcscmp(className, L"WorkerW") == 0) {
+        return FindWindowExW(
+            hwnd,
+            nullptr,
+            L"SHELLDLL_DefView",
+            nullptr
+        ) != nullptr;
+    }
+
+    return false;
+}
+
 
 bool IsShellChromeClass(const WCHAR* className) {
     if (!className) {
@@ -205,7 +230,10 @@ bool IsTaskbarWindow(HWND hwnd) {
 // ============================================================
 
 void DiscoverTaskbars();
+bool IsAltTabWindowClass(const WCHAR* className);
 
+
+HWND FindPrimaryTaskbar();
 bool IsTaskbarActuallyHidden(HWND hwnd);
 bool IsShellUiClass(const WCHAR* className);
 
@@ -250,6 +278,22 @@ BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
         return TRUE;
     }
 
+    BOOL cloaked = FALSE;
+
+    if (
+        SUCCEEDED(
+            DwmGetWindowAttribute(
+                hwnd,
+                DWMWA_CLOAKED,
+                &cloaked,
+                sizeof(cloaked)
+            )
+        ) &&
+        cloaked
+    ) {
+        return TRUE;
+    }
+
     RECT rect = {};
 
     if (!GetWindowRect(hwnd, &rect)) {
@@ -266,26 +310,6 @@ BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
     if (
         GetWindow(hwnd, GW_OWNER) != nullptr &&
         !(exStyle & WS_EX_APPWINDOW)
-    ) {
-        return TRUE;
-    }
-
-    /*
-     * DWM cloaking is relatively expensive, so query it only after the
-     * cheaper visibility/style/geometry checks.
-     */
-    BOOL cloaked = FALSE;
-
-    if (
-        SUCCEEDED(
-            DwmGetWindowAttribute(
-                hwnd,
-                DWMWA_CLOAKED,
-                &cloaked,
-                sizeof(cloaked)
-            )
-        ) &&
-        cloaked
     ) {
         return TRUE;
     }
@@ -447,21 +471,23 @@ bool IsShellUiClass(const WCHAR* className) {
         return false;
     }
 
-    /*
-     * Windows 11 shell flyouts:
-     * - ControlCenterWindow: newer Quick Settings / Notifications hosts.
-     * - Xaml_WindowedPopupClass: XAML popup surfaces used by Start,
-     *   Action Center/flyouts and other shell UI.
-     * - TopLevelWindowForOverflowXamlIsland / NotifyIconOverflowWindow:
-     *   notification/overflow surfaces.
-     * - #32771: the system Alt+Tab switcher window.
-     */
     return
         wcscmp(className, L"ControlCenterWindow") == 0 ||
         wcscmp(className, L"Xaml_WindowedPopupClass") == 0 ||
         wcscmp(className, L"TopLevelWindowForOverflowXamlIsland") == 0 ||
         wcscmp(className, L"NotifyIconOverflowWindow") == 0 ||
-        wcscmp(className, L"#32771") == 0;
+        wcscmp(className, L"Windows.UI.Core.CoreWindow") == 0;
+}
+
+
+bool IsAltTabWindowClass(const WCHAR* className) {
+    if (!className) {
+        return false;
+    }
+
+    return
+        wcscmp(className, L"#32771") == 0 ||
+        wcscmp(className, L"XamlExplorerHostIslandWindow") == 0;
 }
 
 
@@ -489,25 +515,32 @@ bool IsVisibleShellFlyoutForMonitor(
         return false;
     }
 
-    /*
-     * For an actual visible flyout, use the popup/window class rather than
-     * the owning shell process. ShellExperienceHost and StartMenuExperienceHost
-     * can own other visible windows even when no flyout is open.
-     */
     if (!IsShellUiClass(className)) {
         return false;
     }
 
-    RECT windowRect = {};
+    /*
+     * XAML popup classes are used by ordinary applications too.
+     * Require a known Windows shell process before treating one as a
+     * taskbar-preserving shell flyout.
+     */
+    WCHAR processName[MAX_PATH] = {};
 
-    if (!GetWindowRect(hwnd, &windowRect)) {
+    if (
+        !GetWindowProcessName(
+            hwnd,
+            processName,
+            ARRAYSIZE(processName)
+        )
+    ) {
         return false;
     }
 
-    if (
-        windowRect.right <= windowRect.left ||
-        windowRect.bottom <= windowRect.top
-    ) {
+    bool knownShellProcess =
+        _wcsicmp(processName, L"explorer.exe") == 0 ||
+        IsKnownShellUiProcess(processName);
+
+    if (!knownShellProcess) {
         return false;
     }
 
@@ -523,6 +556,19 @@ bool IsVisibleShellFlyoutForMonitor(
             )
         ) &&
         cloaked
+    ) {
+        return false;
+    }
+
+    RECT windowRect = {};
+
+    if (!GetWindowRect(hwnd, &windowRect)) {
+        return false;
+    }
+
+    if (
+        windowRect.right <= windowRect.left ||
+        windowRect.bottom <= windowRect.top
     ) {
         return false;
     }
@@ -599,11 +645,7 @@ BOOL CALLBACK EnumAltTabWindowProc(
     bool* found =
         reinterpret_cast<bool*>(lParam);
 
-    if (!found) {
-        return FALSE;
-    }
-
-    if (!IsWindowVisible(hwnd)) {
+    if (!found || !IsWindowVisible(hwnd)) {
         return TRUE;
     }
 
@@ -614,17 +656,61 @@ BOOL CALLBACK EnumAltTabWindowProc(
             hwnd,
             className,
             ARRAYSIZE(className)
-        ) == 0
+        ) == 0 ||
+        !IsAltTabWindowClass(className)
     ) {
         return TRUE;
     }
 
-    if (wcscmp(className, L"#32771") == 0) {
-        *found = true;
-        return FALSE;
+    /*
+     * The modern Windows 11 switcher uses
+     * XamlExplorerHostIslandWindow. Restrict it to the shell processes
+     * that actually host the task switcher.
+     */
+    if (
+        wcscmp(
+            className,
+            L"XamlExplorerHostIslandWindow"
+        ) == 0
+    ) {
+        WCHAR processName[MAX_PATH] = {};
+
+        if (
+            !GetWindowProcessName(
+                hwnd,
+                processName,
+                ARRAYSIZE(processName)
+            )
+        ) {
+            return TRUE;
+        }
+
+        if (
+            _wcsicmp(processName, L"explorer.exe") != 0 &&
+            _wcsicmp(processName, L"ShellExperienceHost.exe") != 0
+        ) {
+            return TRUE;
+        }
     }
 
-    return TRUE;
+    BOOL cloaked = FALSE;
+
+    if (
+        SUCCEEDED(
+            DwmGetWindowAttribute(
+                hwnd,
+                DWMWA_CLOAKED,
+                &cloaked,
+                sizeof(cloaked)
+            )
+        ) &&
+        cloaked
+    ) {
+        return TRUE;
+    }
+
+    *found = true;
+    return FALSE;
 }
 
 
@@ -656,22 +742,35 @@ bool IsAltTabActive() {
 }
 
 
-bool IsShellUiForegroundOnMonitor(HMONITOR monitor, HWND foreground) {
+bool IsShellUiForegroundOnMonitor(
+    HMONITOR monitor,
+    HWND foreground
+) {
     if (!monitor || !foreground) {
         return false;
     }
 
     WCHAR className[256] = {};
 
-    bool knownClass =
+    if (
         GetClassNameW(
             foreground,
             className,
             ARRAYSIZE(className)
-        ) != 0 &&
-        IsShellUiClass(className);
+        ) == 0
+    ) {
+        return false;
+    }
 
-    if (!knownClass && !IsShellUiWindow(foreground)) {
+    if (IsAltTabWindowClass(className)) {
+        return true;
+    }
+
+    if (!IsShellUiClass(className)) {
+        return false;
+    }
+
+    if (!IsShellUiWindow(foreground)) {
         return false;
     }
 
@@ -916,6 +1015,16 @@ void SetTaskbarVisibility(bool show) {
 }
 
 
+bool IsPrimaryTaskbarHidden() {
+    HWND primary = FindPrimaryTaskbar();
+
+    if (!primary) {
+        return false;
+    }
+
+    return IsWindowVisible(primary) == FALSE;
+}
+
 
 // ============================================================
 // Hover zone
@@ -1078,12 +1187,6 @@ void UpdateTaskbarState() {
             std::memory_order_relaxed
         );
 
-    /*
-     * Alt+Tab is global, so detect it once per state update rather than once
-     * for every taskbar.
-     */
-    bool altTabActive = IsAltTabActive();
-
     for (size_t i = 0; i < g_taskbarCount; ++i) {
         TaskbarState& taskbar =
             g_taskbars[i];
@@ -1109,6 +1212,13 @@ void UpdateTaskbarState() {
         bool hovering =
             IsCursorInTaskbarHoverZone(taskbar);
 
+        bool shellFlyoutOpen =
+            taskbar.shellUiForeground ||
+            HasVisibleShellFlyout(taskbar.monitor);
+
+        bool altTabActive =
+            IsAltTabActive();
+
         /*
          * If a normal application is present on this monitor, that
          * monitor's taskbar remains visible even when another monitor
@@ -1116,7 +1226,6 @@ void UpdateTaskbarState() {
          */
         if (taskbar.hasApplication) {
             taskbar.shownDueToHover = false;
-            taskbar.shownDueToAltTab = false;
             taskbar.hideDeadline = 0;
 
             SetWindowVisibilityIfNeeded(
@@ -1126,10 +1235,6 @@ void UpdateTaskbarState() {
 
             continue;
         }
-
-        bool shellFlyoutOpen =
-            taskbar.shellUiForeground ||
-            HasVisibleShellFlyout(taskbar.monitor);
 
         /*
          * Windows shell flyouts (Start, Search, Notifications, Quick
@@ -1348,6 +1453,10 @@ LRESULT CALLBACK SystemMessageWindowProc(
 
     switch (message) {
     case WM_SETTINGCHANGE:
+        /*
+         * Native taskbar auto-hide can be changed from Windows Settings.
+         * Re-query it only when this targeted system notification arrives.
+         */
         RefreshPerMonitorState();
         UpdateTaskbarState();
         return 0;

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -1,72 +1,50 @@
 // ==WindhawkMod==
-// @id hide-taskbar-only-on-desktop
-// @name Hide Taskbar Only on Desktop
-// @description Hides the taskbar on desktop while preserving taskbar and Windows shell UI interaction
-// @version 1.13.0
-// @author Sahil Dashoni
-// @github https://github.com/Sahil-Dashoni
-// @include windhawk.exe
-// @compilerOptions -lshell32 -ldwmapi
+// @id              hide-taskbar-only-on-desktop
+// @name            Hide Taskbar Only on Desktop
+// @description     Hides the taskbar on the desktop, shows it for other windows or when you hover near the bottom edge
+// @version 2.0.0
+// @author          Sahil Dashoni
+// @github          https://github.com/Sahil-Dashoni
+// @include         explorer.exe
+// @compilerOptions -ldwmapi
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
 /*
-# Hide Taskbar Only on Desktop
+# Hide Taskbar on Desktop
 
-Hides the Windows taskbar when the desktop is active, while keeping it
-visible whenever an application or shell UI is active.
+Hides each selected taskbar whenever its own monitor is showing only the
+desktop (or its application windows are all minimized), and shows it again
+when an application or relevant Windows shell UI needs it.
 
-## Features
+You can also peek at the taskbar by moving the mouse to the bottom of the
+screen while on the desktop - the reveal zone matches the taskbar's own
+height (plus a small extra margin you can configure), not just a thin
+strip at the very bottom, so hovering anywhere over where the taskbar
+would be counts. The hover reveal is selectable per display; select individual displays or All displays. The delay before hiding only applies to that peek: hover
+in, then move away, and it waits a moment before hiding again. Every other
+hide (switching to the desktop, closing or minimizing the last window,
+etc.) hides instantly, no delay.
 
-- Hides the taskbar on the desktop.
-- Shows the taskbar when an application becomes active.
-- Automatically hides the taskbar after minimizing or closing the last application.
-- Reveals the taskbar when the mouse enters the taskbar-sized hover area.
-- The hover area follows the taskbar on the cursor's monitor.
-- Uses the taskbar's actual rectangle and per-monitor DPI.
-- Adds a configurable extra hover margin in millimeters.
-- Uses a configurable delay after leaving the hover area.
-- The delay is only used after a hover reveal.
-- Minimizing or closing the last application hides the taskbar immediately.
-- Keeps the taskbar available while interacting with taskbar buttons.
-- Supports secondary taskbars on additional monitors.
-- Uses independent per-monitor desktop/application state.
-- If an application is open on one monitor while another monitor is
-  showing the desktop, only the desktop monitor's taskbar is hidden.
-- Supports bottom, top, left and right taskbar positions.
-- Keeps the taskbar visible for Windows shell flyouts such as Start,
-  Search, Notifications, Quick Settings and the Start context menu.
-- Keeps the taskbar visible while Alt+Tab is open, then uses the same
-  configurable hide delay after Alt+Tab closes.
-- Minimizing the last application clears any previous hover-reveal delay
-  and hides the taskbar immediately on that monitor.
-- Runs as a Windhawk tool instead of being injected into Explorer.
-
-## Notes
-
-This mod intentionally differs from native Windows auto-hide:
-it hides the taskbar window without changing the desktop work area.
-
-Because the taskbar is controlled by a separate tool process, an unexpected
-termination of that process while the taskbar is hidden can leave the taskbar
-hidden until Explorer is restarted. Normal disable/unload paths restore it.
-
-For predictable behavior, disable Windows' own "Automatically hide the
-taskbar" option while this mod is enabled.
-
-This mod uses only foreground/minimize Windows events for application state
-changes and only uses a short timer while cursor hover handling is actually
-needed. It deliberately avoids system-wide object show/hide/destroy hooks.
-
-On multi-monitor systems, each monitor's taskbar is evaluated independently.
-A normal visible application intersecting a monitor keeps that monitor's
-taskbar visible; a monitor with only the desktop can hide its taskbar.
-
-Windows shell flyouts are treated as temporary shell interaction and keep
-the taskbar visible while they are open. Alt+Tab is likewise treated as an
-active shell interaction.
-
-This mod was created with AI assistance.
+### Notes
+- Works with a single taskbar, and optionally with secondary taskbars on
+  extra monitors (toggle in the settings).
+- Pressing the Windows key or clicking the Start button still works even
+  while the taskbar is hidden, and will bring the taskbar back, since the
+  Start menu counts as "another window".
+- Each monitor's "on desktop" state re-verifies itself roughly 10 times a
+  second by checking for any other visible, non-minimized window on that
+  monitor, rather than depending on a single event. Maximized windows use
+  Windows' monitor assignment, while normal/spanning windows count on each
+  display they actually intersect. This makes minimizing the last window on
+  one display hide that display's taskbar without affecting another display
+  that still has an application open.
+- Opening Start, the system tray overflow ("show hidden icons"), or the
+  notification/clock panel keeps the corresponding taskbar visible. Real foreground applications also take precedence over a stale desktop
+  scan, including foreground windows that do not expose a normal title or
+  APPWINDOW style.
+- On multi-display setups, the hover zone uses only the taskbar and DPI of
+  the display under the cursor; it never falls back to the primary taskbar.
 */
 // ==/WindhawkModReadme==
 
@@ -75,223 +53,232 @@ This mod was created with AI assistance.
 - extraHoverMarginMm: 5
   $name: Extra hover margin (mm)
   $description: >-
-    Adds extra space around the taskbar reveal area. The taskbar's own
-    dimensions are automatically included. Default is 5 mm.
-
+    The reveal zone at the bottom of the screen automatically matches your
+    taskbar's actual height (including your display scaling), so hovering
+    anywhere over where the taskbar would be reveals it. This setting adds
+    a bit of extra margin above that, in millimeters, so you don't need to
+    be pixel-perfect. Default 5mm.
 - autoHideDelayMs: 700
-  $name: Auto-hide delay (ms)
+  $name: Auto-hide delay after hover (ms)
   $description: >-
-    How long the taskbar remains visible after a hover reveal or after
-    Alt+Tab closes while no application is active on that monitor.
-    Other hides, such as minimizing the last application, are immediate.
-
-- hideSecondaryTaskbars: true
-  $name: Hide secondary taskbars
+    How long to wait, after moving the mouse away from the bottom-edge
+    hover zone, before the taskbar hides again. Only applies to that case
+    - other hides (e.g. minimizing the last window) are instant.
+    Default 700ms.
+- hoverRevealOnMonitors: ["all"]
+  $name: Reveal taskbar on bottom-edge hover
   $description: >-
-    Also hide taskbars on additional monitors. When disabled, secondary
-    taskbars are always restored.
+    Select the displays where bottom-edge hovering should reveal the taskbar.
+    Select All displays to enable it everywhere, or replace it with one or
+    more individual displays.
+  $options:
+  - all: All displays
+  - monitor1: Display 1 (primary)
+  - monitor2: Display 2
+  - monitor3: Display 3
+  - monitor4: Display 4
+  - monitor5: Display 5
+  - monitor6: Display 6
+  - monitor7: Display 7
+  - monitor8: Display 8
+  - monitor9: Display 9
+  - monitor10: Display 10
+  - monitor11: Display 11
+  - monitor12: Display 12
+  - monitor13: Display 13
+  - monitor14: Display 14
+  - monitor15: Display 15
+  - monitor16: Display 16
+- hideOnMonitors: ["all"]
+  $name: Taskbars to hide on desktop
+  $description: >-
+    Select one or more displays. Display 1 is the primary display.
+    Choose All displays to hide every connected display. Use Add to select
+    multiple displays.
+  $options:
+  - all: All displays
+  - monitor1: Display 1 (primary)
+  - monitor2: Display 2
+  - monitor3: Display 3
+  - monitor4: Display 4
+  - monitor5: Display 5
+  - monitor6: Display 6
+  - monitor7: Display 7
+  - monitor8: Display 8
+  - monitor9: Display 9
+  - monitor10: Display 10
+  - monitor11: Display 11
+  - monitor12: Display 12
+  - monitor13: Display 13
+  - monitor14: Display 14
+  - monitor15: Display 15
+  - monitor16: Display 16
 */
 // ==/WindhawkModSettings==
 
 #include <windows.h>
-#include <shellapi.h>
 #include <dwmapi.h>
-#include <atomic>
-#include <stdio.h>
-#include <string.h>
 #include <wchar.h>
 
-struct Settings {
-    std::atomic<int> extraHoverMarginMm{5};
-    std::atomic<DWORD> autoHideDelayMs{700};
-    std::atomic<bool> hideSecondaryTaskbars{true};
-};
+constexpr size_t kMaxMonitorNumbers = 16;
 
-Settings g_settings;
+struct {
+    int extraHoverMarginMm;
+    DWORD autoHideDelayMs;
+    bool hideAllMonitors;
+    bool hideMonitor[kMaxMonitorNumbers + 1];
+    bool hoverAllMonitors;
+    bool hoverMonitor[kMaxMonitorNumbers + 1];
+} settings = {};
 
-HANDLE g_hThread = nullptr;
-DWORD g_threadId = 0;
-HANDLE g_hThreadReadyEvent = nullptr;
+HWINEVENTHOOK g_hWinEventHookForeground;
+HANDLE g_hThread;
+DWORD g_threadId;
+bool g_shownDueToHover = false;  // taskbar currently shown because of hover
+HMONITOR g_hoverMonitor = nullptr; // monitor whose taskbar was revealed
+ULONGLONG g_hideDeadline = 0;      // pending hover-dismiss deadline
 
-constexpr UINT WM_APP_REFRESH_STATE = WM_APP + 1;
-constexpr UINT WM_APP_STOP_THREAD = WM_APP + 2;
-constexpr UINT kHoverTimerIntervalMs = 200;
+bool IsShellChromeClass(const WCHAR* className) {
+    static const WCHAR* kShellClasses[] = {
+        L"Progman",
+        L"WorkerW",
+        L"Shell_TrayWnd",
+        L"Shell_SecondaryTrayWnd",
+        L"TaskListThumbnailWnd",
+        L"SysShadow",
+        L"tooltips_class32",
+        L"MSCTFIME UI",
+        L"IME",
+    };
 
-UINT_PTR g_hoverTimerId = 0;
-
-std::atomic<bool> g_refreshPosted{false};
-std::atomic<bool> g_immediateHidePending{false};
-ULONGLONG g_lastApplicationScanTick = 0;
-constexpr ULONGLONG kApplicationRescanIntervalMs = 1000;
-
-constexpr size_t kMaxTaskbars = 16;
-constexpr size_t kMaxWinEventHooks = 3;
-
-struct TaskbarState {
-    HWND hwnd = nullptr;
-    HMONITOR monitor = nullptr;
-    RECT monitorRect = {};
-    RECT taskbarRect = {};
-    bool isSecondary = false;
-    bool hasApplication = false;
-    bool taskbarIsForeground = false;
-    bool shellUiForeground = false;
-    bool shellFlyoutVisible = false;
-    HWND shellFlyoutHwnd = nullptr;
-    bool shownDueToHover = false;
-    bool shownDueToAltTab = false;
-    ULONGLONG hideDeadline = 0;
-};
-
-TaskbarState g_taskbars[kMaxTaskbars] = {};
-size_t g_taskbarCount = 0;
-
-bool g_altTabActive = false;
-
-HWINEVENTHOOK g_hWinEventHooks[kMaxWinEventHooks] = {};
-
-
-// Hidden window used to receive setting/display notifications without
-// installing broad system-wide EVENT_OBJECT_* hooks.
-HWND g_hSystemMessageWindow = nullptr;
-UINT g_taskbarCreatedMsg = 0;
-const wchar_t kSystemMessageWindowClass[] =
-    L"HideTaskbarOnlyOnDesktop.SystemMessageWindow";
-
-// ============================================================
-// Utility
-// ============================================================
-
-bool IsDesktopWindow(HWND hwnd) {
-    if (!hwnd) {
-        return false;
-    }
-
-    WCHAR className[256] = {};
-
-    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
-        return false;
-    }
-
-    if (wcscmp(className, L"Progman") == 0) {
-        return true;
-    }
-
-    if (wcscmp(className, L"WorkerW") == 0) {
-        /*
-         * Explorer can keep multiple WorkerW wallpaper windows alive.
-         * They are desktop infrastructure regardless of their children.
-         */
-        return true;
+    for (const WCHAR* shellClass : kShellClasses) {
+        if (wcscmp(className, shellClass) == 0) {
+            return true;
+        }
     }
 
     return false;
 }
 
-
-bool IsShellChromeClass(const WCHAR* className) {
-    if (!className) {
+bool IsDesktopInfrastructureWindow(HWND hwnd, const WCHAR* className) {
+    if (!hwnd || !className) {
         return false;
     }
 
-    return
-        wcscmp(className, L"Windows.UI.Core.CoreWindow") == 0 ||
-        wcscmp(className, L"Xaml_WindowedPopupClass") == 0 ||
-        wcscmp(className, L"ControlCenterWindow") == 0 ||
-        wcscmp(className, L"TopLevelWindowForOverflowXamlIsland") == 0 ||
-        wcscmp(className, L"NotifyIconOverflowWindow") == 0;
+    /*
+     * Progman and WorkerW are Explorer's desktop/wallpaper infrastructure.
+     * WorkerW can exist with or without SHELLDLL_DefView, so neither should
+     * ever be classified as an application.
+     */
+    if (
+        wcscmp(className, L"Progman") == 0 ||
+        wcscmp(className, L"WorkerW") == 0
+    ) {
+        return true;
+    }
+
+    HWND shellWindow = GetShellWindow();
+
+    return shellWindow && hwnd == shellWindow;
 }
 
 
-bool IsTaskbarWindow(HWND hwnd) {
-    if (!hwnd) {
-        return false;
-    }
+constexpr size_t kMaxTaskbars = 32;
 
-    WCHAR className[256] = {};
-
-    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
-        return false;
-    }
-
-    return wcscmp(className, L"Shell_TrayWnd") == 0 ||
-           wcscmp(className, L"Shell_SecondaryTrayWnd") == 0;
-}
-
-
-// ============================================================
-// Window detection
-// ============================================================
-
-struct ForegroundInfo {
+struct TaskbarMonitorState {
     HWND hwnd = nullptr;
-    WCHAR className[256] = {};
-    WCHAR processName[MAX_PATH] = {};
-    bool classValid = false;
-    bool processValid = false;
+    HMONITOR monitor = nullptr;
+    int monitorNumber = 0;
+    bool desktopOnly = true;
 };
 
-void DiscoverTaskbars();
-bool IsAltTabWindowClass(const WCHAR* className);
+TaskbarMonitorState g_taskbarStates[kMaxTaskbars] = {};
+size_t g_taskbarStateCount = 0;
 
-
-HWND FindPrimaryTaskbar();
-bool IsTaskbarActuallyHidden(HWND hwnd);
-bool IsShellUiClass(const WCHAR* className);
-bool IsCursorOverTaskbarShellPopup(HWND taskbar);
-bool IsShellUiForegroundOnMonitor(
-    HMONITOR monitor,
-    const ForegroundInfo& info
-);
-bool IsForegroundApplicationOnMonitor(
-    const ForegroundInfo& info,
-    HMONITOR monitor
-);
-bool GetWindowProcessName(HWND hwnd, WCHAR* name, size_t nameCount);
-bool IsKnownShellUiProcess(const WCHAR* processName);
-bool IsShellUiWindow(HWND hwnd);
-
-struct AppMonitorScan {
-    TaskbarState* taskbars;
-    size_t count;
-    HWND shellWindow;
-    bool altTabActive;
+struct MonitorWindowScanContext {
+    HMONITOR monitor;
+    bool found;
 };
 
-BOOL CALLBACK EnumWindowsProc(
+
+bool IsLikelyApplicationWindow(
+    HWND hwnd,
+    const WCHAR* className
+) {
+    if (
+        !hwnd ||
+        !className ||
+        !IsWindowVisible(hwnd) ||
+        IsIconic(hwnd)
+    ) {
+        return false;
+    }
+
+    if (GetWindow(hwnd, GW_OWNER) != nullptr) {
+        return false;
+    }
+
+    LONG_PTR exStyle =
+        GetWindowLongPtrW(
+            hwnd,
+            GWL_EXSTYLE
+        );
+
+    if (exStyle & WS_EX_TOOLWINDOW) {
+        return false;
+    }
+
+    BOOL cloaked = FALSE;
+
+    if (
+        SUCCEEDED(
+            DwmGetWindowAttribute(
+                hwnd,
+                DWMWA_CLOAKED,
+                &cloaked,
+                sizeof(cloaked)
+            )
+        ) &&
+        cloaked
+    ) {
+        return false;
+    }
+
+    if (
+        IsDesktopInfrastructureWindow(
+            hwnd,
+            className
+        ) ||
+        IsShellChromeClass(
+            className
+        )
+    ) {
+        return false;
+    }
+
+    /*
+     * Do not count a visible, titleless helper surface as an application
+     * unless it explicitly opts into normal app-window treatment.
+     */
+    if (exStyle & WS_EX_APPWINDOW) {
+        return true;
+    }
+
+    return GetWindowTextLengthW(hwnd) > 0;
+}
+
+
+BOOL CALLBACK EnumWindowsForMonitorProc(
     HWND hwnd,
     LPARAM lParam
 ) {
-    AppMonitorScan* scan =
-        reinterpret_cast<AppMonitorScan*>(lParam);
+    MonitorWindowScanContext* context =
+        reinterpret_cast<MonitorWindowScanContext*>(lParam);
 
-    if (!scan || !scan->taskbars) {
+    if (!context || !context->monitor) {
         return TRUE;
     }
 
-    if (!IsWindowVisible(hwnd) || IsIconic(hwnd)) {
-        return TRUE;
-    }
-
-    if (IsTaskbarWindow(hwnd)) {
-        return TRUE;
-    }
-
-    if (hwnd == scan->shellWindow) {
-        return TRUE;
-    }
-
-    /*
-     * Explicitly ignore the desktop itself.
-     */
-    if (IsDesktopWindow(hwnd)) {
-        return TRUE;
-    }
-
-    /*
-     * GetShellWindow() is also supplied in scan->shellWindow, but keep the
-     * explicit desktop shell class check as a second line of defense.
-     */
     WCHAR className[256] = {};
 
     if (
@@ -304,186 +291,133 @@ BOOL CALLBACK EnumWindowsProc(
         return TRUE;
     }
 
-    /*
-     * Detect the Alt+Tab switcher in this same EnumWindows pass.
-     */
-    if (IsAltTabWindowClass(className)) {
-        if (
-            wcscmp(
-                className,
-                L"XamlExplorerHostIslandWindow"
-            ) == 0
-        ) {
-            WCHAR processName[MAX_PATH] = {};
-
-            if (
-                GetWindowProcessName(
-                    hwnd,
-                    processName,
-                    ARRAYSIZE(processName)
-                ) &&
-                (
-                    _wcsicmp(
-                        processName,
-                        L"explorer.exe"
-                    ) == 0 ||
-                    _wcsicmp(
-                        processName,
-                        L"ShellExperienceHost.exe"
-                    ) == 0
-                )
-            ) {
-                scan->altTabActive = true;
-            }
-        } else {
-            scan->altTabActive = true;
-        }
-
-        return TRUE;
-    }
-
-    /*
-     * UWP / Store applications such as Calculator and Settings use
-     * ApplicationFrameWindow hosted by ApplicationFrameHost.exe.
-     * Handle this before the generic owner/tool-window filters so the
-     * application's top-level frame is always counted as an application.
-     */
-    if (
-        wcscmp(
-            className,
-            L"ApplicationFrameWindow"
-        ) == 0
-    ) {
-        WCHAR processName[MAX_PATH] = {};
-
-        if (
-            GetWindowProcessName(
-                hwnd,
-                processName,
-                ARRAYSIZE(processName)
-            ) &&
-            _wcsicmp(
-                processName,
-                L"ApplicationFrameHost.exe"
-            ) == 0
-        ) {
-            RECT rect = {};
-
-            if (GetWindowRect(hwnd, &rect)) {
-                for (size_t i = 0; i < scan->count; ++i) {
-                    RECT intersection = {};
-
-                    if (
-                        IntersectRect(
-                            &intersection,
-                            &scan->taskbars[i].monitorRect,
-                            &rect
-                        )
-                    ) {
-                        scan->taskbars[i].hasApplication = true;
-                    }
-                }
-            }
-
-            return TRUE;
-        }
-    }
-
-    /*
-     * CoreWindow and XAML popup classes can belong to normal apps too.
-     * Only shell-owned instances are treated as shell UI.
-     */
-    if (
-        IsShellChromeClass(className) &&
-        IsShellUiWindow(hwnd)
-    ) {
-        BOOL cloaked = FALSE;
-
-        if (
-            !(
-                SUCCEEDED(
-                    DwmGetWindowAttribute(
-                        hwnd,
-                        DWMWA_CLOAKED,
-                        &cloaked,
-                        sizeof(cloaked)
-                    )
-                ) &&
-                cloaked
-            )
-        ) {
-            RECT rect = {};
-
-            if (GetWindowRect(hwnd, &rect)) {
-                HWND owner =
-                    GetWindow(
-                        hwnd,
-                        GW_OWNER
-                    );
-
-                bool isContextMenu =
-                    wcscmp(
-                        className,
-                        L"#32768"
-                    ) == 0;
-
-                for (size_t i = 0; i < scan->count; ++i) {
-                    RECT intersection = {};
-
-                    bool taskbarOwned =
-                        owner == scan->taskbars[i].hwnd;
-
-                    bool shouldTrack =
-                        !isContextMenu ||
-                        taskbarOwned;
-
-                    if (
-                        shouldTrack &&
-                        IntersectRect(
-                            &intersection,
-                            &scan->taskbars[i].monitorRect,
-                            &rect
-                        )
-                    ) {
-                        scan->taskbars[i].shellFlyoutVisible = true;
-                        scan->taskbars[i].shellFlyoutHwnd = hwnd;
-                    }
-                }
-            }
-        }
-
-        return TRUE;
-    }
-
-    LONG_PTR exStyle =
-        GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
-
-    if (exStyle & WS_EX_TOOLWINDOW) {
+    if (!IsLikelyApplicationWindow(
+            hwnd,
+            className
+        )) {
         return TRUE;
     }
 
     RECT rect = {};
 
-    if (!GetWindowRect(hwnd, &rect)) {
-        return TRUE;
-    }
-
     if (
+        !GetWindowRect(
+            hwnd,
+            &rect
+        ) ||
         rect.right <= rect.left ||
         rect.bottom <= rect.top
     ) {
         return TRUE;
     }
 
+    MONITORINFO targetInfo = {};
+    targetInfo.cbSize = sizeof(targetInfo);
+
     if (
-        GetWindow(hwnd, GW_OWNER) != nullptr &&
-        !(exStyle & WS_EX_APPWINDOW)
+        !GetMonitorInfoW(
+            context->monitor,
+            &targetInfo
+        )
     ) {
         return TRUE;
     }
 
+    WINDOWPLACEMENT placement = {};
+    placement.length = sizeof(placement);
+
+    if (
+        GetWindowPlacement(
+            hwnd,
+            &placement
+        ) &&
+        placement.showCmd == SW_SHOWMAXIMIZED
+    ) {
+        HMONITOR windowMonitor =
+            MonitorFromWindow(
+                hwnd,
+                MONITOR_DEFAULTTONEAREST
+            );
+
+        if (
+            windowMonitor ==
+            context->monitor
+        ) {
+            context->found = true;
+            return FALSE;
+        }
+
+        return TRUE;
+    }
+
     /*
-     * DWM is deliberately queried after the cheaper filters.
+     * Normal and spanning windows use their actual visible rectangle. This
+     * lets one window legitimately count on more than one display.
+     */
+    RECT intersection = {};
+
+    if (
+        IntersectRect(
+            &intersection,
+            &rect,
+            &targetInfo.rcMonitor
+        )
+    ) {
+        context->found = true;
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+
+bool HasOtherVisibleWindowOnMonitor(
+    HMONITOR monitor
+) {
+    MonitorWindowScanContext context = {
+        monitor,
+        false
+    };
+
+    EnumWindows(
+        EnumWindowsForMonitorProc,
+        reinterpret_cast<LPARAM>(&context)
+    );
+
+    return context.found;
+}
+
+
+bool IsForegroundApplicationWindow(
+    HWND hwnd,
+    const WCHAR* className
+) {
+    if (
+        !hwnd ||
+        !className ||
+        !IsWindowVisible(hwnd) ||
+        IsIconic(hwnd)
+    ) {
+        return false;
+    }
+
+    if (
+        IsDesktopInfrastructureWindow(
+            hwnd,
+            className
+        ) ||
+        IsShellChromeClass(
+            className
+        )
+    ) {
+        return false;
+    }
+
+    /*
+     * The foreground window is a stronger signal than a background helper
+     * window discovered by EnumWindows. Do not require a title or
+     * WS_EX_APPWINDOW here; this covers shell-integrated applications and
+     * virtual-display/application windows which may be titleless.
      */
     BOOL cloaked = FALSE;
 
@@ -498,66 +432,708 @@ BOOL CALLBACK EnumWindowsProc(
         ) &&
         cloaked
     ) {
+        return false;
+    }
+
+    return true;
+}
+
+
+void RefreshDesktopState() {
+    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+        TaskbarMonitorState& state =
+            g_taskbarStates[i];
+
+        if (!state.monitor) {
+            state.desktopOnly = true;
+            continue;
+        }
+
+        state.desktopOnly =
+            !HasOtherVisibleWindowOnMonitor(
+                state.monitor
+            );
+    }
+
+    /*
+     * The per-monitor scan is the authoritative baseline. A real foreground
+     * application is an additional immediate signal for its own monitor.
+     *
+     * Crucially, Progman/WorkerW are never used for this override because
+     * Windows may associate the desktop foreground window with the primary
+     * display even when the user clicked another display's desktop.
+     */
+    HWND foreground = GetForegroundWindow();
+
+    if (!foreground ||
+        !IsWindowVisible(foreground) ||
+        IsIconic(foreground)) {
+        return;
+    }
+
+    WCHAR className[256] = {};
+
+    if (
+        GetClassNameW(
+            foreground,
+            className,
+            ARRAYSIZE(className)
+        ) == 0
+    ) {
+        return;
+    }
+
+    if (
+        IsDesktopInfrastructureWindow(
+            foreground,
+            className
+        ) ||
+        IsShellChromeClass(
+            className
+        )
+    ) {
+        return;
+    }
+
+    if (!IsForegroundApplicationWindow(
+            foreground,
+            className
+        )) {
+        return;
+    }
+
+    /*
+     * The foreground window is an immediate signal that its display is
+     * active. Prefer the monitor Windows assigns to the window. For unusual
+     * virtual/maximized display geometry, verify that choice against the
+     * actual foreground rectangle and use the monitor with the largest
+     * visible intersection when it differs.
+     */
+    HMONITOR foregroundMonitor =
+        MonitorFromWindow(
+            foreground,
+            MONITOR_DEFAULTTONEAREST
+        );
+
+    /*
+     * Keep the foreground override tied to the monitor Windows assigns to
+     * the foreground window. The per-monitor scan already handles normal
+     * windows that span multiple displays, so there is no need to enumerate
+     * MonitorList here (which would also create a declaration-order
+     * dependency).
+     */
+
+    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+        if (
+            g_taskbarStates[i].monitor ==
+            foregroundMonitor
+        ) {
+            g_taskbarStates[i].desktopOnly = false;
+            break;
+        }
+    }
+}
+
+struct MonitorEntry {
+    HMONITOR monitor;
+    RECT rect;
+    bool primary;
+    wchar_t deviceName[32];
+};
+
+struct MonitorList {
+    MonitorEntry entries[kMaxMonitorNumbers];
+    size_t count;
+};
+
+
+BOOL CALLBACK CollectMonitorProc(
+    HMONITOR monitor,
+    HDC,
+    LPRECT,
+    LPARAM lParam
+) {
+    MonitorList* list =
+        reinterpret_cast<MonitorList*>(lParam);
+
+    if (!list || list->count >= kMaxMonitorNumbers) {
+        return FALSE;
+    }
+
+    MONITORINFOEXW info = {};
+    info.cbSize = sizeof(info);
+
+    if (!GetMonitorInfoW(
+            monitor,
+            &info
+        )) {
         return TRUE;
     }
 
-    for (size_t i = 0; i < scan->count; ++i) {
-        RECT intersection = {};
+    MonitorEntry& entry =
+        list->entries[list->count++];
+
+    entry.monitor = monitor;
+    entry.rect = info.rcMonitor;
+    entry.primary =
+        (info.dwFlags & MONITORINFOF_PRIMARY) != 0;
+
+    wcsncpy_s(
+        entry.deviceName,
+        ARRAYSIZE(entry.deviceName),
+        info.szDevice,
+        _TRUNCATE
+    );
+
+    return TRUE;
+}
+
+
+int GetDisplayDeviceNumber(
+    const wchar_t* deviceName
+) {
+    if (!deviceName) {
+        return 0;
+    }
+
+    /*
+     * Windows normally exposes the desktop display devices as DISPLAY1,
+     * DISPLAY2, ... . We use that OS-provided identity for numbering instead
+     * of the screen coordinates. This means moving a display left/right in
+     * Windows Display Settings does not change its selected display number.
+     */
+    constexpr wchar_t kPrefix[] = L"\\\\.\\DISPLAY";
+
+    size_t prefixLength =
+        ARRAYSIZE(kPrefix) - 1;
+
+    if (
+        wcsncmp(
+            deviceName,
+            kPrefix,
+            prefixLength
+        ) != 0
+    ) {
+        return 0;
+    }
+
+    wchar_t* endNumber = nullptr;
+
+    long number =
+        wcstol(
+            deviceName + prefixLength,
+            &endNumber,
+            10
+        );
+
+    if (
+        endNumber == deviceName + prefixLength ||
+        *endNumber != L'\0' ||
+        number < 1 ||
+        number > static_cast<long>(
+            kMaxMonitorNumbers
+        )
+    ) {
+        return 0;
+    }
+
+    return static_cast<int>(number);
+}
+
+
+void SortDisplaysForSelection(
+    MonitorList& list
+) {
+    /*
+     * Keep the primary display as Display 1 for the user-facing setting.
+     * For all other displays, prefer Windows' DISPLAYn number. This is much
+     * more stable than sorting by x/y coordinates.
+     *
+     * If Windows gives us an unexpected device name, fall back to the
+     * previous deterministic coordinate ordering.
+     */
+    size_t primaryIndex = list.count;
+
+    for (size_t i = 0; i < list.count; ++i) {
+        if (list.entries[i].primary) {
+            primaryIndex = i;
+            break;
+        }
+    }
+
+    if (
+        primaryIndex < list.count &&
+        primaryIndex != 0
+    ) {
+        MonitorEntry primary =
+            list.entries[primaryIndex];
+
+        for (size_t i = primaryIndex; i > 0; --i) {
+            list.entries[i] =
+                list.entries[i - 1];
+        }
+
+        list.entries[0] = primary;
+    }
+
+    for (size_t i = 1; i < list.count; ++i) {
+        size_t best = i;
+        int bestNumber =
+            GetDisplayDeviceNumber(
+                list.entries[best].deviceName
+            );
+
+        for (size_t j = i + 1; j < list.count; ++j) {
+            int candidateNumber =
+                GetDisplayDeviceNumber(
+                    list.entries[j].deviceName
+                );
+
+            bool candidateIsBetter = false;
+
+            if (
+                candidateNumber > 0 &&
+                bestNumber == 0
+            ) {
+                candidateIsBetter = true;
+            } else if (
+                candidateNumber > 0 &&
+                bestNumber > 0 &&
+                candidateNumber < bestNumber
+            ) {
+                candidateIsBetter = true;
+            } else if (
+                candidateNumber == 0 &&
+                bestNumber == 0
+            ) {
+                const RECT& a =
+                    list.entries[best].rect;
+                const RECT& b =
+                    list.entries[j].rect;
+
+                candidateIsBetter =
+                    b.top < a.top ||
+                    (
+                        b.top == a.top &&
+                        b.left < a.left
+                    );
+            }
+
+            if (candidateIsBetter) {
+                best = j;
+                bestNumber = candidateNumber;
+            }
+        }
+
+        if (best != i) {
+            MonitorEntry temp =
+                list.entries[i];
+
+            list.entries[i] =
+                list.entries[best];
+
+            list.entries[best] =
+                temp;
+        }
+    }
+}
+
+
+MonitorList GetCurrentMonitors() {
+    MonitorList list = {};
+
+    EnumDisplayMonitors(
+        nullptr,
+        nullptr,
+        CollectMonitorProc,
+        reinterpret_cast<LPARAM>(&list)
+    );
+
+    SortDisplaysForSelection(list);
+
+    return list;
+}
+
+
+int GetMonitorNumber(
+    const MonitorList& list,
+    HMONITOR monitor
+) {
+    for (size_t i = 0; i < list.count; ++i) {
+        if (list.entries[i].monitor == monitor) {
+            return static_cast<int>(i + 1);
+        }
+    }
+
+    return 0;
+}
+
+
+bool ShouldHideMonitor(int monitorNumber) {
+    if (
+        monitorNumber < 1 ||
+        monitorNumber > static_cast<int>(kMaxMonitorNumbers)
+    ) {
+        return false;
+    }
+
+    return
+        settings.hideAllMonitors ||
+        settings.hideMonitor[monitorNumber];
+}
+
+bool ShouldRevealOnHover(int monitorNumber) {
+    if (
+        monitorNumber < 1 ||
+        monitorNumber > static_cast<int>(kMaxMonitorNumbers)
+    ) {
+        return false;
+    }
+
+    return
+        settings.hoverAllMonitors ||
+        settings.hoverMonitor[monitorNumber];
+}
+
+
+void RefreshTaskbarMonitorStates() {
+    TaskbarMonitorState oldStates[kMaxTaskbars] = {};
+    size_t oldCount = g_taskbarStateCount;
+
+    MonitorList monitors =
+        GetCurrentMonitors();
+
+    for (size_t i = 0; i < oldCount; ++i) {
+        oldStates[i] = g_taskbarStates[i];
+    }
+
+    g_taskbarStateCount = 0;
+
+    auto addTaskbar = [&](HWND hwnd, bool secondary) {
+        (void)secondary;
 
         if (
-            IntersectRect(
-                &intersection,
-                &scan->taskbars[i].monitorRect,
-                &rect
-            )
+            !hwnd ||
+            g_taskbarStateCount >= kMaxTaskbars
         ) {
-            scan->taskbars[i].hasApplication = true;
+            return;
         }
+
+        RECT taskbarRect = {};
+
+        if (!GetWindowRect(
+                hwnd,
+                &taskbarRect
+            )) {
+            return;
+        }
+
+        // The Shell taskbar HWND is tied to its actual display. Using
+        // MonitorFromWindow() avoids inferring ownership from transient
+        // taskbar geometry, which can be misleading with virtual displays.
+        HMONITOR monitor =
+            MonitorFromWindow(
+                hwnd,
+                MONITOR_DEFAULTTONEAREST
+            );
+
+        if (!monitor) {
+            POINT taskbarCenter = {
+                taskbarRect.left +
+                    (taskbarRect.right - taskbarRect.left) / 2,
+                taskbarRect.top +
+                    (taskbarRect.bottom - taskbarRect.top) / 2
+            };
+
+            monitor =
+                MonitorFromPoint(
+                    taskbarCenter,
+                    MONITOR_DEFAULTTONEAREST
+                );
+        }
+
+        TaskbarMonitorState state = {};
+        state.hwnd = hwnd;
+        state.monitor = monitor;
+        state.monitorNumber =
+            GetMonitorNumber(
+                monitors,
+                monitor
+            );
+
+        for (size_t i = 0; i < oldCount; ++i) {
+            if (oldStates[i].hwnd == hwnd) {
+                state.desktopOnly =
+                    oldStates[i].desktopOnly;
+                break;
+            }
+        }
+
+        g_taskbarStates[g_taskbarStateCount++] = state;
+    };
+
+    addTaskbar(
+        FindWindowW(
+            L"Shell_TrayWnd",
+            nullptr
+        ),
+        false
+    );
+
+    HWND secondary = nullptr;
+
+    while (
+        (secondary = FindWindowExW(
+            nullptr,
+            secondary,
+            L"Shell_SecondaryTrayWnd",
+            nullptr
+        )) != nullptr
+    ) {
+        addTaskbar(
+            secondary,
+            true
+        );
+    }
+}
+
+
+bool IsShellFlyoutWindow(HWND hwnd) {
+    if (
+        !hwnd ||
+        !IsWindow(hwnd) ||
+        !IsWindowVisible(hwnd)
+    ) {
+        return false;
+    }
+
+    WCHAR className[128] = {};
+
+    if (
+        GetClassNameW(
+            hwnd,
+            className,
+            ARRAYSIZE(className)
+        ) == 0
+    ) {
+        return false;
+    }
+
+    /*
+     * These are shell/XAML popup classes used by Windows 11 for taskbar
+     * flyouts such as the notification/calendar and quick-settings surfaces.
+     * The class check is intentionally combined with the Explorer process
+     * check below so an identically named third-party window isn't treated as
+     * shell UI.
+     */
+    bool knownFlyoutClass =
+        wcscmp(
+            className,
+            L"Xaml_WindowedPopupClass"
+        ) == 0 ||
+        wcscmp(
+            className,
+            L"Windows.UI.Core.CoreWindow"
+        ) == 0 ||
+        wcscmp(
+            className,
+            L"TopLevelWindowForOverflowXamlIsland"
+        ) == 0 ||
+        wcscmp(
+            className,
+            L"NotifyIconOverflowWindow"
+        ) == 0;
+
+    if (!knownFlyoutClass) {
+        return false;
+    }
+
+    DWORD processId = 0;
+
+    GetWindowThreadProcessId(
+        hwnd,
+        &processId
+    );
+
+    if (!processId) {
+        return false;
+    }
+
+    HWND taskbar =
+        FindWindowW(
+            L"Shell_TrayWnd",
+            nullptr
+        );
+
+    DWORD taskbarProcessId = 0;
+
+    if (taskbar) {
+        GetWindowThreadProcessId(
+            taskbar,
+            &taskbarProcessId
+        );
+    }
+
+    /*
+     * Use the taskbar's Explorer process as the primary trust boundary.
+     * For secondary taskbars, Explorer is still the owning process, but a
+     * taskbar recreation can briefly leave the primary lookup unavailable.
+     */
+    if (
+        taskbarProcessId != 0 &&
+        processId == taskbarProcessId
+    ) {
+        return true;
+    }
+
+    DWORD explorerProcessId = 0;
+    HWND shellWindow = GetShellWindow();
+
+    if (shellWindow) {
+        GetWindowThreadProcessId(
+            shellWindow,
+            &explorerProcessId
+        );
+    }
+
+    return
+        explorerProcessId != 0 &&
+        processId == explorerProcessId;
+}
+
+
+struct ShellFlyoutScanContext {
+    HMONITOR targetMonitor;
+    bool found;
+};
+
+
+BOOL CALLBACK ShellFlyoutEnumProc(
+    HWND hwnd,
+    LPARAM lParam
+) {
+    ShellFlyoutScanContext* context =
+        reinterpret_cast<ShellFlyoutScanContext*>(lParam);
+
+    if (
+        !context ||
+        !IsShellFlyoutWindow(hwnd)
+    ) {
+        return TRUE;
+    }
+
+    RECT rect = {};
+
+    if (!GetWindowRect(hwnd, &rect)) {
+        return TRUE;
+    }
+
+    POINT center = {
+        rect.left +
+            (rect.right - rect.left) / 2,
+        rect.top +
+            (rect.bottom - rect.top) / 2
+    };
+
+    HMONITOR flyoutMonitor =
+        MonitorFromPoint(
+            center,
+            MONITOR_DEFAULTTONEAREST
+        );
+
+    if (flyoutMonitor == context->targetMonitor) {
+        context->found = true;
+        return FALSE;
     }
 
     return TRUE;
 }
 
 
-void ScanApplicationWindows() {
-    for (size_t i = 0; i < g_taskbarCount; ++i) {
-        g_taskbars[i].hasApplication = false;
-        g_taskbars[i].shellFlyoutVisible = false;
-        g_taskbars[i].shellFlyoutHwnd = nullptr;
+bool HasVisibleShellFlyoutOnMonitor(
+    HMONITOR monitor
+) {
+    if (!monitor) {
+        return false;
     }
 
-    g_altTabActive = false;
-
-    if (!g_taskbarCount) {
-        return;
-    }
-
-    AppMonitorScan scan{
-        g_taskbars,
-        g_taskbarCount,
-        GetShellWindow(),
+    ShellFlyoutScanContext context = {
+        monitor,
         false
     };
 
     EnumWindows(
-        EnumWindowsProc,
-        reinterpret_cast<LPARAM>(&scan)
+        ShellFlyoutEnumProc,
+        reinterpret_cast<LPARAM>(&context)
     );
 
-    g_altTabActive = scan.altTabActive;
+    return context.found;
 }
 
 
-// ============================================================
-// Foreground / taskbar interaction
-// ============================================================
+bool IsAltTabActive() {
+    /*
+     * The legacy Alt+Tab switcher uses #32771. Windows 11's XAML host can
+     * remain present after the switcher closes, so do not treat that host
+     * alone as proof that Alt+Tab is active.
+     */
+    HWND foreground = GetForegroundWindow();
 
-bool IsTaskbarForegroundAndUnderCursor(HWND taskbar) {
-    if (!IsTaskbarWindow(taskbar)) {
+    if (foreground) {
+        WCHAR className[128] = {};
+
+        if (
+            GetClassNameW(
+                foreground,
+                className,
+                ARRAYSIZE(className)
+            ) != 0 &&
+            wcscmp(className, L"#32771") == 0
+        ) {
+            return true;
+        }
+    }
+
+    /*
+     * While the Alt+Tab chord is physically held, keep the taskbar visible
+     * even if the switcher's foreground window is hosted differently.
+     */
+    return
+        (GetAsyncKeyState(VK_MENU) & 0x8000) != 0 &&
+        (GetAsyncKeyState(VK_TAB) & 0x8000) != 0;
+}
+
+
+bool IsTaskbarPopupClass(
+    const WCHAR* className
+) {
+    if (!className) {
         return false;
     }
 
-    if (GetForegroundWindow() != taskbar) {
+    return
+        wcscmp(className, L"#32768") == 0 ||
+        wcscmp(className, L"Xaml_WindowedPopupClass") == 0 ||
+        wcscmp(
+            className,
+            L"TopLevelWindowForOverflowXamlIsland"
+        ) == 0 ||
+        wcscmp(
+            className,
+            L"NotifyIconOverflowWindow"
+        ) == 0 ||
+        wcscmp(
+            className,
+            L"TaskbarOverflowWnd"
+        ) == 0;
+}
+
+
+bool IsTaskbarPopupOpen(HWND taskbar) {
+    if (
+        !taskbar ||
+        !IsWindow(taskbar)
+    ) {
         return false;
     }
 
@@ -567,42 +1143,38 @@ bool IsTaskbarForegroundAndUnderCursor(HWND taskbar) {
         return false;
     }
 
-    RECT rect = {};
+    HMONITOR taskbarMonitor =
+        MonitorFromWindow(
+            taskbar,
+            MONITOR_DEFAULTTONEAREST
+        );
 
-    if (!GetWindowRect(taskbar, &rect)) {
+    HMONITOR cursorMonitor =
+        MonitorFromPoint(
+            pt,
+            MONITOR_DEFAULTTONEAREST
+        );
+
+    if (
+        !taskbarMonitor ||
+        cursorMonitor != taskbarMonitor
+    ) {
         return false;
     }
 
-    return PtInRect(&rect, pt) != FALSE;
-}
+    HWND current = WindowFromPoint(pt);
 
-
-
-
-
-
-
-
-
-
-
-
-bool IsCursorOverTaskbarShellPopup(HWND taskbar) {
-    if (!taskbar || !IsTaskbarWindow(taskbar)) {
+    if (!current) {
         return false;
     }
 
-    POINT pt = {};
+    HWND root = GetAncestor(
+        current,
+        GA_ROOT
+    );
 
-    if (!GetCursorPos(&pt)) {
-        return false;
-    }
-
-    HWND hwnd =
-        WindowFromPoint(pt);
-
-    if (!hwnd) {
-        return false;
+    if (root) {
+        current = root;
     }
 
     DWORD taskbarProcessId = 0;
@@ -617,79 +1189,62 @@ bool IsCursorOverTaskbarShellPopup(HWND taskbar) {
     }
 
     /*
-     * Walk the window's parent/owner chain. A Start context menu may be a
-     * standard #32768 menu or a XAML popup and may never become foreground.
+     * A taskbar/Start popup may not become the foreground window. Walk the
+     * window's parent/owner chain from the window under the cursor instead.
+     * This works for normal #32768 menus as well as XAML shell popups.
      */
-    HWND current = hwnd;
+    for (
+        int depth = 0;
+        current && depth < 12;
+        ++depth
+    ) {
+        if (current == taskbar) {
+            return false;
+        }
 
-    for (int depth = 0; current && depth < 12; ++depth) {
-        if (current != taskbar) {
-            WCHAR className[128] = {};
+        WCHAR className[128] = {};
+
+        if (
+            GetClassNameW(
+                current,
+                className,
+                ARRAYSIZE(className)
+            ) != 0
+        ) {
+            bool popupClass =
+                IsTaskbarPopupClass(
+                    className
+                );
 
             if (
-                GetClassNameW(
-                    current,
-                    className,
-                    ARRAYSIZE(className)
-                ) != 0
+                popupClass &&
+                IsWindowVisible(current)
             ) {
-                bool popupClass =
-                    wcscmp(
-                        className,
-                        L"#32768"
-                    ) == 0 ||
-                    wcscmp(
-                        className,
-                        L"Xaml_WindowedPopupClass"
-                    ) == 0 ||
-                    wcscmp(
-                        className,
-                        L"Windows.UI.Core.CoreWindow"
-                    ) == 0;
+                DWORD popupProcessId = 0;
 
+                GetWindowThreadProcessId(
+                    current,
+                    &popupProcessId
+                );
+
+                /*
+                 * Prefer the taskbar's Explorer process. A shell popup from
+                 * one of the known shell UI processes is also accepted.
+                 */
                 if (
-                    popupClass &&
-                    IsWindowVisible(current)
+                    popupProcessId == taskbarProcessId
                 ) {
-                    DWORD popupProcessId = 0;
-
-                    GetWindowThreadProcessId(
-                        current,
-                        &popupProcessId
-                    );
-
-                    if (
-                        popupProcessId == taskbarProcessId
-                    ) {
-                        return true;
-                    }
-
-                    WCHAR processName[MAX_PATH] = {};
-
-                    if (
-                        GetWindowProcessName(
-                            current,
-                            processName,
-                            ARRAYSIZE(processName)
-                        ) &&
-                        IsKnownShellUiProcess(
-                            processName
-                        )
-                    ) {
-                        return true;
-                    }
+                    return true;
                 }
+
             }
         }
 
-        HWND parent =
-            GetParent(current);
-
-        HWND owner =
-            GetWindow(
-                current,
-                GW_OWNER
-            );
+        HWND parent = GetParent(current);
+        HWND owner = GetWindow(
+            current,
+            GW_OWNER
+        );
 
         if (
             parent &&
@@ -710,1507 +1265,716 @@ bool IsCursorOverTaskbarShellPopup(HWND taskbar) {
 }
 
 
-bool IsForegroundApplicationOnMonitor(
-    const ForegroundInfo& info,
-    HMONITOR monitor
-) {
+bool IsTaskbarShellPopupForeground(HWND taskbar) {
+    HWND foreground =
+        GetForegroundWindow();
+
     if (
-        !monitor ||
-        !info.hwnd ||
-        !info.classValid
+        !foreground ||
+        foreground == taskbar
     ) {
         return false;
     }
 
-    if (
-        !IsWindowVisible(info.hwnd) ||
-        IsIconic(info.hwnd)
-    ) {
-        return false;
-    }
-
-    if (
-        IsTaskbarWindow(info.hwnd) ||
-        IsDesktopWindow(info.hwnd)
-    ) {
-        return false;
-    }
-
-    if (IsAltTabWindowClass(info.className)) {
-        return false;
-    }
-
-    if (
-        info.processValid &&
-        IsShellChromeClass(info.className) &&
-        IsKnownShellUiProcess(info.processName)
-    ) {
-        return false;
-    }
-
-    LONG_PTR exStyle =
-        GetWindowLongPtrW(
-            info.hwnd,
-            GWL_EXSTYLE
-        );
-
-    if (exStyle & WS_EX_TOOLWINDOW) {
-        return false;
-    }
-
-    BOOL cloaked = FALSE;
-
-    if (
-        SUCCEEDED(
-            DwmGetWindowAttribute(
-                info.hwnd,
-                DWMWA_CLOAKED,
-                &cloaked,
-                sizeof(cloaked)
-            )
-        ) &&
-        cloaked
-    ) {
-        return false;
-    }
-
-    RECT rect = {};
-
-    if (!GetWindowRect(info.hwnd, &rect)) {
-        return false;
-    }
-
-    MONITORINFO mi = {};
-    mi.cbSize = sizeof(mi);
-
-    if (!GetMonitorInfoW(monitor, &mi)) {
-        return false;
-    }
-
-    RECT intersection = {};
-
-    return IntersectRect(
-        &intersection,
-        &mi.rcMonitor,
-        &rect
-    ) != FALSE;
-}
-
-
-bool GetWindowProcessName(HWND hwnd, WCHAR* name, size_t nameCount) {
-    if (!hwnd || !name || nameCount == 0) {
-        return false;
-    }
-
-    DWORD processId = 0;
-
-    if (!GetWindowThreadProcessId(hwnd, &processId) || !processId) {
-        return false;
-    }
-
-    HANDLE process = OpenProcess(
-        PROCESS_QUERY_LIMITED_INFORMATION,
-        FALSE,
-        processId
-    );
-
-    if (!process) {
-        return false;
-    }
-
-    DWORD size = static_cast<DWORD>(nameCount);
-
-    BOOL result = QueryFullProcessImageNameW(
-        process,
-        0,
-        name,
-        &size
-    );
-
-    CloseHandle(process);
-
-    if (!result || size == 0) {
-        return false;
-    }
-
-    const WCHAR* baseName = wcsrchr(name, L'\\');
-
-    if (baseName) {
-        baseName++;
-        size_t length = wcslen(baseName);
-
-        if (length + 1 <= nameCount) {
-            memmove(name, baseName, (length + 1) * sizeof(WCHAR));
-        }
-    }
-
-    return true;
-}
-
-
-bool IsKnownShellUiProcess(const WCHAR* processName) {
-    if (!processName) {
-        return false;
-    }
-
-    return
-        _wcsicmp(processName, L"explorer.exe") == 0 ||
-        _wcsicmp(processName, L"StartMenuExperienceHost.exe") == 0 ||
-        _wcsicmp(processName, L"ShellExperienceHost.exe") == 0 ||
-        _wcsicmp(processName, L"ShellHost.exe") == 0 ||
-        _wcsicmp(processName, L"SearchHost.exe") == 0 ||
-        _wcsicmp(processName, L"SearchApp.exe") == 0 ||
-        _wcsicmp(processName, L"TextInputHost.exe") == 0;
-}
-
-
-bool IsShellUiWindow(HWND hwnd) {
-    if (!hwnd || IsTaskbarWindow(hwnd)) {
-        return false;
-    }
-
-    WCHAR className[256] = {};
-
-    if (
-        GetClassNameW(
-            hwnd,
-            className,
-            ARRAYSIZE(className)
-        ) == 0
-    ) {
-        return false;
-    }
-
-    /*
-     * Do not classify ordinary explorer.exe windows (or arbitrary shell
-     * process windows) as shell UI. The class must first be one of the
-     * explicitly supported flyout/shell classes.
-     */
-    if (!IsShellUiClass(className)) {
-        return false;
-    }
-
-    WCHAR processName[MAX_PATH] = {};
-
-    if (!GetWindowProcessName(
-            hwnd,
-            processName,
-            ARRAYSIZE(processName)
-        )) {
-        return false;
-    }
-
-    return IsKnownShellUiProcess(processName);
-}
-
-
-bool IsShellUiClass(const WCHAR* className) {
-    if (!className) {
-        return false;
-    }
-
-    return
-        wcscmp(className, L"ControlCenterWindow") == 0 ||
-        wcscmp(className, L"Xaml_WindowedPopupClass") == 0 ||
-        wcscmp(className, L"TopLevelWindowForOverflowXamlIsland") == 0 ||
-        wcscmp(className, L"NotifyIconOverflowWindow") == 0 ||
-        wcscmp(className, L"Windows.UI.Core.CoreWindow") == 0 ||
-        wcscmp(className, L"Windows.UI.Core.CoreComponent") == 0 ||
-        wcscmp(className, L"#32768") == 0;
-}
-
-
-bool IsAltTabWindowClass(const WCHAR* className) {
-    if (!className) {
-        return false;
-    }
-
-    return
-        wcscmp(className, L"#32771") == 0 ||
-        wcscmp(className, L"XamlExplorerHostIslandWindow") == 0;
-}
-
-
-
-
-
-
-
-ForegroundInfo GetForegroundInfo(HWND hwnd) {
-    ForegroundInfo info = {};
-    info.hwnd = hwnd;
-
-    if (!hwnd) {
-        return info;
-    }
-
-    info.classValid =
-        GetClassNameW(
-            hwnd,
-            info.className,
-            ARRAYSIZE(info.className)
-        ) != 0;
-
-    if (info.classValid) {
-        info.processValid =
-            GetWindowProcessName(
-                hwnd,
-                info.processName,
-                ARRAYSIZE(info.processName)
-            );
-    }
-
-    return info;
-}
-
-
-
-
-
-bool IsShellUiForegroundOnMonitor(
-    HMONITOR monitor,
-    const ForegroundInfo& info
-) {
-    if (
-        !monitor ||
-        !info.hwnd ||
-        !info.classValid
-    ) {
-        return false;
-    }
-
-    if (IsAltTabWindowClass(info.className)) {
-        return true;
-    }
-
-    if (
-        !info.processValid ||
-        !IsShellUiClass(info.className) ||
-        !IsKnownShellUiProcess(info.processName)
-    ) {
-        return false;
-    }
-
-    RECT rect = {};
-
-    if (!GetWindowRect(info.hwnd, &rect)) {
-        return false;
-    }
-
-    MONITORINFO mi = {};
-    mi.cbSize = sizeof(mi);
-
-    if (!GetMonitorInfoW(monitor, &mi)) {
-        return false;
-    }
-
-    RECT intersection = {};
-
-    return IntersectRect(
-        &intersection,
-        &mi.rcMonitor,
-        &rect
-    ) != FALSE;
-}
-
-
-void RefreshTaskbarForegroundState() {
-    HWND foreground = GetForegroundWindow();
-    ForegroundInfo foregroundInfo =
-        GetForegroundInfo(foreground);
-
-    for (size_t i = 0; i < g_taskbarCount; ++i) {
-        TaskbarState& taskbar = g_taskbars[i];
-
-        bool foregroundIsTaskbar =
-            foreground == taskbar.hwnd;
-
-        bool cursorOverTaskbar =
-            IsTaskbarForegroundAndUnderCursor(
-                taskbar.hwnd
-            );
-
-        taskbar.taskbarIsForeground =
-            foregroundIsTaskbar;
-
-        taskbar.shellUiForeground =
-            IsShellUiForegroundOnMonitor(
-                taskbar.monitor,
-                foregroundInfo
-            );
-
-        if (cursorOverTaskbar) {
-            taskbar.shownDueToHover = true;
-            taskbar.shownDueToAltTab = false;
-            taskbar.hideDeadline = 0;
-        }
-    }
-}
-
-void RefreshPerMonitorState() {
-    /*
-     * Application visibility is determined independently for each monitor.
-     * A window spanning multiple monitors keeps taskbars on all intersected
-     * monitors visible.
-     */
-    DiscoverTaskbars();
-    ScanApplicationWindows();
-    g_lastApplicationScanTick = GetTickCount64();
-    RefreshTaskbarForegroundState();
-}
-
-
-// ============================================================
-// Taskbar discovery
-// ============================================================
-
-bool IsSecondaryTaskbar(HWND hwnd) {
-    if (!hwnd) {
-        return false;
-    }
-
-    WCHAR className[256] = {};
-
-    if (
-        GetClassNameW(
-            hwnd,
-            className,
-            ARRAYSIZE(className)
-        ) == 0
-    ) {
-        return false;
-    }
-
-    return wcscmp(
-        className,
-        L"Shell_SecondaryTrayWnd"
-    ) == 0;
-}
-
-
-void DiscoverTaskbars() {
-    TaskbarState oldStates[kMaxTaskbars] = {};
-    size_t oldCount = g_taskbarCount;
-
-    for (size_t i = 0; i < oldCount; ++i) {
-        oldStates[i] = g_taskbars[i];
-    }
-
-    g_taskbarCount = 0;
-
-    auto addTaskbar = [&](HWND hwnd) {
-        if (!hwnd || g_taskbarCount >= kMaxTaskbars) {
-            return;
-        }
-
-        for (size_t i = 0; i < g_taskbarCount; ++i) {
-            if (g_taskbars[i].hwnd == hwnd) {
-                return;
-            }
-        }
-
-        HMONITOR monitor =
-            MonitorFromWindow(
-                hwnd,
-                MONITOR_DEFAULTTONULL
-            );
-
-        if (!monitor) {
-            return;
-        }
-
-        MONITORINFO mi = {};
-        mi.cbSize = sizeof(mi);
-
-        if (!GetMonitorInfoW(monitor, &mi)) {
-            return;
-        }
-
-        TaskbarState state = {};
-        state.hwnd = hwnd;
-        state.monitor = monitor;
-        state.monitorRect = mi.rcMonitor;
-        state.isSecondary = IsSecondaryTaskbar(hwnd);
-
-        GetWindowRect(
-            hwnd,
-            &state.taskbarRect
-        );
-
-        for (size_t i = 0; i < oldCount; ++i) {
-            if (oldStates[i].hwnd == hwnd) {
-                state.shownDueToHover =
-                    oldStates[i].shownDueToHover;
-                state.shownDueToAltTab =
-                    oldStates[i].shownDueToAltTab;
-                state.hideDeadline =
-                    oldStates[i].hideDeadline;
-                state.shellFlyoutVisible =
-                    oldStates[i].shellFlyoutVisible;
-                state.shellFlyoutHwnd =
-                    oldStates[i].shellFlyoutHwnd;
-                break;
-            }
-        }
-
-        g_taskbars[g_taskbarCount++] = state;
-    };
-
-    addTaskbar(
-        FindWindowW(
-            L"Shell_TrayWnd",
+    DWORD foregroundThreadId =
+        GetWindowThreadProcessId(
+            foreground,
             nullptr
+        );
+
+    DWORD taskbarThreadId =
+        GetWindowThreadProcessId(
+            taskbar,
+            nullptr
+        );
+
+    if (
+        !foregroundThreadId ||
+        !taskbarThreadId ||
+        foregroundThreadId != taskbarThreadId
+    ) {
+        return false;
+    }
+
+    WCHAR className[128] = {};
+
+    if (
+        !GetClassNameW(
+            foreground,
+            className,
+            ARRAYSIZE(className)
         )
-    );
-
-    HWND secondary = nullptr;
-
-    while (
-        (secondary = FindWindowExW(
-            nullptr,
-            secondary,
-            L"Shell_SecondaryTrayWnd",
-            nullptr
-        )) != nullptr
     ) {
-        addTaskbar(secondary);
+        return false;
     }
+
+    if (!IsTaskbarPopupClass(className)) {
+        return false;
+    }
+
+    HMONITOR taskbarMonitor =
+        MonitorFromWindow(
+            taskbar,
+            MONITOR_DEFAULTTONEAREST
+        );
+
+    HMONITOR popupMonitor =
+        MonitorFromWindow(
+            foreground,
+            MONITOR_DEFAULTTONEAREST
+        );
+
+    POINT cursorPoint = {};
+    if (!GetCursorPos(&cursorPoint)) {
+        return false;
+    }
+
+    HMONITOR cursorMonitor =
+        MonitorFromPoint(
+            cursorPoint,
+            MONITOR_DEFAULTTONEAREST
+        );
+
+    return
+        taskbarMonitor &&
+        popupMonitor &&
+        cursorMonitor &&
+        taskbarMonitor == popupMonitor &&
+        popupMonitor == cursorMonitor;
 }
 
 
-// ============================================================
-// Taskbar visibility
-// ============================================================
-
-HWND FindPrimaryTaskbar() {
-    return FindWindowW(L"Shell_TrayWnd", nullptr);
-}
-
-bool IsTaskbarActuallyHidden(HWND hwnd) {
-    return hwnd != nullptr && IsWindowVisible(hwnd) == FALSE;
-}
-
-void SetWindowVisibilityIfNeeded(HWND hwnd, bool show) {
-    if (!hwnd) {
+void SetTaskbarState(
+    TaskbarMonitorState& state,
+    bool show
+) {
+    if (
+        !state.hwnd ||
+        !IsWindow(state.hwnd)
+    ) {
         return;
     }
 
-    bool visible = IsWindowVisible(hwnd) != FALSE;
+    bool visible =
+        IsWindowVisible(state.hwnd) != FALSE;
 
     if (visible != show) {
-        ShowWindowAsync(
-            hwnd,
-            show ? SW_SHOWNA : SW_HIDE
+        ShowWindow(
+            state.hwnd,
+            show ? SW_SHOW : SW_HIDE
         );
-    }
-}
-
-
-void SetSecondaryTaskbarsVisibility(bool show) {
-    HWND secondary = nullptr;
-
-    while (
-        (secondary = FindWindowExW(
-            nullptr,
-            secondary,
-            L"Shell_SecondaryTrayWnd",
-            nullptr
-        )) != nullptr
-    ) {
-        SetWindowVisibilityIfNeeded(secondary, show);
     }
 }
 
 
 void SetTaskbarVisibility(bool show) {
-    HWND primary = FindPrimaryTaskbar();
-
-    if (primary) {
-        SetWindowVisibilityIfNeeded(primary, show);
+    HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
+    if (hTaskbar) {
+        ShowWindow(hTaskbar, show ? SW_SHOW : SW_HIDE);
     }
 
-    bool hideSecondary =
-        g_settings.hideSecondaryTaskbars.load(
-            std::memory_order_relaxed
-        );
-
-    // When the setting is disabled, secondary taskbars must be restored
-    // even while the primary taskbar is hidden on the desktop.
-    if (show || hideSecondary) {
-        SetSecondaryTaskbarsVisibility(show);
-    } else {
-        SetSecondaryTaskbarsVisibility(true);
-    }
-}
-
-
-
-
-
-// ============================================================
-// Hover zone
-// ============================================================
-
-int MillimetersToPixels(int mm, UINT dpi) {
-    if (mm <= 0 || dpi == 0) {
-        return 0;
-    }
-
-    // px = mm * dpi / 25.4
-    // Using integer arithmetic:
-    // px = mm * 10 * dpi / 254
-    return MulDiv(
-        mm * 10,
-        static_cast<int>(dpi),
-        254
-    );
-}
-
-
-bool IsCursorInTaskbarHoverZone(
-    TaskbarState& taskbar
-) {
-    if (!taskbar.hwnd) {
-        return false;
-    }
-
-    if (
-        taskbar.isSecondary &&
-        !g_settings.hideSecondaryTaskbars.load(
-            std::memory_order_relaxed
-        )
+    HWND hSecondary = nullptr;
+    while (
+        (hSecondary = FindWindowExW(
+            nullptr,
+            hSecondary,
+            L"Shell_SecondaryTrayWnd",
+            nullptr
+        )) != nullptr
     ) {
-        return false;
+        ShowWindow(
+            hSecondary,
+            show ? SW_SHOW : SW_HIDE
+        );
+    }
+}
+
+// The reveal zone matches the taskbar's own current height (whatever size
+// and display scaling you actually have it set to), plus a configurable
+// extra margin on top. Falls back to a small DPI-scaled default if the
+// taskbar's rect can't be read for some reason.
+int GetHoverZonePx(HWND hTaskbar, UINT dpi) {
+    int marginPx = (int)((double)settings.extraHoverMarginMm / 25.4 * dpi);
+
+    RECT tbRect;
+    if (hTaskbar && GetWindowRect(hTaskbar, &tbRect)) {
+        int taskbarHeight = tbRect.bottom - tbRect.top;
+        if (taskbarHeight > 0) {
+            return taskbarHeight + marginPx;
+        }
     }
 
-    POINT pt = {};
+    // Fallback: assume a ~48px (at 100% scaling) default taskbar height.
+    int fallbackHeight = (int)(48.0 * dpi / 96.0);
+    return fallbackHeight + marginPx;
+}
 
+// True if the cursor is within the taskbar-height-sized zone at the bottom
+// edge of whichever monitor it's currently on.
+bool IsCursorNearBottomEdge(HMONITOR cursorMonitor) {
+    POINT pt;
     if (!GetCursorPos(&pt)) {
         return false;
     }
 
-    RECT taskbarRect = taskbar.taskbarRect;
+    if (!cursorMonitor) {
+        return false;
+    }
+
+    MONITORINFO mi = {sizeof(mi)};
+
+    if (!GetMonitorInfoW(
+            cursorMonitor,
+            &mi
+        )) {
+        return false;
+    }
 
     if (
-        taskbarRect.right <= taskbarRect.left ||
-        taskbarRect.bottom <= taskbarRect.top
+        pt.x < mi.rcMonitor.left ||
+        pt.x > mi.rcMonitor.right
     ) {
-        if (!GetWindowRect(taskbar.hwnd, &taskbarRect)) {
-            return false;
-        }
+        return false;
+    }
 
+    HWND hTaskbar = nullptr;
+
+    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
         if (
-            taskbarRect.right <= taskbarRect.left ||
-            taskbarRect.bottom <= taskbarRect.top
+            g_taskbarStates[i].monitor == cursorMonitor &&
+            g_taskbarStates[i].hwnd
         ) {
-            return false;
-        }
-
-        taskbar.taskbarRect = taskbarRect;
-    }
-
-    UINT dpi = GetDpiForWindow(taskbar.hwnd);
-
-    if (!dpi) {
-        dpi = 96;
-    }
-
-    int marginPx =
-        MillimetersToPixels(
-            g_settings.extraHoverMarginMm.load(
-                std::memory_order_relaxed
-            ),
-            dpi
-        );
-
-    int monitorWidth =
-        taskbar.monitorRect.right -
-        taskbar.monitorRect.left;
-
-    int monitorHeight =
-        taskbar.monitorRect.bottom -
-        taskbar.monitorRect.top;
-
-    int maxMargin =
-        monitorWidth < monitorHeight
-            ? monitorWidth / 2
-            : monitorHeight / 2;
-
-    if (marginPx > maxMargin) {
-        marginPx = maxMargin;
-    }
-
-    RECT hoverRect = taskbarRect;
-
-    InflateRect(
-        &hoverRect,
-        marginPx,
-        marginPx
-    );
-
-    return PtInRect(
-        &hoverRect,
-        pt
-    ) != FALSE;
-}
-
-
-// ============================================================
-// Timer management
-// ============================================================
-
-void StopHoverTimer() {
-    if (g_hoverTimerId) {
-        KillTimer(
-            nullptr,
-            g_hoverTimerId
-        );
-
-        g_hoverTimerId = 0;
-    }
-}
-
-
-void EnsureHoverTimer(bool needed) {
-    if (!needed) {
-        StopHoverTimer();
-        return;
-    }
-
-    if (g_hoverTimerId) {
-        return;
-    }
-
-    g_hoverTimerId =
-        SetTimer(
-            nullptr,
-            0,
-            kHoverTimerIntervalMs,
-            nullptr
-        );
-
-    if (!g_hoverTimerId) {
-        Wh_Log(
-            L"SetTimer failed: %lu",
-            GetLastError()
-        );
-    }
-}
-
-
-// ============================================================
-// State machine
-// ============================================================
-
-void UpdateTaskbarState() {
-    if (!g_taskbarCount) {
-        StopHoverTimer();
-        return;
-    }
-
-    /*
-     * Shell flyouts can close without producing a useful foreground/minimize
-     * event for this tool. Refresh only the foreground shell state here;
-     * application state remains event-driven.
-     */
-    ULONGLONG now = GetTickCount64();
-
-    /*
-     * Some background window closes/appearances do not change the
-     * foreground window. Reconcile application state once per second,
-     * rather than doing a full EnumWindows scan every 200 ms.
-     */
-    if (
-        g_lastApplicationScanTick == 0 ||
-        now - g_lastApplicationScanTick >=
-            kApplicationRescanIntervalMs
-    ) {
-        ScanApplicationWindows();
-        g_lastApplicationScanTick = now;
-    }
-
-    HWND foreground = GetForegroundWindow();
-    ForegroundInfo foregroundInfo =
-        GetForegroundInfo(foreground);
-
-    DWORD delay =
-        g_settings.autoHideDelayMs.load(
-            std::memory_order_relaxed
-        );
-
-    bool hideSecondaryTaskbars =
-        g_settings.hideSecondaryTaskbars.load(
-            std::memory_order_relaxed
-        );
-
-    for (size_t i = 0; i < g_taskbarCount; ++i) {
-        TaskbarState& taskbar =
-            g_taskbars[i];
-
-        bool controlled =
-            !taskbar.isSecondary ||
-            g_settings.hideSecondaryTaskbars.load(
-                std::memory_order_relaxed
-            );
-
-        if (!controlled) {
-            taskbar.shownDueToHover = false;
-            taskbar.hideDeadline = 0;
-
-            SetWindowVisibilityIfNeeded(
-                taskbar.hwnd,
-                true
-            );
-
-            continue;
-        }
-
-        bool hovering =
-            IsCursorInTaskbarHoverZone(taskbar);
-
-        bool currentShellUi =
-            IsShellUiForegroundOnMonitor(
-                taskbar.monitor,
-                foregroundInfo
-            );
-
-        bool foregroundApplication =
-            IsForegroundApplicationOnMonitor(
-                foregroundInfo,
-                taskbar.monitor
-            );
-
-        taskbar.shellUiForeground =
-            currentShellUi;
-
-        /*
-         * A Start/taskbar context menu may not become the foreground HWND.
-         * Detect the popup under the cursor without doing a full enumeration.
-         */
-        bool taskbarShellPopup = false;
-
-        if (hovering) {
-            taskbarShellPopup =
-                IsCursorOverTaskbarShellPopup(
-                    taskbar.hwnd
-                );
-        }
-
-        /*
-         * Shell UI state is allowed to keep the taskbar visible while the
-         * corresponding shell surface is open.
-         */
-        bool shellFlyoutOpen =
-            currentShellUi ||
-            taskbarShellPopup ||
-            (
-                taskbar.shellFlyoutVisible &&
-                taskbar.shellFlyoutHwnd &&
-                IsWindowVisible(
-                    taskbar.shellFlyoutHwnd
-                )
-            );
-
-        bool altTabActive =
-            g_altTabActive;
-
-        /*
-         * If a normal application is present on this monitor, that
-         * monitor's taskbar remains visible even when another monitor
-         * is on the desktop.
-         */
-        if (
-            taskbar.hasApplication ||
-            foregroundApplication
-        ) {
-            taskbar.hasApplication = true;
-            taskbar.shownDueToHover = false;
-            taskbar.shownDueToAltTab = false;
-            taskbar.hideDeadline = 0;
-
-            SetWindowVisibilityIfNeeded(
-                taskbar.hwnd,
-                true
-            );
-
-            continue;
-        }
-
-        /*
-         * Windows shell flyouts (Start, Search, Notifications, Quick
-         * Settings, tray overflow, etc.) and Alt+Tab must keep the
-         * taskbar visible while they are being used.
-         */
-        if (altTabActive) {
-            /*
-             * Alt+Tab is an explicit shell interaction. Keep the taskbar
-             * visible while the switcher is open and remember that this
-             * reveal came from Alt+Tab so the normal hide delay is applied
-             * after Alt+Tab closes.
-             */
-            taskbar.shownDueToAltTab = true;
-            taskbar.hideDeadline = 0;
-
-            SetWindowVisibilityIfNeeded(
-                taskbar.hwnd,
-                true
-            );
-
-            continue;
-        }
-
-        if (shellFlyoutOpen) {
-            taskbar.hideDeadline = 0;
-
-            SetWindowVisibilityIfNeeded(
-                taskbar.hwnd,
-                true
-            );
-
-            continue;
-        }
-
-        /*
-         * Hovering the taskbar reveals it immediately.
-         */
-        if (hovering) {
-            taskbar.shownDueToHover = true;
-            taskbar.shownDueToAltTab = false;
-            taskbar.hideDeadline = 0;
-
-            SetWindowVisibilityIfNeeded(
-                taskbar.hwnd,
-                true
-            );
-
-            continue;
-        }
-
-        /*
-         * A taskbar click/reveal is tracked by shownDueToHover. Once the
-         * cursor leaves the taskbar, the configured delay below is used.
-         * Do not use Shell_TrayWnd being foreground as a permanent
-         * "keep visible" condition, because Explorer may retain that
-         * foreground window after the cursor leaves.
-         *
-         * Keyboard taskbar navigation such as Win+T is handled by the
-         * foreground check only while the actual taskbar is the focused
-         * window and the shell remains active; the hover state is still
-         * what controls mouse-leave hiding.
-         */
-
-        /*
-         * Apply the delay only after a hover/click reveal.
-         */
-        if (
-            taskbar.taskbarIsForeground &&
-            !taskbar.shownDueToHover
-        ) {
-            if (!taskbar.hideDeadline) {
-                taskbar.hideDeadline =
-                    now +
-                    static_cast<ULONGLONG>(delay);
-            }
-
-            if (now >= taskbar.hideDeadline) {
-                SetWindowVisibilityIfNeeded(
-                    taskbar.hwnd,
-                    false
-                );
-
-                taskbar.hideDeadline = 0;
-
-                /*
-                 * Shell_TrayWnd may remain the foreground HWND briefly
-                 * after it is hidden. Clear the stale cached state so
-                 * the next timer tick doesn't immediately show it again.
-                 */
-                taskbar.taskbarIsForeground = false;
-            } else {
-                SetWindowVisibilityIfNeeded(
-                    taskbar.hwnd,
-                    true
-                );
-            }
-
-            continue;
-        }
-
-        if (taskbar.shownDueToAltTab) {
-            /*
-             * Alt+Tab has just closed. Apply the exact same configured delay
-             * used by the hover reveal instead of hiding immediately.
-             */
-            if (!taskbar.hideDeadline) {
-                taskbar.hideDeadline =
-                    now +
-                    static_cast<ULONGLONG>(delay);
-            } else if (now >= taskbar.hideDeadline) {
-                SetWindowVisibilityIfNeeded(
-                    taskbar.hwnd,
-                    false
-                );
-
-                taskbar.hideDeadline = 0;
-                taskbar.shownDueToAltTab = false;
-            }
-
-            continue;
-        }
-
-        if (taskbar.shownDueToHover) {
-            if (!taskbar.hideDeadline) {
-                taskbar.hideDeadline =
-                    now +
-                    static_cast<ULONGLONG>(delay);
-            } else if (now >= taskbar.hideDeadline) {
-                SetWindowVisibilityIfNeeded(
-                    taskbar.hwnd,
-                    false
-                );
-
-                taskbar.hideDeadline = 0;
-                taskbar.shownDueToHover = false;
-            }
-
-            continue;
-        }
-
-        /*
-         * No application and no reveal: hide this monitor's taskbar
-         * immediately.
-         */
-        SetWindowVisibilityIfNeeded(
-            taskbar.hwnd,
-            false
-        );
-
-        taskbar.hideDeadline = 0;
-    }
-
-    bool needTimer = false;
-
-    for (size_t i = 0; i < g_taskbarCount; ++i) {
-        TaskbarState& taskbar =
-            g_taskbars[i];
-
-        bool controlled =
-            !taskbar.isSecondary ||
-            g_settings.hideSecondaryTaskbars.load(
-                std::memory_order_relaxed
-            );
-
-        if (!controlled) {
-            continue;
-        }
-
-        if (
-            taskbar.hasApplication == false ||
-            taskbar.taskbarIsForeground ||
-            taskbar.shellUiForeground ||
-            taskbar.shownDueToHover ||
-            taskbar.shownDueToAltTab ||
-            IsTaskbarActuallyHidden(taskbar.hwnd)
-        ) {
-            needTimer = true;
+            hTaskbar = g_taskbarStates[i].hwnd;
             break;
         }
     }
 
-    EnsureHoverTimer(needTimer);
-}
-
-
-// ============================================================
-// Worker refresh message
-// ============================================================
-
-void RequestStateRefresh() {
-    if (!g_threadId) {
-        return;
-    }
-
-    bool expected = false;
-
-    if (
-        !g_refreshPosted.compare_exchange_strong(
-            expected,
-            true,
-            std::memory_order_acq_rel,
-            std::memory_order_relaxed
-        )
-    ) {
-        return;
-    }
-
-    if (
-        !PostThreadMessageW(
-            g_threadId,
-            WM_APP_REFRESH_STATE,
-            0,
-            0
-        )
-    ) {
-        g_refreshPosted.store(
-            false,
-            std::memory_order_release
-        );
-    }
-}
-
-
-// ============================================================
-// System notification window
-// ============================================================
-
-LRESULT CALLBACK SystemMessageWindowProc(
-    HWND hwnd,
-    UINT message,
-    WPARAM wParam,
-    LPARAM lParam
-) {
-    UNREFERENCED_PARAMETER(hwnd);
-    UNREFERENCED_PARAMETER(wParam);
-    UNREFERENCED_PARAMETER(lParam);
-
-    if (
-        g_taskbarCreatedMsg &&
-        message == g_taskbarCreatedMsg
-    ) {
-        RequestStateRefresh();
-        return 0;
-    }
-
-    switch (message) {
-    case WM_SETTINGCHANGE:
-    case WM_DISPLAYCHANGE:
-    case WM_DPICHANGED:
-        /*
-         * Queue the state refresh on the worker thread rather than doing
-         * a complete EnumWindows sweep synchronously in this callback.
-         */
-        RequestStateRefresh();
-        return 0;
-
-    case WM_NCDESTROY:
-        if (g_hSystemMessageWindow == hwnd) {
-            g_hSystemMessageWindow = nullptr;
-        }
-        break;
-    }
-
-    return DefWindowProcW(hwnd, message, wParam, lParam);
-}
-
-
-bool CreateSystemMessageWindow() {
-    g_taskbarCreatedMsg =
-        RegisterWindowMessageW(L"TaskbarCreated");
-
-    if (!g_taskbarCreatedMsg) {
-        Wh_Log(
-            L"RegisterWindowMessageW(TaskbarCreated) failed: %lu",
-            GetLastError()
-        );
-    }
-
-    WNDCLASSW wc = {};
-    wc.lpfnWndProc = SystemMessageWindowProc;
-    wc.hInstance = GetModuleHandleW(nullptr);
-    wc.lpszClassName = kSystemMessageWindowClass;
-
-    if (!RegisterClassW(&wc)) {
-        DWORD error = GetLastError();
-
-        if (error != ERROR_CLASS_ALREADY_EXISTS) {
-            Wh_Log(
-                L"RegisterClassW failed: %lu",
-                error
-            );
-            return false;
-        }
-    }
-
-    g_hSystemMessageWindow =
-        CreateWindowExW(
-            0,
-            kSystemMessageWindowClass,
-            L"Hide Taskbar Only on Desktop",
-            WS_OVERLAPPED,
-            0,
-            0,
-            0,
-            0,
-            nullptr,
-            nullptr,
-            GetModuleHandleW(nullptr),
-            nullptr
-        );
-
-    if (!g_hSystemMessageWindow) {
-        Wh_Log(
-            L"CreateWindowExW failed: %lu",
-            GetLastError()
-        );
+    /*
+     * Do not fall back to the primary taskbar for a secondary display.
+     * A primary-taskbar fallback can give the secondary display the wrong
+     * reveal-zone geometry during taskbar transitions.
+     */
+    if (!hTaskbar) {
         return false;
     }
 
-    return true;
-}
+    UINT dpi =
+        GetDpiForWindow(hTaskbar);
 
-
-void DestroySystemMessageWindow() {
-    if (g_hSystemMessageWindow) {
-        DestroyWindow(g_hSystemMessageWindow);
-        g_hSystemMessageWindow = nullptr;
+    int hotZonePx =
+        GetHoverZonePx(
+            hTaskbar,
+            dpi
+        );
+    if (hotZonePx < 1) {
+        hotZonePx = 1;
     }
 
-    g_taskbarCreatedMsg = 0;
+    return pt.y >= mi.rcMonitor.bottom - hotZonePx;
 }
 
-
-// ============================================================
-// WinEvent hook
-// ============================================================
-
-bool IsRelevantWinEvent(DWORD event) {
-    return
-        event == EVENT_SYSTEM_FOREGROUND ||
-        event == EVENT_SYSTEM_MINIMIZESTART ||
-        event == EVENT_SYSTEM_MINIMIZEEND ||
-        event == EVENT_SYSTEM_MOVESIZEEND;
-}
-
-
-void CALLBACK WinEventProc(
-    HWINEVENTHOOK,
-    DWORD event,
-    HWND,
-    LONG idObject,
-    LONG idChild,
-    DWORD,
-    DWORD
-) {
-    if (
-        idObject != OBJID_WINDOW ||
-        idChild != CHILDID_SELF ||
-        !IsRelevantWinEvent(event)
-    ) {
-        return;
-    }
+// Single place that decides whether the taskbar should be shown or hidden.
+// Only the "hover then move away" case gets a delay; every other hide is
+// instant.
+void UpdateTaskbarState() {
+    RefreshTaskbarMonitorStates();
 
     /*
-     * Foreground changes are the main state transition we care about.
-     * Minimize start/end are needed for the last-application case.
-     *
-     * We deliberately do not hook EVENT_OBJECT_SHOW/HIDE/DESTROY here.
-     * Those events are system-wide and can fire for menus, tooltips,
-     * controls and other transient windows. Avoiding them prevents a
-     * synchronous SHAppBarMessage call on every such event.
+     * Determine the cursor monitor first. Each taskbar is evaluated
+     * independently below; an application on one display must never make
+     * another display's taskbar follow the same desktop state.
      */
-    if (
-        event == EVENT_SYSTEM_MINIMIZESTART ||
-        event == EVENT_SYSTEM_MINIMIZEEND
-    ) {
-        g_immediateHidePending.store(
-            true,
-            std::memory_order_release
-        );
-    }
+    int cursorMonitorNumber = 0;
+    HMONITOR cursorMonitor = nullptr;
 
-    RequestStateRefresh();
-}
+    POINT cursorPoint = {};
+    if (GetCursorPos(&cursorPoint)) {
+        MonitorList monitors = GetCurrentMonitors();
 
-
-// ============================================================
-// Worker thread
-// ============================================================
-
-bool InstallWinEventHookFor(
-    DWORD eventMin,
-    DWORD eventMax,
-    size_t index
-) {
-    if (index >= kMaxWinEventHooks) {
-        return false;
-    }
-
-    g_hWinEventHooks[index] =
-        SetWinEventHook(
-            eventMin,
-            eventMax,
-            nullptr,
-            WinEventProc,
-            0,
-            0,
-            WINEVENT_OUTOFCONTEXT
-        );
-
-    if (!g_hWinEventHooks[index]) {
-        Wh_Log(
-            L"SetWinEventHook(index=%zu, %lu, %lu) failed: %lu",
-            index,
-            eventMin,
-            eventMax,
-            GetLastError()
-        );
-
-        return false;
-    }
-
-    return true;
-}
-
-
-void UninstallWinEventHooks() {
-    for (size_t i = 0; i < kMaxWinEventHooks; i++) {
-        if (g_hWinEventHooks[i]) {
-            UnhookWinEvent(
-                g_hWinEventHooks[i]
+        cursorMonitor =
+            MonitorFromPoint(
+                cursorPoint,
+                MONITOR_DEFAULTTONEAREST
             );
 
-            g_hWinEventHooks[i] = nullptr;
-        }
-    }
-}
-
-
-DWORD WINAPI HookThread(LPVOID) {
-    /*
-     * Use real physical screen coordinates for mixed-DPI monitors.
-     */
-    SetThreadDpiAwarenessContext(
-        DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
-    );
-
-    /*
-     * Force creation of this thread's USER message queue before
-     * signalling readiness. This makes PostThreadMessageW safe.
-     */
-    MSG initialMessage = {};
-
-    PeekMessageW(
-        &initialMessage,
-        nullptr,
-        WM_USER,
-        WM_USER,
-        PM_NOREMOVE
-    );
-
-    if (g_hThreadReadyEvent) {
-        SetEvent(g_hThreadReadyEvent);
-    }
-
-    if (!CreateSystemMessageWindow()) {
-        Wh_Log(L"CreateSystemMessageWindow failed");
-    }
-
-    /*
-     * Only hook events that represent meaningful application-state
-     * transitions. In particular, do not hook EVENT_OBJECT_SHOW/HIDE/
-     * DESTROY because those are generated system-wide for large numbers
-     * of transient windows and controls.
-     */
-    bool hookOk = true;
-
-    hookOk &= InstallWinEventHookFor(
-        EVENT_SYSTEM_FOREGROUND,
-        EVENT_SYSTEM_FOREGROUND,
-        0
-    );
-
-    hookOk &= InstallWinEventHookFor(
-        EVENT_SYSTEM_MINIMIZESTART,
-        EVENT_SYSTEM_MINIMIZEEND,
-        1
-    );
-
-    hookOk &= InstallWinEventHookFor(
-        EVENT_SYSTEM_MOVESIZEEND,
-        EVENT_SYSTEM_MOVESIZEEND,
-        2
-    );
-
-    if (!hookOk) {
-        Wh_Log(
-            L"One or more WinEvent hooks failed"
-        );
-    }
-
-    /*
-     * Apply the correct initial state after the worker and hooks exist.
-     */
-    RefreshPerMonitorState();
-    UpdateTaskbarState();
-
-    MSG msg = {};
-
-    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
-        if (msg.message == WM_APP_STOP_THREAD) {
-            PostQuitMessage(0);
-            continue;
-        }
-
-        if (msg.message == WM_APP_REFRESH_STATE) {
-            g_refreshPosted.store(
-                false,
-                std::memory_order_release
+        cursorMonitorNumber =
+            GetMonitorNumber(
+                monitors,
+                cursorMonitor
             );
+    }
 
-            bool immediateHide =
-                g_immediateHidePending.exchange(
-                    false,
-                    std::memory_order_acq_rel
+    bool hovering =
+        cursorMonitorNumber != 0 &&
+        ShouldRevealOnHover(cursorMonitorNumber) &&
+        IsCursorNearBottomEdge(cursorMonitor);
+
+    /*
+     * Desktop/application state is already calculated independently for each
+     * monitor. Hover only affects the taskbar on the display under the cursor;
+     * all other taskbars retain their own state.
+     */
+    /*
+     * Keep the taskbar visible while a Windows shell flyout is open.
+     * This covers notification/calendar and quick-settings style surfaces
+     * without classifying ordinary application windows as shell UI.
+     */
+    /*
+     * Shell flyouts are local to the display under the cursor for the
+     * interaction model of this mod. Do not globally preempt the state of
+     * unrelated displays.
+     */
+    bool shellFlyoutOpen =
+        cursorMonitor &&
+        HasVisibleShellFlyoutOnMonitor(
+            cursorMonitor
+        );
+
+    if (shellFlyoutOpen) {
+        g_hideDeadline = 0;
+        g_shownDueToHover = false;
+        g_hoverMonitor = nullptr;
+
+        for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+            TaskbarMonitorState& state =
+                g_taskbarStates[i];
+
+            bool show =
+                state.monitor == cursorMonitor ||
+                !state.desktopOnly ||
+                !ShouldHideMonitor(
+                    state.monitorNumber
                 );
 
-            RefreshPerMonitorState();
+            SetTaskbarState(
+                state,
+                show
+            );
+        }
 
-            if (immediateHide) {
-                for (size_t i = 0; i < g_taskbarCount; ++i) {
-                    if (!g_taskbars[i].hasApplication) {
-                        /*
-                         * A minimize/restore event is an application-state
-                         * transition, not a taskbar hover. Do not let an
-                         * earlier hover reveal delay this hide.
-                         */
-                        g_taskbars[i].shownDueToHover = false;
-                        g_taskbars[i].shownDueToAltTab = false;
-                        g_taskbars[i].hideDeadline = 0;
+        return;
+    }
 
-                        /*
-                         * If Explorer reports Shell_TrayWnd as foreground
-                         * during the transition, it must not keep the
-                         * desktop taskbar visible.
-                         */
-                        g_taskbars[i].taskbarIsForeground = false;
-                    }
-                }
+    /*
+     * Alt+Tab/Task View is another shell interaction where hiding the
+     * taskbar underneath the switcher is undesirable.
+     */
+    if (IsAltTabActive()) {
+        g_hideDeadline = 0;
+        g_shownDueToHover = false;
+        g_hoverMonitor = nullptr;
+
+        for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+            SetTaskbarState(
+                g_taskbarStates[i],
+                true
+            );
+        }
+
+        return;
+    }
+
+    // Check taskbar-owned menus before hover so an actual right-click menu
+    // always wins over the generic bottom-edge hover state.
+    bool taskbarPopupOpen = false;
+
+    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+        if (
+            IsTaskbarPopupOpen(
+                g_taskbarStates[i].hwnd
+            ) ||
+            IsTaskbarShellPopupForeground(
+                g_taskbarStates[i].hwnd
+            )
+        ) {
+            taskbarPopupOpen = true;
+            break;
+        }
+    }
+
+    if (taskbarPopupOpen) {
+        g_hideDeadline = 0;
+        g_shownDueToHover = false;
+        g_hoverMonitor = nullptr;
+
+        /*
+         * Only keep the taskbar whose own popup is active visible.
+         * Other displays continue following their independent state.
+         */
+        for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+            TaskbarMonitorState& state =
+                g_taskbarStates[i];
+
+            bool ownPopup =
+                IsTaskbarPopupOpen(state.hwnd) ||
+                IsTaskbarShellPopupForeground(state.hwnd);
+
+            bool show =
+                ownPopup ||
+                !state.desktopOnly ||
+                !ShouldHideMonitor(
+                    state.monitorNumber
+                );
+
+            SetTaskbarState(
+                state,
+                show
+            );
+        }
+
+        return;
+    }
+
+    if (hovering) {
+        g_hideDeadline = 0;
+        g_shownDueToHover = true;
+        g_hoverMonitor = cursorMonitor;
+
+        for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+            TaskbarMonitorState& state =
+                g_taskbarStates[i];
+
+            bool show =
+                !state.desktopOnly ||
+                !ShouldHideMonitor(
+                    state.monitorNumber
+                ) ||
+                state.monitor == g_hoverMonitor;
+
+            SetTaskbarState(
+                state,
+                show
+            );
+        }
+
+        return;
+    }
+
+    if (g_shownDueToHover) {
+        ULONGLONG now = GetTickCount64();
+
+        /*
+         * A hover reveal belongs to one monitor. Crossing to another display
+         * cancels the old monitor's temporary hover ownership immediately.
+         */
+        if (
+            !g_hoverMonitor ||
+            cursorMonitor != g_hoverMonitor
+        ) {
+            for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+                TaskbarMonitorState& state =
+                    g_taskbarStates[i];
+
+                SetTaskbarState(
+                    state,
+                    !state.desktopOnly ||
+                    !ShouldHideMonitor(
+                        state.monitorNumber
+                    )
+                );
             }
 
-            UpdateTaskbarState();
-            continue;
+            g_hideDeadline = 0;
+            g_shownDueToHover = false;
+            g_hoverMonitor = nullptr;
+
+            return;
+        }
+
+        if (g_hideDeadline == 0) {
+            g_hideDeadline =
+                now +
+                settings.autoHideDelayMs;
         }
 
         if (
-            msg.message == WM_TIMER &&
-            msg.wParam == g_hoverTimerId
+            g_hideDeadline != 0 &&
+            now < g_hideDeadline
         ) {
-            /*
-             * The timer is only for cursor hover and hide deadlines.
-             * Application, shell-flyout and Alt+Tab state is refreshed
-             * by WinEvent/system-notification messages.
-             */
-            UpdateTaskbarState();
+            for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+                TaskbarMonitorState& state =
+                    g_taskbarStates[i];
 
-            continue;
+                bool show =
+                    !state.desktopOnly ||
+                    !ShouldHideMonitor(
+                        state.monitorNumber
+                    ) ||
+                    state.monitor == g_hoverMonitor;
+
+                SetTaskbarState(
+                    state,
+                    show
+                );
+            }
+
+            return;
         }
 
+        for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+            TaskbarMonitorState& state =
+                g_taskbarStates[i];
+
+            SetTaskbarState(
+                state,
+                !state.desktopOnly ||
+                !ShouldHideMonitor(
+                    state.monitorNumber
+                )
+            );
+        }
+
+        g_hideDeadline = 0;
+        g_shownDueToHover = false;
+        g_hoverMonitor = nullptr;
+        return;
+    }
+
+    /*
+     * Each taskbar now follows its own monitor's desktop/application state.
+     * Only selected displays are hidden while they are desktop-only.
+     */
+    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+        TaskbarMonitorState& state =
+            g_taskbarStates[i];
+
+        SetTaskbarState(
+            state,
+            !state.desktopOnly ||
+            !ShouldHideMonitor(
+                state.monitorNumber
+            )
+        );
+    }
+    g_hoverMonitor = nullptr;
+}
+
+
+void CALLBACK WinEventProc(HWINEVENTHOOK hWinEventHook, DWORD event,
+                            HWND hwnd, LONG idObject, LONG idChild,
+                            DWORD idEventThread, DWORD dwmsEventTime) {
+    if (idObject != OBJID_WINDOW || event != EVENT_SYSTEM_FOREGROUND) {
+        return;
+    }
+
+    // Quick, instant reaction for the common case (switching to a real
+    // window). The poll timer re-verifies everything ~10x/sec regardless,
+    // which is what reliably catches the minimize/close-last-window case.
+    RefreshDesktopState();
+    UpdateTaskbarState();
+}
+
+void CALLBACK TimerProc(HWND hwnd, UINT uMsg, UINT_PTR idEvent,
+                         DWORD dwTime) {
+    RefreshDesktopState();
+    UpdateTaskbarState();
+}
+
+// WINEVENT_OUTOFCONTEXT and a polling SetTimer both need a thread that
+// pumps messages, so we spin up a dedicated thread for this instead of
+// relying on whichever thread happens to call Wh_ModInit.
+DWORD WINAPI HookThread(LPVOID param) {
+    g_hWinEventHookForeground = SetWinEventHook(
+        EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND, nullptr,
+        WinEventProc, 0, 0, WINEVENT_OUTOFCONTEXT);
+
+    if (!g_hWinEventHookForeground) {
+        Wh_Log(L"SetWinEventHook(EVENT_SYSTEM_FOREGROUND) failed; using 100 ms polling fallback");
+    }
+
+    RefreshDesktopState();
+    UpdateTaskbarState();
+
+    const UINT kPollIntervalMs = 100;
+    UINT_PTR timerId = SetTimer(nullptr, 0, kPollIntervalMs, TimerProc);
+
+    MSG msg;
+    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
         TranslateMessage(&msg);
         DispatchMessageW(&msg);
     }
 
-    StopHoverTimer();
-
-    UninstallWinEventHooks();
-
-    /*
-     * Always restore the user's visible taskbars when the tool exits.
-     */
-    SetTaskbarVisibility(true);
-    DestroySystemMessageWindow();
-
-    g_refreshPosted.store(
-        false,
-        std::memory_order_release
-    );
-
-    g_immediateHidePending.store(
-        false,
-        std::memory_order_release
-    );
+    if (timerId) {
+        KillTimer(nullptr, timerId);
+    }
+    if (g_hWinEventHookForeground) {
+        UnhookWinEvent(g_hWinEventHookForeground);
+        g_hWinEventHookForeground = nullptr;
+    }
 
     return 0;
 }
 
-
-// ============================================================
-// Settings
-// ============================================================
-
 void LoadSettings() {
-    int margin =
+    int extraHoverMarginMm =
         Wh_GetIntSetting(
             L"extraHoverMarginMm"
         );
 
-    int delay =
+    if (extraHoverMarginMm < 0) {
+        extraHoverMarginMm = 0;
+    } else if (extraHoverMarginMm > 50) {
+        extraHoverMarginMm = 50;
+    }
+
+    settings.extraHoverMarginMm =
+        extraHoverMarginMm;
+
+    int autoHideDelayMs =
         Wh_GetIntSetting(
             L"autoHideDelayMs"
         );
 
-    if (delay < 0) {
-        delay = 0;
-    } else if (delay > 60000) {
-        delay = 60000;
+    if (autoHideDelayMs < 0) {
+        autoHideDelayMs = 0;
+    } else if (autoHideDelayMs > 10000) {
+        autoHideDelayMs = 10000;
     }
 
-    bool secondary =
-        Wh_GetIntSetting(
-            L"hideSecondaryTaskbars"
-        ) != 0;
+    settings.autoHideDelayMs =
+        static_cast<DWORD>(
+            autoHideDelayMs
+        );
 
-    if (margin < 0) {
-        margin = 0;
+    settings.hideAllMonitors = false;
+
+    for (
+        size_t i = 1;
+        i <= kMaxMonitorNumbers;
+        ++i
+    ) {
+        settings.hideMonitor[i] = false;
+        settings.hoverMonitor[i] = false;
     }
 
-    if (margin > 100) {
-        margin = 100;
+    settings.hoverAllMonitors = false;
+
+    bool foundSelection = false;
+
+    for (
+        size_t i = 0;
+        i < kMaxMonitorNumbers;
+        ++i
+    ) {
+        PCWSTR value =
+            Wh_GetStringSetting(
+                L"hideOnMonitors[%d]",
+                static_cast<int>(i)
+            );
+
+        if (!value || !*value) {
+            Wh_FreeStringSetting(value);
+            break;
+        }
+
+        foundSelection = true;
+
+        if (
+            wcscmp(
+                value,
+                L"all"
+            ) == 0
+        ) {
+            settings.hideAllMonitors = true;
+        } else if (
+            wcsncmp(
+                value,
+                L"monitor",
+                7
+            ) == 0
+        ) {
+            wchar_t* endNumber = nullptr;
+
+            long number =
+                wcstol(
+                    value + 7,
+                    &endNumber,
+                    10
+                );
+
+            if (
+                endNumber &&
+                *endNumber == L'\0' &&
+                number >= 1 &&
+                number <=
+                    static_cast<long>(
+                        kMaxMonitorNumbers
+                    )
+            ) {
+                settings.hideMonitor[number] = true;
+            }
+        }
+
+        Wh_FreeStringSetting(value);
     }
 
-    g_settings.extraHoverMarginMm.store(
-        margin,
-        std::memory_order_relaxed
-    );
+    if (!foundSelection) {
+        settings.hideAllMonitors = true;
+    }
 
-    g_settings.autoHideDelayMs.store(
-        static_cast<DWORD>(delay),
-        std::memory_order_relaxed
-    );
+    // Empty hover selection intentionally means disabled.
+    for (
+        size_t i = 0;
+        i < kMaxMonitorNumbers;
+        ++i
+    ) {
+        PCWSTR value =
+            Wh_GetStringSetting(
+                L"hoverRevealOnMonitors[%d]",
+                static_cast<int>(i)
+            );
 
-    g_settings.hideSecondaryTaskbars.store(
-        secondary,
-        std::memory_order_relaxed
-    );
+        if (!value || !*value) {
+            Wh_FreeStringSetting(value);
+            break;
+        }
+
+        if (
+            wcscmp(
+                value,
+                L"all"
+            ) == 0
+        ) {
+            settings.hoverAllMonitors = true;
+        } else if (
+            wcsncmp(
+                value,
+                L"monitor",
+                7
+            ) == 0
+        ) {
+            wchar_t* endNumber = nullptr;
+
+            long number =
+                wcstol(
+                    value + 7,
+                    &endNumber,
+                    10
+                );
+
+            if (
+                endNumber &&
+                *endNumber == L'\0' &&
+                number >= 1 &&
+                number <=
+                    static_cast<long>(
+                        kMaxMonitorNumbers
+                    )
+            ) {
+                settings.hoverMonitor[number] = true;
+            }
+        }
+
+        Wh_FreeStringSetting(value);
+    }
 }
 
-
-// ============================================================
-// Tool callbacks
-// ============================================================
-
-BOOL WhTool_ModInit() {
-    Wh_Log(
-        L"Hide Taskbar Only on Desktop: Init"
-    );
+// The mod is being initialized, load settings, hook functions, and do other
+// initialization stuff if required.
+BOOL Wh_ModInit() {
+    Wh_Log(L"Init");
 
     LoadSettings();
-
-    g_hThreadReadyEvent =
-        CreateEventW(
-            nullptr,
-            TRUE,
-            FALSE,
-            nullptr
-        );
-
-    if (!g_hThreadReadyEvent) {
-        Wh_Log(
-            L"CreateEvent failed: %lu",
-            GetLastError()
-        );
-
-        return FALSE;
-    }
 
     g_hThread =
         CreateThread(
@@ -2223,327 +1987,36 @@ BOOL WhTool_ModInit() {
         );
 
     if (!g_hThread) {
-        Wh_Log(
-            L"CreateThread failed: %lu",
-            GetLastError()
-        );
-
-        CloseHandle(g_hThreadReadyEvent);
-        g_hThreadReadyEvent = nullptr;
-
-        return FALSE;
-    }
-
-    /*
-     * Wait until the worker has created its message queue.
-     *
-     * The event handle remains valid until the worker is joined.
-     * This avoids a race where the worker could call SetEvent on a
-     * handle that the init thread already closed after a timeout.
-     */
-    DWORD result =
-        WaitForSingleObject(
-            g_hThreadReadyEvent,
-            5000
-        );
-
-    if (result != WAIT_OBJECT_0) {
-        Wh_Log(
-            L"Worker thread failed to become ready"
-        );
-
-        /*
-         * Ask the worker to stop using the same message queue that
-         * will later be used for normal refresh requests.
-         */
-        while (
-            !PostThreadMessageW(
-                g_threadId,
-                WM_APP_STOP_THREAD,
-                0,
-                0
-            )
-        ) {
-            if (
-                WaitForSingleObject(
-                    g_hThread,
-                    100
-                ) != WAIT_TIMEOUT
-            ) {
-                break;
-            }
-        }
-
-        WaitForSingleObject(
-            g_hThread,
-            INFINITE
-        );
-
-        CloseHandle(g_hThread);
-        g_hThread = nullptr;
-        g_threadId = 0;
-
-        CloseHandle(g_hThreadReadyEvent);
-        g_hThreadReadyEvent = nullptr;
-
+        Wh_Log(L"CreateThread failed");
         return FALSE;
     }
 
     return TRUE;
 }
 
-
-void WhTool_ModSettingsChanged() {
-    Wh_Log(
-        L"Hide Taskbar Only on Desktop: Settings changed"
-    );
-
-    LoadSettings();
-
-    /*
-     * Apply settings immediately instead of waiting for a timer tick.
-     * In particular, this restores secondary taskbars when the setting
-     * changes from ON to OFF while the desktop is already active.
-     */
-    RequestStateRefresh();
-}
-
-
-void WhTool_ModUninit() {
-    Wh_Log(
-        L"Hide Taskbar Only on Desktop: Uninit"
-    );
+// The mod is being unloaded, free all allocated resources.
+void Wh_ModUninit() {
+    Wh_Log(L"Uninit");
 
     if (g_hThread) {
-        /*
-         * Never unload the mod while the worker could still execute
-         * code from it. Use an application message which converts to
-         * PostQuitMessage on the worker thread.
-         */
-        while (
-            !PostThreadMessageW(
-                g_threadId,
-                WM_APP_STOP_THREAD,
-                0,
-                0
-            )
-        ) {
-            if (
-                WaitForSingleObject(
-                    g_hThread,
-                    100
-                ) != WAIT_TIMEOUT
-            ) {
-                break;
-            }
-        }
-
-        /*
-         * IMPORTANT:
-         * No finite timeout here. The module must remain mapped until
-         * the worker has completely stopped and removed its hooks.
-         */
-        WaitForSingleObject(
-            g_hThread,
-            INFINITE
-        );
-
+        PostThreadMessageW(g_threadId, WM_QUIT, 0, 0);
+        WaitForSingleObject(g_hThread, 3000);
         CloseHandle(g_hThread);
-
         g_hThread = nullptr;
-        g_threadId = 0;
     }
 
-    if (g_hThreadReadyEvent) {
-        CloseHandle(g_hThreadReadyEvent);
-        g_hThreadReadyEvent = nullptr;
-    }
-
+    // Always leave the taskbar visible when the mod is disabled/unloaded.
     /*
-     * Final restoration in case the worker exited through an unusual
-     * path. ShowWindow on an already-visible taskbar is harmless.
+     * Always restore every taskbar when the mod is unloaded. The state list
+     * may be empty if Explorer recreated the taskbar during shutdown, so also
+     * use the existing direct visibility helper as a fallback.
      */
     SetTaskbarVisibility(true);
 }
 
-
-////////////////////////////////////////////////////////////////////////////////
-// Windhawk tool mod implementation for mods which don't need to inject to other
-// processes or hook other functions. Context:
-// https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process
-//
-// The mod will load and run in a dedicated windhawk.exe process.
-//
-// Paste the code below as part of the mod code, and use these callbacks:
-// * WhTool_ModInit
-// * WhTool_ModSettingsChanged
-// * WhTool_ModUninit
-//
-// Currently, other callbacks are not supported.
-
-bool g_isToolModProcessLauncher;
-HANDLE g_toolModProcessMutex;
-
-void WINAPI EntryPoint_Hook() {
-    Wh_Log(L">");
-    ExitThread(0);
-}
-
-BOOL Wh_ModInit() {
-    DWORD sessionId;
-    if (ProcessIdToSessionId(GetCurrentProcessId(), &sessionId) &&
-        sessionId == 0) {
-        return FALSE;
-    }
-
-    bool isExcluded = false;
-    bool isToolModProcess = false;
-    bool isCurrentToolModProcess = false;
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);
-
-    if (!argv) {
-        Wh_Log(L"CommandLineToArgvW failed");
-        return FALSE;
-    }
-
-    for (int i = 1; i < argc; i++) {
-        if (wcscmp(argv[i], L"-service") == 0 ||
-            wcscmp(argv[i], L"-service-start") == 0 ||
-            wcscmp(argv[i], L"-service-stop") == 0) {
-            isExcluded = true;
-            break;
-        }
-    }
-
-    for (int i = 1; i < argc - 1; i++) {
-        if (wcscmp(argv[i], L"-tool-mod") == 0) {
-            isToolModProcess = true;
-            if (wcscmp(argv[i + 1], WH_MOD_ID) == 0) {
-                isCurrentToolModProcess = true;
-            }
-            break;
-        }
-    }
-
-    LocalFree(argv);
-
-    if (isExcluded) {
-        return FALSE;
-    }
-
-    if (isCurrentToolModProcess) {
-        g_toolModProcessMutex =
-            CreateMutex(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
-
-        if (!g_toolModProcessMutex) {
-            Wh_Log(L"CreateMutex failed");
-            ExitProcess(1);
-        }
-
-        if (GetLastError() == ERROR_ALREADY_EXISTS) {
-            Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
-            ExitProcess(1);
-        }
-
-        if (!WhTool_ModInit()) {
-            ExitProcess(1);
-        }
-
-        IMAGE_DOS_HEADER* dosHeader =
-            (IMAGE_DOS_HEADER*)GetModuleHandle(nullptr);
-        IMAGE_NT_HEADERS* ntHeaders =
-            (IMAGE_NT_HEADERS*)((BYTE*)dosHeader + dosHeader->e_lfanew);
-
-        DWORD entryPointRVA = ntHeaders->OptionalHeader.AddressOfEntryPoint;
-        void* entryPoint = (BYTE*)dosHeader + entryPointRVA;
-
-        Wh_SetFunctionHook(entryPoint, (void*)EntryPoint_Hook, nullptr);
-        return TRUE;
-    }
-
-    if (isToolModProcess) {
-        return FALSE;
-    }
-
-    g_isToolModProcessLauncher = true;
-    return TRUE;
-}
-
-void Wh_ModAfterInit() {
-    if (!g_isToolModProcessLauncher) {
-        return;
-    }
-
-    WCHAR currentProcessPath[MAX_PATH];
-    switch (GetModuleFileName(nullptr, currentProcessPath,
-                              ARRAYSIZE(currentProcessPath))) {
-        case 0:
-        case ARRAYSIZE(currentProcessPath):
-            Wh_Log(L"GetModuleFileName failed");
-            return;
-    }
-
-    WCHAR
-    commandLine[MAX_PATH + 2 +
-                (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
-    swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
-               WH_MOD_ID);
-
-    HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
-    if (!kernelModule) {
-        kernelModule = GetModuleHandle(L"kernel32.dll");
-        if (!kernelModule) {
-            Wh_Log(L"No kernelbase.dll/kernel32.dll");
-            return;
-        }
-    }
-
-    using CreateProcessInternalW_t = BOOL(WINAPI*)(
-        HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
-        LPSECURITY_ATTRIBUTES lpProcessAttributes,
-        LPSECURITY_ATTRIBUTES lpThreadAttributes, WINBOOL bInheritHandles,
-        DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory,
-        LPSTARTUPINFOW lpStartupInfo,
-        LPPROCESS_INFORMATION lpProcessInformation,
-        PHANDLE hRestrictedUserToken);
-    CreateProcessInternalW_t pCreateProcessInternalW =
-        (CreateProcessInternalW_t)GetProcAddress(kernelModule,
-                                                 "CreateProcessInternalW");
-    if (!pCreateProcessInternalW) {
-        Wh_Log(L"No CreateProcessInternalW");
-        return;
-    }
-
-    STARTUPINFO si{
-        .cb = sizeof(STARTUPINFO),
-        .dwFlags = STARTF_FORCEOFFFEEDBACK,
-    };
-    PROCESS_INFORMATION pi;
-    if (!pCreateProcessInternalW(nullptr, currentProcessPath, commandLine,
-                                 nullptr, nullptr, FALSE, NORMAL_PRIORITY_CLASS,
-                                 nullptr, nullptr, &si, &pi, nullptr)) {
-        Wh_Log(L"CreateProcess failed");
-        return;
-    }
-
-    CloseHandle(pi.hProcess);
-    CloseHandle(pi.hThread);
-}
-
+// The mod settings were changed, reload them.
 void Wh_ModSettingsChanged() {
-    if (g_isToolModProcessLauncher) {
-        return;
-    }
+    Wh_Log(L"SettingsChanged");
 
-    WhTool_ModSettingsChanged();
-}
-
-void Wh_ModUninit() {
-    if (g_isToolModProcessLauncher) {
-        return;
-    }
-
-    WhTool_ModUninit();
-    ExitProcess(0);
+    LoadSettings();
 }

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -1,12 +1,11 @@
 // ==WindhawkMod==
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
-// @description     Hides selected taskbars only while their display is showing the desktop
-// @version         4.6.0
+// @description     Desktop-only taskbar hiding using a dedicated Windhawk tool process
+// @version         5.0.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
-// @include         explorer.exe
 // @compilerOptions -ldwmapi
 // ==/WindhawkMod==
 
@@ -105,32 +104,21 @@ Known shell window classes and the relevant Windows shell processes are consider
 
 Shell interaction detection is handled separately from the normal application-window check.
 
-## Explorer Integration
+## Taskbar Visibility
 
-The mod includes a small Explorer-side protection for a specific taskbar visibility transition.
+The taskbar is hidden by adding `WS_EX_LAYERED` and setting its alpha to `0` with `SetLayeredWindowAttributes`. This makes the taskbar fully transparent without changing its normal `ShowWindow` visibility state.
 
-When a secondary taskbar has been hidden by the mod, Windows Explorer may independently attempt to show that taskbar using `ShowWindow(..., SW_SHOWNA)`.
+The transparency approach keeps the taskbar window alive while removing its visible presentation. This allows the dedicated Windhawk tool process to manage taskbar visibility without injecting a `ShowWindow` hook or maintaining an Explorer-side taskbar visibility hook.
 
-The mod blocks that specific transition only while the taskbar is still owned by a running instance of the mod's dedicated tool process.
+The visibility mechanism is intentionally separate from the desktop/application-state decision logic. The display selection, shell interaction handling, hover reveal, taskbar recreation, and event-driven refresh logic remain unchanged.
 
-The protection is intentionally narrow:
+### Transparency Recovery and State Ownership
 
-- It applies only to the secondary taskbar.
-- It applies only to a taskbar marked as hidden by this mod.
-- It applies only to the `SW_SHOWNA` transition.
-- Other Explorer `ShowWindow` calls are passed through normally.
+The dedicated tool process keeps ownership of taskbars it makes transparent in its local taskbar state. A taskbar is restored to normal opacity and has `WS_EX_LAYERED` removed when the mod decides that it should be visible and during normal tool-process shutdown.
 
-This prevents a brief secondary-taskbar flash while leaving unrelated Explorer window behavior unchanged.
+If the taskbar window is recreated, the new window is rediscovered and evaluated again by the same per-display state logic.
 
-### Failure Recovery
-
-The taskbar ownership marker contains the process ID and creation time of the dedicated tool process that hid the taskbar.
-
-If that process is no longer running, the Explorer-side check removes the stale marker and restores the taskbar through Explorer's normal `ShowWindow` path.
-
-This prevents an unexpected tool-process termination from leaving a taskbar hidden or permanently blocking Explorer from restoring it.
-
-Stale hidden-taskbar state is also checked during Explorer initialization and by a low-frequency Explorer-side recovery check for both primary and secondary taskbars.
+The mod runs as a dedicated `windhawk.exe` tool-mod process. The normal Windhawk instance acts as the launcher, while the taskbar-state logic runs in a separate Windhawk process instance. No `ShowWindow` hook or taskbar-show hook is used.
 
 ## Multi-Monitor Example
 
@@ -167,13 +155,9 @@ Display identity is tracked using monitor/device information rather than relying
 
 ## Taskbar Ownership
 
-The mod tracks whether a taskbar was actually hidden by the mod.
+The mod tracks whether a taskbar has been transparent by its own taskbar-state logic.
 
-This prevents the mod from unnecessarily restoring or changing taskbar visibility that it did not cause itself.
-
-Ownership is also associated with the dedicated tool process so that stale ownership can be detected after an unexpected process termination.
-
-When the owning tool process is no longer running, stale ownership can be cleared and the affected taskbar can recover through Explorer's normal visibility path.
+This prevents the mod from unnecessarily restoring or changing a taskbar that it did not make transparent. Ownership is local to the dedicated tool process because the mod does not use a cross-process Explorer marker.
 
 ## Performance
 
@@ -187,11 +171,11 @@ The mod uses:
 - A periodic safety poll for missed or unusual transitions
 - A one-shot timer for hover dismissal
 
-The Explorer-side hook performs only the narrow visibility check required for secondary-taskbar flash prevention. A separate low-frequency Explorer recovery thread only checks for stale mod-owned taskbar state and does not participate in normal taskbar visibility decisions.
+The dedicated `windhawk.exe` tool process performs taskbar visibility changes directly through layered-window transparency. No separate Explorer-side `ShowWindow` or taskbar-show hook is used, and no second recovery thread runs in the launcher instance.
 
 Cursor sampling backs off when hover tracking is not needed and also backs off after repeated cursor-position failures.
 
-The periodic safety poll provides a recovery path for missed or unusual transitions. The current implementation uses a fixed short polling interval; this may be optimized further in a future revision.
+The periodic safety poll provides a recovery path for missed or unusual transitions. The implementation intentionally retains the existing 250 ms interval.
 
 ## Limitations
 
@@ -346,8 +330,6 @@ struct WindowScanResult {
 HWINEVENTHOOK g_foregroundHook = nullptr;
 HWINEVENTHOOK g_minimizeHook = nullptr;
 HWINEVENTHOOK g_moveHook = nullptr;
-HWINEVENTHOOK g_taskbarShowHook = nullptr;
-DWORD g_taskbarShowHookProcessId = 0;
 
 HANDLE g_workerThread = nullptr;
 DWORD g_workerThreadId = 0;
@@ -366,337 +348,99 @@ CursorHoverSnapshot g_cursorHoverSnapshots[kMaxTaskbars] = {};
 size_t g_cursorHoverSnapshotCount = 0;
 SRWLOCK g_cursorHoverSnapshotLock = SRWLOCK_INIT;
 
-constexpr wchar_t kHiddenByModProperty[] =
-    L"Windhawk.HideTaskbarOnlyOnDesktop.HiddenByMod";
-constexpr wchar_t kHiddenByModCreationTimeLowProperty[] =
-    L"Windhawk.HideTaskbarOnlyOnDesktop.HiddenByMod.CreationTimeLow";
-constexpr wchar_t kHiddenByModCreationTimeHighProperty[] =
-    L"Windhawk.HideTaskbarOnlyOnDesktop.HiddenByMod.CreationTimeHigh";
-
-// Explorer-side protection for the secondary-taskbar shell transition.
-// The dedicated tool process remains authoritative for taskbar state. Explorer
-// only consults the per-window property and blocks SW_SHOWNA for an explicitly
-// hidden secondary taskbar while its owning tool process is still alive.
-using ShowWindow_t = decltype(&ShowWindow);
-ShowWindow_t g_explorerShowWindowOriginal = nullptr;
-bool g_isExplorerProcess = false;
-
-DWORD g_hiddenTaskbarOwnerPid = 0;
-HANDLE g_hiddenTaskbarOwnerProcess = nullptr;
-FILETIME g_hiddenTaskbarOwnerCreationTime = {};
-HANDLE g_explorerRecoveryThread = nullptr;
-HANDLE g_explorerRecoveryStopEvent = nullptr;
-SRWLOCK g_hiddenTaskbarOwnerCacheLock = SRWLOCK_INIT;
-
-bool GetProcessCreationTime(
-    HANDLE process,
-    FILETIME* creationTime
-) {
-    if (!process || !creationTime) {
+// A layered window with alpha 0 is used as the physical taskbar visibility
+// mechanism. The taskbar state machine remains in the dedicated
+// Explorer tool process.
+bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
+    if (!hwnd || !IsWindow(hwnd)) {
         return false;
     }
 
-    FILETIME exitTime = {};
-    FILETIME kernelTime = {};
-    FILETIME userTime = {};
-
-    return GetProcessTimes(
-        process,
-        creationTime,
-        &exitTime,
-        &kernelTime,
-        &userTime
-    ) != FALSE;
-}
-
-void RecoverStaleHiddenTaskbars();
-bool SetHiddenTaskbarOwnershipMarker(HWND hwnd);
-void RemoveHiddenTaskbarOwnershipMarker(HWND hwnd);
-void RestoreHiddenTaskbarOwnershipMarker(HWND hwnd);
-
-void ResetHiddenTaskbarOwnerCache() {
-    AcquireSRWLockExclusive(
-        &g_hiddenTaskbarOwnerCacheLock
-    );
-
-    if (g_hiddenTaskbarOwnerProcess) {
-        CloseHandle(
-            g_hiddenTaskbarOwnerProcess
-        );
-        g_hiddenTaskbarOwnerProcess = nullptr;
-    }
-
-    g_hiddenTaskbarOwnerPid = 0;
-    g_hiddenTaskbarOwnerCreationTime = {};
-
-    ReleaseSRWLockExclusive(
-        &g_hiddenTaskbarOwnerCacheLock
-    );
-}
-
-bool IsExplorerTaskbar(HWND hwnd) {
-    if (!hwnd) {
+    LONG_PTR exStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+    if (exStyle == 0 && GetLastError() != ERROR_SUCCESS) {
         return false;
     }
 
-    WCHAR className[128] = {};
-
-    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
-        return false;
-    }
-
-    return wcscmp(className, L"Shell_TrayWnd") == 0 ||
-           wcscmp(className, L"Shell_SecondaryTrayWnd") == 0;
-}
-
-bool IsExplorerSecondaryTaskbar(HWND hwnd) {
-    if (!hwnd) {
-        return false;
-    }
-
-    WCHAR className[128] = {};
-
-    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
-        return false;
-    }
-
-    return wcscmp(className, L"Shell_SecondaryTrayWnd") == 0;
-}
-
-bool IsHiddenTaskbarOwnerAlive(HWND hwnd) {
-    if (!IsExplorerTaskbar(hwnd)) {
-        return false;
-    }
-
-    HANDLE marker = GetPropW(hwnd, kHiddenByModProperty);
-    if (!marker) {
-        return false;
-    }
-
-    DWORD ownerPid = static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(marker));
-
-    const bool hasCreationTime =
-        GetPropW(hwnd, kHiddenByModCreationTimeLowProperty) != nullptr &&
-        GetPropW(hwnd, kHiddenByModCreationTimeHighProperty) != nullptr;
-
-    FILETIME markerCreationTime = {};
-    markerCreationTime.dwLowDateTime =
-        static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(
-            GetPropW(hwnd, kHiddenByModCreationTimeLowProperty)));
-    markerCreationTime.dwHighDateTime =
-        static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(
-            GetPropW(hwnd, kHiddenByModCreationTimeHighProperty)));
-
-
-    if (!ownerPid) {
-        RemovePropW(hwnd, kHiddenByModProperty);
-        RemovePropW(hwnd, kHiddenByModCreationTimeLowProperty);
-        RemovePropW(hwnd, kHiddenByModCreationTimeHighProperty);
-        return false;
-    }
-
-    bool ownerAlive = false;
-
-    AcquireSRWLockExclusive(&g_hiddenTaskbarOwnerCacheLock);
-
-    if (ownerPid != g_hiddenTaskbarOwnerPid) {
-        if (g_hiddenTaskbarOwnerProcess) {
-            CloseHandle(g_hiddenTaskbarOwnerProcess);
-            g_hiddenTaskbarOwnerProcess = nullptr;
-        }
-
-        g_hiddenTaskbarOwnerPid = ownerPid;
-        g_hiddenTaskbarOwnerCreationTime = {};
-        g_hiddenTaskbarOwnerProcess =
-            OpenProcess(
-                SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION,
-                FALSE,
-                ownerPid
+    if (hide) {
+        if (!SetWindowLongPtrW(
+                hwnd,
+                GWL_EXSTYLE,
+                exStyle | WS_EX_LAYERED
+            )) {
+            Wh_Log(
+                L"SetWindowLongPtrW(GWL_EXSTYLE, WS_EX_LAYERED) failed for 0x%p: %lu",
+                hwnd,
+                GetLastError()
             );
+            return false;
+        }
 
-        if (g_hiddenTaskbarOwnerProcess) {
-            GetProcessCreationTime(
-                g_hiddenTaskbarOwnerProcess,
-                &g_hiddenTaskbarOwnerCreationTime
+        if (!SetLayeredWindowAttributes(
+                hwnd,
+                0,
+                0,
+                LWA_ALPHA
+            )) {
+            Wh_Log(
+                L"SetLayeredWindowAttributes(alpha=0) failed for 0x%p: %lu",
+                hwnd,
+                GetLastError()
             );
-        }
-    }
-
-    ownerAlive =
-        g_hiddenTaskbarOwnerProcess &&
-        WaitForSingleObject(g_hiddenTaskbarOwnerProcess, 0) == WAIT_TIMEOUT;
-
-    if (ownerAlive && !hasCreationTime) {
-        // Markers created by older versions contained only a PID. Treat them
-        // as stale once this version is running so a reused PID cannot inherit
-        // hidden-taskbar ownership accidentally. The tool process will rebuild
-        // the marker if the taskbar still needs to remain hidden.
-        ownerAlive = false;
-    } else if (
-        ownerAlive &&
-        CompareFileTime(
-            &markerCreationTime,
-            &g_hiddenTaskbarOwnerCreationTime
-        ) != 0
-    ) {
-        ownerAlive = false;
-    }
-
-
-    if (!ownerAlive) {
-        RemovePropW(hwnd, kHiddenByModProperty);
-        RemovePropW(hwnd, kHiddenByModCreationTimeLowProperty);
-        RemovePropW(hwnd, kHiddenByModCreationTimeHighProperty);
-
-        if (g_hiddenTaskbarOwnerProcess) {
-            CloseHandle(g_hiddenTaskbarOwnerProcess);
-            g_hiddenTaskbarOwnerProcess = nullptr;
+            return false;
         }
 
-        g_hiddenTaskbarOwnerPid = 0;
-        g_hiddenTaskbarOwnerCreationTime = {};
-    }
-
-    ReleaseSRWLockExclusive(&g_hiddenTaskbarOwnerCacheLock);
-
-    return ownerAlive;
-}
-
-
-void RecoverStaleHiddenTaskbar(HWND hwnd) {
-    if (!IsExplorerTaskbar(hwnd) ||
-        !GetPropW(hwnd, kHiddenByModProperty)) {
-        return;
-    }
-
-
-    if (IsHiddenTaskbarOwnerAlive(hwnd)) {
-        return;
-    }
-
-
-    if (g_explorerShowWindowOriginal) {
-        RemoveHiddenTaskbarOwnershipMarker(hwnd);
-        g_explorerShowWindowOriginal(hwnd, SW_SHOWNA);
-    }
-}
-
-void RecoverStaleHiddenTaskbars() {
-    RecoverStaleHiddenTaskbar(FindWindowW(L"Shell_TrayWnd", nullptr));
-
-    HWND secondary = nullptr;
-
-    while ((secondary = FindWindowExW(
-                nullptr,
-                secondary,
-                L"Shell_SecondaryTrayWnd",
-                nullptr)) != nullptr) {
-        RecoverStaleHiddenTaskbar(secondary);
-    }
-}
-
-DWORD WINAPI ExplorerRecoveryThread(LPVOID) {
-    constexpr DWORD kRecoveryCheckIntervalMs = 1000;
-
-    for (;;) {
-        DWORD result = WaitForSingleObject(
-            g_explorerRecoveryStopEvent,
-            kRecoveryCheckIntervalMs
+        SetWindowPos(
+            hwnd,
+            nullptr,
+            0, 0, 0, 0,
+            SWP_NOMOVE |
+            SWP_NOSIZE |
+            SWP_NOZORDER |
+            SWP_NOACTIVATE |
+            SWP_FRAMECHANGED
         );
 
-        if (result != WAIT_TIMEOUT) {
-            break;
-        }
-
-        RecoverStaleHiddenTaskbars();
+        return true;
     }
 
-    return 0;
-}
-
-bool StartExplorerRecoveryThread() {
-    g_explorerRecoveryStopEvent =
-        CreateEventW(nullptr, TRUE, FALSE, nullptr);
-
-    if (!g_explorerRecoveryStopEvent) {
-        Wh_Log(L"CreateEventW(explorer recovery) failed: %lu", GetLastError());
-        return false;
-    }
-
-    g_explorerRecoveryThread = CreateThread(
-        nullptr,
-        0,
-        ExplorerRecoveryThread,
-        nullptr,
-        0,
-        nullptr
-    );
-
-    if (!g_explorerRecoveryThread) {
-        Wh_Log(L"CreateThread(explorer recovery) failed: %lu", GetLastError());
-        CloseHandle(g_explorerRecoveryStopEvent);
-        g_explorerRecoveryStopEvent = nullptr;
-        return false;
-    }
-
-    return true;
-}
-
-void StopExplorerRecoveryThread() {
-    if (g_explorerRecoveryStopEvent) {
-        SetEvent(g_explorerRecoveryStopEvent);
-    }
-
-    if (g_explorerRecoveryThread) {
-        // The thread is executing code from the injected module, so it must be
-        // fully stopped before Explorer unloads the mod.
-        WaitForSingleObject(g_explorerRecoveryThread, INFINITE);
-        CloseHandle(g_explorerRecoveryThread);
-        g_explorerRecoveryThread = nullptr;
-    }
-
-    if (g_explorerRecoveryStopEvent) {
-        CloseHandle(g_explorerRecoveryStopEvent);
-        g_explorerRecoveryStopEvent = nullptr;
-    }
-}
-
-BOOL WINAPI ExplorerShowWindowHook(HWND hwnd, int nCmdShow) {
-    if (nCmdShow == SW_SHOWNA && IsExplorerTaskbar(hwnd)) {
-        const bool marked =
-            GetPropW(hwnd, kHiddenByModProperty) != nullptr;
-
-        if (marked) {
-            const bool ownerAlive = IsHiddenTaskbarOwnerAlive(hwnd);
-
-            if (!ownerAlive && g_explorerShowWindowOriginal) {
-                RemoveHiddenTaskbarOwnershipMarker(hwnd);
-                return g_explorerShowWindowOriginal(hwnd, SW_SHOWNA);
-            }
-
-            if (ownerAlive && IsExplorerSecondaryTaskbar(hwnd)) {
-                return FALSE;
-            }
-        }
-    }
-
-    return g_explorerShowWindowOriginal(hwnd, nCmdShow);
-}
-
-bool InstallExplorerVisibilityHook() {
-
-    if (
-        !WindhawkUtils::SetFunctionHook(
-            ShowWindow,
-            ExplorerShowWindowHook,
-            &g_explorerShowWindowOriginal
-        )
-    ) {
+    // Restore full opacity before removing WS_EX_LAYERED.
+    if (!SetLayeredWindowAttributes(
+            hwnd,
+            0,
+            255,
+            LWA_ALPHA
+        )) {
         Wh_Log(
-            L"Failed to hook Explorer ShowWindow"
+            L"SetLayeredWindowAttributes(alpha=255) failed for 0x%p: %lu",
+            hwnd,
+            GetLastError()
         );
         return false;
     }
+
+    if (!SetWindowLongPtrW(
+            hwnd,
+            GWL_EXSTYLE,
+            exStyle & ~static_cast<LONG_PTR>(WS_EX_LAYERED)
+        )) {
+        Wh_Log(
+            L"SetWindowLongPtrW(remove WS_EX_LAYERED) failed for 0x%p: %lu",
+            hwnd,
+            GetLastError()
+        );
+        return false;
+    }
+
+    SetWindowPos(
+        hwnd,
+        nullptr,
+        0, 0, 0, 0,
+        SWP_NOMOVE |
+        SWP_NOSIZE |
+        SWP_NOZORDER |
+        SWP_NOACTIVATE |
+        SWP_FRAMECHANGED
+    );
 
     return true;
 }
@@ -1487,18 +1231,18 @@ bool IsApplicationWindowCandidate(
         return false;
     }
 
-    BOOL cloaked = FALSE;
+    BOOL transparent = FALSE;
 
     if (
         SUCCEEDED(
             DwmGetWindowAttribute(
                 hwnd,
                 DWMWA_CLOAKED,
-                &cloaked,
-                sizeof(cloaked)
+                &transparent,
+                sizeof(transparent)
             )
         ) &&
-        cloaked
+        transparent
     ) {
         return false;
     }
@@ -1668,7 +1412,7 @@ void ScanWindowsOnce(
             ) &&
             !IsShellChromeClass(className)
         ) {
-            BOOL cloaked = FALSE;
+            BOOL transparent = FALSE;
 
             if (
                 !(
@@ -1676,11 +1420,11 @@ void ScanWindowsOnce(
                         DwmGetWindowAttribute(
                             foreground,
                             DWMWA_CLOAKED,
-                            &cloaked,
-                            sizeof(cloaked)
+                            &transparent,
+                            sizeof(transparent)
                         )
                     ) &&
-                    cloaked
+                    transparent
                 )
             ) {
                 HMONITOR foregroundMonitor =
@@ -1764,11 +1508,7 @@ void RefreshTaskbarMonitorStates(
         }
 
         state.desktopOnly = true;
-        state.hiddenByMod =
-            GetPropW(
-                hwnd,
-                kHiddenByModProperty
-            ) != nullptr;
+        state.hiddenByMod = false;
 
         for (size_t i = 0; i < oldCount; ++i) {
             if (oldStates[i].hwnd == hwnd) {
@@ -1829,78 +1569,6 @@ bool ShouldHideTaskbar(
 }
 
 
-bool SetHiddenTaskbarOwnershipMarker(HWND hwnd) {
-    if (!hwnd) {
-        return false;
-    }
-
-    FILETIME creationTime = {};
-    if (!GetProcessCreationTime(
-            GetCurrentProcess(),
-            &creationTime
-        )) {
-        Wh_Log(L"GetProcessTimes(current process) failed: %lu", GetLastError());
-        return SetPropW(
-            hwnd,
-            kHiddenByModProperty,
-            reinterpret_cast<HANDLE>(
-                static_cast<ULONG_PTR>(GetCurrentProcessId())
-            )
-        ) != FALSE;
-    }
-
-    const bool pidSet = SetPropW(
-        hwnd,
-        kHiddenByModProperty,
-        reinterpret_cast<HANDLE>(
-            static_cast<ULONG_PTR>(GetCurrentProcessId())
-        )
-    ) != FALSE;
-
-    const bool lowSet = SetPropW(
-        hwnd,
-        kHiddenByModCreationTimeLowProperty,
-        reinterpret_cast<HANDLE>(
-            static_cast<ULONG_PTR>(creationTime.dwLowDateTime)
-        )
-    ) != FALSE;
-
-    const bool highSet = SetPropW(
-        hwnd,
-        kHiddenByModCreationTimeHighProperty,
-        reinterpret_cast<HANDLE>(
-            static_cast<ULONG_PTR>(creationTime.dwHighDateTime)
-        )
-    ) != FALSE;
-
-    if (!pidSet || !lowSet || !highSet) {
-        Wh_Log(L"Set hidden taskbar ownership metadata failed for 0x%p: %lu",
-               hwnd, GetLastError());
-        RemovePropW(hwnd, kHiddenByModCreationTimeLowProperty);
-        RemovePropW(hwnd, kHiddenByModCreationTimeHighProperty);
-    }
-
-    return pidSet;
-}
-
-void RemoveHiddenTaskbarOwnershipMarker(HWND hwnd) {
-    if (!hwnd) {
-        return;
-    }
-
-    RemovePropW(hwnd, kHiddenByModProperty);
-    RemovePropW(hwnd, kHiddenByModCreationTimeLowProperty);
-    RemovePropW(hwnd, kHiddenByModCreationTimeHighProperty);
-}
-
-void RestoreHiddenTaskbarOwnershipMarker(HWND hwnd) {
-    if (!hwnd) {
-        return;
-    }
-
-    SetHiddenTaskbarOwnershipMarker(hwnd);
-}
-
 void SetTaskbarState(
     TaskbarMonitorState& state,
     bool show
@@ -1917,58 +1585,25 @@ void SetTaskbarState(
             return;
         }
 
-        // Clear our ownership marker before showing so Explorer is never left
-        // with a hidden taskbar that still looks owned by this mod. Keep the
-        // normal transition synchronous so Explorer cannot queue a stale SHOW
-        // behind our state reconciliation.
-        RemoveHiddenTaskbarOwnershipMarker(state.hwnd);
-
-        ShowWindow(
-            state.hwnd,
-            SW_SHOWNA
-        );
-
-        if (IsWindowVisible(state.hwnd)) {
+        if (MakeTaskbarTransparent(state.hwnd, false)) {
             state.hiddenByMod = false;
-        } else {
-            // Restore the marker if the show operation did not make the taskbar
-            // visible. This keeps ownership explicit rather than leaving a
-            // silently hidden, unowned taskbar behind.
-            RestoreHiddenTaskbarOwnershipMarker(state.hwnd);
-            state.hiddenByMod = true;
         }
 
         return;
     }
 
-    if (!IsWindowVisible(state.hwnd)) {
-        state.hiddenByMod =
-            state.hiddenByMod ||
-            GetPropW(
-                state.hwnd,
-                kHiddenByModProperty
-            ) != nullptr;
+    if (state.hiddenByMod) {
         return;
     }
 
-    if (!SetHiddenTaskbarOwnershipMarker(state.hwnd)) {
-        Wh_Log(
-            L"Set hidden taskbar ownership marker failed for 0x%p: %lu",
-            state.hwnd,
-            GetLastError()
-        );
+    // Do not take ownership of a taskbar that is already hidden by another
+    // mechanism. The mod tracks its own transparency state separately.
+    if (!IsWindowVisible(state.hwnd)) {
+        return;
     }
 
-    ShowWindow(
-        state.hwnd,
-        SW_HIDE
-    );
-
-    if (!IsWindowVisible(state.hwnd)) {
+    if (MakeTaskbarTransparent(state.hwnd, true)) {
         state.hiddenByMod = true;
-    } else {
-        RemoveHiddenTaskbarOwnershipMarker(state.hwnd);
-        state.hiddenByMod = false;
     }
 }
 
@@ -2340,9 +1975,6 @@ void UpdateTaskbarState() {
 
     g_displayTopologySignature = topologySignature;
 
-    for (size_t i = 0; i < monitors.count; ++i) {
-    }
-
     BindConfiguredMonitorSelections(
         monitors
     );
@@ -2569,27 +2201,6 @@ void CancelHoverExpireTimer() {
     }
 }
 
-bool IsTaskbarWindow(HWND hwnd) {
-    if (!hwnd || !IsWindow(hwnd)) {
-        return false;
-    }
-
-    WCHAR className[128] = {};
-
-    if (
-        GetClassNameW(
-            hwnd,
-            className,
-            ARRAYSIZE(className)
-        ) == 0
-    ) {
-        return false;
-    }
-
-    return
-        wcscmp(className, L"Shell_TrayWnd") == 0 ||
-        wcscmp(className, L"Shell_SecondaryTrayWnd") == 0;
-}
 
 bool IsCursorInConfiguredHoverZoneAtPoint(
     POINT pt,
@@ -2776,97 +2387,19 @@ DWORD WINAPI CursorSamplingThread(LPVOID) {
 void CALLBACK WinEventProc(
     HWINEVENTHOOK,
     DWORD event,
-    HWND hwnd,
-    LONG idObject,
+    HWND,
+    LONG,
     LONG,
     DWORD,
     DWORD
 ) {
-    /*
-     * Explorer can re-show a secondary taskbar while the user interacts with
-     * the primary taskbar or other shell UI. Handle only SHOW for the exact
-     * taskbar window classes. The callback never changes Explorer windows
-     * directly; it only schedules the serialized worker update. We intentionally
-     * do not watch HIDE.
-     */
     if (
-        event == EVENT_OBJECT_SHOW &&
-        idObject == OBJID_WINDOW &&
-        IsTaskbarWindow(hwnd)
+        event == EVENT_SYSTEM_FOREGROUND ||
+        event == EVENT_SYSTEM_MINIMIZESTART ||
+        event == EVENT_SYSTEM_MINIMIZEEND ||
+        event == EVENT_SYSTEM_MOVESIZEEND
     ) {
-        /*
-         * While the cursor is already inside the configured hover zone,
-         * Explorer may emit SHOW for more than one taskbar during the same
-         * shell transition. The worker's hover calculation is authoritative,
-         * so don't enqueue an additional refresh that can immediately undo
-         * and repeat the hover visibility transition.
-         *
-         * Outside the hover zone the narrow SHOW hook is retained so an
-         * Explorer re-show is reconciled promptly.
-         */
-        if (IsCursorInConfiguredHoverZone()) {
-            return;
-        }
-
         PostRefresh();
-        return;
-    }
-
-    if (event == EVENT_SYSTEM_FOREGROUND) {
-        PostRefresh();
-        return;
-    }
-
-    if (
-        event != EVENT_SYSTEM_MINIMIZESTART &&
-        event != EVENT_SYSTEM_MINIMIZEEND &&
-        event != EVENT_SYSTEM_MOVESIZEEND
-    ) {
-        return;
-    }
-
-    PostRefresh();
-}
-
-
-void EnsureTaskbarShowHook() {
-    HWND taskbar =
-        FindWindowW(
-            L"Shell_TrayWnd",
-            nullptr
-        );
-
-    DWORD explorerPid = 0;
-    if (taskbar) {
-        GetWindowThreadProcessId(
-            taskbar,
-            &explorerPid
-        );
-    }
-
-    if (explorerPid == g_taskbarShowHookProcessId) {
-        return;
-    }
-
-
-    SafeUnhookWinEvent(g_taskbarShowHook);
-    g_taskbarShowHookProcessId = 0;
-
-    if (explorerPid) {
-        g_taskbarShowHook = SetWinEventHook(
-            EVENT_OBJECT_SHOW,
-            EVENT_OBJECT_SHOW,
-            nullptr,
-            WinEventProc,
-            explorerPid,
-            0,
-            WINEVENT_OUTOFCONTEXT
-        );
-
-        if (g_taskbarShowHook) {
-            g_taskbarShowHookProcessId = explorerPid;
-        } else {
-        }
     }
 }
 
@@ -3051,7 +2584,6 @@ DWORD WINAPI WorkerThread(
             WINEVENT_OUTOFCONTEXT
         );
 
-    EnsureTaskbarShowHook();
     UpdateTaskbarState();
 
     // Keep a true periodic safety poll. It is only a fallback for shell/window
@@ -3086,8 +2618,7 @@ DWORD WINAPI WorkerThread(
                 continue;
             }
 
-            EnsureTaskbarShowHook();
-            UpdateTaskbarState();
+                    UpdateTaskbarState();
 
             continue;
         }
@@ -3101,8 +2632,7 @@ DWORD WINAPI WorkerThread(
                 0
             );
 
-            EnsureTaskbarShowHook();
-            UpdateTaskbarState();
+                    UpdateTaskbarState();
 
             // Do not lose a refresh posted while UpdateTaskbarState() ran.
             if (InterlockedExchange(
@@ -3117,8 +2647,7 @@ DWORD WINAPI WorkerThread(
 
         if (msg.message == WM_APP_SETTINGS) {
             LoadSettings();
-            EnsureTaskbarShowHook();
-            UpdateTaskbarState();
+                    UpdateTaskbarState();
 
 
             continue;
@@ -3141,8 +2670,6 @@ DWORD WINAPI WorkerThread(
     SafeUnhookWinEvent(g_foregroundHook);
     SafeUnhookWinEvent(g_minimizeHook);
     SafeUnhookWinEvent(g_moveHook);
-    SafeUnhookWinEvent(g_taskbarShowHook);
-    g_taskbarShowHookProcessId = 0;
 
     DestroyWorkerMessageWindow();
 
@@ -3409,51 +2936,16 @@ void WhTool_ModSettingsChanged() {
 }
 
 void RestoreAllTaskbars() {
-    auto restoreTaskbarIfMarked = [](HWND hwnd) {
-        if (
-            !hwnd ||
-            !IsWindow(hwnd) ||
-            !GetPropW(
-                hwnd,
-                kHiddenByModProperty
-            )
-        ) {
-            return;
+    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+        TaskbarMonitorState& state = g_taskbarStates[i];
+
+        if (!state.hwnd || !state.hiddenByMod) {
+            continue;
         }
 
-        // Remove ownership before the restore request so Explorer cannot treat
-        // its own SHOW path as an attempt to violate the mod's hidden state.
-        RemoveHiddenTaskbarOwnershipMarker(hwnd);
-
-        // Teardown must not wait on Explorer's UI thread.
-        if (!ShowWindowAsync(
-                hwnd,
-                SW_SHOWNA
-            )) {
-            // Keep explicit ownership if the asynchronous restore request could
-            // not be queued.
-            SetHiddenTaskbarOwnershipMarker(hwnd);
+        if (MakeTaskbarTransparent(state.hwnd, false)) {
+            state.hiddenByMod = false;
         }
-    };
-
-    restoreTaskbarIfMarked(
-        FindWindowW(
-            L"Shell_TrayWnd",
-            nullptr
-        )
-    );
-
-    HWND secondary = nullptr;
-
-    while (
-        (secondary = FindWindowExW(
-            nullptr,
-            secondary,
-            L"Shell_SecondaryTrayWnd",
-            nullptr
-        )) != nullptr
-    ) {
-        restoreTaskbarIfMarked(secondary);
     }
 }
 
@@ -3555,43 +3047,9 @@ void WhTool_ModUninit() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Explorer is a special target for this hybrid mod. The standard tool-mod
-// launcher is kept below as the documented Windhawk boilerplate; the Explorer
-// branch wraps around it without changing the tool-process logic.
-
-bool IsCurrentProcessExplorer() {
-    WCHAR modulePath[MAX_PATH] = {};
-
-    DWORD length =
-        GetModuleFileNameW(
-            nullptr,
-            modulePath,
-            ARRAYSIZE(modulePath)
-        );
-
-    if (
-        length == 0 ||
-        length >= ARRAYSIZE(modulePath)
-    ) {
-        return false;
-    }
-
-    const WCHAR* moduleName =
-        wcsrchr(
-            modulePath,
-            L'\\'
-        );
-
-    moduleName =
-        moduleName
-            ? moduleName + 1
-            : modulePath;
-
-    return _wcsicmp(
-        moduleName,
-        L"explorer.exe"
-    ) == 0;
-}
+// Standard Windhawk tool-mod launcher. The mod is targeted at windhawk.exe so
+// the launcher can start the state-management logic in a dedicated Windhawk
+// process.
 
 #define Wh_ModInit WindhawkToolModLauncher_Wh_ModInit
 #define Wh_ModAfterInit WindhawkToolModLauncher_Wh_ModAfterInit
@@ -3750,7 +3208,7 @@ void Wh_ModAfterInit() {
         .cb = sizeof(STARTUPINFO),
         .dwFlags = STARTF_FORCEOFFFEEDBACK,
     };
-    PROCESS_INFORMATION pi;
+    PROCESS_INFORMATION pi{};
     if (!pCreateProcessInternalW(nullptr, currentProcessPath, commandLine,
                                  nullptr, nullptr, FALSE, NORMAL_PRIORITY_CLASS,
                                  nullptr, nullptr, &si, &pi, nullptr)) {
@@ -3786,53 +3244,17 @@ void Wh_ModUninit() {
 #undef Wh_ModUninit
 
 BOOL Wh_ModInit() {
-    if (IsCurrentProcessExplorer()) {
-        g_isExplorerProcess = true;
-        if (!InstallExplorerVisibilityHook()) {
-            return FALSE;
-        }
-
-        Wh_Log(
-    L"Explorer init: original=%p",
-    g_explorerShowWindowOriginal
-);
-
-        RecoverStaleHiddenTaskbars();
-        StartExplorerRecoveryThread();
-
-        Wh_Log(
-    L"Explorer init: original=%p",
-    g_explorerShowWindowOriginal
-);
-        return TRUE;
-    }
-
     return WindhawkToolModLauncher_Wh_ModInit();
 }
 
 void Wh_ModAfterInit() {
-    if (g_isExplorerProcess) {
-        return;
-    }
-
     WindhawkToolModLauncher_Wh_ModAfterInit();
 }
 
 void Wh_ModSettingsChanged() {
-    if (g_isExplorerProcess) {
-        return;
-    }
-
     WindhawkToolModLauncher_Wh_ModSettingsChanged();
 }
 
 void Wh_ModUninit() {
-    if (g_isExplorerProcess) {
-        StopExplorerRecoveryThread();
-        ResetHiddenTaskbarOwnerCache();
-        return;
-    }
-
     WindhawkToolModLauncher_Wh_ModUninit();
 }
-

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Hides selected taskbars while their displays show only the desktop
-// @version         5.8.0
+// @version         5.9.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -30,7 +30,7 @@ This Windhawk mod hides selected taskbars when their corresponding display is sh
 
 For each selected display, the mod checks whether a relevant visible, non-minimized application is present. Supported Windows shell surfaces and desktop infrastructure are excluded from the normal application check.
 
-When a display is showing only the desktop, its selected bottom-docked taskbar can be hidden. An application on that display, keyboard-driven taskbar focus such as Win+T or Win+B, or supported shell interaction can keep the taskbar visible. Mouse interaction with the taskbar does not prevent it from hiding after hover dismissal.
+When a display is showing only the desktop, its selected bottom-docked taskbar can be hidden. An application on that display, keyboard-driven taskbar focus such as Win+T or Win+B, or supported shell interaction can keep the taskbar visible. Mouse interaction with the taskbar does not prevent it from hiding after hover dismissal. Borderless fullscreen content is tracked per display after it enters fullscreen and keeps that display's taskbar hidden even if another display later becomes foreground; leaving fullscreen clears the tracked state.
 
 Applications spanning multiple displays are considered for every display they intersect, so each affected display can independently remain visible.
 
@@ -49,7 +49,7 @@ Display selections are evaluated using the current logical monitor numbering eac
 
 ## Hover Reveal
 
-For bottom-docked taskbars, moving the cursor into the configured bottom-edge area reveals the taskbar. The hover zone follows the taskbar's actual height and display scaling, with an optional extra margin.
+For bottom-docked taskbars, moving the cursor into the configured bottom-edge area reveals the taskbar. The hover zone follows the taskbar's actual height and display scaling, with an optional extra margin. A taskbar on a display currently tracked as fullscreen does not reveal from bottom-edge hover.
 
 After the cursor leaves the area, the taskbar hides again after the configured delay. Moving the cursor between displays also updates which taskbar is currently revealed.
 
@@ -91,19 +91,36 @@ The mod supports up to 16 display/taskbar entries and uses the current logical d
 
 ## Performance and Refreshing
 
-The full application and display scan runs in the dedicated tool process rather than inside Explorer.
+The full application and display scan runs in the dedicated tool process rather than inside Explorer. Fullscreen state is cached by the actual HMONITOR only after an actual fullscreen window has entered the foreground, avoiding false positives from unrelated borderless background windows and preventing monitor-enumeration changes from moving fullscreen ownership to another display.
+
+Fullscreen state is retained while the cached fullscreen window remains the last fullscreen owner of its monitor, even when focus moves to another display or a transient minimize event is reported. A normal application becoming foreground on that same monitor clears the cached fullscreen owner. Desktop and taskbar foreground transitions on another monitor do not clear it.
 
 The mod uses:
 
 - A dedicated worker thread for state management
 - A lightweight cursor-sampling thread for hover detection
-- Event-driven refreshes for relevant foreground, minimize/move, window show/hide/destroy, display, theme, settings, and taskbar recreation changes
-- A periodic 250 ms safety poll for missed or unusual transitions
+- Event-driven refreshes for relevant foreground, minimize/move, window show/hide/destroy/cloak/uncloak, display, theme, settings, and taskbar recreation changes
+- A periodic 2 second safety poll for missed or unusual transitions
 - A one-shot timer for hover dismissal
 
-The 250 ms safety poll is intentionally retained as a fallback and does not replace the normal event-driven refresh path. Native Windows taskbar auto-hide state is cached and refreshed when settings or relevant shell/taskbar changes occur rather than being queried on every safety tick.
+The 2 second safety poll is intentionally retained as a fallback and does not replace the normal event-driven refresh path. Native Windows taskbar auto-hide state is cached and refreshed when settings or relevant shell/taskbar changes occur rather than being queried on every safety tick.
 
 When no displays are configured for desktop-based hiding, the mod skips the application and shell-popup scans and restores any taskbars that may still be hidden by an earlier configuration.
+
+## Known Fullscreen Multi-Monitor Issue
+
+There is currently an unresolved edge case involving a fullscreen window on the primary display and interaction with a secondary display. The intended behavior is that the primary taskbar remains hidden for as long as the primary display is still owned by a tracked fullscreen window, even when focus or mouse interaction moves to another display.
+
+The reproducible failure pattern is:
+
+1. Start a borderless/monitor-sized fullscreen application on the primary display.
+2. Move the cursor to the secondary display.
+3. Click the secondary display's desktop before interacting with its taskbar.
+4. The primary taskbar can incorrectly become visible, even though the fullscreen application is still active on the primary display.
+
+A closely related sequence is that interacting with the secondary taskbar first can leave the primary taskbar correctly hidden, while clicking the secondary desktop first can expose the bug. The problem is predominantly observed with the primary display; equivalent fullscreen behavior on the secondary display generally behaves correctly.
+
+The current implementation already keeps fullscreen ownership associated with the actual `HMONITOR`, caches fullscreen only after the fullscreen window becomes foreground, avoids clearing the cache for ordinary transient shell-focus/minimize-start transitions, and avoids changing the existing shell-interaction classification. Despite those protections, the edge case remains unresolved and needs a more fundamental state-transition analysis rather than another superficial fullscreen check.
 
 ## Limitations
 
@@ -239,12 +256,14 @@ struct TaskbarMonitorState {
 
 struct WindowScanResult {
     bool applicationOnMonitor[kMaxMonitorNumbers];
+    bool fullscreenOnMonitor[kMaxMonitorNumbers];
 };
 
 HWINEVENTHOOK g_foregroundHook = nullptr;
 HWINEVENTHOOK g_minimizeHook = nullptr;
 HWINEVENTHOOK g_moveHook = nullptr;
 HWINEVENTHOOK g_objectHook = nullptr;
+HWINEVENTHOOK g_cloakHook = nullptr;
 
 HANDLE g_workerThread = nullptr;
 DWORD g_workerThreadId = 0;
@@ -588,10 +607,23 @@ bool g_appBarRegistered = false;
 bool g_hoverActive = false;
 HMONITOR g_hoverMonitor = nullptr;
 ULONGLONG g_hoverDeadline = 0;
-HWND g_keyboardFocusedTaskbar = nullptr;
-bool g_suppressHoverUntilCursorLeaves = false;
-
 LONG g_refreshPosted = 0;
+// Tracks whether the current foreground taskbar activation came from mouse
+// interaction rather than keyboard-driven taskbar navigation. Mouse activation
+// must not make a desktop-only taskbar stay visible after hover dismissal.
+LONG g_taskbarForegroundMouseActivated = 0;
+ULONGLONG g_lastMinimizeEventTick = 0;
+bool g_ignoreTaskbarForegroundAfterMinimize = false;
+// A fullscreen window is cached only after that window has actually entered
+// the foreground. The cache is keyed by the HMONITOR itself rather than by
+// monitor-enumeration index, so a shell/foreground transition cannot move the
+// fullscreen owner to a different display.
+struct FullscreenMonitorOwner {
+    HMONITOR monitor;
+    HWND hwnd;
+};
+
+FullscreenMonitorOwner g_fullscreenOwners[kMaxMonitorNumbers] = {};
 void LoadSettings();
 void WhTool_ModUninit();
 void ArmHoverExpireTimer(DWORD delayMs);
@@ -648,7 +680,11 @@ bool IsDesktopInfrastructureWindow(
 
     HWND shellWindow = GetShellWindow();
 
-    return shellWindow && shellWindow == hwnd;
+    if (shellWindow && shellWindow == hwnd) {
+        return true;
+    }
+
+    return GetPropW(hwnd, L"DesktopWindow") != nullptr;
 }
 
 BOOL CALLBACK CollectMonitorProc(
@@ -997,6 +1033,13 @@ bool IsApplicationWindowCandidate(
         return false;
     }
 
+    if (IsDesktopInfrastructureWindow(
+            hwnd,
+            className
+        )) {
+        return false;
+    }
+
     if (IsShellSurfaceWindow(
             hwnd,
             className
@@ -1038,6 +1081,257 @@ struct ScanContext {
     WindowScanResult* result;
 };
 
+bool IsFullscreenWindowForMonitor(
+    HWND hwnd,
+    const MonitorEntry& monitorEntry
+) {
+    if (
+        !hwnd ||
+        !IsWindow(hwnd)
+    ) {
+        return false;
+    }
+
+    LONG_PTR style =
+        GetWindowLongPtrW(
+            hwnd,
+            GWL_STYLE
+        );
+
+    if (
+        (style & WS_POPUP) == 0 ||
+        (style & WS_CAPTION) != 0 ||
+        (style & WS_THICKFRAME) != 0
+    ) {
+        return false;
+    }
+
+    RECT rect = {};
+
+    if (
+        !GetWindowRect(
+            hwnd,
+            &rect
+        ) ||
+        rect.right <= rect.left ||
+        rect.bottom <= rect.top
+    ) {
+        return false;
+    }
+
+    constexpr LONG kFullscreenTolerance = 2;
+
+    return
+        abs(rect.left - monitorEntry.rect.left) <= kFullscreenTolerance &&
+        abs(rect.top - monitorEntry.rect.top) <= kFullscreenTolerance &&
+        abs(rect.right - monitorEntry.rect.right) <= kFullscreenTolerance &&
+        abs(rect.bottom - monitorEntry.rect.bottom) <= kFullscreenTolerance;
+}
+
+int FindFullscreenOwnerIndex(HMONITOR monitor) {
+    if (!monitor) {
+        return -1;
+    }
+
+    for (size_t i = 0; i < kMaxMonitorNumbers; ++i) {
+        if (g_fullscreenOwners[i].monitor == monitor) {
+            return static_cast<int>(i);
+        }
+    }
+
+    return -1;
+}
+
+bool IsMonitorFullscreenCached(HMONITOR monitor) {
+    const int index = FindFullscreenOwnerIndex(monitor);
+
+    return
+        index >= 0 &&
+        g_fullscreenOwners[index].hwnd != nullptr &&
+        IsWindow(g_fullscreenOwners[index].hwnd);
+}
+
+void SetFullscreenOwner(HMONITOR monitor, HWND hwnd) {
+    if (!monitor || !hwnd) {
+        return;
+    }
+
+    int index = FindFullscreenOwnerIndex(monitor);
+
+    if (index < 0) {
+        for (size_t i = 0; i < kMaxMonitorNumbers; ++i) {
+            if (!g_fullscreenOwners[i].monitor) {
+                index = static_cast<int>(i);
+                break;
+            }
+        }
+    }
+
+    if (index >= 0) {
+        g_fullscreenOwners[index].monitor = monitor;
+        g_fullscreenOwners[index].hwnd = hwnd;
+    }
+}
+
+void ClearFullscreenOwnersForWindow(HWND hwnd) {
+    if (!hwnd) {
+        return;
+    }
+
+    for (size_t i = 0; i < kMaxMonitorNumbers; ++i) {
+        if (g_fullscreenOwners[i].hwnd == hwnd) {
+            g_fullscreenOwners[i] = {};
+        }
+    }
+}
+
+void ClearInvalidFullscreenWindowCache(
+    const MonitorList& monitors
+) {
+    // Keep fullscreen ownership tied to the actual HMONITOR. An accessibility
+    // or foreground transition on another display must not reassign this state.
+    for (size_t i = 0; i < kMaxMonitorNumbers; ++i) {
+        if (!g_fullscreenOwners[i].monitor) {
+            continue;
+        }
+
+        bool monitorStillPresent = false;
+
+        for (size_t monitorIndex = 0;
+             monitorIndex < monitors.count;
+             ++monitorIndex) {
+            if (monitors.entries[monitorIndex].monitor ==
+                g_fullscreenOwners[i].monitor) {
+                monitorStillPresent = true;
+                break;
+            }
+        }
+
+        if (!monitorStillPresent ||
+            !g_fullscreenOwners[i].hwnd ||
+            !IsWindow(g_fullscreenOwners[i].hwnd)) {
+            g_fullscreenOwners[i] = {};
+        }
+    }
+}
+
+bool IsTaskbarWindow(
+    HWND hwnd
+) {
+    if (!hwnd) {
+        return false;
+    }
+
+    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+        if (g_taskbarStates[i].hwnd == hwnd) {
+            return true;
+        }
+    }
+
+    WCHAR className[256] = {};
+    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
+        return false;
+    }
+
+    return
+        wcscmp(className, L"Shell_TrayWnd") == 0 ||
+        wcscmp(className, L"Shell_SecondaryTrayWnd") == 0;
+}
+
+bool IsForegroundNormalApplication(
+    HWND hwnd
+) {
+    if (
+        !hwnd ||
+        !IsWindowVisible(hwnd) ||
+        IsIconic(hwnd)
+    ) {
+        return false;
+    }
+
+    WCHAR className[256] = {};
+    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
+        return false;
+    }
+
+    if (
+        IsDesktopInfrastructureWindow(hwnd, className) ||
+        IsShellChromeClass(className) ||
+        IsShellSurfaceWindow(hwnd, className) ||
+        IsTaskbarWindow(hwnd)
+    ) {
+        return false;
+    }
+
+    return IsApplicationWindowCandidate(hwnd, className);
+}
+
+void ClearFullscreenOwnerForForegroundApplication(
+    HWND hwnd
+) {
+    // A real application becoming foreground means only that application's
+    // monitor has a new foreground owner. Desktop, shell and taskbar
+    // transitions deliberately do not clear fullscreen ownership.
+    if (!IsForegroundNormalApplication(hwnd)) {
+        return;
+    }
+
+    HMONITOR monitor =
+        MonitorFromWindow(
+            hwnd,
+            MONITOR_DEFAULTTONEAREST
+        );
+
+    const int ownerIndex =
+        FindFullscreenOwnerIndex(monitor);
+
+    if (ownerIndex >= 0 &&
+        g_fullscreenOwners[ownerIndex].hwnd != hwnd) {
+        g_fullscreenOwners[ownerIndex] = {};
+    }
+}
+
+void NoteForegroundFullscreenWindow(
+    const MonitorList& monitors,
+    HWND hwnd
+) {
+    if (!hwnd || !IsWindow(hwnd)) {
+        return;
+    }
+
+    for (size_t i = 0; i < monitors.count; ++i) {
+        if (IsFullscreenWindowForMonitor(
+                hwnd,
+                monitors.entries[i]
+            )) {
+            SetFullscreenOwner(
+                monitors.entries[i].monitor,
+                hwnd
+            );
+        }
+    }
+}
+
+void RefreshFullscreenWindowCache(
+    const MonitorList& monitors
+) {
+    ClearInvalidFullscreenWindowCache(monitors);
+
+    HWND foreground = GetForegroundWindow();
+
+    // Only an actual foreground application on the same HMONITOR can replace
+    // fullscreen ownership. Clicking the desktop or taskbar on another display
+    // does not clear the primary display's fullscreen owner.
+    ClearFullscreenOwnerForForegroundApplication(
+        foreground
+    );
+
+    NoteForegroundFullscreenWindow(
+        monitors,
+        foreground
+    );
+}
+
 BOOL CALLBACK ScanWindowsWithMonitorsProc(
     HWND hwnd,
     LPARAM lParam
@@ -1053,15 +1347,21 @@ BOOL CALLBACK ScanWindowsWithMonitorsProc(
         return TRUE;
     }
 
-    bool allMonitorsOccupied = true;
+    bool allMonitorsClassified = true;
     for (size_t i = 0; i < context->monitors->count; ++i) {
-        if (!context->result->applicationOnMonitor[i]) {
-            allMonitorsOccupied = false;
+        if (
+            !context->result->applicationOnMonitor[i] &&
+            !context->result->fullscreenOnMonitor[i]
+        ) {
+            allMonitorsClassified = false;
             break;
         }
     }
 
-    if (allMonitorsOccupied && context->monitors->count != 0) {
+    if (
+        allMonitorsClassified &&
+        context->monitors->count != 0
+    ) {
         return FALSE;
     }
 
@@ -1157,6 +1457,15 @@ void ScanWindowsOnce(
 ) {
     result = {};
 
+    RefreshFullscreenWindowCache(monitors);
+
+    for (size_t i = 0; i < monitors.count; ++i) {
+        result.fullscreenOnMonitor[i] =
+            IsMonitorFullscreenCached(
+                monitors.entries[i].monitor
+            );
+    }
+
     ScanContext context = {
         &monitors,
         &result
@@ -1223,7 +1532,9 @@ void ScanWindowsOnce(
                         monitors.entries[i].monitor ==
                         foregroundMonitor
                     ) {
-                        result.applicationOnMonitor[i] = true;
+                        if (!result.fullscreenOnMonitor[i]) {
+                            result.applicationOnMonitor[i] = true;
+                        }
                         break;
                     }
                 }
@@ -1795,7 +2106,6 @@ void UpdateTaskbarState() {
             g_hoverActive = false;
             g_hoverMonitor = nullptr;
             g_hoverDeadline = 0;
-            g_suppressHoverUntilCursorLeaves = false;
             CancelHoverExpireTimer();
             ApplyBaseTaskbarState();
             UpdateCursorHoverSnapshot();
@@ -1826,6 +2136,7 @@ void UpdateTaskbarState() {
                 state.monitor
             ) {
                 state.desktopOnly =
+                    IsMonitorFullscreenCached(state.monitor) ||
                     !scan.applicationOnMonitor[
                         monitorIndex
                     ];
@@ -1835,20 +2146,30 @@ void UpdateTaskbarState() {
 
     }
 
-    if (g_keyboardFocusedTaskbar) {
-        bool found = false;
-        for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-            if (g_taskbarStates[i].hwnd == g_keyboardFocusedTaskbar) {
-                g_taskbarStates[i].desktopOnly = false;
-                found = true;
-                break;
-            }
-        }
+    // Treat the currently foreground taskbar as occupied only when it has
+    // keyboard-driven focus. A taskbar foreground activation caused by a mouse
+    // click, including clicking a taskbar icon to minimize/maximize, must not
+    // prevent a desktop-only taskbar from hiding after hover dismissal.
+    HWND foreground = GetForegroundWindow();
+    // After minimizing an application, Windows may briefly leave the primary
+    // taskbar as the global foreground window. Treat that foreground state as
+    // stale for the duration of this post-minimize window instead of allowing
+    // it to make the primary desktop-only taskbar appear occupied.
+    const bool postMinimizeTaskbarForeground =
+        g_ignoreTaskbarForegroundAfterMinimize;
 
-        if (!found) {
-            g_keyboardFocusedTaskbar = nullptr;
-        }
-    }
+    const bool taskbarForegroundMouseActivated =
+        InterlockedCompareExchange(
+            &g_taskbarForegroundMouseActivated,
+            0,
+            0
+        ) != 0;
+
+    // The foreground taskbar override is applied only after the current cursor
+    // monitor is known. Windows may report the primary Shell_TrayWnd as the
+    // foreground window after a click on another display's desktop. That must
+    // not make the primary taskbar visible while the cursor is on the secondary
+    // display.
 
     POINT cursorPoint = {};
     HMONITOR cursorMonitor = nullptr;
@@ -1860,6 +2181,28 @@ void UpdateTaskbarState() {
                 MONITOR_DEFAULTTONEAREST
             );
 
+    }
+
+    if (!postMinimizeTaskbarForeground &&
+        !taskbarForegroundMouseActivated &&
+        cursorMonitor) {
+        for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+            if (g_taskbarStates[i].hwnd != foreground ||
+                g_taskbarStates[i].monitor != cursorMonitor) {
+                continue;
+            }
+
+            const bool fullscreenOnTaskbarMonitor =
+                IsMonitorFullscreenCached(
+                    g_taskbarStates[i].monitor
+                );
+
+            if (!fullscreenOnTaskbarMonitor) {
+                g_taskbarStates[i].desktopOnly = false;
+            }
+
+            break;
+        }
     }
 
     HWND cursorTaskbar = nullptr;
@@ -1882,23 +2225,49 @@ void UpdateTaskbarState() {
         break;
     }
 
-    const bool cursorInHoverZone =
+    bool cursorMonitorFullscreen = false;
+
+    for (size_t i = 0; i < monitors.count; ++i) {
+        if (monitors.entries[i].monitor == cursorMonitor) {
+            cursorMonitorFullscreen =
+                scan.fullscreenOnMonitor[i];
+            break;
+        }
+    }
+
+    bool hoverMonitorFullscreen = false;
+
+    if (g_hoverMonitor) {
+        for (size_t i = 0; i < monitors.count; ++i) {
+            if (monitors.entries[i].monitor == g_hoverMonitor) {
+                hoverMonitorFullscreen =
+                    scan.fullscreenOnMonitor[i];
+                break;
+            }
+        }
+    }
+
+    // A fullscreen transition invalidates an existing hover reveal on that
+    // same display. The cursor may already be on another monitor, so use
+    // g_hoverMonitor rather than cursorMonitor for this check.
+    if (g_hoverActive && hoverMonitorFullscreen) {
+        g_hoverActive = false;
+        g_hoverMonitor = nullptr;
+        g_hoverDeadline = 0;
+        hoverMonitorFullscreen = false;
+        CancelHoverExpireTimer();
+    }
+
+    const bool hovering =
         cursorTaskbar &&
         cursorMonitor &&
         cursorHoverConfigured &&
+        !cursorMonitorFullscreen &&
         IsPointNearBottomEdge(
             cursorTaskbar,
             cursorMonitor,
             cursorPoint
         );
-
-    if (!cursorInHoverZone) {
-        g_suppressHoverUntilCursorLeaves = false;
-    }
-
-    const bool hovering =
-        cursorInHoverZone &&
-        !g_suppressHoverUntilCursorLeaves;
 
     if (hovering) {
         g_hoverActive = true;
@@ -1912,7 +2281,8 @@ void UpdateTaskbarState() {
 
             SetTaskbarState(
                 state,
-                state.monitor == g_hoverMonitor ||
+                (state.monitor == g_hoverMonitor &&
+                 !cursorMonitorFullscreen) ||
                 !state.desktopOnly ||
                 !ShouldHideTaskbar(state)
             );
@@ -1943,7 +2313,8 @@ void UpdateTaskbarState() {
 
                 SetTaskbarState(
                     state,
-                    state.monitor == g_hoverMonitor ||
+                    (state.monitor == g_hoverMonitor &&
+                     !hoverMonitorFullscreen) ||
                     !state.desktopOnly ||
                     !ShouldHideTaskbar(state)
                 );
@@ -1954,10 +2325,16 @@ void UpdateTaskbarState() {
         }
 
         ShellPopupScanResult shellPopups = {};
-        ScanVisibleShellPopupsOnce(
-            monitors,
-            shellPopups
-        );
+        const bool ignorePostMinimizeShellPopup =
+            g_lastMinimizeEventTick != 0 &&
+            GetTickCount64() - g_lastMinimizeEventTick < 1000;
+
+        if (!ignorePostMinimizeShellPopup) {
+            ScanVisibleShellPopupsOnce(
+                monitors,
+                shellPopups
+            );
+        }
 
         bool shellPopupPresent = false;
         for (size_t i = 0; i < g_taskbarStateCount; ++i) {
@@ -1978,25 +2355,40 @@ void UpdateTaskbarState() {
             // Keep the revealed taskbar visible while a shell popup/context
             // menu is still open, even when the cursor has moved outside the
             // popup. The popup itself is what keeps the interaction alive.
+            // A popup observed immediately after minimize is ignored above so
+            // stale taskbar UI cannot pin the first post-minimize hover cycle.
             for (size_t i = 0; i < g_taskbarStateCount; ++i) {
                 TaskbarMonitorState& state =
                     g_taskbarStates[i];
 
                 bool shellPopupOnMonitor = false;
-                for (size_t monitorIndex = 0; monitorIndex < monitors.count; ++monitorIndex) {
-                    if (monitors.entries[monitorIndex].monitor == state.monitor) {
+                bool stateFullscreenOnMonitor = false;
+
+                for (
+                    size_t monitorIndex = 0;
+                    monitorIndex < monitors.count;
+                    ++monitorIndex
+                ) {
+                    if (
+                        monitors.entries[monitorIndex].monitor ==
+                        state.monitor
+                    ) {
                         shellPopupOnMonitor =
                             shellPopups.visibleOnMonitor[monitorIndex];
+                        stateFullscreenOnMonitor =
+                            scan.fullscreenOnMonitor[monitorIndex];
                         break;
                     }
                 }
 
                 SetTaskbarState(
                     state,
-                    state.monitor == g_hoverMonitor ||
+                    (state.monitor == g_hoverMonitor &&
+                     !hoverMonitorFullscreen) ||
                     !state.desktopOnly ||
                     !ShouldHideTaskbar(state) ||
-                    shellPopupOnMonitor
+                    (shellPopupOnMonitor &&
+                     !stateFullscreenOnMonitor)
                 );
             }
 
@@ -2195,103 +2587,176 @@ void CALLBACK WinEventProc(
     DWORD
 ) {
     if (event == EVENT_SYSTEM_FOREGROUND) {
-        g_keyboardFocusedTaskbar = nullptr;
+        MonitorList monitors = GetCurrentMonitors();
+        RefreshFullscreenWindowCache(monitors);
+        NoteForegroundFullscreenWindow(
+            monitors,
+            hwnd
+        );
+
+        const bool postMinimizeTaskbarForeground =
+            g_ignoreTaskbarForegroundAfterMinimize;
+
+        bool isTaskbarForeground = false;
 
         if (hwnd) {
-            WCHAR className[64] = {};
-            if (GetClassNameW(
-                    hwnd,
-                    className,
-                    ARRAYSIZE(className)
-                ) != 0 &&
-                (wcscmp(className, L"Shell_TrayWnd") == 0 ||
-                 wcscmp(className, L"Shell_SecondaryTrayWnd") == 0)) {
-                POINT cursorPoint = {};
-                RECT taskbarRect = {};
-                bool cursorOverTaskbar = false;
-
-                if (GetCursorPos(&cursorPoint) &&
-                    GetWindowRect(hwnd, &taskbarRect)) {
-                    cursorOverTaskbar =
-                        PtInRect(&taskbarRect, cursorPoint) != FALSE;
-                }
-
-                // A taskbar focused while the cursor is elsewhere is treated
-                // as keyboard-driven focus (for example Win+T/Win+B/Win+number).
-                // Do not infer keyboard focus during a just-completed minimize
-                // while hover suppression is active; that foreground transition
-                // can simply be the taskbar taking focus after the app closes.
-                // A taskbar focused with the cursor over it is treated as mouse
-                // interaction and may hide normally after hover dismissal.
-                if (!cursorOverTaskbar && !g_suppressHoverUntilCursorLeaves) {
-                    g_keyboardFocusedTaskbar = hwnd;
+            for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+                if (g_taskbarStates[i].hwnd == hwnd) {
+                    isTaskbarForeground = true;
+                    break;
                 }
             }
         }
+
+        if (!isTaskbarForeground) {
+            // A real foreground transition away from the taskbar means the
+            // stale taskbar foreground produced by the minimize is gone.
+            g_ignoreTaskbarForegroundAfterMinimize = false;
+            InterlockedExchange(
+                &g_taskbarForegroundMouseActivated,
+                0
+            );
+            PostRefresh();
+            return;
+        }
+
+        if (postMinimizeTaskbarForeground) {
+            InterlockedExchange(
+                &g_taskbarForegroundMouseActivated,
+                1
+            );
+            PostRefresh();
+            return;
+        }
+
+        POINT cursorPoint = {};
+            bool cursorOverTaskbar = false;
+
+            if (GetCursorPos(&cursorPoint)) {
+                cursorOverTaskbar =
+                    WindowFromPoint(cursorPoint) == hwnd;
+
+                if (!cursorOverTaskbar) {
+                    RECT taskbarRect = {};
+                    if (GetWindowRect(hwnd, &taskbarRect)) {
+                        cursorOverTaskbar =
+                            PtInRect(&taskbarRect, cursorPoint) != FALSE;
+                    }
+                }
+            }
+
+            const bool mouseButtonDown =
+                (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0 ||
+                (GetAsyncKeyState(VK_RBUTTON) & 0x8000) != 0 ||
+                (GetAsyncKeyState(VK_MBUTTON) & 0x8000) != 0;
+
+        InterlockedExchange(
+            &g_taskbarForegroundMouseActivated,
+            (cursorOverTaskbar || mouseButtonDown) ? 1 : 0
+        );
 
         PostRefresh();
         return;
     }
 
     if (event == EVENT_SYSTEM_MINIMIZESTART) {
-        POINT cursorPoint = {};
-        bool cursorOverTaskbar = false;
-
-        if (GetCursorPos(&cursorPoint)) {
-            for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-                RECT taskbarRect = {};
-                if (GetWindowRect(g_taskbarStates[i].hwnd, &taskbarRect) &&
-                    PtInRect(&taskbarRect, cursorPoint) != FALSE) {
-                    cursorOverTaskbar = true;
-                    break;
-                }
-            }
-        }
-
-        g_keyboardFocusedTaskbar = nullptr;
-        g_suppressHoverUntilCursorLeaves = !cursorOverTaskbar;
-        g_hoverActive = false;
-        g_hoverMonitor = nullptr;
-        g_hoverDeadline = 0;
-        CancelHoverExpireTimer();
+        // Do not immediately discard fullscreen ownership here. Windows can
+        // emit a transient minimize-start while shell focus moves between
+        // displays, and clearing the owner at this point can make the primary
+        // taskbar reappear even though fullscreen content is still active.
+        // A genuine minimize is finalized in MINIMIZEEND below.
+        g_lastMinimizeEventTick = GetTickCount64();
+        g_ignoreTaskbarForegroundAfterMinimize = true;
+        InterlockedExchange(
+            &g_taskbarForegroundMouseActivated,
+            1
+        );
         PostRefresh();
         return;
     }
 
     if (event == EVENT_SYSTEM_MINIMIZEEND) {
-        // The start event already decided whether this was a mouse/taskbar
-        // interaction or an external minimize. Reconcile the final state now.
-        g_keyboardFocusedTaskbar = nullptr;
+        g_lastMinimizeEventTick = GetTickCount64();
+        g_ignoreTaskbarForegroundAfterMinimize = true;
+
+        // A completed minimize starts a fresh hover cycle. Any hover state
+        // carried from the taskbar/application interaction that initiated the
+        // minimize must not survive into the first post-minimize cursor move.
+        g_hoverActive = false;
+        g_hoverMonitor = nullptr;
+        g_hoverDeadline = 0;
+        CancelHoverExpireTimer();
+
+        // Windows can leave the taskbar as the foreground window after an
+        // application has finished minimizing. Treat that activation as stale
+        // mouse-style taskbar interaction rather than keyboard taskbar focus.
+        // This also covers minimizing by clicking a taskbar button itself.
+        HWND foreground = GetForegroundWindow();
+        bool foregroundIsTaskbar = false;
+
+        if (foreground) {
+            for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+                if (g_taskbarStates[i].hwnd == foreground) {
+                    foregroundIsTaskbar = true;
+                    break;
+                }
+            }
+        }
+
+        if (foregroundIsTaskbar) {
+            InterlockedExchange(
+                &g_taskbarForegroundMouseActivated,
+                1
+            );
+        }
+
+        // Clear fullscreen ownership only after a minimize has actually
+        // completed and only when the cached window is still minimized.
+        // If the minimize was transient or cancelled, keep fullscreen
+        // ownership so focus changes on another display cannot expose the
+        // primary taskbar.
+        if (hwnd && IsIconic(hwnd)) {
+            ClearFullscreenOwnersForWindow(hwnd);
+        }
+
         PostRefresh();
+        UpdateCursorHoverSnapshot();
         return;
     }
 
     if (event == EVENT_SYSTEM_MOVESIZEEND) {
+        MonitorList monitors = GetCurrentMonitors();
+        ClearInvalidFullscreenWindowCache(monitors);
         PostRefresh();
         return;
-    }
-
-    if (
-        event == EVENT_OBJECT_DESTROY &&
-        hwnd &&
-        hwnd == g_keyboardFocusedTaskbar
-    ) {
-        g_keyboardFocusedTaskbar = nullptr;
     }
 
     if (
         (event == EVENT_OBJECT_DESTROY ||
          event == EVENT_OBJECT_SHOW ||
-         event == EVENT_OBJECT_HIDE) &&
+         event == EVENT_OBJECT_HIDE ||
+         event == EVENT_OBJECT_CLOAKED ||
+         event == EVENT_OBJECT_UNCLOAKED) &&
         hwnd &&
         idObject == OBJID_WINDOW &&
         idChild == CHILDID_SELF
     ) {
+        if (event == EVENT_OBJECT_DESTROY) {
+            for (size_t i = 0; i < kMaxMonitorNumbers; ++i) {
+                if (g_fullscreenOwners[i].hwnd == hwnd) {
+                    g_fullscreenOwners[i] = {};
+                }
+            }
+        }
+
+        // Hide/cloak notifications can be transient while a fullscreen browser
+        // changes activation state. Revalidate against the current window state
+        // instead of eagerly discarding the cache from the accessibility event.
+        MonitorList monitors = GetCurrentMonitors();
+        ClearInvalidFullscreenWindowCache(monitors);
         PostRefresh();
     }
 }
-
-
 
 LRESULT CALLBACK WorkerMessageWindowProc(
     HWND hwnd,
@@ -2470,7 +2935,7 @@ DWORD WINAPI WorkerThread(
 
     if (!CreateWorkerMessageWindow()) {
         Wh_Log(
-            L"CreateWorkerMessageWindow failed; continuing with WinEvent/safety-poll handling"
+            L"CreateWorkerMessageWindow failed; continuing with WinEvent/2-second safety-poll handling"
         );
     }
 
@@ -2519,12 +2984,23 @@ DWORD WINAPI WorkerThread(
             WINEVENT_OUTOFCONTEXT
         );
 
+    g_cloakHook =
+        SetWinEventHook(
+            EVENT_OBJECT_CLOAKED,
+            EVENT_OBJECT_UNCLOAKED,
+            nullptr,
+            WinEventProc,
+            0,
+            0,
+            WINEVENT_OUTOFCONTEXT
+        );
+
     UpdateTaskbarState();
 
     // Keep a true periodic safety poll. It is only a fallback for shell/window
     // transitions that do not produce a usable accessibility event. Refresh
     // events never re-arm this timer, so frequent events cannot postpone it.
-    constexpr UINT kSafetyPollIntervalMs = 250;
+    constexpr UINT kSafetyPollIntervalMs = 2000;
     UINT_PTR timerId =
         SetTimer(
             nullptr,
@@ -2598,6 +3074,7 @@ DWORD WINAPI WorkerThread(
     SafeUnhookWinEvent(g_minimizeHook);
     SafeUnhookWinEvent(g_moveHook);
     SafeUnhookWinEvent(g_objectHook);
+    SafeUnhookWinEvent(g_cloakHook);
 
     DestroyWorkerMessageWindow();
 

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Desktop-only taskbar hiding using a dedicated Windhawk tool process
-// @version         5.1.0
+// @version         5.2.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -38,21 +38,25 @@ When an application becomes active on the display, or when a relevant Windows sh
 
 The taskbar is hidden directly rather than enabling Windows' native taskbar auto-hide mode. The mod therefore does not intentionally change the Windows desktop work area when hiding the taskbar.
 
-## Difference from Existing Taskbar Auto-Hide Mods
+## Difference from Existing Taskbar Mods
 
-This mod shares some concepts with existing taskbar auto-hide projects, but it is focused on a different user-visible behavior and implementation model.
+This mod overlaps with several taskbar customization mods, but its main purpose is different: **the taskbar is hidden only when its own display is showing only the desktop**. It is also designed around independent per-display control.
 
-**`taskbar-auto-hide-when-maximized`** primarily provides visibility modes based on application-window state, such as maximized or intersected windows. This mod uses a desktop-only predicate: a selected taskbar remains visible whenever its display has a visible, non-minimized application window and hides only when that display has no such application window.
+**`taskbar-fade`** is the closest existing mod. It also uses layered-window transparency, supports hover reveal, and provides a **Smart Idle (Only hide on empty desktop)** option. However, its desktop detection is based on idle/focus-oriented behavior rather than this mod's per-display desktop-only predicate. This mod evaluates each display independently and lets the user choose exactly which displays should hide and which displays should support hover reveal.
 
-This means the behavior is not limited to maximized, snapped, fullscreen, or taskbar-intersecting windows.
+For example, with two displays, an application can remain open on display 1 while the selected taskbar on display 2 hides because display 2 is showing only the desktop. The taskbar on display 1 is unaffected by the state of display 2. The same per-display rule applies when applications span multiple displays.
 
-**`taskbar-auto-hide-per-monitor`** provides per-monitor control over Windows' native taskbar auto-hide behavior. This mod also allows displays to be configured independently, but it directly controls the taskbar window instead of changing Windows' native auto-hide state.
+This distinction is especially important when comparing the mod with `taskbar-fade`: the goal here is not simply to make the taskbar fade or disappear while idle, but to provide **explicit per-display desktop-only visibility**.
 
-**`taskbar-auto-hide-custom-activation-area`** changes the activation area used by Windows' native taskbar auto-hide behavior. This mod instead performs its own desktop/application-state detection and provides its own configurable bottom-edge hover area.
+**`taskbar-auto-hide-when-maximized`** primarily provides visibility based on maximized or intersecting application windows. This mod instead uses a desktop-only predicate and does not require an application to be maximized, fullscreen, snapped, or intersecting the taskbar.
 
-The work-area behavior is also different. The mod directly hides the taskbar window without intentionally modifying the Windows desktop work area.
+**`taskbar-auto-hide-per-monitor`** provides per-monitor control over Windows' native taskbar auto-hide behavior. This mod also allows displays to be configured independently, but directly controls the taskbar window instead of changing Windows' native auto-hide state.
 
-The combination of desktop-only visibility, independent per-display selection, direct taskbar control, custom hover reveal, and shell-interaction handling is the intended focus of this mod.
+**`taskbar-auto-hide-custom-activation-area`** changes the activation area used by Windows' native auto-hide behavior. This mod instead performs its own desktop/application-state detection and provides its own configurable bottom-edge hover area.
+
+The work-area behavior is also different from native auto-hide: the mod hides the taskbar visually without intentionally changing the Windows desktop work area.
+
+The intended focus of this mod is therefore the combination of **desktop-only visibility, explicit per-display selection, stable monitor identity tracking, direct taskbar control, configurable hover reveal, and shell-interaction handling**.
 
 ## Per-Display Configuration
 
@@ -184,6 +188,9 @@ The periodic safety poll provides a recovery path for missed or unusual transiti
 - Display device names can change after display configuration changes.
 - The current display-selection configuration supports up to 16 display entries.
 - The mod intentionally keeps Windows' native taskbar auto-hide setting separate from its own hiding behavior.
+- Hiding the taskbar does not increase the desktop work area; maximized windows may still leave the normal taskbar space reserved.
+- If the dedicated tool process is terminated unexpectedly while a taskbar is hidden, the taskbar may remain invisible until Explorer is restarted.
+- This mod may conflict with other taskbar transparency/customization mods that also modify the taskbar's layered-window style or opacity.
 - Windows shell window classes and processes can change between Windows releases, so shell-interaction detection may require updates for future Windows versions.
 - The mod is designed specifically around Windows' Explorer/taskbar behavior and is not intended to be a general-purpose taskbar customization framework.
 
@@ -350,37 +357,35 @@ SRWLOCK g_cursorHoverSnapshotLock = SRWLOCK_INIT;
 
 // A layered window with alpha 0 is used as the physical taskbar visibility
 // mechanism. The taskbar state machine remains in the dedicated
-// Explorer tool process.
+// Windhawk tool process.
 bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
     if (!hwnd || !IsWindow(hwnd)) {
         return false;
     }
 
+    SetLastError(ERROR_SUCCESS);
     LONG_PTR exStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
     if (exStyle == 0 && GetLastError() != ERROR_SUCCESS) {
         return false;
     }
 
     if (hide) {
-        if (!SetWindowLongPtrW(
-                hwnd,
-                GWL_EXSTYLE,
-                exStyle | WS_EX_LAYERED
-            )) {
+        SetLastError(ERROR_SUCCESS);
+        LONG_PTR previousExStyle = SetWindowLongPtrW(
+            hwnd,
+            GWL_EXSTYLE,
+            exStyle | WS_EX_LAYERED | WS_EX_TRANSPARENT
+        );
+        if (previousExStyle == 0 && GetLastError() != ERROR_SUCCESS) {
             Wh_Log(
-                L"SetWindowLongPtrW(GWL_EXSTYLE, WS_EX_LAYERED) failed for 0x%p: %lu",
+                L"SetWindowLongPtrW(GWL_EXSTYLE, hide flags) failed for 0x%p: %lu",
                 hwnd,
                 GetLastError()
             );
             return false;
         }
 
-        if (!SetLayeredWindowAttributes(
-                hwnd,
-                0,
-                0,
-                LWA_ALPHA
-            )) {
+        if (!SetLayeredWindowAttributes(hwnd, 0, 0, LWA_ALPHA)) {
             Wh_Log(
                 L"SetLayeredWindowAttributes(alpha=0) failed for 0x%p: %lu",
                 hwnd,
@@ -397,19 +402,14 @@ bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
             SWP_NOSIZE |
             SWP_NOZORDER |
             SWP_NOACTIVATE |
-            SWP_FRAMECHANGED
+            SWP_FRAMECHANGED |
+            SWP_ASYNCWINDOWPOS
         );
 
         return true;
     }
 
-    // Restore full opacity before removing WS_EX_LAYERED.
-    if (!SetLayeredWindowAttributes(
-            hwnd,
-            0,
-            255,
-            LWA_ALPHA
-        )) {
+    if (!SetLayeredWindowAttributes(hwnd, 0, 255, LWA_ALPHA)) {
         Wh_Log(
             L"SetLayeredWindowAttributes(alpha=255) failed for 0x%p: %lu",
             hwnd,
@@ -418,13 +418,15 @@ bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
         return false;
     }
 
-    if (!SetWindowLongPtrW(
-            hwnd,
-            GWL_EXSTYLE,
-            exStyle & ~static_cast<LONG_PTR>(WS_EX_LAYERED)
-        )) {
+    SetLastError(ERROR_SUCCESS);
+    LONG_PTR previousExStyle = SetWindowLongPtrW(
+        hwnd,
+        GWL_EXSTYLE,
+        exStyle & ~static_cast<LONG_PTR>(WS_EX_LAYERED | WS_EX_TRANSPARENT)
+    );
+    if (previousExStyle == 0 && GetLastError() != ERROR_SUCCESS) {
         Wh_Log(
-            L"SetWindowLongPtrW(remove WS_EX_LAYERED) failed for 0x%p: %lu",
+            L"SetWindowLongPtrW(remove hide flags) failed for 0x%p: %lu",
             hwnd,
             GetLastError()
         );
@@ -439,7 +441,8 @@ bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
         SWP_NOSIZE |
         SWP_NOZORDER |
         SWP_NOACTIVATE |
-        SWP_FRAMECHANGED
+        SWP_FRAMECHANGED |
+        SWP_ASYNCWINDOWPOS
     );
 
     return true;
@@ -814,11 +817,38 @@ MonitorList GetCurrentMonitors() {
             if (keyPrimary != prevPrimary) {
                 shouldMoveBefore = keyPrimary;
             } else {
-                shouldMoveBefore =
-                    wcscmp(
-                        key.deviceName,
-                        list.entries[j - 1].deviceName
-                    ) < 0;
+                const wchar_t* keyNumberText = key.deviceName;
+                const wchar_t* previousNumberText =
+                    list.entries[j - 1].deviceName;
+
+                if (wcsncmp(keyNumberText, L"\\\\.\\DISPLAY", 11) == 0 &&
+                    wcsncmp(previousNumberText, L"\\\\.\\DISPLAY", 11) == 0) {
+                    wchar_t* keyEnd = nullptr;
+                    wchar_t* previousEnd = nullptr;
+                    long keyNumber = wcstol(keyNumberText + 11, &keyEnd, 10);
+                    long previousNumber =
+                        wcstol(previousNumberText + 11, &previousEnd, 10);
+
+                    if (keyEnd != keyNumberText + 11 &&
+                        *keyEnd == L'\0' &&
+                        previousEnd != previousNumberText + 11 &&
+                        *previousEnd == L'\0' &&
+                        keyNumber != previousNumber) {
+                        shouldMoveBefore = keyNumber < previousNumber;
+                    } else {
+                        shouldMoveBefore =
+                            wcscmp(
+                                key.deviceName,
+                                list.entries[j - 1].deviceName
+                            ) < 0;
+                    }
+                } else {
+                    shouldMoveBefore =
+                        wcscmp(
+                            key.deviceName,
+                            list.entries[j - 1].deviceName
+                        ) < 0;
+                }
             }
 
             if (!shouldMoveBefore) {
@@ -1545,6 +1575,29 @@ void RefreshTaskbarMonitorStates(
     ) {
         addTaskbar(secondary);
     }
+
+    // Restore any previously hidden taskbar that was not rediscovered.
+    // A transient enumeration failure must not leave a valid taskbar stranded.
+    for (size_t i = 0; i < oldCount; ++i) {
+        if (!oldStates[i].hiddenByMod ||
+            !oldStates[i].hwnd ||
+            !IsWindow(oldStates[i].hwnd)) {
+            continue;
+        }
+
+        bool rediscovered = false;
+        for (size_t j = 0; j < g_taskbarStateCount; ++j) {
+            if (g_taskbarStates[j].hwnd == oldStates[i].hwnd) {
+                rediscovered = true;
+                break;
+            }
+        }
+
+        if (!rediscovered) {
+            MakeTaskbarTransparent(oldStates[i].hwnd, false);
+        }
+    }
+
 }
 
 bool IsNativeAutoHideEnabled() {
@@ -1582,6 +1635,20 @@ void SetTaskbarState(
 
     if (show) {
         if (!state.hiddenByMod) {
+            return;
+        }
+
+        SetLastError(ERROR_SUCCESS);
+        LONG_PTR exStyle = GetWindowLongPtrW(
+            state.hwnd,
+            GWL_EXSTYLE
+        );
+        if (exStyle == 0 && GetLastError() != ERROR_SUCCESS) {
+            return;
+        }
+
+        if (!(exStyle & WS_EX_LAYERED)) {
+            state.hiddenByMod = false;
             return;
         }
 
@@ -2199,62 +2266,6 @@ void CancelHoverExpireTimer() {
             kHoverExpireTimerId
         );
     }
-}
-
-
-bool IsCursorInConfiguredHoverZoneAtPoint(
-    POINT pt,
-    HMONITOR cursorMonitor
-) {
-    if (!cursorMonitor) {
-        return false;
-    }
-
-    TaskbarMonitorState* cursorState = nullptr;
-
-    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-        if (
-            g_taskbarStates[i].monitor ==
-            cursorMonitor
-        ) {
-            cursorState = &g_taskbarStates[i];
-            break;
-        }
-    }
-
-    if (
-        !cursorState ||
-        !ShouldRevealOnHover(*cursorState)
-    ) {
-        return false;
-    }
-
-    return
-        cursorState->hwnd &&
-        IsPointNearBottomEdge(
-            cursorState->hwnd,
-            cursorMonitor,
-            pt
-        );
-}
-
-bool IsCursorInConfiguredHoverZone() {
-    POINT pt = {};
-
-    if (!GetCursorPos(&pt)) {
-        return false;
-    }
-
-    HMONITOR cursorMonitor =
-        MonitorFromPoint(
-            pt,
-            MONITOR_DEFAULTTONEAREST
-        );
-
-    return IsCursorInConfiguredHoverZoneAtPoint(
-        pt,
-        cursorMonitor
-    );
 }
 
 
@@ -3069,7 +3080,13 @@ void WINAPI EntryPoint_Hook() {
 }
 
 BOOL Wh_ModInit() {
-    bool isService = false;
+    DWORD sessionId;
+    if (ProcessIdToSessionId(GetCurrentProcessId(), &sessionId) &&
+        sessionId == 0) {
+        return FALSE;
+    }
+
+    bool isExcluded = false;
     bool isToolModProcess = false;
     bool isCurrentToolModProcess = false;
     int argc;
@@ -3080,8 +3097,10 @@ BOOL Wh_ModInit() {
     }
 
     for (int i = 1; i < argc; i++) {
-        if (wcscmp(argv[i], L"-service") == 0) {
-            isService = true;
+        if (wcscmp(argv[i], L"-service") == 0 ||
+            wcscmp(argv[i], L"-service-start") == 0 ||
+            wcscmp(argv[i], L"-service-stop") == 0) {
+            isExcluded = true;
             break;
         }
     }
@@ -3098,7 +3117,7 @@ BOOL Wh_ModInit() {
 
     LocalFree(argv);
 
-    if (isService) {
+    if (isExcluded) {
         return FALSE;
     }
 
@@ -3154,10 +3173,9 @@ void Wh_ModAfterInit() {
     }
 
     WCHAR commandLine[MAX_PATH + 2 +
-                      (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") /
-                       sizeof(WCHAR)) - 1];
-    swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"",
-               currentProcessPath, WH_MOD_ID);
+                      (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
+    swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
+               WH_MOD_ID);
 
     HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
     if (!kernelModule) {

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              hide-taskbar-only-on-desktop
-// @name            Hide Taskbar Only on Desktop 
+// @name            Hide Taskbar Only on Desktop
 // @description     Desktop-only taskbar hiding using a dedicated Windhawk tool process
-// @version         5.3.0
+// @version         5.4.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -14,9 +14,7 @@
 
 # Hide Taskbar Only on Desktop
 
-This Windhawk mod hides selected taskbars when their corresponding display is showing only the desktop, and shows them again when an application or relevant Windows shell interaction requires the taskbar.
-
-Each display is evaluated independently. An application being open on one display does not prevent the taskbar on another selected display from hiding when that display is showing only the desktop.
+This Windhawk mod hides selected taskbars when their corresponding display is showing only the desktop. Each display is evaluated independently.
 
 ## Demo
 
@@ -30,73 +28,36 @@ Each display is evaluated independently. An application being open on one displa
 
 ## How It Works
 
-For each selected display, the mod determines whether there is a visible, non-minimized application window associated with that display.
+For each selected display, the mod checks whether a relevant visible application is present. Supported Windows shell surfaces are excluded from the application check, and shell popups are handled separately during hover dismissal.
 
-When no relevant application window is present, the selected taskbar on that display can be hidden.
+When the display is showing only the desktop, its selected taskbar can be hidden. Applications and configured hover reveal control normal visibility, while supported shell popups can extend a hover-revealed taskbar's visible period.
 
-When an application becomes active on the display, or when a relevant Windows shell interaction requires the taskbar, it is shown again.
+The taskbar is hidden using layered-window transparency rather than Windows' native auto-hide mode, so the mod does not intentionally change the desktop work area.
 
-The taskbar is hidden directly rather than enabling Windows' native taskbar auto-hide mode. The mod therefore does not intentionally change the Windows desktop work area when hiding the taskbar.
+## Per-Display Settings
 
-## Difference from Existing Taskbar Mods
+You can configure independently:
 
-This mod overlaps with several taskbar customization mods, but its main purpose is different: **the taskbar is hidden only when its own display is showing only the desktop**. It is also designed around independent per-display control.
+- Which displays should hide their taskbar on the desktop
+- Which displays should support bottom-edge hover reveal
 
-**`taskbar-fade`** is the closest existing mod. It also uses layered-window transparency, supports hover reveal, and provides a **Smart Idle (Only hide on empty desktop)** option. However, its desktop detection is based on idle/focus-oriented behavior rather than this mod's per-display desktop-only predicate. This mod evaluates each display independently and lets the user choose exactly which displays should hide and which displays should support hover reveal.
-
-For example, with two displays, an application can remain open on display 1 while the selected taskbar on display 2 hides because display 2 is showing only the desktop. The taskbar on display 1 is unaffected by the state of display 2. The same per-display rule applies when applications span multiple displays.
-
-This distinction is especially important when comparing the mod with `taskbar-fade`: the goal here is not simply to make the taskbar fade or disappear while idle, but to provide **explicit per-display desktop-only visibility**.
-
-**`taskbar-auto-hide-when-maximized`** primarily provides visibility based on maximized or intersecting application windows. This mod instead uses a desktop-only predicate and does not require an application to be maximized, fullscreen, snapped, or intersecting the taskbar.
-
-**`taskbar-auto-hide-per-monitor`** provides per-monitor control over Windows' native taskbar auto-hide behavior. This mod also allows displays to be configured independently, but directly controls the taskbar window instead of changing Windows' native auto-hide state.
-
-**`taskbar-auto-hide-custom-activation-area`** changes the activation area used by Windows' native auto-hide behavior. This mod instead performs its own desktop/application-state detection and provides its own configurable bottom-edge hover area.
-
-The work-area behavior is also different from native auto-hide: the mod hides the taskbar visually without intentionally changing the Windows desktop work area.
-
-The intended focus of this mod is therefore the combination of **desktop-only visibility, explicit per-display selection, stable monitor identity tracking, direct taskbar control, configurable hover reveal, and shell-interaction handling**.
-
-## Per-Display Configuration
-
-The mod supports independent configuration for each display.
-
-Users can configure:
-
-- Which displays should use desktop-based taskbar hiding
-- Which displays should allow hover reveal
-
-Display selection can target:
-
-- All displays
-- Individual displays
-
-Display selections use the mod's display-selection entries and stable monitor/device identity tracking. Windows device names such as `\\.\DISPLAY1` are used internally to identify monitors, but these identifiers may differ from the display numbers shown in Windows Display Settings.
-
-The mod tracks monitor/device identity so that a selected display can remain associated with the same detected physical monitor when Windows temporarily changes `DISPLAYn` ordering during the current session.
+You can select all displays or individual logical display numbers. The mod also keeps a stable monitor/device association when Windows changes its internal `DISPLAYn` numbering during the current session.
 
 ## Hover Reveal
 
-For bottom-docked taskbars, the mod provides a configurable bottom-edge hover area.
+For bottom-docked taskbars, moving the cursor into the configured bottom-edge area reveals the taskbar.
 
-When the cursor enters the configured area of a selected display, a taskbar hidden by the mod is revealed.
+After the cursor leaves the area, the taskbar hides again after the configured delay.
 
-When the cursor leaves the hover area, the taskbar remains visible for the configured delay before being hidden again.
+The hover area follows the taskbar height and display scaling, with an optional extra margin in pixels.
 
-The hover area is calculated using the taskbar's current height and display DPI together with the configured additional margin.
-
-Hover reveal applies only to bottom-docked taskbars. Taskbars docked to the top or sides are not affected by this feature.
-
-The hover-dismiss delay applies only to hover-based hiding. Other state changes, such as a display becoming desktop-only again, are handled independently.
-
-Cursor tracking uses a dedicated lightweight sampling thread. It uses faster sampling when hover tracking is active and backs off when hover tracking is not needed. The sampler also backs off after repeated cursor-position failures.
+Hover reveal does not apply to taskbars docked to the top or sides.
 
 ## Windows Shell Interactions
 
-The mod accounts for relevant Windows shell surfaces so that the taskbar does not disappear unnecessarily while the user is interacting with Windows.
+The mod recognizes supported Windows shell surfaces separately from normal application windows. This prevents shell UI from being mistaken for an ordinary application when deciding whether a display is desktop-only.
 
-This includes supported situations involving:
+Supported shell surfaces include:
 
 - Start menu
 - Taskbar menus and popups
@@ -104,105 +65,24 @@ This includes supported situations involving:
 - Notification and Quick Settings surfaces
 - Alt+Tab and related task-switching UI
 
-Known shell window classes and the relevant Windows shell processes are considered when identifying these surfaces.
+Shell popups are also checked while a hover-revealed taskbar is waiting to hide, so an open supported popup can keep that revealed taskbar visible.
 
-Shell interaction detection is handled separately from the normal application-window check.
+## Multi-Monitor Behavior
 
-## Taskbar Visibility
+Each selected display is evaluated independently. For example, an application can remain open on display 1 while the selected taskbar on display 2 hides because display 2 is showing only the desktop.
 
-The taskbar is hidden by adding `WS_EX_LAYERED` and setting its alpha to `0` with `SetLayeredWindowAttributes`. This makes the taskbar fully transparent without changing its normal `ShowWindow` visibility state.
-
-The transparency approach keeps the taskbar window alive while removing its visible presentation. This allows the dedicated Windhawk tool process to manage taskbar visibility without injecting a `ShowWindow` hook or maintaining an Explorer-side taskbar visibility hook.
-
-The visibility mechanism is intentionally separate from the desktop/application-state decision logic. The display selection, shell interaction handling, hover reveal, taskbar recreation, and event-driven refresh logic remain unchanged.
-
-### Transparency Recovery and State Ownership
-
-The dedicated tool process keeps ownership of taskbars it makes transparent in its local taskbar state. A taskbar is restored to normal opacity and has `WS_EX_LAYERED` removed when the mod decides that it should be visible and during normal tool-process shutdown.
-
-If the taskbar window is recreated, the new window is rediscovered and evaluated again by the same per-display state logic.
-
-The mod runs as a dedicated `windhawk.exe` tool-mod process. The normal Windhawk instance acts as the launcher, while the taskbar-state logic runs in a separate Windhawk process instance. No `ShowWindow` hook or taskbar-show hook is used.
-
-## Multi-Monitor Example
-
-Consider a system with two displays:
-
-1. An application is open on display 1.
-2. Display 2 is showing only the desktop.
-3. The selected taskbar on display 1 remains visible.
-4. The selected taskbar on display 2 hides.
-5. Moving the cursor into display 2's configured bottom-edge area reveals its taskbar.
-6. After leaving the hover area, the taskbar hides again after the configured delay.
-7. Opening an application on display 2 causes its taskbar to remain visible.
-
-The same logic is applied independently to each selected display.
-
-Applications that span multiple displays are considered for every display they intersect, while maximized windows use the monitor assignment provided by Windows.
-
-## Explorer and Display Changes
-
-The mod refreshes its taskbar and display state when relevant shell or display configuration changes occur.
-
-This allows taskbar state to be rebuilt when:
-
-- Taskbars are recreated
-- Explorer-related state changes
-- The display topology changes
-- Monitors are added or removed
-- Display configuration changes
-- Settings are changed
-
-Taskbars are rediscovered rather than assuming that their window handles remain unchanged.
-
-Display identity is tracked using monitor/device information rather than relying solely on the current `DISPLAYn` ordering.
-
-## Taskbar Ownership
-
-The mod tracks whether a taskbar has been made transparent by its own taskbar-state logic.
-
-A window property marker is stored on taskbars hidden by the mod so a newly started dedicated tool process can reclaim and restore a taskbar left hidden by an unexpected previous-process termination. The marker is attached to the taskbar window itself; the mod still does not inject into Explorer.
-
-## Performance
-
-The full application and display scan runs in the dedicated tool process rather than inside Explorer.
-
-The mod uses:
-
-- A dedicated worker thread for state management
-- A lightweight cursor-sampling thread for hover detection
-- Event-driven refreshes for relevant window and shell changes
-- A periodic safety poll for missed or unusual transitions
-- A one-shot timer for hover dismissal
-
-The dedicated `windhawk.exe` tool process performs taskbar visibility changes directly through layered-window transparency. No separate Explorer-side `ShowWindow` or taskbar-show hook is used, and no second recovery thread runs in the launcher instance.
-
-Cursor sampling backs off when hover tracking is not needed and also backs off after repeated cursor-position failures.
-
-The periodic safety poll provides a recovery path for missed or unusual transitions. The implementation intentionally retains the existing 250 ms interval.
+Applications spanning multiple displays are considered for each display they intersect.
 
 ## Limitations
 
 - Hover reveal is supported only for bottom-docked taskbars.
-- Windows display device names such as `\\.\DISPLAY1` may differ from the display numbering shown in Windows Display Settings.
-- Display device names can change after display configuration changes.
-- The current display-selection configuration supports up to 16 display entries.
-- The mod intentionally keeps Windows' native taskbar auto-hide setting separate from its own hiding behavior.
-- Hiding the taskbar does not increase the desktop work area; maximized windows may still leave the normal taskbar space reserved.
-- If the dedicated tool process is terminated unexpectedly while a taskbar is hidden, the next instance of this mod can reclaim the marked taskbar; if the taskbar itself is recreated before recovery, the old window marker is naturally discarded.
-- This mod may conflict with other taskbar transparency/customization mods that also modify the taskbar's layered-window style or opacity.
-- Windows shell window classes and processes can change between Windows releases, so shell-interaction detection may require updates for future Windows versions.
-- The mod is designed specifically around Windows' Explorer/taskbar behavior and is not intended to be a general-purpose taskbar customization framework.
+- Hiding the taskbar does not increase the desktop work area, so maximized windows may still leave the normal taskbar space reserved.
+- Windows display device names such as `\\.\DISPLAY1` may differ from the logical display numbers used by the settings UI.
+- The display-selection configuration supports up to 16 display entries.
+- The mod keeps Windows' native taskbar auto-hide setting separate from its own hiding behavior.
+- Other taskbar transparency/customization mods that modify the same taskbar window can conflict with this mod.
+- Windows shell window classes and processes can change between Windows releases, so shell-interaction detection may need updates for future Windows versions.
 
-## Goal
-
-The goal is not to replace Windows' native taskbar auto-hide or provide a general-purpose taskbar customization framework.
-
-The goal is a specific behavior:
-
-> **Hide the taskbar when its display is showing only the desktop.**
-
-The mod combines independent per-display application-state detection with configurable display selection, stable monitor identity tracking, shell-interaction handling, direct taskbar control, and a configurable bottom-edge hover-reveal area.
 */
 // ==/WindhawkModReadme==
 
@@ -348,7 +228,6 @@ struct CursorHoverSnapshot {
     HMONITOR monitor;
     RECT monitorRect;
     int hotZonePx;
-    bool enabled;
 };
 
 CursorHoverSnapshot g_cursorHoverSnapshots[kMaxTaskbars] = {};
@@ -429,10 +308,16 @@ bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
     }
 
     if (hide) {
-        // Do not overwrite the original state when a taskbar is already owned
-        // by this mod (for example after a refresh in the same process).
-        if (GetPropW(hwnd, kTaskbarOwnershipProp) != nullptr) {
+        // If another component removed WS_EX_LAYERED while this mod still had
+        // ownership, the saved properties no longer describe the current window
+        // state. Drop the stale ownership and recapture the current state below.
+        if (GetPropW(hwnd, kTaskbarOwnershipProp) != nullptr &&
+            (exStyle & WS_EX_LAYERED) != 0) {
             return SetLayeredWindowAttributes(hwnd, 0, 0, LWA_ALPHA) != 0;
+        }
+
+        if (GetPropW(hwnd, kTaskbarOwnershipProp) != nullptr) {
+            RemoveTaskbarOwnershipProperties(hwnd);
         }
 
         COLORREF colorKey = 0;
@@ -1855,6 +1740,10 @@ void SetTaskbarState(
         }
 
         if (!(exStyle & WS_EX_LAYERED)) {
+            // Another component removed the layering style while the taskbar
+            // was owned by this mod. Drop the stale marker so a later hide can
+            // recapture the taskbar's current state instead of using stale data.
+            RemoveTaskbarOwnershipProperties(state.hwnd);
             state.hiddenByMod = false;
             return;
         }
@@ -2140,7 +2029,6 @@ void UpdateCursorHoverSnapshot() {
 
         CursorHoverSnapshot& snapshot = snapshots[snapshotCount++];
         snapshot.monitor = state.monitor;
-        snapshot.enabled = true;
 
         MONITORINFO mi = {};
         mi.cbSize = sizeof(mi);
@@ -2198,10 +2086,7 @@ bool IsCursorInConfiguredHoverZoneAtSnapshot(
         const CursorHoverSnapshot& snapshot =
             g_cursorHoverSnapshots[i];
 
-        if (
-            !snapshot.enabled ||
-            snapshot.monitor != cursorMonitor
-        ) {
+        if (snapshot.monitor != cursorMonitor) {
             continue;
         }
 
@@ -2376,7 +2261,7 @@ void UpdateTaskbarState() {
         break;
     }
 
-    const bool cursorInHoverZone =
+    const bool hovering =
         cursorTaskbar &&
         cursorMonitor &&
         cursorHoverConfigured &&
@@ -2384,10 +2269,6 @@ void UpdateTaskbarState() {
             cursorTaskbar,
             cursorMonitor
         );
-
-    const bool hovering =
-        cursorInHoverZone;
-
 
     if (hovering) {
         g_hoverActive = true;
@@ -2578,19 +2459,14 @@ void PostRefresh() {
     }
 }
 
-bool HasEnabledHoverSnapshot() {
+bool HasHoverSnapshots() {
     AcquireSRWLockShared(
         &g_cursorHoverSnapshotLock
     );
 
     bool result = false;
 
-    for (size_t i = 0; i < g_cursorHoverSnapshotCount; ++i) {
-        if (g_cursorHoverSnapshots[i].enabled) {
-            result = true;
-            break;
-        }
-    }
+    result = g_cursorHoverSnapshotCount != 0;
 
     ReleaseSRWLockShared(
         &g_cursorHoverSnapshotLock
@@ -2610,7 +2486,7 @@ DWORD WINAPI CursorSamplingThread(LPVOID) {
 
     for (;;) {
         const bool hoverTrackingActive =
-            HasEnabledHoverSnapshot();
+            HasHoverSnapshots();
 
         DWORD waitMs =
             hoverTrackingActive

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              hide-taskbar-only-on-desktop
-// @name            Hide Taskbar Only on Desktop
+// @name            Hide Taskbar Only on Desktop 
 // @description     Desktop-only taskbar hiding using a dedicated Windhawk tool process
-// @version         5.2.0
+// @version         5.3.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -159,9 +159,9 @@ Display identity is tracked using monitor/device information rather than relying
 
 ## Taskbar Ownership
 
-The mod tracks whether a taskbar has been transparent by its own taskbar-state logic.
+The mod tracks whether a taskbar has been made transparent by its own taskbar-state logic.
 
-This prevents the mod from unnecessarily restoring or changing a taskbar that it did not make transparent. Ownership is local to the dedicated tool process because the mod does not use a cross-process Explorer marker.
+A window property marker is stored on taskbars hidden by the mod so a newly started dedicated tool process can reclaim and restore a taskbar left hidden by an unexpected previous-process termination. The marker is attached to the taskbar window itself; the mod still does not inject into Explorer.
 
 ## Performance
 
@@ -189,7 +189,7 @@ The periodic safety poll provides a recovery path for missed or unusual transiti
 - The current display-selection configuration supports up to 16 display entries.
 - The mod intentionally keeps Windows' native taskbar auto-hide setting separate from its own hiding behavior.
 - Hiding the taskbar does not increase the desktop work area; maximized windows may still leave the normal taskbar space reserved.
-- If the dedicated tool process is terminated unexpectedly while a taskbar is hidden, the taskbar may remain invisible until Explorer is restarted.
+- If the dedicated tool process is terminated unexpectedly while a taskbar is hidden, the next instance of this mod can reclaim the marked taskbar; if the taskbar itself is recreated before recovery, the old window marker is naturally discarded.
 - This mod may conflict with other taskbar transparency/customization mods that also modify the taskbar's layered-window style or opacity.
 - Windows shell window classes and processes can change between Windows releases, so shell-interaction detection may require updates for future Windows versions.
 - The mod is designed specifically around Windows' Explorer/taskbar behavior and is not intended to be a general-purpose taskbar customization framework.
@@ -358,6 +358,65 @@ SRWLOCK g_cursorHoverSnapshotLock = SRWLOCK_INIT;
 // A layered window with alpha 0 is used as the physical taskbar visibility
 // mechanism. The taskbar state machine remains in the dedicated
 // Windhawk tool process.
+//
+// The properties below are deliberately stored on the taskbar window itself so
+// a newly started tool process can reclaim a taskbar hidden by an older process.
+constexpr wchar_t kTaskbarOwnershipProp[] =
+    L"windhawk-hide-taskbar-only-on-desktop-ownership";
+constexpr wchar_t kTaskbarOriginalExStyleProp[] =
+    L"windhawk-hide-taskbar-only-on-desktop-original-exstyle";
+constexpr wchar_t kTaskbarOriginalLayeredColorKeyProp[] =
+    L"windhawk-hide-taskbar-only-on-desktop-original-color-key";
+constexpr wchar_t kTaskbarOriginalLayeredAlphaProp[] =
+    L"windhawk-hide-taskbar-only-on-desktop-original-alpha";
+constexpr wchar_t kTaskbarOriginalLayeredFlagsProp[] =
+    L"windhawk-hide-taskbar-only-on-desktop-original-layered-flags";
+constexpr wchar_t kTaskbarOriginalLayeredAttributesValidProp[] =
+    L"windhawk-hide-taskbar-only-on-desktop-original-layered-valid";
+
+bool GetWindowUlongPtrProp(
+    HWND hwnd,
+    const wchar_t* name,
+    ULONG_PTR* value
+) {
+    if (!hwnd || !name || !value) {
+        return false;
+    }
+
+    HANDLE prop = GetPropW(hwnd, name);
+    if (!prop) {
+        return false;
+    }
+
+    *value = reinterpret_cast<ULONG_PTR>(prop) - 1;
+    return true;
+}
+
+bool SetWindowUlongPtrProp(
+    HWND hwnd,
+    const wchar_t* name,
+    ULONG_PTR value
+) {
+    return SetPropW(
+        hwnd,
+        name,
+        reinterpret_cast<HANDLE>(value + 1)
+    ) != 0;
+}
+
+void RemoveTaskbarOwnershipProperties(HWND hwnd) {
+    if (!hwnd) {
+        return;
+    }
+
+    RemovePropW(hwnd, kTaskbarOwnershipProp);
+    RemovePropW(hwnd, kTaskbarOriginalExStyleProp);
+    RemovePropW(hwnd, kTaskbarOriginalLayeredColorKeyProp);
+    RemovePropW(hwnd, kTaskbarOriginalLayeredAlphaProp);
+    RemovePropW(hwnd, kTaskbarOriginalLayeredFlagsProp);
+    RemovePropW(hwnd, kTaskbarOriginalLayeredAttributesValidProp);
+}
+
 bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
     if (!hwnd || !IsWindow(hwnd)) {
         return false;
@@ -370,6 +429,64 @@ bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
     }
 
     if (hide) {
+        // Do not overwrite the original state when a taskbar is already owned
+        // by this mod (for example after a refresh in the same process).
+        if (GetPropW(hwnd, kTaskbarOwnershipProp) != nullptr) {
+            return SetLayeredWindowAttributes(hwnd, 0, 0, LWA_ALPHA) != 0;
+        }
+
+        COLORREF colorKey = 0;
+        BYTE alpha = 255;
+        DWORD layeredFlags = 0;
+        const bool originalLayered =
+            (exStyle & WS_EX_LAYERED) != 0;
+        const bool originalLayeredAttributesValid =
+            originalLayered &&
+            GetLayeredWindowAttributes(
+                hwnd,
+                &colorKey,
+                &alpha,
+                &layeredFlags
+            ) != FALSE;
+
+        if (!SetWindowUlongPtrProp(
+                hwnd,
+                kTaskbarOriginalExStyleProp,
+                static_cast<ULONG_PTR>(exStyle))) {
+            Wh_Log(L"Failed to save original taskbar extended style for 0x%p", hwnd);
+            return false;
+        }
+
+        if (!SetWindowUlongPtrProp(
+                hwnd,
+                kTaskbarOriginalLayeredColorKeyProp,
+                static_cast<ULONG_PTR>(colorKey)) ||
+            !SetWindowUlongPtrProp(
+                hwnd,
+                kTaskbarOriginalLayeredAlphaProp,
+                static_cast<ULONG_PTR>(alpha)) ||
+            !SetWindowUlongPtrProp(
+                hwnd,
+                kTaskbarOriginalLayeredFlagsProp,
+                static_cast<ULONG_PTR>(layeredFlags)) ||
+            !SetWindowUlongPtrProp(
+                hwnd,
+                kTaskbarOriginalLayeredAttributesValidProp,
+                originalLayeredAttributesValid ? 1 : 0)) {
+            RemoveTaskbarOwnershipProperties(hwnd);
+            Wh_Log(L"Failed to save original layered attributes for 0x%p", hwnd);
+            return false;
+        }
+
+        // Mark ownership before changing the window so another tool process
+        // can reclaim the taskbar even if this process terminates immediately
+        // after this point.
+        if (!SetPropW(hwnd, kTaskbarOwnershipProp, reinterpret_cast<HANDLE>(1))) {
+            RemoveTaskbarOwnershipProperties(hwnd);
+            Wh_Log(L"Failed to mark taskbar ownership for 0x%p", hwnd);
+            return false;
+        }
+
         SetLastError(ERROR_SUCCESS);
         LONG_PTR previousExStyle = SetWindowLongPtrW(
             hwnd,
@@ -377,6 +494,7 @@ bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
             exStyle | WS_EX_LAYERED | WS_EX_TRANSPARENT
         );
         if (previousExStyle == 0 && GetLastError() != ERROR_SUCCESS) {
+            RemoveTaskbarOwnershipProperties(hwnd);
             Wh_Log(
                 L"SetWindowLongPtrW(GWL_EXSTYLE, hide flags) failed for 0x%p: %lu",
                 hwnd,
@@ -386,6 +504,9 @@ bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
         }
 
         if (!SetLayeredWindowAttributes(hwnd, 0, 0, LWA_ALPHA)) {
+            // Restore the original style if applying the hiding operation failed.
+            SetWindowLongPtrW(hwnd, GWL_EXSTYLE, exStyle);
+            RemoveTaskbarOwnershipProperties(hwnd);
             Wh_Log(
                 L"SetLayeredWindowAttributes(alpha=0) failed for 0x%p: %lu",
                 hwnd,
@@ -409,9 +530,91 @@ bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
         return true;
     }
 
-    if (!SetLayeredWindowAttributes(hwnd, 0, 255, LWA_ALPHA)) {
+    if (GetPropW(hwnd, kTaskbarOwnershipProp) == nullptr) {
+        return false;
+    }
+
+    ULONG_PTR originalExStyleValue = 0;
+    ULONG_PTR originalColorKeyValue = 0;
+    ULONG_PTR originalAlphaValue = 255;
+    ULONG_PTR originalFlagsValue = 0;
+    ULONG_PTR originalLayeredAttributesValidValue = 0;
+
+    const bool haveOriginalExStyle = GetWindowUlongPtrProp(
+        hwnd,
+        kTaskbarOriginalExStyleProp,
+        &originalExStyleValue
+    );
+    const bool haveOriginalColorKey = GetWindowUlongPtrProp(
+        hwnd,
+        kTaskbarOriginalLayeredColorKeyProp,
+        &originalColorKeyValue
+    );
+    const bool haveOriginalAlpha = GetWindowUlongPtrProp(
+        hwnd,
+        kTaskbarOriginalLayeredAlphaProp,
+        &originalAlphaValue
+    );
+    const bool haveOriginalFlags = GetWindowUlongPtrProp(
+        hwnd,
+        kTaskbarOriginalLayeredFlagsProp,
+        &originalFlagsValue
+    );
+    const bool haveOriginalLayeredValid = GetWindowUlongPtrProp(
+        hwnd,
+        kTaskbarOriginalLayeredAttributesValidProp,
+        &originalLayeredAttributesValidValue
+    );
+
+    if (!haveOriginalExStyle) {
+        Wh_Log(L"Missing original taskbar style for owned taskbar 0x%p", hwnd);
+        return false;
+    }
+
+    const LONG_PTR originalExStyle =
+        static_cast<LONG_PTR>(originalExStyleValue);
+    const bool originalLayered =
+        (originalExStyle & WS_EX_LAYERED) != 0;
+    const bool originalAttributesValid =
+        haveOriginalLayeredValid &&
+        originalLayeredAttributesValidValue != 0 &&
+        haveOriginalColorKey &&
+        haveOriginalAlpha &&
+        haveOriginalFlags;
+
+    bool restoredAttributes = true;
+    if (originalLayered) {
+        if (originalAttributesValid) {
+            restoredAttributes = SetLayeredWindowAttributes(
+                hwnd,
+                static_cast<COLORREF>(originalColorKeyValue),
+                static_cast<BYTE>(originalAlphaValue),
+                static_cast<DWORD>(originalFlagsValue)
+            ) != FALSE;
+        } else {
+            // GetLayeredWindowAttributes can fail for a layered window that was
+            // not configured through SetLayeredWindowAttributes. In that case
+            // the exact original alpha state is unknowable, so prefer restoring
+            // visibility rather than leaving the taskbar at the mod's alpha=0.
+            restoredAttributes = SetLayeredWindowAttributes(
+                hwnd,
+                0,
+                255,
+                LWA_ALPHA
+            ) != FALSE;
+        }
+    } else {
+        restoredAttributes = SetLayeredWindowAttributes(
+            hwnd,
+            0,
+            255,
+            LWA_ALPHA
+        ) != FALSE;
+    }
+
+    if (!restoredAttributes) {
         Wh_Log(
-            L"SetLayeredWindowAttributes(alpha=255) failed for 0x%p: %lu",
+            L"Failed to restore layered attributes for owned taskbar 0x%p: %lu",
             hwnd,
             GetLastError()
         );
@@ -422,11 +625,11 @@ bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
     LONG_PTR previousExStyle = SetWindowLongPtrW(
         hwnd,
         GWL_EXSTYLE,
-        exStyle & ~static_cast<LONG_PTR>(WS_EX_LAYERED | WS_EX_TRANSPARENT)
+        originalExStyle
     );
     if (previousExStyle == 0 && GetLastError() != ERROR_SUCCESS) {
         Wh_Log(
-            L"SetWindowLongPtrW(remove hide flags) failed for 0x%p: %lu",
+            L"SetWindowLongPtrW(restore original style) failed for 0x%p: %lu",
             hwnd,
             GetLastError()
         );
@@ -445,6 +648,7 @@ bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
         SWP_ASYNCWINDOWPOS
     );
 
+    RemoveTaskbarOwnershipProperties(hwnd);
     return true;
 }
 
@@ -1175,9 +1379,12 @@ bool IsShellSurfaceWindow(
         &pid
     );
 
-    if (IsTaskbarPopupClass(className)) {
-        return true;
-    }
+    if (
+    IsTaskbarPopupClass(className) &&
+    (IsExplorerProcess(pid) || IsKnownShellProcess(pid))
+) {
+    return true;
+}
 
     if (
         IsAltTabClass(className) &&
@@ -1674,30 +1881,36 @@ void SetTaskbarState(
     }
 }
 
-struct VisibleShellPopupContext {
-    HMONITOR monitor;
-    bool found;
+struct ShellPopupScanResult {
+    bool visibleOnMonitor[kMaxMonitorNumbers];
 };
 
-BOOL CALLBACK FindVisibleShellPopupOnMonitorProc(
+struct PopupScanContext {
+    const MonitorList* monitors;
+    ShellPopupScanResult* result;
+};
+
+BOOL CALLBACK ScanVisibleShellPopupsProc(
     HWND hwnd,
     LPARAM lParam
 ) {
-    auto* context =
-        reinterpret_cast<VisibleShellPopupContext*>(lParam);
-
-    if (!context || context->found || !IsWindowVisible(hwnd)) {
-        return context && context->found ? FALSE : TRUE;
-    }
-
-    WCHAR className[256] = {};
-    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
+    auto* context = reinterpret_cast<PopupScanContext*>(lParam);
+    if (!context || !context->monitors || !context->result ||
+        !IsWindowVisible(hwnd)) {
         return TRUE;
     }
 
-    if (!IsTaskbarPopupClass(className) ||
+    WCHAR className[256] = {};
+    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0 ||
+        !IsTaskbarPopupClass(className) ||
         IsShellChromeClass(className) ||
         IsDesktopInfrastructureWindow(hwnd, className)) {
+        return TRUE;
+    }
+
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hwnd, &pid);
+    if (!(IsExplorerProcess(pid) || IsKnownShellProcess(pid))) {
         return TRUE;
     }
 
@@ -1706,36 +1919,31 @@ BOOL CALLBACK FindVisibleShellPopupOnMonitorProc(
         return TRUE;
     }
 
-    MONITORINFO mi = {};
-    mi.cbSize = sizeof(mi);
-    if (!context->monitor ||
-        !GetMonitorInfoW(context->monitor, &mi)) {
-        return TRUE;
-    }
-
-    RECT intersection = {};
-    if (IntersectRect(&intersection, &rect, &mi.rcMonitor)) {
-        context->found = true;
-        return FALSE;
+    for (size_t i = 0; i < context->monitors->count; ++i) {
+        RECT intersection = {};
+        if (IntersectRect(
+                &intersection,
+                &rect,
+                &context->monitors->entries[i].rect)) {
+            context->result->visibleOnMonitor[i] = true;
+        }
     }
 
     return TRUE;
 }
 
-bool IsVisibleShellPopupOnMonitor(HMONITOR monitor) {
-    if (!monitor) {
-        return false;
-    }
+void ScanVisibleShellPopupsOnce(
+    const MonitorList& monitors,
+    ShellPopupScanResult& result
+) {
+    result = {};
 
-    VisibleShellPopupContext context = {};
-    context.monitor = monitor;
+    PopupScanContext context = {&monitors, &result};
 
     EnumWindows(
-        FindVisibleShellPopupOnMonitorProc,
+        ScanVisibleShellPopupsProc,
         reinterpret_cast<LPARAM>(&context)
     );
-
-    return context.found;
 }
 
 void ApplyBaseTaskbarState() {
@@ -2012,6 +2220,47 @@ bool IsCursorInConfiguredHoverZoneAtSnapshot(
     return result;
 }
 
+bool IsStableDeviceIdPresent(
+    const MonitorList& monitors,
+    const wchar_t* stableDeviceId
+) {
+    if (!stableDeviceId || stableDeviceId[0] == L'\0') {
+        return false;
+    }
+
+    for (size_t i = 0; i < monitors.count; ++i) {
+        if (StableDeviceIdsMatch(
+                stableDeviceId,
+                monitors.entries[i].stableDeviceId)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void ReconcileStaleMonitorSelectionBindings(
+    const MonitorList& monitors
+) {
+    for (int configuredNumber = 1;
+         configuredNumber <= static_cast<int>(kMaxMonitorNumbers);
+         ++configuredNumber) {
+        if (g_hideMonitorBindings[configuredNumber].configured &&
+            !IsStableDeviceIdPresent(
+                monitors,
+                g_hideMonitorBindings[configuredNumber].stableDeviceId)) {
+            g_hideMonitorBindings[configuredNumber] = {};
+        }
+
+        if (g_hoverMonitorBindings[configuredNumber].configured &&
+            !IsStableDeviceIdPresent(
+                monitors,
+                g_hoverMonitorBindings[configuredNumber].stableDeviceId)) {
+            g_hoverMonitorBindings[configuredNumber] = {};
+        }
+    }
+}
+
 void UpdateTaskbarState() {
 
     MonitorList monitors =
@@ -2038,6 +2287,8 @@ void UpdateTaskbarState() {
         g_hoverMonitor = nullptr;
         g_hoverDeadline = 0;
         CancelHoverExpireTimer();
+
+        ReconcileStaleMonitorSelectionBindings(monitors);
     }
 
     g_displayTopologySignature = topologySignature;
@@ -2056,10 +2307,16 @@ void UpdateTaskbarState() {
         IsNativeAutoHideEnabled();
 
     WindowScanResult scan = {};
+    ShellPopupScanResult shellPopups = {};
 
     ScanWindowsOnce(
         monitors,
         scan
+    );
+
+    ScanVisibleShellPopupsOnce(
+        monitors,
+        shellPopups
     );
 
     for (size_t i = 0; i < g_taskbarStateCount; ++i) {
@@ -2188,8 +2445,14 @@ void UpdateTaskbarState() {
         bool shellPopupPresent = false;
         for (size_t i = 0; i < g_taskbarStateCount; ++i) {
             TaskbarMonitorState& state = g_taskbarStates[i];
-            if (IsVisibleShellPopupOnMonitor(state.monitor)) {
-                shellPopupPresent = true;
+            for (size_t monitorIndex = 0; monitorIndex < monitors.count; ++monitorIndex) {
+                if (monitors.entries[monitorIndex].monitor == state.monitor &&
+                    shellPopups.visibleOnMonitor[monitorIndex]) {
+                    shellPopupPresent = true;
+                    break;
+                }
+            }
+            if (shellPopupPresent) {
                 break;
             }
         }
@@ -2202,11 +2465,20 @@ void UpdateTaskbarState() {
                 TaskbarMonitorState& state =
                     g_taskbarStates[i];
 
+                bool shellPopupOnMonitor = false;
+                for (size_t monitorIndex = 0; monitorIndex < monitors.count; ++monitorIndex) {
+                    if (monitors.entries[monitorIndex].monitor == state.monitor) {
+                        shellPopupOnMonitor =
+                            shellPopups.visibleOnMonitor[monitorIndex];
+                        break;
+                    }
+                }
+
                 SetTaskbarState(
                     state,
                     !state.desktopOnly ||
                     !ShouldHideTaskbar(state) ||
-                    IsVisibleShellPopupOnMonitor(state.monitor)
+                    shellPopupOnMonitor
                 );
             }
 
@@ -2838,6 +3110,10 @@ BOOL WhTool_ModInit() {
     // ShouldHideMonitor() returns false even when the UI says "All displays".
     LoadSettings();
 
+    // Recover ownership left by an unexpectedly terminated previous tool
+    // process before the new worker starts making visibility decisions.
+    RestoreAllTaskbars();
+
     g_workerReadyEvent =
         CreateEventW(
             nullptr,
@@ -2946,6 +3222,15 @@ void WhTool_ModSettingsChanged() {
     }
 }
 
+BOOL CALLBACK RestoreMarkedTaskbarProc(HWND hwnd, LPARAM) {
+    if (!hwnd || GetPropW(hwnd, kTaskbarOwnershipProp) == nullptr) {
+        return TRUE;
+    }
+
+    MakeTaskbarTransparent(hwnd, false);
+    return TRUE;
+}
+
 void RestoreAllTaskbars() {
     for (size_t i = 0; i < g_taskbarStateCount; ++i) {
         TaskbarMonitorState& state = g_taskbarStates[i];
@@ -2958,6 +3243,14 @@ void RestoreAllTaskbars() {
             state.hiddenByMod = false;
         }
     }
+
+    // Reclaim taskbars hidden by a previous dedicated tool-process instance.
+    // This also covers taskbars that were hidden shortly before an unexpected
+    // process termination and therefore never reached the local state table.
+    EnumWindows(
+        RestoreMarkedTaskbarProc,
+        0
+    );
 }
 
 bool WaitForThreadWithTimeout(

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Desktop-only taskbar hiding using a dedicated Windhawk tool process
-// @version         5.6.0
+// @version         5.7.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -206,6 +206,7 @@ constexpr size_t kMaxTaskbars = 16;
 
 constexpr UINT WM_APP_REFRESH = WM_APP + 1;
 constexpr UINT WM_APP_SETTINGS = WM_APP + 2;
+constexpr UINT WM_APP_NATIVE_AUTOHIDE = WM_APP + 3;
 constexpr UINT_PTR kSafetyTimerId = 1;
 constexpr UINT_PTR kHoverExpireTimerId = 2;
 
@@ -581,6 +582,7 @@ UINT g_taskbarCreatedMessage = 0;
 TaskbarMonitorState g_taskbarStates[kMaxTaskbars] = {};
 size_t g_taskbarStateCount = 0;
 bool g_nativeAutoHideEnabled = false;
+bool g_appBarRegistered = false;
 
 bool g_hoverActive = false;
 HMONITOR g_hoverMonitor = nullptr;
@@ -1392,7 +1394,45 @@ void SetTaskbarState(
     }
 
     if (state.hiddenByMod) {
-        return;
+        SetLastError(ERROR_SUCCESS);
+        LONG_PTR exStyle = GetWindowLongPtrW(
+            state.hwnd,
+            GWL_EXSTYLE
+        );
+        if (exStyle == 0 && GetLastError() != ERROR_SUCCESS) {
+            return;
+        }
+
+        if (!(exStyle & WS_EX_LAYERED) ||
+            GetPropW(state.hwnd, kTaskbarOwnershipProp) == nullptr) {
+            RemoveTaskbarOwnershipProperties(state.hwnd);
+            state.hiddenByMod = false;
+        } else {
+            COLORREF colorKey = 0;
+            BYTE alpha = 0;
+            DWORD layeredFlags = 0;
+
+            const bool attributesAvailable =
+                GetLayeredWindowAttributes(
+                    state.hwnd,
+                    &colorKey,
+                    &alpha,
+                    &layeredFlags
+                ) != FALSE;
+
+            if (!attributesAvailable ||
+                !(layeredFlags & LWA_ALPHA) ||
+                alpha != 0) {
+                SetLayeredWindowAttributes(
+                    state.hwnd,
+                    0,
+                    0,
+                    LWA_ALPHA
+                );
+            }
+
+            return;
+        }
     }
 
     // Do not take ownership of a taskbar that is already hidden by another
@@ -1427,9 +1467,7 @@ BOOL CALLBACK ScanVisibleShellPopupsProc(
 
     WCHAR className[256] = {};
     if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0 ||
-        !IsTaskbarPopupClass(className) ||
-        IsShellChromeClass(className) ||
-        IsDesktopInfrastructureWindow(hwnd, className)) {
+        !IsTaskbarPopupClass(className)) {
         return TRUE;
     }
 
@@ -2037,9 +2075,8 @@ bool HasHoverSnapshots() {
         &g_cursorHoverSnapshotLock
     );
 
-    bool result = false;
-
-    result = g_cursorHoverSnapshotCount != 0;
+    const bool result =
+        g_cursorHoverSnapshotCount != 0;
 
     ReleaseSRWLockShared(
         &g_cursorHoverSnapshotLock
@@ -2151,6 +2188,14 @@ LRESULT CALLBACK WorkerMessageWindowProc(
         return 0;
     }
 
+    if (message == WM_APP_NATIVE_AUTOHIDE) {
+        if (wParam == ABN_STATECHANGE) {
+            RefreshNativeAutoHideState();
+            PostRefresh();
+        }
+        return 0;
+    }
+
     if (
         message == g_taskbarCreatedMessage ||
         message == WM_DISPLAYCHANGE ||
@@ -2236,10 +2281,30 @@ bool CreateWorkerMessageWindow() {
         return false;
     }
 
+    APPBARDATA appBar = {};
+    appBar.cbSize = sizeof(appBar);
+    appBar.hWnd = g_workerMessageWindow;
+    appBar.uCallbackMessage = WM_APP_NATIVE_AUTOHIDE;
+
+    g_appBarRegistered =
+        SHAppBarMessage(ABM_NEW, &appBar) != 0;
+
+    if (!g_appBarRegistered) {
+        Wh_Log(L"SHAppBarMessage(ABM_NEW) failed; native auto-hide state-change notifications unavailable");
+    }
+
     return true;
 }
 
 void DestroyWorkerMessageWindow() {
+    if (g_appBarRegistered && g_workerMessageWindow) {
+        APPBARDATA appBar = {};
+        appBar.cbSize = sizeof(appBar);
+        appBar.hWnd = g_workerMessageWindow;
+        SHAppBarMessage(ABM_REMOVE, &appBar);
+        g_appBarRegistered = false;
+    }
+
     if (g_workerMessageWindow) {
         DestroyWindow(g_workerMessageWindow);
         g_workerMessageWindow = nullptr;
@@ -2805,9 +2870,7 @@ void WhTool_ModUninit() {
         SafeCloseHandle(g_workerThread);
     }
 
-    if (g_workerReadyEvent) {
-        SafeCloseHandle(g_workerReadyEvent);
-    }
+    SafeCloseHandle(g_workerReadyEvent);
 
     /*
      * Restore all currently discoverable taskbars when the tool exits.
@@ -2986,6 +3049,9 @@ void Wh_ModSettingsChanged() {
 
 void Wh_ModUninit() {
     if (g_isToolModProcessLauncher) {
+        // Recover taskbars left transparent if the dedicated tool process
+        // terminated before its normal cleanup path could run.
+        RestoreAllTaskbars();
         return;
     }
 

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
-// @description     Desktop-only taskbar hiding using a dedicated Windhawk tool process
-// @version         5.7.0
+// @description     Hides selected taskbars while their displays show only the desktop
+// @version         5.8.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -30,7 +30,7 @@ This Windhawk mod hides selected taskbars when their corresponding display is sh
 
 For each selected display, the mod checks whether a relevant visible, non-minimized application is present. Supported Windows shell surfaces and desktop infrastructure are excluded from the normal application check.
 
-When a display is showing only the desktop, its selected bottom-docked taskbar can be hidden. An application on that display, taskbar keyboard focus, or supported shell interaction can keep the taskbar visible.
+When a display is showing only the desktop, its selected bottom-docked taskbar can be hidden. An application on that display, keyboard-driven taskbar focus such as Win+T or Win+B, or supported shell interaction can keep the taskbar visible. Mouse interaction with the taskbar does not prevent it from hiding after hover dismissal.
 
 Applications spanning multiple displays are considered for every display they intersect, so each affected display can independently remain visible.
 
@@ -71,7 +71,7 @@ Supported shell surfaces include:
 
 Supported shell popup classes are checked during hover dismissal. A supported popup can keep the corresponding taskbar visible while it is being dismissed, and the currently hovered taskbar remains visible during that grace period as well.
 
-The taskbar is also treated as occupied when the taskbar itself is the foreground window, preventing keyboard navigation such as `Win+T`, `Win+B`, or `Win+number` from operating on an invisible taskbar.
+The taskbar is treated as occupied when it receives keyboard-driven foreground focus, preventing keyboard navigation such as `Win+T`, `Win+B`, or `Win+number` from operating on an invisible taskbar. A taskbar focused by mouse interaction can still hide normally after the hover grace period ends.
 
 ## Taskbar State and Recovery
 
@@ -97,7 +97,7 @@ The mod uses:
 
 - A dedicated worker thread for state management
 - A lightweight cursor-sampling thread for hover detection
-- Event-driven refreshes for relevant foreground, minimize/move, display, theme, settings, and taskbar recreation changes
+- Event-driven refreshes for relevant foreground, minimize/move, window show/hide/destroy, display, theme, settings, and taskbar recreation changes
 - A periodic 250 ms safety poll for missed or unusual transitions
 - A one-shot timer for hover dismissal
 
@@ -244,6 +244,7 @@ struct WindowScanResult {
 HWINEVENTHOOK g_foregroundHook = nullptr;
 HWINEVENTHOOK g_minimizeHook = nullptr;
 HWINEVENTHOOK g_moveHook = nullptr;
+HWINEVENTHOOK g_objectHook = nullptr;
 
 HANDLE g_workerThread = nullptr;
 DWORD g_workerThreadId = 0;
@@ -587,6 +588,8 @@ bool g_appBarRegistered = false;
 bool g_hoverActive = false;
 HMONITOR g_hoverMonitor = nullptr;
 ULONGLONG g_hoverDeadline = 0;
+HWND g_keyboardFocusedTaskbar = nullptr;
+bool g_suppressHoverUntilCursorLeaves = false;
 
 LONG g_refreshPosted = 0;
 void LoadSettings();
@@ -1005,8 +1008,14 @@ bool IsApplicationWindowCandidate(
         return false;
     }
 
-    BOOL transparent = FALSE;
+    // Background title-less helper surfaces are ignored. A title-less
+    // application becomes covered by the foreground-window path.
+    if (!((exStyle & WS_EX_APPWINDOW) != 0 ||
+          GetWindowTextLengthW(hwnd) > 0)) {
+        return false;
+    }
 
+    BOOL transparent = FALSE;
     if (
         SUCCEEDED(
             DwmGetWindowAttribute(
@@ -1021,21 +1030,7 @@ bool IsApplicationWindowCandidate(
         return false;
     }
 
-    if (
-        IsDesktopInfrastructureWindow(
-            hwnd,
-            className
-        ) ||
-        IsShellChromeClass(className)
-    ) {
-        return false;
-    }
-
-    // Background title-less helper surfaces are ignored. A title-less
-    // application becomes covered by the foreground-window path.
-    return
-        (exStyle & WS_EX_APPWINDOW) != 0 ||
-        GetWindowTextLengthW(hwnd) > 0;
+    return true;
 }
 
 struct ScanContext {
@@ -1056,6 +1051,18 @@ BOOL CALLBACK ScanWindowsWithMonitorsProc(
         !context->result
     ) {
         return TRUE;
+    }
+
+    bool allMonitorsOccupied = true;
+    for (size_t i = 0; i < context->monitors->count; ++i) {
+        if (!context->result->applicationOnMonitor[i]) {
+            allMonitorsOccupied = false;
+            break;
+        }
+    }
+
+    if (allMonitorsOccupied && context->monitors->count != 0) {
+        return FALSE;
     }
 
     WCHAR className[256] = {};
@@ -1788,6 +1795,7 @@ void UpdateTaskbarState() {
             g_hoverActive = false;
             g_hoverMonitor = nullptr;
             g_hoverDeadline = 0;
+            g_suppressHoverUntilCursorLeaves = false;
             CancelHoverExpireTimer();
             ApplyBaseTaskbarState();
             UpdateCursorHoverSnapshot();
@@ -1827,11 +1835,18 @@ void UpdateTaskbarState() {
 
     }
 
-    HWND foreground = GetForegroundWindow();
-    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
-        if (g_taskbarStates[i].hwnd == foreground) {
-            g_taskbarStates[i].desktopOnly = false;
-            break;
+    if (g_keyboardFocusedTaskbar) {
+        bool found = false;
+        for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+            if (g_taskbarStates[i].hwnd == g_keyboardFocusedTaskbar) {
+                g_taskbarStates[i].desktopOnly = false;
+                found = true;
+                break;
+            }
+        }
+
+        if (!found) {
+            g_keyboardFocusedTaskbar = nullptr;
         }
     }
 
@@ -1867,7 +1882,7 @@ void UpdateTaskbarState() {
         break;
     }
 
-    const bool hovering =
+    const bool cursorInHoverZone =
         cursorTaskbar &&
         cursorMonitor &&
         cursorHoverConfigured &&
@@ -1876,6 +1891,14 @@ void UpdateTaskbarState() {
             cursorMonitor,
             cursorPoint
         );
+
+    if (!cursorInHoverZone) {
+        g_suppressHoverUntilCursorLeaves = false;
+    }
+
+    const bool hovering =
+        cursorInHoverZone &&
+        !g_suppressHoverUntilCursorLeaves;
 
     if (hovering) {
         g_hoverActive = true;
@@ -1989,7 +2012,16 @@ void UpdateTaskbarState() {
 
         CancelHoverExpireTimer();
 
-        ApplyBaseTaskbarState();
+        for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+            TaskbarMonitorState& state =
+                g_taskbarStates[i];
+
+            SetTaskbarState(
+                state,
+                !state.desktopOnly ||
+                !ShouldHideTaskbar(state)
+            );
+        }
         UpdateCursorHoverSnapshot();
         return;
     }
@@ -2156,21 +2188,109 @@ DWORD WINAPI CursorSamplingThread(LPVOID) {
 void CALLBACK WinEventProc(
     HWINEVENTHOOK,
     DWORD event,
-    HWND,
-    LONG,
-    LONG,
+    HWND hwnd,
+    LONG idObject,
+    LONG idChild,
     DWORD,
     DWORD
 ) {
+    if (event == EVENT_SYSTEM_FOREGROUND) {
+        g_keyboardFocusedTaskbar = nullptr;
+
+        if (hwnd) {
+            WCHAR className[64] = {};
+            if (GetClassNameW(
+                    hwnd,
+                    className,
+                    ARRAYSIZE(className)
+                ) != 0 &&
+                (wcscmp(className, L"Shell_TrayWnd") == 0 ||
+                 wcscmp(className, L"Shell_SecondaryTrayWnd") == 0)) {
+                POINT cursorPoint = {};
+                RECT taskbarRect = {};
+                bool cursorOverTaskbar = false;
+
+                if (GetCursorPos(&cursorPoint) &&
+                    GetWindowRect(hwnd, &taskbarRect)) {
+                    cursorOverTaskbar =
+                        PtInRect(&taskbarRect, cursorPoint) != FALSE;
+                }
+
+                // A taskbar focused while the cursor is elsewhere is treated
+                // as keyboard-driven focus (for example Win+T/Win+B/Win+number).
+                // Do not infer keyboard focus during a just-completed minimize
+                // while hover suppression is active; that foreground transition
+                // can simply be the taskbar taking focus after the app closes.
+                // A taskbar focused with the cursor over it is treated as mouse
+                // interaction and may hide normally after hover dismissal.
+                if (!cursorOverTaskbar && !g_suppressHoverUntilCursorLeaves) {
+                    g_keyboardFocusedTaskbar = hwnd;
+                }
+            }
+        }
+
+        PostRefresh();
+        return;
+    }
+
+    if (event == EVENT_SYSTEM_MINIMIZESTART) {
+        POINT cursorPoint = {};
+        bool cursorOverTaskbar = false;
+
+        if (GetCursorPos(&cursorPoint)) {
+            for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+                RECT taskbarRect = {};
+                if (GetWindowRect(g_taskbarStates[i].hwnd, &taskbarRect) &&
+                    PtInRect(&taskbarRect, cursorPoint) != FALSE) {
+                    cursorOverTaskbar = true;
+                    break;
+                }
+            }
+        }
+
+        g_keyboardFocusedTaskbar = nullptr;
+        g_suppressHoverUntilCursorLeaves = !cursorOverTaskbar;
+        g_hoverActive = false;
+        g_hoverMonitor = nullptr;
+        g_hoverDeadline = 0;
+        CancelHoverExpireTimer();
+        PostRefresh();
+        return;
+    }
+
+    if (event == EVENT_SYSTEM_MINIMIZEEND) {
+        // The start event already decided whether this was a mouse/taskbar
+        // interaction or an external minimize. Reconcile the final state now.
+        g_keyboardFocusedTaskbar = nullptr;
+        PostRefresh();
+        return;
+    }
+
+    if (event == EVENT_SYSTEM_MOVESIZEEND) {
+        PostRefresh();
+        return;
+    }
+
     if (
-        event == EVENT_SYSTEM_FOREGROUND ||
-        event == EVENT_SYSTEM_MINIMIZESTART ||
-        event == EVENT_SYSTEM_MINIMIZEEND ||
-        event == EVENT_SYSTEM_MOVESIZEEND
+        event == EVENT_OBJECT_DESTROY &&
+        hwnd &&
+        hwnd == g_keyboardFocusedTaskbar
+    ) {
+        g_keyboardFocusedTaskbar = nullptr;
+    }
+
+    if (
+        (event == EVENT_OBJECT_DESTROY ||
+         event == EVENT_OBJECT_SHOW ||
+         event == EVENT_OBJECT_HIDE) &&
+        hwnd &&
+        idObject == OBJID_WINDOW &&
+        idChild == CHILDID_SELF
     ) {
         PostRefresh();
     }
 }
+
 
 
 LRESULT CALLBACK WorkerMessageWindowProc(
@@ -2388,6 +2508,17 @@ DWORD WINAPI WorkerThread(
             WINEVENT_OUTOFCONTEXT
         );
 
+    g_objectHook =
+        SetWinEventHook(
+            EVENT_OBJECT_DESTROY,
+            EVENT_OBJECT_HIDE,
+            nullptr,
+            WinEventProc,
+            0,
+            0,
+            WINEVENT_OUTOFCONTEXT
+        );
+
     UpdateTaskbarState();
 
     // Keep a true periodic safety poll. It is only a fallback for shell/window
@@ -2466,6 +2597,7 @@ DWORD WINAPI WorkerThread(
     SafeUnhookWinEvent(g_foregroundHook);
     SafeUnhookWinEvent(g_minimizeHook);
     SafeUnhookWinEvent(g_moveHook);
+    SafeUnhookWinEvent(g_objectHook);
 
     DestroyWorkerMessageWindow();
 
@@ -3049,9 +3181,6 @@ void Wh_ModSettingsChanged() {
 
 void Wh_ModUninit() {
     if (g_isToolModProcessLauncher) {
-        // Recover taskbars left transparent if the dedicated tool process
-        // terminated before its normal cleanup path could run.
-        RestoreAllTaskbars();
         return;
     }
 

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Desktop-only taskbar hiding using a dedicated Windhawk tool process
-// @version         5.5.0
+// @version         5.6.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -45,7 +45,7 @@ You can configure independently:
 
 You can select all displays or individual logical display numbers. The settings use the current logical monitor order rather than the internal Windows `DISPLAYn` device identifier.
 
-The mod keeps a stable monitor/device association when Windows changes its internal `DISPLAYn` numbering during the current session. When a display topology change invalidates an old association, stale selection bindings are reconciled instead of silently following an unrelated monitor.
+Display selections are evaluated using the current logical monitor numbering each time the display list is refreshed. If Windows changes the logical display order after a display is added, removed, or rearranged, the configured display numbers follow the new current numbering.
 
 ## Hover Reveal
 
@@ -87,7 +87,7 @@ Each selected display is evaluated independently. For example, an application ca
 
 An application spanning multiple displays keeps the taskbars on every intersected display visible. A taskbar can also be revealed independently by hovering its own configured bottom-edge area.
 
-The mod supports up to 16 display/taskbar entries and retains the existing logical display numbering system used by the settings UI.
+The mod supports up to 16 display/taskbar entries and uses the current logical display numbering reported by monitor enumeration.
 
 ## Performance and Refreshing
 
@@ -170,9 +170,9 @@ When no displays are configured for desktop-based hiding, the mod skips the appl
     These numbers may differ from the display numbers shown in Windows Display
     Settings. Choose All displays to hide every connected display. Only
     bottom-docked taskbars participate in desktop-based hiding. Use Add to
-    select multiple displays. When a physical display is reconnected and Windows
-    renumbers DISPLAYn, the mod keeps the selection bound to the same detected
-    monitor device when possible.
+    select multiple displays. Selections use the current logical display
+    numbering, so the selected number may refer to a different physical
+    display after Windows changes the display order.
   $options:
   - all: All displays
   - monitor1: Display 1
@@ -221,8 +221,6 @@ struct {
 struct MonitorEntry {
     HMONITOR monitor;
     RECT rect;
-    wchar_t deviceName[32];
-    wchar_t stableDeviceId[256];
 };
 
 struct MonitorList {
@@ -234,14 +232,8 @@ struct TaskbarMonitorState {
     HWND hwnd;
     HMONITOR monitor;
     int monitorNumber;
-    wchar_t stableDeviceId[256];
     bool desktopOnly;
     bool hiddenByMod;
-};
-
-struct MonitorSelectionBinding {
-    bool configured;
-    wchar_t stableDeviceId[256];
 };
 
 struct WindowScanResult {
@@ -540,11 +532,23 @@ bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
         return false;
     }
 
+    constexpr LONG_PTR kModExStyleBits =
+        WS_EX_LAYERED | WS_EX_TRANSPARENT;
+
     SetLastError(ERROR_SUCCESS);
+    LONG_PTR currentExStyle = GetWindowLongPtrW(
+        hwnd,
+        GWL_EXSTYLE
+    );
+    if (currentExStyle == 0 && GetLastError() != ERROR_SUCCESS) {
+        return false;
+    }
+
     LONG_PTR previousExStyle = SetWindowLongPtrW(
         hwnd,
         GWL_EXSTYLE,
-        originalExStyle
+        (currentExStyle & ~kModExStyleBits) |
+        (originalExStyle & kModExStyleBits)
     );
     if (previousExStyle == 0 && GetLastError() != ERROR_SUCCESS) {
         Wh_Log(
@@ -574,16 +578,9 @@ bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
 HWND g_workerMessageWindow = nullptr;
 ATOM g_workerWindowClassAtom = 0;
 UINT g_taskbarCreatedMessage = 0;
-ULONGLONG g_displayTopologySignature = 0;
-
 TaskbarMonitorState g_taskbarStates[kMaxTaskbars] = {};
 size_t g_taskbarStateCount = 0;
 bool g_nativeAutoHideEnabled = false;
-
-MonitorSelectionBinding
-    g_hideMonitorBindings[kMaxMonitorNumbers + 1] = {};
-MonitorSelectionBinding
-    g_hoverMonitorBindings[kMaxMonitorNumbers + 1] = {};
 
 bool g_hoverActive = false;
 HMONITOR g_hoverMonitor = nullptr;
@@ -649,220 +646,6 @@ bool IsDesktopInfrastructureWindow(
     return shellWindow && shellWindow == hwnd;
 }
 
-struct StableMonitorDeviceCacheEntry {
-    bool valid;
-    wchar_t deviceName[32];
-    wchar_t stableDeviceId[256];
-};
-
-StableMonitorDeviceCacheEntry
-    g_stableMonitorDeviceCache[kMaxMonitorNumbers] = {};
-
-void ClearStableMonitorDeviceIdCache() {
-    for (auto& entry : g_stableMonitorDeviceCache) {
-        entry = {};
-    }
-}
-
-bool GetStableMonitorDeviceId(
-    const wchar_t* deviceName,
-    wchar_t* output,
-    size_t outputCount
-) {
-    if (
-        !deviceName ||
-        !output ||
-        outputCount == 0
-    ) {
-        return false;
-    }
-
-    output[0] = L'\0';
-
-    for (const auto& entry : g_stableMonitorDeviceCache) {
-        if (
-            entry.valid &&
-            wcscmp(
-                entry.deviceName,
-                deviceName
-            ) == 0
-        ) {
-            wcsncpy_s(
-                output,
-                outputCount,
-                entry.stableDeviceId,
-                _TRUNCATE
-            );
-            return output[0] != L'\0';
-        }
-    }
-
-    wchar_t stableDeviceId[256] = {};
-    DISPLAY_DEVICEW adapter = {};
-    adapter.cb = sizeof(adapter);
-
-    for (
-        DWORD adapterIndex = 0;
-        EnumDisplayDevicesW(
-            nullptr,
-            adapterIndex,
-            &adapter,
-            0
-        );
-        ++adapterIndex
-    ) {
-        if (
-            wcscmp(
-                adapter.DeviceName,
-                deviceName
-            ) != 0
-        ) {
-            adapter = {};
-            adapter.cb = sizeof(adapter);
-            continue;
-        }
-
-        DISPLAY_DEVICEW monitor = {};
-        monitor.cb = sizeof(monitor);
-
-        if (
-            EnumDisplayDevicesW(
-                adapter.DeviceName,
-                0,
-                &monitor,
-                0
-            ) &&
-            monitor.DeviceID[0] != L'\0'
-        ) {
-            wcsncpy_s(
-                stableDeviceId,
-                ARRAYSIZE(stableDeviceId),
-                monitor.DeviceID,
-                _TRUNCATE
-            );
-        } else if (adapter.DeviceID[0] != L'\0') {
-            wcsncpy_s(
-                stableDeviceId,
-                ARRAYSIZE(stableDeviceId),
-                adapter.DeviceID,
-                _TRUNCATE
-            );
-        }
-
-        break;
-    }
-
-    if (stableDeviceId[0] == L'\0') {
-        return false;
-    }
-
-    for (auto& entry : g_stableMonitorDeviceCache) {
-        if (!entry.valid) {
-            entry.valid = true;
-
-            wcsncpy_s(
-                entry.deviceName,
-                ARRAYSIZE(entry.deviceName),
-                deviceName,
-                _TRUNCATE
-            );
-
-            wcsncpy_s(
-                entry.stableDeviceId,
-                ARRAYSIZE(entry.stableDeviceId),
-                stableDeviceId,
-                _TRUNCATE
-            );
-
-            break;
-        }
-    }
-
-    wcsncpy_s(
-        output,
-        outputCount,
-        stableDeviceId,
-        _TRUNCATE
-    );
-
-    return output[0] != L'\0';
-}
-
-void ResetMonitorSelectionBindings() {
-    for (
-        size_t i = 0;
-        i <= kMaxMonitorNumbers;
-        ++i
-    ) {
-        g_hideMonitorBindings[i] = {};
-        g_hoverMonitorBindings[i] = {};
-    }
-}
-
-void BindSelectionIdentity(
-    int configuredNumber,
-    const MonitorList& monitors,
-    const bool* selected,
-    MonitorSelectionBinding* bindings
-) {
-    if (
-        configuredNumber < 1 ||
-        configuredNumber > static_cast<int>(kMaxMonitorNumbers) ||
-        !selected ||
-        !bindings ||
-        !selected[configuredNumber] ||
-        bindings[configuredNumber].configured
-    ) {
-        return;
-    }
-
-    for (size_t i = 0; i < monitors.count; ++i) {
-        // Settings use the logical order of the currently connected
-        // monitors rather than the Windows DISPLAYn device identifier.
-        // This keeps "Display 2" usable even when Windows happens to name
-        // that monitor DISPLAY25, DISPLAY9, or another non-sequential value.
-        if (static_cast<int>(i + 1) == configuredNumber) {
-            if (monitors.entries[i].stableDeviceId[0] != L'\0') {
-                bindings[configuredNumber].configured = true;
-                wcsncpy_s(
-                    bindings[configuredNumber].stableDeviceId,
-                    ARRAYSIZE(
-                        bindings[configuredNumber].stableDeviceId
-                    ),
-                    monitors.entries[i].stableDeviceId,
-                    _TRUNCATE
-                );
-            }
-
-            return;
-        }
-    }
-}
-
-void BindConfiguredMonitorSelections(
-    const MonitorList& monitors
-) {
-    for (
-        int configuredNumber = 1;
-        configuredNumber <= static_cast<int>(kMaxMonitorNumbers);
-        ++configuredNumber
-    ) {
-        BindSelectionIdentity(
-            configuredNumber,
-            monitors,
-            g_settings.hideMonitor,
-            g_hideMonitorBindings
-        );
-
-        BindSelectionIdentity(
-            configuredNumber,
-            monitors,
-            g_settings.hoverMonitor,
-            g_hoverMonitorBindings
-        );
-    }
-}
-
 BOOL CALLBACK CollectMonitorProc(
     HMONITOR monitor,
     HDC,
@@ -888,18 +671,6 @@ BOOL CALLBACK CollectMonitorProc(
 
     entry.monitor = monitor;
     entry.rect = info.rcMonitor;
-    wcsncpy_s(
-        entry.deviceName,
-        ARRAYSIZE(entry.deviceName),
-        info.szDevice,
-        _TRUNCATE
-    );
-
-    GetStableMonitorDeviceId(
-        entry.deviceName,
-        entry.stableDeviceId,
-        ARRAYSIZE(entry.stableDeviceId)
-    );
 
     return TRUE;
 }
@@ -914,118 +685,7 @@ MonitorList GetCurrentMonitors() {
         reinterpret_cast<LPARAM>(&list)
     );
 
-    // Give the settings UI a deterministic, user-friendly numbering: the
-    // primary display is Display 1, followed by the remaining active displays
-    // ordered by their Windows device name. The actual device number is only
-    // an internal identifier and is never used as the selection index.
-    for (size_t i = 1; i < list.count; ++i) {
-        MonitorEntry key = list.entries[i];
-        MONITORINFO miKey = {};
-        miKey.cbSize = sizeof(miKey);
-        const bool keyPrimary =
-            key.monitor &&
-            GetMonitorInfoW(key.monitor, &miKey) &&
-            (miKey.dwFlags & MONITORINFOF_PRIMARY) != 0;
-
-        size_t j = i;
-        while (j > 0) {
-            MONITORINFO miPrev = {};
-            miPrev.cbSize = sizeof(miPrev);
-            const bool prevPrimary =
-                list.entries[j - 1].monitor &&
-                GetMonitorInfoW(list.entries[j - 1].monitor, &miPrev) &&
-                (miPrev.dwFlags & MONITORINFOF_PRIMARY) != 0;
-
-            bool shouldMoveBefore = false;
-            if (keyPrimary != prevPrimary) {
-                shouldMoveBefore = keyPrimary;
-            } else {
-                const wchar_t* keyNumberText = key.deviceName;
-                const wchar_t* previousNumberText =
-                    list.entries[j - 1].deviceName;
-
-                if (wcsncmp(keyNumberText, L"\\\\.\\DISPLAY", 11) == 0 &&
-                    wcsncmp(previousNumberText, L"\\\\.\\DISPLAY", 11) == 0) {
-                    wchar_t* keyEnd = nullptr;
-                    wchar_t* previousEnd = nullptr;
-                    long keyNumber = wcstol(keyNumberText + 11, &keyEnd, 10);
-                    long previousNumber =
-                        wcstol(previousNumberText + 11, &previousEnd, 10);
-
-                    if (keyEnd != keyNumberText + 11 &&
-                        *keyEnd == L'\0' &&
-                        previousEnd != previousNumberText + 11 &&
-                        *previousEnd == L'\0' &&
-                        keyNumber != previousNumber) {
-                        shouldMoveBefore = keyNumber < previousNumber;
-                    } else {
-                        shouldMoveBefore =
-                            wcscmp(
-                                key.deviceName,
-                                list.entries[j - 1].deviceName
-                            ) < 0;
-                    }
-                } else {
-                    shouldMoveBefore =
-                        wcscmp(
-                            key.deviceName,
-                            list.entries[j - 1].deviceName
-                        ) < 0;
-                }
-            }
-
-            if (!shouldMoveBefore) {
-                break;
-            }
-
-            list.entries[j] = list.entries[j - 1];
-            --j;
-        }
-        list.entries[j] = key;
-    }
-
     return list;
-}
-
-ULONGLONG HashDisplayTopology(
-    const MonitorList& monitors
-) {
-    // FNV-1a style hash over monitor device names and geometry. The signature
-    // is only used to detect that the topology changed, not as a stable ID.
-    ULONGLONG hash = 1469598103934665603ull;
-
-    auto mixByte = [&](unsigned char value) {
-        hash ^= value;
-        hash *= 1099511628211ull;
-    };
-
-    auto mixInt = [&](LONG value) {
-        unsigned long v = static_cast<unsigned long>(value);
-        for (int shift = 0; shift < 32; shift += 8) {
-            mixByte(static_cast<unsigned char>((v >> shift) & 0xff));
-        }
-    };
-
-    mixInt(static_cast<LONG>(monitors.count));
-
-    for (size_t i = 0; i < monitors.count; ++i) {
-        const MonitorEntry& entry = monitors.entries[i];
-
-        mixInt(entry.rect.left);
-        mixInt(entry.rect.top);
-        mixInt(entry.rect.right);
-        mixInt(entry.rect.bottom);
-
-        for (const wchar_t* pName = entry.deviceName; *pName; ++pName) {
-            wchar_t ch = *pName;
-            mixByte(static_cast<unsigned char>(ch & 0xff));
-            mixByte(static_cast<unsigned char>((ch >> 8) & 0xff));
-        }
-
-        mixByte(0);
-    }
-
-    return hash;
 }
 
 int GetMonitorNumber(
@@ -1045,55 +705,15 @@ int GetMonitorNumber(
 
 bool IsBottomDockedTaskbar(HWND hTaskbar, HMONITOR monitor);
 
-bool StableDeviceIdsMatch(
-    const wchar_t* left,
-    const wchar_t* right
-) {
-    return
-        left &&
-        right &&
-        left[0] != L'\0' &&
-        right[0] != L'\0' &&
-        wcscmp(left, right) == 0;
-}
-
 bool IsMonitorSelected(
     int monitorNumber,
-    const wchar_t* stableDeviceId,
-    const bool* selected,
-    const MonitorSelectionBinding* bindings
+    const bool* selected
 ) {
-    if (!selected || !bindings) {
-        return false;
-    }
-
-    if (
+    return
+        selected &&
         monitorNumber >= 1 &&
         monitorNumber <= static_cast<int>(kMaxMonitorNumbers) &&
-        selected[monitorNumber] &&
-        !bindings[monitorNumber].configured
-    ) {
-        return true;
-    }
-
-    for (
-        int configuredNumber = 1;
-        configuredNumber <= static_cast<int>(kMaxMonitorNumbers);
-        ++configuredNumber
-    ) {
-        if (
-            selected[configuredNumber] &&
-            bindings[configuredNumber].configured &&
-            StableDeviceIdsMatch(
-                stableDeviceId,
-                bindings[configuredNumber].stableDeviceId
-            )
-        ) {
-            return true;
-        }
-    }
-
-    return false;
+        selected[monitorNumber];
 }
 
 bool ShouldHideMonitor(
@@ -1105,9 +725,7 @@ bool ShouldHideMonitor(
 
     return IsMonitorSelected(
         state.monitorNumber,
-        state.stableDeviceId,
-        g_settings.hideMonitor,
-        g_hideMonitorBindings
+        g_settings.hideMonitor
     );
 }
 
@@ -1120,9 +738,7 @@ bool ShouldRevealOnHover(
 
     return IsMonitorSelected(
         state.monitorNumber,
-        state.stableDeviceId,
-        g_settings.hoverMonitor,
-        g_hoverMonitorBindings
+        g_settings.hoverMonitor
     );
 }
 
@@ -1644,24 +1260,6 @@ void RefreshTaskbarMonitorStates(
                 monitor
             );
 
-        for (
-            size_t monitorIndex = 0;
-            monitorIndex < monitors.count;
-            ++monitorIndex
-        ) {
-            if (
-                monitors.entries[monitorIndex].monitor ==
-                monitor
-            ) {
-                wcsncpy_s(
-                    state.stableDeviceId,
-                    ARRAYSIZE(state.stableDeviceId),
-                    monitors.entries[monitorIndex].stableDeviceId,
-                    _TRUNCATE
-                );
-                break;
-            }
-        }
 
         state.desktopOnly = true;
         state.hiddenByMod = false;
@@ -2127,82 +1725,10 @@ bool IsCursorInConfiguredHoverZoneAtSnapshot(
     return result;
 }
 
-bool IsStableDeviceIdPresent(
-    const MonitorList& monitors,
-    const wchar_t* stableDeviceId
-) {
-    if (!stableDeviceId || stableDeviceId[0] == L'\0') {
-        return false;
-    }
-
-    for (size_t i = 0; i < monitors.count; ++i) {
-        if (StableDeviceIdsMatch(
-                stableDeviceId,
-                monitors.entries[i].stableDeviceId)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-void ReconcileStaleMonitorSelectionBindings(
-    const MonitorList& monitors
-) {
-    for (int configuredNumber = 1;
-         configuredNumber <= static_cast<int>(kMaxMonitorNumbers);
-         ++configuredNumber) {
-        if (g_hideMonitorBindings[configuredNumber].configured &&
-            !IsStableDeviceIdPresent(
-                monitors,
-                g_hideMonitorBindings[configuredNumber].stableDeviceId)) {
-            g_hideMonitorBindings[configuredNumber] = {};
-        }
-
-        if (g_hoverMonitorBindings[configuredNumber].configured &&
-            !IsStableDeviceIdPresent(
-                monitors,
-                g_hoverMonitorBindings[configuredNumber].stableDeviceId)) {
-            g_hoverMonitorBindings[configuredNumber] = {};
-        }
-    }
-}
-
 void UpdateTaskbarState() {
 
     MonitorList monitors =
         GetCurrentMonitors();
-
-    ULONGLONG topologySignature =
-        HashDisplayTopology(monitors);
-
-    if (
-        g_displayTopologySignature != 0 &&
-        topologySignature != g_displayTopologySignature
-    ) {
-        ClearStableMonitorDeviceIdCache();
-
-        // Rebuild the monitor list after clearing the cache so every current
-        // monitor gets a fresh stable device identity before selection binding.
-        monitors = GetCurrentMonitors();
-        topologySignature = HashDisplayTopology(monitors);
-
-        // A display add/remove, arrangement change, or geometry/DPI transition
-        // can invalidate the current hover monitor. Reconcile from the base
-        // state instead of carrying old hover state across the transition.
-        g_hoverActive = false;
-        g_hoverMonitor = nullptr;
-        g_hoverDeadline = 0;
-        CancelHoverExpireTimer();
-
-        ReconcileStaleMonitorSelectionBindings(monitors);
-    }
-
-    g_displayTopologySignature = topologySignature;
-
-    BindConfiguredMonitorSelections(
-        monitors
-    );
 
     RefreshTaskbarMonitorStates(
         monitors
@@ -2882,7 +2408,6 @@ DWORD WINAPI WorkerThread(
 }
 
 void LoadSettings() {
-    ResetMonitorSelectionBindings();
 
     int hoverMargin =
         Wh_GetIntSetting(

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Desktop-only taskbar hiding using a dedicated Windhawk tool process
-// @version         5.0.0
+// @version         5.1.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -3047,16 +3047,6 @@ void WhTool_ModUninit() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Standard Windhawk tool-mod launcher. The mod is targeted at windhawk.exe so
-// the launcher can start the state-management logic in a dedicated Windhawk
-// process.
-
-#define Wh_ModInit WindhawkToolModLauncher_Wh_ModInit
-#define Wh_ModAfterInit WindhawkToolModLauncher_Wh_ModAfterInit
-#define Wh_ModSettingsChanged WindhawkToolModLauncher_Wh_ModSettingsChanged
-#define Wh_ModUninit WindhawkToolModLauncher_Wh_ModUninit
-
-////////////////////////////////////////////////////////////////////////////////
 // Windhawk tool mod implementation for mods which don't need to inject to other
 // processes or hook other functions. Context:
 // https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process
@@ -3079,12 +3069,6 @@ void WINAPI EntryPoint_Hook() {
 }
 
 BOOL Wh_ModInit() {
-    DWORD sessionId;
-    if (ProcessIdToSessionId(GetCurrentProcessId(), &sessionId) &&
-        sessionId == 0) {
-        return FALSE;
-    }
-
     bool isService = false;
     bool isToolModProcess = false;
     bool isCurrentToolModProcess = false;
@@ -3096,9 +3080,7 @@ BOOL Wh_ModInit() {
     }
 
     for (int i = 1; i < argc; i++) {
-        if (wcscmp(argv[i], L"-service") == 0 ||
-            wcscmp(argv[i], L"-service-start") == 0 ||
-            wcscmp(argv[i], L"-service-stop") == 0) {
+        if (wcscmp(argv[i], L"-service") == 0) {
             isService = true;
             break;
         }
@@ -3119,7 +3101,6 @@ BOOL Wh_ModInit() {
     if (isService) {
         return FALSE;
     }
-
 
     if (isCurrentToolModProcess) {
         g_toolModProcessMutex =
@@ -3172,12 +3153,11 @@ void Wh_ModAfterInit() {
             return;
     }
 
-    WCHAR
-    commandLine[MAX_PATH + 2 +
-                (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
-    swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
-               WH_MOD_ID);
-
+    WCHAR commandLine[MAX_PATH + 2 +
+                      (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") /
+                       sizeof(WCHAR)) - 1];
+    swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"",
+               currentProcessPath, WH_MOD_ID);
 
     HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
     if (!kernelModule) {
@@ -3208,14 +3188,13 @@ void Wh_ModAfterInit() {
         .cb = sizeof(STARTUPINFO),
         .dwFlags = STARTF_FORCEOFFFEEDBACK,
     };
-    PROCESS_INFORMATION pi{};
+    PROCESS_INFORMATION pi;
     if (!pCreateProcessInternalW(nullptr, currentProcessPath, commandLine,
-                                 nullptr, nullptr, FALSE, NORMAL_PRIORITY_CLASS,
-                                 nullptr, nullptr, &si, &pi, nullptr)) {
+                                  nullptr, nullptr, FALSE, NORMAL_PRIORITY_CLASS,
+                                  nullptr, nullptr, &si, &pi, nullptr)) {
         Wh_Log(L"CreateProcess failed");
         return;
     }
-
 
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
@@ -3236,25 +3215,4 @@ void Wh_ModUninit() {
 
     WhTool_ModUninit();
     ExitProcess(0);
-}
-
-#undef Wh_ModInit
-#undef Wh_ModAfterInit
-#undef Wh_ModSettingsChanged
-#undef Wh_ModUninit
-
-BOOL Wh_ModInit() {
-    return WindhawkToolModLauncher_Wh_ModInit();
-}
-
-void Wh_ModAfterInit() {
-    WindhawkToolModLauncher_Wh_ModAfterInit();
-}
-
-void Wh_ModSettingsChanged() {
-    WindhawkToolModLauncher_Wh_ModSettingsChanged();
-}
-
-void Wh_ModUninit() {
-    WindhawkToolModLauncher_Wh_ModUninit();
 }

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Desktop-only taskbar hiding using a dedicated Windhawk tool process
-// @version         5.4.0
+// @version         5.5.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -28,9 +28,11 @@ This Windhawk mod hides selected taskbars when their corresponding display is sh
 
 ## How It Works
 
-For each selected display, the mod checks whether a relevant visible application is present. Supported Windows shell surfaces are excluded from the application check, and shell popups are handled separately during hover dismissal.
+For each selected display, the mod checks whether a relevant visible, non-minimized application is present. Supported Windows shell surfaces and desktop infrastructure are excluded from the normal application check.
 
-When the display is showing only the desktop, its selected taskbar can be hidden. Applications and configured hover reveal control normal visibility, while supported shell popups can extend a hover-revealed taskbar's visible period.
+When a display is showing only the desktop, its selected bottom-docked taskbar can be hidden. An application on that display, taskbar keyboard focus, or supported shell interaction can keep the taskbar visible.
+
+Applications spanning multiple displays are considered for every display they intersect, so each affected display can independently remain visible.
 
 The taskbar is hidden using layered-window transparency rather than Windows' native auto-hide mode, so the mod does not intentionally change the desktop work area.
 
@@ -41,17 +43,19 @@ You can configure independently:
 - Which displays should hide their taskbar on the desktop
 - Which displays should support bottom-edge hover reveal
 
-You can select all displays or individual logical display numbers. The mod also keeps a stable monitor/device association when Windows changes its internal `DISPLAYn` numbering during the current session.
+You can select all displays or individual logical display numbers. The settings use the current logical monitor order rather than the internal Windows `DISPLAYn` device identifier.
+
+The mod keeps a stable monitor/device association when Windows changes its internal `DISPLAYn` numbering during the current session. When a display topology change invalidates an old association, stale selection bindings are reconciled instead of silently following an unrelated monitor.
 
 ## Hover Reveal
 
-For bottom-docked taskbars, moving the cursor into the configured bottom-edge area reveals the taskbar.
+For bottom-docked taskbars, moving the cursor into the configured bottom-edge area reveals the taskbar. The hover zone follows the taskbar's actual height and display scaling, with an optional extra margin.
 
-After the cursor leaves the area, the taskbar hides again after the configured delay.
+After the cursor leaves the area, the taskbar hides again after the configured delay. Moving the cursor between displays also updates which taskbar is currently revealed.
 
-The hover area follows the taskbar height and display scaling, with an optional extra margin in pixels.
+Hover tracking uses a dedicated cursor-sampling thread. It samples faster when hover tracking is needed, backs off when it is not needed, and backs off further after repeated cursor-position failures. Hover-eligible taskbars that would currently be hidden are published to the sampler so cursor-leave detection does not depend solely on the periodic safety poll.
 
-Hover reveal does not apply to taskbars docked to the top or sides.
+Hover reveal does not apply to taskbars docked to the top or sides. Desktop-based hiding also applies only to bottom-docked taskbars.
 
 ## Windows Shell Interactions
 
@@ -65,21 +69,51 @@ Supported shell surfaces include:
 - Notification and Quick Settings surfaces
 - Alt+Tab and related task-switching UI
 
-Shell popups are also checked while a hover-revealed taskbar is waiting to hide, so an open supported popup can keep that revealed taskbar visible.
+Supported shell popup classes are checked during hover dismissal. A supported popup can keep the corresponding taskbar visible while it is being dismissed, and the currently hovered taskbar remains visible during that grace period as well.
+
+The taskbar is also treated as occupied when the taskbar itself is the foreground window, preventing keyboard navigation such as `Win+T`, `Win+B`, or `Win+number` from operating on an invisible taskbar.
+
+## Taskbar State and Recovery
+
+The mod uses `WS_EX_LAYERED` with `SetLayeredWindowAttributes` and alpha 0 to hide the taskbar without changing its normal `ShowWindow` visibility state. It runs the state-management logic in a dedicated `windhawk.exe` tool-mod process rather than injecting a taskbar `ShowWindow` hook into Explorer.
+
+Before hiding a taskbar, the mod records the relevant original extended-window style and layered-window attributes on the taskbar itself. An ownership marker identifies taskbars whose transparency was applied by this mod.
+
+If a taskbar is recreated, the new taskbar is rediscovered and evaluated again. If the dedicated tool process is restarted after an unexpected termination, a new instance can reclaim taskbars still carrying the ownership marker. If another component removes `WS_EX_LAYERED` while the mod still has ownership, the stale ownership data is discarded so the current taskbar state can be captured again safely on a later hide.
 
 ## Multi-Monitor Behavior
 
 Each selected display is evaluated independently. For example, an application can remain open on display 1 while the selected taskbar on display 2 hides because display 2 is showing only the desktop.
 
-Applications spanning multiple displays are considered for each display they intersect.
+An application spanning multiple displays keeps the taskbars on every intersected display visible. A taskbar can also be revealed independently by hovering its own configured bottom-edge area.
+
+The mod supports up to 16 display/taskbar entries and retains the existing logical display numbering system used by the settings UI.
+
+## Performance and Refreshing
+
+The full application and display scan runs in the dedicated tool process rather than inside Explorer.
+
+The mod uses:
+
+- A dedicated worker thread for state management
+- A lightweight cursor-sampling thread for hover detection
+- Event-driven refreshes for relevant foreground, minimize/move, display, theme, settings, and taskbar recreation changes
+- A periodic 250 ms safety poll for missed or unusual transitions
+- A one-shot timer for hover dismissal
+
+The 250 ms safety poll is intentionally retained as a fallback and does not replace the normal event-driven refresh path. Native Windows taskbar auto-hide state is cached and refreshed when settings or relevant shell/taskbar changes occur rather than being queried on every safety tick.
+
+When no displays are configured for desktop-based hiding, the mod skips the application and shell-popup scans and restores any taskbars that may still be hidden by an earlier configuration.
 
 ## Limitations
 
-- Hover reveal is supported only for bottom-docked taskbars.
+- Desktop-based hiding and hover reveal are supported only for bottom-docked taskbars.
 - Hiding the taskbar does not increase the desktop work area, so maximized windows may still leave the normal taskbar space reserved.
 - Windows display device names such as `\\.\DISPLAY1` may differ from the logical display numbers used by the settings UI.
 - The display-selection configuration supports up to 16 display entries.
-- The mod keeps Windows' native taskbar auto-hide setting separate from its own hiding behavior.
+- The mod keeps Windows' native taskbar auto-hide setting separate from its own hiding behavior. If native auto-hide is enabled, this mod does not take over that taskbar.
+- Because the taskbar is made fully transparent, flashing taskbar buttons and tray notifications are not visually available while that taskbar is hidden by the mod.
+- If the dedicated tool process is terminated unexpectedly, a taskbar may remain invisible and click-through until the mod is started again or the taskbar is otherwise recreated; the next mod instance can reclaim marked taskbars.
 - Other taskbar transparency/customization mods that modify the same taskbar window can conflict with this mod.
 - Windows shell window classes and processes can change between Windows releases, so shell-interaction detection may need updates for future Windows versions.
 
@@ -558,7 +592,7 @@ ULONGLONG g_hoverDeadline = 0;
 LONG g_refreshPosted = 0;
 void LoadSettings();
 void WhTool_ModUninit();
-void ArmHoverExpireTimer();
+void ArmHoverExpireTimer(DWORD delayMs);
 void CancelHoverExpireTimer();
 void RestoreAllTaskbars();
 bool WaitForThreadWithTimeout(
@@ -1699,6 +1733,10 @@ bool IsNativeAutoHideEnabled() {
     return (SHAppBarMessage(ABM_GETSTATE, &data) & ABS_AUTOHIDE) != 0;
 }
 
+void RefreshNativeAutoHideState() {
+    g_nativeAutoHideEnabled = IsNativeAutoHideEnabled();
+}
+
 bool ShouldHideTaskbar(
     const TaskbarMonitorState& state
 ) {
@@ -1993,23 +2031,6 @@ bool IsPointNearBottomEdge(
         pt.y < mi.rcMonitor.bottom;
 }
 
-bool IsCursorNearBottomEdge(
-    HWND hTaskbar,
-    HMONITOR cursorMonitor
-) {
-    POINT pt = {};
-
-    if (!GetCursorPos(&pt)) {
-        return false;
-    }
-
-    return IsPointNearBottomEdge(
-        hTaskbar,
-        cursorMonitor,
-        pt
-    );
-}
-
 void UpdateCursorHoverSnapshot() {
     CursorHoverSnapshot snapshots[kMaxTaskbars] = {};
     size_t snapshotCount = 0;
@@ -2021,8 +2042,9 @@ void UpdateCursorHoverSnapshot() {
 
         const TaskbarMonitorState& state = g_taskbarStates[i];
 
-        if (!state.hiddenByMod ||
-            !ShouldRevealOnHover(state) ||
+        if (!ShouldRevealOnHover(state) ||
+            !state.desktopOnly ||
+            !ShouldHideTaskbar(state) ||
             !IsBottomDockedTaskbar(state.hwnd, state.monitor)) {
             continue;
         }
@@ -2186,22 +2208,34 @@ void UpdateTaskbarState() {
         monitors
     );
 
-    // ABM_GETSTATE reports the native auto-hide setting globally. Sample it
-    // once per reconciliation and reuse the result for every taskbar.
-    g_nativeAutoHideEnabled =
-        IsNativeAutoHideEnabled();
+    // If no display is configured for desktop-based hiding, there is no reason
+    // to continue with cursor or shell-popup work. Reconcile any taskbars that
+    // may still be hidden from an earlier configuration before returning.
+    if (!g_settings.hideAllMonitors) {
+        bool anyHideMonitorSelected = false;
+        for (size_t i = 1; i <= kMaxMonitorNumbers; ++i) {
+            if (g_settings.hideMonitor[i]) {
+                anyHideMonitorSelected = true;
+                break;
+            }
+        }
+
+        if (!anyHideMonitorSelected) {
+            g_hoverActive = false;
+            g_hoverMonitor = nullptr;
+            g_hoverDeadline = 0;
+            CancelHoverExpireTimer();
+            ApplyBaseTaskbarState();
+            UpdateCursorHoverSnapshot();
+            return;
+        }
+    }
 
     WindowScanResult scan = {};
-    ShellPopupScanResult shellPopups = {};
 
     ScanWindowsOnce(
         monitors,
         scan
-    );
-
-    ScanVisibleShellPopupsOnce(
-        monitors,
-        shellPopups
     );
 
     for (size_t i = 0; i < g_taskbarStateCount; ++i) {
@@ -2227,6 +2261,14 @@ void UpdateTaskbarState() {
             }
         }
 
+    }
+
+    HWND foreground = GetForegroundWindow();
+    for (size_t i = 0; i < g_taskbarStateCount; ++i) {
+        if (g_taskbarStates[i].hwnd == foreground) {
+            g_taskbarStates[i].desktopOnly = false;
+            break;
+        }
     }
 
     POINT cursorPoint = {};
@@ -2265,9 +2307,10 @@ void UpdateTaskbarState() {
         cursorTaskbar &&
         cursorMonitor &&
         cursorHoverConfigured &&
-        IsCursorNearBottomEdge(
+        IsPointNearBottomEdge(
             cursorTaskbar,
-            cursorMonitor
+            cursorMonitor,
+            cursorPoint
         );
 
     if (hovering) {
@@ -2288,8 +2331,8 @@ void UpdateTaskbarState() {
             );
         }
 
-        // Snapshot the state after visibility reconciliation. The cursor sampler
-        // must see the taskbars that are actually hidden by the mod.
+        // Publish hover-eligible taskbars that would be hidden so the cursor
+        // sampler can also detect the cursor leaving a revealed hover zone.
         UpdateCursorHoverSnapshot();
         return;
     }
@@ -2303,7 +2346,7 @@ void UpdateTaskbarState() {
                 now +
                 g_settings.autoHideDelayMs;
 
-            ArmHoverExpireTimer();
+            ArmHoverExpireTimer(g_settings.autoHideDelayMs);
         }
 
         if (now < g_hoverDeadline) {
@@ -2322,6 +2365,12 @@ void UpdateTaskbarState() {
             UpdateCursorHoverSnapshot();
             return;
         }
+
+        ShellPopupScanResult shellPopups = {};
+        ScanVisibleShellPopupsOnce(
+            monitors,
+            shellPopups
+        );
 
         bool shellPopupPresent = false;
         for (size_t i = 0; i < g_taskbarStateCount; ++i) {
@@ -2357,6 +2406,7 @@ void UpdateTaskbarState() {
 
                 SetTaskbarState(
                     state,
+                    state.monitor == g_hoverMonitor ||
                     !state.desktopOnly ||
                     !ShouldHideTaskbar(state) ||
                     shellPopupOnMonitor
@@ -2364,7 +2414,7 @@ void UpdateTaskbarState() {
             }
 
             g_hoverDeadline = now + 100;
-            ArmHoverExpireTimer();
+            ArmHoverExpireTimer(100);
             UpdateCursorHoverSnapshot();
             return;
         }
@@ -2394,15 +2444,12 @@ void UpdateTaskbarState() {
     UpdateCursorHoverSnapshot();
 }
 
-void ArmHoverExpireTimer() {
+void ArmHoverExpireTimer(DWORD delayMs) {
     if (!g_workerMessageWindow) {
         return;
     }
 
-    UINT delay =
-        g_settings.autoHideDelayMs == 0
-            ? 1
-            : g_settings.autoHideDelayMs;
+    UINT delay = delayMs == 0 ? 1 : delayMs;
 
     SetTimer(
         g_workerMessageWindow,
@@ -2584,6 +2631,13 @@ LRESULT CALLBACK WorkerMessageWindowProc(
         message == WM_SETTINGCHANGE ||
         message == WM_THEMECHANGED
     ) {
+        if (
+            message == g_taskbarCreatedMessage ||
+            message == WM_SETTINGCHANGE
+        ) {
+            RefreshNativeAutoHideState();
+        }
+
         PostRefresh();
         return 0;
     }
@@ -2793,21 +2847,13 @@ DWORD WINAPI WorkerThread(
 
                     UpdateTaskbarState();
 
-            // Do not lose a refresh posted while UpdateTaskbarState() ran.
-            if (InterlockedExchange(
-                    &g_refreshPosted,
-                    0
-                ) != 0) {
-                PostRefresh();
-            }
-
             continue;
         }
 
         if (msg.message == WM_APP_SETTINGS) {
             LoadSettings();
-                    UpdateTaskbarState();
-
+            RefreshNativeAutoHideState();
+            UpdateTaskbarState();
 
             continue;
         }
@@ -2986,6 +3032,10 @@ BOOL WhTool_ModInit() {
     // ShouldHideMonitor() returns false even when the UI says "All displays".
     LoadSettings();
 
+    // Cache the native auto-hide setting at startup. It is refreshed only when
+    // settings or shell/taskbar recreation messages indicate it may have changed.
+    RefreshNativeAutoHideState();
+
     // Recover ownership left by an unexpectedly terminated previous tool
     // process before the new worker starts making visibility decisions.
     RestoreAllTaskbars();
@@ -3035,6 +3085,20 @@ BOOL WhTool_ModInit() {
         );
 
         RestoreAllTaskbars();
+
+        if (g_workerThread) {
+            if (!PostThreadMessageW(
+                    g_workerThreadId,
+                    WM_QUIT,
+                    0,
+                    0
+                )) {
+                Wh_Log(
+                    L"PostThreadMessageW(WM_QUIT) during startup cleanup failed: %lu",
+                    GetLastError()
+                );
+            }
+        }
 
         if (!WaitForThreadWithTimeout(
                 g_workerThread,

--- a/mods/hide-taskbar-only-on-desktop.wh.cpp
+++ b/mods/hide-taskbar-only-on-desktop.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-taskbar-only-on-desktop
 // @name            Hide Taskbar Only on Desktop
 // @description     Hides selected taskbars while their displays show only the desktop
-// @version         5.9.0
+// @version         6.0.0
 // @author          Sahil Dashoni
 // @github          https://github.com/Sahil-Dashoni
 // @include         windhawk.exe
@@ -79,7 +79,7 @@ The mod uses `WS_EX_LAYERED` with `SetLayeredWindowAttributes` and alpha 0 to hi
 
 Before hiding a taskbar, the mod records the relevant original extended-window style and layered-window attributes on the taskbar itself. An ownership marker identifies taskbars whose transparency was applied by this mod.
 
-If a taskbar is recreated, the new taskbar is rediscovered and evaluated again. If the dedicated tool process is restarted after an unexpected termination, a new instance can reclaim taskbars still carrying the ownership marker. If another component removes `WS_EX_LAYERED` while the mod still has ownership, the stale ownership data is discarded so the current taskbar state can be captured again safely on a later hide.
+If a taskbar is recreated, the new taskbar is rediscovered and evaluated again. If the dedicated tool process is restarted after an unexpected termination, a new instance can reclaim taskbars still carrying the ownership marker. If another component removes `WS_EX_LAYERED` while the mod still has ownership, the stale ownership data is discarded safely and the mod-owned `WS_EX_LAYERED`/`WS_EX_TRANSPARENT` bits are reconciled before a later hide recaptures the current taskbar state. Restoring a taskbar changes only the extended-style bits owned by this mod; unrelated extended-style changes are preserved.
 
 ## Multi-Monitor Behavior
 
@@ -89,13 +89,15 @@ An application spanning multiple displays keeps the taskbars on every intersecte
 
 The mod supports up to 16 display/taskbar entries and uses the current logical display numbering reported by monitor enumeration.
 
+## Fullscreen and Multi-Monitor State
+
+Borderless fullscreen content is tracked as a sticky session for the display that owns it. The fullscreen test accepts borderless windows even when they retain a normal overlapped window style; it uses the exact monitor rectangle (within a small tolerance), the absence of a caption and resize frame, and explicit exclusion of Windows shell, desktop, and taskbar windows. It does not require WS_POPUP.
+
+Once a fullscreen window enters the foreground, its HMONITOR remains associated with that fullscreen owner while focus moves between displays. Normal desktop/taskbar/shell transitions, transient hide or cloak notifications, and the ordinary safety refresh do not invalidate that ownership. The session ends only when the owner explicitly leaves fullscreen while foreground, completes a real minimize, is destroyed, or moves to another monitor. This keeps a secondary-display desktop click from exposing the primary taskbar while fullscreen content remains active.
+
 ## Performance and Refreshing
 
-The full application and display scan runs in the dedicated tool process rather than inside Explorer. Fullscreen state is cached by the actual HMONITOR only after an actual fullscreen window has entered the foreground, avoiding false positives from unrelated borderless background windows and preventing monitor-enumeration changes from moving fullscreen ownership to another display.
-
-Fullscreen state is retained while the cached fullscreen window remains the last fullscreen owner of its monitor, even when focus moves to another display or a transient minimize event is reported. A normal application becoming foreground on that same monitor clears the cached fullscreen owner. Desktop and taskbar foreground transitions on another monitor do not clear it.
-
-The mod uses:
+The full application and display scan runs in the dedicated tool process rather than inside Explorer. The mod uses:
 
 - A dedicated worker thread for state management
 - A lightweight cursor-sampling thread for hover detection
@@ -107,21 +109,6 @@ The 2 second safety poll is intentionally retained as a fallback and does not re
 
 When no displays are configured for desktop-based hiding, the mod skips the application and shell-popup scans and restores any taskbars that may still be hidden by an earlier configuration.
 
-## Known Fullscreen Multi-Monitor Issue
-
-There is currently an unresolved edge case involving a fullscreen window on the primary display and interaction with a secondary display. The intended behavior is that the primary taskbar remains hidden for as long as the primary display is still owned by a tracked fullscreen window, even when focus or mouse interaction moves to another display.
-
-The reproducible failure pattern is:
-
-1. Start a borderless/monitor-sized fullscreen application on the primary display.
-2. Move the cursor to the secondary display.
-3. Click the secondary display's desktop before interacting with its taskbar.
-4. The primary taskbar can incorrectly become visible, even though the fullscreen application is still active on the primary display.
-
-A closely related sequence is that interacting with the secondary taskbar first can leave the primary taskbar correctly hidden, while clicking the secondary desktop first can expose the bug. The problem is predominantly observed with the primary display; equivalent fullscreen behavior on the secondary display generally behaves correctly.
-
-The current implementation already keeps fullscreen ownership associated with the actual `HMONITOR`, caches fullscreen only after the fullscreen window becomes foreground, avoids clearing the cache for ordinary transient shell-focus/minimize-start transitions, and avoids changing the existing shell-interaction classification. Despite those protections, the edge case remains unresolved and needs a more fundamental state-transition analysis rather than another superficial fullscreen check.
-
 ## Limitations
 
 - Desktop-based hiding and hover reveal are supported only for bottom-docked taskbars.
@@ -132,6 +119,7 @@ The current implementation already keeps fullscreen ownership associated with th
 - Because the taskbar is made fully transparent, flashing taskbar buttons and tray notifications are not visually available while that taskbar is hidden by the mod.
 - If the dedicated tool process is terminated unexpectedly, a taskbar may remain invisible and click-through until the mod is started again or the taskbar is otherwise recreated; the next mod instance can reclaim marked taskbars.
 - Other taskbar transparency/customization mods that modify the same taskbar window can conflict with this mod.
+- Borderless fullscreen detection intentionally treats a visible, monitor-sized, captionless and non-resizable application as fullscreen; unusual applications with that exact window presentation may therefore keep their taskbar hidden.
 - Windows shell window classes and processes can change between Windows releases, so shell-interaction detection may need updates for future Windows versions.
 
 */
@@ -300,6 +288,9 @@ constexpr wchar_t kTaskbarOriginalLayeredFlagsProp[] =
 constexpr wchar_t kTaskbarOriginalLayeredAttributesValidProp[] =
     L"windhawk-hide-taskbar-only-on-desktop-original-layered-valid";
 
+constexpr LONG_PTR kModTaskbarExStyleBits =
+    WS_EX_LAYERED | WS_EX_TRANSPARENT;
+
 bool GetWindowUlongPtrProp(
     HWND hwnd,
     const wchar_t* name,
@@ -343,6 +334,61 @@ void RemoveTaskbarOwnershipProperties(HWND hwnd) {
     RemovePropW(hwnd, kTaskbarOriginalLayeredAttributesValidProp);
 }
 
+bool DropStaleTaskbarOwnership(
+    HWND hwnd,
+    LONG_PTR currentExStyle
+) {
+    if (!hwnd) {
+        return false;
+    }
+
+    LONG_PTR restoredExStyle =
+        currentExStyle & ~kModTaskbarExStyleBits;
+
+    ULONG_PTR savedExStyleValue = 0;
+    if (GetWindowUlongPtrProp(
+            hwnd,
+            kTaskbarOriginalExStyleProp,
+            &savedExStyleValue)) {
+        const LONG_PTR savedExStyle =
+            static_cast<LONG_PTR>(savedExStyleValue);
+        restoredExStyle |=
+            savedExStyle & kModTaskbarExStyleBits;
+    }
+
+    if (restoredExStyle != currentExStyle) {
+        SetLastError(ERROR_SUCCESS);
+        LONG_PTR previousExStyle = SetWindowLongPtrW(
+            hwnd,
+            GWL_EXSTYLE,
+            restoredExStyle
+        );
+        if (previousExStyle == 0 && GetLastError() != ERROR_SUCCESS) {
+            Wh_Log(
+                L"SetWindowLongPtrW(drop stale taskbar ownership) failed for 0x%p: %lu",
+                hwnd,
+                GetLastError()
+            );
+            return false;
+        }
+
+        SetWindowPos(
+            hwnd,
+            nullptr,
+            0, 0, 0, 0,
+            SWP_NOMOVE |
+            SWP_NOSIZE |
+            SWP_NOZORDER |
+            SWP_NOACTIVATE |
+            SWP_FRAMECHANGED |
+            SWP_ASYNCWINDOWPOS
+        );
+    }
+
+    RemoveTaskbarOwnershipProperties(hwnd);
+    return true;
+}
+
 bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
     if (!hwnd || !IsWindow(hwnd)) {
         return false;
@@ -355,16 +401,25 @@ bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
     }
 
     if (hide) {
-        // If another component removed WS_EX_LAYERED while this mod still had
-        // ownership, the saved properties no longer describe the current window
-        // state. Drop the stale ownership and recapture the current state below.
-        if (GetPropW(hwnd, kTaskbarOwnershipProp) != nullptr &&
-            (exStyle & WS_EX_LAYERED) != 0) {
-            return SetLayeredWindowAttributes(hwnd, 0, 0, LWA_ALPHA) != 0;
-        }
+        const bool ownedByMod =
+            GetPropW(hwnd, kTaskbarOwnershipProp) != nullptr;
 
-        if (GetPropW(hwnd, kTaskbarOwnershipProp) != nullptr) {
-            RemoveTaskbarOwnershipProperties(hwnd);
+        // If another component removed WS_EX_LAYERED while this mod still had
+        // ownership, discard the stale state and remove only the extended-style
+        // bits controlled by this mod. The current taskbar state can then be
+        // captured cleanly for a new hide operation below.
+        if (ownedByMod && (exStyle & WS_EX_LAYERED) == 0) {
+            if (!DropStaleTaskbarOwnership(hwnd, exStyle)) {
+                return false;
+            }
+
+            SetLastError(ERROR_SUCCESS);
+            exStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+            if (exStyle == 0 && GetLastError() != ERROR_SUCCESS) {
+                return false;
+            }
+        } else if (ownedByMod) {
+            return SetLayeredWindowAttributes(hwnd, 0, 0, LWA_ALPHA) != 0;
         }
 
         COLORREF colorKey = 0;
@@ -438,6 +493,17 @@ bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
         if (!SetLayeredWindowAttributes(hwnd, 0, 0, LWA_ALPHA)) {
             // Restore the original style if applying the hiding operation failed.
             SetWindowLongPtrW(hwnd, GWL_EXSTYLE, exStyle);
+            SetWindowPos(
+                hwnd,
+                nullptr,
+                0, 0, 0, 0,
+                SWP_NOMOVE |
+                SWP_NOSIZE |
+                SWP_NOZORDER |
+                SWP_NOACTIVATE |
+                SWP_FRAMECHANGED |
+                SWP_ASYNCWINDOWPOS
+            );
             RemoveTaskbarOwnershipProperties(hwnd);
             Wh_Log(
                 L"SetLayeredWindowAttributes(alpha=0) failed for 0x%p: %lu",
@@ -464,6 +530,12 @@ bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
 
     if (GetPropW(hwnd, kTaskbarOwnershipProp) == nullptr) {
         return false;
+    }
+
+    if ((exStyle & WS_EX_LAYERED) == 0) {
+        // The mod no longer has a layered taskbar to restore from. Drop the
+        // stale ownership without leaving its click-through bit behind.
+        return DropStaleTaskbarOwnership(hwnd, exStyle);
     }
 
     ULONG_PTR originalExStyleValue = 0;
@@ -553,9 +625,6 @@ bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
         return false;
     }
 
-    constexpr LONG_PTR kModExStyleBits =
-        WS_EX_LAYERED | WS_EX_TRANSPARENT;
-
     SetLastError(ERROR_SUCCESS);
     LONG_PTR currentExStyle = GetWindowLongPtrW(
         hwnd,
@@ -568,8 +637,8 @@ bool MakeTaskbarTransparent(HWND hwnd, bool hide) {
     LONG_PTR previousExStyle = SetWindowLongPtrW(
         hwnd,
         GWL_EXSTYLE,
-        (currentExStyle & ~kModExStyleBits) |
-        (originalExStyle & kModExStyleBits)
+        (currentExStyle & ~kModTaskbarExStyleBits) |
+        (originalExStyle & kModTaskbarExStyleBits)
     );
     if (previousExStyle == 0 && GetLastError() != ERROR_SUCCESS) {
         Wh_Log(
@@ -616,8 +685,8 @@ ULONGLONG g_lastMinimizeEventTick = 0;
 bool g_ignoreTaskbarForegroundAfterMinimize = false;
 // A fullscreen window is cached only after that window has actually entered
 // the foreground. The cache is keyed by the HMONITOR itself rather than by
-// monitor-enumeration index, so a shell/foreground transition cannot move the
-// fullscreen owner to a different display.
+// monitor-enumeration index. Once claimed, ownership is sticky until an explicit
+// fullscreen lifecycle event ends it.
 struct FullscreenMonitorOwner {
     HMONITOR monitor;
     HWND hwnd;
@@ -1081,13 +1150,34 @@ struct ScanContext {
     WindowScanResult* result;
 };
 
+bool IsTaskbarWindow(HWND hwnd);
+
 bool IsFullscreenWindowForMonitor(
     HWND hwnd,
     const MonitorEntry& monitorEntry
 ) {
     if (
         !hwnd ||
-        !IsWindow(hwnd)
+        !IsWindow(hwnd) ||
+        !IsWindowVisible(hwnd) ||
+        IsIconic(hwnd)
+    ) {
+        return false;
+    }
+
+    WCHAR className[256] = {};
+    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0) {
+        return false;
+    }
+
+    // Desktop, shell chrome, shell surfaces, and taskbars can also be monitor
+    // sized and borderless. They must never become fullscreen owners merely
+    // because their geometry happens to match a monitor.
+    if (
+        IsDesktopInfrastructureWindow(hwnd, className) ||
+        IsShellChromeClass(className) ||
+        IsShellSurfaceWindow(hwnd, className) ||
+        IsTaskbarWindow(hwnd)
     ) {
         return false;
     }
@@ -1098,8 +1188,11 @@ bool IsFullscreenWindowForMonitor(
             GWL_STYLE
         );
 
+    // Do not require WS_POPUP here. Chromium/Edge-style borderless fullscreen
+    // windows can retain a normal overlapped style while removing the caption
+    // and resize frame. The authoritative signal for this mod is an exact
+    // monitor-sized rectangle together with the absence of caption/frame.
     if (
-        (style & WS_POPUP) == 0 ||
         (style & WS_CAPTION) != 0 ||
         (style & WS_THICKFRAME) != 0
     ) {
@@ -1142,13 +1235,37 @@ int FindFullscreenOwnerIndex(HMONITOR monitor) {
     return -1;
 }
 
+bool IsFullscreenOwnerOnSameMonitor(HWND hwnd, HMONITOR monitor) {
+    if (!hwnd || !IsWindow(hwnd) || !monitor) {
+        return false;
+    }
+
+    return MonitorFromWindow(
+        hwnd,
+        MONITOR_DEFAULTTONEAREST
+    ) == monitor;
+}
+
 bool IsMonitorFullscreenCached(HMONITOR monitor) {
     const int index = FindFullscreenOwnerIndex(monitor);
 
-    return
-        index >= 0 &&
-        g_fullscreenOwners[index].hwnd != nullptr &&
-        IsWindow(g_fullscreenOwners[index].hwnd);
+    if (index < 0 || !g_fullscreenOwners[index].hwnd) {
+        return false;
+    }
+
+    // This is deliberately a pure ownership query. Do not validate fullscreen
+    // geometry here: this function is called during the ordinary taskbar scan,
+    // including shell transitions on another monitor. Windows can transiently
+    // change a fullscreen window's visibility/geometry during those transitions.
+    // The owner is retired only by explicit fullscreen lifecycle events below.
+    HWND owner = g_fullscreenOwners[index].hwnd;
+
+    if (!IsFullscreenOwnerOnSameMonitor(owner, monitor)) {
+        g_fullscreenOwners[index] = {};
+        return false;
+    }
+
+    return true;
 }
 
 void SetFullscreenOwner(HMONITOR monitor, HWND hwnd) {
@@ -1185,31 +1302,73 @@ void ClearFullscreenOwnersForWindow(HWND hwnd) {
     }
 }
 
+void ValidateFullscreenOwnerForMonitor(
+    HMONITOR monitor,
+    const MonitorList& monitors
+) {
+    const int index = FindFullscreenOwnerIndex(monitor);
+    if (index < 0 || !g_fullscreenOwners[index].hwnd) {
+        return;
+    }
+
+    HWND owner = g_fullscreenOwners[index].hwnd;
+
+    if (!IsFullscreenOwnerOnSameMonitor(owner, monitor)) {
+        g_fullscreenOwners[index] = {};
+        return;
+    }
+
+    // Exact fullscreen geometry is authoritative only for the owner itself.
+    // This function is called from explicit owner lifecycle transitions, not
+    // from every generic refresh triggered by another display.
+    if (GetForegroundWindow() != owner) {
+        return;
+    }
+
+    for (size_t monitorIndex = 0;
+         monitorIndex < monitors.count;
+         ++monitorIndex) {
+        if (monitors.entries[monitorIndex].monitor != monitor) {
+            continue;
+        }
+
+        if (!IsFullscreenWindowForMonitor(
+                owner,
+                monitors.entries[monitorIndex]
+            )) {
+            g_fullscreenOwners[index] = {};
+        }
+        break;
+    }
+}
+
 void ClearInvalidFullscreenWindowCache(
     const MonitorList& monitors
 ) {
-    // Keep fullscreen ownership tied to the actual HMONITOR. An accessibility
-    // or foreground transition on another display must not reassign this state.
+    // General refreshes only retire fullscreen owners when the owning HMONITOR
+    // disappears or the owner is actually moved to another monitor. Do not use
+    // visibility, cloaking, or foreground state here; those transitions are too
+    // noisy during cross-display shell interaction.
     for (size_t i = 0; i < kMaxMonitorNumbers; ++i) {
         if (!g_fullscreenOwners[i].monitor) {
             continue;
         }
 
-        bool monitorStillPresent = false;
+        HMONITOR monitor = g_fullscreenOwners[i].monitor;
+        HWND owner = g_fullscreenOwners[i].hwnd;
 
+        bool monitorStillPresent = false;
         for (size_t monitorIndex = 0;
              monitorIndex < monitors.count;
              ++monitorIndex) {
-            if (monitors.entries[monitorIndex].monitor ==
-                g_fullscreenOwners[i].monitor) {
+            if (monitors.entries[monitorIndex].monitor == monitor) {
                 monitorStillPresent = true;
                 break;
             }
         }
 
         if (!monitorStillPresent ||
-            !g_fullscreenOwners[i].hwnd ||
-            !IsWindow(g_fullscreenOwners[i].hwnd)) {
+            !IsFullscreenOwnerOnSameMonitor(owner, monitor)) {
             g_fullscreenOwners[i] = {};
         }
     }
@@ -1267,11 +1426,12 @@ bool IsForegroundNormalApplication(
 }
 
 void ClearFullscreenOwnerForForegroundApplication(
+    const MonitorList& monitors,
     HWND hwnd
 ) {
-    // A real application becoming foreground means only that application's
-    // monitor has a new foreground owner. Desktop, shell and taskbar
-    // transitions deliberately do not clear fullscreen ownership.
+    // A real application becoming foreground on the same display is an explicit
+    // ownership transition. Shell/desktop/taskbar foreground transitions are
+    // intentionally ignored.
     if (!IsForegroundNormalApplication(hwnd)) {
         return;
     }
@@ -1285,10 +1445,21 @@ void ClearFullscreenOwnerForForegroundApplication(
     const int ownerIndex =
         FindFullscreenOwnerIndex(monitor);
 
-    if (ownerIndex >= 0 &&
-        g_fullscreenOwners[ownerIndex].hwnd != hwnd) {
-        g_fullscreenOwners[ownerIndex] = {};
+    if (ownerIndex < 0 ||
+        g_fullscreenOwners[ownerIndex].hwnd == hwnd) {
+        // If the fullscreen owner itself is foreground, explicitly validate
+        // whether it is still fullscreen before keeping the session alive.
+        ValidateFullscreenOwnerForMonitor(
+            monitor,
+            monitors
+        );
+        return;
     }
+
+    // A different normal application has taken foreground on this same
+    // monitor. Retire the previous fullscreen session. This is deliberately
+    // scoped to the same HMONITOR; activity on another display cannot affect it.
+    g_fullscreenOwners[ownerIndex] = {};
 }
 
 void NoteForegroundFullscreenWindow(
@@ -1296,6 +1467,15 @@ void NoteForegroundFullscreenWindow(
     HWND hwnd
 ) {
     if (!hwnd || !IsWindow(hwnd)) {
+        return;
+    }
+
+    WCHAR className[256] = {};
+    if (GetClassNameW(hwnd, className, ARRAYSIZE(className)) == 0 ||
+        IsDesktopInfrastructureWindow(hwnd, className) ||
+        IsShellChromeClass(className) ||
+        IsShellSurfaceWindow(hwnd, className) ||
+        IsTaskbarWindow(hwnd)) {
         return;
     }
 
@@ -1323,8 +1503,22 @@ void RefreshFullscreenWindowCache(
     // fullscreen ownership. Clicking the desktop or taskbar on another display
     // does not clear the primary display's fullscreen owner.
     ClearFullscreenOwnerForForegroundApplication(
+        monitors,
         foreground
     );
+
+    // Explicitly validate the cached owner only when it is itself foreground.
+    // This is an owner lifecycle check, not a generic cache invalidation pass.
+    if (foreground) {
+        HMONITOR foregroundMonitor = MonitorFromWindow(
+            foreground,
+            MONITOR_DEFAULTTONEAREST
+        );
+        ValidateFullscreenOwnerForMonitor(
+            foregroundMonitor,
+            monitors
+        );
+    }
 
     NoteForegroundFullscreenWindow(
         monitors,
@@ -1697,10 +1891,11 @@ void SetTaskbarState(
 
         if (!(exStyle & WS_EX_LAYERED)) {
             // Another component removed the layering style while the taskbar
-            // was owned by this mod. Drop the stale marker so a later hide can
-            // recapture the taskbar's current state instead of using stale data.
-            RemoveTaskbarOwnershipProperties(state.hwnd);
-            state.hiddenByMod = false;
+            // was owned by this mod. Remove all stale mod-owned style bits before
+            // dropping ownership so the visible taskbar cannot remain click-through.
+            if (DropStaleTaskbarOwnership(state.hwnd, exStyle)) {
+                state.hiddenByMod = false;
+            }
             return;
         }
 
@@ -1723,8 +1918,13 @@ void SetTaskbarState(
 
         if (!(exStyle & WS_EX_LAYERED) ||
             GetPropW(state.hwnd, kTaskbarOwnershipProp) == nullptr) {
-            RemoveTaskbarOwnershipProperties(state.hwnd);
-            state.hiddenByMod = false;
+            if (GetPropW(state.hwnd, kTaskbarOwnershipProp) != nullptr &&
+                DropStaleTaskbarOwnership(state.hwnd, exStyle)) {
+                state.hiddenByMod = false;
+            } else {
+                RemoveTaskbarOwnershipProperties(state.hwnd);
+                state.hiddenByMod = false;
+            }
         } else {
             COLORREF colorKey = 0;
             BYTE alpha = 0;
@@ -2589,10 +2789,6 @@ void CALLBACK WinEventProc(
     if (event == EVENT_SYSTEM_FOREGROUND) {
         MonitorList monitors = GetCurrentMonitors();
         RefreshFullscreenWindowCache(monitors);
-        NoteForegroundFullscreenWindow(
-            monitors,
-            hwnd
-        );
 
         const bool postMinimizeTaskbarForeground =
             g_ignoreTaskbarForegroundAfterMinimize;
@@ -2726,6 +2922,29 @@ void CALLBACK WinEventProc(
 
     if (event == EVENT_SYSTEM_MOVESIZEEND) {
         MonitorList monitors = GetCurrentMonitors();
+
+        if (hwnd) {
+            // If the cached fullscreen owner moved, either keep it on its
+            // original monitor only while it is still there, or retire it.
+            for (size_t i = 0; i < kMaxMonitorNumbers; ++i) {
+                if (g_fullscreenOwners[i].hwnd != hwnd) {
+                    continue;
+                }
+
+                if (!IsFullscreenOwnerOnSameMonitor(
+                        hwnd,
+                        g_fullscreenOwners[i].monitor
+                    )) {
+                    g_fullscreenOwners[i] = {};
+                } else {
+                    ValidateFullscreenOwnerForMonitor(
+                        g_fullscreenOwners[i].monitor,
+                        monitors
+                    );
+                }
+            }
+        }
+
         ClearInvalidFullscreenWindowCache(monitors);
         PostRefresh();
         return;
@@ -2750,10 +2969,9 @@ void CALLBACK WinEventProc(
         }
 
         // Hide/cloak notifications can be transient while a fullscreen browser
-        // changes activation state. Revalidate against the current window state
-        // instead of eagerly discarding the cache from the accessibility event.
-        MonitorList monitors = GetCurrentMonitors();
-        ClearInvalidFullscreenWindowCache(monitors);
+        // changes activation state. They do not end fullscreen ownership. Only
+        // destruction above, explicit minimize completion, move completion, or
+        // an owner-foreground fullscreen-exit validation can retire the session.
         PostRefresh();
     }
 }


### PR DESCRIPTION
# Hide Taskbar Only on Desktop

This Windhawk mod hides selected bottom-docked taskbars when their display has no relevant application, and also keeps the taskbar hidden while a detected borderless fullscreen window occupies that display. Each display is evaluated independently, with layered transparency, fullscreen handling, shell-surface detection, taskbar ownership, and recovery handled by the dedicated Windhawk tool process.

An application being open on one display does not prevent the taskbar on another selected display from hiding when that second display has no relevant application.

## Demo

### Multiple Displays

![Multiple Display](https://raw.githubusercontent.com/Sahil-Dashoni/Hide-Taskbar-Only-on-Desktop-Windhawk-Mod/refs/heads/main/Assets/multiple-display.gif)

### Single Display

![Single Display](https://raw.githubusercontent.com/Sahil-Dashoni/Hide-Taskbar-Only-on-Desktop-Windhawk-Mod/refs/heads/main/Assets/single-display.gif)

## How It Works

For each selected display, the mod determines whether there is a visible, non-minimized application window associated with that display.

When no relevant application window is present, the selected taskbar on that display can be hidden.

When an application becomes active on the display, the taskbar can become visible again. Supported Windows shell interactions, keyboard-driven taskbar interaction, and bottom-edge hover reveal can also temporarily make the taskbar visible.

Fullscreen content is handled separately. A detected borderless fullscreen window keeps its display in the hidden taskbar state even though that display is not considered desktop-only. Explicit shell interaction or keyboard-driven taskbar interaction can still reveal the taskbar when fullscreen is active.

The application-state decision is evaluated independently for each configured display. Windows that span multiple displays are considered for every display they intersect, while maximized windows use the monitor assignment provided by Windows.

The fullscreen ownership logic is also scoped to the owning display. Once a fullscreen window has established ownership of a display, unrelated focus changes on another display do not incorrectly retire that fullscreen state.

The taskbar itself is also tracked when keyboard-driven taskbar navigation has activated it. This allows interactions such as Win+T, Win+B, and Win+number to work with a taskbar controlled by the mod. Keyboard taskbar focus is handled separately from ordinary mouse interaction, so a taskbar activated by a mouse click can still return to the hidden state after hover dismissal.

The mod also evaluates supported Windows shell surfaces separately from normal application windows. This prevents supported shell interaction from being treated as ordinary application activity while still allowing the taskbar to remain available when Windows UI requires it.

The taskbar is hidden directly rather than enabling Windows' native taskbar auto-hide mode. Hiding it does not intentionally change the normal Windows desktop work area.

## Difference from Existing Taskbar Mods

This mod overlaps with several taskbar customization approaches, but its primary behavior is different: **each configured display independently hides its taskbar when that display has no relevant application, with detected fullscreen content handled as a separate hidden state.**

### `taskbar-fade`

`taskbar-fade` and this mod both use layered-window transparency and can reveal the taskbar from the bottom edge. They therefore overlap in their underlying taskbar mechanism.

The main difference is the visibility model. This mod uses an explicit **per-display application/desktop state** as its primary rule. The user can independently choose which displays participate in desktop-only hiding and which displays allow bottom-edge hover reveal.

This mod also includes the per-display fullscreen ownership, shell-interaction, keyboard-taskbar, minimize-transition, taskbar-ownership, display-change, and recovery handling required by that state model.

The two mods should not be used on the same taskbar at the same time because both can modify the taskbar's layered-window/style state.

### Native Windows Auto-Hide

Windows' native taskbar auto-hide is a separate mechanism. This mod does not enable or replace it.

This mod directly controls the taskbar window's presentation and uses its own application detection and hover-reveal logic.

The desktop work-area behavior is also different: this mod does not intentionally expand the Windows work area when it hides the taskbar.

## Per-Display Configuration

The mod supports independent configuration for each display slot.

Users can configure:

* Which display slots should use desktop-based taskbar hiding
* Which display slots should allow bottom-edge hover reveal

Display selection can target:

* All displays
* Individual display slots

The mod intentionally supports up to **16 fixed logical display slots**.

Display selections normally use the mod's current display-slot numbering. The optional **Stable monitor interface names** setting can pin a display slot to a specific physical monitor.

### Stable Monitor Interface Names

A stable interface mapping associates one configured display slot with a physical monitor by its Windows monitor interface name.

Each mapping contains:

* A display slot from Display 1 through Display 16
* The full monitor interface name returned by `EnumDisplayDevicesW` with `EDD_GET_DEVICE_INTERFACE_NAME`

A mapping does not depend on its position in the settings list, so Display 10 can be configured directly without creating mappings for Displays 1 through 9.

Pinned monitors always use their configured display slots.

Monitors that are not pinned fill the remaining display slots in their current logical order.

There are no overflow or displacement slots. The mapping system always works within the fixed 16 display slots.

If multiple mappings target the same display slot or the same physical monitor, the last matching mapping takes precedence.

For example, if a physical monitor is mapped to Display 2, that physical monitor uses Display 2 while the remaining unpinned monitors fill the other available display slots in their current logical order.

If the mapped monitor is disconnected, its configured mapping remains stored, but it cannot occupy the slot while the physical monitor is absent. The remaining detected monitors fill the available slots normally. When the mapped physical monitor returns, the mapping can take effect again.

## Finding Monitor Interface Names

To find monitor interface names on Windows, run this in PowerShell:

```powershell
Add-Type @'
using System;
using System.Runtime.InteropServices;

public static class DisplayDevices2 {
    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
    public struct DISPLAY_DEVICE {
        public int cb;
        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
        public string DeviceName;
        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
        public string DeviceString;
        public int StateFlags;
        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
        public string DeviceID;
        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
        public string DeviceKey;
    }

    [DllImport("user32.dll", CharSet = CharSet.Unicode, EntryPoint = "EnumDisplayDevicesW")]
    public static extern bool EnumDisplayDevices(
        string lpDevice,
        uint iDevNum,
        ref DISPLAY_DEVICE lpDisplayDevice,
        uint dwFlags);
}
'@

for ($i = 1; $i -le 16; $i++) {
    $m = New-Object DisplayDevices2+DISPLAY_DEVICE
    $m.cb = [Runtime.InteropServices.Marshal]::SizeOf($m)

    if ([DisplayDevices2]::EnumDisplayDevices("\\.\DISPLAY$i", 0, [ref]$m, 1)) {
        Write-Host "Display $i : $($m.DeviceString)"
        Write-Host "Interface : $($m.DeviceID)"
        Write-Host ""
    }
}
```

Copy the full value shown after **Interface :** and paste it into the interface-name field for the display slot you want to attach to that physical monitor.

The configuration supports up to 16 display slots.

## Hover Reveal

For bottom-docked taskbars, the mod provides a configurable bottom-edge hover area.

When the cursor enters the configured bottom-edge area of a selected display, a taskbar hidden by the mod can be revealed.

When the cursor leaves the hover area, the taskbar remains visible for the configured delay before being hidden again.

The hover area is calculated from the taskbar's current height and display DPI together with the configured additional margin.

Hover reveal applies only to bottom-docked taskbars. Taskbars docked to the top or sides are not affected by this feature.

The hover-dismiss delay applies only to hover-based hiding. Other visibility transitions, such as a display becoming desktop-only again, are handled independently.

Supported shell popup activity can extend the visible period of a hover-revealed taskbar while the corresponding shell interaction is still being dismissed or used.

Cursor tracking uses a dedicated lightweight sampling thread. The active sampling interval is 50 ms while hover tracking is needed and normally backs off to 250 ms when it is not. Additional backoff is used after repeated cursor-position failures.

## Windows Shell Interactions

The mod accounts for supported Windows shell surfaces so that the taskbar does not disappear unnecessarily while the user is interacting with Windows UI.

This includes supported situations involving:

* Start and Search
* Taskbar menus and popups
* Tray and notification-related shell surfaces
* Other recognized Windows shell surfaces

Known Windows shell classes and recognized shell processes are considered when identifying these surfaces.

Shell interaction detection is handled separately from the normal application-window check.

Shell surfaces are excluded from the ordinary application-window predicate where appropriate, while supported shell popup detection is handled separately when deciding whether a hover-revealed taskbar should remain visible.

The mod validates recognized shell popup ownership against Explorer or known Windows shell processes rather than treating every window with a similar class name as trusted shell interaction.

Shell-popup enumeration is deferred until the hover-dismissal path actually needs popup information rather than being performed during every normal state refresh.

## Fullscreen and Multi-Monitor State

The mod tracks detected borderless fullscreen content independently for each display.

Fullscreen detection does not require `WS_POPUP`. It uses monitor-sized geometry, the absence of a caption and resize frame, and explicit exclusion of desktop, shell, and taskbar windows.

A fullscreen owner is established from a window that has actually become foreground on that display.

Once established, fullscreen ownership is kept scoped to that display. Moving focus to another display therefore does not incorrectly clear the first display's fullscreen state.

The cached fullscreen owner must still represent valid visible window state. If the owner becomes hidden, minimized, cloaked, or moves to another monitor, the fullscreen state can be cleared.

A visible, monitor-sized, captionless, non-resizable application may be treated as fullscreen. This is a heuristic and may produce false positives for applications that happen to match those characteristics.

Applications spanning multiple displays are considered for every display they intersect.

## Taskbar Visibility

The taskbar is hidden by making its window layered, setting its alpha to `0`, and enabling click-through behavior.

The taskbar remains a normal window rather than being hidden with `ShowWindow`, so the mod can manage its presentation without replacing the taskbar's native window visibility state.

The visibility mechanism is separate from the application-state decision logic. Display selection, fullscreen handling, shell interaction, hover reveal, taskbar recreation, ownership recovery, and event-driven refreshes are all separate parts of the state machine.

## Transparency Recovery and State Ownership

Before modifying a taskbar, the mod records the relevant original extended-window style and layered-window attributes when they can be read successfully.

This information is associated with the taskbar window so that the mod can restore the state that existed before its transparency was applied.

A taskbar hidden by the mod receives an ownership marker on the taskbar window itself. This allows the dedicated tool process to distinguish the mod's own transparency state from unrelated taskbar changes.

If the taskbar is still marked as owned and remains layered, the mod can re-assert the hidden alpha without unnecessarily recapturing its current state.

If another component changes the taskbar's layered state, the mod validates the current state rather than assuming that its previous hidden state is still valid.

When restoring the extended style, the mod removes only the style bits it added when the original style information is available, preserving unrelated extended-style changes made by other components.

If the original layered attributes could not be read when the taskbar was captured, the mod cannot reconstruct those exact original values. Restoration therefore falls back to making the taskbar fully visible and removing the layered style.

If the taskbar window is recreated, the new taskbar is rediscovered and evaluated again. The old window's ownership marker does not transfer to the new window.

The mod runs as a dedicated `windhawk.exe` tool-mod process. The normal Windhawk instance acts as the launcher while the taskbar state logic runs in the dedicated tool process.

At startup, the dedicated tool process checks for taskbars still carrying the mod's ownership marker. This provides a recovery path when a previous dedicated tool process terminated unexpectedly while a taskbar was hidden.

During normal shutdown, taskbars owned by the mod are restored.

## Multi-Monitor Example

Consider a system with two displays:

1. An application is open on Display 1.
2. Display 2 has no relevant application.
3. The selected taskbar on Display 1 remains visible.
4. The selected taskbar on Display 2 hides.
5. Moving the cursor into Display 2's configured bottom-edge area reveals its taskbar.
6. After leaving the hover area, the taskbar hides again after the configured delay.
7. Opening an application on Display 2 causes its taskbar to remain visible.
8. Supported shell interaction can temporarily keep the taskbar visible.
9. Keyboard-driven taskbar focus can reveal the taskbar when necessary.
10. Once the relevant interaction has ended, the taskbar returns to the hidden state when Display 2 again has no relevant application.

The same logic is applied independently to every selected display.

Applications spanning multiple displays are considered for every display they intersect, while maximized windows use the monitor assignment provided by Windows.

Changing the state of one display does not directly force another selected display to become visible or hidden.

## Explorer and Display Changes

The mod refreshes its taskbar and display state when relevant taskbar, display, settings, and shell-related changes occur.

This allows its state to be rebuilt when:

* Taskbars are recreated
* Explorer/taskbar state is recreated or refreshed
* The display topology changes
* Monitors are added or removed
* Display configuration changes
* Settings are changed
* Relevant window or shell state changes occur

Taskbars are rediscovered rather than assuming that their existing window handles remain unchanged.

Display selection normally uses the mod's current fixed display-slot assignment.

When a stable monitor interface mapping is configured, the selected physical monitor is assigned to its configured display slot whenever that monitor is detected.

Unpinned monitors fill the remaining display slots in their current logical order.

## Taskbar Ownership

The mod tracks whether a taskbar has been made transparent by its own taskbar-state logic.

A window-property marker is stored on taskbars hidden by the mod so a newly started dedicated tool process can reclaim a taskbar left hidden by an unexpected previous-process termination.

The ownership information also stores relevant original layered-window state when available so restoration can return the taskbar to its previous presentation state.

Ownership is validated against the current taskbar window state. If another component changes the taskbar's layered configuration, the mod can detect the change instead of indefinitely trusting stale local state.

When the taskbar is destroyed and recreated, the old ownership marker naturally disappears with the old window.

## Performance

The full application and display scan runs in the dedicated tool process rather than inside Explorer.

The mod uses:

* A dedicated worker thread for state management
* A lightweight cursor-sampling thread for hover detection
* Event-driven refreshes for relevant window and shell changes
* A periodic **5-second safety poll** for missed or unusual transitions
* A one-shot hover-dismissal timer, with supported shell popups rechecked during the dismissal path

Cursor sampling uses a 50 ms active interval and normally backs off to 250 ms when hover tracking is not needed. It also backs off further after repeated cursor-position failures.

The periodic safety poll is a fallback mechanism rather than the primary update mechanism. Normal state changes are handled through event-driven refreshes and the worker logic.

The dedicated process performs taskbar transparency changes directly. No Explorer-side `ShowWindow` or taskbar-show hook is used.

## Limitations

* Hover reveal and desktop-based hiding are supported only for bottom-docked taskbars.
* The display-selection configuration supports up to 16 fixed display slots.
* Display slots normally follow the mod's current logical monitor ordering unless a stable interface mapping pins a slot to a physical monitor.
* Stable monitor mappings are limited to monitors that are currently detected. A configured mapping does not create a display slot when its physical monitor is disconnected.
* Hiding the taskbar does not increase the Windows desktop work area. Maximized windows may still leave the normal taskbar space reserved.
* The hidden taskbar is click-through while the mod has made it transparent.
* If the dedicated tool process terminates unexpectedly while a taskbar is hidden, the taskbar can remain transparent and click-through until the next dedicated tool-process startup recovers the ownership state, or Explorer is restarted/rebuilt.
* If another taskbar customization component independently changes the taskbar's layered-window style or attributes, the mod may need to discard stale ownership information and capture the current taskbar state again.
* This mod may conflict with other taskbar transparency or customization mods that modify the same taskbar window.
* Windows shell classes and processes can change between Windows releases, so shell-interaction detection may require updates for future Windows versions.
* Shell popup behavior depends on recognizing supported shell window classes and associated Windows shell processes.
* A non-fullscreen application window that intersects a display can cause that display to be considered active.
* A visible, monitor-sized, captionless, non-resizable application may be treated as fullscreen even when it is not intended to be fullscreen.
* While fullscreen detection is active for a display, bottom-edge mouse hover does not reveal that display's taskbar. **Win+T** or **Start** can be used to access it through supported keyboard or shell interaction.
* Flashing taskbar buttons and tray-related notifications are not visible while the taskbar is transparent.
* If the cursor moves directly from one hidden-taskbar display to another, the previously revealed taskbar can be hidden as hover focus moves to the other display.
* The mod is designed specifically around Windows Explorer/taskbar behavior and is not intended to be a general-purpose taskbar customization framework.

## Implementation Scope

The implementation intentionally retains separate fullscreen tracking, shell/XAML detection, per-display state, stable monitor interface mapping, hover sampling, taskbar ownership and recovery, and event-driven refresh logic.

These systems provide concrete behavior and recovery paths rather than existing only for code structure or optimization.

The mod therefore does not remove these systems merely to reduce code size when doing so would remove fullscreen handling, multi-monitor behavior, shell interaction handling, stable monitor selection, hover behavior, or taskbar recovery.

## Goal

The goal is not to replace Windows' native taskbar auto-hide or provide a general-purpose taskbar customization framework.

The goal is:

> **Hide the taskbar when its display has no relevant application, while keeping fullscreen and supported Windows interactions handled correctly.**

The mod combines independent per-display application-state detection with configurable display selection, optional stable physical-monitor mapping, direct taskbar control, shell-interaction handling, fullscreen ownership, layered-window ownership and recovery, taskbar recreation handling, foreground-taskbar protection, event-driven refreshes, and a configurable bottom-edge hover-reveal area.

The result is intended to provide independent taskbar visibility for each configured display while retaining recovery behavior when taskbars are recreated, display configurations change, shell interactions occur, another component changes the taskbar's layered state, or the dedicated tool process needs to reclaim taskbar state.


<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [x] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
