### PR TITLE
add faster-virtual-desktop-switching.wh.cpp

### DIFF
--- a/mods/faster-virtual-desktop-switching.wh.cpp
+++ b/mods/faster-virtual-desktop-switching.wh.cpp
@@ -18,6 +18,8 @@ Removes the long-standing pre-animation lag caused by oversized wallpaper thumbn
 
 ![GIF](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/faster-virtual-desktop-switching/faster-virtual-desktop-switching.gif)
 
+_Note: This can make the wallpaper look softer during the switch. The mod is a no-op on Windows 10._
+
 Windows 11 can synchronously request a full-monitor-sized wallpaper thumbnail
 before beginning a virtual desktop transition. On a high-DPI display with specific wallpaper
 configurations, that request can take roughly 136-169 ms when warm and more than one second 
@@ -72,15 +74,8 @@ ThumbnailCacheGetThumbnail g_thumbnailCacheApiGetThumbnailOriginal = nullptr;
 MakeBackgroundThumbnailFromThumbnailCache
     g_makeBackgroundThumbnailOriginal = nullptr;
 LoadLibraryExW_t g_loadLibraryExWOriginal = nullptr;
-HMODULE g_twinuiPcShell = nullptr;
-HMODULE g_thumbnailCacheServer = nullptr;
 thread_local int g_makeBackgroundThumbnailDepth = 0;
-constexpr LONG kHookPending = 0;
-constexpr LONG kHookInstalling = 1;
-constexpr LONG kHookInstalled = 2;
-constexpr LONG kHookFailed = 3;
-volatile LONG g_backgroundHookState = kHookPending;
-volatile LONG g_thumbnailHookState = kHookPending;
+volatile LONG g_twinuiPcShellHookAttempted = FALSE;
 volatile LONG g_thumbcacheHookAttempted = FALSE;
 volatile LONG g_windowsStorageHookAttempted = FALSE;
 volatile LONG g_maximumThumbnailSize = 1024;
