### PR TITLE
Bump to 1.7.0: cover common display languages in chevron detection  

### DIFF
--- a/mods/tray-hover-expand.wh.cpp
+++ b/mods/tray-hover-expand.wh.cpp
@@ -32,19 +32,25 @@ mod in a dedicated process and does not inject into the shell.
   hover (and optionally closes it when you move away).
 
 ## How the chevron is detected
-The "Show Hidden Icons" chevron has no language-independent unique identifier on
-Windows 11 (it shares AutomationId `SystemTrayIcon` with the clock, volume,
-battery, etc., and exposes no ExpandCollapse pattern). So detection is a hybrid:
-1. Match the button by name (the keyword list covers the most common Windows
-   display languages by default and can be extended in the settings).
-2. If no name matches (other languages), fall back to the leftmost tray button
-   with the configured AutomationId, which is normally the chevron.
+Only tray elements are ever considered, so no taskbar application button can be
+selected. Among those, detection goes:
+1. By class name, which is language-independent: the chevron is the only tray
+   element whose class name is `SystemTray.NormalButton` while its AutomationId
+   is `SystemTrayIcon`. Notification icons share the class but use a different
+   AutomationId, and the clock, volume, network, battery and "show desktop"
+   buttons share the AutomationId but use other classes.
+2. By name, in case a future Windows build renames those classes. The keyword
+   list covers the most common display languages and can be extended.
+3. Otherwise nothing happens. The mod does not guess, because invoking an
+   unidentified tray button would open whatever it happens to be.
 
 ## Notes
-- If your display language is not in the default keyword list, hover the chevron
-  with the mod disabled and add a fragment of its tooltip text to the "Chevron
-  name keywords" setting. Without a name match the mod falls back to a
-  positional guess, which can land on a different tray button.
+- If the chevron is not identified, the mod logs every tray candidate it saw
+  (class name, AutomationId, position, name). That log is what to attach to a
+  bug report.
+- Updating the mod does not change settings you have already saved. If you saved
+  settings before v1.7.0, reset "Chevron name keywords" to pick up the new
+  defaults.
 - If auto-collapse does not work, the flyout window class name may differ on your
   build. Change it in the "Flyout window class" setting.
 - Windows shows a "Hide" tooltip over the chevron while the flyout is open, which
@@ -75,21 +81,25 @@ Działa jako „tool mod" w osobnym procesie i nie wstrzykuje się do powłoki.
   najechaniu (a opcjonalnie zamyka po odjechaniu kursorem).
 
 ### Jak wykrywana jest strzałka
-Strzałka „Pokaż ukryte ikony" nie ma w Windows 11 unikalnego, niezależnego od
-języka identyfikatora (dzieli AutomationId `SystemTrayIcon` z zegarem,
-głośnością, baterią itd. i nie udostępnia wzorca ExpandCollapse). Wykrywanie
-jest więc hybrydowe:
-1. Dopasowanie przycisku po nazwie (domyślna lista słów kluczowych obejmuje
-   najpopularniejsze języki interfejsu Windows; można ją rozszerzyć w
-   ustawieniach).
-2. Gdy nazwa nie pasuje (inne języki) — pierwszy od lewej przycisk zasobnika ze
-   skonfigurowanym AutomationId, którym zwykle jest strzałka.
+Brane pod uwagę są wyłącznie elementy zasobnika, więc żaden przycisk aplikacji
+z paska zadań nie może zostać wybrany. Wśród nich wykrywanie przebiega tak:
+1. Po nazwie klasy, niezależnie od języka: strzałka jest jedynym elementem
+   zasobnika o klasie `SystemTray.NormalButton` i jednocześnie AutomationId
+   `SystemTrayIcon`. Ikony powiadomień mają tę samą klasę, ale inne
+   AutomationId, a zegar, głośność, sieć, bateria i „pokaż pulpit" mają to samo
+   AutomationId, ale inne klasy.
+2. Po nazwie, na wypadek gdyby przyszła kompilacja Windows zmieniła te klasy.
+   Lista słów kluczowych obejmuje najpopularniejsze języki i można ją rozszerzyć.
+3. W przeciwnym razie nic się nie dzieje. Mod nie zgaduje, bo uruchomienie
+   nierozpoznanego przycisku zasobnika otworzyłoby cokolwiek, czym on jest.
 
 ### Uwagi
-- Jeśli Twojego języka wyświetlania nie ma na domyślnej liście, najedź na
-  strzałkę przy wyłączonym modzie i dodaj fragment tekstu jej podpowiedzi do
-  ustawienia „Słowa kluczowe nazwy strzałki". Bez dopasowania po nazwie mod
-  korzysta ze zgadywania po pozycji, które może trafić w inny przycisk zasobnika.
+- Gdy strzałka nie zostanie rozpoznana, mod zapisuje w logu wszystkich
+  kandydatów z zasobnika (nazwa klasy, AutomationId, pozycja, nazwa). To ten log
+  warto dołączyć do zgłoszenia błędu.
+- Aktualizacja moda nie zmienia ustawień, które zostały już zapisane. Jeśli
+  zapisywałeś ustawienia przed wersją 1.7.0, przywróć domyślne w polu „Słowa
+  kluczowe nazwy strzałki", aby otrzymać nową listę.
 - Jeśli auto-zwijanie nie działa, nazwa klasy okna schowka może się różnić na
   Twojej kompilacji systemu. Zmień ją w ustawieniu „Klasa okna schowka".
 - Gdy schowek jest otwarty, Windows pokazuje nad strzałką podpowiedź „Ukryj",
@@ -124,11 +134,21 @@ jest więc hybrydowe:
   $name:pl-PL: Margines obszaru najechania (piksele)
   $description: Enlarges the hover area around the chevron button.
   $description:pl-PL: Powiększa obszar najechania wokół przycisku strzałki.
-- keywords: ["hidden icons", "ukryte ikony", "rozwiń", "verborgen pictogrammen", "ausgeblendete symbole", "icônes masquées", "iconos ocultos", "icone nascoste", "ícones ocultos", "skryté ikony", "rejtett ikonok", "pictograme ascunse", "dolda ikoner", "skjulte ikoner", "piilotetut kuvakkeet", "gizli simgeleri", "скрытые значки", "приховані піктограми", "κρυφών εικονιδίων", "隐藏的图标", "隱藏的圖示", "隠れている", "숨겨진 아이콘", "overflow"]
+- keywords: ["hidden icons", "ukryte ikony", "verborgen pictogrammen", "ausgeblendete symbole", "icônes masquées", "iconos ocultos", "icone nascoste", "ícones ocultos", "skryté ikony", "rejtett ikonok", "pictograme ascunse", "dolda ikoner", "skjulte ikoner", "piilotetut kuvakkeet", "gizli simgeleri", "скрытые значки", "приховані піктограми", "κρυφών εικονιδίων", "隐藏的图标", "隱藏的圖示", "隠れている", "숨겨진 아이콘"]
   $name: Chevron name keywords
   $name:pl-PL: Słowa kluczowe nazwy strzałki
-  $description: Case-insensitive substrings used to match the chevron button name. The most common Windows display languages are covered by default. If yours is missing, hover the chevron with the mod disabled and add a fragment of the tooltip text here.
-  $description:pl-PL: Fragmenty nazwy przycisku strzałki (wielkość liter bez znaczenia). Domyślnie pokryte są najpopularniejsze języki interfejsu Windows. Jeśli brakuje Twojego, najedź na strzałkę przy wyłączonym modzie i dodaj tu fragment tekstu podpowiedzi.
+  $description: Only used when the chevron cannot be identified by its class name. Case-insensitive substrings, matched against tray buttons only. The most common Windows display languages are covered by default.
+  $description:pl-PL: Używane tylko wtedy, gdy strzałki nie da się rozpoznać po nazwie klasy. Fragmenty nazwy (wielkość liter bez znaczenia), porównywane wyłącznie z przyciskami zasobnika. Domyślnie pokryte są najpopularniejsze języki interfejsu Windows.
+- chevronClass: SystemTray.NormalButton
+  $name: Chevron class name
+  $name:pl-PL: Nazwa klasy strzałki
+  $description: Primary, language-independent identification. The chevron is the only tray element that has this class name together with the AutomationId below. Change it if a future Windows build renames it.
+  $description:pl-PL: Podstawowe rozpoznawanie, niezależne od języka. Strzałka jest jedynym elementem zasobnika, który ma tę nazwę klasy razem z poniższym AutomationId. Zmień ją, jeśli przyszła kompilacja Windows zmieni nazwę.
+- positionalFallback: false
+  $name: Guess the chevron by position as a last resort
+  $name:pl-PL: W ostateczności zgaduj strzałkę po pozycji
+  $description: When the chevron matches neither the class name nor any keyword, assume it is the leftmost tray button. This is a guess and can select a different button, such as Quick Settings, so it is off by default and the mod simply does nothing instead.
+  $description:pl-PL: Gdy strzałka nie pasuje ani do nazwy klasy, ani do żadnego słowa kluczowego, uznaje za nią pierwszy od lewej przycisk zasobnika. To zgadywanie i może trafić w inny przycisk, na przykład Szybkie ustawienia, dlatego domyślnie jest wyłączone, a mod po prostu nic nie robi.
 - suppressInFullscreen: true
   $name: Do not activate over fullscreen apps
   $name:pl-PL: Nie aktywuj na aplikacjach pełnoekranowych
@@ -163,7 +183,6 @@ jest więc hybrydowe:
 #include <atomic>
 #include <string>
 #include <vector>
-#include <algorithm>
 
 #ifndef __IUIAutomation_FWD_DEFINED__
 #error "UI Automation headers are missing"
