### PR TITLE
Add Num Lock Lockdown

### DIFF
--- a/mods/numlock-lockdown.wh.cpp
+++ b/mods/numlock-lockdown.wh.cpp
@@ -2,7 +2,7 @@
 // @id              numlock-lockdown
 // @name            Num Lock Lockdown
 // @description     Keeps Num Lock permanently ON, with a modifier key for temporary override
-// @version         1.1.1
+// @version         1.1.2
 // @author          tonythethompson
 // @github          https://github.com/tonythethompson
 // @include         windhawk.exe
@@ -26,7 +26,7 @@ covers the few cases the hook cannot see.
 | Normal use | Num Lock stays ON. The Num Lock key does nothing (default). |
 | Hold Shift + press Num Lock | Normal toggle is allowed. |
 | Release Shift | Num Lock is forced back ON if it is off. |
-| Sleep/wake, RDP, or another program turns it off | Forced back ON on the next event, or on the safety check. |
+| Sleep/wake, RDP, or another program turns it off | Forced back ON on the next event, on unlock/resume/focus change, or on the safety check. |
 | Mod disabled | The Num Lock *key* behaves normally again. The LED is left ON (the last forced state), not restored to whatever it was before the mod ran. |
 
 Hold **Left Shift** or **Right Shift** to temporarily turn Num Lock off (for
@@ -50,7 +50,9 @@ keeps overhead low and avoids tying Num Lock to the shell process.
   when an elevated window is focused, the injected Num Lock pulse is
   dropped and neither the return value nor `GetLastError` reports it. Run
   Windhawk as administrator if you need the force-on to work while an
-  elevated app is in front. The safety check retries after focus changes.
+  elevated app is in front. When focus moves back to a normal window, a
+  foreground-change hook retries the pulse. The safety check is a slower
+  fallback for cases with no focus change.
 - The hook also cannot see some Remote Desktop / KVM paths. Session-unlock
   / resume handlers and the safety check cover those.
 - If the hook misses a modifier key-up (elevated window or secure desktop),
@@ -58,8 +60,11 @@ keeps overhead low and avoids tying Num Lock to the shell process.
   the worker does the same before skipping a force-on.
 - **Block** also swallows the ToggleKeys accessibility shortcut (hold Num
   Lock for 5 seconds). Use **Allow** if you need that shortcut.
-- Synthetic Num Lock presses this mod sends are tagged and ignored by the
-  hook, so the force-on path cannot fight itself.
+- Synthetic Num Lock presses this mod sends are tagged and ignored by
+  *this* hook, so the force-on path cannot fight itself. Other apps still
+  see those injected presses (the pulse has to reach the OS to move the
+  LED). A game bound to Num Lock can therefore see a synthetic press when
+  a force-on fires, even in **Block** mode.
 - In "allow" mode, holding Num Lock without the modifier can leave it off
   until you release the key. Auto-repeat is swallowed so the LED does not
   flicker; force-on runs on key-up.
@@ -94,8 +99,9 @@ keeps overhead low and avoids tying Num Lock to the shell process.
   $name: Safety check interval (seconds)
   $description: >-
     Optional fallback that re-checks Num Lock in case it was turned off by
-    sleep, RDP, or an elevated app the hook cannot see. 0 disables the timer.
-    10 seconds is a light default.
+    sleep, RDP, or an elevated app the hook cannot see. Focus change, unlock,
+    and resume already retry without this timer. 0 disables it. 10 seconds
+    is a light default.
 */
 // ==/WindhawkModSettings==
 
@@ -119,9 +125,6 @@ constexpr UINT WM_APP_UPDATE_TIMER = WM_APP + 2;
 constexpr UINT WM_APP_QUIT = WM_APP + 3;
 
 constexpr UINT_PTR kSafetyTimerId = 1;
-constexpr UINT_PTR kDeferredForceTimerId = 2;
-constexpr UINT kDeferredForceDelayMs = 50;
-constexpr int kDeferredForceMaxTries = 2;
 
 // dwExtraInfo stamped on every synthetic Num Lock we send, so the hook can
 // let our own keystrokes through without treating them as user input.
@@ -167,9 +170,6 @@ std::atomic<bool> g_swallowedNumLockDown{false};
 // taps during typing do not wake the worker.
 std::atomic<bool> g_overrideUsedThisHold{false};
 
-// Worker thread only. Counts deferred "toggle may not have landed" retries.
-int g_deferredForceTries = 0;
-
 // ---------------------------------------------------------------------------
 // Worker thread / window / hook
 // ---------------------------------------------------------------------------
@@ -186,6 +186,7 @@ std::atomic<bool> g_hookQuit{false};
 HANDLE g_workerReadyEvent = nullptr;
 HANDLE g_hookReadyEvent = nullptr;
 HPOWERNOTIFY g_suspendResumeNotify = nullptr;
+HWINEVENTHOOK g_foregroundHook = nullptr;
 bool g_sessionNotifyRegistered = false;
 
 // ---------------------------------------------------------------------------
@@ -264,11 +265,11 @@ void LoadSettings() {
 bool IsOverrideVk(DWORD vk) {
     switch (CurrentModifier()) {
         case OverrideModifier::Shift:
-            return vk == VK_LSHIFT || vk == VK_RSHIFT || vk == VK_SHIFT;
+            return vk == VK_LSHIFT || vk == VK_RSHIFT;
         case OverrideModifier::Ctrl:
-            return vk == VK_LCONTROL || vk == VK_RCONTROL || vk == VK_CONTROL;
+            return vk == VK_LCONTROL || vk == VK_RCONTROL;
         case OverrideModifier::Alt:
-            return vk == VK_LMENU || vk == VK_RMENU || vk == VK_MENU;
+            return vk == VK_LMENU || vk == VK_RMENU;
         case OverrideModifier::Win:
             return vk == VK_LWIN || vk == VK_RWIN;
         case OverrideModifier::None:
@@ -290,13 +291,6 @@ void SetModifierDown(DWORD vk, bool down) {
         case VK_RMENU:
         case VK_RWIN:
             g_rightModDown.store(down, std::memory_order_relaxed);
-            break;
-        case VK_SHIFT:
-        case VK_CONTROL:
-        case VK_MENU:
-            // Generic VK_* (no L/R). Treat as the left key so a single
-            // flag still covers "modifier is held".
-            g_leftModDown.store(down, std::memory_order_relaxed);
             break;
         default:
             break;
@@ -388,30 +382,15 @@ void SendNumLockPulse() {
     }
 }
 
-enum class ForceResult {
-    Sent,
-    AlreadyOn,
-    OverrideHeld,
-};
-
 // Must run on the worker thread, never inside the LL hook.
-ForceResult ForceNumLockOn(bool logSafety) {
-    if (IsOverrideHeldVerified()) {
-        return ForceResult::OverrideHeld;
-    }
-    if (IsNumLockOn()) {
-        return ForceResult::AlreadyOn;
+void ForceNumLockOn(bool logSafety) {
+    if (IsOverrideHeldVerified() || IsNumLockOn()) {
+        return;
     }
     if (logSafety) {
         Wh_Log(L"Safety check: Num Lock was off, forcing ON");
     }
     SendNumLockPulse();
-    return ForceResult::Sent;
-}
-
-void ArmDeferredForceOn(HWND hwnd) {
-    g_deferredForceTries = 0;
-    SetTimer(hwnd, kDeferredForceTimerId, kDeferredForceDelayMs, nullptr);
 }
 
 void UninstallKeyboardHook() {
@@ -542,6 +521,10 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
         }
 
         if (IsOverrideHeld()) {
+            // Allow mode: Num Lock went down alone, then Shift was held
+            // before key-up. Honour the hold, and mark it used so Shift-up
+            // still forces ON.
+            g_overrideUsedThisHold.store(true, std::memory_order_relaxed);
             return Pass(nCode, wParam, lParam);
         }
 
@@ -580,26 +563,19 @@ void UnregisterPowerAndSession(HWND hwnd) {
         }
         g_suspendResumeNotify = nullptr;
     }
+
+    if (g_foregroundHook) {
+        UnhookWinEvent(g_foregroundHook);
+        g_foregroundHook = nullptr;
+    }
 }
 
 LRESULT CALLBACK WorkerWndProc(HWND hwnd, UINT msg, WPARAM wParam,
                                LPARAM lParam) {
     switch (msg) {
-        case WM_APP_FORCE_ON: {
-            const ForceResult result = ForceNumLockOn(false);
-            switch (result) {
-                case ForceResult::AlreadyOn:
-                    // Toggle may not have been applied yet. Look again shortly.
-                    // Do not retry after Sent: a second pulse would toggle OFF.
-                    // Do not retry after OverrideHeld: the hold is real.
-                    ArmDeferredForceOn(hwnd);
-                    break;
-                case ForceResult::Sent:
-                case ForceResult::OverrideHeld:
-                    break;
-            }
+        case WM_APP_FORCE_ON:
+            ForceNumLockOn(false);
             return 0;
-        }
 
         case WM_APP_UPDATE_TIMER:
             SeedModifierState();
@@ -614,14 +590,6 @@ LRESULT CALLBACK WorkerWndProc(HWND hwnd, UINT msg, WPARAM wParam,
         case WM_TIMER:
             if (wParam == kSafetyTimerId) {
                 ForceNumLockOn(true);
-            } else if (wParam == kDeferredForceTimerId) {
-                KillTimer(hwnd, kDeferredForceTimerId);
-                if (ForceNumLockOn(false) == ForceResult::AlreadyOn &&
-                    g_deferredForceTries < kDeferredForceMaxTries) {
-                    ++g_deferredForceTries;
-                    SetTimer(hwnd, kDeferredForceTimerId, kDeferredForceDelayMs,
-                             nullptr);
-                }
             }
             return 0;
 
@@ -662,6 +630,22 @@ HMODULE GetCurrentModuleHandle() {
                        reinterpret_cast<LPCWSTR>(&LowLevelKeyboardProc),
                        &module);
     return module;
+}
+
+void CALLBACK ForegroundEventProc(HWINEVENTHOOK, DWORD, HWND, LONG, LONG, DWORD,
+                                  DWORD) {
+    RequestForceOn();
+}
+
+void RegisterForegroundHook() {
+    g_foregroundHook = SetWinEventHook(
+        EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND, nullptr,
+        ForegroundEventProc, 0, 0,
+        WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS);
+    if (!g_foregroundHook) {
+        Wh_Log(L"SetWinEventHook(EVENT_SYSTEM_FOREGROUND) failed: %lu",
+               GetLastError());
+    }
 }
 
 void RegisterPowerAndSession(HWND hwnd) {
@@ -729,6 +713,7 @@ DWORD WINAPI WorkerThreadProc(LPVOID) {
     }
 
     RegisterPowerAndSession(hwnd);
+    RegisterForegroundHook();
 
     SeedModifierState();
     ForceNumLockOn(false);
@@ -746,7 +731,6 @@ DWORD WINAPI WorkerThreadProc(LPVOID) {
     hwnd = g_workerHwnd.exchange(nullptr, std::memory_order_acq_rel);
     if (hwnd) {
         KillTimer(hwnd, kSafetyTimerId);
-        KillTimer(hwnd, kDeferredForceTimerId);
         UnregisterPowerAndSession(hwnd);
         DestroyWindow(hwnd);
     }
@@ -789,6 +773,13 @@ DWORD WINAPI HookThreadProc(LPVOID) {
     PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
 
     TryInstallKeyboardHook();
+    for (int attempt = 1; attempt < 3 &&
+                          !g_keyboardHook.load(std::memory_order_acquire) &&
+                          !g_hookQuit.load(std::memory_order_relaxed);
+         ++attempt) {
+        Sleep(100);
+        TryInstallKeyboardHook();
+    }
 
     if (g_hookReadyEvent) {
         SetEvent(g_hookReadyEvent);
@@ -832,6 +823,8 @@ BOOL WhTool_ModInit() {
 
     if (WaitForSingleObject(g_workerReadyEvent, 5000) != WAIT_OBJECT_0) {
         Wh_Log(L"Worker thread did not become ready in time");
+        WhTool_ModUninit();
+        return FALSE;
     }
 
     g_hookThread =
@@ -844,6 +837,8 @@ BOOL WhTool_ModInit() {
 
     if (WaitForSingleObject(g_hookReadyEvent, 5000) != WAIT_OBJECT_0) {
         Wh_Log(L"Hook thread did not become ready in time");
+        WhTool_ModUninit();
+        return FALSE;
     }
 
     if (!g_workerHwnd.load(std::memory_order_acquire)) {

--- a/mods/numlock-lockdown.wh.cpp
+++ b/mods/numlock-lockdown.wh.cpp
@@ -2,7 +2,7 @@
 // @id              numlock-lockdown
 // @name            Num Lock Lockdown
 // @description     Keeps Num Lock permanently ON, with a modifier key for temporary override
-// @version         1.1.6
+// @version         1.1.7
 // @author          tonythethompson
 // @github          https://github.com/tonythethompson
 // @include         windhawk.exe
@@ -61,7 +61,9 @@ keeps overhead low and avoids tying Num Lock to the shell process.
   the next Num Lock event re-reads the real modifier state from the OS, and
   the worker does the same before skipping a force-on.
 - **Block** also swallows the ToggleKeys accessibility shortcut (hold Num
-  Lock for 5 seconds). Use **Allow** if you need that shortcut.
+  Lock for 5 seconds) and the MouseKeys shortcut (Left Alt + Left Shift +
+  Num Lock) whenever your override modifier is not Shift or Alt. Use
+  **Allow** if you need those shortcuts.
 - Synthetic Num Lock presses this mod sends are tagged and ignored by
   *this* hook, so the force-on path cannot fight itself. Other apps still
   see those injected presses (the pulse has to reach the OS to move the
@@ -139,6 +141,9 @@ constexpr UINT_PTR kSafetyTimerId = 1;
 // Worker-thread only. Caps evidence-driven rehooks so an elevated window
 // that keeps Num Lock off (UIPI) does not swap the hook every safety tick.
 constexpr ULONGLONG kRehookMinIntervalMs = 60 * 1000;
+// SendInput is asynchronous; wait for the injected toggle to land before
+// sending another pulse or Num Lock can flip back OFF.
+constexpr ULONGLONG kPulseDebounceMs = 300;
 
 // dwExtraInfo stamped on every synthetic Num Lock we send, so the hook can
 // let our own keystrokes through without treating them as user input.
@@ -163,7 +168,8 @@ std::atomic<bool> g_blockNumLockKey{true};
 std::atomic<int> g_safetyCheckSeconds{10};
 
 // ---------------------------------------------------------------------------
-// Live input state, updated only from the hook (cheap atomics)
+// Live input state (atomics). The hook updates these on key events;
+// the worker also re-seeds from GetAsyncKeyState when verifying a hold.
 // ---------------------------------------------------------------------------
 
 std::atomic<bool> g_leftModDown{false};
@@ -204,6 +210,8 @@ HWINEVENTHOOK g_foregroundHook = nullptr;
 bool g_sessionNotifyRegistered = false;
 // Worker thread only. Last time we posted WM_APP_REHOOK.
 ULONGLONG g_lastRehookMs = 0;
+// Worker thread only. Last time we sent a Num Lock pulse.
+ULONGLONG g_lastPulseMs = 0;
 
 // ---------------------------------------------------------------------------
 // Settings
@@ -409,11 +417,15 @@ void UninstallKeyboardHook() {
 
 // Worker thread only. Unconditional: unlock/resume.
 void RequestRehook() {
-    g_lastRehookMs = GetTickCount64();
     DWORD threadId = g_hookThreadId.load(std::memory_order_acquire);
-    if (threadId) {
-        PostThreadMessageW(threadId, WM_APP_REHOOK, 0, 0);
+    if (!threadId) {
+        return;
     }
+    if (!PostThreadMessageW(threadId, WM_APP_REHOOK, 0, 0)) {
+        Wh_Log(L"PostThreadMessageW(WM_APP_REHOOK) failed: %lu", GetLastError());
+        return;
+    }
+    g_lastRehookMs = GetTickCount64();
 }
 
 // Worker thread only. Num Lock found off is the signal the hook may have
@@ -427,14 +439,23 @@ void RequestEvidenceRehook() {
 }
 
 // Must run on the worker thread, never inside the LL hook.
-void ForceNumLockOn(bool logSafety) {
+void ForceNumLockOn(bool fromSafetyCheck) {
     if (IsOverrideHeldVerified() || IsNumLockOn()) {
         return;
     }
-    if (logSafety) {
-        Wh_Log(L"Safety check: Num Lock was off, forcing ON");
+
+    const ULONGLONG now = GetTickCount64();
+    if (g_lastPulseMs != 0 && now - g_lastPulseMs < kPulseDebounceMs) {
+        return;
     }
-    RequestEvidenceRehook();
+
+    if (fromSafetyCheck) {
+        Wh_Log(L"Safety check: Num Lock was off, forcing ON");
+        // Nothing reported this one, so the hook may have been dropped.
+        RequestEvidenceRehook();
+    }
+
+    g_lastPulseMs = now;
     SendNumLockPulse();
 }
 
@@ -499,10 +520,12 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
 
         // Only wake the worker after an override was actually used. Ordinary
         // Shift taps during typing stay on this thread.
-        if (isUp && !IsOverrideHeld() &&
-            !g_allowedNumLockDown.load(std::memory_order_relaxed) &&
-            g_overrideUsedThisHold.exchange(false, std::memory_order_relaxed)) {
-            RequestForceOn();
+        if (isUp && !IsOverrideHeld()) {
+            const bool used =
+                g_overrideUsedThisHold.exchange(false, std::memory_order_relaxed);
+            if (used && !g_allowedNumLockDown.load(std::memory_order_relaxed)) {
+                RequestForceOn();
+            }
         }
 
         return Pass(nCode, wParam, lParam);

--- a/mods/numlock-lockdown.wh.cpp
+++ b/mods/numlock-lockdown.wh.cpp
@@ -1,0 +1,1115 @@
+// ==WindhawkMod==
+// @id              numlock-lockdown
+// @name            Num Lock Lockdown
+// @description     Keeps Num Lock permanently ON, with a modifier key for temporary override
+// @version         1.0.8
+// @author          Tony Thompson
+// @github          https://github.com/tonythethompson
+// @include         windhawk.exe
+// @compilerOptions -luser32 -lshell32 -lwtsapi32
+// @license         MIT
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Num Lock Lockdown
+
+Keeps Num Lock ON with almost no background work. A low-level keyboard hook
+watches the Num Lock key and the override modifier. There is no continuous
+polling. An optional slow safety timer (off, or every few seconds) covers the
+few cases the hook cannot see.
+
+## Behavior
+
+| Situation | Result |
+| --- | --- |
+| Normal use | Num Lock stays ON. The Num Lock key does nothing (default). |
+| Hold Shift + press Num Lock | Normal toggle is allowed. |
+| Release Shift | Num Lock is forced back ON if it is off. |
+| Sleep/wake, RDP, or another program turns it off | Forced back ON on the next event, or on the safety check. |
+| Mod disabled | Normal Windows Num Lock behavior is restored. |
+
+Hold **Left Shift** or **Right Shift** to temporarily turn Num Lock off (for
+example when you need the numpad as arrow keys). As soon as you release Shift,
+Num Lock is turned back on.
+
+## Why a tool mod?
+
+The mod is loaded into a dedicated `windhawk.exe` process (`@include
+windhawk.exe`). It does not inject into Explorer or every running app. That
+keeps overhead low and avoids tying Num Lock to the shell process.
+
+## Notes
+
+- The keyboard hook cannot see keystrokes sent to a higher-integrity
+  (elevated) window because of UIPI. If Windhawk is not running as
+  administrator, enable the safety check so an elevated app that turns Num
+  Lock off is corrected within a few seconds.
+- The hook also cannot see some Remote Desktop / KVM paths. The safety check
+  and session-unlock / resume handlers cover those.
+- Synthetic Num Lock presses this mod sends are tagged and ignored by the
+  hook, so the force-on path cannot fight itself.
+- In "allow" mode, holding Num Lock without the modifier can leave it off
+  until you release the key. Auto-repeat is swallowed so the LED does not
+  flicker; force-on runs on key-up.
+- The Win key is never blocked. Only Num Lock is filtered. If you hold Win and
+  press numpad 1/3/5/9, Windows may type those digits because Win+Numpad1 is
+  not the same shortcut as Win+1 on the number row. That is OS behavior.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- overrideModifier: shift
+  $name: Temporary override modifier
+  $description: >-
+    Hold this key to toggle Num Lock normally. When you release it, Num Lock
+    is forced back ON. Left and right keys both count.
+  $options:
+    - shift: Shift (left or right)
+    - ctrl: Ctrl (left or right)
+    - alt: Alt (left or right)
+    - win: Win (left or right)
+    - none: None (always force ON, no override)
+- numLockKeyMode: block
+  $name: Num Lock key without modifier
+  $description: >-
+    What happens when Num Lock is pressed without the override modifier.
+  $options:
+    - block: Block the key (does nothing)
+    - allow: Allow the press, then force Num Lock back ON on key-up. Holding the key can leave it off until release.
+- safetyCheckSeconds: 10
+  $name: Safety check interval (seconds)
+  $description: >-
+    Optional fallback that re-checks Num Lock in case it was turned off by
+    sleep, RDP, or an elevated app the hook cannot see. 0 disables the timer.
+    10 seconds is a light default.
+*/
+// ==/WindhawkModSettings==
+
+#include <atomic>
+#include <wchar.h>
+
+#include <windows.h>
+#include <wtsapi32.h>
+
+#include <windhawk_api.h>
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+// Posted from the hook (and from settings/power/session handlers) so SendInput
+// never runs inside the low-level hook callback. An LL hook blocks all
+// keyboard input until it returns.
+constexpr UINT WM_APP_FORCE_ON = WM_APP + 1;
+constexpr UINT WM_APP_UPDATE_TIMER = WM_APP + 2;
+constexpr UINT WM_APP_QUIT = WM_APP + 3;
+
+constexpr UINT_PTR kSafetyTimerId = 1;
+constexpr UINT_PTR kDeferredForceTimerId = 2;
+
+// dwExtraInfo stamped on every synthetic Num Lock we send, so the hook can
+// let our own keystrokes through without treating them as user input.
+constexpr ULONG_PTR kInjectedNumLockExtraInfo = 0x4E4C4F4B;  // 'NLOK'
+
+constexpr wchar_t kWorkerClass[] = L"Windhawk.ForceNumLock.Worker";
+
+// ---------------------------------------------------------------------------
+// Settings (written on the Windhawk / worker thread, read from the hook)
+// ---------------------------------------------------------------------------
+
+enum class OverrideModifier : int {
+    None = 0,
+    Shift = 1,
+    Ctrl = 2,
+    Alt = 3,
+    Win = 4,
+};
+
+std::atomic<int> g_overrideModifier{static_cast<int>(OverrideModifier::Shift)};
+std::atomic<bool> g_blockNumLockKey{true};
+std::atomic<int> g_safetyCheckSeconds{10};
+
+// ---------------------------------------------------------------------------
+// Live input state, updated only from the hook (cheap atomics)
+// ---------------------------------------------------------------------------
+
+std::atomic<bool> g_leftModDown{false};
+std::atomic<bool> g_rightModDown{false};
+
+// True while a physical Num Lock key is down that we allowed through because
+// the override modifier was held at key-down. The matching key-up must also
+// be allowed, even if Shift was released in between, so the key cannot stick
+// and so a pending toggle cannot race our force-on pulse.
+std::atomic<bool> g_allowedNumLockDown{false};
+
+// True after we swallowed a Num Lock key-down (block mode). Matching key-up
+// and auto-repeat downs are swallowed too, so the key cannot stick.
+std::atomic<bool> g_swallowedNumLockDown{false};
+
+// ---------------------------------------------------------------------------
+// Worker thread / window / hook
+// ---------------------------------------------------------------------------
+
+// Hook thread publishes these; other threads only load. Uninit may unhook
+// via exchange so a wedged hook thread cannot leave the hook installed.
+std::atomic<HHOOK> g_keyboardHook{nullptr};
+std::atomic<HMODULE> g_hookModule{nullptr};
+std::atomic<HWND> g_workerHwnd{nullptr};
+HANDLE g_workerThread = nullptr;
+HANDLE g_hookThread = nullptr;
+std::atomic<DWORD> g_workerThreadId{0};
+std::atomic<DWORD> g_hookThreadId{0};
+std::atomic<bool> g_hookInstalled{false};
+std::atomic<bool> g_hookQuit{false};
+HANDLE g_workerReadyEvent = nullptr;
+HANDLE g_hookReadyEvent = nullptr;
+HANDLE g_hookStopEvent = nullptr;
+HPOWERNOTIFY g_suspendResumeNotify = nullptr;
+bool g_sessionNotifyRegistered = false;
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+OverrideModifier CurrentModifier() {
+    return static_cast<OverrideModifier>(
+        g_overrideModifier.load(std::memory_order_relaxed));
+}
+
+bool IsOverrideHeld() {
+    return g_leftModDown.load(std::memory_order_relaxed) ||
+           g_rightModDown.load(std::memory_order_relaxed);
+}
+
+bool IsNumLockOn() {
+    return (GetKeyState(VK_NUMLOCK) & 1) != 0;
+}
+
+bool ParseModifier(PCWSTR value, OverrideModifier* out) {
+    if (!value || !out) {
+        return false;
+    }
+    if (_wcsicmp(value, L"none") == 0) {
+        *out = OverrideModifier::None;
+        return true;
+    }
+    if (_wcsicmp(value, L"ctrl") == 0) {
+        *out = OverrideModifier::Ctrl;
+        return true;
+    }
+    if (_wcsicmp(value, L"alt") == 0) {
+        *out = OverrideModifier::Alt;
+        return true;
+    }
+    if (_wcsicmp(value, L"win") == 0) {
+        *out = OverrideModifier::Win;
+        return true;
+    }
+    if (_wcsicmp(value, L"shift") == 0) {
+        *out = OverrideModifier::Shift;
+        return true;
+    }
+    return false;
+}
+
+void LoadSettings() {
+    OverrideModifier modifier = OverrideModifier::Shift;
+    PCWSTR modifierSetting = Wh_GetStringSetting(L"overrideModifier");
+    if (modifierSetting) {
+        OverrideModifier parsed = OverrideModifier::Shift;
+        if (ParseModifier(modifierSetting, &parsed)) {
+            modifier = parsed;
+        }
+        Wh_FreeStringSetting(modifierSetting);
+    }
+    g_overrideModifier.store(static_cast<int>(modifier),
+                             std::memory_order_relaxed);
+
+    bool blockKey = true;
+    PCWSTR keyMode = Wh_GetStringSetting(L"numLockKeyMode");
+    if (keyMode) {
+        if (_wcsicmp(keyMode, L"allow") == 0) {
+            blockKey = false;
+        }
+        Wh_FreeStringSetting(keyMode);
+    }
+    g_blockNumLockKey.store(blockKey, std::memory_order_relaxed);
+
+    int seconds = Wh_GetIntSetting(L"safetyCheckSeconds");
+    if (seconds < 0) {
+        seconds = 0;
+    } else if (seconds > 3600) {
+        seconds = 3600;
+    }
+    g_safetyCheckSeconds.store(seconds, std::memory_order_relaxed);
+}
+
+bool IsOverrideVk(DWORD vk) {
+    switch (CurrentModifier()) {
+        case OverrideModifier::Shift:
+            return vk == VK_LSHIFT || vk == VK_RSHIFT || vk == VK_SHIFT;
+        case OverrideModifier::Ctrl:
+            return vk == VK_LCONTROL || vk == VK_RCONTROL || vk == VK_CONTROL;
+        case OverrideModifier::Alt:
+            return vk == VK_LMENU || vk == VK_RMENU || vk == VK_MENU;
+        case OverrideModifier::Win:
+            return vk == VK_LWIN || vk == VK_RWIN;
+        case OverrideModifier::None:
+            return false;
+    }
+    return false;
+}
+
+void SetModifierDown(DWORD vk, bool down) {
+    switch (vk) {
+        case VK_LSHIFT:
+        case VK_LCONTROL:
+        case VK_LMENU:
+        case VK_LWIN:
+            g_leftModDown.store(down, std::memory_order_relaxed);
+            break;
+        case VK_RSHIFT:
+        case VK_RCONTROL:
+        case VK_RMENU:
+        case VK_RWIN:
+            g_rightModDown.store(down, std::memory_order_relaxed);
+            break;
+        case VK_SHIFT:
+        case VK_CONTROL:
+        case VK_MENU:
+            // Generic VK_* (no L/R). Treat as the left key so a single
+            // flag still covers "modifier is held".
+            g_leftModDown.store(down, std::memory_order_relaxed);
+            break;
+        default:
+            break;
+    }
+}
+
+void SeedModifierState() {
+    g_leftModDown.store(false, std::memory_order_relaxed);
+    g_rightModDown.store(false, std::memory_order_relaxed);
+
+    switch (CurrentModifier()) {
+        case OverrideModifier::Shift:
+            g_leftModDown.store(GetAsyncKeyState(VK_LSHIFT) < 0,
+                                std::memory_order_relaxed);
+            g_rightModDown.store(GetAsyncKeyState(VK_RSHIFT) < 0,
+                                 std::memory_order_relaxed);
+            break;
+        case OverrideModifier::Ctrl:
+            g_leftModDown.store(GetAsyncKeyState(VK_LCONTROL) < 0,
+                                std::memory_order_relaxed);
+            g_rightModDown.store(GetAsyncKeyState(VK_RCONTROL) < 0,
+                                 std::memory_order_relaxed);
+            break;
+        case OverrideModifier::Alt:
+            g_leftModDown.store(GetAsyncKeyState(VK_LMENU) < 0,
+                                std::memory_order_relaxed);
+            g_rightModDown.store(GetAsyncKeyState(VK_RMENU) < 0,
+                                 std::memory_order_relaxed);
+            break;
+        case OverrideModifier::Win:
+            g_leftModDown.store(GetAsyncKeyState(VK_LWIN) < 0,
+                                std::memory_order_relaxed);
+            g_rightModDown.store(GetAsyncKeyState(VK_RWIN) < 0,
+                                 std::memory_order_relaxed);
+            break;
+        case OverrideModifier::None:
+            break;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Force Num Lock ON (worker thread only)
+// ---------------------------------------------------------------------------
+
+void RequestForceOn() {
+    HWND hwnd = g_workerHwnd.load(std::memory_order_acquire);
+    if (hwnd) {
+        PostMessageW(hwnd, WM_APP_FORCE_ON, 0, 0);
+    }
+}
+
+// SendInput runs on the worker thread. The LL hook lives on a dedicated
+// hook thread that is sitting in GetMessage, so Windows can deliver the
+// callback there without this thread unhooking. No observation gap.
+void SendNumLockPulse() {
+    INPUT inputs[2] = {};
+
+    inputs[0].type = INPUT_KEYBOARD;
+    inputs[0].ki.wVk = VK_NUMLOCK;
+    inputs[0].ki.wScan = 0x45;
+    inputs[0].ki.dwFlags = KEYEVENTF_EXTENDEDKEY;
+    inputs[0].ki.dwExtraInfo = kInjectedNumLockExtraInfo;
+
+    inputs[1].type = INPUT_KEYBOARD;
+    inputs[1].ki.wVk = VK_NUMLOCK;
+    inputs[1].ki.wScan = 0x45;
+    inputs[1].ki.dwFlags = KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP;
+    inputs[1].ki.dwExtraInfo = kInjectedNumLockExtraInfo;
+
+    if (SendInput(2, inputs, sizeof(INPUT)) != 2) {
+        Wh_Log(L"SendInput(VK_NUMLOCK) failed: %lu", GetLastError());
+    }
+}
+
+enum class ForceReason {
+    Startup,
+    Event,
+    Timer,
+    Settings,
+};
+
+// Must run on the worker thread, never inside the LL hook.
+void ForceNumLockOn(ForceReason reason) {
+    if (IsOverrideHeld()) {
+        return;
+    }
+    if (IsNumLockOn()) {
+        return;
+    }
+    if (reason == ForceReason::Timer) {
+        Wh_Log(L"Safety check: Num Lock was off, forcing ON");
+    }
+    SendNumLockPulse();
+}
+
+void ArmDeferredForceOn(HWND hwnd) {
+    SetTimer(hwnd, kDeferredForceTimerId, 0, nullptr);
+}
+
+void UninstallKeyboardHook() {
+    HHOOK hook = g_keyboardHook.exchange(nullptr, std::memory_order_acq_rel);
+    if (hook) {
+        UnhookWindowsHookEx(hook);
+    }
+    g_hookInstalled.store(false, std::memory_order_release);
+}
+
+void UpdateSafetyTimer() {
+    HWND hwnd = g_workerHwnd.load(std::memory_order_acquire);
+    if (!hwnd) {
+        return;
+    }
+
+    KillTimer(hwnd, kSafetyTimerId);
+
+    int seconds = g_safetyCheckSeconds.load(std::memory_order_relaxed);
+    if (seconds <= 0) {
+        return;
+    }
+
+    const UINT intervalMs = static_cast<UINT>(seconds) * 1000;
+
+    // Prefer a coalescable timer so a 10s safety check can share a wakeup
+    // with other timers instead of forcing its own interrupt. 1000 ms
+    // tolerance is enough for a fallback check.
+    using SetCoalescableTimer_t = UINT_PTR(WINAPI*)(HWND, UINT_PTR, UINT,
+                                                    TIMERPROC, ULONG);
+    if (HMODULE user32 = GetModuleHandleW(L"user32.dll")) {
+        auto pSetCoalescableTimer =
+            reinterpret_cast<SetCoalescableTimer_t>(
+                GetProcAddress(user32, "SetCoalescableTimer"));
+        if (pSetCoalescableTimer) {
+            if (pSetCoalescableTimer(hwnd, kSafetyTimerId, intervalMs, nullptr,
+                                     1000)) {
+                return;
+            }
+        }
+    }
+
+    if (!SetTimer(hwnd, kSafetyTimerId, intervalMs, nullptr)) {
+        Wh_Log(L"SetTimer failed: %lu", GetLastError());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Low-level keyboard hook (keep this path tiny)
+// ---------------------------------------------------------------------------
+
+bool IsOwnInjectedNumLock(const KBDLLHOOKSTRUCT* info) {
+    return (info->flags & LLKHF_INJECTED) &&
+           info->dwExtraInfo == kInjectedNumLockExtraInfo;
+}
+
+// hhk is ignored on modern Windows. Passing null avoids reading g_keyboardHook
+// from the callback, including during unload.
+LRESULT Pass(int nCode, WPARAM wParam, LPARAM lParam) {
+    return CallNextHookEx(nullptr, nCode, wParam, lParam);
+}
+
+LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
+    if (nCode != HC_ACTION) {
+        return Pass(nCode, wParam, lParam);
+    }
+
+    const KBDLLHOOKSTRUCT* info =
+        reinterpret_cast<const KBDLLHOOKSTRUCT*>(lParam);
+    if (!info) {
+        return Pass(nCode, wParam, lParam);
+    }
+
+    const DWORD vk = info->vkCode;
+    const bool isDown = wParam == WM_KEYDOWN || wParam == WM_SYSKEYDOWN;
+    const bool isUp = wParam == WM_KEYUP || wParam == WM_SYSKEYUP;
+
+    // Our own force-on pulse must always reach the OS.
+    if (vk == VK_NUMLOCK && IsOwnInjectedNumLock(info)) {
+        return Pass(nCode, wParam, lParam);
+    }
+
+    // Track the override modifier first so a Shift-down that arrives in this
+    // same callback sequence is visible to a following Num Lock press.
+    if (IsOverrideVk(vk)) {
+        SetModifierDown(vk, isDown && !isUp);
+
+        // Shift released: restore Num Lock unless a user Num Lock key-up is
+        // still outstanding (that up would toggle after our pulse).
+        if (isUp && !IsOverrideHeld() &&
+            !g_allowedNumLockDown.load(std::memory_order_relaxed)) {
+            RequestForceOn();
+        }
+
+        return Pass(nCode, wParam, lParam);
+    }
+
+    if (vk != VK_NUMLOCK) {
+        return Pass(nCode, wParam, lParam);
+    }
+
+    if (isDown) {
+        if (IsOverrideHeld()) {
+            g_allowedNumLockDown.store(true, std::memory_order_relaxed);
+            g_swallowedNumLockDown.store(false, std::memory_order_relaxed);
+            return Pass(nCode, wParam, lParam);
+        }
+
+        g_allowedNumLockDown.store(false, std::memory_order_relaxed);
+
+        if (g_blockNumLockKey.load(std::memory_order_relaxed)) {
+            g_swallowedNumLockDown.store(true, std::memory_order_relaxed);
+            return 1;  // Swallow: key does nothing, including auto-repeat.
+        }
+
+        // Allow the first down through, swallow repeats so the LED does not
+        // flicker on every typematic repeat before we force ON at key-up.
+        if (g_swallowedNumLockDown.exchange(true, std::memory_order_relaxed)) {
+            return 1;
+        }
+        return Pass(nCode, wParam, lParam);
+    }
+
+    if (isUp) {
+        const bool allowed =
+            g_allowedNumLockDown.exchange(false, std::memory_order_relaxed);
+        const bool swallowed =
+            g_swallowedNumLockDown.exchange(false, std::memory_order_relaxed);
+
+        if (allowed) {
+            // Deliver the matching up first so any toggle settles, then
+            // force ON if the override is no longer held. Posting before
+            // CallNextHookEx can run the pulse, then lose to this key-up.
+            const LRESULT result =
+                Pass(nCode, wParam, lParam);
+            if (!IsOverrideHeld()) {
+                RequestForceOn();
+            }
+            return result;
+        }
+
+        if (swallowed && g_blockNumLockKey.load(std::memory_order_relaxed)) {
+            return 1;
+        }
+
+        if (IsOverrideHeld()) {
+            return Pass(nCode, wParam, lParam);
+        }
+
+        if (g_blockNumLockKey.load(std::memory_order_relaxed)) {
+            return 1;
+        }
+
+        const LRESULT result =
+            Pass(nCode, wParam, lParam);
+        RequestForceOn();
+        return result;
+    }
+
+    return Pass(nCode, wParam, lParam);
+}
+
+// ---------------------------------------------------------------------------
+// Worker window (timers, session/power, marshaled force-on)
+// ---------------------------------------------------------------------------
+
+void UnregisterPowerAndSession(HWND hwnd) {
+    if (g_sessionNotifyRegistered) {
+        WTSUnRegisterSessionNotification(hwnd);
+        g_sessionNotifyRegistered = false;
+    }
+
+    if (g_suspendResumeNotify) {
+        using UnregisterSuspendResumeNotification_t =
+            BOOL(WINAPI*)(HPOWERNOTIFY);
+        if (HMODULE user32 = GetModuleHandleW(L"user32.dll")) {
+            auto pUnregister = reinterpret_cast<
+                UnregisterSuspendResumeNotification_t>(
+                GetProcAddress(user32, "UnregisterSuspendResumeNotification"));
+            if (pUnregister) {
+                pUnregister(g_suspendResumeNotify);
+            }
+        }
+        g_suspendResumeNotify = nullptr;
+    }
+}
+
+LRESULT CALLBACK WorkerWndProc(HWND hwnd, UINT msg, WPARAM wParam,
+                               LPARAM lParam) {
+    switch (msg) {
+        case WM_APP_FORCE_ON:
+            ForceNumLockOn(ForceReason::Event);
+            ArmDeferredForceOn(hwnd);
+            return 0;
+
+        case WM_APP_UPDATE_TIMER:
+            SeedModifierState();
+            UpdateSafetyTimer();
+            ForceNumLockOn(ForceReason::Settings);
+            return 0;
+
+        case WM_APP_QUIT:
+            PostQuitMessage(0);
+            return 0;
+
+        case WM_TIMER:
+            if (wParam == kSafetyTimerId) {
+                ForceNumLockOn(ForceReason::Timer);
+            } else if (wParam == kDeferredForceTimerId) {
+                KillTimer(hwnd, kDeferredForceTimerId);
+                ForceNumLockOn(ForceReason::Event);
+            }
+            return 0;
+
+        case WM_WTSSESSION_CHANGE:
+            switch (wParam) {
+                case WTS_SESSION_UNLOCK:
+                case WTS_CONSOLE_CONNECT:
+                case WTS_REMOTE_CONNECT:
+                    ForceNumLockOn(ForceReason::Event);
+                    break;
+                default:
+                    break;
+            }
+            return 0;
+
+        case WM_POWERBROADCAST:
+            switch (wParam) {
+                case PBT_APMRESUMEAUTOMATIC:
+                case PBT_APMRESUMESUSPEND:
+#ifdef PBT_APMRESUMECRITICAL
+                case PBT_APMRESUMECRITICAL:
+#endif
+                    ForceNumLockOn(ForceReason::Event);
+                    break;
+                default:
+                    break;
+            }
+            return TRUE;
+
+        default:
+            break;
+    }
+
+    return DefWindowProcW(hwnd, msg, wParam, lParam);
+}
+
+HMODULE GetCurrentModuleHandle() {
+    HMODULE module = nullptr;
+    GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                           GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                       reinterpret_cast<LPCWSTR>(&LowLevelKeyboardProc),
+                       &module);
+    return module;
+}
+
+bool RegisterPowerAndSession(HWND hwnd) {
+    if (WTSRegisterSessionNotification(hwnd, NOTIFY_FOR_THIS_SESSION)) {
+        g_sessionNotifyRegistered = true;
+    } else {
+        Wh_Log(L"WTSRegisterSessionNotification failed: %lu", GetLastError());
+    }
+
+    using RegisterSuspendResumeNotification_t =
+        HPOWERNOTIFY(WINAPI*)(HANDLE, DWORD);
+    if (HMODULE user32 = GetModuleHandleW(L"user32.dll")) {
+        auto pRegister =
+            reinterpret_cast<RegisterSuspendResumeNotification_t>(
+                GetProcAddress(user32, "RegisterSuspendResumeNotification"));
+        if (pRegister) {
+            g_suspendResumeNotify =
+                pRegister(hwnd, DEVICE_NOTIFY_WINDOW_HANDLE);
+            if (!g_suspendResumeNotify) {
+                Wh_Log(L"RegisterSuspendResumeNotification failed: %lu",
+                       GetLastError());
+            }
+        }
+    }
+
+    return true;
+}
+
+DWORD WINAPI WorkerThreadProc(LPVOID) {
+    g_workerThreadId.store(GetCurrentThreadId(), std::memory_order_release);
+
+    MSG msg;
+    // Create the thread queue before we signal ready so Uninit's
+    // PostThreadMessage(WM_QUIT) cannot be dropped during early unload.
+    PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+
+    HMODULE module = GetCurrentModuleHandle();
+
+    WNDCLASSEXW wc = {sizeof(wc)};
+    wc.lpfnWndProc = WorkerWndProc;
+    wc.hInstance = module;
+    wc.lpszClassName = kWorkerClass;
+    if (!RegisterClassExW(&wc) && GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
+        Wh_Log(L"RegisterClassExW failed: %lu", GetLastError());
+        if (g_workerReadyEvent) {
+            SetEvent(g_workerReadyEvent);
+        }
+        g_workerThreadId.store(0, std::memory_order_release);
+        return 1;
+    }
+
+    HWND hwnd =
+        CreateWindowExW(0, kWorkerClass, L"", 0, 0, 0, 0, 0, HWND_MESSAGE,
+                        nullptr, module, nullptr);
+    g_workerHwnd.store(hwnd, std::memory_order_release);
+    if (!hwnd) {
+        Wh_Log(L"CreateWindowExW failed: %lu", GetLastError());
+        if (g_workerReadyEvent) {
+            SetEvent(g_workerReadyEvent);
+        }
+        g_workerThreadId.store(0, std::memory_order_release);
+        return 1;
+    }
+
+    RegisterPowerAndSession(hwnd);
+
+    SeedModifierState();
+    ForceNumLockOn(ForceReason::Startup);
+    UpdateSafetyTimer();
+
+    if (g_workerReadyEvent) {
+        SetEvent(g_workerReadyEvent);
+    }
+
+    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+
+    hwnd = g_workerHwnd.exchange(nullptr, std::memory_order_acq_rel);
+    if (hwnd) {
+        KillTimer(hwnd, kSafetyTimerId);
+        KillTimer(hwnd, kDeferredForceTimerId);
+        UnregisterPowerAndSession(hwnd);
+        DestroyWindow(hwnd);
+    }
+
+    UnregisterClassW(kWorkerClass, module);
+    g_workerThreadId.store(0, std::memory_order_release);
+    return 0;
+}
+
+// Dedicated hook thread: owns WH_KEYBOARD_LL and nothing else. SendInput
+// stays on the worker so the hook never has to come down for a pulse.
+DWORD WINAPI HookThreadProc(LPVOID) {
+    g_hookThreadId.store(GetCurrentThreadId(), std::memory_order_release);
+
+    MSG msg;
+    PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+
+    g_hookModule.store(GetCurrentModuleHandle(), std::memory_order_release);
+
+    DWORD delayMs = 50;
+    bool signaledReady = false;
+    bool loggedPersistentFailure = false;
+    unsigned attempts = 0;
+
+    while (!g_hookQuit.load(std::memory_order_relaxed) &&
+           !g_keyboardHook.load(std::memory_order_acquire)) {
+        ++attempts;
+        HHOOK hook = SetWindowsHookExW(
+            WH_KEYBOARD_LL, LowLevelKeyboardProc,
+            g_hookModule.load(std::memory_order_acquire), 0);
+        if (g_hookQuit.load(std::memory_order_acquire)) {
+            if (hook) {
+                UnhookWindowsHookEx(hook);
+            }
+            break;
+        }
+        g_keyboardHook.store(hook, std::memory_order_release);
+        if (hook) {
+            g_hookInstalled.store(true, std::memory_order_release);
+            if (attempts > 1) {
+                Wh_Log(L"Keyboard hook installed on retry %u", attempts);
+            }
+            break;
+        }
+
+        Wh_Log(L"SetWindowsHookExW(WH_KEYBOARD_LL) failed: %lu (retry in %u ms)",
+               GetLastError(), delayMs);
+        if (delayMs >= 2000 && !loggedPersistentFailure) {
+            Wh_Log(L"Keyboard hook still not installed after %u attempts; "
+                   L"retrying every 2s. Safety timer covers Num Lock until then.",
+                   attempts);
+            loggedPersistentFailure = true;
+        }
+
+        if (!signaledReady && g_hookReadyEvent) {
+            SetEvent(g_hookReadyEvent);
+            signaledReady = true;
+        }
+
+        if (g_hookStopEvent) {
+            WaitForSingleObject(g_hookStopEvent, delayMs);
+        }
+        if (delayMs < 2000) {
+            delayMs *= 2;
+        }
+    }
+
+    if (!signaledReady && g_hookReadyEvent) {
+        SetEvent(g_hookReadyEvent);
+    }
+
+    if (!g_keyboardHook.load(std::memory_order_acquire)) {
+        g_hookInstalled.store(false, std::memory_order_release);
+        g_hookThreadId.store(0, std::memory_order_release);
+        return 1;
+    }
+
+    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+
+    UninstallKeyboardHook();
+    g_hookModule.store(nullptr, std::memory_order_release);
+    g_hookThreadId.store(0, std::memory_order_release);
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Tool-mod lifecycle
+// ---------------------------------------------------------------------------
+
+void WhTool_ModUninit();
+
+BOOL WhTool_ModInit() {
+    LoadSettings();
+    g_hookQuit.store(false, std::memory_order_relaxed);
+
+    g_workerReadyEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    g_hookReadyEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    g_hookStopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    if (!g_workerReadyEvent || !g_hookReadyEvent || !g_hookStopEvent) {
+        Wh_Log(L"CreateEventW failed: %lu", GetLastError());
+        WhTool_ModUninit();
+        return FALSE;
+    }
+
+    g_workerThread =
+        CreateThread(nullptr, 0, WorkerThreadProc, nullptr, 0, nullptr);
+    if (!g_workerThread) {
+        Wh_Log(L"CreateThread failed: %lu", GetLastError());
+        WhTool_ModUninit();
+        return FALSE;
+    }
+
+    if (WaitForSingleObject(g_workerReadyEvent, 5000) != WAIT_OBJECT_0) {
+        Wh_Log(L"Worker thread did not become ready in time");
+    }
+
+    g_hookThread =
+        CreateThread(nullptr, 0, HookThreadProc, nullptr, 0, nullptr);
+    if (!g_hookThread) {
+        Wh_Log(L"CreateThread (hook) failed: %lu", GetLastError());
+        WhTool_ModUninit();
+        return FALSE;
+    }
+
+    if (WaitForSingleObject(g_hookReadyEvent, 5000) != WAIT_OBJECT_0) {
+        Wh_Log(L"Hook thread did not become ready in time");
+    }
+
+    if (g_workerReadyEvent) {
+        CloseHandle(g_workerReadyEvent);
+        g_workerReadyEvent = nullptr;
+    }
+    if (g_hookReadyEvent) {
+        CloseHandle(g_hookReadyEvent);
+        g_hookReadyEvent = nullptr;
+    }
+
+    if (!g_workerHwnd.load(std::memory_order_acquire)) {
+        Wh_Log(L"Worker window was not created");
+        WhTool_ModUninit();
+        return FALSE;
+    }
+
+    if (!g_hookInstalled.load(std::memory_order_acquire)) {
+        Wh_Log(L"Keyboard hook not installed yet; retrying in the background");
+    }
+
+    return TRUE;
+}
+
+void WhTool_ModSettingsChanged() {
+    LoadSettings();
+
+    HWND hwnd = g_workerHwnd.load(std::memory_order_acquire);
+    if (hwnd) {
+        PostMessageW(hwnd, WM_APP_UPDATE_TIMER, 0, 0);
+    }
+}
+
+void WhTool_ModUninit() {
+    g_hookQuit.store(true, std::memory_order_release);
+    if (g_hookStopEvent) {
+        SetEvent(g_hookStopEvent);
+    }
+
+    // Unhook from this thread so a stuck hook callback cannot keep the
+    // filter installed after disable. The hook thread's own unhook is then
+    // a no-op (exchange already cleared the handle).
+    UninstallKeyboardHook();
+
+    DWORD hookThreadId = g_hookThreadId.load(std::memory_order_acquire);
+    if (hookThreadId) {
+        PostThreadMessageW(hookThreadId, WM_QUIT, 0, 0);
+    }
+    if (g_hookThread) {
+        if (WaitForSingleObject(g_hookThread, 2000) != WAIT_OBJECT_0) {
+            Wh_Log(L"Hook thread did not exit in time; process exit will "
+                   L"tear it down");
+        }
+        CloseHandle(g_hookThread);
+        g_hookThread = nullptr;
+    }
+
+    HWND hwnd = g_workerHwnd.load(std::memory_order_acquire);
+    if (hwnd) {
+        PostMessageW(hwnd, WM_APP_QUIT, 0, 0);
+    } else {
+        DWORD threadId = g_workerThreadId.load(std::memory_order_acquire);
+        if (threadId) {
+            PostThreadMessageW(threadId, WM_QUIT, 0, 0);
+        }
+    }
+
+    if (g_workerThread) {
+        if (WaitForSingleObject(g_workerThread, 2000) != WAIT_OBJECT_0) {
+            Wh_Log(L"Worker thread did not exit in time; process exit will "
+                   L"tear it down");
+        }
+        CloseHandle(g_workerThread);
+        g_workerThread = nullptr;
+    }
+
+    if (g_workerReadyEvent) {
+        CloseHandle(g_workerReadyEvent);
+        g_workerReadyEvent = nullptr;
+    }
+    if (g_hookReadyEvent) {
+        CloseHandle(g_hookReadyEvent);
+        g_hookReadyEvent = nullptr;
+    }
+    if (g_hookStopEvent) {
+        CloseHandle(g_hookStopEvent);
+        g_hookStopEvent = nullptr;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Windhawk tool mod implementation for mods which don't need to inject to other
+// processes or hook other functions. Context:
+// https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process
+//
+// The mod will load and run in a dedicated windhawk.exe process.
+//
+// Paste the code below as part of the mod code, and use these callbacks:
+// * WhTool_ModInit
+// * WhTool_ModSettingsChanged
+// * WhTool_ModUninit
+//
+// Currently, other callbacks are not supported.
+
+bool g_isToolModProcessLauncher;
+HANDLE g_toolModProcessMutex;
+
+void WINAPI EntryPoint_Hook() {
+    Wh_Log(L">");
+    ExitThread(0);
+}
+
+BOOL Wh_ModInit() {
+    DWORD sessionId;
+    if (ProcessIdToSessionId(GetCurrentProcessId(), &sessionId) &&
+        sessionId == 0) {
+        return FALSE;
+    }
+
+    bool isExcluded = false;
+    bool isToolModProcess = false;
+    bool isCurrentToolModProcess = false;
+    int argc;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);
+    if (!argv) {
+        Wh_Log(L"CommandLineToArgvW failed");
+        return FALSE;
+    }
+
+    for (int i = 1; i < argc; i++) {
+        if (wcscmp(argv[i], L"-service") == 0 ||
+            wcscmp(argv[i], L"-service-start") == 0 ||
+            wcscmp(argv[i], L"-service-stop") == 0) {
+            isExcluded = true;
+            break;
+        }
+    }
+
+    for (int i = 1; i < argc - 1; i++) {
+        if (wcscmp(argv[i], L"-tool-mod") == 0) {
+            isToolModProcess = true;
+            if (wcscmp(argv[i + 1], WH_MOD_ID) == 0) {
+                isCurrentToolModProcess = true;
+            }
+            break;
+        }
+    }
+
+    LocalFree(argv);
+
+    if (isExcluded) {
+        return FALSE;
+    }
+
+    if (isCurrentToolModProcess) {
+        g_toolModProcessMutex =
+            CreateMutex(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
+        if (!g_toolModProcessMutex) {
+            Wh_Log(L"CreateMutex failed");
+            ExitProcess(1);
+        }
+
+        if (GetLastError() == ERROR_ALREADY_EXISTS) {
+            Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
+            ExitProcess(1);
+        }
+
+        if (!WhTool_ModInit()) {
+            ExitProcess(1);
+        }
+
+        IMAGE_DOS_HEADER* dosHeader =
+            (IMAGE_DOS_HEADER*)GetModuleHandle(nullptr);
+        IMAGE_NT_HEADERS* ntHeaders =
+            (IMAGE_NT_HEADERS*)((BYTE*)dosHeader + dosHeader->e_lfanew);
+
+        DWORD entryPointRVA = ntHeaders->OptionalHeader.AddressOfEntryPoint;
+        void* entryPoint = (BYTE*)dosHeader + entryPointRVA;
+
+        Wh_SetFunctionHook(entryPoint, (void*)EntryPoint_Hook, nullptr);
+        return TRUE;
+    }
+
+    if (isToolModProcess) {
+        return FALSE;
+    }
+
+    g_isToolModProcessLauncher = true;
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    if (!g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WCHAR currentProcessPath[MAX_PATH];
+    switch (GetModuleFileName(nullptr, currentProcessPath,
+                              ARRAYSIZE(currentProcessPath))) {
+        case 0:
+        case ARRAYSIZE(currentProcessPath):
+            Wh_Log(L"GetModuleFileName failed");
+            return;
+    }
+
+    WCHAR
+    commandLine[MAX_PATH + 2 +
+                (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
+    swprintf(commandLine, ARRAYSIZE(commandLine), L"\"%s\" -tool-mod \"%s\"",
+             currentProcessPath, WH_MOD_ID);
+
+    HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
+    if (!kernelModule) {
+        kernelModule = GetModuleHandle(L"kernel32.dll");
+        if (!kernelModule) {
+            Wh_Log(L"No kernelbase.dll/kernel32.dll");
+            return;
+        }
+    }
+
+    using CreateProcessInternalW_t = BOOL(WINAPI*)(
+        HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
+        LPSECURITY_ATTRIBUTES lpProcessAttributes,
+        LPSECURITY_ATTRIBUTES lpThreadAttributes, WINBOOL bInheritHandles,
+        DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory,
+        LPSTARTUPINFOW lpStartupInfo,
+        LPPROCESS_INFORMATION lpProcessInformation,
+        PHANDLE hRestrictedUserToken);
+    CreateProcessInternalW_t pCreateProcessInternalW =
+        (CreateProcessInternalW_t)GetProcAddress(kernelModule,
+                                                 "CreateProcessInternalW");
+    if (!pCreateProcessInternalW) {
+        Wh_Log(L"No CreateProcessInternalW");
+        return;
+    }
+
+    STARTUPINFO si{
+        .cb = sizeof(STARTUPINFO),
+        .dwFlags = STARTF_FORCEOFFFEEDBACK,
+    };
+    PROCESS_INFORMATION pi;
+    if (!pCreateProcessInternalW(nullptr, currentProcessPath, commandLine,
+                                 nullptr, nullptr, FALSE, NORMAL_PRIORITY_CLASS,
+                                 nullptr, nullptr, &si, &pi, nullptr)) {
+        Wh_Log(L"CreateProcess failed");
+        return;
+    }
+
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+}
+
+void Wh_ModSettingsChanged() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModSettingsChanged();
+}
+
+void Wh_ModUninit() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModUninit();
+    ExitProcess(0);
+}

--- a/mods/numlock-lockdown.wh.cpp
+++ b/mods/numlock-lockdown.wh.cpp
@@ -2,7 +2,7 @@
 // @id              numlock-lockdown
 // @name            Num Lock Lockdown
 // @description     Keeps Num Lock permanently ON, with a modifier key for temporary override
-// @version         1.1.2
+// @version         1.1.3
 // @author          tonythethompson
 // @github          https://github.com/tonythethompson
 // @include         windhawk.exe
@@ -88,13 +88,13 @@ keeps overhead low and avoids tying Num Lock to the shell process.
     - win: Win (left or right)
     - none: None (always force ON, no override)
 - numLockKeyMode: block
-  $name: Num Lock key without modifier
+  $name: Pressing Num Lock alone
   $description: >-
-    What happens when Num Lock is pressed without the override modifier.
-    Block swallows the key for every process, including games that bind it.
+    What should happen when you press Num Lock without holding Shift (or
+    whichever override you picked).
   $options:
-    - block: Block the key (does nothing)
-    - allow: Allow the press, then force Num Lock back ON on key-up. Holding the key can leave it off until release.
+    - block: Ignore it. Games and other apps will not see the key either.
+    - allow: Let it toggle, then turn Num Lock back on when you let go. If you hold the key, Num Lock can stay off until you release it.
 - safetyCheckSeconds: 10
   $name: Safety check interval (seconds)
   $description: >-

--- a/mods/numlock-lockdown.wh.cpp
+++ b/mods/numlock-lockdown.wh.cpp
@@ -2,7 +2,7 @@
 // @id              numlock-lockdown
 // @name            Num Lock Lockdown
 // @description     Keeps Num Lock permanently ON, with a modifier key for temporary override
-// @version         1.1.8
+// @version         1.1.9
 // @author          tonythethompson
 // @github          https://github.com/tonythethompson
 // @include         windhawk.exe
@@ -138,6 +138,9 @@ constexpr UINT WM_APP_QUIT = WM_APP + 3;
 constexpr UINT WM_APP_REHOOK = WM_APP + 4;
 
 constexpr UINT_PTR kSafetyTimerId = 1;
+// Retries a missing keyboard hook when the safety check is disabled.
+constexpr UINT_PTR kHookRetryTimerId = 2;
+constexpr UINT kHookRetryIntervalMs = 60 * 1000;
 // SendInput is asynchronous; wait for the injected toggle to land before
 // sending another pulse or Num Lock can flip back OFF.
 constexpr ULONGLONG kPulseDebounceMs = 300;
@@ -421,6 +424,12 @@ void RequestRehook() {
     }
 }
 
+void RequestRehookIfMissing() {
+    if (!g_keyboardHook.load(std::memory_order_acquire)) {
+        RequestRehook();
+    }
+}
+
 // Must run on the worker thread, never inside the LL hook.
 void ForceNumLockOn(bool fromSafetyCheck) {
     if (IsOverrideHeldVerified() || IsNumLockOn()) {
@@ -440,6 +449,19 @@ void ForceNumLockOn(bool fromSafetyCheck) {
     SendNumLockPulse();
 }
 
+void UpdateHookRetryTimer(HWND hwnd) {
+    KillTimer(hwnd, kHookRetryTimerId);
+
+    int seconds = g_safetyCheckSeconds.load(std::memory_order_relaxed);
+    if (seconds > 0) {
+        return;
+    }
+
+    if (!SetTimer(hwnd, kHookRetryTimerId, kHookRetryIntervalMs, nullptr)) {
+        Wh_Log(L"SetTimer (hook retry) failed: %lu", GetLastError());
+    }
+}
+
 void UpdateSafetyTimer() {
     HWND hwnd = g_workerHwnd.load(std::memory_order_acquire);
     if (!hwnd) {
@@ -447,6 +469,7 @@ void UpdateSafetyTimer() {
     }
 
     KillTimer(hwnd, kSafetyTimerId);
+    UpdateHookRetryTimer(hwnd);
 
     int seconds = g_safetyCheckSeconds.load(std::memory_order_relaxed);
     if (seconds <= 0) {
@@ -622,7 +645,10 @@ LRESULT CALLBACK WorkerWndProc(HWND hwnd, UINT msg, WPARAM wParam,
 
         case WM_TIMER:
             if (wParam == kSafetyTimerId) {
+                RequestRehookIfMissing();
                 ForceNumLockOn(true);
+            } else if (wParam == kHookRetryTimerId) {
+                RequestRehookIfMissing();
             }
             return 0;
 
@@ -757,6 +783,7 @@ DWORD WINAPI WorkerThreadProc(LPVOID) {
     hwnd = g_workerHwnd.exchange(nullptr, std::memory_order_acq_rel);
     if (hwnd) {
         KillTimer(hwnd, kSafetyTimerId);
+        KillTimer(hwnd, kHookRetryTimerId);
         UnregisterPowerAndSession(hwnd);
         DestroyWindow(hwnd);
     }

--- a/mods/numlock-lockdown.wh.cpp
+++ b/mods/numlock-lockdown.wh.cpp
@@ -2,7 +2,7 @@
 // @id              numlock-lockdown
 // @name            Num Lock Lockdown
 // @description     Keeps Num Lock permanently ON, with a modifier key for temporary override
-// @version         1.1.4
+// @version         1.1.5
 // @author          tonythethompson
 // @github          https://github.com/tonythethompson
 // @include         windhawk.exe
@@ -69,7 +69,8 @@ keeps overhead low and avoids tying Num Lock to the shell process.
   a force-on fires, even in **Block** mode.
 - In "allow" mode, holding Num Lock without the modifier can leave it off
   until you release the key. Auto-repeat is swallowed so the LED does not
-  flicker; force-on runs on key-up.
+  flicker; force-on runs on key-up. If the safety check is on (10 s by
+  default), it can still force Num Lock back ON while the key is held.
 - The Win key is never blocked. Only Num Lock is filtered. If you hold Win and
   press numpad 1/3/5/9, Windows may type those digits because Win+Numpad1 is
   not the same shortcut as Win+1 on the number row. That is OS behavior.
@@ -95,17 +96,19 @@ keeps overhead low and avoids tying Num Lock to the shell process.
   $name: Pressing Num Lock alone
   $description: >-
     What should happen when you press Num Lock without holding Shift (or
-    whichever override you picked).
+    whichever override you picked). In allow mode, holding the key can leave
+    Num Lock off until you release it; the safety check may still turn it
+    back on before then.
   $options:
     - block: Ignore it. Games and other apps will not see the key either.
-    - allow: Let it toggle, then turn Num Lock back on when you let go. If you hold the key, Num Lock can stay off until you release it.
+    - allow: Let it toggle, then turn Num Lock back on when you let go.
 - safetyCheckSeconds: 10
   $name: Safety check interval (seconds)
   $description: >-
     Optional fallback that re-checks Num Lock in case it was turned off by
     sleep, RDP, or an elevated app the hook cannot see. Focus change, unlock,
     and resume already retry without this timer. 0 disables it. 10 seconds
-    is a light default.
+    is a light default. Values above 3600 seconds are treated as 3600.
 */
 // ==/WindhawkModSettings==
 
@@ -127,11 +130,16 @@ keeps overhead low and avoids tying Num Lock to the shell process.
 constexpr UINT WM_APP_FORCE_ON = WM_APP + 1;
 constexpr UINT WM_APP_UPDATE_TIMER = WM_APP + 2;
 constexpr UINT WM_APP_QUIT = WM_APP + 3;
-// Posted to the hook thread (hwnd is null). Unhook + SetWindowsHookEx so a
-// hook Windows silently dropped after a timeout can be put back.
+// Posted to the hook thread (hwnd is null). Install a fresh hook first, then
+// drop the old one, so a timeout-dropped or failed hook can be recovered
+// without a gap if SetWindowsHookEx fails.
 constexpr UINT WM_APP_REHOOK = WM_APP + 4;
 
 constexpr UINT_PTR kSafetyTimerId = 1;
+// Independent of safetyCheckSeconds (including 0). Recovers a WH_KEYBOARD_LL
+// hook Windows silently removed after a timeout.
+constexpr UINT_PTR kHookRetryTimerId = 2;
+constexpr UINT kHookRetryIntervalMs = 60 * 1000;
 
 // dwExtraInfo stamped on every synthetic Num Lock we send, so the hook can
 // let our own keystrokes through without treating them as user input.
@@ -267,6 +275,7 @@ void LoadSettings() {
         seconds = 3600;
     }
     g_safetyCheckSeconds.store(seconds, std::memory_order_relaxed);
+    g_overrideUsedThisHold.store(false, std::memory_order_relaxed);
 }
 
 bool IsOverrideVk(DWORD vk) {
@@ -336,6 +345,7 @@ void SeedModifierState() {
 void ClearStaleKeyFlags() {
     g_allowedNumLockDown.store(false, std::memory_order_relaxed);
     g_swallowedNumLockDown.store(false, std::memory_order_relaxed);
+    g_overrideUsedThisHold.store(false, std::memory_order_relaxed);
 }
 
 // Worker thread only: a cached "held" can be stale if the hook missed a
@@ -430,6 +440,17 @@ void UpdateSafetyTimer() {
     const UINT intervalMs = static_cast<UINT>(seconds) * 1000;
     if (!SetTimer(hwnd, kSafetyTimerId, intervalMs, nullptr)) {
         Wh_Log(L"SetTimer failed: %lu", GetLastError());
+    }
+}
+
+void StartHookRetryTimer() {
+    HWND hwnd = g_workerHwnd.load(std::memory_order_acquire);
+    if (!hwnd) {
+        return;
+    }
+
+    if (!SetTimer(hwnd, kHookRetryTimerId, kHookRetryIntervalMs, nullptr)) {
+        Wh_Log(L"SetTimer (hook retry) failed: %lu", GetLastError());
     }
 }
 
@@ -565,16 +586,7 @@ void UnregisterPowerAndSession(HWND hwnd) {
     }
 
     if (g_suspendResumeNotify) {
-        using UnregisterSuspendResumeNotification_t =
-            BOOL(WINAPI*)(HPOWERNOTIFY);
-        if (HMODULE user32 = GetModuleHandleW(L"user32.dll")) {
-            auto pUnregister = reinterpret_cast<
-                UnregisterSuspendResumeNotification_t>(
-                GetProcAddress(user32, "UnregisterSuspendResumeNotification"));
-            if (pUnregister) {
-                pUnregister(g_suspendResumeNotify);
-            }
-        }
+        UnregisterSuspendResumeNotification(g_suspendResumeNotify);
         g_suspendResumeNotify = nullptr;
     }
 
@@ -604,6 +616,8 @@ LRESULT CALLBACK WorkerWndProc(HWND hwnd, UINT msg, WPARAM wParam,
         case WM_TIMER:
             if (wParam == kSafetyTimerId) {
                 ForceNumLockOn(true);
+            } else if (wParam == kHookRetryTimerId) {
+                RequestRehook();
             }
             return 0;
 
@@ -672,20 +686,10 @@ void RegisterPowerAndSession(HWND hwnd) {
         Wh_Log(L"WTSRegisterSessionNotification failed: %lu", GetLastError());
     }
 
-    using RegisterSuspendResumeNotification_t =
-        HPOWERNOTIFY(WINAPI*)(HANDLE, DWORD);
-    if (HMODULE user32 = GetModuleHandleW(L"user32.dll")) {
-        auto pRegister =
-            reinterpret_cast<RegisterSuspendResumeNotification_t>(
-                GetProcAddress(user32, "RegisterSuspendResumeNotification"));
-        if (pRegister) {
-            g_suspendResumeNotify =
-                pRegister(hwnd, DEVICE_NOTIFY_WINDOW_HANDLE);
-            if (!g_suspendResumeNotify) {
-                Wh_Log(L"RegisterSuspendResumeNotification failed: %lu",
-                       GetLastError());
-            }
-        }
+    g_suspendResumeNotify =
+        RegisterSuspendResumeNotification(hwnd, DEVICE_NOTIFY_WINDOW_HANDLE);
+    if (!g_suspendResumeNotify) {
+        Wh_Log(L"RegisterSuspendResumeNotification failed: %lu", GetLastError());
     }
 }
 
@@ -735,6 +739,7 @@ DWORD WINAPI WorkerThreadProc(LPVOID) {
     SeedModifierState();
     ForceNumLockOn(false);
     UpdateSafetyTimer();
+    StartHookRetryTimer();
 
     if (g_workerReadyEvent) {
         SetEvent(g_workerReadyEvent);
@@ -748,6 +753,7 @@ DWORD WINAPI WorkerThreadProc(LPVOID) {
     hwnd = g_workerHwnd.exchange(nullptr, std::memory_order_acq_rel);
     if (hwnd) {
         KillTimer(hwnd, kSafetyTimerId);
+        KillTimer(hwnd, kHookRetryTimerId);
         UnregisterPowerAndSession(hwnd);
         DestroyWindow(hwnd);
     }
@@ -781,6 +787,34 @@ void TryInstallKeyboardHook() {
     }
 }
 
+// Install a new hook first, then drop the previous handle. If SetWindowsHookEx
+// fails, a still-working hook is left in place. If Windows already dropped the
+// old hook, the stored handle is stale and this puts a live one back.
+void ReinstallKeyboardHook() {
+    if (g_hookQuit.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    HHOOK fresh = SetWindowsHookExW(WH_KEYBOARD_LL, LowLevelKeyboardProc,
+                                    GetCurrentModuleHandle(), 0);
+    if (g_hookQuit.load(std::memory_order_acquire)) {
+        if (fresh) {
+            UnhookWindowsHookEx(fresh);
+        }
+        return;
+    }
+    if (!fresh) {
+        Wh_Log(L"SetWindowsHookExW(WH_KEYBOARD_LL) failed: %lu",
+               GetLastError());
+        return;
+    }
+
+    HHOOK old = g_keyboardHook.exchange(fresh, std::memory_order_acq_rel);
+    if (old) {
+        UnhookWindowsHookEx(old);
+    }
+}
+
 // Dedicated hook thread: owns WH_KEYBOARD_LL and nothing else. SendInput
 // stays on the worker so the hook never has to come down for a pulse.
 DWORD WINAPI HookThreadProc(LPVOID) {
@@ -804,8 +838,7 @@ DWORD WINAPI HookThreadProc(LPVOID) {
 
     while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
         if (!msg.hwnd && msg.message == WM_APP_REHOOK) {
-            UninstallKeyboardHook();
-            TryInstallKeyboardHook();
+            ReinstallKeyboardHook();
             continue;
         }
         TranslateMessage(&msg);

--- a/mods/numlock-lockdown.wh.cpp
+++ b/mods/numlock-lockdown.wh.cpp
@@ -2,7 +2,7 @@
 // @id              numlock-lockdown
 // @name            Num Lock Lockdown
 // @description     Keeps Num Lock permanently ON, with a modifier key for temporary override
-// @version         1.1.7
+// @version         1.1.8
 // @author          tonythethompson
 // @github          https://github.com/tonythethompson
 // @include         windhawk.exe
@@ -138,9 +138,6 @@ constexpr UINT WM_APP_QUIT = WM_APP + 3;
 constexpr UINT WM_APP_REHOOK = WM_APP + 4;
 
 constexpr UINT_PTR kSafetyTimerId = 1;
-// Worker-thread only. Caps evidence-driven rehooks so an elevated window
-// that keeps Num Lock off (UIPI) does not swap the hook every safety tick.
-constexpr ULONGLONG kRehookMinIntervalMs = 60 * 1000;
 // SendInput is asynchronous; wait for the injected toggle to land before
 // sending another pulse or Num Lock can flip back OFF.
 constexpr ULONGLONG kPulseDebounceMs = 300;
@@ -208,8 +205,6 @@ HANDLE g_hookReadyEvent = nullptr;
 HPOWERNOTIFY g_suspendResumeNotify = nullptr;
 HWINEVENTHOOK g_foregroundHook = nullptr;
 bool g_sessionNotifyRegistered = false;
-// Worker thread only. Last time we posted WM_APP_REHOOK.
-ULONGLONG g_lastRehookMs = 0;
 // Worker thread only. Last time we sent a Num Lock pulse.
 ULONGLONG g_lastPulseMs = 0;
 
@@ -415,7 +410,7 @@ void UninstallKeyboardHook() {
     }
 }
 
-// Worker thread only. Unconditional: unlock/resume.
+// Worker thread only. Unlock/resume only.
 void RequestRehook() {
     DWORD threadId = g_hookThreadId.load(std::memory_order_acquire);
     if (!threadId) {
@@ -423,19 +418,7 @@ void RequestRehook() {
     }
     if (!PostThreadMessageW(threadId, WM_APP_REHOOK, 0, 0)) {
         Wh_Log(L"PostThreadMessageW(WM_APP_REHOOK) failed: %lu", GetLastError());
-        return;
     }
-    g_lastRehookMs = GetTickCount64();
-}
-
-// Worker thread only. Num Lock found off is the signal the hook may have
-// been dropped. Do not swap a healthy hook on a timer.
-void RequestEvidenceRehook() {
-    const ULONGLONG now = GetTickCount64();
-    if (g_lastRehookMs != 0 && now - g_lastRehookMs < kRehookMinIntervalMs) {
-        return;
-    }
-    RequestRehook();
 }
 
 // Must run on the worker thread, never inside the LL hook.
@@ -451,8 +434,6 @@ void ForceNumLockOn(bool fromSafetyCheck) {
 
     if (fromSafetyCheck) {
         Wh_Log(L"Safety check: Num Lock was off, forcing ON");
-        // Nothing reported this one, so the hook may have been dropped.
-        RequestEvidenceRehook();
     }
 
     g_lastPulseMs = now;
@@ -846,13 +827,6 @@ DWORD WINAPI HookThreadProc(LPVOID) {
     PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
 
     TryInstallKeyboardHook();
-    for (int attempt = 1; attempt < 3 &&
-                          !g_keyboardHook.load(std::memory_order_acquire) &&
-                          !g_hookQuit.load(std::memory_order_relaxed);
-         ++attempt) {
-        Sleep(100);
-        TryInstallKeyboardHook();
-    }
 
     if (g_hookReadyEvent) {
         SetEvent(g_hookReadyEvent);
@@ -925,9 +899,7 @@ BOOL WhTool_ModInit() {
     }
 
     if (!g_keyboardHook.load(std::memory_order_acquire)) {
-        Wh_Log(L"Keyboard hook failed to install");
-        WhTool_ModUninit();
-        return FALSE;
+        Wh_Log(L"Keyboard hook failed to install; will retry on unlock/resume");
     }
 
     return TRUE;

--- a/mods/numlock-lockdown.wh.cpp
+++ b/mods/numlock-lockdown.wh.cpp
@@ -2,7 +2,7 @@
 // @id              numlock-lockdown
 // @name            Num Lock Lockdown
 // @description     Keeps Num Lock permanently ON, with a modifier key for temporary override
-// @version         1.0.8
+// @version         1.0.9
 // @author          Tony Thompson
 // @github          https://github.com/tonythethompson
 // @include         windhawk.exe
@@ -27,11 +27,15 @@ few cases the hook cannot see.
 | Hold Shift + press Num Lock | Normal toggle is allowed. |
 | Release Shift | Num Lock is forced back ON if it is off. |
 | Sleep/wake, RDP, or another program turns it off | Forced back ON on the next event, or on the safety check. |
-| Mod disabled | Normal Windows Num Lock behavior is restored. |
+| Mod disabled | The Num Lock *key* behaves normally again. The LED is left ON (the last forced state), not restored to whatever it was before the mod ran. |
 
 Hold **Left Shift** or **Right Shift** to temporarily turn Num Lock off (for
 example when you need the numpad as arrow keys). As soon as you release Shift,
 Num Lock is turned back on.
+
+**Block** (the default) swallows Num Lock for every process, so a game or app
+that uses Num Lock as a hotkey will not see the key. Use **Allow** if you need
+those binds; the mod still forces Num Lock back ON on key-up.
 
 ## Why a tool mod?
 
@@ -47,6 +51,9 @@ keeps overhead low and avoids tying Num Lock to the shell process.
   Lock off is corrected within a few seconds.
 - The hook also cannot see some Remote Desktop / KVM paths. The safety check
   and session-unlock / resume handlers cover those.
+- If the hook misses a modifier key-up (elevated window or secure desktop),
+  the worker re-reads the real key state before trusting a cached "held", so
+  the safety timer cannot stay inert.
 - Synthetic Num Lock presses this mod sends are tagged and ignored by the
   hook, so the force-on path cannot fight itself.
 - In "allow" mode, holding Num Lock without the modifier can leave it off
@@ -75,6 +82,7 @@ keeps overhead low and avoids tying Num Lock to the shell process.
   $name: Num Lock key without modifier
   $description: >-
     What happens when Num Lock is pressed without the override modifier.
+    Block swallows the key for every process, including games that bind it.
   $options:
     - block: Block the key (does nothing)
     - allow: Allow the press, then force Num Lock back ON on key-up. Holding the key can leave it off until release.
@@ -88,12 +96,12 @@ keeps overhead low and avoids tying Num Lock to the shell process.
 // ==/WindhawkModSettings==
 
 #include <atomic>
-#include <wchar.h>
 
 #include <windows.h>
 #include <wtsapi32.h>
 
 #include <windhawk_api.h>
+#include <windhawk_utils.h>
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -106,6 +114,10 @@ constexpr UINT WM_APP_FORCE_ON = WM_APP + 1;
 constexpr UINT WM_APP_UPDATE_TIMER = WM_APP + 2;
 constexpr UINT WM_APP_QUIT = WM_APP + 3;
 
+// Posted to the hook thread to retry SetWindowsHookEx if the first attempt
+// failed. The hook thread stays in its message loop either way.
+constexpr UINT WM_APP_ENSURE_HOOK = WM_APP + 4;
+
 constexpr UINT_PTR kSafetyTimerId = 1;
 constexpr UINT_PTR kDeferredForceTimerId = 2;
 
@@ -113,7 +125,7 @@ constexpr UINT_PTR kDeferredForceTimerId = 2;
 // let our own keystrokes through without treating them as user input.
 constexpr ULONG_PTR kInjectedNumLockExtraInfo = 0x4E4C4F4B;  // 'NLOK'
 
-constexpr wchar_t kWorkerClass[] = L"Windhawk.ForceNumLock.Worker";
+constexpr wchar_t kWorkerClass[] = L"Windhawk.NumLockLockdown.Worker";
 
 // ---------------------------------------------------------------------------
 // Settings (written on the Windhawk / worker thread, read from the hook)
@@ -155,17 +167,14 @@ std::atomic<bool> g_swallowedNumLockDown{false};
 // Hook thread publishes these; other threads only load. Uninit may unhook
 // via exchange so a wedged hook thread cannot leave the hook installed.
 std::atomic<HHOOK> g_keyboardHook{nullptr};
-std::atomic<HMODULE> g_hookModule{nullptr};
 std::atomic<HWND> g_workerHwnd{nullptr};
 HANDLE g_workerThread = nullptr;
 HANDLE g_hookThread = nullptr;
 std::atomic<DWORD> g_workerThreadId{0};
 std::atomic<DWORD> g_hookThreadId{0};
-std::atomic<bool> g_hookInstalled{false};
 std::atomic<bool> g_hookQuit{false};
 HANDLE g_workerReadyEvent = nullptr;
 HANDLE g_hookReadyEvent = nullptr;
-HANDLE g_hookStopEvent = nullptr;
 HPOWERNOTIFY g_suspendResumeNotify = nullptr;
 bool g_sessionNotifyRegistered = false;
 
@@ -216,24 +225,20 @@ bool ParseModifier(PCWSTR value, OverrideModifier* out) {
 
 void LoadSettings() {
     OverrideModifier modifier = OverrideModifier::Shift;
-    PCWSTR modifierSetting = Wh_GetStringSetting(L"overrideModifier");
-    if (modifierSetting) {
-        OverrideModifier parsed = OverrideModifier::Shift;
-        if (ParseModifier(modifierSetting, &parsed)) {
-            modifier = parsed;
-        }
-        Wh_FreeStringSetting(modifierSetting);
+    WindhawkUtils::StringSetting modifierSetting =
+        WindhawkUtils::StringSetting::make(L"overrideModifier");
+    OverrideModifier parsed = OverrideModifier::Shift;
+    if (ParseModifier(modifierSetting.get(), &parsed)) {
+        modifier = parsed;
     }
     g_overrideModifier.store(static_cast<int>(modifier),
                              std::memory_order_relaxed);
 
     bool blockKey = true;
-    PCWSTR keyMode = Wh_GetStringSetting(L"numLockKeyMode");
-    if (keyMode) {
-        if (_wcsicmp(keyMode, L"allow") == 0) {
-            blockKey = false;
-        }
-        Wh_FreeStringSetting(keyMode);
+    WindhawkUtils::StringSetting keyMode =
+        WindhawkUtils::StringSetting::make(L"numLockKeyMode");
+    if (keyMode.get() && _wcsicmp(keyMode.get(), L"allow") == 0) {
+        blockKey = false;
     }
     g_blockNumLockKey.store(blockKey, std::memory_order_relaxed);
 
@@ -258,8 +263,12 @@ bool IsOverrideVk(DWORD vk) {
             return vk == VK_LWIN || vk == VK_RWIN;
         case OverrideModifier::None:
             return false;
+        default: {
+            const OverrideModifier unmatched = CurrentModifier();
+            static_cast<void>(unmatched);
+            return false;
+        }
     }
-    return false;
 }
 
 void SetModifierDown(DWORD vk, bool down) {
@@ -319,7 +328,34 @@ void SeedModifierState() {
             break;
         case OverrideModifier::None:
             break;
+        default: {
+            const OverrideModifier unmatched = CurrentModifier();
+            static_cast<void>(unmatched);
+            break;
+        }
     }
+}
+
+void ClearStaleKeyFlags() {
+    g_allowedNumLockDown.store(false, std::memory_order_relaxed);
+    g_swallowedNumLockDown.store(false, std::memory_order_relaxed);
+}
+
+// Worker thread only: a cached "held" can be stale if the hook missed a
+// key-up (elevated window / secure desktop), so confirm against the OS.
+bool IsOverrideHeldVerified() {
+    if (IsOverrideHeld()) {
+        SeedModifierState();
+    }
+    if (IsOverrideHeld()) {
+        return true;
+    }
+    // Modifier is not held. If Num Lock is also up, a missed key-up can
+    // leave the swallow / allow flags stuck; clear them.
+    if (GetAsyncKeyState(VK_NUMLOCK) >= 0) {
+        ClearStaleKeyFlags();
+    }
+    return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -330,6 +366,13 @@ void RequestForceOn() {
     HWND hwnd = g_workerHwnd.load(std::memory_order_acquire);
     if (hwnd) {
         PostMessageW(hwnd, WM_APP_FORCE_ON, 0, 0);
+    }
+}
+
+void RequestEnsureHook() {
+    DWORD threadId = g_hookThreadId.load(std::memory_order_acquire);
+    if (threadId) {
+        PostThreadMessageW(threadId, WM_APP_ENSURE_HOOK, 0, 0);
     }
 }
 
@@ -356,25 +399,17 @@ void SendNumLockPulse() {
     }
 }
 
-enum class ForceReason {
-    Startup,
-    Event,
-    Timer,
-    Settings,
-};
-
 // Must run on the worker thread, never inside the LL hook.
-void ForceNumLockOn(ForceReason reason) {
-    if (IsOverrideHeld()) {
-        return;
+// Returns true if a pulse was sent.
+bool ForceNumLockOn(bool logSafety) {
+    if (IsOverrideHeldVerified() || IsNumLockOn()) {
+        return false;
     }
-    if (IsNumLockOn()) {
-        return;
-    }
-    if (reason == ForceReason::Timer) {
+    if (logSafety) {
         Wh_Log(L"Safety check: Num Lock was off, forcing ON");
     }
     SendNumLockPulse();
+    return true;
 }
 
 void ArmDeferredForceOn(HWND hwnd) {
@@ -386,7 +421,6 @@ void UninstallKeyboardHook() {
     if (hook) {
         UnhookWindowsHookEx(hook);
     }
-    g_hookInstalled.store(false, std::memory_order_release);
 }
 
 void UpdateSafetyTimer() {
@@ -403,24 +437,6 @@ void UpdateSafetyTimer() {
     }
 
     const UINT intervalMs = static_cast<UINT>(seconds) * 1000;
-
-    // Prefer a coalescable timer so a 10s safety check can share a wakeup
-    // with other timers instead of forcing its own interrupt. 1000 ms
-    // tolerance is enough for a fallback check.
-    using SetCoalescableTimer_t = UINT_PTR(WINAPI*)(HWND, UINT_PTR, UINT,
-                                                    TIMERPROC, ULONG);
-    if (HMODULE user32 = GetModuleHandleW(L"user32.dll")) {
-        auto pSetCoalescableTimer =
-            reinterpret_cast<SetCoalescableTimer_t>(
-                GetProcAddress(user32, "SetCoalescableTimer"));
-        if (pSetCoalescableTimer) {
-            if (pSetCoalescableTimer(hwnd, kSafetyTimerId, intervalMs, nullptr,
-                                     1000)) {
-                return;
-            }
-        }
-    }
-
     if (!SetTimer(hwnd, kSafetyTimerId, intervalMs, nullptr)) {
         Wh_Log(L"SetTimer failed: %lu", GetLastError());
     }
@@ -464,7 +480,7 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
     // Track the override modifier first so a Shift-down that arrives in this
     // same callback sequence is visible to a following Num Lock press.
     if (IsOverrideVk(vk)) {
-        SetModifierDown(vk, isDown && !isUp);
+        SetModifierDown(vk, isDown);
 
         // Shift released: restore Num Lock unless a user Num Lock key-up is
         // still outstanding (that up would toggle after our pulse).
@@ -512,8 +528,7 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
             // Deliver the matching up first so any toggle settles, then
             // force ON if the override is no longer held. Posting before
             // CallNextHookEx can run the pulse, then lose to this key-up.
-            const LRESULT result =
-                Pass(nCode, wParam, lParam);
+            const LRESULT result = Pass(nCode, wParam, lParam);
             if (!IsOverrideHeld()) {
                 RequestForceOn();
             }
@@ -532,8 +547,7 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
             return 1;
         }
 
-        const LRESULT result =
-            Pass(nCode, wParam, lParam);
+        const LRESULT result = Pass(nCode, wParam, lParam);
         RequestForceOn();
         return result;
     }
@@ -570,14 +584,18 @@ LRESULT CALLBACK WorkerWndProc(HWND hwnd, UINT msg, WPARAM wParam,
                                LPARAM lParam) {
     switch (msg) {
         case WM_APP_FORCE_ON:
-            ForceNumLockOn(ForceReason::Event);
-            ArmDeferredForceOn(hwnd);
+            if (!ForceNumLockOn(false)) {
+                // Nothing sent: the user's toggle may not have been applied
+                // yet, so look again shortly. Do not arm after a pulse:
+                // SendInput is async and a second pulse would toggle OFF.
+                ArmDeferredForceOn(hwnd);
+            }
             return 0;
 
         case WM_APP_UPDATE_TIMER:
             SeedModifierState();
             UpdateSafetyTimer();
-            ForceNumLockOn(ForceReason::Settings);
+            ForceNumLockOn(false);
             return 0;
 
         case WM_APP_QUIT:
@@ -586,10 +604,11 @@ LRESULT CALLBACK WorkerWndProc(HWND hwnd, UINT msg, WPARAM wParam,
 
         case WM_TIMER:
             if (wParam == kSafetyTimerId) {
-                ForceNumLockOn(ForceReason::Timer);
+                RequestEnsureHook();
+                ForceNumLockOn(true);
             } else if (wParam == kDeferredForceTimerId) {
                 KillTimer(hwnd, kDeferredForceTimerId);
-                ForceNumLockOn(ForceReason::Event);
+                ForceNumLockOn(false);
             }
             return 0;
 
@@ -598,7 +617,8 @@ LRESULT CALLBACK WorkerWndProc(HWND hwnd, UINT msg, WPARAM wParam,
                 case WTS_SESSION_UNLOCK:
                 case WTS_CONSOLE_CONNECT:
                 case WTS_REMOTE_CONNECT:
-                    ForceNumLockOn(ForceReason::Event);
+                    RequestEnsureHook();
+                    ForceNumLockOn(false);
                     break;
                 default:
                     break;
@@ -609,10 +629,8 @@ LRESULT CALLBACK WorkerWndProc(HWND hwnd, UINT msg, WPARAM wParam,
             switch (wParam) {
                 case PBT_APMRESUMEAUTOMATIC:
                 case PBT_APMRESUMESUSPEND:
-#ifdef PBT_APMRESUMECRITICAL
-                case PBT_APMRESUMECRITICAL:
-#endif
-                    ForceNumLockOn(ForceReason::Event);
+                    RequestEnsureHook();
+                    ForceNumLockOn(false);
                     break;
                 default:
                     break;
@@ -675,7 +693,7 @@ DWORD WINAPI WorkerThreadProc(LPVOID) {
     wc.lpfnWndProc = WorkerWndProc;
     wc.hInstance = module;
     wc.lpszClassName = kWorkerClass;
-    if (!RegisterClassExW(&wc) && GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
+    if (!RegisterClassExW(&wc)) {
         Wh_Log(L"RegisterClassExW failed: %lu", GetLastError());
         if (g_workerReadyEvent) {
             SetEvent(g_workerReadyEvent);
@@ -690,6 +708,7 @@ DWORD WINAPI WorkerThreadProc(LPVOID) {
     g_workerHwnd.store(hwnd, std::memory_order_release);
     if (!hwnd) {
         Wh_Log(L"CreateWindowExW failed: %lu", GetLastError());
+        UnregisterClassW(kWorkerClass, module);
         if (g_workerReadyEvent) {
             SetEvent(g_workerReadyEvent);
         }
@@ -700,7 +719,7 @@ DWORD WINAPI WorkerThreadProc(LPVOID) {
     RegisterPowerAndSession(hwnd);
 
     SeedModifierState();
-    ForceNumLockOn(ForceReason::Startup);
+    ForceNumLockOn(false);
     UpdateSafetyTimer();
 
     if (g_workerReadyEvent) {
@@ -725,6 +744,30 @@ DWORD WINAPI WorkerThreadProc(LPVOID) {
     return 0;
 }
 
+void TryInstallKeyboardHook() {
+    if (g_hookQuit.load(std::memory_order_acquire)) {
+        return;
+    }
+    if (g_keyboardHook.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    HHOOK hook = SetWindowsHookExW(WH_KEYBOARD_LL, LowLevelKeyboardProc,
+                                   GetCurrentModuleHandle(), 0);
+    if (g_hookQuit.load(std::memory_order_acquire)) {
+        if (hook) {
+            UnhookWindowsHookEx(hook);
+        }
+        return;
+    }
+
+    g_keyboardHook.store(hook, std::memory_order_release);
+    if (!hook) {
+        Wh_Log(L"SetWindowsHookExW(WH_KEYBOARD_LL) failed: %lu",
+               GetLastError());
+    }
+}
+
 // Dedicated hook thread: owns WH_KEYBOARD_LL and nothing else. SendInput
 // stays on the worker so the hook never has to come down for a pulse.
 DWORD WINAPI HookThreadProc(LPVOID) {
@@ -733,73 +776,22 @@ DWORD WINAPI HookThreadProc(LPVOID) {
     MSG msg;
     PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
 
-    g_hookModule.store(GetCurrentModuleHandle(), std::memory_order_release);
+    TryInstallKeyboardHook();
 
-    DWORD delayMs = 50;
-    bool signaledReady = false;
-    bool loggedPersistentFailure = false;
-    unsigned attempts = 0;
-
-    while (!g_hookQuit.load(std::memory_order_relaxed) &&
-           !g_keyboardHook.load(std::memory_order_acquire)) {
-        ++attempts;
-        HHOOK hook = SetWindowsHookExW(
-            WH_KEYBOARD_LL, LowLevelKeyboardProc,
-            g_hookModule.load(std::memory_order_acquire), 0);
-        if (g_hookQuit.load(std::memory_order_acquire)) {
-            if (hook) {
-                UnhookWindowsHookEx(hook);
-            }
-            break;
-        }
-        g_keyboardHook.store(hook, std::memory_order_release);
-        if (hook) {
-            g_hookInstalled.store(true, std::memory_order_release);
-            if (attempts > 1) {
-                Wh_Log(L"Keyboard hook installed on retry %u", attempts);
-            }
-            break;
-        }
-
-        Wh_Log(L"SetWindowsHookExW(WH_KEYBOARD_LL) failed: %lu (retry in %u ms)",
-               GetLastError(), delayMs);
-        if (delayMs >= 2000 && !loggedPersistentFailure) {
-            Wh_Log(L"Keyboard hook still not installed after %u attempts; "
-                   L"retrying every 2s. Safety timer covers Num Lock until then.",
-                   attempts);
-            loggedPersistentFailure = true;
-        }
-
-        if (!signaledReady && g_hookReadyEvent) {
-            SetEvent(g_hookReadyEvent);
-            signaledReady = true;
-        }
-
-        if (g_hookStopEvent) {
-            WaitForSingleObject(g_hookStopEvent, delayMs);
-        }
-        if (delayMs < 2000) {
-            delayMs *= 2;
-        }
-    }
-
-    if (!signaledReady && g_hookReadyEvent) {
+    if (g_hookReadyEvent) {
         SetEvent(g_hookReadyEvent);
     }
 
-    if (!g_keyboardHook.load(std::memory_order_acquire)) {
-        g_hookInstalled.store(false, std::memory_order_release);
-        g_hookThreadId.store(0, std::memory_order_release);
-        return 1;
-    }
-
     while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+        if (msg.message == WM_APP_ENSURE_HOOK) {
+            TryInstallKeyboardHook();
+            continue;
+        }
         TranslateMessage(&msg);
         DispatchMessageW(&msg);
     }
 
     UninstallKeyboardHook();
-    g_hookModule.store(nullptr, std::memory_order_release);
     g_hookThreadId.store(0, std::memory_order_release);
     return 0;
 }
@@ -816,8 +808,7 @@ BOOL WhTool_ModInit() {
 
     g_workerReadyEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
     g_hookReadyEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
-    g_hookStopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
-    if (!g_workerReadyEvent || !g_hookReadyEvent || !g_hookStopEvent) {
+    if (!g_workerReadyEvent || !g_hookReadyEvent) {
         Wh_Log(L"CreateEventW failed: %lu", GetLastError());
         WhTool_ModUninit();
         return FALSE;
@@ -847,23 +838,14 @@ BOOL WhTool_ModInit() {
         Wh_Log(L"Hook thread did not become ready in time");
     }
 
-    if (g_workerReadyEvent) {
-        CloseHandle(g_workerReadyEvent);
-        g_workerReadyEvent = nullptr;
-    }
-    if (g_hookReadyEvent) {
-        CloseHandle(g_hookReadyEvent);
-        g_hookReadyEvent = nullptr;
-    }
-
     if (!g_workerHwnd.load(std::memory_order_acquire)) {
         Wh_Log(L"Worker window was not created");
         WhTool_ModUninit();
         return FALSE;
     }
 
-    if (!g_hookInstalled.load(std::memory_order_acquire)) {
-        Wh_Log(L"Keyboard hook not installed yet; retrying in the background");
+    if (!g_keyboardHook.load(std::memory_order_acquire)) {
+        Wh_Log(L"Keyboard hook not installed yet; safety timer will retry");
     }
 
     return TRUE;
@@ -878,11 +860,15 @@ void WhTool_ModSettingsChanged() {
     }
 }
 
+void CloseEventHandle(HANDLE* event) {
+    if (*event) {
+        CloseHandle(*event);
+        *event = nullptr;
+    }
+}
+
 void WhTool_ModUninit() {
     g_hookQuit.store(true, std::memory_order_release);
-    if (g_hookStopEvent) {
-        SetEvent(g_hookStopEvent);
-    }
 
     // Unhook from this thread so a stuck hook callback cannot keep the
     // filter installed after disable. The hook thread's own unhook is then
@@ -894,12 +880,19 @@ void WhTool_ModUninit() {
         PostThreadMessageW(hookThreadId, WM_QUIT, 0, 0);
     }
     if (g_hookThread) {
-        if (WaitForSingleObject(g_hookThread, 2000) != WAIT_OBJECT_0) {
+        const bool joined =
+            WaitForSingleObject(g_hookThread, 2000) == WAIT_OBJECT_0;
+        if (!joined) {
             Wh_Log(L"Hook thread did not exit in time; process exit will "
                    L"tear it down");
         }
         CloseHandle(g_hookThread);
         g_hookThread = nullptr;
+        if (joined) {
+            CloseEventHandle(&g_hookReadyEvent);
+        }
+    } else {
+        CloseEventHandle(&g_hookReadyEvent);
     }
 
     HWND hwnd = g_workerHwnd.load(std::memory_order_acquire);
@@ -913,25 +906,19 @@ void WhTool_ModUninit() {
     }
 
     if (g_workerThread) {
-        if (WaitForSingleObject(g_workerThread, 2000) != WAIT_OBJECT_0) {
+        const bool joined =
+            WaitForSingleObject(g_workerThread, 2000) == WAIT_OBJECT_0;
+        if (!joined) {
             Wh_Log(L"Worker thread did not exit in time; process exit will "
                    L"tear it down");
         }
         CloseHandle(g_workerThread);
         g_workerThread = nullptr;
-    }
-
-    if (g_workerReadyEvent) {
-        CloseHandle(g_workerReadyEvent);
-        g_workerReadyEvent = nullptr;
-    }
-    if (g_hookReadyEvent) {
-        CloseHandle(g_hookReadyEvent);
-        g_hookReadyEvent = nullptr;
-    }
-    if (g_hookStopEvent) {
-        CloseHandle(g_hookStopEvent);
-        g_hookStopEvent = nullptr;
+        if (joined) {
+            CloseEventHandle(&g_workerReadyEvent);
+        }
+    } else {
+        CloseEventHandle(&g_workerReadyEvent);
     }
 }
 
@@ -1053,8 +1040,8 @@ void Wh_ModAfterInit() {
     WCHAR
     commandLine[MAX_PATH + 2 +
                 (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
-    swprintf(commandLine, ARRAYSIZE(commandLine), L"\"%s\" -tool-mod \"%s\"",
-             currentProcessPath, WH_MOD_ID);
+    swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
+               WH_MOD_ID);
 
     HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
     if (!kernelModule) {

--- a/mods/numlock-lockdown.wh.cpp
+++ b/mods/numlock-lockdown.wh.cpp
@@ -2,7 +2,7 @@
 // @id              numlock-lockdown
 // @name            Num Lock Lockdown
 // @description     Keeps Num Lock permanently ON, with a modifier key for temporary override
-// @version         1.1.3
+// @version         1.1.4
 // @author          tonythethompson
 // @github          https://github.com/tonythethompson
 // @include         windhawk.exe
@@ -29,9 +29,11 @@ covers the few cases the hook cannot see.
 | Sleep/wake, RDP, or another program turns it off | Forced back ON on the next event, on unlock/resume/focus change, or on the safety check. |
 | Mod disabled | The Num Lock *key* behaves normally again. The LED is left ON (the last forced state), not restored to whatever it was before the mod ran. |
 
-Hold **Left Shift** or **Right Shift** to temporarily turn Num Lock off (for
-example when you need the numpad as arrow keys). As soon as you release Shift,
-Num Lock is turned back on.
+Hold **Left Shift** or **Right Shift** and press Num Lock to toggle it
+normally for as long as you keep Shift down. While Shift is held, numpad
+arrows are Shift+Arrow in most apps (extend selection), not plain arrows.
+Ctrl, Alt, and Win have the same kind of extra meaning. Release the
+override and Num Lock is turned back on.
 
 **Block** (the default) swallows Num Lock for every process, so a game or app
 that uses Num Lock as a hotkey will not see the key. Use **Allow** if you need
@@ -79,8 +81,10 @@ keeps overhead low and avoids tying Num Lock to the shell process.
 - overrideModifier: shift
   $name: Temporary override modifier
   $description: >-
-    Hold this key to toggle Num Lock normally. When you release it, Num Lock
-    is forced back ON. Left and right keys both count.
+    Hold this key and press Num Lock to toggle it. While the key is down,
+    numpad arrows keep that modifier (Shift+Arrow extends selection in most
+    apps). When you release it, Num Lock is turned back on. Left and right
+    keys both count.
   $options:
     - shift: Shift (left or right)
     - ctrl: Ctrl (left or right)
@@ -123,6 +127,9 @@ keeps overhead low and avoids tying Num Lock to the shell process.
 constexpr UINT WM_APP_FORCE_ON = WM_APP + 1;
 constexpr UINT WM_APP_UPDATE_TIMER = WM_APP + 2;
 constexpr UINT WM_APP_QUIT = WM_APP + 3;
+// Posted to the hook thread (hwnd is null). Unhook + SetWindowsHookEx so a
+// hook Windows silently dropped after a timeout can be put back.
+constexpr UINT WM_APP_REHOOK = WM_APP + 4;
 
 constexpr UINT_PTR kSafetyTimerId = 1;
 
@@ -400,6 +407,13 @@ void UninstallKeyboardHook() {
     }
 }
 
+void RequestRehook() {
+    DWORD threadId = g_hookThreadId.load(std::memory_order_acquire);
+    if (threadId) {
+        PostThreadMessageW(threadId, WM_APP_REHOOK, 0, 0);
+    }
+}
+
 void UpdateSafetyTimer() {
     HWND hwnd = g_workerHwnd.load(std::memory_order_acquire);
     if (!hwnd) {
@@ -598,6 +612,7 @@ LRESULT CALLBACK WorkerWndProc(HWND hwnd, UINT msg, WPARAM wParam,
                 case WTS_SESSION_UNLOCK:
                 case WTS_CONSOLE_CONNECT:
                 case WTS_REMOTE_CONNECT:
+                    RequestRehook();
                     ForceNumLockOn(false);
                     break;
                 default:
@@ -609,6 +624,7 @@ LRESULT CALLBACK WorkerWndProc(HWND hwnd, UINT msg, WPARAM wParam,
             switch (wParam) {
                 case PBT_APMRESUMEAUTOMATIC:
                 case PBT_APMRESUMESUSPEND:
+                    RequestRehook();
                     ForceNumLockOn(false);
                     break;
                 default:
@@ -634,7 +650,8 @@ HMODULE GetCurrentModuleHandle() {
 
 void CALLBACK ForegroundEventProc(HWINEVENTHOOK, DWORD, HWND, LONG, LONG, DWORD,
                                   DWORD) {
-    RequestForceOn();
+    // Same thread that called SetWinEventHook (the worker).
+    ForceNumLockOn(false);
 }
 
 void RegisterForegroundHook() {
@@ -786,6 +803,11 @@ DWORD WINAPI HookThreadProc(LPVOID) {
     }
 
     while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+        if (!msg.hwnd && msg.message == WM_APP_REHOOK) {
+            UninstallKeyboardHook();
+            TryInstallKeyboardHook();
+            continue;
+        }
         TranslateMessage(&msg);
         DispatchMessageW(&msg);
     }

--- a/mods/numlock-lockdown.wh.cpp
+++ b/mods/numlock-lockdown.wh.cpp
@@ -2,7 +2,7 @@
 // @id              numlock-lockdown
 // @name            Num Lock Lockdown
 // @description     Keeps Num Lock permanently ON, with a modifier key for temporary override
-// @version         1.1.5
+// @version         1.1.6
 // @author          tonythethompson
 // @github          https://github.com/tonythethompson
 // @include         windhawk.exe
@@ -136,10 +136,9 @@ constexpr UINT WM_APP_QUIT = WM_APP + 3;
 constexpr UINT WM_APP_REHOOK = WM_APP + 4;
 
 constexpr UINT_PTR kSafetyTimerId = 1;
-// Independent of safetyCheckSeconds (including 0). Recovers a WH_KEYBOARD_LL
-// hook Windows silently removed after a timeout.
-constexpr UINT_PTR kHookRetryTimerId = 2;
-constexpr UINT kHookRetryIntervalMs = 60 * 1000;
+// Worker-thread only. Caps evidence-driven rehooks so an elevated window
+// that keeps Num Lock off (UIPI) does not swap the hook every safety tick.
+constexpr ULONGLONG kRehookMinIntervalMs = 60 * 1000;
 
 // dwExtraInfo stamped on every synthetic Num Lock we send, so the hook can
 // let our own keystrokes through without treating them as user input.
@@ -203,6 +202,8 @@ HANDLE g_hookReadyEvent = nullptr;
 HPOWERNOTIFY g_suspendResumeNotify = nullptr;
 HWINEVENTHOOK g_foregroundHook = nullptr;
 bool g_sessionNotifyRegistered = false;
+// Worker thread only. Last time we posted WM_APP_REHOOK.
+ULONGLONG g_lastRehookMs = 0;
 
 // ---------------------------------------------------------------------------
 // Settings
@@ -399,6 +400,32 @@ void SendNumLockPulse() {
     }
 }
 
+void UninstallKeyboardHook() {
+    HHOOK hook = g_keyboardHook.exchange(nullptr, std::memory_order_acq_rel);
+    if (hook) {
+        UnhookWindowsHookEx(hook);
+    }
+}
+
+// Worker thread only. Unconditional: unlock/resume.
+void RequestRehook() {
+    g_lastRehookMs = GetTickCount64();
+    DWORD threadId = g_hookThreadId.load(std::memory_order_acquire);
+    if (threadId) {
+        PostThreadMessageW(threadId, WM_APP_REHOOK, 0, 0);
+    }
+}
+
+// Worker thread only. Num Lock found off is the signal the hook may have
+// been dropped. Do not swap a healthy hook on a timer.
+void RequestEvidenceRehook() {
+    const ULONGLONG now = GetTickCount64();
+    if (g_lastRehookMs != 0 && now - g_lastRehookMs < kRehookMinIntervalMs) {
+        return;
+    }
+    RequestRehook();
+}
+
 // Must run on the worker thread, never inside the LL hook.
 void ForceNumLockOn(bool logSafety) {
     if (IsOverrideHeldVerified() || IsNumLockOn()) {
@@ -407,21 +434,8 @@ void ForceNumLockOn(bool logSafety) {
     if (logSafety) {
         Wh_Log(L"Safety check: Num Lock was off, forcing ON");
     }
+    RequestEvidenceRehook();
     SendNumLockPulse();
-}
-
-void UninstallKeyboardHook() {
-    HHOOK hook = g_keyboardHook.exchange(nullptr, std::memory_order_acq_rel);
-    if (hook) {
-        UnhookWindowsHookEx(hook);
-    }
-}
-
-void RequestRehook() {
-    DWORD threadId = g_hookThreadId.load(std::memory_order_acquire);
-    if (threadId) {
-        PostThreadMessageW(threadId, WM_APP_REHOOK, 0, 0);
-    }
 }
 
 void UpdateSafetyTimer() {
@@ -440,17 +454,6 @@ void UpdateSafetyTimer() {
     const UINT intervalMs = static_cast<UINT>(seconds) * 1000;
     if (!SetTimer(hwnd, kSafetyTimerId, intervalMs, nullptr)) {
         Wh_Log(L"SetTimer failed: %lu", GetLastError());
-    }
-}
-
-void StartHookRetryTimer() {
-    HWND hwnd = g_workerHwnd.load(std::memory_order_acquire);
-    if (!hwnd) {
-        return;
-    }
-
-    if (!SetTimer(hwnd, kHookRetryTimerId, kHookRetryIntervalMs, nullptr)) {
-        Wh_Log(L"SetTimer (hook retry) failed: %lu", GetLastError());
     }
 }
 
@@ -616,8 +619,6 @@ LRESULT CALLBACK WorkerWndProc(HWND hwnd, UINT msg, WPARAM wParam,
         case WM_TIMER:
             if (wParam == kSafetyTimerId) {
                 ForceNumLockOn(true);
-            } else if (wParam == kHookRetryTimerId) {
-                RequestRehook();
             }
             return 0;
 
@@ -739,7 +740,6 @@ DWORD WINAPI WorkerThreadProc(LPVOID) {
     SeedModifierState();
     ForceNumLockOn(false);
     UpdateSafetyTimer();
-    StartHookRetryTimer();
 
     if (g_workerReadyEvent) {
         SetEvent(g_workerReadyEvent);
@@ -753,7 +753,6 @@ DWORD WINAPI WorkerThreadProc(LPVOID) {
     hwnd = g_workerHwnd.exchange(nullptr, std::memory_order_acq_rel);
     if (hwnd) {
         KillTimer(hwnd, kSafetyTimerId);
-        KillTimer(hwnd, kHookRetryTimerId);
         UnregisterPowerAndSession(hwnd);
         DestroyWindow(hwnd);
     }

--- a/mods/numlock-lockdown.wh.cpp
+++ b/mods/numlock-lockdown.wh.cpp
@@ -2,8 +2,8 @@
 // @id              numlock-lockdown
 // @name            Num Lock Lockdown
 // @description     Keeps Num Lock permanently ON, with a modifier key for temporary override
-// @version         1.1.0
-// @author          Tony Thompson
+// @version         1.1.1
+// @author          tonythethompson
 // @github          https://github.com/tonythethompson
 // @include         windhawk.exe
 // @compilerOptions -luser32 -lshell32 -lwtsapi32

--- a/mods/numlock-lockdown.wh.cpp
+++ b/mods/numlock-lockdown.wh.cpp
@@ -2,7 +2,7 @@
 // @id              numlock-lockdown
 // @name            Num Lock Lockdown
 // @description     Keeps Num Lock permanently ON, with a modifier key for temporary override
-// @version         1.0.9
+// @version         1.1.0
 // @author          Tony Thompson
 // @github          https://github.com/tonythethompson
 // @include         windhawk.exe
@@ -15,9 +15,9 @@
 # Num Lock Lockdown
 
 Keeps Num Lock ON with almost no background work. A low-level keyboard hook
-watches the Num Lock key and the override modifier. There is no continuous
-polling. An optional slow safety timer (off, or every few seconds) covers the
-few cases the hook cannot see.
+watches the Num Lock key and the override modifier. There is no fast polling.
+An optional slow safety check (off, or every few seconds; 10 s by default)
+covers the few cases the hook cannot see.
 
 ## Behavior
 
@@ -46,14 +46,18 @@ keeps overhead low and avoids tying Num Lock to the shell process.
 ## Notes
 
 - The keyboard hook cannot see keystrokes sent to a higher-integrity
-  (elevated) window because of UIPI. If Windhawk is not running as
-  administrator, enable the safety check so an elevated app that turns Num
-  Lock off is corrected within a few seconds.
-- The hook also cannot see some Remote Desktop / KVM paths. The safety check
-  and session-unlock / resume handlers cover those.
+  (elevated) window because of UIPI. `SendInput` is also subject to UIPI:
+  when an elevated window is focused, the injected Num Lock pulse is
+  dropped and neither the return value nor `GetLastError` reports it. Run
+  Windhawk as administrator if you need the force-on to work while an
+  elevated app is in front. The safety check retries after focus changes.
+- The hook also cannot see some Remote Desktop / KVM paths. Session-unlock
+  / resume handlers and the safety check cover those.
 - If the hook misses a modifier key-up (elevated window or secure desktop),
-  the worker re-reads the real key state before trusting a cached "held", so
-  the safety timer cannot stay inert.
+  the next Num Lock event re-reads the real modifier state from the OS, and
+  the worker does the same before skipping a force-on.
+- **Block** also swallows the ToggleKeys accessibility shortcut (hold Num
+  Lock for 5 seconds). Use **Allow** if you need that shortcut.
 - Synthetic Num Lock presses this mod sends are tagged and ignored by the
   hook, so the force-on path cannot fight itself.
 - In "allow" mode, holding Num Lock without the modifier can leave it off
@@ -114,12 +118,10 @@ constexpr UINT WM_APP_FORCE_ON = WM_APP + 1;
 constexpr UINT WM_APP_UPDATE_TIMER = WM_APP + 2;
 constexpr UINT WM_APP_QUIT = WM_APP + 3;
 
-// Posted to the hook thread to retry SetWindowsHookEx if the first attempt
-// failed. The hook thread stays in its message loop either way.
-constexpr UINT WM_APP_ENSURE_HOOK = WM_APP + 4;
-
 constexpr UINT_PTR kSafetyTimerId = 1;
 constexpr UINT_PTR kDeferredForceTimerId = 2;
+constexpr UINT kDeferredForceDelayMs = 50;
+constexpr int kDeferredForceMaxTries = 2;
 
 // dwExtraInfo stamped on every synthetic Num Lock we send, so the hook can
 // let our own keystrokes through without treating them as user input.
@@ -160,6 +162,14 @@ std::atomic<bool> g_allowedNumLockDown{false};
 // and auto-repeat downs are swallowed too, so the key cannot stick.
 std::atomic<bool> g_swallowedNumLockDown{false};
 
+// Set when a Num Lock press was allowed because the override was held.
+// Modifier key-up only asks for a force-on after that, so ordinary Shift
+// taps during typing do not wake the worker.
+std::atomic<bool> g_overrideUsedThisHold{false};
+
+// Worker thread only. Counts deferred "toggle may not have landed" retries.
+int g_deferredForceTries = 0;
+
 // ---------------------------------------------------------------------------
 // Worker thread / window / hook
 // ---------------------------------------------------------------------------
@@ -197,7 +207,7 @@ bool IsNumLockOn() {
 }
 
 bool ParseModifier(PCWSTR value, OverrideModifier* out) {
-    if (!value || !out) {
+    if (!out) {
         return false;
     }
     if (_wcsicmp(value, L"none") == 0) {
@@ -237,7 +247,7 @@ void LoadSettings() {
     bool blockKey = true;
     WindhawkUtils::StringSetting keyMode =
         WindhawkUtils::StringSetting::make(L"numLockKeyMode");
-    if (keyMode.get() && _wcsicmp(keyMode.get(), L"allow") == 0) {
+    if (_wcsicmp(keyMode.get(), L"allow") == 0) {
         blockKey = false;
     }
     g_blockNumLockKey.store(blockKey, std::memory_order_relaxed);
@@ -263,12 +273,8 @@ bool IsOverrideVk(DWORD vk) {
             return vk == VK_LWIN || vk == VK_RWIN;
         case OverrideModifier::None:
             return false;
-        default: {
-            const OverrideModifier unmatched = CurrentModifier();
-            static_cast<void>(unmatched);
-            return false;
-        }
     }
+    return false;
 }
 
 void SetModifierDown(DWORD vk, bool down) {
@@ -298,42 +304,32 @@ void SetModifierDown(DWORD vk, bool down) {
 }
 
 void SeedModifierState() {
-    g_leftModDown.store(false, std::memory_order_relaxed);
-    g_rightModDown.store(false, std::memory_order_relaxed);
+    bool left = false;
+    bool right = false;
 
     switch (CurrentModifier()) {
         case OverrideModifier::Shift:
-            g_leftModDown.store(GetAsyncKeyState(VK_LSHIFT) < 0,
-                                std::memory_order_relaxed);
-            g_rightModDown.store(GetAsyncKeyState(VK_RSHIFT) < 0,
-                                 std::memory_order_relaxed);
+            left = GetAsyncKeyState(VK_LSHIFT) < 0;
+            right = GetAsyncKeyState(VK_RSHIFT) < 0;
             break;
         case OverrideModifier::Ctrl:
-            g_leftModDown.store(GetAsyncKeyState(VK_LCONTROL) < 0,
-                                std::memory_order_relaxed);
-            g_rightModDown.store(GetAsyncKeyState(VK_RCONTROL) < 0,
-                                 std::memory_order_relaxed);
+            left = GetAsyncKeyState(VK_LCONTROL) < 0;
+            right = GetAsyncKeyState(VK_RCONTROL) < 0;
             break;
         case OverrideModifier::Alt:
-            g_leftModDown.store(GetAsyncKeyState(VK_LMENU) < 0,
-                                std::memory_order_relaxed);
-            g_rightModDown.store(GetAsyncKeyState(VK_RMENU) < 0,
-                                 std::memory_order_relaxed);
+            left = GetAsyncKeyState(VK_LMENU) < 0;
+            right = GetAsyncKeyState(VK_RMENU) < 0;
             break;
         case OverrideModifier::Win:
-            g_leftModDown.store(GetAsyncKeyState(VK_LWIN) < 0,
-                                std::memory_order_relaxed);
-            g_rightModDown.store(GetAsyncKeyState(VK_RWIN) < 0,
-                                 std::memory_order_relaxed);
+            left = GetAsyncKeyState(VK_LWIN) < 0;
+            right = GetAsyncKeyState(VK_RWIN) < 0;
             break;
         case OverrideModifier::None:
             break;
-        default: {
-            const OverrideModifier unmatched = CurrentModifier();
-            static_cast<void>(unmatched);
-            break;
-        }
     }
+
+    g_leftModDown.store(left, std::memory_order_relaxed);
+    g_rightModDown.store(right, std::memory_order_relaxed);
 }
 
 void ClearStaleKeyFlags() {
@@ -369,13 +365,6 @@ void RequestForceOn() {
     }
 }
 
-void RequestEnsureHook() {
-    DWORD threadId = g_hookThreadId.load(std::memory_order_acquire);
-    if (threadId) {
-        PostThreadMessageW(threadId, WM_APP_ENSURE_HOOK, 0, 0);
-    }
-}
-
 // SendInput runs on the worker thread. The LL hook lives on a dedicated
 // hook thread that is sitting in GetMessage, so Windows can deliver the
 // callback there without this thread unhooking. No observation gap.
@@ -399,21 +388,30 @@ void SendNumLockPulse() {
     }
 }
 
+enum class ForceResult {
+    Sent,
+    AlreadyOn,
+    OverrideHeld,
+};
+
 // Must run on the worker thread, never inside the LL hook.
-// Returns true if a pulse was sent.
-bool ForceNumLockOn(bool logSafety) {
-    if (IsOverrideHeldVerified() || IsNumLockOn()) {
-        return false;
+ForceResult ForceNumLockOn(bool logSafety) {
+    if (IsOverrideHeldVerified()) {
+        return ForceResult::OverrideHeld;
+    }
+    if (IsNumLockOn()) {
+        return ForceResult::AlreadyOn;
     }
     if (logSafety) {
         Wh_Log(L"Safety check: Num Lock was off, forcing ON");
     }
     SendNumLockPulse();
-    return true;
+    return ForceResult::Sent;
 }
 
 void ArmDeferredForceOn(HWND hwnd) {
-    SetTimer(hwnd, kDeferredForceTimerId, 0, nullptr);
+    g_deferredForceTries = 0;
+    SetTimer(hwnd, kDeferredForceTimerId, kDeferredForceDelayMs, nullptr);
 }
 
 void UninstallKeyboardHook() {
@@ -482,10 +480,11 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
     if (IsOverrideVk(vk)) {
         SetModifierDown(vk, isDown);
 
-        // Shift released: restore Num Lock unless a user Num Lock key-up is
-        // still outstanding (that up would toggle after our pulse).
+        // Only wake the worker after an override was actually used. Ordinary
+        // Shift taps during typing stay on this thread.
         if (isUp && !IsOverrideHeld() &&
-            !g_allowedNumLockDown.load(std::memory_order_relaxed)) {
+            !g_allowedNumLockDown.load(std::memory_order_relaxed) &&
+            g_overrideUsedThisHold.exchange(false, std::memory_order_relaxed)) {
             RequestForceOn();
         }
 
@@ -496,10 +495,15 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
         return Pass(nCode, wParam, lParam);
     }
 
+    // Num Lock is rare. Re-read the modifier from the OS so a missed
+    // key-up (UIPI / secure desktop) cannot leave the cache stuck "held".
+    SeedModifierState();
+
     if (isDown) {
         if (IsOverrideHeld()) {
             g_allowedNumLockDown.store(true, std::memory_order_relaxed);
             g_swallowedNumLockDown.store(false, std::memory_order_relaxed);
+            g_overrideUsedThisHold.store(true, std::memory_order_relaxed);
             return Pass(nCode, wParam, lParam);
         }
 
@@ -526,12 +530,10 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
 
         if (allowed) {
             // Deliver the matching up first so any toggle settles, then
-            // force ON if the override is no longer held. Posting before
-            // CallNextHookEx can run the pulse, then lose to this key-up.
+            // ask the worker to force ON. The worker re-verifies the hold
+            // and no-ops if the override is still actually down.
             const LRESULT result = Pass(nCode, wParam, lParam);
-            if (!IsOverrideHeld()) {
-                RequestForceOn();
-            }
+            RequestForceOn();
             return result;
         }
 
@@ -583,14 +585,21 @@ void UnregisterPowerAndSession(HWND hwnd) {
 LRESULT CALLBACK WorkerWndProc(HWND hwnd, UINT msg, WPARAM wParam,
                                LPARAM lParam) {
     switch (msg) {
-        case WM_APP_FORCE_ON:
-            if (!ForceNumLockOn(false)) {
-                // Nothing sent: the user's toggle may not have been applied
-                // yet, so look again shortly. Do not arm after a pulse:
-                // SendInput is async and a second pulse would toggle OFF.
-                ArmDeferredForceOn(hwnd);
+        case WM_APP_FORCE_ON: {
+            const ForceResult result = ForceNumLockOn(false);
+            switch (result) {
+                case ForceResult::AlreadyOn:
+                    // Toggle may not have been applied yet. Look again shortly.
+                    // Do not retry after Sent: a second pulse would toggle OFF.
+                    // Do not retry after OverrideHeld: the hold is real.
+                    ArmDeferredForceOn(hwnd);
+                    break;
+                case ForceResult::Sent:
+                case ForceResult::OverrideHeld:
+                    break;
             }
             return 0;
+        }
 
         case WM_APP_UPDATE_TIMER:
             SeedModifierState();
@@ -604,11 +613,15 @@ LRESULT CALLBACK WorkerWndProc(HWND hwnd, UINT msg, WPARAM wParam,
 
         case WM_TIMER:
             if (wParam == kSafetyTimerId) {
-                RequestEnsureHook();
                 ForceNumLockOn(true);
             } else if (wParam == kDeferredForceTimerId) {
                 KillTimer(hwnd, kDeferredForceTimerId);
-                ForceNumLockOn(false);
+                if (ForceNumLockOn(false) == ForceResult::AlreadyOn &&
+                    g_deferredForceTries < kDeferredForceMaxTries) {
+                    ++g_deferredForceTries;
+                    SetTimer(hwnd, kDeferredForceTimerId, kDeferredForceDelayMs,
+                             nullptr);
+                }
             }
             return 0;
 
@@ -617,7 +630,6 @@ LRESULT CALLBACK WorkerWndProc(HWND hwnd, UINT msg, WPARAM wParam,
                 case WTS_SESSION_UNLOCK:
                 case WTS_CONSOLE_CONNECT:
                 case WTS_REMOTE_CONNECT:
-                    RequestEnsureHook();
                     ForceNumLockOn(false);
                     break;
                 default:
@@ -629,7 +641,6 @@ LRESULT CALLBACK WorkerWndProc(HWND hwnd, UINT msg, WPARAM wParam,
             switch (wParam) {
                 case PBT_APMRESUMEAUTOMATIC:
                 case PBT_APMRESUMESUSPEND:
-                    RequestEnsureHook();
                     ForceNumLockOn(false);
                     break;
                 default:
@@ -653,7 +664,7 @@ HMODULE GetCurrentModuleHandle() {
     return module;
 }
 
-bool RegisterPowerAndSession(HWND hwnd) {
+void RegisterPowerAndSession(HWND hwnd) {
     if (WTSRegisterSessionNotification(hwnd, NOTIFY_FOR_THIS_SESSION)) {
         g_sessionNotifyRegistered = true;
     } else {
@@ -675,8 +686,6 @@ bool RegisterPowerAndSession(HWND hwnd) {
             }
         }
     }
-
-    return true;
 }
 
 DWORD WINAPI WorkerThreadProc(LPVOID) {
@@ -702,9 +711,12 @@ DWORD WINAPI WorkerThreadProc(LPVOID) {
         return 1;
     }
 
-    HWND hwnd =
-        CreateWindowExW(0, kWorkerClass, L"", 0, 0, 0, 0, 0, HWND_MESSAGE,
-                        nullptr, module, nullptr);
+    // Hidden top-level window (not HWND_MESSAGE). WTSRegisterSessionNotification
+    // does not deliver WM_WTSSESSION_CHANGE to message-only windows.
+    // WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE keeps it out of Alt+Tab; never shown.
+    HWND hwnd = CreateWindowExW(
+        WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE, kWorkerClass, L"", WS_OVERLAPPED, 0,
+        0, 0, 0, nullptr, nullptr, module, nullptr);
     g_workerHwnd.store(hwnd, std::memory_order_release);
     if (!hwnd) {
         Wh_Log(L"CreateWindowExW failed: %lu", GetLastError());
@@ -783,10 +795,6 @@ DWORD WINAPI HookThreadProc(LPVOID) {
     }
 
     while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
-        if (msg.message == WM_APP_ENSURE_HOOK) {
-            TryInstallKeyboardHook();
-            continue;
-        }
         TranslateMessage(&msg);
         DispatchMessageW(&msg);
     }
@@ -845,7 +853,9 @@ BOOL WhTool_ModInit() {
     }
 
     if (!g_keyboardHook.load(std::memory_order_acquire)) {
-        Wh_Log(L"Keyboard hook not installed yet; safety timer will retry");
+        Wh_Log(L"Keyboard hook failed to install");
+        WhTool_ModUninit();
+        return FALSE;
     }
 
     return TRUE;


### PR DESCRIPTION
Adds **Num Lock Lockdown**, a lightweight tool mod that keeps Num Lock permanently ON. It runs in a dedicated `windhawk.exe` process with a low-level keyboard hook. Hold Shift (or another modifier) to toggle Num Lock normally. Releasing the modifier, session unlock, resume, and an optional safety timer force it back ON.

The PR adds a single file, `mods/numlock-lockdown.wh.cpp`, matching the `@id`.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

- Initial public release.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [x] Another AI (please specify): Cursor
- - [ ] Other (please specify):

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.