@@ -150,6 +145,9 @@ HRESULT STDMETHODCALLTYPE ThumbnailCacheGetThumbnailHook(
     DWORD* outFlags,
     WtsThumbnailId* thumbnailId) {
     requestedSize = ClampTransitionThumbnailSize(requestedSize);
+    if (!g_thumbnailCacheGetThumbnailOriginal) {
+        return E_FAIL;
+    }
     return g_thumbnailCacheGetThumbnailOriginal(
         self,
         shellItem,
@@ -169,6 +167,9 @@ HRESULT STDMETHODCALLTYPE ThumbnailCacheApiGetThumbnailHook(
     DWORD* outFlags,
     WtsThumbnailId* thumbnailId) {
     requestedSize = ClampTransitionThumbnailSize(requestedSize);
+    if (!g_thumbnailCacheApiGetThumbnailOriginal) {
+        return E_FAIL;
+    }
     return g_thumbnailCacheApiGetThumbnailOriginal(
         self,
         shellItem,
@@ -182,7 +183,8 @@ HRESULT STDMETHODCALLTYPE ThumbnailCacheApiGetThumbnailHook(
 // Hook the outer wallpaper helper so the thumbnail-cache detour can identify
 // its dynamic call context without relying on compiler code layout.
 bool HookBackgroundThumbnailHelper(HMODULE module) {
-    if (!module) {
+    if (!module || InterlockedExchange(
+                       &g_twinuiPcShellHookAttempted, TRUE)) {
         return false;
     }
 
@@ -199,11 +201,15 @@ bool HookBackgroundThumbnailHelper(HMODULE module) {
         },
     };
 
-    if (!WindhawkUtils::HookSymbols(
-            module, symbolHooks, ARRAYSIZE(symbolHooks)) ||
-        !g_makeBackgroundThumbnailOriginal) {
+    const bool symbolsHooked = WindhawkUtils::HookSymbols(
+        module, symbolHooks, ARRAYSIZE(symbolHooks));
+    if (!g_makeBackgroundThumbnailOriginal) {
         Wh_Log(L"Failed to hook the virtual desktop wallpaper helper");
         return false;
+    }
+    if (!symbolsHooked) {
+        Wh_Log(L"HookSymbols reported a failure after registering the "
+               L"virtual desktop wallpaper helper hook");
     }
     return true;
 }
@@ -211,30 +217,9 @@ bool HookBackgroundThumbnailHelper(HMODULE module) {
 // The implementation moved from windows.storage.dll to thumbcache.dll. Hook
 // the concrete method by symbol in whichever naturally loaded module provides
 // it, avoiding COM activation and a hard-coded vtable slot.
-bool HookThumbnailCache(HMODULE module) {
-    if (!module || InterlockedCompareExchange(
-                       &g_thumbnailHookState,
-                       kHookInstalling,
-                       kHookPending) != kHookPending) {
-        return false;
-    }
-
-    volatile LONG* attemptState =
-        GetModuleHandleW(L"thumbcache.dll") == module
-            ? &g_thumbcacheHookAttempted
-            : &g_windowsStorageHookAttempted;
-    if (InterlockedExchange(attemptState, TRUE)) {
-        InterlockedExchange(&g_thumbnailHookState, kHookPending);
-        return false;
-    }
-
-    if (!GetModuleHandleExW(
-            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
-            reinterpret_cast<LPCWSTR>(module),
-            &g_thumbnailCacheServer)) {
-        Wh_Log(L"Failed to retain the thumbnail-cache module: %lu",
-               GetLastError());
-        InterlockedExchange(&g_thumbnailHookState, kHookPending);
+bool HookThumbnailCache(
+    HMODULE module, volatile LONG* hookAttempted, PCWSTR moduleName) {
+    if (!module || InterlockedExchange(hookAttempted, TRUE)) {
         return false;
     }
 
@@ -260,97 +245,48 @@ bool HookThumbnailCache(HMODULE module) {
         },
     };
 
-    if (!WindhawkUtils::HookSymbols(
-            module, symbolHooks, ARRAYSIZE(symbolHooks)) ||
-        (!g_thumbnailCacheGetThumbnailOriginal &&
-         !g_thumbnailCacheApiGetThumbnailOriginal)) {
-        g_thumbnailCacheGetThumbnailOriginal = nullptr;
-        g_thumbnailCacheApiGetThumbnailOriginal = nullptr;
-        FreeLibrary(g_thumbnailCacheServer);
-        g_thumbnailCacheServer = nullptr;
-        InterlockedExchange(&g_thumbnailHookState, kHookPending);
+    const bool symbolsHooked = WindhawkUtils::HookSymbols(
+        module, symbolHooks, ARRAYSIZE(symbolHooks));
+    const bool registeredHook = g_thumbnailCacheGetThumbnailOriginal ||
+                                g_thumbnailCacheApiGetThumbnailOriginal;
+    if (!registeredHook) {
+        Wh_Log(L"Failed to hook thumbnail cache in %s", moduleName);
         return false;
     }
+    if (!symbolsHooked) {
+        Wh_Log(L"HookSymbols reported a failure after registering a "
+               L"thumbnail cache hook in %s",
+               moduleName);
+    }
 
-    InterlockedExchange(&g_thumbnailHookState, kHookInstalled);
     Wh_Log(L"Hooked thumbnail cache in %s (concrete=%d api=%d)",
-           GetModuleHandleW(L"thumbcache.dll") == module
-               ? L"thumbcache.dll"
-               : L"windows.storage.dll",
+           moduleName,
            g_thumbnailCacheGetThumbnailOriginal != nullptr,
            g_thumbnailCacheApiGetThumbnailOriginal != nullptr);
     return true;
 }
 
 bool HookLoadedThumbnailCache() {
-    constexpr PCWSTR moduleNames[] = {
-        L"thumbcache.dll",
-        L"windows.storage.dll",
-    };
-    for (PCWSTR moduleName : moduleNames) {
-        HMODULE module = GetModuleHandleW(moduleName);
-        if (module && HookThumbnailCache(module)) {
-            return true;
-        }
+    if (g_thumbnailCacheGetThumbnailOriginal ||
+        g_thumbnailCacheApiGetThumbnailOriginal) {
+        return false;
     }
 
-    if (InterlockedCompareExchange(
-            &g_thumbcacheHookAttempted, FALSE, FALSE) &&
-        InterlockedCompareExchange(
-            &g_windowsStorageHookAttempted, FALSE, FALSE)) {
-        InterlockedCompareExchange(
-            &g_thumbnailHookState, kHookFailed, kHookPending);
+    if (HMODULE thumbcache = GetModuleHandleW(L"thumbcache.dll");
+        thumbcache && HookThumbnailCache(
+                          thumbcache,
+                          &g_thumbcacheHookAttempted,
+                          L"thumbcache.dll")) {
+        return true;
+    }
+    if (HMODULE windowsStorage = GetModuleHandleW(L"windows.storage.dll");
+        windowsStorage && HookThumbnailCache(
+                              windowsStorage,
+                              &g_windowsStorageHookAttempted,
+                              L"windows.storage.dll")) {
+        return true;
     }
     return false;
-}
-
-// Balance the module references retained for the lifetime of the hooks.
-void ReleaseModuleReferences() {
-    if (g_thumbnailCacheServer) {
-        FreeLibrary(g_thumbnailCacheServer);
-        g_thumbnailCacheServer = nullptr;
-    }
-
-    if (g_twinuiPcShell) {
-        FreeLibrary(g_twinuiPcShell);
-        g_twinuiPcShell = nullptr;
-    }
-}
-
-bool HookBackgroundThumbnailModule(HMODULE twinuiPcShell) {
-    if (InterlockedCompareExchange(
-            &g_backgroundHookState,
-            kHookInstalling,
-            kHookPending) != kHookPending) {
-        return false;
-    }
-    if (!GetModuleHandleExW(
-            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
-            reinterpret_cast<LPCWSTR>(twinuiPcShell),
-            &g_twinuiPcShell)) {
-        Wh_Log(L"Failed to retain twinui.pcshell.dll: %lu", GetLastError());
-        InterlockedExchange(&g_backgroundHookState, kHookFailed);
-        return false;
-    }
-
-    if (!HookBackgroundThumbnailHelper(twinuiPcShell)) {
-        FreeLibrary(g_twinuiPcShell);
-        g_twinuiPcShell = nullptr;
-        InterlockedExchange(&g_backgroundHookState, kHookFailed);
-        return false;
-    }
-
-    InterlockedExchange(&g_backgroundHookState, kHookInstalled);
-    return true;
-}
-
-bool ApplyLateHooks() {
-    SetLastError(ERROR_SUCCESS);
-    if (!Wh_ApplyHookOperations()) {
-        Wh_Log(L"Failed to apply late-loaded hooks: %lu", GetLastError());
-        return false;
-    }
-    return true;
 }
 
 HMODULE WINAPI LoadLibraryExWHook(
@@ -364,30 +300,14 @@ HMODULE WINAPI LoadLibraryExWHook(
     }
 
     HMODULE twinuiPcShell = GetModuleHandleW(L"twinui.pcshell.dll");
-    HMODULE thumbcache = GetModuleHandleW(L"thumbcache.dll");
-    HMODULE windowsStorage = GetModuleHandleW(L"windows.storage.dll");
-    if (module != twinuiPcShell && module != thumbcache &&
-        module != windowsStorage) {
-        return module;
-    }
-
-    bool registeredHook = false;
-    if (twinuiPcShell &&
-        InterlockedCompareExchange(
-            &g_backgroundHookState, kHookPending, kHookPending) ==
-            kHookPending) {
-        registeredHook = HookBackgroundThumbnailModule(twinuiPcShell);
-    }
-
-    if ((thumbcache || windowsStorage) &&
-        InterlockedCompareExchange(
-            &g_thumbnailHookState, kHookPending, kHookPending) ==
-            kHookPending) {
-        registeredHook = HookLoadedThumbnailCache() || registeredHook;
-    }
+    bool registeredHook = HookBackgroundThumbnailHelper(twinuiPcShell);
+    registeredHook = HookLoadedThumbnailCache() || registeredHook;
 
     if (registeredHook) {
-        ApplyLateHooks();
+        SetLastError(ERROR_SUCCESS);
+        if (!Wh_ApplyHookOperations()) {
+            Wh_Log(L"Failed to apply late-loaded hooks: %lu", GetLastError());
+        }
     }
     return module;
 }
@@ -419,49 +339,16 @@ BOOL Wh_ModInit() {
 
     if (HMODULE twinuiPcShell =
             GetModuleHandleW(L"twinui.pcshell.dll")) {
-        if (!HookBackgroundThumbnailModule(twinuiPcShell)) {
+        if (!HookBackgroundThumbnailHelper(twinuiPcShell)) {
             return FALSE;
         }
     }
 
     HookLoadedThumbnailCache();
-    if (InterlockedCompareExchange(
-            &g_thumbnailHookState, kHookPending, kHookPending) ==
-        kHookFailed) {
-        return FALSE;
-    }
 
     return TRUE;
 }
 
-void Wh_ModAfterInit() {
-    bool registeredHook = false;
-    if (HMODULE twinuiPcShell =
-            GetModuleHandleW(L"twinui.pcshell.dll")) {
-        if (InterlockedCompareExchange(
-                &g_backgroundHookState, kHookPending, kHookPending) ==
-            kHookPending) {
-            registeredHook = HookBackgroundThumbnailModule(twinuiPcShell);
-        }
-    }
-
-    if (InterlockedCompareExchange(
-            &g_thumbnailHookState, kHookPending, kHookPending) ==
-        kHookPending) {
-        registeredHook = HookLoadedThumbnailCache() || registeredHook;
-    }
-
-    if (registeredHook) {
-        ApplyLateHooks();
-    }
-}
-
 void Wh_ModSettingsChanged() {
     LoadSettings();
-}
-
-void Wh_ModUninit() {
-    // Windhawk calls this after removing registered hooks, so the implementation
-    // DLLs can no longer be entered through this mod's detour.
-    ReleaseModuleReferences();
 }

--- a/mods/faster-virtual-desktop-switching.wh.cpp
+++ b/mods/faster-virtual-desktop-switching.wh.cpp
@@ -38,7 +38,7 @@ Laptop users who use three- or four-finger swipe gestures can especially benefit
 /*
 - maximumThumbnailSize: 1024
   $name: Maximum thumbnail size
-  $description: Requested size used for the transition wallpaper. Microsoft documents 1024 as the maximum supported value.
+  $description: Requested size used for the transition wallpaper, clamped to the range 64-1024. Microsoft documents 1024 as the maximum supported value.
 */
 // ==/WindhawkModSettings==
 
@@ -290,9 +290,8 @@ bool HookBackgroundThumbnailHelper(HMODULE module) {
             {
                 L"protected: long __cdecl VirtualDesktopGestureWindow::MakeBackgroundThumbnailFromThumbnailCache(struct IDCompThumbnail *,struct IVirtualDesktop *,struct HSTRING__ *,struct tagRECT,struct IDCompThumbnail * *)",
             },
-            reinterpret_cast<void**>(&g_makeBackgroundThumbnailOriginal),
-            reinterpret_cast<void*>(
-                MakeBackgroundThumbnailFromThumbnailCacheHook),
+            &g_makeBackgroundThumbnailOriginal,
+            MakeBackgroundThumbnailFromThumbnailCacheHook,
             false,
         },
     };
@@ -331,16 +330,16 @@ bool HookThumbnailCache(
             {
                 L"public: virtual long __cdecl CThumbnailCache::GetThumbnail(struct IShellItem *,unsigned int,enum WTS_FLAGS,struct ISharedBitmap * *,enum WTS_CACHEFLAGS *,struct WTS_THUMBNAILID *)",
             },
-            reinterpret_cast<void**>(getThumbnailOriginal),
-            reinterpret_cast<void*>(getThumbnailHook),
+            getThumbnailOriginal,
+            getThumbnailHook,
             true,
         },
         {
             {
                 L"public: virtual long __cdecl CThumbnailCacheAPI::GetThumbnail(struct IShellItem *,unsigned int,enum WTS_FLAGS,struct ISharedBitmap * *,enum WTS_CACHEFLAGS *,struct WTS_THUMBNAILID *)",
             },
-            reinterpret_cast<void**>(apiGetThumbnailOriginal),
-            reinterpret_cast<void*>(apiGetThumbnailHook),
+            apiGetThumbnailOriginal,
+            apiGetThumbnailHook,
             true,
         },
     };
@@ -367,34 +366,41 @@ bool HookThumbnailCache(
 }
 
 bool HookLoadedThumbnailCache() {
-    bool registeredHook = false;
+    if (g_thumbcacheGetThumbnailOriginal ||
+        g_thumbcacheApiGetThumbnailOriginal ||
+        g_windowsStorageGetThumbnailOriginal ||
+        g_windowsStorageApiGetThumbnailOriginal) {
+        return false;
+    }
+
     if (!g_thumbcacheHookAttempted.load()) {
         if (HMODULE thumbcache = GetModuleHandleW(L"thumbcache.dll")) {
-            registeredHook = HookThumbnailCache(
-                thumbcache,
-                &g_thumbcacheHookAttempted,
-                L"thumbcache.dll",
-                &g_thumbcacheGetThumbnailOriginal,
-                ThumbcacheGetThumbnailHook,
-                &g_thumbcacheApiGetThumbnailOriginal,
-                ThumbcacheApiGetThumbnailHook);
+            if (HookThumbnailCache(
+                    thumbcache,
+                    &g_thumbcacheHookAttempted,
+                    L"thumbcache.dll",
+                    &g_thumbcacheGetThumbnailOriginal,
+                    ThumbcacheGetThumbnailHook,
+                    &g_thumbcacheApiGetThumbnailOriginal,
+                    ThumbcacheApiGetThumbnailHook)) {
+                return true;
+            }
         }
     }
     if (!g_windowsStorageHookAttempted.load()) {
         if (HMODULE windowsStorage =
                 GetModuleHandleW(L"windows.storage.dll")) {
-            registeredHook = HookThumbnailCache(
-                                 windowsStorage,
-                                 &g_windowsStorageHookAttempted,
-                                 L"windows.storage.dll",
-                                 &g_windowsStorageGetThumbnailOriginal,
-                                 WindowsStorageGetThumbnailHook,
-                                 &g_windowsStorageApiGetThumbnailOriginal,
-                                 WindowsStorageApiGetThumbnailHook) ||
-                             registeredHook;
+            return HookThumbnailCache(
+                windowsStorage,
+                &g_windowsStorageHookAttempted,
+                L"windows.storage.dll",
+                &g_windowsStorageGetThumbnailOriginal,
+                WindowsStorageGetThumbnailHook,
+                &g_windowsStorageApiGetThumbnailOriginal,
+                WindowsStorageApiGetThumbnailHook);
         }
     }
-    return registeredHook;
+    return false;
 }
 
 bool IsHookSetupComplete() {
@@ -404,8 +410,12 @@ bool IsHookSetupComplete() {
     if (!g_makeBackgroundThumbnailOriginal) {
         return true;
     }
-    return g_thumbcacheHookAttempted.load() &&
-           g_windowsStorageHookAttempted.load();
+    return g_thumbcacheGetThumbnailOriginal ||
+           g_thumbcacheApiGetThumbnailOriginal ||
+           g_windowsStorageGetThumbnailOriginal ||
+           g_windowsStorageApiGetThumbnailOriginal ||
+           (g_thumbcacheHookAttempted.load() &&
+            g_windowsStorageHookAttempted.load());
 }
 
 void ProcessLateHookWork() {
@@ -512,6 +522,12 @@ BOOL Wh_ModInit() {
     }
 
     return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    if (!g_hookSetupComplete.load()) {
+        ProcessLateHookWork();
+    }
 }
 
 void Wh_ModSettingsChanged() {

--- a/mods/faster-virtual-desktop-switching.wh.cpp
+++ b/mods/faster-virtual-desktop-switching.wh.cpp
@@ -54,7 +54,7 @@ struct WtsThumbnailId {
     BYTE value[16];
 };
 
-using ThumbnailCacheGetThumbnail = HRESULT(*)(
+using ThumbnailCacheGetThumbnail = HRESULT(STDMETHODCALLTYPE*)(
     void* self,
     void* shellItem,
     UINT requestedSize,
@@ -62,7 +62,7 @@ using ThumbnailCacheGetThumbnail = HRESULT(*)(
     void** sharedBitmap,
     DWORD* outFlags,
     WtsThumbnailId* thumbnailId);
-using MakeBackgroundThumbnailFromThumbnailCache = HRESULT(*)(
+using MakeBackgroundThumbnailFromThumbnailCache = HRESULT(STDMETHODCALLTYPE*)(
     void* self,
     void* dcompThumbnail,
     void* virtualDesktop,
@@ -71,6 +71,8 @@ using MakeBackgroundThumbnailFromThumbnailCache = HRESULT(*)(
     void** result);
 using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 
+// Every target needs its own original pointer. Reusing one across registrations
+// would make an earlier detour call whichever target was registered last.
 ThumbnailCacheGetThumbnail g_thumbcacheGetThumbnailOriginal = nullptr;
 ThumbnailCacheGetThumbnail g_thumbcacheApiGetThumbnailOriginal = nullptr;
 ThumbnailCacheGetThumbnail g_windowsStorageGetThumbnailOriginal = nullptr;
@@ -82,9 +84,6 @@ thread_local int g_makeBackgroundThumbnailDepth = 0;
 std::atomic_bool g_twinuiPcShellHookAttempted{false};
 std::atomic_bool g_thumbcacheHookAttempted{false};
 std::atomic_bool g_windowsStorageHookAttempted{false};
-std::atomic_bool g_hookWorkInProgress{false};
-std::atomic_bool g_hookWorkPending{false};
-std::atomic_bool g_hookSetupComplete{false};
 std::atomic_bool g_thumbnailClampLogged{false};
 std::atomic<int> g_maximumThumbnailSize{1024};
 
@@ -98,6 +97,7 @@ void LoadSettings() {
         maximumSize = 1024;
     }
     g_maximumThumbnailSize.store(maximumSize);
+    g_thumbnailClampLogged.store(false);
 }
 
 bool IsWindows11OrGreater() {
@@ -118,20 +118,7 @@ bool IsWindows11OrGreater() {
            versionInfo.dwBuildNumber >= 22000;
 }
 
-// Return true for the shell process, including early Explorer startup before
-// its shell window exists. Separate folder processes are skipped once known.
-bool IsOrMayBecomeShellExplorer() {
-    HWND shellWindow = GetShellWindow();
-    if (!shellWindow) {
-        return true;
-    }
-
-    DWORD shellProcessId = 0;
-    GetWindowThreadProcessId(shellWindow, &shellProcessId);
-    return shellProcessId == GetCurrentProcessId();
-}
-
-HRESULT MakeBackgroundThumbnailFromThumbnailCacheHook(
+HRESULT STDMETHODCALLTYPE MakeBackgroundThumbnailFromThumbnailCacheHook(
     void* self,
     void* dcompThumbnail,
     void* virtualDesktop,
@@ -186,9 +173,6 @@ HRESULT CallThumbnailCacheGetThumbnail(
     DWORD* outFlags,
     WtsThumbnailId* thumbnailId) {
     requestedSize = ClampTransitionThumbnailSize(requestedSize);
-    if (!original) {
-        return E_FAIL;
-    }
     return original(
         self,
         shellItem,
@@ -309,9 +293,9 @@ bool HookBackgroundThumbnailHelper(HMODULE module) {
     return true;
 }
 
-// The implementation moved from windows.storage.dll to thumbcache.dll. Hook
-// the concrete method by symbol in whichever naturally loaded module provides
-// it, avoiding COM activation and a hard-coded vtable slot.
+// The implementation moved between windows.storage.dll and thumbcache.dll.
+// Hook each loaded copy independently, avoiding COM activation and a hard-coded
+// vtable slot.
 bool HookThumbnailCache(
     HMODULE module,
     std::atomic_bool* hookAttempted,
@@ -365,105 +349,50 @@ bool HookThumbnailCache(
     return true;
 }
 
-bool HookLoadedThumbnailCache() {
-    if (g_thumbcacheGetThumbnailOriginal ||
-        g_thumbcacheApiGetThumbnailOriginal ||
-        g_windowsStorageGetThumbnailOriginal ||
-        g_windowsStorageApiGetThumbnailOriginal) {
+bool HandleLoadedModule(HMODULE module) {
+    if (!module) {
         return false;
     }
 
-    if (!g_thumbcacheHookAttempted.load()) {
-        if (HMODULE thumbcache = GetModuleHandleW(L"thumbcache.dll")) {
-            if (HookThumbnailCache(
-                    thumbcache,
-                    &g_thumbcacheHookAttempted,
-                    L"thumbcache.dll",
-                    &g_thumbcacheGetThumbnailOriginal,
-                    ThumbcacheGetThumbnailHook,
-                    &g_thumbcacheApiGetThumbnailOriginal,
-                    ThumbcacheApiGetThumbnailHook)) {
-                return true;
-            }
-        }
+    if (!g_twinuiPcShellHookAttempted.load() &&
+        module == GetModuleHandleW(L"twinui.pcshell.dll")) {
+        return HookBackgroundThumbnailHelper(module);
     }
-    if (!g_windowsStorageHookAttempted.load()) {
-        if (HMODULE windowsStorage =
-                GetModuleHandleW(L"windows.storage.dll")) {
-            return HookThumbnailCache(
-                windowsStorage,
-                &g_windowsStorageHookAttempted,
-                L"windows.storage.dll",
-                &g_windowsStorageGetThumbnailOriginal,
-                WindowsStorageGetThumbnailHook,
-                &g_windowsStorageApiGetThumbnailOriginal,
-                WindowsStorageApiGetThumbnailHook);
-        }
+    if (!g_thumbcacheHookAttempted.load() &&
+        module == GetModuleHandleW(L"thumbcache.dll")) {
+        return HookThumbnailCache(
+            module,
+            &g_thumbcacheHookAttempted,
+            L"thumbcache.dll",
+            &g_thumbcacheGetThumbnailOriginal,
+            ThumbcacheGetThumbnailHook,
+            &g_thumbcacheApiGetThumbnailOriginal,
+            ThumbcacheApiGetThumbnailHook);
+    }
+    if (!g_windowsStorageHookAttempted.load() &&
+        module == GetModuleHandleW(L"windows.storage.dll")) {
+        return HookThumbnailCache(
+            module,
+            &g_windowsStorageHookAttempted,
+            L"windows.storage.dll",
+            &g_windowsStorageGetThumbnailOriginal,
+            WindowsStorageGetThumbnailHook,
+            &g_windowsStorageApiGetThumbnailOriginal,
+            WindowsStorageApiGetThumbnailHook);
     }
     return false;
 }
 
-bool IsHookSetupComplete() {
-    if (!g_twinuiPcShellHookAttempted.load()) {
-        return false;
-    }
-    if (!g_makeBackgroundThumbnailOriginal) {
-        return true;
-    }
-    return g_thumbcacheGetThumbnailOriginal ||
-           g_thumbcacheApiGetThumbnailOriginal ||
-           g_windowsStorageGetThumbnailOriginal ||
-           g_windowsStorageApiGetThumbnailOriginal ||
-           (g_thumbcacheHookAttempted.load() &&
-            g_windowsStorageHookAttempted.load());
-}
-
-void ProcessLateHookWork() {
-    // Never wait inside the loader hook. A nested or concurrent load asks the
-    // current owner to rescan and returns immediately.
-    g_hookWorkPending.store(true);
-
-    for (;;) {
-        bool expected = false;
-        if (!g_hookWorkInProgress.compare_exchange_strong(expected, true)) {
-            return;
-        }
-
-        do {
-            g_hookWorkPending.store(false);
-
-            bool registeredHook = false;
-            if (!g_twinuiPcShellHookAttempted.load()) {
-                registeredHook = HookBackgroundThumbnailHelper(
-                    GetModuleHandleW(L"twinui.pcshell.dll"));
-            }
-            if (g_makeBackgroundThumbnailOriginal) {
-                registeredHook =
-                    HookLoadedThumbnailCache() || registeredHook;
-            }
-
-            if (registeredHook) {
-                SetLastError(ERROR_SUCCESS);
-                if (!Wh_ApplyHookOperations()) {
-                    Wh_Log(L"Failed to apply late-loaded hooks: %lu",
-                           GetLastError());
-                }
-            }
-
-            if (IsHookSetupComplete()) {
-                g_hookSetupComplete.store(true);
-            }
-        } while (!g_hookSetupComplete.load() &&
-                 g_hookWorkPending.exchange(false));
-
-        g_hookWorkInProgress.store(false);
-        // Close the handoff race where a request arrives after the final
-        // pending check but before ownership is released.
-        if (g_hookSetupComplete.load() ||
-            !g_hookWorkPending.exchange(false)) {
-            return;
-        }
-    }
+bool HandleAlreadyLoadedModules() {
+    bool hooksRegistered = HandleLoadedModule(
+        GetModuleHandleW(L"twinui.pcshell.dll"));
+    hooksRegistered = HandleLoadedModule(
+                          GetModuleHandleW(L"thumbcache.dll")) ||
+                      hooksRegistered;
+    hooksRegistered = HandleLoadedModule(
+                          GetModuleHandleW(L"windows.storage.dll")) ||
+                      hooksRegistered;
+    return hooksRegistered;
 }
 
 HMODULE WINAPI LoadLibraryExWHook(
@@ -476,8 +405,8 @@ HMODULE WINAPI LoadLibraryExWHook(
         return module;
     }
 
-    if (!g_hookSetupComplete.load(std::memory_order_relaxed)) {
-        ProcessLateHookWork();
+    if (HandleLoadedModule(module) && !Wh_ApplyHookOperations()) {
+        Wh_Log(L"Failed to apply late-loaded hooks");
     }
     return module;
 }
@@ -491,12 +420,6 @@ BOOL Wh_ModInit() {
     }
 
     LoadSettings();
-
-    if (!IsOrMayBecomeShellExplorer()) {
-        Wh_Log(L"Skipping non-shell explorer.exe process %lu",
-               GetCurrentProcessId());
-        return FALSE;
-    }
 
     HMODULE kernelBase = GetModuleHandleW(L"kernelbase.dll");
     auto loadLibraryExW = kernelBase
@@ -512,21 +435,18 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
-    if (HMODULE twinuiPcShell =
-            GetModuleHandleW(L"twinui.pcshell.dll")) {
-        if (!HookBackgroundThumbnailHelper(twinuiPcShell)) {
-            return FALSE;
-        }
-        HookLoadedThumbnailCache();
-        g_hookSetupComplete.store(IsHookSetupComplete());
+    HandleAlreadyLoadedModules();
+    if (g_twinuiPcShellHookAttempted.load() &&
+        !g_makeBackgroundThumbnailOriginal) {
+        return FALSE;
     }
 
     return TRUE;
 }
 
 void Wh_ModAfterInit() {
-    if (!g_hookSetupComplete.load()) {
-        ProcessLateHookWork();
+    if (HandleAlreadyLoadedModules() && !Wh_ApplyHookOperations()) {
+        Wh_Log(L"Failed to apply hooks in Wh_ModAfterInit");
     }
 }
 

--- a/mods/faster-virtual-desktop-switching.wh.cpp
+++ b/mods/faster-virtual-desktop-switching.wh.cpp
@@ -226,6 +226,7 @@ bool HookThumbnailCache(HMODULE module) {
         return false;
     }
 
+    // thumbcache.dll / windows.storage.dll
     WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
             {

--- a/mods/faster-virtual-desktop-switching.wh.cpp
+++ b/mods/faster-virtual-desktop-switching.wh.cpp
@@ -154,6 +154,7 @@ bool ResolveTargetFunctionRange() {
     }
 
     void* targetFunction = nullptr;
+    // twinui.pcshell.dll
     WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
             {

--- a/mods/faster-virtual-desktop-switching.wh.cpp
+++ b/mods/faster-virtual-desktop-switching.wh.cpp
@@ -78,8 +78,11 @@ thread_local int g_makeBackgroundThumbnailDepth = 0;
 constexpr LONG kHookPending = 0;
 constexpr LONG kHookInstalling = 1;
 constexpr LONG kHookInstalled = 2;
+constexpr LONG kHookFailed = 3;
 volatile LONG g_backgroundHookState = kHookPending;
 volatile LONG g_thumbnailHookState = kHookPending;
+volatile LONG g_thumbcacheHookAttempted = FALSE;
+volatile LONG g_windowsStorageHookAttempted = FALSE;
 volatile LONG g_maximumThumbnailSize = 1024;
 
 // Load settings atomically because Explorer can switch desktops while the
@@ -216,6 +219,15 @@ bool HookThumbnailCache(HMODULE module) {
         return false;
     }
 
+    volatile LONG* attemptState =
+        GetModuleHandleW(L"thumbcache.dll") == module
+            ? &g_thumbcacheHookAttempted
+            : &g_windowsStorageHookAttempted;
+    if (InterlockedExchange(attemptState, TRUE)) {
+        InterlockedExchange(&g_thumbnailHookState, kHookPending);
+        return false;
+    }
+
     if (!GetModuleHandleExW(
             GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
             reinterpret_cast<LPCWSTR>(module),
@@ -281,6 +293,14 @@ bool HookLoadedThumbnailCache() {
             return true;
         }
     }
+
+    if (InterlockedCompareExchange(
+            &g_thumbcacheHookAttempted, FALSE, FALSE) &&
+        InterlockedCompareExchange(
+            &g_windowsStorageHookAttempted, FALSE, FALSE)) {
+        InterlockedCompareExchange(
+            &g_thumbnailHookState, kHookFailed, kHookPending);
+    }
     return false;
 }
 
@@ -309,14 +329,14 @@ bool HookBackgroundThumbnailModule(HMODULE twinuiPcShell) {
             reinterpret_cast<LPCWSTR>(twinuiPcShell),
             &g_twinuiPcShell)) {
         Wh_Log(L"Failed to retain twinui.pcshell.dll: %lu", GetLastError());
-        InterlockedExchange(&g_backgroundHookState, kHookPending);
+        InterlockedExchange(&g_backgroundHookState, kHookFailed);
         return false;
     }
 
     if (!HookBackgroundThumbnailHelper(twinuiPcShell)) {
         FreeLibrary(g_twinuiPcShell);
         g_twinuiPcShell = nullptr;
-        InterlockedExchange(&g_backgroundHookState, kHookPending);
+        InterlockedExchange(&g_backgroundHookState, kHookFailed);
         return false;
     }
 
@@ -380,7 +400,7 @@ BOOL Wh_ModInit() {
     if (!IsOrMayBecomeShellExplorer()) {
         Wh_Log(L"Skipping non-shell explorer.exe process %lu",
                GetCurrentProcessId());
-        return TRUE;
+        return FALSE;
     }
 
     HMODULE kernelBase = GetModuleHandleW(L"kernelbase.dll");

--- a/mods/faster-virtual-desktop-switching.wh.cpp
+++ b/mods/faster-virtual-desktop-switching.wh.cpp
@@ -82,6 +82,9 @@ thread_local int g_makeBackgroundThumbnailDepth = 0;
 std::atomic_bool g_twinuiPcShellHookAttempted{false};
 std::atomic_bool g_thumbcacheHookAttempted{false};
 std::atomic_bool g_windowsStorageHookAttempted{false};
+std::atomic_bool g_hookWorkInProgress{false};
+std::atomic_bool g_hookWorkPending{false};
+std::atomic_bool g_hookSetupComplete{false};
 std::atomic_bool g_thumbnailClampLogged{false};
 std::atomic<int> g_maximumThumbnailSize{1024};
 
@@ -365,30 +368,92 @@ bool HookThumbnailCache(
 
 bool HookLoadedThumbnailCache() {
     bool registeredHook = false;
-    if (HMODULE thumbcache = GetModuleHandleW(L"thumbcache.dll");
-        thumbcache) {
-        registeredHook = HookThumbnailCache(
-            thumbcache,
-            &g_thumbcacheHookAttempted,
-            L"thumbcache.dll",
-            &g_thumbcacheGetThumbnailOriginal,
-            ThumbcacheGetThumbnailHook,
-            &g_thumbcacheApiGetThumbnailOriginal,
-            ThumbcacheApiGetThumbnailHook);
+    if (!g_thumbcacheHookAttempted.load()) {
+        if (HMODULE thumbcache = GetModuleHandleW(L"thumbcache.dll")) {
+            registeredHook = HookThumbnailCache(
+                thumbcache,
+                &g_thumbcacheHookAttempted,
+                L"thumbcache.dll",
+                &g_thumbcacheGetThumbnailOriginal,
+                ThumbcacheGetThumbnailHook,
+                &g_thumbcacheApiGetThumbnailOriginal,
+                ThumbcacheApiGetThumbnailHook);
+        }
     }
-    if (HMODULE windowsStorage = GetModuleHandleW(L"windows.storage.dll");
-        windowsStorage) {
-        registeredHook = HookThumbnailCache(
-                             windowsStorage,
-                             &g_windowsStorageHookAttempted,
-                             L"windows.storage.dll",
-                             &g_windowsStorageGetThumbnailOriginal,
-                             WindowsStorageGetThumbnailHook,
-                             &g_windowsStorageApiGetThumbnailOriginal,
-                             WindowsStorageApiGetThumbnailHook) ||
-                         registeredHook;
+    if (!g_windowsStorageHookAttempted.load()) {
+        if (HMODULE windowsStorage =
+                GetModuleHandleW(L"windows.storage.dll")) {
+            registeredHook = HookThumbnailCache(
+                                 windowsStorage,
+                                 &g_windowsStorageHookAttempted,
+                                 L"windows.storage.dll",
+                                 &g_windowsStorageGetThumbnailOriginal,
+                                 WindowsStorageGetThumbnailHook,
+                                 &g_windowsStorageApiGetThumbnailOriginal,
+                                 WindowsStorageApiGetThumbnailHook) ||
+                             registeredHook;
+        }
     }
     return registeredHook;
+}
+
+bool IsHookSetupComplete() {
+    if (!g_twinuiPcShellHookAttempted.load()) {
+        return false;
+    }
+    if (!g_makeBackgroundThumbnailOriginal) {
+        return true;
+    }
+    return g_thumbcacheHookAttempted.load() &&
+           g_windowsStorageHookAttempted.load();
+}
+
+void ProcessLateHookWork() {
+    // Never wait inside the loader hook. A nested or concurrent load asks the
+    // current owner to rescan and returns immediately.
+    g_hookWorkPending.store(true);
+
+    for (;;) {
+        bool expected = false;
+        if (!g_hookWorkInProgress.compare_exchange_strong(expected, true)) {
+            return;
+        }
+
+        do {
+            g_hookWorkPending.store(false);
+
+            bool registeredHook = false;
+            if (!g_twinuiPcShellHookAttempted.load()) {
+                registeredHook = HookBackgroundThumbnailHelper(
+                    GetModuleHandleW(L"twinui.pcshell.dll"));
+            }
+            if (g_makeBackgroundThumbnailOriginal) {
+                registeredHook =
+                    HookLoadedThumbnailCache() || registeredHook;
+            }
+
+            if (registeredHook) {
+                SetLastError(ERROR_SUCCESS);
+                if (!Wh_ApplyHookOperations()) {
+                    Wh_Log(L"Failed to apply late-loaded hooks: %lu",
+                           GetLastError());
+                }
+            }
+
+            if (IsHookSetupComplete()) {
+                g_hookSetupComplete.store(true);
+            }
+        } while (!g_hookSetupComplete.load() &&
+                 g_hookWorkPending.exchange(false));
+
+        g_hookWorkInProgress.store(false);
+        // Close the handoff race where a request arrives after the final
+        // pending check but before ownership is released.
+        if (g_hookSetupComplete.load() ||
+            !g_hookWorkPending.exchange(false)) {
+            return;
+        }
+    }
 }
 
 HMODULE WINAPI LoadLibraryExWHook(
@@ -401,17 +466,8 @@ HMODULE WINAPI LoadLibraryExWHook(
         return module;
     }
 
-    HMODULE twinuiPcShell = GetModuleHandleW(L"twinui.pcshell.dll");
-    bool registeredHook = HookBackgroundThumbnailHelper(twinuiPcShell);
-    if (g_makeBackgroundThumbnailOriginal) {
-        registeredHook = HookLoadedThumbnailCache() || registeredHook;
-    }
-
-    if (registeredHook) {
-        SetLastError(ERROR_SUCCESS);
-        if (!Wh_ApplyHookOperations()) {
-            Wh_Log(L"Failed to apply late-loaded hooks: %lu", GetLastError());
-        }
+    if (!g_hookSetupComplete.load(std::memory_order_relaxed)) {
+        ProcessLateHookWork();
     }
     return module;
 }
@@ -452,6 +508,7 @@ BOOL Wh_ModInit() {
             return FALSE;
         }
         HookLoadedThumbnailCache();
+        g_hookSetupComplete.store(IsHookSetupComplete());
     }
 
     return TRUE;

--- a/mods/faster-virtual-desktop-switching.wh.cpp
+++ b/mods/faster-virtual-desktop-switching.wh.cpp
@@ -226,7 +226,7 @@ bool HookThumbnailCache(HMODULE module) {
         return false;
     }
 
-    // thumbcache.dll / windows.storage.dll
+    // thumbcache.dll, windows.storage.dll
     WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
             {

--- a/mods/faster-virtual-desktop-switching.wh.cpp
+++ b/mods/faster-virtual-desktop-switching.wh.cpp
@@ -45,8 +45,6 @@ Laptop users who use three- or four-finger swipe gestures can especially benefit
 #include <windhawk_api.h>
 #include <windhawk_utils.h>
 
-#include <cstdint>
-
 namespace {
 
 struct WtsThumbnailId {
@@ -78,12 +76,27 @@ using ThumbnailCacheGetThumbnail = HRESULT(STDMETHODCALLTYPE*)(
     IUnknown** sharedBitmap,
     DWORD* outFlags,
     WtsThumbnailId* thumbnailId);
+using MakeBackgroundThumbnailFromThumbnailCache = HRESULT(*)(
+    void* self,
+    void* dcompThumbnail,
+    void* virtualDesktop,
+    void* wallpaperPath,
+    RECT bounds,
+    void** result);
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 
 ThumbnailCacheGetThumbnail g_getThumbnailOriginal = nullptr;
+MakeBackgroundThumbnailFromThumbnailCache
+    g_makeBackgroundThumbnailOriginal = nullptr;
+LoadLibraryExW_t g_loadLibraryExWOriginal = nullptr;
 HMODULE g_twinuiPcShell = nullptr;
 HMODULE g_thumbnailCacheServer = nullptr;
-uintptr_t g_targetFunctionStart = 0;
-uintptr_t g_targetFunctionEnd = 0;
+thread_local int g_makeBackgroundThumbnailDepth = 0;
+constexpr LONG kCorePending = 0;
+constexpr LONG kCoreInitializing = 1;
+constexpr LONG kCoreInitialized = 2;
+constexpr LONG kCoreFailed = -1;
+volatile LONG g_coreInitializationState = kCorePending;
 volatile LONG g_maximumThumbnailSize = 1024;
 
 // Load settings atomically because Explorer can switch desktops while the
@@ -111,9 +124,27 @@ bool IsOrMayBecomeShellExplorer() {
     return shellProcessId == GetCurrentProcessId();
 }
 
-// Clamp only calls originating inside Windows' virtual desktop wallpaper
+HRESULT MakeBackgroundThumbnailFromThumbnailCacheHook(
+    void* self,
+    void* dcompThumbnail,
+    void* virtualDesktop,
+    void* wallpaperPath,
+    RECT bounds,
+    void** result) {
+    ++g_makeBackgroundThumbnailDepth;
+    const HRESULT resultCode = g_makeBackgroundThumbnailOriginal(
+        self,
+        dcompThumbnail,
+        virtualDesktop,
+        wallpaperPath,
+        bounds,
+        result);
+    --g_makeBackgroundThumbnailDepth;
+    return resultCode;
+}
+
+// Clamp only calls made synchronously by Windows' virtual desktop wallpaper
 // helper. All other thumbnail-cache clients receive their original arguments.
-__attribute__((noinline))
 HRESULT STDMETHODCALLTYPE GetThumbnailHook(
     IThumbnailCacheMinimal* self,
     IUnknown* shellItem,
@@ -122,11 +153,7 @@ HRESULT STDMETHODCALLTYPE GetThumbnailHook(
     IUnknown** sharedBitmap,
     DWORD* outFlags,
     WtsThumbnailId* thumbnailId) {
-    const uintptr_t returnAddress = reinterpret_cast<uintptr_t>(
-        __builtin_return_address(0));
-
-    if (returnAddress >= g_targetFunctionStart &&
-        returnAddress < g_targetFunctionEnd) {
+    if (g_makeBackgroundThumbnailDepth > 0) {
         const UINT maximumSize = static_cast<UINT>(
             InterlockedCompareExchange(&g_maximumThumbnailSize, 0, 0));
         if (requestedSize > maximumSize) {
@@ -144,74 +171,32 @@ HRESULT STDMETHODCALLTYPE GetThumbnailHook(
         thumbnailId);
 }
 
-// Resolve the target for the loaded Windows build, then obtain its exact code
-// range from the platform unwind table. No private function is detoured.
-bool ResolveTargetFunctionRange() {
-    g_twinuiPcShell = LoadLibraryExW(
-        L"twinui.pcshell.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-    if (!g_twinuiPcShell) {
-        Wh_Log(L"Failed to load twinui.pcshell.dll: %lu", GetLastError());
+// Hook the outer wallpaper helper so the thumbnail-cache detour can identify
+// its dynamic call context without relying on compiler code layout.
+bool HookBackgroundThumbnailHelper(HMODULE module) {
+    if (!module) {
         return false;
     }
 
-    void* targetFunction = nullptr;
     // twinui.pcshell.dll
     WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
             {
                 L"protected: long __cdecl VirtualDesktopGestureWindow::MakeBackgroundThumbnailFromThumbnailCache(struct IDCompThumbnail *,struct IVirtualDesktop *,struct HSTRING__ *,struct tagRECT,struct IDCompThumbnail * *)",
             },
-            &targetFunction,
-            nullptr,
+            reinterpret_cast<void**>(&g_makeBackgroundThumbnailOriginal),
+            reinterpret_cast<void*>(
+                MakeBackgroundThumbnailFromThumbnailCacheHook),
             false,
         },
     };
 
     if (!WindhawkUtils::HookSymbols(
-            g_twinuiPcShell, symbolHooks, ARRAYSIZE(symbolHooks)) ||
-        !targetFunction) {
-        Wh_Log(L"Failed to resolve the virtual desktop wallpaper helper");
+            module, symbolHooks, ARRAYSIZE(symbolHooks)) ||
+        !g_makeBackgroundThumbnailOriginal) {
+        Wh_Log(L"Failed to hook the virtual desktop wallpaper helper");
         return false;
     }
-
-    DWORD64 imageBase = 0;
-    PRUNTIME_FUNCTION runtimeFunction = RtlLookupFunctionEntry(
-        reinterpret_cast<DWORD64>(targetFunction),
-        &imageBase,
-        nullptr);
-    if (!runtimeFunction || !imageBase) {
-        Wh_Log(L"Failed to obtain the virtual desktop helper's unwind range");
-        return false;
-    }
-
-    const uintptr_t functionStart = static_cast<uintptr_t>(
-        imageBase + runtimeFunction->BeginAddress);
-#if defined(_M_ARM64) || defined(_ARM64_)
-    DWORD functionLength = 0;
-    if (runtimeFunction->Flag == PdataRefToFullXdata) {
-        const auto* unwindData = reinterpret_cast<
-            const IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA*>(
-                imageBase + runtimeFunction->UnwindData);
-        functionLength = unwindData->FunctionLength * 4;
-    } else if (runtimeFunction->Flag == PdataPackedUnwindFunction ||
-               runtimeFunction->Flag == PdataPackedUnwindFragment) {
-        functionLength = runtimeFunction->FunctionLength * 4;
-    }
-    const uintptr_t functionEnd = functionStart + functionLength;
-#else
-    const uintptr_t functionEnd = static_cast<uintptr_t>(
-        imageBase + runtimeFunction->EndAddress);
-#endif
-    const uintptr_t symbolAddress = reinterpret_cast<uintptr_t>(targetFunction);
-    if (functionEnd <= functionStart || symbolAddress < functionStart ||
-        symbolAddress >= functionEnd ||
-        functionEnd - functionStart > 0x4000) {
-        Wh_Log(L"Resolved an invalid virtual desktop helper range");
-        return false;
-    }
-
-    g_targetFunctionStart = functionStart;
-    g_targetFunctionEnd = functionEnd;
     return true;
 }
 
@@ -295,6 +280,68 @@ void ReleaseModuleReferences() {
     }
 }
 
+bool InitializeCore(HMODULE twinuiPcShell, bool applyHookOperations) {
+    if (InterlockedCompareExchange(
+            &g_coreInitializationState,
+            kCoreInitializing,
+            kCorePending) != kCorePending) {
+        return InterlockedCompareExchange(
+                   &g_coreInitializationState, 0, 0) == kCoreInitialized;
+    }
+
+    if (!IsOrMayBecomeShellExplorer()) {
+        Wh_Log(L"Skipping non-shell explorer.exe process %lu",
+               GetCurrentProcessId());
+        InterlockedExchange(&g_coreInitializationState, kCoreFailed);
+        return false;
+    }
+
+    if (!GetModuleHandleExW(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+            reinterpret_cast<LPCWSTR>(twinuiPcShell),
+            &g_twinuiPcShell)) {
+        Wh_Log(L"Failed to retain twinui.pcshell.dll: %lu", GetLastError());
+        InterlockedExchange(&g_coreInitializationState, kCoreFailed);
+        return false;
+    }
+
+    if (!HookBackgroundThumbnailHelper(twinuiPcShell) ||
+        !HookThumbnailCache()) {
+        ReleaseModuleReferences();
+        InterlockedExchange(&g_coreInitializationState, kCoreFailed);
+        return false;
+    }
+
+    if (applyHookOperations) {
+        SetLastError(ERROR_SUCCESS);
+        if (!Wh_ApplyHookOperations()) {
+            Wh_Log(L"Failed to apply late-loaded hooks: %lu", GetLastError());
+            InterlockedExchange(&g_coreInitializationState, kCoreFailed);
+            return false;
+        }
+    }
+
+    InterlockedExchange(&g_coreInitializationState, kCoreInitialized);
+    Wh_Log(L"Initialized: maximumThumbnailSize=%ld",
+           InterlockedCompareExchange(&g_maximumThumbnailSize, 0, 0));
+    return true;
+}
+
+HMODULE WINAPI LoadLibraryExWHook(
+    LPCWSTR fileName, HANDLE file, DWORD flags) {
+    HMODULE module = g_loadLibraryExWOriginal(fileName, file, flags);
+    constexpr DWORD dataOnlyFlags =
+        LOAD_LIBRARY_AS_DATAFILE | LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE |
+        LOAD_LIBRARY_AS_IMAGE_RESOURCE;
+    if (module && !(flags & dataOnlyFlags) &&
+        InterlockedCompareExchange(&g_coreInitializationState, 0, 0) ==
+            kCorePending &&
+        GetModuleHandleW(L"twinui.pcshell.dll") == module) {
+        InitializeCore(module, true);
+    }
+    return module;
+}
+
 }  // namespace
 
 BOOL Wh_ModInit() {
@@ -306,14 +353,38 @@ BOOL Wh_ModInit() {
         return TRUE;
     }
 
-    if (!ResolveTargetFunctionRange() || !HookThumbnailCache()) {
-        ReleaseModuleReferences();
+    if (HMODULE twinuiPcShell =
+            GetModuleHandleW(L"twinui.pcshell.dll")) {
+        return InitializeCore(twinuiPcShell, false) ? TRUE : FALSE;
+    }
+
+    HMODULE kernelBase = GetModuleHandleW(L"kernelbase.dll");
+    auto loadLibraryExW = kernelBase
+        ? reinterpret_cast<LoadLibraryExW_t>(
+              GetProcAddress(kernelBase, "LoadLibraryExW"))
+        : nullptr;
+    if (!loadLibraryExW ||
+        !WindhawkUtils::SetFunctionHook(
+            loadLibraryExW,
+            LoadLibraryExWHook,
+            &g_loadLibraryExWOriginal)) {
+        Wh_Log(L"Failed to hook kernelbase!LoadLibraryExW");
         return FALSE;
     }
 
-    Wh_Log(L"Initialized: maximumThumbnailSize=%ld",
-           InterlockedCompareExchange(&g_maximumThumbnailSize, 0, 0));
     return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    if (InterlockedCompareExchange(
+            &g_coreInitializationState, 0, 0) != kCorePending) {
+        return;
+    }
+
+    if (HMODULE twinuiPcShell =
+            GetModuleHandleW(L"twinui.pcshell.dll")) {
+        InitializeCore(twinuiPcShell, true);
+    }
 }
 
 void Wh_ModSettingsChanged() {

--- a/mods/faster-virtual-desktop-switching.wh.cpp
+++ b/mods/faster-virtual-desktop-switching.wh.cpp
@@ -46,6 +46,8 @@ Laptop users who use three- or four-finger swipe gestures can especially benefit
 #include <windhawk_api.h>
 #include <windhawk_utils.h>
 
+#include <atomic>
+
 namespace {
 
 struct WtsThumbnailId {
@@ -69,16 +71,19 @@ using MakeBackgroundThumbnailFromThumbnailCache = HRESULT(*)(
     void** result);
 using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 
-ThumbnailCacheGetThumbnail g_thumbnailCacheGetThumbnailOriginal = nullptr;
-ThumbnailCacheGetThumbnail g_thumbnailCacheApiGetThumbnailOriginal = nullptr;
+ThumbnailCacheGetThumbnail g_thumbcacheGetThumbnailOriginal = nullptr;
+ThumbnailCacheGetThumbnail g_thumbcacheApiGetThumbnailOriginal = nullptr;
+ThumbnailCacheGetThumbnail g_windowsStorageGetThumbnailOriginal = nullptr;
+ThumbnailCacheGetThumbnail g_windowsStorageApiGetThumbnailOriginal = nullptr;
 MakeBackgroundThumbnailFromThumbnailCache
     g_makeBackgroundThumbnailOriginal = nullptr;
 LoadLibraryExW_t g_loadLibraryExWOriginal = nullptr;
 thread_local int g_makeBackgroundThumbnailDepth = 0;
-volatile LONG g_twinuiPcShellHookAttempted = FALSE;
-volatile LONG g_thumbcacheHookAttempted = FALSE;
-volatile LONG g_windowsStorageHookAttempted = FALSE;
-volatile LONG g_maximumThumbnailSize = 1024;
+std::atomic_bool g_twinuiPcShellHookAttempted{false};
+std::atomic_bool g_thumbcacheHookAttempted{false};
+std::atomic_bool g_windowsStorageHookAttempted{false};
+std::atomic_bool g_thumbnailClampLogged{false};
+std::atomic<int> g_maximumThumbnailSize{1024};
 
 // Load settings atomically because Explorer can switch desktops while the
 // Windhawk settings callback runs on another thread.
@@ -89,7 +94,7 @@ void LoadSettings() {
     } else if (maximumSize > 1024) {
         maximumSize = 1024;
     }
-    InterlockedExchange(&g_maximumThumbnailSize, maximumSize);
+    g_maximumThumbnailSize.store(maximumSize);
 }
 
 // Return true for the shell process, including early Explorer startup before
@@ -112,16 +117,23 @@ HRESULT MakeBackgroundThumbnailFromThumbnailCacheHook(
     void* wallpaperPath,
     RECT bounds,
     void** result) {
-    ++g_makeBackgroundThumbnailDepth;
-    const HRESULT resultCode = g_makeBackgroundThumbnailOriginal(
+    struct DepthGuard {
+        DepthGuard() {
+            ++g_makeBackgroundThumbnailDepth;
+        }
+
+        ~DepthGuard() {
+            --g_makeBackgroundThumbnailDepth;
+        }
+    } depthGuard;
+
+    return g_makeBackgroundThumbnailOriginal(
         self,
         dcompThumbnail,
         virtualDesktop,
         wallpaperPath,
         bounds,
         result);
-    --g_makeBackgroundThumbnailDepth;
-    return resultCode;
 }
 
 UINT ClampTransitionThumbnailSize(UINT requestedSize) {
@@ -129,14 +141,22 @@ UINT ClampTransitionThumbnailSize(UINT requestedSize) {
         return requestedSize;
     }
 
-    const UINT maximumSize = static_cast<UINT>(
-        InterlockedCompareExchange(&g_maximumThumbnailSize, 0, 0));
-    return requestedSize > maximumSize ? maximumSize : requestedSize;
+    const UINT maximumSize =
+        static_cast<UINT>(g_maximumThumbnailSize.load());
+    if (requestedSize <= maximumSize) {
+        return requestedSize;
+    }
+
+    if (!g_thumbnailClampLogged.exchange(true)) {
+        Wh_Log(L"Clamped virtual desktop wallpaper thumbnail from %u to %u",
+               requestedSize,
+               maximumSize);
+    }
+    return maximumSize;
 }
 
-// Clamp only calls made synchronously by Windows' virtual desktop wallpaper
-// helper. All other thumbnail-cache clients receive their original arguments.
-HRESULT STDMETHODCALLTYPE ThumbnailCacheGetThumbnailHook(
+HRESULT CallThumbnailCacheGetThumbnail(
+    ThumbnailCacheGetThumbnail original,
     void* self,
     void* shellItem,
     UINT requestedSize,
@@ -145,10 +165,10 @@ HRESULT STDMETHODCALLTYPE ThumbnailCacheGetThumbnailHook(
     DWORD* outFlags,
     WtsThumbnailId* thumbnailId) {
     requestedSize = ClampTransitionThumbnailSize(requestedSize);
-    if (!g_thumbnailCacheGetThumbnailOriginal) {
+    if (!original) {
         return E_FAIL;
     }
-    return g_thumbnailCacheGetThumbnailOriginal(
+    return original(
         self,
         shellItem,
         requestedSize,
@@ -158,7 +178,9 @@ HRESULT STDMETHODCALLTYPE ThumbnailCacheGetThumbnailHook(
         thumbnailId);
 }
 
-HRESULT STDMETHODCALLTYPE ThumbnailCacheApiGetThumbnailHook(
+// Clamp only calls made synchronously by Windows' virtual desktop wallpaper
+// helper. All other thumbnail-cache clients receive their original arguments.
+HRESULT STDMETHODCALLTYPE ThumbcacheGetThumbnailHook(
     void* self,
     void* shellItem,
     UINT requestedSize,
@@ -166,11 +188,65 @@ HRESULT STDMETHODCALLTYPE ThumbnailCacheApiGetThumbnailHook(
     void** sharedBitmap,
     DWORD* outFlags,
     WtsThumbnailId* thumbnailId) {
-    requestedSize = ClampTransitionThumbnailSize(requestedSize);
-    if (!g_thumbnailCacheApiGetThumbnailOriginal) {
-        return E_FAIL;
-    }
-    return g_thumbnailCacheApiGetThumbnailOriginal(
+    return CallThumbnailCacheGetThumbnail(
+        g_thumbcacheGetThumbnailOriginal,
+        self,
+        shellItem,
+        requestedSize,
+        flags,
+        sharedBitmap,
+        outFlags,
+        thumbnailId);
+}
+
+HRESULT STDMETHODCALLTYPE ThumbcacheApiGetThumbnailHook(
+    void* self,
+    void* shellItem,
+    UINT requestedSize,
+    DWORD flags,
+    void** sharedBitmap,
+    DWORD* outFlags,
+    WtsThumbnailId* thumbnailId) {
+    return CallThumbnailCacheGetThumbnail(
+        g_thumbcacheApiGetThumbnailOriginal,
+        self,
+        shellItem,
+        requestedSize,
+        flags,
+        sharedBitmap,
+        outFlags,
+        thumbnailId);
+}
+
+HRESULT STDMETHODCALLTYPE WindowsStorageGetThumbnailHook(
+    void* self,
+    void* shellItem,
+    UINT requestedSize,
+    DWORD flags,
+    void** sharedBitmap,
+    DWORD* outFlags,
+    WtsThumbnailId* thumbnailId) {
+    return CallThumbnailCacheGetThumbnail(
+        g_windowsStorageGetThumbnailOriginal,
+        self,
+        shellItem,
+        requestedSize,
+        flags,
+        sharedBitmap,
+        outFlags,
+        thumbnailId);
+}
+
+HRESULT STDMETHODCALLTYPE WindowsStorageApiGetThumbnailHook(
+    void* self,
+    void* shellItem,
+    UINT requestedSize,
+    DWORD flags,
+    void** sharedBitmap,
+    DWORD* outFlags,
+    WtsThumbnailId* thumbnailId) {
+    return CallThumbnailCacheGetThumbnail(
+        g_windowsStorageApiGetThumbnailOriginal,
         self,
         shellItem,
         requestedSize,
@@ -183,8 +259,7 @@ HRESULT STDMETHODCALLTYPE ThumbnailCacheApiGetThumbnailHook(
 // Hook the outer wallpaper helper so the thumbnail-cache detour can identify
 // its dynamic call context without relying on compiler code layout.
 bool HookBackgroundThumbnailHelper(HMODULE module) {
-    if (!module || InterlockedExchange(
-                       &g_twinuiPcShellHookAttempted, TRUE)) {
+    if (!module || g_twinuiPcShellHookAttempted.exchange(true)) {
         return false;
     }
 
@@ -218,8 +293,14 @@ bool HookBackgroundThumbnailHelper(HMODULE module) {
 // the concrete method by symbol in whichever naturally loaded module provides
 // it, avoiding COM activation and a hard-coded vtable slot.
 bool HookThumbnailCache(
-    HMODULE module, volatile LONG* hookAttempted, PCWSTR moduleName) {
-    if (!module || InterlockedExchange(hookAttempted, TRUE)) {
+    HMODULE module,
+    std::atomic_bool* hookAttempted,
+    PCWSTR moduleName,
+    ThumbnailCacheGetThumbnail* getThumbnailOriginal,
+    ThumbnailCacheGetThumbnail getThumbnailHook,
+    ThumbnailCacheGetThumbnail* apiGetThumbnailOriginal,
+    ThumbnailCacheGetThumbnail apiGetThumbnailHook) {
+    if (!module || hookAttempted->exchange(true)) {
         return false;
     }
 
@@ -229,26 +310,24 @@ bool HookThumbnailCache(
             {
                 L"public: virtual long __cdecl CThumbnailCache::GetThumbnail(struct IShellItem *,unsigned int,enum WTS_FLAGS,struct ISharedBitmap * *,enum WTS_CACHEFLAGS *,struct WTS_THUMBNAILID *)",
             },
-            reinterpret_cast<void**>(
-                &g_thumbnailCacheGetThumbnailOriginal),
-            reinterpret_cast<void*>(ThumbnailCacheGetThumbnailHook),
+            reinterpret_cast<void**>(getThumbnailOriginal),
+            reinterpret_cast<void*>(getThumbnailHook),
             true,
         },
         {
             {
                 L"public: virtual long __cdecl CThumbnailCacheAPI::GetThumbnail(struct IShellItem *,unsigned int,enum WTS_FLAGS,struct ISharedBitmap * *,enum WTS_CACHEFLAGS *,struct WTS_THUMBNAILID *)",
             },
-            reinterpret_cast<void**>(
-                &g_thumbnailCacheApiGetThumbnailOriginal),
-            reinterpret_cast<void*>(ThumbnailCacheApiGetThumbnailHook),
+            reinterpret_cast<void**>(apiGetThumbnailOriginal),
+            reinterpret_cast<void*>(apiGetThumbnailHook),
             true,
         },
     };
 
     const bool symbolsHooked = WindhawkUtils::HookSymbols(
         module, symbolHooks, ARRAYSIZE(symbolHooks));
-    const bool registeredHook = g_thumbnailCacheGetThumbnailOriginal ||
-                                g_thumbnailCacheApiGetThumbnailOriginal;
+    const bool registeredHook = *getThumbnailOriginal ||
+                                *apiGetThumbnailOriginal;
     if (!registeredHook) {
         Wh_Log(L"Failed to hook thumbnail cache in %s", moduleName);
         return false;
@@ -261,32 +340,37 @@ bool HookThumbnailCache(
 
     Wh_Log(L"Hooked thumbnail cache in %s (concrete=%d api=%d)",
            moduleName,
-           g_thumbnailCacheGetThumbnailOriginal != nullptr,
-           g_thumbnailCacheApiGetThumbnailOriginal != nullptr);
+           *getThumbnailOriginal != nullptr,
+           *apiGetThumbnailOriginal != nullptr);
     return true;
 }
 
 bool HookLoadedThumbnailCache() {
-    if (g_thumbnailCacheGetThumbnailOriginal ||
-        g_thumbnailCacheApiGetThumbnailOriginal) {
-        return false;
-    }
-
+    bool registeredHook = false;
     if (HMODULE thumbcache = GetModuleHandleW(L"thumbcache.dll");
-        thumbcache && HookThumbnailCache(
-                          thumbcache,
-                          &g_thumbcacheHookAttempted,
-                          L"thumbcache.dll")) {
-        return true;
+        thumbcache) {
+        registeredHook = HookThumbnailCache(
+            thumbcache,
+            &g_thumbcacheHookAttempted,
+            L"thumbcache.dll",
+            &g_thumbcacheGetThumbnailOriginal,
+            ThumbcacheGetThumbnailHook,
+            &g_thumbcacheApiGetThumbnailOriginal,
+            ThumbcacheApiGetThumbnailHook);
     }
     if (HMODULE windowsStorage = GetModuleHandleW(L"windows.storage.dll");
-        windowsStorage && HookThumbnailCache(
-                              windowsStorage,
-                              &g_windowsStorageHookAttempted,
-                              L"windows.storage.dll")) {
-        return true;
+        windowsStorage) {
+        registeredHook = HookThumbnailCache(
+                             windowsStorage,
+                             &g_windowsStorageHookAttempted,
+                             L"windows.storage.dll",
+                             &g_windowsStorageGetThumbnailOriginal,
+                             WindowsStorageGetThumbnailHook,
+                             &g_windowsStorageApiGetThumbnailOriginal,
+                             WindowsStorageApiGetThumbnailHook) ||
+                         registeredHook;
     }
-    return false;
+    return registeredHook;
 }
 
 HMODULE WINAPI LoadLibraryExWHook(

--- a/mods/faster-virtual-desktop-switching.wh.cpp
+++ b/mods/faster-virtual-desktop-switching.wh.cpp
@@ -7,7 +7,7 @@
 // @github          https://github.com/Meteony
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lole32 -luser32
+// @compilerOptions -luser32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -41,7 +41,6 @@ Laptop users who use three- or four-finger swipe gestures can especially benefit
 // ==/WindhawkModSettings==
 
 #include <windows.h>
-#include <objbase.h>
 #include <windhawk_api.h>
 #include <windhawk_utils.h>
 
@@ -51,29 +50,12 @@ struct WtsThumbnailId {
     BYTE value[16];
 };
 
-struct IThumbnailCacheMinimal : IUnknown {
-    virtual HRESULT STDMETHODCALLTYPE GetThumbnail(
-        IUnknown* shellItem,
-        UINT requestedSize,
-        DWORD flags,
-        IUnknown** sharedBitmap,
-        DWORD* outFlags,
-        WtsThumbnailId* thumbnailId) = 0;
-};
-
-constexpr GUID kClsidLocalThumbnailCache = {
-    0x50ef4544, 0xac9f, 0x4a8e,
-    {0xb2, 0x1b, 0x8a, 0x26, 0x18, 0x0d, 0xb1, 0x3f}};
-constexpr GUID kIidThumbnailCache = {
-    0xf676c15d, 0x596a, 0x4ce2,
-    {0x82, 0x34, 0x33, 0x99, 0x6f, 0x44, 0x5d, 0xb1}};
-
-using ThumbnailCacheGetThumbnail = HRESULT(STDMETHODCALLTYPE*)(
-    IThumbnailCacheMinimal* self,
-    IUnknown* shellItem,
+using ThumbnailCacheGetThumbnail = HRESULT(*)(
+    void* self,
+    void* shellItem,
     UINT requestedSize,
     DWORD flags,
-    IUnknown** sharedBitmap,
+    void** sharedBitmap,
     DWORD* outFlags,
     WtsThumbnailId* thumbnailId);
 using MakeBackgroundThumbnailFromThumbnailCache = HRESULT(*)(
@@ -85,18 +67,19 @@ using MakeBackgroundThumbnailFromThumbnailCache = HRESULT(*)(
     void** result);
 using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 
-ThumbnailCacheGetThumbnail g_getThumbnailOriginal = nullptr;
+ThumbnailCacheGetThumbnail g_thumbnailCacheGetThumbnailOriginal = nullptr;
+ThumbnailCacheGetThumbnail g_thumbnailCacheApiGetThumbnailOriginal = nullptr;
 MakeBackgroundThumbnailFromThumbnailCache
     g_makeBackgroundThumbnailOriginal = nullptr;
 LoadLibraryExW_t g_loadLibraryExWOriginal = nullptr;
 HMODULE g_twinuiPcShell = nullptr;
 HMODULE g_thumbnailCacheServer = nullptr;
 thread_local int g_makeBackgroundThumbnailDepth = 0;
-constexpr LONG kCorePending = 0;
-constexpr LONG kCoreInitializing = 1;
-constexpr LONG kCoreInitialized = 2;
-constexpr LONG kCoreFailed = -1;
-volatile LONG g_coreInitializationState = kCorePending;
+constexpr LONG kHookPending = 0;
+constexpr LONG kHookInstalling = 1;
+constexpr LONG kHookInstalled = 2;
+volatile LONG g_backgroundHookState = kHookPending;
+volatile LONG g_thumbnailHookState = kHookPending;
 volatile LONG g_maximumThumbnailSize = 1024;
 
 // Load settings atomically because Explorer can switch desktops while the
@@ -143,25 +126,47 @@ HRESULT MakeBackgroundThumbnailFromThumbnailCacheHook(
     return resultCode;
 }
 
-// Clamp only calls made synchronously by Windows' virtual desktop wallpaper
-// helper. All other thumbnail-cache clients receive their original arguments.
-HRESULT STDMETHODCALLTYPE GetThumbnailHook(
-    IThumbnailCacheMinimal* self,
-    IUnknown* shellItem,
-    UINT requestedSize,
-    DWORD flags,
-    IUnknown** sharedBitmap,
-    DWORD* outFlags,
-    WtsThumbnailId* thumbnailId) {
-    if (g_makeBackgroundThumbnailDepth > 0) {
-        const UINT maximumSize = static_cast<UINT>(
-            InterlockedCompareExchange(&g_maximumThumbnailSize, 0, 0));
-        if (requestedSize > maximumSize) {
-            requestedSize = maximumSize;
-        }
+UINT ClampTransitionThumbnailSize(UINT requestedSize) {
+    if (g_makeBackgroundThumbnailDepth <= 0) {
+        return requestedSize;
     }
 
-    return g_getThumbnailOriginal(
+    const UINT maximumSize = static_cast<UINT>(
+        InterlockedCompareExchange(&g_maximumThumbnailSize, 0, 0));
+    return requestedSize > maximumSize ? maximumSize : requestedSize;
+}
+
+// Clamp only calls made synchronously by Windows' virtual desktop wallpaper
+// helper. All other thumbnail-cache clients receive their original arguments.
+HRESULT STDMETHODCALLTYPE ThumbnailCacheGetThumbnailHook(
+    void* self,
+    void* shellItem,
+    UINT requestedSize,
+    DWORD flags,
+    void** sharedBitmap,
+    DWORD* outFlags,
+    WtsThumbnailId* thumbnailId) {
+    requestedSize = ClampTransitionThumbnailSize(requestedSize);
+    return g_thumbnailCacheGetThumbnailOriginal(
+        self,
+        shellItem,
+        requestedSize,
+        flags,
+        sharedBitmap,
+        outFlags,
+        thumbnailId);
+}
+
+HRESULT STDMETHODCALLTYPE ThumbnailCacheApiGetThumbnailHook(
+    void* self,
+    void* shellItem,
+    UINT requestedSize,
+    DWORD flags,
+    void** sharedBitmap,
+    DWORD* outFlags,
+    WtsThumbnailId* thumbnailId) {
+    requestedSize = ClampTransitionThumbnailSize(requestedSize);
+    return g_thumbnailCacheApiGetThumbnailOriginal(
         self,
         shellItem,
         requestedSize,
@@ -200,74 +205,85 @@ bool HookBackgroundThumbnailHelper(HMODULE module) {
     return true;
 }
 
-// Activate the public thumbnail-cache COM class long enough to discover its
-// implementation, then pin only the implementing DLL for the hook lifetime.
-bool HookThumbnailCache() {
-    const HRESULT initializeResult =
-        CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
-    const bool uninitializeCom = SUCCEEDED(initializeResult);
-    if (FAILED(initializeResult) &&
-        initializeResult != RPC_E_CHANGED_MODE) {
-        Wh_Log(L"COM initialization failed: 0x%08lX",
-               static_cast<unsigned long>(initializeResult));
+// The implementation moved from windows.storage.dll to thumbcache.dll. Hook
+// the concrete method by symbol in whichever naturally loaded module provides
+// it, avoiding COM activation and a hard-coded vtable slot.
+bool HookThumbnailCache(HMODULE module) {
+    if (!module || InterlockedCompareExchange(
+                       &g_thumbnailHookState,
+                       kHookInstalling,
+                       kHookPending) != kHookPending) {
         return false;
     }
 
-    IThumbnailCacheMinimal* cache = nullptr;
-    const HRESULT activationResult = CoCreateInstance(
-        kClsidLocalThumbnailCache,
-        nullptr,
-        CLSCTX_INPROC_SERVER,
-        kIidThumbnailCache,
-        reinterpret_cast<void**>(&cache));
-    if (FAILED(activationResult) || !cache) {
-        Wh_Log(L"LocalThumbnailCache activation failed: 0x%08lX",
-               static_cast<unsigned long>(activationResult));
-        if (uninitializeCom) {
-            CoUninitialize();
-        }
+    if (!GetModuleHandleExW(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+            reinterpret_cast<LPCWSTR>(module),
+            &g_thumbnailCacheServer)) {
+        Wh_Log(L"Failed to retain the thumbnail-cache module: %lu",
+               GetLastError());
+        InterlockedExchange(&g_thumbnailHookState, kHookPending);
         return false;
     }
 
-    void** vtable = *reinterpret_cast<void***>(cache);
-    void* getThumbnailImplementation = vtable[3];
-    const BOOL modulePinned = GetModuleHandleExW(
-        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
-        reinterpret_cast<LPCWSTR>(getThumbnailImplementation),
-        &g_thumbnailCacheServer);
-    const DWORD modulePinError = modulePinned ? ERROR_SUCCESS : GetLastError();
+    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+        {
+            {
+                L"public: virtual long __cdecl CThumbnailCache::GetThumbnail(struct IShellItem *,unsigned int,enum WTS_FLAGS,struct ISharedBitmap * *,enum WTS_CACHEFLAGS *,struct WTS_THUMBNAILID *)",
+            },
+            reinterpret_cast<void**>(
+                &g_thumbnailCacheGetThumbnailOriginal),
+            reinterpret_cast<void*>(ThumbnailCacheGetThumbnailHook),
+            true,
+        },
+        {
+            {
+                L"public: virtual long __cdecl CThumbnailCacheAPI::GetThumbnail(struct IShellItem *,unsigned int,enum WTS_FLAGS,struct ISharedBitmap * *,enum WTS_CACHEFLAGS *,struct WTS_THUMBNAILID *)",
+            },
+            reinterpret_cast<void**>(
+                &g_thumbnailCacheApiGetThumbnailOriginal),
+            reinterpret_cast<void*>(ThumbnailCacheApiGetThumbnailHook),
+            true,
+        },
+    };
 
-    bool hookRegistered = false;
-    if (modulePinned) {
-        hookRegistered = Wh_SetFunctionHook(
-            getThumbnailImplementation,
-            reinterpret_cast<void*>(GetThumbnailHook),
-            reinterpret_cast<void**>(&g_getThumbnailOriginal)) != FALSE;
-    }
-
-    cache->Release();
-    if (uninitializeCom) {
-        CoUninitialize();
-    }
-
-    if (!modulePinned) {
-        Wh_Log(L"Failed to pin the thumbnail-cache implementation: %lu",
-               modulePinError);
-        return false;
-    }
-
-    if (!hookRegistered || !g_getThumbnailOriginal) {
-        Wh_Log(L"Failed to hook IThumbnailCache::GetThumbnail");
+    if (!WindhawkUtils::HookSymbols(
+            module, symbolHooks, ARRAYSIZE(symbolHooks)) ||
+        (!g_thumbnailCacheGetThumbnailOriginal &&
+         !g_thumbnailCacheApiGetThumbnailOriginal)) {
+        g_thumbnailCacheGetThumbnailOriginal = nullptr;
+        g_thumbnailCacheApiGetThumbnailOriginal = nullptr;
         FreeLibrary(g_thumbnailCacheServer);
         g_thumbnailCacheServer = nullptr;
+        InterlockedExchange(&g_thumbnailHookState, kHookPending);
         return false;
     }
 
+    InterlockedExchange(&g_thumbnailHookState, kHookInstalled);
+    Wh_Log(L"Hooked thumbnail cache in %s (concrete=%d api=%d)",
+           GetModuleHandleW(L"thumbcache.dll") == module
+               ? L"thumbcache.dll"
+               : L"windows.storage.dll",
+           g_thumbnailCacheGetThumbnailOriginal != nullptr,
+           g_thumbnailCacheApiGetThumbnailOriginal != nullptr);
     return true;
 }
 
-// Balance local module references on every initialization failure. Hook
-// removal is owned by Windhawk and occurs before Wh_ModUninit.
+bool HookLoadedThumbnailCache() {
+    constexpr PCWSTR moduleNames[] = {
+        L"thumbcache.dll",
+        L"windows.storage.dll",
+    };
+    for (PCWSTR moduleName : moduleNames) {
+        HMODULE module = GetModuleHandleW(moduleName);
+        if (module && HookThumbnailCache(module)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Balance the module references retained for the lifetime of the hooks.
 void ReleaseModuleReferences() {
     if (g_thumbnailCacheServer) {
         FreeLibrary(g_thumbnailCacheServer);
@@ -280,50 +296,39 @@ void ReleaseModuleReferences() {
     }
 }
 
-bool InitializeCore(HMODULE twinuiPcShell, bool applyHookOperations) {
+bool HookBackgroundThumbnailModule(HMODULE twinuiPcShell) {
     if (InterlockedCompareExchange(
-            &g_coreInitializationState,
-            kCoreInitializing,
-            kCorePending) != kCorePending) {
-        return InterlockedCompareExchange(
-                   &g_coreInitializationState, 0, 0) == kCoreInitialized;
-    }
-
-    if (!IsOrMayBecomeShellExplorer()) {
-        Wh_Log(L"Skipping non-shell explorer.exe process %lu",
-               GetCurrentProcessId());
-        InterlockedExchange(&g_coreInitializationState, kCoreFailed);
+            &g_backgroundHookState,
+            kHookInstalling,
+            kHookPending) != kHookPending) {
         return false;
     }
-
     if (!GetModuleHandleExW(
             GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
             reinterpret_cast<LPCWSTR>(twinuiPcShell),
             &g_twinuiPcShell)) {
         Wh_Log(L"Failed to retain twinui.pcshell.dll: %lu", GetLastError());
-        InterlockedExchange(&g_coreInitializationState, kCoreFailed);
+        InterlockedExchange(&g_backgroundHookState, kHookPending);
         return false;
     }
 
-    if (!HookBackgroundThumbnailHelper(twinuiPcShell) ||
-        !HookThumbnailCache()) {
-        ReleaseModuleReferences();
-        InterlockedExchange(&g_coreInitializationState, kCoreFailed);
+    if (!HookBackgroundThumbnailHelper(twinuiPcShell)) {
+        FreeLibrary(g_twinuiPcShell);
+        g_twinuiPcShell = nullptr;
+        InterlockedExchange(&g_backgroundHookState, kHookPending);
         return false;
     }
 
-    if (applyHookOperations) {
-        SetLastError(ERROR_SUCCESS);
-        if (!Wh_ApplyHookOperations()) {
-            Wh_Log(L"Failed to apply late-loaded hooks: %lu", GetLastError());
-            InterlockedExchange(&g_coreInitializationState, kCoreFailed);
-            return false;
-        }
-    }
+    InterlockedExchange(&g_backgroundHookState, kHookInstalled);
+    return true;
+}
 
-    InterlockedExchange(&g_coreInitializationState, kCoreInitialized);
-    Wh_Log(L"Initialized: maximumThumbnailSize=%ld",
-           InterlockedCompareExchange(&g_maximumThumbnailSize, 0, 0));
+bool ApplyLateHooks() {
+    SetLastError(ERROR_SUCCESS);
+    if (!Wh_ApplyHookOperations()) {
+        Wh_Log(L"Failed to apply late-loaded hooks: %lu", GetLastError());
+        return false;
+    }
     return true;
 }
 
@@ -333,11 +338,35 @@ HMODULE WINAPI LoadLibraryExWHook(
     constexpr DWORD dataOnlyFlags =
         LOAD_LIBRARY_AS_DATAFILE | LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE |
         LOAD_LIBRARY_AS_IMAGE_RESOURCE;
-    if (module && !(flags & dataOnlyFlags) &&
-        InterlockedCompareExchange(&g_coreInitializationState, 0, 0) ==
-            kCorePending &&
-        GetModuleHandleW(L"twinui.pcshell.dll") == module) {
-        InitializeCore(module, true);
+    if (!module || (flags & dataOnlyFlags)) {
+        return module;
+    }
+
+    HMODULE twinuiPcShell = GetModuleHandleW(L"twinui.pcshell.dll");
+    HMODULE thumbcache = GetModuleHandleW(L"thumbcache.dll");
+    HMODULE windowsStorage = GetModuleHandleW(L"windows.storage.dll");
+    if (module != twinuiPcShell && module != thumbcache &&
+        module != windowsStorage) {
+        return module;
+    }
+
+    bool registeredHook = false;
+    if (twinuiPcShell &&
+        InterlockedCompareExchange(
+            &g_backgroundHookState, kHookPending, kHookPending) ==
+            kHookPending) {
+        registeredHook = HookBackgroundThumbnailModule(twinuiPcShell);
+    }
+
+    if ((thumbcache || windowsStorage) &&
+        InterlockedCompareExchange(
+            &g_thumbnailHookState, kHookPending, kHookPending) ==
+            kHookPending) {
+        registeredHook = HookLoadedThumbnailCache() || registeredHook;
+    }
+
+    if (registeredHook) {
+        ApplyLateHooks();
     }
     return module;
 }
@@ -351,11 +380,6 @@ BOOL Wh_ModInit() {
         Wh_Log(L"Skipping non-shell explorer.exe process %lu",
                GetCurrentProcessId());
         return TRUE;
-    }
-
-    if (HMODULE twinuiPcShell =
-            GetModuleHandleW(L"twinui.pcshell.dll")) {
-        return InitializeCore(twinuiPcShell, false) ? TRUE : FALSE;
     }
 
     HMODULE kernelBase = GetModuleHandleW(L"kernelbase.dll");
@@ -372,18 +396,37 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
+    if (HMODULE twinuiPcShell =
+            GetModuleHandleW(L"twinui.pcshell.dll")) {
+        if (!HookBackgroundThumbnailModule(twinuiPcShell)) {
+            return FALSE;
+        }
+    }
+
+    HookLoadedThumbnailCache();
+
     return TRUE;
 }
 
 void Wh_ModAfterInit() {
-    if (InterlockedCompareExchange(
-            &g_coreInitializationState, 0, 0) != kCorePending) {
-        return;
-    }
-
+    bool registeredHook = false;
     if (HMODULE twinuiPcShell =
             GetModuleHandleW(L"twinui.pcshell.dll")) {
-        InitializeCore(twinuiPcShell, true);
+        if (InterlockedCompareExchange(
+                &g_backgroundHookState, kHookPending, kHookPending) ==
+            kHookPending) {
+            registeredHook = HookBackgroundThumbnailModule(twinuiPcShell);
+        }
+    }
+
+    if (InterlockedCompareExchange(
+            &g_thumbnailHookState, kHookPending, kHookPending) ==
+        kHookPending) {
+        registeredHook = HookLoadedThumbnailCache() || registeredHook;
+    }
+
+    if (registeredHook) {
+        ApplyLateHooks();
     }
 }
 

--- a/mods/faster-virtual-desktop-switching.wh.cpp
+++ b/mods/faster-virtual-desktop-switching.wh.cpp
@@ -144,7 +144,7 @@ HRESULT STDMETHODCALLTYPE GetThumbnailHook(
 }
 
 // Resolve the target for the loaded Windows build, then obtain its exact code
-// range from the x64 unwind table. No private function is detoured.
+// range from the platform unwind table. No private function is detoured.
 bool ResolveTargetFunctionRange() {
     g_twinuiPcShell = LoadLibraryExW(
         L"twinui.pcshell.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
@@ -184,10 +184,25 @@ bool ResolveTargetFunctionRange() {
 
     const uintptr_t functionStart = static_cast<uintptr_t>(
         imageBase + runtimeFunction->BeginAddress);
+#if defined(_M_ARM64) || defined(_ARM64_)
+    DWORD functionLength = 0;
+    if (runtimeFunction->Flag == PdataRefToFullXdata) {
+        const auto* unwindData = reinterpret_cast<
+            const IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA*>(
+                imageBase + runtimeFunction->UnwindData);
+        functionLength = unwindData->FunctionLength * 4;
+    } else if (runtimeFunction->Flag == PdataPackedUnwindFunction ||
+               runtimeFunction->Flag == PdataPackedUnwindFragment) {
+        functionLength = runtimeFunction->FunctionLength * 4;
+    }
+    const uintptr_t functionEnd = functionStart + functionLength;
+#else
     const uintptr_t functionEnd = static_cast<uintptr_t>(
         imageBase + runtimeFunction->EndAddress);
+#endif
     const uintptr_t symbolAddress = reinterpret_cast<uintptr_t>(targetFunction);
-    if (symbolAddress < functionStart || symbolAddress >= functionEnd ||
+    if (functionEnd <= functionStart || symbolAddress < functionStart ||
+        symbolAddress >= functionEnd ||
         functionEnd - functionStart > 0x4000) {
         Wh_Log(L"Resolved an invalid virtual desktop helper range");
         return false;

--- a/mods/faster-virtual-desktop-switching.wh.cpp
+++ b/mods/faster-virtual-desktop-switching.wh.cpp
@@ -97,6 +97,24 @@ void LoadSettings() {
     g_maximumThumbnailSize.store(maximumSize);
 }
 
+bool IsWindows11OrGreater() {
+    using RtlGetVersion_t = LONG(WINAPI*)(OSVERSIONINFOW*);
+    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+    auto rtlGetVersion = ntdll
+        ? reinterpret_cast<RtlGetVersion_t>(
+              GetProcAddress(ntdll, "RtlGetVersion"))
+        : nullptr;
+    if (!rtlGetVersion) {
+        return false;
+    }
+
+    OSVERSIONINFOW versionInfo{};
+    versionInfo.dwOSVersionInfoSize = sizeof(versionInfo);
+    return rtlGetVersion(&versionInfo) == 0 &&
+           versionInfo.dwMajorVersion >= 10 &&
+           versionInfo.dwBuildNumber >= 22000;
+}
+
 // Return true for the shell process, including early Explorer startup before
 // its shell window exists. Separate folder processes are skipped once known.
 bool IsOrMayBecomeShellExplorer() {
@@ -385,7 +403,9 @@ HMODULE WINAPI LoadLibraryExWHook(
 
     HMODULE twinuiPcShell = GetModuleHandleW(L"twinui.pcshell.dll");
     bool registeredHook = HookBackgroundThumbnailHelper(twinuiPcShell);
-    registeredHook = HookLoadedThumbnailCache() || registeredHook;
+    if (g_makeBackgroundThumbnailOriginal) {
+        registeredHook = HookLoadedThumbnailCache() || registeredHook;
+    }
 
     if (registeredHook) {
         SetLastError(ERROR_SUCCESS);
@@ -399,6 +419,11 @@ HMODULE WINAPI LoadLibraryExWHook(
 }  // namespace
 
 BOOL Wh_ModInit() {
+    if (!IsWindows11OrGreater()) {
+        Wh_Log(L"Skipping unsupported Windows version");
+        return FALSE;
+    }
+
     LoadSettings();
 
     if (!IsOrMayBecomeShellExplorer()) {
@@ -426,9 +451,8 @@ BOOL Wh_ModInit() {
         if (!HookBackgroundThumbnailHelper(twinuiPcShell)) {
             return FALSE;
         }
+        HookLoadedThumbnailCache();
     }
-
-    HookLoadedThumbnailCache();
 
     return TRUE;
 }

--- a/mods/faster-virtual-desktop-switching.wh.cpp
+++ b/mods/faster-virtual-desktop-switching.wh.cpp
@@ -1,0 +1,310 @@
+// ==WindhawkMod==
+// @id              faster-virtual-desktop-switching
+// @name            Faster Virtual Desktop Switching
+// @description     Removes the long pre-animation lag caused by oversized wallpaper thumbnail requests on Windows 11.
+// @version         1.0
+// @author          meteoni
+// @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -lole32 -luser32
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Faster Virtual Desktop Switching
+
+Removes the long-standing pre-animation lag caused by oversized wallpaper thumbnail requests on Windows 11.
+
+![GIF](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/faster-virtual-desktop-switching/faster-virtual-desktop-switching.gif)
+
+Windows 11 can synchronously request a full-monitor-sized wallpaper thumbnail
+before beginning a virtual desktop transition. On a high-DPI display with specific wallpaper
+configurations, that request can take roughly 136-169 ms when warm and more than one second 
+when cold (exact figure depends).
+
+This mod caps that request to the maximum size documented for `IThumbnailCache`, which is 
+1024 pixels. In testing, that netted a latency reduction of ~150ms, effectively eliminating 
+the long-standing pre-animation stutter issue. 
+
+Laptop users who use three- or four-finger swipe gestures can especially benefit from this mod. 
+
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- maximumThumbnailSize: 1024
+  $name: Maximum thumbnail size
+  $description: Requested size used for the transition wallpaper. Microsoft documents 1024 as the maximum supported value.
+*/
+// ==/WindhawkModSettings==
+
+#include <windows.h>
+#include <objbase.h>
+#include <windhawk_api.h>
+#include <windhawk_utils.h>
+
+#include <cstdint>
+
+namespace {
+
+struct WtsThumbnailId {
+    BYTE value[16];
+};
+
+struct IThumbnailCacheMinimal : IUnknown {
+    virtual HRESULT STDMETHODCALLTYPE GetThumbnail(
+        IUnknown* shellItem,
+        UINT requestedSize,
+        DWORD flags,
+        IUnknown** sharedBitmap,
+        DWORD* outFlags,
+        WtsThumbnailId* thumbnailId) = 0;
+};
+
+constexpr GUID kClsidLocalThumbnailCache = {
+    0x50ef4544, 0xac9f, 0x4a8e,
+    {0xb2, 0x1b, 0x8a, 0x26, 0x18, 0x0d, 0xb1, 0x3f}};
+constexpr GUID kIidThumbnailCache = {
+    0xf676c15d, 0x596a, 0x4ce2,
+    {0x82, 0x34, 0x33, 0x99, 0x6f, 0x44, 0x5d, 0xb1}};
+
+using ThumbnailCacheGetThumbnail = HRESULT(STDMETHODCALLTYPE*)(
+    IThumbnailCacheMinimal* self,
+    IUnknown* shellItem,
+    UINT requestedSize,
+    DWORD flags,
+    IUnknown** sharedBitmap,
+    DWORD* outFlags,
+    WtsThumbnailId* thumbnailId);
+
+ThumbnailCacheGetThumbnail g_getThumbnailOriginal = nullptr;
+HMODULE g_twinuiPcShell = nullptr;
+HMODULE g_thumbnailCacheServer = nullptr;
+uintptr_t g_targetFunctionStart = 0;
+uintptr_t g_targetFunctionEnd = 0;
+volatile LONG g_maximumThumbnailSize = 1024;
+
+// Load settings atomically because Explorer can switch desktops while the
+// Windhawk settings callback runs on another thread.
+void LoadSettings() {
+    int maximumSize = Wh_GetIntSetting(L"maximumThumbnailSize");
+    if (maximumSize < 64) {
+        maximumSize = 64;
+    } else if (maximumSize > 1024) {
+        maximumSize = 1024;
+    }
+    InterlockedExchange(&g_maximumThumbnailSize, maximumSize);
+}
+
+// Return true for the shell process, including early Explorer startup before
+// its shell window exists. Separate folder processes are skipped once known.
+bool IsOrMayBecomeShellExplorer() {
+    HWND shellWindow = GetShellWindow();
+    if (!shellWindow) {
+        return true;
+    }
+
+    DWORD shellProcessId = 0;
+    GetWindowThreadProcessId(shellWindow, &shellProcessId);
+    return shellProcessId == GetCurrentProcessId();
+}
+
+// Clamp only calls originating inside Windows' virtual desktop wallpaper
+// helper. All other thumbnail-cache clients receive their original arguments.
+__attribute__((noinline))
+HRESULT STDMETHODCALLTYPE GetThumbnailHook(
+    IThumbnailCacheMinimal* self,
+    IUnknown* shellItem,
+    UINT requestedSize,
+    DWORD flags,
+    IUnknown** sharedBitmap,
+    DWORD* outFlags,
+    WtsThumbnailId* thumbnailId) {
+    const uintptr_t returnAddress = reinterpret_cast<uintptr_t>(
+        __builtin_return_address(0));
+
+    if (returnAddress >= g_targetFunctionStart &&
+        returnAddress < g_targetFunctionEnd) {
+        const UINT maximumSize = static_cast<UINT>(
+            InterlockedCompareExchange(&g_maximumThumbnailSize, 0, 0));
+        if (requestedSize > maximumSize) {
+            requestedSize = maximumSize;
+        }
+    }
+
+    return g_getThumbnailOriginal(
+        self,
+        shellItem,
+        requestedSize,
+        flags,
+        sharedBitmap,
+        outFlags,
+        thumbnailId);
+}
+
+// Resolve the target for the loaded Windows build, then obtain its exact code
+// range from the x64 unwind table. No private function is detoured.
+bool ResolveTargetFunctionRange() {
+    g_twinuiPcShell = LoadLibraryExW(
+        L"twinui.pcshell.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!g_twinuiPcShell) {
+        Wh_Log(L"Failed to load twinui.pcshell.dll: %lu", GetLastError());
+        return false;
+    }
+
+    void* targetFunction = nullptr;
+    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+        {
+            {
+                L"protected: long __cdecl VirtualDesktopGestureWindow::MakeBackgroundThumbnailFromThumbnailCache(struct IDCompThumbnail *,struct IVirtualDesktop *,struct HSTRING__ *,struct tagRECT,struct IDCompThumbnail * *)",
+            },
+            &targetFunction,
+            nullptr,
+            false,
+        },
+    };
+
+    if (!WindhawkUtils::HookSymbols(
+            g_twinuiPcShell, symbolHooks, ARRAYSIZE(symbolHooks)) ||
+        !targetFunction) {
+        Wh_Log(L"Failed to resolve the virtual desktop wallpaper helper");
+        return false;
+    }
+
+    DWORD64 imageBase = 0;
+    PRUNTIME_FUNCTION runtimeFunction = RtlLookupFunctionEntry(
+        reinterpret_cast<DWORD64>(targetFunction),
+        &imageBase,
+        nullptr);
+    if (!runtimeFunction || !imageBase) {
+        Wh_Log(L"Failed to obtain the virtual desktop helper's unwind range");
+        return false;
+    }
+
+    const uintptr_t functionStart = static_cast<uintptr_t>(
+        imageBase + runtimeFunction->BeginAddress);
+    const uintptr_t functionEnd = static_cast<uintptr_t>(
+        imageBase + runtimeFunction->EndAddress);
+    const uintptr_t symbolAddress = reinterpret_cast<uintptr_t>(targetFunction);
+    if (symbolAddress < functionStart || symbolAddress >= functionEnd ||
+        functionEnd - functionStart > 0x4000) {
+        Wh_Log(L"Resolved an invalid virtual desktop helper range");
+        return false;
+    }
+
+    g_targetFunctionStart = functionStart;
+    g_targetFunctionEnd = functionEnd;
+    return true;
+}
+
+// Activate the public thumbnail-cache COM class long enough to discover its
+// implementation, then pin only the implementing DLL for the hook lifetime.
+bool HookThumbnailCache() {
+    const HRESULT initializeResult =
+        CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+    const bool uninitializeCom = SUCCEEDED(initializeResult);
+    if (FAILED(initializeResult) &&
+        initializeResult != RPC_E_CHANGED_MODE) {
+        Wh_Log(L"COM initialization failed: 0x%08lX",
+               static_cast<unsigned long>(initializeResult));
+        return false;
+    }
+
+    IThumbnailCacheMinimal* cache = nullptr;
+    const HRESULT activationResult = CoCreateInstance(
+        kClsidLocalThumbnailCache,
+        nullptr,
+        CLSCTX_INPROC_SERVER,
+        kIidThumbnailCache,
+        reinterpret_cast<void**>(&cache));
+    if (FAILED(activationResult) || !cache) {
+        Wh_Log(L"LocalThumbnailCache activation failed: 0x%08lX",
+               static_cast<unsigned long>(activationResult));
+        if (uninitializeCom) {
+            CoUninitialize();
+        }
+        return false;
+    }
+
+    void** vtable = *reinterpret_cast<void***>(cache);
+    void* getThumbnailImplementation = vtable[3];
+    const BOOL modulePinned = GetModuleHandleExW(
+        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+        reinterpret_cast<LPCWSTR>(getThumbnailImplementation),
+        &g_thumbnailCacheServer);
+    const DWORD modulePinError = modulePinned ? ERROR_SUCCESS : GetLastError();
+
+    bool hookRegistered = false;
+    if (modulePinned) {
+        hookRegistered = Wh_SetFunctionHook(
+            getThumbnailImplementation,
+            reinterpret_cast<void*>(GetThumbnailHook),
+            reinterpret_cast<void**>(&g_getThumbnailOriginal)) != FALSE;
+    }
+
+    cache->Release();
+    if (uninitializeCom) {
+        CoUninitialize();
+    }
+
+    if (!modulePinned) {
+        Wh_Log(L"Failed to pin the thumbnail-cache implementation: %lu",
+               modulePinError);
+        return false;
+    }
+
+    if (!hookRegistered || !g_getThumbnailOriginal) {
+        Wh_Log(L"Failed to hook IThumbnailCache::GetThumbnail");
+        FreeLibrary(g_thumbnailCacheServer);
+        g_thumbnailCacheServer = nullptr;
+        return false;
+    }
+
+    return true;
+}
+
+// Balance local module references on every initialization failure. Hook
+// removal is owned by Windhawk and occurs before Wh_ModUninit.
+void ReleaseModuleReferences() {
+    if (g_thumbnailCacheServer) {
+        FreeLibrary(g_thumbnailCacheServer);
+        g_thumbnailCacheServer = nullptr;
+    }
+
+    if (g_twinuiPcShell) {
+        FreeLibrary(g_twinuiPcShell);
+        g_twinuiPcShell = nullptr;
+    }
+}
+
+}  // namespace
+
+BOOL Wh_ModInit() {
+    LoadSettings();
+
+    if (!IsOrMayBecomeShellExplorer()) {
+        Wh_Log(L"Skipping non-shell explorer.exe process %lu",
+               GetCurrentProcessId());
+        return TRUE;
+    }
+
+    if (!ResolveTargetFunctionRange() || !HookThumbnailCache()) {
+        ReleaseModuleReferences();
+        return FALSE;
+    }
+
+    Wh_Log(L"Initialized: maximumThumbnailSize=%ld",
+           InterlockedCompareExchange(&g_maximumThumbnailSize, 0, 0));
+    return TRUE;
+}
+
+void Wh_ModSettingsChanged() {
+    LoadSettings();
+}
+
+void Wh_ModUninit() {
+    // Windhawk calls this after removing registered hooks, so the implementation
+    // DLLs can no longer be entered through this mod's detour.
+    ReleaseModuleReferences();
+}

--- a/mods/faster-virtual-desktop-switching.wh.cpp
+++ b/mods/faster-virtual-desktop-switching.wh.cpp
@@ -4,6 +4,7 @@
 // @description     Removes the long pre-animation lag caused by oversized wallpaper thumbnail requests on Windows 11.
 // @version         1.0
 // @author          meteoni
+// @github          https://github.com/Meteony
 // @include         explorer.exe
 // @architecture    x86-64
 // @compilerOptions -lole32 -luser32

--- a/mods/faster-virtual-desktop-switching.wh.cpp
+++ b/mods/faster-virtual-desktop-switching.wh.cpp
@@ -425,6 +425,11 @@ BOOL Wh_ModInit() {
     }
 
     HookLoadedThumbnailCache();
+    if (InterlockedCompareExchange(
+            &g_thumbnailHookState, kHookPending, kHookPending) ==
+        kHookFailed) {
+        return FALSE;
+    }
 
     return TRUE;
 }


### PR DESCRIPTION
## Changelog

Removes the long-standing pre-animation lag caused by oversized wallpaper thumbnail requests on Windows 11.

![GIF](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/faster-virtual-desktop-switching/faster-virtual-desktop-switching.gif)

Windows 11 can synchronously request a full-monitor-sized wallpaper thumbnail
before beginning a virtual desktop transition. On a high-DPI display with specific wallpaper
configurations, that request can take roughly 136-169 ms when warm and more than one second 
when cold (exact figure depends).

This mod caps that request to the maximum size documented for `IThumbnailCache`, which is 
1024 pixels. In testing, that netted a latency reduction of ~150ms, effectively eliminating 
the long-standing pre-animation stutter issue. 

Laptop users who use three- or four-finger swipe gestures can especially benefit from this mod. 

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 