### PR TITLE
Primary taskbar on secondary monitor v1.2.1

### DIFF
--- a/mods/taskbar-primary-on-secondary-monitor.wh.cpp
+++ b/mods/taskbar-primary-on-secondary-monitor.wh.cpp
@@ -2,13 +2,14 @@
 // @id              taskbar-primary-on-secondary-monitor
 // @name            Primary taskbar on secondary monitor
 // @description     Move the primary taskbar, including the tray icons, notifications, action center, etc. to another monitor
-// @version         1.2
+// @version         1.2.1
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
 // @homepage        https://m417z.com/
 // @include         explorer.exe
 // @include         ShellHost.exe
+// @include         StartMenuExperienceHost.exe
 // @architecture    x86-64
 // @compilerOptions -loleaut32 -lruntimeobject -lversion -lwtsapi32
 // ==/WindhawkMod==
@@ -140,6 +141,8 @@ struct {
 enum class Target {
     Explorer,
     ShellHost,  // Win11 24H2.
+    // Only for the start menu alignment, see MonitorFromWindow_Hook.
+    StartMenuExperienceHost,
 };
 
 Target g_target;
@@ -168,6 +171,21 @@ volatile HMONITOR g_overrideMonitor SHARED_SECTION = nullptr;
 DWORD g_lastPressTime;
 HMONITOR g_lastPressMonitor;
 std::atomic<bool> g_lastIsSessionLocked;
+
+// Each target only hooks the functions it needs, while some of the code calling
+// the originals runs in all of them, so they start out as the unhooked
+// functions and are replaced by the trampolines of the hooks that are set.
+using MonitorFromPoint_t = decltype(&MonitorFromPoint);
+MonitorFromPoint_t MonitorFromPoint_Original = MonitorFromPoint;
+
+using MonitorFromRect_t = decltype(&MonitorFromRect);
+MonitorFromRect_t MonitorFromRect_Original = MonitorFromRect;
+
+using MonitorFromWindow_t = decltype(&MonitorFromWindow);
+MonitorFromWindow_t MonitorFromWindow_Original = MonitorFromWindow;
+
+using EnumDisplayDevicesW_t = decltype(&EnumDisplayDevicesW);
+EnumDisplayDevicesW_t EnumDisplayDevicesW_Original = EnumDisplayDevicesW;
 
 HWND FindCurrentProcessTaskbarWnd() {
     HWND hTaskbarWnd = nullptr;
@@ -214,9 +232,6 @@ HMONITOR GetMonitorById(int monitorId) {
 
     return monitorResult;
 }
-
-using EnumDisplayDevicesW_t = decltype(&EnumDisplayDevicesW);
-EnumDisplayDevicesW_t EnumDisplayDevicesW_Original;
 
 HMONITOR GetMonitorByInterfaceNameSubstr(PCWSTR interfaceNameSubstr) {
     HMONITOR monitorResult = nullptr;
@@ -291,10 +306,6 @@ struct GetTargetMonitorParams {
 };
 
 HMONITOR GetTargetMonitor(GetTargetMonitorParams params = {}) {
-    if (g_unloading) {
-        return nullptr;
-    }
-
     bool sessionLocked = IsSessionLocked();
 
     bool sessionLockStateChanged =
@@ -331,7 +342,29 @@ HMONITOR GetTargetMonitor(GetTargetMonitorParams params = {}) {
         }
     }
 
+    if (g_unloading) {
+        // Note: Returning nullptr doesn't restore the taskbar to the primary
+        // monitor on unload.
+        return MonitorFromPoint_Original({0, 0}, MONITOR_DEFAULTTONEAREST);
+    }
+
     HMONITOR monitor = g_overrideMonitor;
+    if (monitor) {
+        // The override monitor handle becomes invalid when the display
+        // configuration changes, e.g. when a remote desktop session adds or
+        // removes a virtual display. Since it takes priority over the
+        // configured monitor and is never revalidated, a stale handle would
+        // keep winning and the primary taskbar would end up stuck to a monitor
+        // that no longer exists. Drop it and fall back to the settings.
+        MONITORINFO monitorInfo = {};
+        monitorInfo.cbSize = sizeof(monitorInfo);
+        if (!GetMonitorInfo(monitor, &monitorInfo)) {
+            Wh_Log(L"Override monitor is stale, falling back to settings");
+            g_overrideMonitor = nullptr;
+            monitor = nullptr;
+        }
+    }
+
     if (!monitor) {
         if (*g_settings.monitorInterfaceName.get()) {
             monitor = GetMonitorByInterfaceNameSubstr(
@@ -344,8 +377,6 @@ HMONITOR GetTargetMonitor(GetTargetMonitorParams params = {}) {
     return monitor;
 }
 
-using MonitorFromPoint_t = decltype(&MonitorFromPoint);
-MonitorFromPoint_t MonitorFromPoint_Original;
 HMONITOR WINAPI MonitorFromPoint_Hook(POINT pt, DWORD dwFlags) {
     auto original = [=] { return MonitorFromPoint_Original(pt, dwFlags); };
 
@@ -365,8 +396,6 @@ HMONITOR WINAPI MonitorFromPoint_Hook(POINT pt, DWORD dwFlags) {
     return monitor;
 }
 
-using MonitorFromRect_t = decltype(&MonitorFromRect);
-MonitorFromRect_t MonitorFromRect_Original;
 HMONITOR WINAPI MonitorFromRect_Hook(LPCRECT lprc, DWORD dwFlags) {
     auto original = [=] { return MonitorFromRect_Original(lprc, dwFlags); };
 
@@ -379,6 +408,54 @@ HMONITOR WINAPI MonitorFromRect_Hook(LPCRECT lprc, DWORD dwFlags) {
 
     HMONITOR monitor = GetTargetMonitor({
         .retAddress = __builtin_return_address(0),
+    });
+    if (!monitor) {
+        return original();
+    }
+
+    return monitor;
+}
+
+// Returns whether the address belongs to the start menu UI, which asks for the
+// monitor to read the taskbar alignment for. StartMenu.dll is the redesigned
+// start menu, StartDocked.dll the older one.
+bool IsStartMenuUIAddress(void* address) {
+    HMODULE module;
+    if (!address ||
+        !GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                               GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                           (PCWSTR)address, &module)) {
+        return false;
+    }
+
+    return module == GetModuleHandle(L"StartMenu.dll") ||
+           module == GetModuleHandle(L"StartDocked.dll");
+}
+
+// The start menu reads the taskbar alignment from
+// WindowsUdk.UI.Shell.TaskbarLayout for the monitor its core window is on,
+// resolved with MONITOR_DEFAULTTOPRIMARY, and keeps its centered default if the
+// layout has no alignment for that monitor. On startup it reads it while the
+// window is still on the real primary monitor, which has no taskbar once the
+// primary taskbar is moved away, and it isn't read again when the window moves
+// to the taskbar's monitor. Point it at the taskbar's monitor instead, which is
+// the one whose alignment the start menu follows.
+HMONITOR WINAPI MonitorFromWindow_Hook(HWND hWnd, DWORD dwFlags) {
+    auto original = [=] { return MonitorFromWindow_Original(hWnd, dwFlags); };
+
+    if (dwFlags != MONITOR_DEFAULTTOPRIMARY) {
+        return original();
+    }
+
+    void* retAddress = __builtin_return_address(0);
+    if (!IsStartMenuUIAddress(retAddress)) {
+        return original();
+    }
+
+    Wh_Log(L">");
+
+    HMONITOR monitor = GetTargetMonitor({
+        .retAddress = retAddress,
     });
     if (!monitor) {
         return original();
@@ -877,16 +954,20 @@ BOOL Wh_ModInit() {
         case 0:
         case ARRAYSIZE(moduleFilePath):
             Wh_Log(L"GetModuleFileName failed");
-            break;
+            return FALSE;
 
         default:
             if (PCWSTR moduleFileName = wcsrchr(moduleFilePath, L'\\')) {
                 moduleFileName++;
                 if (_wcsicmp(moduleFileName, L"ShellHost.exe") == 0) {
                     g_target = Target::ShellHost;
+                } else if (_wcsicmp(moduleFileName,
+                                    L"StartMenuExperienceHost.exe") == 0) {
+                    g_target = Target::StartMenuExperienceHost;
                 }
             } else {
                 Wh_Log(L"GetModuleFileName returned an unsupported path");
+                return FALSE;
             }
             break;
     }
@@ -933,19 +1014,25 @@ BOOL Wh_ModInit() {
         WindhawkUtils::SetFunctionHook(pKernelBaseLoadLibraryExW,
                                        LoadLibraryExW_Hook,
                                        &LoadLibraryExW_Original);
+
+        HookHardwareConfirmatorSymbols();
     }
 
-    HookHardwareConfirmatorSymbols();
+    if (g_target == Target::StartMenuExperienceHost) {
+        WindhawkUtils::SetFunctionHook(MonitorFromWindow,
+                                       MonitorFromWindow_Hook,
+                                       &MonitorFromWindow_Original);
+    } else {
+        WindhawkUtils::SetFunctionHook(MonitorFromPoint, MonitorFromPoint_Hook,
+                                       &MonitorFromPoint_Original);
 
-    WindhawkUtils::SetFunctionHook(MonitorFromPoint, MonitorFromPoint_Hook,
-                                   &MonitorFromPoint_Original);
+        WindhawkUtils::SetFunctionHook(MonitorFromRect, MonitorFromRect_Hook,
+                                       &MonitorFromRect_Original);
 
-    WindhawkUtils::SetFunctionHook(MonitorFromRect, MonitorFromRect_Hook,
-                                   &MonitorFromRect_Original);
-
-    WindhawkUtils::SetFunctionHook(EnumDisplayDevicesW,
-                                   EnumDisplayDevicesW_Hook,
-                                   &EnumDisplayDevicesW_Original);
+        WindhawkUtils::SetFunctionHook(EnumDisplayDevicesW,
+                                       EnumDisplayDevicesW_Hook,
+                                       &EnumDisplayDevicesW_Original);
+    }
 
     g_initialized = true;
 


### PR DESCRIPTION
* Fixed taskbar alignment not affecting the Start menu in some cases when the taskbar is only shown on the primary monitor.
* Fixed invisible taskbar if after switching the primary taskbar with a double/middle click that taskbar is gone, e.g. if the monitor is detached.
* Fixed the taskbar remaining on the secondary monitor when the mod is disabled.