@@ -176,9 +195,11 @@ struct Settings {
     int pad = 4;
     bool hideTooltip = false;
     bool suppressInFullscreen = true;
+    bool positionalFallback = false;
     std::wstring flyoutClass = L"TopLevelWindowForOverflowXamlIsland";
     std::wstring tooltipClass = L"Xaml_WindowedPopupClass";
     std::wstring trayIconAutomationId = L"SystemTrayIcon";
+    std::wstring chevronClass = L"SystemTray.NormalButton";
     // Fragments of the chevron's name ("Show hidden icons") across the most
     // common Windows display languages. Each entry is a distinctive part of the
     // name rather than the whole string, so wording differences between builds
@@ -186,7 +207,6 @@ struct Settings {
     std::vector<std::wstring> keywords = {
         L"hidden icons",            // English
         L"ukryte ikony",            // Polish
-        L"rozwiń",                  // Polish (alternative wording)
         L"verborgen pictogrammen",  // Dutch
         L"ausgeblendete symbole",   // German
         L"icônes masquées",         // French
@@ -206,10 +226,16 @@ struct Settings {
         L"隐藏的图标",                // Chinese (Simplified)
         L"隱藏的圖示",                // Chinese (Traditional)
         L"隠れている",                // Japanese
-        L"숨겨진 아이콘",             // Korean
-        L"overflow"                 // generic fallback
+        L"숨겨진 아이콘"              // Korean
     };
+    // Lowercased copy of `keywords`, built once in LoadSettings so that name
+    // matching does not lowercase every keyword for every candidate element.
+    std::vector<std::wstring> keywordsLower;
 };
+
+// UIA class names of tray elements all share this prefix, which is what makes
+// it possible to exclude the rest of the taskbar from the search.
+static const std::wstring TRAY_CLASS_PREFIX = L"SystemTray.";
 
 // g_settings is guarded by g_settingsLock; the worker thread keeps a private
 // snapshot and refreshes it when g_settingsGeneration changes, so it never
@@ -242,8 +268,8 @@ static std::wstring ToLower(const std::wstring& s) {
 
 static bool NameMatches(const std::wstring& name, const Settings& s) {
     std::wstring low = ToLower(name);
-    for (const auto& k : s.keywords) {
-        if (!k.empty() && low.find(ToLower(k)) != std::wstring::npos) return true;
+    for (const auto& k : s.keywordsLower) {
+        if (!k.empty() && low.find(k) != std::wstring::npos) return true;
     }
     return false;
 }
@@ -302,13 +328,31 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
     v.vt = VT_I4; v.lVal = UIA_ButtonControlTypeId;
     pAuto->CreatePropertyCondition(UIA_ControlTypePropertyId, v, &pCond);
 
-    // Hybrid strategy:
-    //  1) match by name (reliable for configured languages),
-    //  2) fallback: the leftmost button with the configured AutomationId
-    //     (language-independent but heuristic) — used only when no name matches.
-    IUIAutomationElement* nameMatch = nullptr;
-    IUIAutomationElement* leftmost = nullptr;
-    LONG leftmostX = 0;
+    // The Shell_TrayWnd subtree contains every taskbar button: Start, Search,
+    // the task list entries, and only then the tray. Candidates are therefore
+    // restricted to tray elements first, so that neither a name keyword nor the
+    // positional fallback can ever select an application button (whose name is
+    // the window title and can contain anything).
+    //
+    // Three-step detection, most reliable first:
+    //  1) class name + AutomationId, which is language-independent: the chevron
+    //     is the only tray element that is a `chevronClass` button carrying
+    //     `trayIconAutomationId`. Notification icons share the class but use a
+    //     different AutomationId, and the clock, volume, network, battery and
+    //     "show desktop" buttons share the AutomationId but use other classes.
+    //  2) match by name, for builds where those class names change.
+    //  3) nothing: when the chevron cannot be identified, no element is
+    //     returned. Invoking an unidentified tray button would open whatever it
+    //     happens to be, which is how the chevron was mistaken for Quick
+    //     Settings in the field, so guessing is opt-in only.
+    struct Candidate {
+        IUIAutomationElement* el;
+        std::wstring className;
+        std::wstring automationId;
+        std::wstring name;
+        RECT rect;
+    };
+    std::vector<Candidate> cands;
 
     IUIAutomationElementArray* pArr = nullptr;
     if (pCond && SUCCEEDED(pRoot->FindAll(TreeScope_Subtree, pCond, &pArr)) && pArr) {
@@ -317,43 +361,114 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
             IUIAutomationElement* e = nullptr;
             if (FAILED(pArr->GetElement(i, &e)) || !e) continue;
 
-            BSTR name = nullptr;
-            e->get_CurrentName(&name);
-            bool matched = (name && NameMatches(name, s));
-            if (name) SysFreeString(name);
-            if (matched) {
-                nameMatch = e;           // keep the reference; a name match wins
-                break;
-            }
+            BSTR cls = nullptr;
+            e->get_CurrentClassName(&cls);
+            std::wstring className = cls ? cls : L"";
+            if (cls) SysFreeString(cls);
 
-            // Fallback candidate: a tray button with the configured AutomationId.
             BSTR aid = nullptr;
             e->get_CurrentAutomationId(&aid);
-            bool isTrayIcon = (aid && s.trayIconAutomationId == aid);
+            std::wstring automationId = aid ? aid : L"";
             if (aid) SysFreeString(aid);
 
-            if (isTrayIcon) {
-                RECT r;
-                if (SUCCEEDED(e->get_CurrentBoundingRectangle(&r)) &&
-                    (!leftmost || r.left < leftmostX)) {
-                    if (leftmost) leftmost->Release();
-                    leftmost = e;        // keep the new leftmost candidate
-                    leftmostX = r.left;
-                    e = nullptr;
-                }
+            // Only tray elements are eligible; everything else on the taskbar
+            // is discarded before any name or position test is applied. Without
+            // this, a task list button (named after its window title) could
+            // match a keyword and then be invoked.
+            bool isTrayElement =
+                className.compare(0, TRAY_CLASS_PREFIX.size(), TRAY_CLASS_PREFIX) == 0 ||
+                automationId == s.trayIconAutomationId;
+            if (!isTrayElement) { e->Release(); continue; }
+
+            // Elements that are not rendered report an empty {0,0,0,0}
+            // rectangle, which would otherwise pass every geometric test.
+            BOOL offscreen = FALSE;
+            RECT r{};
+            if (FAILED(e->get_CurrentIsOffscreen(&offscreen)) || offscreen ||
+                FAILED(e->get_CurrentBoundingRectangle(&r)) ||
+                r.right <= r.left || r.bottom <= r.top) {
+                e->Release();
+                continue;
             }
-            if (e) e->Release();
+
+            BSTR nm = nullptr;
+            e->get_CurrentName(&nm);
+            std::wstring name = nm ? nm : L"";
+            if (nm) SysFreeString(nm);
+
+            cands.push_back({e, className, automationId, name, r});
         }
         pArr->Release();
     }
     if (pCond) pCond->Release();
     pRoot->Release();
 
-    if (nameMatch) {
-        if (leftmost) leftmost->Release();
-        return nameMatch;
+    int chosen = -1;
+
+    // 1) Language-independent identification, accepted only when it is
+    // unambiguous. If a future build gives several tray elements this same
+    // signature, picking one of them arbitrarily would be a guess.
+    int classMatches = 0, firstClassMatch = -1;
+    for (size_t i = 0; i < cands.size(); i++) {
+        if (cands[i].className == s.chevronClass &&
+            cands[i].automationId == s.trayIconAutomationId) {
+            classMatches++;
+            if (firstClassMatch < 0) firstClassMatch = (int)i;
+        }
     }
-    return leftmost;   // nullptr if nothing matched
+    if (classMatches == 1) {
+        chosen = firstClassMatch;
+    } else if (classMatches > 1) {
+        Wh_Log(L"%d tray elements share the chevron signature, falling back to name",
+               classMatches);
+    }
+
+    // 2) Name match, for builds where the class names change.
+    if (chosen < 0) {
+        for (size_t i = 0; i < cands.size(); i++) {
+            if (NameMatches(cands[i].name, s)) {
+                chosen = (int)i;
+                Wh_Log(L"Chevron matched by name, not by class name");
+                break;
+            }
+        }
+    }
+
+    // 3) Optional positional guess, off by default.
+    if (chosen < 0 && s.positionalFallback) {
+        for (size_t i = 0; i < cands.size(); i++) {
+            if (cands[i].automationId != s.trayIconAutomationId) continue;
+            if (chosen < 0 || cands[i].rect.left < cands[chosen].rect.left) {
+                chosen = (int)i;
+            }
+        }
+        if (chosen >= 0) {
+            Wh_Log(L"Chevron guessed by position: name=%s class=%s x=%d",
+                   cands[chosen].name.c_str(), cands[chosen].className.c_str(),
+                   (int)cands[chosen].rect.left);
+        }
+    }
+
+    // Nothing identified: dump the candidates so that a single log makes the
+    // next unsupported build actionable, and do not touch anything.
+    if (chosen < 0) {
+        Wh_Log(L"Chevron not identified among %d tray candidates:", (int)cands.size());
+        for (size_t i = 0; i < cands.size(); i++) {
+            Wh_Log(L"  [%d] class=%s aid=%s x=%d name=%s", (int)i,
+                   cands[i].className.c_str(), cands[i].automationId.c_str(),
+                   (int)cands[i].rect.left, cands[i].name.c_str());
+        }
+    }
+
+    IUIAutomationElement* result = nullptr;
+    for (size_t i = 0; i < cands.size(); i++) {
+        if ((int)i == chosen) {
+            result = cands[i].el;
+        } else {
+            cands[i].el->Release();
+        }
+    }
+    return result;
 }
 
 static bool PtInRectPad(const RECT& r, POINT pt, int pad) {
@@ -390,9 +505,20 @@ static bool PtOverWindow(HWND hwnd, POINT pt) {
 // overlapping it and sitting at or above its top, i.e. inside the flyout zone)
 // are hidden — never popups elsewhere on screen.
 static void HideChevronTooltip(const Settings& s, const RECT& chevron) {
+    // The tooltip class is the generic WinUI popup host, used by many apps, so
+    // only windows owned by the taskbar's own process are eligible. Without
+    // this, another application's popup could be hidden with no way for the
+    // user to bring it back.
+    DWORD taskbarPid = 0;
+    GetWindowThreadProcessId(FindWindowW(L"Shell_TrayWnd", nullptr), &taskbarPid);
+    if (!taskbarPid) return;
+
     HWND h = nullptr;
     while ((h = FindWindowExW(nullptr, h, s.tooltipClass.c_str(), nullptr))) {
         if (!IsWindowVisible(h)) continue;
+        DWORD pid = 0;
+        GetWindowThreadProcessId(h, &pid);
+        if (pid != taskbarPid) continue;
         RECT r;
         if (!GetWindowRect(h, &r)) continue;
         bool overlapsX = r.left <= chevron.right && r.right >= chevron.left;
@@ -433,6 +559,11 @@ static bool IsForegroundFullscreen() {
 // ---- Worker thread ----
 
 static DWORD WINAPI WorkerThread(LPVOID) {
+    // UIA bounding rectangles are physical screen coordinates. Without per
+    // monitor v2 awareness, GetCursorPos and GetWindowRect would be virtualized
+    // on mixed-DPI setups and the hover test would compare different spaces.
+    SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+
     CoInitializeEx(nullptr, COINIT_MULTITHREADED);
 
     IUIAutomation* pAuto = nullptr;
@@ -462,9 +593,13 @@ static DWORD WINAPI WorkerThread(LPVOID) {
     while (g_running) {
         ULONGLONG now = GetTickCount64();
 
-        if (g_settingsGeneration != settingsGen) {
+        // Read the generation before taking the snapshot. LoadSettings publishes
+        // the settings and only then bumps the counter, so reading it afterwards
+        // could record an update as already applied and drop it.
+        int gen = g_settingsGeneration;
+        if (gen != settingsGen) {
             s = GetSettingsSnapshot();
-            settingsGen = g_settingsGeneration;
+            settingsGen = gen;
             // Settings may change how the chevron is detected, so drop the
             // cached element and re-detect promptly with the new settings.
             if (pBtn) { pBtn->Release(); pBtn = nullptr; }
@@ -610,6 +745,7 @@ static void LoadSettings() {
     s.pad = (int)Wh_GetIntSetting(L"pad");
     s.hideTooltip = Wh_GetIntSetting(L"hideTooltip") != 0;
     s.suppressInFullscreen = Wh_GetIntSetting(L"suppressInFullscreen") != 0;
+    s.positionalFallback = Wh_GetIntSetting(L"positionalFallback") != 0;
     if (s.pollInterval < 10) s.pollInterval = 10;
     if (s.grace < 0) s.grace = 0;
 
@@ -627,6 +763,10 @@ static void LoadSettings() {
     if (*aid) s.trayIconAutomationId = aid;
     Wh_FreeStringSetting(aid);
 
+    PCWSTR cc = Wh_GetStringSetting(L"chevronClass");
+    if (*cc) s.chevronClass = cc;
+    Wh_FreeStringSetting(cc);
+
     std::vector<std::wstring> keywords;
     for (int i = 0;; i++) {
         PCWSTR k = Wh_GetStringSetting(L"keywords[%d]", i);
@@ -636,6 +776,9 @@ static void LoadSettings() {
         if (empty) break;
     }
     if (!keywords.empty()) s.keywords = std::move(keywords);
+
+    s.keywordsLower.reserve(s.keywords.size());
+    for (const auto& k : s.keywords) s.keywordsLower.push_back(ToLower(k));
 
     AcquireSRWLockExclusive(&g_settingsLock);
     g_settings = std::move(s);
@@ -673,8 +816,9 @@ void WhTool_ModUninit() {
         SetEvent(g_stopEvent);
     }
     if (g_thread) {
-        // Safe to wait without a timeout: the worker only blocks in the
-        // interruptible wait above, so it exits promptly once signaled.
+        // Safe to wait without a timeout: the stop event interrupts the poll
+        // sleep, and the cross-process UIA calls the worker can be inside have
+        // their own timeouts, so the wait is bounded even if the shell is busy.
         WaitForSingleObject(g_thread, INFINITE);
         CloseHandle(g_thread);
         g_thread = nullptr;
@@ -800,7 +944,8 @@ void Wh_ModAfterInit() {
             return;
     }
 
-    WCHAR commandLine[MAX_PATH + 2 +
+    WCHAR
+    commandLine[MAX_PATH + 2 +
                 (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
     swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
                WH_MOD_ID);
@@ -815,9 +960,13 @@ void Wh_ModAfterInit() {
     }
 
     using CreateProcessInternalW_t = BOOL(WINAPI*)(
-        HANDLE, LPCWSTR, LPWSTR, LPSECURITY_ATTRIBUTES,
-        LPSECURITY_ATTRIBUTES, WINBOOL, DWORD, LPVOID, LPCWSTR,
-        LPSTARTUPINFOW, LPPROCESS_INFORMATION, PHANDLE);
+        HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
+        LPSECURITY_ATTRIBUTES lpProcessAttributes,
+        LPSECURITY_ATTRIBUTES lpThreadAttributes, WINBOOL bInheritHandles,
+        DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory,
+        LPSTARTUPINFOW lpStartupInfo,
+        LPPROCESS_INFORMATION lpProcessInformation,
+        PHANDLE hRestrictedUserToken);
     CreateProcessInternalW_t pCreateProcessInternalW =
         (CreateProcessInternalW_t)GetProcAddress(kernelModule,
                                                  "CreateProcessInternalW");

--- a/mods/tray-hover-expand.wh.cpp
+++ b/mods/tray-hover-expand.wh.cpp
@@ -475,7 +475,8 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
     }
     if (classMatches == 1) {
         chosen = firstClassMatch;
-    } else if (classMatches > 1 && logCandidates) {
+    } else if (classMatches > 1 && logWeakMatch) {
+        *logWeakMatch = true;
         Wh_Log(L"%d tray elements share the chevron signature, falling back to name",
                classMatches);
     }
@@ -497,7 +498,10 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
     // 3) Optional positional guess, off by default.
     if (chosen < 0 && s.positionalFallback) {
         for (size_t i = 0; i < cands.size(); i++) {
-            if (cands[i].automationId != s.trayIconAutomationId) continue;
+            // Same admission test as isTrayElement, so a build exposing the
+            // chevron under the alternate id still has candidates here.
+            if (cands[i].automationId != s.trayIconAutomationId &&
+                cands[i].automationId != CHEVRON_AUTOMATION_ID_ALT) continue;
             if (chosen < 0 || cands[i].rect.left < cands[chosen].rect.left) {
                 chosen = (int)i;
             }
@@ -744,6 +748,8 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             insideSince = 0;
             dwellFired = false;
             leftAt = 0;             // don't collapse on the first tick back
+            flyoutBelievedOpen = false;
+            clickedInFlyout = false;
             nextRefind = 0;
             loggedCandidates = false;
             loggedWeakMatch = false;
@@ -767,9 +773,12 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             SHORT km = GetAsyncKeyState(VK_MBUTTON);
             anyBtnDown = ((kl | kr | km) & 0x8000) != 0;
             pressedSinceTick = ((kl | kr | km) & 0x0001) != 0;
-        } else {
-            anyBtnDownPrev = false;
         }
+        // Recorded here rather than at the end of the loop, which a `continue`
+        // can skip: that would keep a two-ticks-old value and let the next tick
+        // see a press edge that never happened.
+        bool anyBtnDownEdge = anyBtnDown && !anyBtnDownPrev;
+        anyBtnDownPrev = anyBtnDown;
 
         // Lazily (re-)find the button only when we don't have a valid one. A
         // destroyed or stale element makes the rectangle query below fail,
@@ -861,6 +870,11 @@ static DWORD WINAPI WorkerThread(LPVOID) {
                     insideSince = 0;
                     dwellFired = false;
                     leftAt = 0;             // don't collapse on the first tick back
+                    // Nothing recomputes these without haveRect, and the mouse
+                    // sampling gate reads flyoutBelievedOpen, so leaving it set
+                    // would resume polling the shared key state indefinitely.
+                    flyoutBelievedOpen = false;
+                    clickedInFlyout = false;
                     nextRefind = 0;
                     WaitForSingleObject(g_stopEvent, s.pollInterval);
                     continue;
@@ -946,7 +960,7 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             // Suspend auto-collapse until the flyout closes on its own —
             // collapsing via Invoke would steal focus and dismiss the popup
             // the user just opened.
-            if ((pressedSinceTick || (anyBtnDown && !anyBtnDownPrev)) &&
+            if ((pressedSinceTick || anyBtnDownEdge) &&
                 flyoutVisible && PtOverWindow(flyoutHwnd, pt)) {
                 clickedInFlyout = true;
                 Wh_Log(L"Click inside flyout: auto-collapse suspended");
@@ -977,8 +991,6 @@ static DWORD WINAPI WorkerThread(LPVOID) {
                 leftAt = 0;
             }
         }
-
-        anyBtnDownPrev = anyBtnDown;
 
         // Interruptible sleep: WhTool_ModUninit signals g_stopEvent so the
         // thread wakes immediately regardless of the polling interval.

--- a/mods/tray-hover-expand.wh.cpp
+++ b/mods/tray-hover-expand.wh.cpp
@@ -45,12 +45,17 @@ selected. Among those, detection goes:
    unidentified tray button would open whatever it happens to be.
 
 ## Notes
+- Windows 11 only. The class names this mod identifies the chevron by are
+  Windows 11 shell types, so on Windows 10 nothing is identified and the mod
+  does nothing.
 - If the chevron is not identified, the mod logs every tray candidate it saw
   (class name, AutomationId, position, name). That log is what to attach to a
   bug report.
 - Updating the mod does not change settings you have already saved. If you saved
-  settings before v1.7.0, reset "Chevron name keywords" to pick up the new
-  defaults.
+  settings before v1.7.0 and your language is missing, delete every entry under
+  "Chevron name keywords" and save: an empty list restores the built-in one.
+- Set "Hover delay" to a small value (e.g. 150 ms) if the flyout opens when you
+  only brush past the chevron on the way to the clock.
 - If auto-collapse does not work, the flyout window class name may differ on your
   build. Change it in the "Flyout window class" setting.
 - Windows shows a "Hide" tooltip over the chevron while the flyout is open, which
@@ -94,12 +99,18 @@ z paska zadań nie może zostać wybrany. Wśród nich wykrywanie przebiega tak:
    nierozpoznanego przycisku zasobnika otworzyłoby cokolwiek, czym on jest.
 
 ### Uwagi
+- Tylko Windows 11. Nazwy klas, po których rozpoznawana jest strzałka, to typy
+  powłoki Windows 11, więc w Windows 10 nic nie zostanie rozpoznane i mod nie
+  robi nic.
 - Gdy strzałka nie zostanie rozpoznana, mod zapisuje w logu wszystkich
   kandydatów z zasobnika (nazwa klasy, AutomationId, pozycja, nazwa). To ten log
   warto dołączyć do zgłoszenia błędu.
 - Aktualizacja moda nie zmienia ustawień, które zostały już zapisane. Jeśli
-  zapisywałeś ustawienia przed wersją 1.7.0, przywróć domyślne w polu „Słowa
-  kluczowe nazwy strzałki", aby otrzymać nową listę.
+  zapisywałeś ustawienia przed wersją 1.7.0, a brakuje Twojego języka, usuń
+  wszystkie pozycje w polu „Słowa kluczowe nazwy strzałki" i zapisz: pusta lista
+  przywraca wbudowaną.
+- Ustaw „Opóźnienie otwierania" na niewielką wartość (np. 150 ms), jeśli schowek
+  otwiera się przy samym przejeżdżaniu obok strzałki w drodze do zegara.
 - Jeśli auto-zwijanie nie działa, nazwa klasy okna schowka może się różnić na
   Twojej kompilacji systemu. Zmień ją w ustawieniu „Klasa okna schowka".
 - Gdy schowek jest otwarty, Windows pokazuje nad strzałką podpowiedź „Ukryj",
@@ -124,6 +135,11 @@ z paska zadań nie może zostać wybrany. Wśród nich wykrywanie przebiega tak:
   $name:pl-PL: Częstotliwość sprawdzania (ms)
   $description: How often to check the cursor position. Lower = smoother, more CPU.
   $description:pl-PL: Co ile sprawdzać pozycję kursora. Mniej = płynniej, większe użycie CPU.
+- hoverDelay: 0
+  $name: Hover delay (ms)
+  $name:pl-PL: Opóźnienie otwierania (ms)
+  $description: How long the cursor must stay on the chevron before the flyout opens. 0 opens immediately; a small value stops the flyout from opening when you only brush past the chevron on the way to the clock.
+  $description:pl-PL: Jak długo kursor musi pozostać na strzałce, zanim schowek się otworzy. 0 otwiera natychmiast, a niewielka wartość zapobiega otwieraniu przy samym przejeżdżaniu obok strzałki w drodze do zegara.
 - grace: 200
   $name: Collapse delay (ms)
   $name:pl-PL: Opóźnienie zwijania (ms)
@@ -170,10 +186,10 @@ z paska zadań nie może zostać wybrany. Wśród nich wykrywanie przebiega tak:
   $description: Window class of the chevron tooltip, hidden only when "Hide the chevron tooltip" is enabled. Change it if hiding does not work on your build.
   $description:pl-PL: Klasa okna podpowiedzi strzałki, ukrywanej tylko gdy włączono „Ukryj podpowiedź strzałki". Zmień ją, jeśli ukrywanie nie działa na Twojej kompilacji.
 - trayIconAutomationId: SystemTrayIcon
-  $name: Tray icon AutomationId (fallback)
-  $name:pl-PL: AutomationId ikony zasobnika (mechanizm zapasowy)
-  $description: Used only when the chevron is not matched by name. The leftmost tray button with this AutomationId is then assumed to be the chevron.
-  $description:pl-PL: Używane tylko, gdy strzałki nie uda się dopasować po nazwie. Za strzałkę uznawany jest wtedy pierwszy od lewej przycisk zasobnika o tym AutomationId.
+  $name: Chevron AutomationId
+  $name:pl-PL: AutomationId strzałki
+  $description: The AutomationId paired with "Chevron class name" to identify the chevron. It also tells tray elements apart from taskbar buttons. Change it if a future Windows build renames it.
+  $description:pl-PL: AutomationId strzałki, używane razem z powyższą nazwą klasy. Służy też do odróżnienia elementów zasobnika od przycisków aplikacji na pasku zadań.
 */
 // ==/WindhawkModSettings==
 
@@ -182,6 +198,7 @@ z paska zadań nie może zostać wybrany. Wśród nich wykrywanie przebiega tak:
 #include <uiautomation.h>
 #include <atomic>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #ifndef __IUIAutomation_FWD_DEFINED__
@@ -191,6 +208,7 @@ z paska zadań nie może zostać wybrany. Wśród nich wykrywanie przebiega tak:
 struct Settings {
     bool autoClose = true;
     int pollInterval = 50;
+    int hoverDelay = 0;
     int grace = 200;
     int pad = 4;
     bool hideTooltip = false;
@@ -235,7 +253,13 @@ struct Settings {
 
 // UIA class names of tray elements all share this prefix, which is what makes
 // it possible to exclude the rest of the taskbar from the search.
-static const std::wstring TRAY_CLASS_PREFIX = L"SystemTray.";
+// Every tray element's class name starts with this; taskbar buttons do not.
+static constexpr std::wstring_view TRAY_CLASS_PREFIX = L"SystemTray.";
+
+// Some builds are reported to expose the chevron with this AutomationId instead
+// of the configured one. Accepting both costs nothing, because the class name
+// plus AutomationId pair is only used when exactly one element matches it.
+static constexpr std::wstring_view CHEVRON_AUTOMATION_ID_ALT = L"ChevronButton";
 
 // g_settings is guarded by g_settingsLock; the worker thread keeps a private
 // snapshot and refreshes it when g_settingsGeneration changes, so it never
@@ -316,7 +340,8 @@ static void DoCollapse(IUIAutomationElement* e) {
 // ---- Locating the chevron button ----
 
 static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
-                                                const Settings& s) {
+                                                const Settings& s,
+                                                bool logCandidates) {
     HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
     if (!hTaskbar) return nullptr;
 
@@ -327,6 +352,21 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
     VARIANT v; VariantInit(&v);
     v.vt = VT_I4; v.lVal = UIA_ButtonControlTypeId;
     pAuto->CreatePropertyCondition(UIA_ControlTypePropertyId, v, &pCond);
+
+    // Reading five properties per button one at a time is one cross-process call
+    // each, i.e. a few hundred round trips per walk. A cache request collapses
+    // them into the single FindAllBuildCache call. The default element mode is
+    // Full, so the returned elements still support GetCurrentPatternAs, which is
+    // what DoExpand and DoCollapse need.
+    IUIAutomationCacheRequest* pCache = nullptr;
+    if (SUCCEEDED(pAuto->CreateCacheRequest(&pCache)) && pCache) {
+        pCache->AddProperty(UIA_ClassNamePropertyId);
+        pCache->AddProperty(UIA_AutomationIdPropertyId);
+        pCache->AddProperty(UIA_NamePropertyId);
+        pCache->AddProperty(UIA_IsOffscreenPropertyId);
+        pCache->AddProperty(UIA_BoundingRectanglePropertyId);
+    }
+    const bool cached = (pCache != nullptr);
 
     // The Shell_TrayWnd subtree contains every taskbar button: Start, Search,
     // the task list entries, and only then the tray. Candidates are therefore
@@ -355,19 +395,23 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
     std::vector<Candidate> cands;
 
     IUIAutomationElementArray* pArr = nullptr;
-    if (pCond && SUCCEEDED(pRoot->FindAll(TreeScope_Subtree, pCond, &pArr)) && pArr) {
+    HRESULT hrFind = pCond
+        ? (cached ? pRoot->FindAllBuildCache(TreeScope_Subtree, pCond, pCache, &pArr)
+                  : pRoot->FindAll(TreeScope_Subtree, pCond, &pArr))
+        : E_FAIL;
+    if (SUCCEEDED(hrFind) && pArr) {
         int n = 0; pArr->get_Length(&n);
         for (int i = 0; i < n; i++) {
             IUIAutomationElement* e = nullptr;
             if (FAILED(pArr->GetElement(i, &e)) || !e) continue;
 
             BSTR cls = nullptr;
-            e->get_CurrentClassName(&cls);
+            if (cached) e->get_CachedClassName(&cls); else e->get_CurrentClassName(&cls);
             std::wstring className = cls ? cls : L"";
             if (cls) SysFreeString(cls);
 
             BSTR aid = nullptr;
-            e->get_CurrentAutomationId(&aid);
+            if (cached) e->get_CachedAutomationId(&aid); else e->get_CurrentAutomationId(&aid);
             std::wstring automationId = aid ? aid : L"";
             if (aid) SysFreeString(aid);
 
@@ -375,24 +419,27 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
             // is discarded before any name or position test is applied. Without
             // this, a task list button (named after its window title) could
             // match a keyword and then be invoked.
-            bool isTrayElement =
-                className.compare(0, TRAY_CLASS_PREFIX.size(), TRAY_CLASS_PREFIX) == 0 ||
-                automationId == s.trayIconAutomationId;
+            bool isTrayElement = className.starts_with(TRAY_CLASS_PREFIX) ||
+                                 automationId == s.trayIconAutomationId ||
+                                 automationId == CHEVRON_AUTOMATION_ID_ALT;
             if (!isTrayElement) { e->Release(); continue; }
 
             // Elements that are not rendered report an empty {0,0,0,0}
             // rectangle, which would otherwise pass every geometric test.
             BOOL offscreen = FALSE;
             RECT r{};
-            if (FAILED(e->get_CurrentIsOffscreen(&offscreen)) || offscreen ||
-                FAILED(e->get_CurrentBoundingRectangle(&r)) ||
+            HRESULT hrOff = cached ? e->get_CachedIsOffscreen(&offscreen)
+                                   : e->get_CurrentIsOffscreen(&offscreen);
+            HRESULT hrRect = cached ? e->get_CachedBoundingRectangle(&r)
+                                    : e->get_CurrentBoundingRectangle(&r);
+            if (FAILED(hrOff) || offscreen || FAILED(hrRect) ||
                 r.right <= r.left || r.bottom <= r.top) {
                 e->Release();
                 continue;
             }
 
             BSTR nm = nullptr;
-            e->get_CurrentName(&nm);
+            if (cached) e->get_CachedName(&nm); else e->get_CurrentName(&nm);
             std::wstring name = nm ? nm : L"";
             if (nm) SysFreeString(nm);
 
@@ -400,6 +447,7 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
         }
         pArr->Release();
     }
+    if (pCache) pCache->Release();
     if (pCond) pCond->Release();
     pRoot->Release();
 
@@ -411,7 +459,8 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
     int classMatches = 0, firstClassMatch = -1;
     for (size_t i = 0; i < cands.size(); i++) {
         if (cands[i].className == s.chevronClass &&
-            cands[i].automationId == s.trayIconAutomationId) {
+            (cands[i].automationId == s.trayIconAutomationId ||
+             cands[i].automationId == CHEVRON_AUTOMATION_ID_ALT)) {
             classMatches++;
             if (firstClassMatch < 0) firstClassMatch = (int)i;
         }
@@ -451,7 +500,9 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
 
     // Nothing identified: dump the candidates so that a single log makes the
     // next unsupported build actionable, and do not touch anything.
-    if (chosen < 0) {
+    // Logged once per failure streak: the retry runs every few seconds, and
+    // repeating the whole table would bury the rest of the log.
+    if (chosen < 0 && logCandidates) {
         Wh_Log(L"Chevron not identified among %d tray candidates:", (int)cands.size());
         for (size_t i = 0; i < cands.size(); i++) {
             Wh_Log(L"  [%d] class=%s aid=%s x=%d name=%s", (int)i,
@@ -486,9 +537,21 @@ static const ULONGLONG IDLE_STATE_CHECK_MS = 500;
 // window's visibility is the only reliable state signal. Returns the window
 // handle if the flyout is open, or nullptr otherwise. Resolving the handle
 // once per tick lets callers reuse it instead of each calling FindWindowW.
-static HWND GetVisibleFlyout(const Settings& s) {
-    HWND f = FindWindowW(s.flyoutClass.c_str(), nullptr);
-    return (f && IsWindowVisible(f)) ? f : nullptr;
+// Only windows owned by the taskbar count. The class is user-settable, so a
+// user pointing it at a more generic class must not make the mod track another
+// application's window.
+static HWND GetVisibleFlyout(const Settings& s, DWORD taskbarPid) {
+    HWND h = nullptr;
+    while ((h = FindWindowExW(nullptr, h, s.flyoutClass.c_str(), nullptr))) {
+        if (!IsWindowVisible(h)) continue;
+        if (taskbarPid) {
+            DWORD pid = 0;
+            GetWindowThreadProcessId(h, &pid);
+            if (pid != taskbarPid) continue;
+        }
+        return h;
+    }
+    return nullptr;
 }
 
 static bool PtOverWindow(HWND hwnd, POINT pt) {
@@ -504,13 +567,12 @@ static bool PtOverWindow(HWND hwnd, POINT pt) {
 // popup host, so only windows positioned over the chevron (horizontally
 // overlapping it and sitting at or above its top, i.e. inside the flyout zone)
 // are hidden — never popups elsewhere on screen.
-static void HideChevronTooltip(const Settings& s, const RECT& chevron) {
-    // The tooltip class is the generic WinUI popup host, used by many apps, so
-    // only windows owned by the taskbar's own process are eligible. Without
-    // this, another application's popup could be hidden with no way for the
-    // user to bring it back.
-    DWORD taskbarPid = 0;
-    GetWindowThreadProcessId(FindWindowW(L"Shell_TrayWnd", nullptr), &taskbarPid);
+// The tooltip class is the generic WinUI popup host, used by many apps, so only
+// windows owned by the taskbar's own process are eligible. Without that check,
+// another application's popup could be hidden with no way for the user to bring
+// it back.
+static void HideChevronTooltip(const Settings& s, const RECT& chevron,
+                               DWORD taskbarPid) {
     if (!taskbarPid) return;
 
     HWND h = nullptr;
@@ -529,11 +591,13 @@ static void HideChevronTooltip(const Settings& s, const RECT& chevron) {
     }
 }
 
-// True when the foreground window covers its whole monitor, i.e. a fullscreen
-// app (a fullscreen video, a game, etc.). Maximized windows stop at the work
-// area and therefore do not match. The desktop and shell windows are excluded
-// so an empty desktop is not mistaken for a fullscreen app.
-static bool IsForegroundFullscreen() {
+// True when the foreground window covers the whole monitor that the chevron is
+// on, i.e. a fullscreen app (a fullscreen video, a game, etc.) whose content the
+// flyout would pop up over. Maximized windows stop at the work area and
+// therefore do not match, and a fullscreen app on another monitor does not
+// suppress a taskbar that is fully visible here. The desktop and shell windows
+// are excluded so an empty desktop is not mistaken for a fullscreen app.
+static bool IsFullscreenOverChevron(const RECT& chevron) {
     HWND hwnd = GetForegroundWindow();
     if (!hwnd || hwnd == GetShellWindow()) return false;
 
@@ -546,12 +610,13 @@ static bool IsForegroundFullscreen() {
         }
     }
 
+    HMONITOR mon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+    if (mon != MonitorFromRect(&chevron, MONITOR_DEFAULTTONEAREST)) return false;
+
     RECT wr;
     if (!GetWindowRect(hwnd, &wr)) return false;
     MONITORINFO mi = { sizeof(mi) };
-    if (!GetMonitorInfoW(MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST), &mi)) {
-        return false;
-    }
+    if (!GetMonitorInfoW(mon, &mi)) return false;
     return wr.left <= mi.rcMonitor.left && wr.top <= mi.rcMonitor.top &&
            wr.right >= mi.rcMonitor.right && wr.bottom >= mi.rcMonitor.bottom;
 }
@@ -585,8 +650,12 @@ static DWORD WINAPI WorkerThread(LPVOID) {
     ULONGLONG nextRefind = 0;
     ULONGLONG nextRectRefresh = 0;
     ULONGLONG nextIdleStateCheck = 0;
-    ULONGLONG lastOpenAt = 0;
+    ULONGLONG lastActionAt = 0;
+    ULONGLONG insideSince = 0;
+    DWORD taskbarPid = 0;
     bool overBtnPrev = false;
+    bool dwellFired = false;
+    bool loggedCandidates = false;
     bool clickedInFlyout = false;
     bool anyBtnDownPrev = false;
 
@@ -605,6 +674,7 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             if (pBtn) { pBtn->Release(); pBtn = nullptr; }
             haveRect = false;
             nextRefind = 0;
+            loggedCandidates = false;
         }
 
         // Lazily (re-)find the button only when we don't have a valid one. A
@@ -614,23 +684,41 @@ static DWORD WINAPI WorkerThread(LPVOID) {
         // When the chevron is absent (e.g. no hidden icons), throttle retries
         // to REFIND_INTERVAL_MS instead of walking the tree every tick.
         if (!pBtn && now >= nextRefind) {
-            pBtn = FindOverflowButton(pAuto, s);
+            bool logNow = !loggedCandidates;
+            pBtn = FindOverflowButton(pAuto, s, logNow);
+            loggedCandidates = pBtn ? false : (loggedCandidates || logNow);
             nextRefind = now + REFIND_INTERVAL_MS;
             nextRectRefresh = 0;        // force a fresh rectangle below
+            taskbarPid = 0;
+            GetWindowThreadProcessId(FindWindowW(L"Shell_TrayWnd", nullptr),
+                                     &taskbarPid);
         }
 
         if (pBtn) {
             // Expensive and RARE: query the button rectangle through UIA only
             // periodically, not every tick. The chevron rarely moves.
             if (now >= nextRectRefresh) {
-                RECT r;
-                if (SUCCEEDED(pBtn->get_CurrentBoundingRectangle(&r))) {
+                // An element that is alive but not currently rendered (the
+                // taskbar auto-hid, or the last hidden icon was removed) returns
+                // S_OK with an empty rectangle rather than an error. Keeping it
+                // would turn the top-left corner of the screen into a hover
+                // hotspot, and the alternating valid/empty rectangle under a
+                // stationary cursor is what makes the flyout cycle open and
+                // closed. Treat it exactly like a stale element.
+                RECT r{};
+                BOOL offscreen = FALSE;
+                if (SUCCEEDED(pBtn->get_CurrentBoundingRectangle(&r)) &&
+                    r.right > r.left && r.bottom > r.top &&
+                    SUCCEEDED(pBtn->get_CurrentIsOffscreen(&offscreen)) &&
+                    !offscreen) {
                     cachedRect = r;
                     haveRect = true;
                 } else {
-                    // The element is stale/destroyed (taskbar rebuilt). Drop it
-                    // and re-find promptly on the next tick.
-                    pBtn->Release(); pBtn = nullptr; haveRect = false;
+                    pBtn->Release(); pBtn = nullptr;
+                    haveRect = false;
+                    overBtnPrev = false;    // stale once the button is gone
+                    insideSince = 0;
+                    dwellFired = false;
                     nextRefind = 0;
                     WaitForSingleObject(g_stopEvent, s.pollInterval);
                     continue;
@@ -643,8 +731,20 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             // Cheap and EVERY TICK: only local Win32 calls.
             POINT pt; GetCursorPos(&pt);
             bool overBtn = PtInRectPad(cachedRect, pt, s.pad);
-            bool cooling = (now - lastOpenAt < ACTION_COOLDOWN_MS);
-            bool enterEdge = overBtn && !overBtnPrev && !cooling;
+            bool cooling = (now - lastActionAt < ACTION_COOLDOWN_MS);
+
+            // The cursor must remain on the chevron for the hover delay before
+            // the flyout opens, and each stay produces at most one attempt. With
+            // the default delay of 0 this is the plain enter edge.
+            if (!overBtn) {
+                insideSince = 0;
+                dwellFired = false;
+            } else if (!overBtnPrev) {
+                insideSince = now;
+                dwellFired = false;
+            }
+            bool enterEdge = overBtn && !dwellFired && !cooling &&
+                             now - insideSince >= (ULONGLONG)s.hoverDelay;
 
             // The flyout state is only needed on the cursor-enter edge (to
             // avoid toggling an open flyout closed) and while auto-collapse is
@@ -656,9 +756,9 @@ static DWORD WINAPI WorkerThread(LPVOID) {
                           || (s.autoClose && flyoutBelievedOpen)
                           || (s.hideTooltip && overBtn);
             if (wantState) {
-                flyoutHwnd = GetVisibleFlyout(s);
+                flyoutHwnd = GetVisibleFlyout(s, taskbarPid);
             } else if (s.autoClose && now >= nextIdleStateCheck) {
-                flyoutHwnd = GetVisibleFlyout(s);
+                flyoutHwnd = GetVisibleFlyout(s, taskbarPid);
                 nextIdleStateCheck = now + IDLE_STATE_CHECK_MS;
             }
             bool flyoutVisible = (flyoutHwnd != nullptr);
@@ -667,7 +767,7 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             // While hovering the chevron of an open flyout, suppress the
             // "Hide" tooltip that would otherwise cover the bottom icons.
             if (s.hideTooltip && overBtn && flyoutVisible) {
-                HideChevronTooltip(s, cachedRect);
+                HideChevronTooltip(s, cachedRect, taskbarPid);
             }
 
             // Open only on the cursor-enter edge and only when the flyout is
@@ -677,13 +777,15 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             // taskbar is hidden there, but the cached chevron rect still matches
             // that screen area). Checked only on the edge, so it costs nothing
             // on idle ticks.
-            if (enterEdge && !flyoutVisible &&
-                !(s.suppressInFullscreen && IsForegroundFullscreen())) {
-                DoExpand(pBtn);
-                lastOpenAt = now;
-                flyoutBelievedOpen = true;
-                leftAt = 0;
-                Wh_Log(L"OPEN");
+            if (enterEdge && !flyoutVisible) {
+                dwellFired = true;      // at most one attempt per stay
+                if (!(s.suppressInFullscreen && IsFullscreenOverChevron(cachedRect))) {
+                    DoExpand(pBtn);
+                    lastActionAt = now;
+                    flyoutBelievedOpen = true;
+                    leftAt = 0;
+                    Wh_Log(L"OPEN");
+                }
             }
             overBtnPrev = overBtn;
 
@@ -713,7 +815,12 @@ static DWORD WINAPI WorkerThread(LPVOID) {
                 } else if (leftAt == 0) {
                     leftAt = now;
                 } else if (now - leftAt >= (ULONGLONG)s.grace) {
+                    // The collapse is a second Invoke, i.e. a toggle, and the
+                    // flyout does not disappear instantly. Without arming the
+                    // cooldown here, the next ticks would still see it open and
+                    // invoke the chevron again, re-opening what was just closed.
                     DoCollapse(pBtn);
+                    lastActionAt = now;
                     leftAt = 0;
                     flyoutBelievedOpen = false;
                     Wh_Log(L"CLOSE after grace");
@@ -741,12 +848,14 @@ static void LoadSettings() {
 
     s.autoClose = Wh_GetIntSetting(L"autoClose") != 0;
     s.pollInterval = (int)Wh_GetIntSetting(L"pollInterval");
+    s.hoverDelay = (int)Wh_GetIntSetting(L"hoverDelay");
     s.grace = (int)Wh_GetIntSetting(L"grace");
     s.pad = (int)Wh_GetIntSetting(L"pad");
     s.hideTooltip = Wh_GetIntSetting(L"hideTooltip") != 0;
     s.suppressInFullscreen = Wh_GetIntSetting(L"suppressInFullscreen") != 0;
     s.positionalFallback = Wh_GetIntSetting(L"positionalFallback") != 0;
     if (s.pollInterval < 10) s.pollInterval = 10;
+    if (s.hoverDelay < 0) s.hoverDelay = 0;
     if (s.grace < 0) s.grace = 0;
 
     // Wh_GetStringSetting never returns NULL (it returns L"" on unset/error),

--- a/mods/tray-hover-expand.wh.cpp
+++ b/mods/tray-hover-expand.wh.cpp
@@ -201,10 +201,6 @@ z paska zadań nie może zostać wybrany. Wśród nich wykrywanie przebiega tak:
 #include <string_view>
 #include <vector>
 
-#ifndef __IUIAutomation_FWD_DEFINED__
-#error "UI Automation headers are missing"
-#endif
-
 struct Settings {
     bool autoClose = true;
     int pollInterval = 50;
@@ -259,6 +255,9 @@ static constexpr std::wstring_view TRAY_CLASS_PREFIX = L"SystemTray.";
 // Some builds are reported to expose the chevron with this AutomationId instead
 // of the configured one. Accepting both costs nothing, because the class name
 // plus AutomationId pair is only used when exactly one element matches it.
+// Deliberately fixed rather than exposed as a setting: the configurable value
+// is the one a user would have to change on a future build, and this one only
+// widens what already matches.
 static constexpr std::wstring_view CHEVRON_AUTOMATION_ID_ALT = L"ChevronButton";
 
 // g_settings is guarded by g_settingsLock; the worker thread keeps a private
@@ -339,9 +338,13 @@ static void DoCollapse(IUIAutomationElement* e) {
 
 // ---- Locating the chevron button ----
 
+// logCandidates asks for a one-off diagnostic dump when identification fails;
+// *logged reports whether one was actually emitted, so that the caller only
+// counts a streak as reported when there was something to report.
 static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
                                                 const Settings& s,
-                                                bool logCandidates) {
+                                                bool logCandidates,
+                                                bool* logged) {
     HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
     if (!hTaskbar) return nullptr;
 
@@ -467,7 +470,7 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
     }
     if (classMatches == 1) {
         chosen = firstClassMatch;
-    } else if (classMatches > 1) {
+    } else if (classMatches > 1 && logCandidates) {
         Wh_Log(L"%d tray elements share the chevron signature, falling back to name",
                classMatches);
     }
@@ -501,8 +504,11 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
     // Nothing identified: dump the candidates so that a single log makes the
     // next unsupported build actionable, and do not touch anything.
     // Logged once per failure streak: the retry runs every few seconds, and
-    // repeating the whole table would bury the rest of the log.
-    if (chosen < 0 && logCandidates) {
+    // repeating the whole table would bury the rest of the log. An empty table
+    // just means nothing was rendered (a retracted taskbar), which needs no
+    // diagnosis, so it is not worth a line.
+    if (chosen < 0 && logCandidates && !cands.empty()) {
+        if (logged) *logged = true;
         Wh_Log(L"Chevron not identified among %d tray candidates:", (int)cands.size());
         for (size_t i = 0; i < cands.size(); i++) {
             Wh_Log(L"  [%d] class=%s aid=%s x=%d name=%s", (int)i,
@@ -528,7 +534,13 @@ static bool PtInRectPad(const RECT& r, POINT pt, int pad) {
 }
 
 static const ULONGLONG ACTION_COOLDOWN_MS = 300;
-static const ULONGLONG REFIND_INTERVAL_MS = 3000;
+// Retry the (expensive) chevron lookup quickly while the cursor is at the
+// taskbar, and only occasionally while it is elsewhere. See the worker loop.
+static const ULONGLONG REFIND_NEAR_MS = 250;
+static const ULONGLONG REFIND_IDLE_MS = 1000;
+// How far from the taskbar the cursor still counts as "at the taskbar". Covers
+// the sliver an auto-hidden taskbar leaves at the screen edge while it slides in.
+static const int TASKBAR_REVEAL_PAD = 32;
 static const ULONGLONG RECT_REFRESH_MS = 750;
 static const ULONGLONG IDLE_STATE_CHECK_MS = 500;
 
@@ -673,25 +685,44 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             // cached element and re-detect promptly with the new settings.
             if (pBtn) { pBtn->Release(); pBtn = nullptr; }
             haveRect = false;
+            overBtnPrev = false;
+            insideSince = 0;
+            dwellFired = false;
             nextRefind = 0;
             loggedCandidates = false;
         }
 
+        POINT pt; GetCursorPos(&pt);
+
         // Lazily (re-)find the button only when we don't have a valid one. A
         // destroyed or stale element makes the rectangle query below fail,
-        // which clears pBtn and triggers a prompt re-find — so there is no need
-        // for a periodic cross-process subtree walk while the element is valid.
-        // When the chevron is absent (e.g. no hidden icons), throttle retries
-        // to REFIND_INTERVAL_MS instead of walking the tree every tick.
+        // which clears pBtn and triggers a re-find — so there is no need for a
+        // periodic cross-process subtree walk while the element is valid.
+        //
+        // Re-finding is driven by the cursor rather than by a fixed timer. The
+        // rectangle guard drops the element whenever the chevron stops being
+        // rendered, which for an auto-hiding taskbar happens on every retract,
+        // so a fixed interval would leave the mod idle for up to that interval
+        // after each reveal. Conversely, when nothing is hidden the chevron does
+        // not exist at all and a timer would walk the taskbar subtree forever.
+        // Retry quickly while the cursor is at the taskbar, and not at all while
+        // it is elsewhere, since the chevron cannot be hovered from there anyway.
         if (!pBtn && now >= nextRefind) {
-            bool logNow = !loggedCandidates;
-            pBtn = FindOverflowButton(pAuto, s, logNow);
-            loggedCandidates = pBtn ? false : (loggedCandidates || logNow);
-            nextRefind = now + REFIND_INTERVAL_MS;
-            nextRectRefresh = 0;        // force a fresh rectangle below
-            taskbarPid = 0;
-            GetWindowThreadProcessId(FindWindowW(L"Shell_TrayWnd", nullptr),
-                                     &taskbarPid);
+            RECT tb;
+            HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
+            bool nearTaskbar = hTaskbar && GetWindowRect(hTaskbar, &tb) &&
+                               PtInRectPad(tb, pt, TASKBAR_REVEAL_PAD);
+            if (nearTaskbar) {
+                bool didLog = false;
+                pBtn = FindOverflowButton(pAuto, s, !loggedCandidates, &didLog);
+                loggedCandidates = pBtn ? false : (loggedCandidates || didLog);
+                nextRefind = now + REFIND_NEAR_MS;
+                nextRectRefresh = 0;    // force a fresh rectangle below
+                taskbarPid = 0;
+                GetWindowThreadProcessId(hTaskbar, &taskbarPid);
+            } else {
+                nextRefind = now + REFIND_IDLE_MS;
+            }
         }
 
         if (pBtn) {
@@ -719,6 +750,7 @@ static DWORD WINAPI WorkerThread(LPVOID) {
                     overBtnPrev = false;    // stale once the button is gone
                     insideSince = 0;
                     dwellFired = false;
+                    leftAt = 0;             // don't collapse on the first tick back
                     nextRefind = 0;
                     WaitForSingleObject(g_stopEvent, s.pollInterval);
                     continue;
@@ -729,7 +761,6 @@ static DWORD WINAPI WorkerThread(LPVOID) {
 
         if (haveRect) {
             // Cheap and EVERY TICK: only local Win32 calls.
-            POINT pt; GetCursorPos(&pt);
             bool overBtn = PtInRectPad(cachedRect, pt, s.pad);
             bool cooling = (now - lastActionAt < ACTION_COOLDOWN_MS);
 
@@ -763,6 +794,15 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             }
             bool flyoutVisible = (flyoutHwnd != nullptr);
             flyoutBelievedOpen = flyoutVisible || cooling;
+
+            // A stay that has already seen an open flyout counts as served, so
+            // re-opening requires leaving and re-entering the hit area. Without
+            // this, moving up into the icons and back down onto the chevron
+            // leaves the enter edge armed, and the click that dismisses the
+            // flyout is immediately followed by the mod opening it again.
+            if (overBtn && flyoutVisible) {
+                dwellFired = true;
+            }
 
             // While hovering the chevron of an open flyout, suppress the
             // "Hide" tooltip that would otherwise cover the bottom icons.

--- a/mods/tray-hover-expand.wh.cpp
+++ b/mods/tray-hover-expand.wh.cpp
@@ -58,9 +58,9 @@ selected. Among those, detection goes:
   only brush past the chevron on the way to the clock.
 - If auto-collapse does not work, the flyout window class name may differ on your
   build. Change it in the "Flyout window class" setting.
-- Windows shows a "Hide" tooltip over the chevron while the flyout is open, which
-  can cover the bottom row of icons. Enable "Hide the chevron tooltip" to
-  suppress it.
+- Windows shows a tooltip for the chevron: "Show hidden icons" before the flyout
+  opens, which can appear ahead of it, and "Hide" once it is open, which can cover
+  the bottom row of icons. Enable "Hide the chevron tooltip" to suppress both.
 - By default the flyout is not opened while a fullscreen app is in the foreground
   (e.g. a fullscreen video or a game), so it can't pop up over the content. Turn
   off "Do not activate over fullscreen apps" to always activate.
@@ -113,9 +113,10 @@ z paska zadań nie może zostać wybrany. Wśród nich wykrywanie przebiega tak:
   otwiera się przy samym przejeżdżaniu obok strzałki w drodze do zegara.
 - Jeśli auto-zwijanie nie działa, nazwa klasy okna schowka może się różnić na
   Twojej kompilacji systemu. Zmień ją w ustawieniu „Klasa okna schowka".
-- Gdy schowek jest otwarty, Windows pokazuje nad strzałką podpowiedź „Ukryj",
-  która potrafi zasłaniać dolny rząd ikon. Włącz „Ukryj podpowiedź strzałki",
-  aby ją wyłączyć.
+- Windows pokazuje dla strzałki podpowiedź: „Pokaż ukryte ikony" przed otwarciem
+  schowka, która potrafi wyprzedzić jego pojawienie się, oraz „Ukryj" po otwarciu,
+  która zasłania dolny rząd ikon. Włącz „Ukryj podpowiedź strzałki", aby wyłączyć
+  obie.
 - Domyślnie schowek nie otwiera się, gdy na pierwszym planie jest aplikacja
   pełnoekranowa (np. film na pełnym ekranie lub gra), więc nie wyskoczy on na
   wierzchu treści. Wyłącz „Nie aktywuj na aplikacjach pełnoekranowych", aby
@@ -173,8 +174,8 @@ z paska zadań nie może zostać wybrany. Wśród nich wykrywanie przebiega tak:
 - hideTooltip: false
   $name: Hide the chevron tooltip
   $name:pl-PL: Ukryj podpowiedź strzałki
-  $description: While the flyout is open and the cursor is on the chevron, hide the "Hide" tooltip that Windows shows over the chevron (it can cover the bottom row of icons).
-  $description:pl-PL: Gdy schowek jest otwarty, a kursor jest na strzałce, ukrywa podpowiedź „Ukryj", którą Windows pokazuje nad strzałką (potrafi zasłaniać dolny rząd ikon).
+  $description: While the cursor is on the chevron, hide the tooltip Windows shows for it. That covers both "Show hidden icons", which can appear before the flyout does, and "Hide", which covers the bottom row of icons once it is open.
+  $description:pl-PL: Gdy kursor jest na strzałce, ukrywa pokazywaną dla niej podpowiedź Windows. Dotyczy to zarówno „Pokaż ukryte ikony", która potrafi pojawić się przed schowkiem, jak i „Ukryj", która po otwarciu zasłania dolny rząd ikon.
 - flyoutClass: TopLevelWindowForOverflowXamlIsland
   $name: Flyout window class
   $name:pl-PL: Klasa okna schowka
@@ -566,6 +567,16 @@ static HWND GetVisibleFlyout(const Settings& s, DWORD taskbarPid) {
     return nullptr;
 }
 
+// A tray icon's context menu is a separate window that usually extends past the
+// flyout, so the cursor sitting on it counts as having left the flyout. Menus
+// opened with TrackPopupMenu, which is what most tray icons use, all share this
+// window class, so their presence is a reliable "the user is still busy" signal
+// even when the click that opened the menu was never observed.
+static bool IsPopupMenuOpen() {
+    HWND h = FindWindowW(L"#32768", nullptr);
+    return h && IsWindowVisible(h);
+}
+
 static bool PtOverWindow(HWND hwnd, POINT pt) {
     if (!hwnd) return false;
     RECT r;
@@ -583,9 +594,14 @@ static bool PtOverWindow(HWND hwnd, POINT pt) {
 // windows owned by the taskbar's own process are eligible. Without that check,
 // another application's popup could be hidden with no way for the user to bring
 // it back.
+// The tooltip is matched against the flyout rather than against "above the
+// chevron", because which side it sits on depends on where the taskbar is: with
+// the taskbar on top, both the flyout and the tooltip are below the chevron.
 static void HideChevronTooltip(const Settings& s, const RECT& chevron,
-                               DWORD taskbarPid) {
+                               HWND flyout, DWORD taskbarPid) {
     if (!taskbarPid) return;
+    RECT fly{};
+    bool hasFlyout = flyout && GetWindowRect(flyout, &fly);
 
     HWND h = nullptr;
     while ((h = FindWindowExW(nullptr, h, s.tooltipClass.c_str(), nullptr))) {
@@ -595,9 +611,22 @@ static void HideChevronTooltip(const Settings& s, const RECT& chevron,
         if (pid != taskbarPid) continue;
         RECT r;
         if (!GetWindowRect(h, &r)) continue;
+        // Horizontally aligned with the chevron, and either overlapping the
+        // flyout (the "Hide" tooltip shown while it is open) or sitting right
+        // next to the chevron (the "Show hidden icons" tooltip, which can beat
+        // the flyout to the screen). Both tests are direction-agnostic, so they
+        // hold with the taskbar at the bottom and at the top.
+        if (h == flyout) continue;
         bool overlapsX = r.left <= chevron.right && r.right >= chevron.left;
-        bool aboveChevron = r.bottom <= chevron.bottom;
-        if (overlapsX && aboveChevron) {
+        bool overlapsFlyout = hasFlyout &&
+                              r.left < fly.right && r.right > fly.left &&
+                              r.top < fly.bottom && r.bottom > fly.top;
+        LONG band = chevron.bottom - chevron.top;
+        LONG gapAbove = chevron.top - r.bottom;
+        LONG gapBelow = r.top - chevron.bottom;
+        bool besideChevron = (gapAbove >= 0 && gapAbove <= band) ||
+                             (gapBelow >= 0 && gapBelow <= band);
+        if (overlapsX && (overlapsFlyout || besideChevron)) {
             ShowWindow(h, SW_HIDE);
         }
     }
@@ -804,10 +833,12 @@ static DWORD WINAPI WorkerThread(LPVOID) {
                 dwellFired = true;
             }
 
-            // While hovering the chevron of an open flyout, suppress the
-            // "Hide" tooltip that would otherwise cover the bottom icons.
-            if (s.hideTooltip && overBtn && flyoutVisible) {
-                HideChevronTooltip(s, cachedRect, taskbarPid);
+            // Suppress the chevron's tooltip for as long as the cursor is on it:
+            // the "Hide" tooltip covers the bottom row of icons once the flyout
+            // is open, and the "Show hidden icons" one can appear before the
+            // flyout does, which is most noticeable when a hover delay is set.
+            if (s.hideTooltip && overBtn) {
+                HideChevronTooltip(s, cachedRect, flyoutHwnd, taskbarPid);
             }
 
             // Open only on the cursor-enter edge and only when the flyout is
@@ -834,11 +865,17 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             // Suspend auto-collapse until the flyout closes on its own —
             // collapsing via Invoke would steal focus and dismiss the popup
             // the user just opened.
-            bool anyBtnDown = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) ||
-                              (GetAsyncKeyState(VK_RBUTTON) & 0x8000) ||
-                              (GetAsyncKeyState(VK_MBUTTON) & 0x8000);
-            if (anyBtnDown && !anyBtnDownPrev && flyoutVisible &&
-                PtOverWindow(flyoutHwnd, pt)) {
+            // The state bit alone misses a click that starts and ends between
+            // two ticks, which at a large polling interval is most clicks. The
+            // low bit reports a press since the previous call, so it catches
+            // those regardless of the interval.
+            SHORT kl = GetAsyncKeyState(VK_LBUTTON);
+            SHORT kr = GetAsyncKeyState(VK_RBUTTON);
+            SHORT km = GetAsyncKeyState(VK_MBUTTON);
+            bool anyBtnDown = ((kl | kr | km) & 0x8000) != 0;
+            bool pressedSinceTick = ((kl | kr | km) & 0x0001) != 0;
+            if ((pressedSinceTick || (anyBtnDown && !anyBtnDownPrev)) &&
+                flyoutVisible && PtOverWindow(flyoutHwnd, pt)) {
                 clickedInFlyout = true;
                 Wh_Log(L"Click inside flyout: auto-collapse suspended");
             }
@@ -850,7 +887,7 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             // Auto-collapse once the cursor left both the button and the flyout.
             if (s.autoClose && flyoutVisible && !cooling && !clickedInFlyout) {
                 bool overFlyout = PtOverWindow(flyoutHwnd, pt);
-                if (overBtn || overFlyout) {
+                if (overBtn || overFlyout || IsPopupMenuOpen()) {
                     leftAt = 0;
                 } else if (leftAt == 0) {
                     leftAt = now;

--- a/mods/tray-hover-expand.wh.cpp
+++ b/mods/tray-hover-expand.wh.cpp
@@ -341,11 +341,15 @@ static void DoCollapse(IUIAutomationElement* e) {
 
 // logCandidates asks for a one-off diagnostic dump when identification fails;
 // *logged reports whether one was actually emitted, so that the caller only
-// counts a streak as reported when there was something to report.
+// counts a streak as reported when there was something to report. logWeakMatch
+// is a separate opt-in for the "identified, but not by class name" lines, which
+// the caller silences after the first one: on a build where the class match
+// never works, they would otherwise be logged on every acquisition.
 static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
                                                 const Settings& s,
                                                 bool logCandidates,
-                                                bool* logged) {
+                                                bool* logged,
+                                                bool* logWeakMatch) {
     HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
     if (!hTaskbar) return nullptr;
 
@@ -481,7 +485,8 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
         for (size_t i = 0; i < cands.size(); i++) {
             if (NameMatches(cands[i].name, s)) {
                 chosen = (int)i;
-                if (logCandidates) {
+                if (logWeakMatch) {
+                    *logWeakMatch = true;
                     Wh_Log(L"Chevron matched by name, not by class name");
                 }
                 break;
@@ -497,7 +502,8 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
                 chosen = (int)i;
             }
         }
-        if (chosen >= 0) {
+        if (chosen >= 0 && logWeakMatch) {
+            *logWeakMatch = true;
             Wh_Log(L"Chevron guessed by position: name=%s class=%s x=%d",
                    cands[chosen].name.c_str(), cands[chosen].className.c_str(),
                    (int)cands[chosen].rect.left);
@@ -636,7 +642,11 @@ static void HideChevronTooltip(const Settings& s, const RECT& chevron,
         bool besideChevron = (gapAbove >= 0 && gapAbove <= band) ||
                              (gapBelow >= 0 && gapBelow <= band);
         if (overlapsX && (overlapsFlyout || besideChevron)) {
-            ShowWindow(h, SW_HIDE);
+            // Async: the window belongs to explorer, and the synchronous form
+            // marshals into its UI thread and blocks until that thread handles
+            // it. Hiding a tooltip a frame later is not noticeable; stalling
+            // the poll loop behind a busy shell is.
+            ShowWindowAsync(h, SW_HIDE);
         }
     }
 }
@@ -706,6 +716,11 @@ static DWORD WINAPI WorkerThread(LPVOID) {
     bool overBtnPrev = false;
     bool dwellFired = false;
     bool loggedCandidates = false;
+    // Survives a successful find, unlike loggedCandidates, so that a build
+    // which always matches by name or by position logs that once rather than
+    // on every acquisition.
+    bool loggedWeakMatch = false;
+    ULONGLONG lastWalkAt = 0;
     bool clickedInFlyout = false;
     bool anyBtnDownPrev = false;
     bool nearTaskbarPrev = false;
@@ -728,22 +743,33 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             overBtnPrev = false;
             insideSince = 0;
             dwellFired = false;
+            leftAt = 0;             // don't collapse on the first tick back
             nextRefind = 0;
             loggedCandidates = false;
+            loggedWeakMatch = false;
         }
 
         POINT pt; GetCursorPos(&pt);
 
-        // Sampled every tick, not only when the chevron is available: the low
-        // bit reports a press since the previous call, so skipping calls would
-        // let an arbitrarily old click be reported as fresh once the chevron
-        // comes back. The state bit alone misses a click that starts and ends
-        // between two ticks, which at a large polling interval is most clicks.
-        SHORT kl = GetAsyncKeyState(VK_LBUTTON);
-        SHORT kr = GetAsyncKeyState(VK_RBUTTON);
-        SHORT km = GetAsyncKeyState(VK_MBUTTON);
-        bool anyBtnDown = ((kl | kr | km) & 0x8000) != 0;
-        bool pressedSinceTick = ((kl | kr | km) & 0x0001) != 0;
+        // The "pressed since the previous call" bit is desktop-wide state that
+        // the first caller consumes, so polling it continuously would take it
+        // away from every other application for the whole session. It is only
+        // ever read while auto-collapse is watching an open flyout, so sample
+        // it exactly then: staleness stays bounded by the polling interval for
+        // as long as the result can matter, and the rest of the time the mod
+        // does not touch it at all. flyoutBelievedOpen still holds the previous
+        // tick's value here, which is what makes the first tick covered too.
+        bool anyBtnDown = false;
+        bool pressedSinceTick = false;
+        if (s.autoClose && flyoutBelievedOpen) {
+            SHORT kl = GetAsyncKeyState(VK_LBUTTON);
+            SHORT kr = GetAsyncKeyState(VK_RBUTTON);
+            SHORT km = GetAsyncKeyState(VK_MBUTTON);
+            anyBtnDown = ((kl | kr | km) & 0x8000) != 0;
+            pressedSinceTick = ((kl | kr | km) & 0x0001) != 0;
+        } else {
+            anyBtnDownPrev = false;
+        }
 
         // Lazily (re-)find the button only when we don't have a valid one. A
         // destroyed or stale element makes the rectangle query below fail,
@@ -769,18 +795,30 @@ static DWORD WINAPI WorkerThread(LPVOID) {
         // second try after a reveal.
         RECT tb;
         HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
+        // At least as wide as the hit area, so there is no position the mod
+        // treats as "on the chevron" but not as "at the taskbar".
+        int revealPad = s.pad > TASKBAR_REVEAL_PAD ? s.pad : TASKBAR_REVEAL_PAD;
         bool nearTaskbar = hTaskbar && GetWindowRect(hTaskbar, &tb) &&
-                           PtInRectPad(tb, pt, TASKBAR_REVEAL_PAD);
+                           PtInRectPad(tb, pt, revealPad);
         if (nearTaskbar && !nearTaskbarPrev) {
             refindFailures = 0;
             nextRefind = 0;
         }
         nearTaskbarPrev = nearTaskbar;
 
-        if (!pBtn && nearTaskbar && now >= nextRefind) {
+        // The band-entry reset above clears the backoff, so a cursor crossing
+        // the boundary repeatedly would otherwise earn one full walk per
+        // crossing. This floor keeps the worst case at the fast cadence while
+        // still re-acquiring promptly after an auto-hide reveal.
+        if (!pBtn && nearTaskbar && now >= nextRefind &&
+            now - lastWalkAt >= REFIND_NEAR_MS) {
+            lastWalkAt = now;
             bool didLog = false;
-            pBtn = FindOverflowButton(pAuto, s, !loggedCandidates, &didLog);
+            bool didLogWeak = false;
+            pBtn = FindOverflowButton(pAuto, s, !loggedCandidates, &didLog,
+                                      loggedWeakMatch ? nullptr : &didLogWeak);
             loggedCandidates = pBtn ? false : (loggedCandidates || didLog);
+            loggedWeakMatch = loggedWeakMatch || didLogWeak;
             nextRectRefresh = 0;        // force a fresh rectangle below
             taskbarPid = 0;
             GetWindowThreadProcessId(hTaskbar, &taskbarPid);
@@ -876,8 +914,7 @@ static DWORD WINAPI WorkerThread(LPVOID) {
                 dwellFired = true;
             }
 
-            // Suppress the chevron's tooltip for as long as the cursor is on it:
-            // Suppress the chevron's tooltip while the cursor is on it, both
+            // Suppress the chevron's tooltip while the cursor is on it: both
             // the "Hide" tooltip covering the bottom row of icons once the
             // flyout is open, and the "Show hidden icons" one that can appear
             // before the flyout does.

--- a/mods/tray-hover-expand.wh.cpp
+++ b/mods/tray-hover-expand.wh.cpp
@@ -2,7 +2,7 @@
 // @id              tray-hover-expand
 // @name            Tray hover expand
 // @description     Open the hidden tray icons flyout on hover instead of clicking the chevron; optionally collapse it when the cursor leaves
-// @version         1.6.0
+// @version         1.7.0
 // @author          wygodad
 // @github          https://github.com/wygodad
 // @include         windhawk.exe
@@ -35,14 +35,16 @@ mod in a dedicated process and does not inject into the shell.
 The "Show Hidden Icons" chevron has no language-independent unique identifier on
 Windows 11 (it shares AutomationId `SystemTrayIcon` with the clock, volume,
 battery, etc., and exposes no ExpandCollapse pattern). So detection is a hybrid:
-1. Match the button by name (the keyword list covers English and Polish by
-   default and can be extended in the settings).
+1. Match the button by name (the keyword list covers the most common Windows
+   display languages by default and can be extended in the settings).
 2. If no name matches (other languages), fall back to the leftmost tray button
    with the configured AutomationId, which is normally the chevron.
 
 ## Notes
-- For unsupported languages, add your locale's chevron name to the "Chevron name
-  keywords" setting, or rely on the leftmost-tray-icon fallback.
+- If your display language is not in the default keyword list, hover the chevron
+  with the mod disabled and add a fragment of its tooltip text to the "Chevron
+  name keywords" setting. Without a name match the mod falls back to a
+  positional guess, which can land on a different tray button.
 - If auto-collapse does not work, the flyout window class name may differ on your
   build. Change it in the "Flyout window class" setting.
 - Windows shows a "Hide" tooltip over the chevron while the flyout is open, which
@@ -78,13 +80,16 @@ języka identyfikatora (dzieli AutomationId `SystemTrayIcon` z zegarem,
 głośnością, baterią itd. i nie udostępnia wzorca ExpandCollapse). Wykrywanie
 jest więc hybrydowe:
 1. Dopasowanie przycisku po nazwie (domyślna lista słów kluczowych obejmuje
-   angielski i polski; można ją rozszerzyć w ustawieniach).
+   najpopularniejsze języki interfejsu Windows; można ją rozszerzyć w
+   ustawieniach).
 2. Gdy nazwa nie pasuje (inne języki) — pierwszy od lewej przycisk zasobnika ze
    skonfigurowanym AutomationId, którym zwykle jest strzałka.
 
 ### Uwagi
-- Dla nieobsługiwanych języków dodaj nazwę strzałki w swoim języku do ustawienia
-  „Słowa kluczowe nazwy strzałki" albo polegaj na powyższym mechanizmie zapasowym.
+- Jeśli Twojego języka wyświetlania nie ma na domyślnej liście, najedź na
+  strzałkę przy wyłączonym modzie i dodaj fragment tekstu jej podpowiedzi do
+  ustawienia „Słowa kluczowe nazwy strzałki". Bez dopasowania po nazwie mod
+  korzysta ze zgadywania po pozycji, które może trafić w inny przycisk zasobnika.
 - Jeśli auto-zwijanie nie działa, nazwa klasy okna schowka może się różnić na
   Twojej kompilacji systemu. Zmień ją w ustawieniu „Klasa okna schowka".
 - Gdy schowek jest otwarty, Windows pokazuje nad strzałką podpowiedź „Ukryj",
@@ -119,11 +124,11 @@ jest więc hybrydowe:
   $name:pl-PL: Margines obszaru najechania (piksele)
   $description: Enlarges the hover area around the chevron button.
   $description:pl-PL: Powiększa obszar najechania wokół przycisku strzałki.
-- keywords: ["ukryte ikony", "hidden icons", "rozwiń", "overflow"]
+- keywords: ["hidden icons", "ukryte ikony", "rozwiń", "verborgen pictogrammen", "ausgeblendete symbole", "icônes masquées", "iconos ocultos", "icone nascoste", "ícones ocultos", "skryté ikony", "rejtett ikonok", "pictograme ascunse", "dolda ikoner", "skjulte ikoner", "piilotetut kuvakkeet", "gizli simgeleri", "скрытые значки", "приховані піктограми", "κρυφών εικονιδίων", "隐藏的图标", "隱藏的圖示", "隠れている", "숨겨진 아이콘", "overflow"]
   $name: Chevron name keywords
   $name:pl-PL: Słowa kluczowe nazwy strzałki
-  $description: Case-insensitive substrings used to match the chevron button name. Add your locale's name for "Show Hidden Icons" here.
-  $description:pl-PL: Fragmenty nazwy przycisku strzałki (wielkość liter bez znaczenia). Dodaj tu nazwę „Pokaż ukryte ikony" w swoim języku.
+  $description: Case-insensitive substrings used to match the chevron button name. The most common Windows display languages are covered by default. If yours is missing, hover the chevron with the mod disabled and add a fragment of the tooltip text here.
+  $description:pl-PL: Fragmenty nazwy przycisku strzałki (wielkość liter bez znaczenia). Domyślnie pokryte są najpopularniejsze języki interfejsu Windows. Jeśli brakuje Twojego, najedź na strzałkę przy wyłączonym modzie i dodaj tu fragment tekstu podpowiedzi.
 - suppressInFullscreen: true
   $name: Do not activate over fullscreen apps
   $name:pl-PL: Nie aktywuj na aplikacjach pełnoekranowych
@@ -174,8 +179,35 @@ struct Settings {
     std::wstring flyoutClass = L"TopLevelWindowForOverflowXamlIsland";
     std::wstring tooltipClass = L"Xaml_WindowedPopupClass";
     std::wstring trayIconAutomationId = L"SystemTrayIcon";
+    // Fragments of the chevron's name ("Show hidden icons") across the most
+    // common Windows display languages. Each entry is a distinctive part of the
+    // name rather than the whole string, so wording differences between builds
+    // still match.
     std::vector<std::wstring> keywords = {
-        L"ukryte ikony", L"hidden icons", L"rozwiń", L"overflow"
+        L"hidden icons",            // English
+        L"ukryte ikony",            // Polish
+        L"rozwiń",                  // Polish (alternative wording)
+        L"verborgen pictogrammen",  // Dutch
+        L"ausgeblendete symbole",   // German
+        L"icônes masquées",         // French
+        L"iconos ocultos",          // Spanish
+        L"icone nascoste",          // Italian
+        L"ícones ocultos",          // Portuguese
+        L"skryté ikony",            // Czech, Slovak
+        L"rejtett ikonok",          // Hungarian
+        L"pictograme ascunse",      // Romanian
+        L"dolda ikoner",            // Swedish
+        L"skjulte ikoner",          // Danish, Norwegian
+        L"piilotetut kuvakkeet",    // Finnish
+        L"gizli simgeleri",         // Turkish
+        L"скрытые значки",          // Russian
+        L"приховані піктограми",    // Ukrainian
+        L"κρυφών εικονιδίων",       // Greek
+        L"隐藏的图标",                // Chinese (Simplified)
+        L"隱藏的圖示",                // Chinese (Traditional)
+        L"隠れている",                // Japanese
+        L"숨겨진 아이콘",             // Korean
+        L"overflow"                 // generic fallback
     };
 };
 
@@ -197,9 +229,14 @@ static Settings GetSettingsSnapshot() {
     return s;
 }
 
+// CharLowerBuffW is used instead of towlower because the latter follows the C
+// locale and would leave non-ASCII letters (Cyrillic, Greek, ...) untouched,
+// breaking case-insensitive matching for those locales.
 static std::wstring ToLower(const std::wstring& s) {
     std::wstring r = s;
-    std::transform(r.begin(), r.end(), r.begin(), ::towlower);
+    if (!r.empty()) {
+        CharLowerBuffW(&r[0], (DWORD)r.size());
+    }
     return r;
 }
 

--- a/mods/tray-hover-expand.wh.cpp
+++ b/mods/tray-hover-expand.wh.cpp
@@ -481,7 +481,9 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
         for (size_t i = 0; i < cands.size(); i++) {
             if (NameMatches(cands[i].name, s)) {
                 chosen = (int)i;
-                Wh_Log(L"Chevron matched by name, not by class name");
+                if (logCandidates) {
+                    Wh_Log(L"Chevron matched by name, not by class name");
+                }
                 break;
             }
         }
@@ -538,7 +540,7 @@ static const ULONGLONG ACTION_COOLDOWN_MS = 300;
 // Retry the (expensive) chevron lookup quickly while the cursor is at the
 // taskbar, and only occasionally while it is elsewhere. See the worker loop.
 static const ULONGLONG REFIND_NEAR_MS = 250;
-static const ULONGLONG REFIND_IDLE_MS = 1000;
+static const ULONGLONG REFIND_MAX_MS = 4000;
 // How far from the taskbar the cursor still counts as "at the taskbar". Covers
 // the sliver an auto-hidden taskbar leaves at the screen edge while it slides in.
 static const int TASKBAR_REVEAL_PAD = 32;
@@ -573,8 +575,15 @@ static HWND GetVisibleFlyout(const Settings& s, DWORD taskbarPid) {
 // window class, so their presence is a reliable "the user is still busy" signal
 // even when the click that opened the menu was never observed.
 static bool IsPopupMenuOpen() {
-    HWND h = FindWindowW(L"#32768", nullptr);
-    return h && IsWindowVisible(h);
+    // Enumerate rather than sampling the first hit: menu windows are created
+    // per thread and kept alive hidden afterwards, so the first one in Z-order
+    // is often a leftover from some process that showed a menu earlier, and
+    // testing only that one would report "no menu" while one is on screen.
+    HWND h = nullptr;
+    while ((h = FindWindowExW(nullptr, h, L"#32768", nullptr))) {
+        if (IsWindowVisible(h)) return true;
+    }
+    return false;
 }
 
 static bool PtOverWindow(HWND hwnd, POINT pt) {
@@ -699,6 +708,8 @@ static DWORD WINAPI WorkerThread(LPVOID) {
     bool loggedCandidates = false;
     bool clickedInFlyout = false;
     bool anyBtnDownPrev = false;
+    bool nearTaskbarPrev = false;
+    int refindFailures = 0;
 
     while (g_running) {
         ULONGLONG now = GetTickCount64();
@@ -723,6 +734,17 @@ static DWORD WINAPI WorkerThread(LPVOID) {
 
         POINT pt; GetCursorPos(&pt);
 
+        // Sampled every tick, not only when the chevron is available: the low
+        // bit reports a press since the previous call, so skipping calls would
+        // let an arbitrarily old click be reported as fresh once the chevron
+        // comes back. The state bit alone misses a click that starts and ends
+        // between two ticks, which at a large polling interval is most clicks.
+        SHORT kl = GetAsyncKeyState(VK_LBUTTON);
+        SHORT kr = GetAsyncKeyState(VK_RBUTTON);
+        SHORT km = GetAsyncKeyState(VK_MBUTTON);
+        bool anyBtnDown = ((kl | kr | km) & 0x8000) != 0;
+        bool pressedSinceTick = ((kl | kr | km) & 0x0001) != 0;
+
         // Lazily (re-)find the button only when we don't have a valid one. A
         // destroyed or stale element makes the rectangle query below fail,
         // which clears pBtn and triggers a re-find — so there is no need for a
@@ -734,30 +756,51 @@ static DWORD WINAPI WorkerThread(LPVOID) {
         // so a fixed interval would leave the mod idle for up to that interval
         // after each reveal. Conversely, when nothing is hidden the chevron does
         // not exist at all and a timer would walk the taskbar subtree forever.
-        // Retry quickly while the cursor is at the taskbar, and not at all while
-        // it is elsewhere, since the chevron cannot be hovered from there anyway.
-        if (!pBtn && now >= nextRefind) {
-            RECT tb;
-            HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
-            bool nearTaskbar = hTaskbar && GetWindowRect(hTaskbar, &tb) &&
-                               PtInRectPad(tb, pt, TASKBAR_REVEAL_PAD);
-            if (nearTaskbar) {
-                bool didLog = false;
-                pBtn = FindOverflowButton(pAuto, s, !loggedCandidates, &didLog);
-                loggedCandidates = pBtn ? false : (loggedCandidates || didLog);
-                nextRefind = now + REFIND_NEAR_MS;
-                nextRectRefresh = 0;    // force a fresh rectangle below
-                taskbarPid = 0;
-                GetWindowThreadProcessId(hTaskbar, &taskbarPid);
+        // Retry while the cursor is at the taskbar, and not at all while it is
+        // elsewhere, since the chevron cannot be hovered from there anyway.
+        //
+        // Consecutive failures back off. Without that, a user with no hidden
+        // icons has no chevron to find, so every lookup fails and the fast
+        // cadence would walk the taskbar subtree several times a second for the
+        // whole session, forcing explorer to build automation peers on its UI
+        // thread exactly while the user is working with the taskbar. The
+        // counter resets when the chevron is found and when the cursor enters
+        // the band, so an auto-hiding taskbar still re-acquires on the first or
+        // second try after a reveal.
+        RECT tb;
+        HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
+        bool nearTaskbar = hTaskbar && GetWindowRect(hTaskbar, &tb) &&
+                           PtInRectPad(tb, pt, TASKBAR_REVEAL_PAD);
+        if (nearTaskbar && !nearTaskbarPrev) {
+            refindFailures = 0;
+            nextRefind = 0;
+        }
+        nearTaskbarPrev = nearTaskbar;
+
+        if (!pBtn && nearTaskbar && now >= nextRefind) {
+            bool didLog = false;
+            pBtn = FindOverflowButton(pAuto, s, !loggedCandidates, &didLog);
+            loggedCandidates = pBtn ? false : (loggedCandidates || didLog);
+            nextRectRefresh = 0;        // force a fresh rectangle below
+            taskbarPid = 0;
+            GetWindowThreadProcessId(hTaskbar, &taskbarPid);
+            if (pBtn) {
+                refindFailures = 0;
             } else {
-                nextRefind = now + REFIND_IDLE_MS;
+                ULONGLONG delay = REFIND_NEAR_MS << (refindFailures < 4 ? refindFailures : 4);
+                if (delay > REFIND_MAX_MS) delay = REFIND_MAX_MS;
+                if (refindFailures < 100) refindFailures++;
+                nextRefind = now + delay;
             }
         }
 
         if (pBtn) {
             // Expensive and RARE: query the button rectangle through UIA only
             // periodically, not every tick. The chevron rarely moves.
-            if (now >= nextRectRefresh) {
+            // Only while the cursor is at the taskbar: elsewhere the refreshed
+            // rectangle cannot change any decision, so paying two cross-process
+            // calls a second forever would be pure waste.
+            if (nearTaskbar && now >= nextRectRefresh) {
                 // An element that is alive but not currently rendered (the
                 // taskbar auto-hid, or the last hidden icon was removed) returns
                 // S_OK with an empty rectangle rather than an error. Keeping it
@@ -834,9 +877,10 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             }
 
             // Suppress the chevron's tooltip for as long as the cursor is on it:
-            // the "Hide" tooltip covers the bottom row of icons once the flyout
-            // is open, and the "Show hidden icons" one can appear before the
-            // flyout does, which is most noticeable when a hover delay is set.
+            // Suppress the chevron's tooltip while the cursor is on it, both
+            // the "Hide" tooltip covering the bottom row of icons once the
+            // flyout is open, and the "Show hidden icons" one that can appear
+            // before the flyout does.
             if (s.hideTooltip && overBtn) {
                 HideChevronTooltip(s, cachedRect, flyoutHwnd, taskbarPid);
             }
@@ -865,21 +909,11 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             // Suspend auto-collapse until the flyout closes on its own —
             // collapsing via Invoke would steal focus and dismiss the popup
             // the user just opened.
-            // The state bit alone misses a click that starts and ends between
-            // two ticks, which at a large polling interval is most clicks. The
-            // low bit reports a press since the previous call, so it catches
-            // those regardless of the interval.
-            SHORT kl = GetAsyncKeyState(VK_LBUTTON);
-            SHORT kr = GetAsyncKeyState(VK_RBUTTON);
-            SHORT km = GetAsyncKeyState(VK_MBUTTON);
-            bool anyBtnDown = ((kl | kr | km) & 0x8000) != 0;
-            bool pressedSinceTick = ((kl | kr | km) & 0x0001) != 0;
             if ((pressedSinceTick || (anyBtnDown && !anyBtnDownPrev)) &&
                 flyoutVisible && PtOverWindow(flyoutHwnd, pt)) {
                 clickedInFlyout = true;
                 Wh_Log(L"Click inside flyout: auto-collapse suspended");
             }
-            anyBtnDownPrev = anyBtnDown;
             if (!flyoutVisible && !cooling) {
                 clickedInFlyout = false;
             }
@@ -907,6 +941,8 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             }
         }
 
+        anyBtnDownPrev = anyBtnDown;
+
         // Interruptible sleep: WhTool_ModUninit signals g_stopEvent so the
         // thread wakes immediately regardless of the polling interval.
         WaitForSingleObject(g_stopEvent, s.pollInterval);
@@ -931,6 +967,10 @@ static void LoadSettings() {
     s.hideTooltip = Wh_GetIntSetting(L"hideTooltip") != 0;
     s.suppressInFullscreen = Wh_GetIntSetting(L"suppressInFullscreen") != 0;
     s.positionalFallback = Wh_GetIntSetting(L"positionalFallback") != 0;
+    if (s.pad < 0) s.pad = 0;
+    if (s.pad > 64) s.pad = 64;     // a large pad turns much of the screen into
+                                    // a hover hotspot; a negative one shrinks
+                                    // the hit area below the button itself
     if (s.pollInterval < 10) s.pollInterval = 10;
     if (s.hoverDelay < 0) s.hoverDelay = 0;
     if (s.grace < 0) s.grace = 0;


### PR DESCRIPTION
This updates the already-published **Tray hover expand** mod to 1.7.0.

The main change is how the chevron is identified. Until now it was matched by its localized name, with a positional guess as a fallback, so users whose display language was not in the keyword list fell through to that guess, which can select a different tray button and invoke it. It is now identified by its class name together with its AutomationId, which is the same in every display language, and when it cannot be identified the mod does nothing at all instead of guessing.

The rest of the changes come from user reports about auto-collapse, the chevron tooltip and tray icon context menus.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

- Identify the chevron by its class name plus AutomationId, independent of the  display language, and accept it only when exactly one element matches
- Restrict detection to tray elements, so no taskbar button can be matched by a keyword and invoked
- Do nothing instead of guessing the chevron by position when it cannot be identified; the guess is now an opt-in setting, off by default
- Cover the most common Windows display languages in the name fallback
- Add a "Hover delay" setting, so the flyout does not open when the cursor only brushes past the chevron
- Keep tray icon context menus usable: detect clicks that fall between polling ticks, and never collapse while a context menu is open
- Suppress the chevron tooltip whenever the cursor is on it, covering both "Show hidden icons" and "Hide", and with the taskbar on either edge
- Hide only tooltips owned by the taskbar process
- Do not treat an unrendered chevron as a hover target, which could turn the corner of the screen into a hotspot and make the flyout cycle
- Drive re-finding from the cursor instead of a fixed timer, with backoff on repeated failures, so an auto-hiding taskbar works immediately on reveal and a taskbar with no hidden icons costs almost nothing
- Scope the fullscreen check to the monitor the chevron is on
- Set per-monitor-v2 DPI awareness on the worker thread
- Document that the mod is Windows 11 only, and how to restore the keyword defaults

Fixes #5257
Fixes #4684
Fixes #4732
Fixes #4747
Fixes #4524

Note on #4524: two of its three points are fixed here, along with the context menu problem raised in a follow-up comment. The remaining one, the flyout occasionally taking a second to disappear, I was unable to reproduce; the reporter has been asked to say so if it persists.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [x] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
