### PR TITLE
Add Taskbar Network Speed Indicator mod (net-speed-taskbar)

### DIFF
--- a/mods/net-speed-taskbar.wh.cpp
+++ b/mods/net-speed-taskbar.wh.cpp
@@ -2,7 +2,7 @@
 // @id          net-speed-taskbar
 // @name        Taskbar Network Speed Indicator
 // @description A free-floating network speed widget you can place anywhere along the taskbar, featuring a sparkline chart and multiple layouts.
-// @version     1.3
+// @version     1.4
 // @author      Narayan
 // @github      https://github.com/NarayanChetri
 // @homepage    https://narayanchetri.dev
@@ -33,6 +33,13 @@ actually be an `explorer.exe` image.
 - Choose from different looks: Side-by-Side, Top-Down, Chart, or Minimal.
 - Move the widget anywhere along your taskbar using the Horizontal Position setting.
 - Click-through: it won't get in the way of your taskbar buttons.
+- Recovers automatically on an Explorer crash/restart, not just a clean shell exit.
+- Hides while a full-screen app or game covers the taskbar's monitor.
+
+Note: [Taskbar Clock Customization](https://windhawk.net) and
+[taskbar-system-info](https://windhawk.net) both offer similar taskbar network
+readouts. This mod's differentiators are the free horizontal placement anywhere
+along the taskbar and the sparkline chart layouts.
 */
 // ==/WindhawkModReadme==
 
@@ -58,6 +65,11 @@ actually be an `explorer.exe` image.
 */
 // ==/WindhawkModSettings==
 
+// winsock2.h must come before windows.h so that iphlpapi.h pulls in the
+// netioapi.h declarations (GetIfEntry2 / MIB_IF_ROW2) instead of only the
+// legacy 32-bit-counter API.
+#include <winsock2.h>
+#include <ws2tcpip.h>
 #include <windows.h>
 #include <gdiplus.h>
 #include <iphlpapi.h>
@@ -150,8 +162,6 @@ int g_currentWidgetHeight = 0;
 ULONGLONG g_lastTick = 0;
 ULONG64 g_lastIn = 0;
 ULONG64 g_lastOut = 0;
-ULONG64 g_cumIn = 0;
-ULONG64 g_cumOut = 0;
 double g_downBps = 0.0;
 double g_upBps = 0.0;
 
@@ -257,6 +267,10 @@ void GetThemeDimensions(const std::wstring& theme, int& width, int& height) {
     }
 }
 
+// Uses GetIfEntry2 / MIB_IF_ROW2 (64-bit counters), so no 32-bit-wrap
+// emulation is needed. A counter reset (adapter toggle, driver reset,
+// resume from sleep) is instead caught in UpdateSpeedSample by comparing
+// against the previous sample.
 bool GetTotalOctets(ULONG64* inOctets, ULONG64* outOctets) {
     ULONGLONG now = GetTickCount64();
     if (g_bestIfIndex == 0 || (now - g_lastRouteCheck) > 10000) {
@@ -272,22 +286,14 @@ bool GetTotalOctets(ULONG64* inOctets, ULONG64* outOctets) {
 
     if (g_bestIfIndex == 0) return false;
 
-    // Windhawk's bundled mingw headers only declare the older MIB_IFROW /
-    // GetIfEntry (32-bit counters), not MIB_IF_ROW2 / GetIfEntry2. The
-    // 32-bit wrap (~34s on a gigabit link) is handled explicitly in
-    // UpdateSpeedSample via a 64-bit running total.
-    MIB_IFROW row{};
-    row.dwIndex = g_bestIfIndex;
-    if (GetIfEntry(&row) != NO_ERROR) {
+    MIB_IF_ROW2 row{};
+    row.InterfaceIndex = g_bestIfIndex;
+    if (GetIfEntry2(&row) != NO_ERROR || row.OperStatus != IfOperStatusUp) {
         return false;
     }
 
-    if (row.dwOperStatus != MIB_IF_OPER_STATUS_OPERATIONAL && row.dwOperStatus != MIB_IF_OPER_STATUS_CONNECTED) {
-        return false;
-    }
-
-    *inOctets = row.dwInOctets;
-    *outOctets = row.dwOutOctets;
+    *inOctets = row.InOctets;
+    *outOctets = row.OutOctets;
     return true;
 }
 
@@ -311,31 +317,24 @@ void UpdateSpeedSample() {
         g_lastTick = 0;
     } else {
         ULONGLONG now = GetTickCount64();
-        bool discontinuity = (g_lastTick == 0);
+        // A raw counter smaller than the previous sample means the adapter's
+        // counters were reset, not that they wrapped (64-bit wrap isn't a
+        // practical concern). Report 0 for that sample and resync.
+        bool discontinuity = (g_lastTick == 0) || (rawIn < g_lastIn) || (rawOut < g_lastOut);
 
-        if (discontinuity) {
-            g_cumIn = rawIn;
-            g_cumOut = rawOut;
-        } else {
-            auto accumulate = [](ULONG64& cumulative, ULONG64 rawSample) {
-                ULONG64 prevLow = cumulative & 0xFFFFFFFFULL;
-                ULONG64 delta = (rawSample >= prevLow)
-                                     ? (rawSample - prevLow)
-                                     : (0x100000000ULL - prevLow + rawSample);
-                cumulative += delta;
-            };
-            accumulate(g_cumIn, rawIn);
-            accumulate(g_cumOut, rawOut);
-
+        if (!discontinuity) {
             double elapsedSec = (now - g_lastTick) / 1000.0;
             if (elapsedSec > 0.05) {
-                g_downBps = (double)(g_cumIn - g_lastIn) / elapsedSec;
-                g_upBps = (double)(g_cumOut - g_lastOut) / elapsedSec;
+                g_downBps = (double)(rawIn - g_lastIn) / elapsedSec;
+                g_upBps = (double)(rawOut - g_lastOut) / elapsedSec;
             }
+        } else {
+            g_downBps = 0.0;
+            g_upBps = 0.0;
         }
 
-        g_lastIn = g_cumIn;
-        g_lastOut = g_cumOut;
+        g_lastIn = rawIn;
+        g_lastOut = rawOut;
         g_lastTick = now;
     }
 
@@ -344,8 +343,24 @@ void UpdateSpeedSample() {
     g_historyIdx = (g_historyIdx + 1) % kHistorySize;
 }
 
+// True when the foreground window exactly covers the taskbar's monitor,
+// which is Explorer's own signal that a full-screen app/game is active
+// (Shell_TrayWnd stays IsWindowVisible==TRUE, just pushed down in Z-order).
+bool IsFullScreenBlockingTaskbar(HWND hTaskbar) {
+    HWND fg = GetForegroundWindow();
+    if (!fg || fg == GetShellWindow()) return false;
+
+    HMONITOR mon = MonitorFromWindow(hTaskbar, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO mi{sizeof(mi)};
+    RECT fgRect{};
+    if (!GetMonitorInfo(mon, &mi) || !GetWindowRect(fg, &fgRect)) return false;
+
+    return EqualRect(&fgRect, &mi.rcMonitor);
+}
+
 void RepositionWidget(HWND hWnd, const Settings& s) {
-    if (!IsWindow(g_hCachedTaskbar) || !IsWindowVisible(g_hCachedTaskbar)) {
+    if (!IsWindow(g_hCachedTaskbar) || !IsWindowVisible(g_hCachedTaskbar) ||
+        IsFullScreenBlockingTaskbar(g_hCachedTaskbar)) {
         if (IsWindowVisible(hWnd)) ShowWindow(hWnd, SW_HIDE);
         return;
     }
@@ -572,11 +587,17 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         case WM_TIMER:
             if (wParam == kTimerId) {
                 UpdateSpeedSample();
-                if (g_hCachedTaskbar && IsWindow(g_hCachedTaskbar)) {
-                    Settings s = GetSafeSettings();
-                    RepositionWidget(hWnd, s);
-                    RenderWidget(hWnd, s.opacity);
+                if (!g_hCachedTaskbar || !IsWindow(g_hCachedTaskbar)) {
+                    // Taskbar vanished without a destroy event (e.g. Explorer
+                    // crashed rather than exiting cleanly). Tear down so the
+                    // outer loop re-attaches to the new taskbar.
+                    g_hCachedTaskbar = nullptr;
+                    PostMessageW(hWnd, WM_CLOSE, 0, 0);
+                    return 0;
                 }
+                Settings s = GetSafeSettings();
+                RepositionWidget(hWnd, s);
+                RenderWidget(hWnd, s.opacity);
             }
             return 0;
         case WM_ERASEBKGND:
@@ -799,8 +820,15 @@ void WhTool_ModSettingsChanged() {
 
 ////////////////////////////////////////////////////////////////////////////////
 // Windhawk tool mod implementation for mods which don't need to inject to
-// other processes or hook other functions. Pasted verbatim from:
+// other processes or hook other functions. Based on:
 // https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process
+//
+// Deviation from the verbatim snippet: only the real Explorer shell process
+// (started with no command-line arguments) becomes the tool-mod launcher.
+// Without this, every explorer.exe instance -- including short-lived
+// /factory,{...} -Embedding COM-server instances and separate-process
+// folder windows -- would spawn and immediately exit a throwaway tool-mod
+// process on every launch.
 
 bool g_isToolModProcessLauncher;
 HANDLE g_toolModProcessMutex;
@@ -846,6 +874,11 @@ BOOL Wh_ModInit() {
         }
     }
 
+    // Only the shell instance (no arguments) should be treated as a
+    // candidate launcher; -Embedding COM servers, folder windows, etc.
+    // shouldn't spawn a tool-mod process of their own.
+    bool isPlainShellInstance = (argc == 1);
+
     LocalFree(argv);
 
     if (isExcluded) {
@@ -885,7 +918,7 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
-    g_isToolModProcessLauncher = true;
+    g_isToolModProcessLauncher = isPlainShellInstance;
     return TRUE;
 }
 

--- a/mods/net-speed-taskbar.wh.cpp
+++ b/mods/net-speed-taskbar.wh.cpp
@@ -1,13 +1,13 @@
 // ==WindhawkMod==
 // @id          net-speed-taskbar
 // @name        Taskbar Network Speed Indicator
-// @description A clean, lightweight tool that displays your live internet download and upload speeds right on the Windows taskbar.
-// @version     1.0
+// @description A free-floating network speed widget you can place anywhere along the taskbar, featuring a sparkline chart and multiple layouts.
+// @version     1.1
 // @author      Narayan
 // @github      https://github.com/NarayanChetri
 // @homepage    https://narayanchetri.dev
 // @include     explorer.exe
-// @compilerOptions -lgdiplus -liphlpapi -lgdi32 -luser32 -DWIN32_LEAN_AND_MEAN
+// @compilerOptions -lgdiplus -liphlpapi
 // @architecture    x86-64
 // @license         MIT
 // ==/WindhawkMod==
@@ -16,8 +16,7 @@
 /*
 # Taskbar Network Speed Indicator
 
-Draws a small floating widget docked to the taskbar that shows your current
-download and upload internet speed, refreshed every second.
+Unlike the existing "Taskbar Clock Customization" mod, this is a free-floating widget that can be placed anywhere along the taskbar, featuring a real-time sparkline chart and multiple distinct visual layouts. It shows your current download and upload internet speed, refreshed every second.
 
 ![Demo](https://raw.githubusercontent.com/NarayanChetri/Files/main/taskbar-speed-indicator.gif)
 
@@ -58,6 +57,10 @@ download and upload internet speed, refreshed every second.
 */
 // ==/WindhawkModSettings==
 
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0A00
+#endif
+
 #include <winsock2.h>
 #include <ws2ipdef.h>
 #include <windows.h>
@@ -71,6 +74,8 @@ download and upload internet speed, refreshed every second.
 #include <vector>
 #include <memory>
 #include <mutex>
+#include <cstdio>
+#include <windhawk_utils.h>
 
 using namespace Gdiplus;
 
@@ -92,19 +97,25 @@ Settings g_settings;
 std::mutex g_settingsMutex;
 
 std::atomic<HWND> g_hWnd{nullptr};
+std::mutex g_wndLifecycleMutex; // Guards creation, publication, and teardown of g_hWnd
+
 std::atomic<bool> g_posUpdatePending{false};
+std::atomic<bool> g_exiting{false};
 ULONG_PTR g_gdiplusToken = 0;
 constexpr UINT_PTR kTimerId = 1001;
 
 HANDLE g_hThread = nullptr;
 DWORD g_threadId = 0;
 HANDLE g_hQueueReady = nullptr;
-HANDLE g_hMutex = nullptr;
+HANDLE g_hExitEvent = nullptr;
 
 HWINEVENTHOOK g_hLocationHook = nullptr;
 HWINEVENTHOOK g_hDestroyHook = nullptr;
 DWORD g_taskbarPid = 0;
 DWORD g_taskbarTid = 0;
+HWND g_hCachedTaskbar = nullptr;
+
+RECT g_lastWidgetRect = {0, 0, 0, 0};
 
 ULONGLONG g_lastTick = 0;
 ULONG64 g_lastIn = 0;
@@ -114,8 +125,6 @@ double g_upBps = 0.0;
 
 DWORD g_bestIfIndex = 0;
 ULONGLONG g_lastRouteCheck = 0;
-
-const wchar_t* kClassName = L"WindhawkNetSpeedWidgetWnd";
 
 const size_t kHistorySize = 20;
 std::vector<double> g_downHistory(kHistorySize, 0.0);
@@ -133,8 +142,14 @@ struct GdiObjects {
     std::unique_ptr<Gdiplus::Pen> dividerPen;
     std::unique_ptr<Gdiplus::Pen> downChartPen;
     std::unique_ptr<Gdiplus::Pen> upChartPen;
+
+    bool IsValid() const {
+        return font && largeFont && bgBrush && downBrush && upBrush && 
+               shadowBrush && borderPen && dividerPen && downChartPen && upChartPen;
+    }
 };
-std::unique_ptr<GdiObjects> g_gdi;
+
+[[clang::no_destroy]] std::unique_ptr<GdiObjects> g_gdi;
 UINT g_currentDpi = 96;
 
 HINSTANCE GetCurrentModuleHandle() {
@@ -152,11 +167,7 @@ Settings GetSafeSettings() {
 
 void LoadSettingsLocked() {
     std::lock_guard<std::mutex> lock(g_settingsMutex);
-    
-    PCWSTR pTheme = Wh_GetStringSetting(L"theme");
-    g_settings.theme = pTheme ? pTheme : L"Minimal";
-    if (pTheme) Wh_FreeStringSetting(pTheme);
-    
+    g_settings.theme = WindhawkUtils::StringSetting::make(L"theme").get();
     g_settings.horizontalPosition = std::clamp((int)Wh_GetIntSetting(L"horizontalPosition"), 0, 100);
     g_settings.verticalNudge = std::clamp((int)Wh_GetIntSetting(L"verticalNudge"), -1000, 1000);
     g_settings.updateIntervalMs = std::max((int)Wh_GetIntSetting(L"updateIntervalMs"), 200);
@@ -165,13 +176,13 @@ void LoadSettingsLocked() {
 }
 
 void RebuildGdiObjects(int fontSize, const std::wstring& theme, UINT dpi) {
-    g_gdi = std::make_unique<GdiObjects>();
+    auto newGdi = std::make_unique<GdiObjects>();
 
     Gdiplus::FontFamily fontFamily(L"Segoe UI");
     float scaledFontSize = (float)MulDiv(fontSize, dpi, 96);
 
-    g_gdi->font = std::make_unique<Gdiplus::Font>(&fontFamily, scaledFontSize, FontStyleRegular, UnitPixel);
-    g_gdi->largeFont = std::make_unique<Gdiplus::Font>(&fontFamily, scaledFontSize * 1.3f, FontStyleBold, UnitPixel);
+    newGdi->font = std::make_unique<Gdiplus::Font>(&fontFamily, scaledFontSize, FontStyleRegular, UnitPixel);
+    newGdi->largeFont = std::make_unique<Gdiplus::Font>(&fontFamily, scaledFontSize * 1.3f, FontStyleBold, UnitPixel);
     
     Color bgColor = Color(240, 18, 20, 22);
     Color downColor = Color(255, 64, 169, 255); 
@@ -183,17 +194,21 @@ void RebuildGdiObjects(int fontSize, const std::wstring& theme, UINT dpi) {
         upColor = Color(255, 200, 200, 200);
     }
 
-    g_gdi->bgBrush = std::make_unique<Gdiplus::SolidBrush>(bgColor);
-    g_gdi->downBrush = std::make_unique<Gdiplus::SolidBrush>(downColor);
-    g_gdi->upBrush = std::make_unique<Gdiplus::SolidBrush>(upColor);
-    g_gdi->shadowBrush = std::make_unique<Gdiplus::SolidBrush>(Color(200, 0, 0, 0));
-    g_gdi->borderPen = std::make_unique<Gdiplus::Pen>(Color(60, 255, 255, 255), 1.0f);
-    g_gdi->dividerPen = std::make_unique<Gdiplus::Pen>(Color(40, 255, 255, 255), 1.0f);
-    g_gdi->downChartPen = std::make_unique<Gdiplus::Pen>(downColor, 1.5f);
-    g_gdi->upChartPen = std::make_unique<Gdiplus::Pen>(upColor, 1.5f);
+    newGdi->bgBrush = std::make_unique<Gdiplus::SolidBrush>(bgColor);
+    newGdi->downBrush = std::make_unique<Gdiplus::SolidBrush>(downColor);
+    newGdi->upBrush = std::make_unique<Gdiplus::SolidBrush>(upColor);
+    newGdi->shadowBrush = std::make_unique<Gdiplus::SolidBrush>(Color(200, 0, 0, 0));
+    newGdi->borderPen = std::make_unique<Gdiplus::Pen>(Color(60, 255, 255, 255), 1.0f);
+    newGdi->dividerPen = std::make_unique<Gdiplus::Pen>(Color(40, 255, 255, 255), 1.0f);
+    newGdi->downChartPen = std::make_unique<Gdiplus::Pen>(downColor, 1.5f);
+    newGdi->upChartPen = std::make_unique<Gdiplus::Pen>(upColor, 1.5f);
     
-    g_gdi->downChartPen->SetLineJoin(LineJoinRound);
-    g_gdi->upChartPen->SetLineJoin(LineJoinRound);
+    newGdi->downChartPen->SetLineJoin(LineJoinRound);
+    newGdi->upChartPen->SetLineJoin(LineJoinRound);
+
+    if (newGdi->IsValid()) {
+        g_gdi = std::move(newGdi);
+    }
 }
 
 void GetThemeDimensions(const std::wstring& theme, int& width, int& height) {
@@ -223,24 +238,16 @@ bool GetTotalOctets(ULONG64* inOctets, ULONG64* outOctets) {
 
     if (g_bestIfIndex == 0) return false;
 
-    PMIB_IF_TABLE2 table = nullptr;
-    if (GetIfTable2(&table) != NO_ERROR) {
+    MIB_IF_ROW2 row{};
+    row.InterfaceIndex = g_bestIfIndex;
+    if (GetIfEntry2(&row) != NO_ERROR) {
         return false;
     }
 
-    ULONG64 in = 0, out = 0;
-    for (ULONG i = 0; i < table->NumEntries; i++) {
-        const MIB_IF_ROW2& row = table->Table[i];
-        if (row.InterfaceIndex != g_bestIfIndex) continue;
-        if (row.Type == IF_TYPE_SOFTWARE_LOOPBACK || row.Type == IF_TYPE_TUNNEL) continue;
-        if (row.OperStatus != IfOperStatusUp) continue;
-        in += row.InOctets;
-        out += row.OutOctets;
-    }
+    if (row.OperStatus != IfOperStatusUp) return false;
 
-    FreeMibTable(table);
-    *inOctets = in;
-    *outOctets = out;
+    *inOctets = row.InOctets;
+    *outOctets = row.OutOctets;
     return true;
 }
 
@@ -258,78 +265,42 @@ std::wstring FormatSpeed(double bytesPerSec) {
 
 void UpdateSpeedSample() {
     ULONG64 in = 0, out = 0;
-    if (!GetTotalOctets(&in, &out)) return;
-
-    ULONGLONG now = GetTickCount64();
-    if (g_lastTick != 0) {
-        double elapsedSec = (now - g_lastTick) / 1000.0;
-        if (elapsedSec > 0.05) {
-            g_downBps = (in >= g_lastIn) ? (in - g_lastIn) / elapsedSec : 0.0;
-            g_upBps = (out >= g_lastOut) ? (out - g_lastOut) / elapsedSec : 0.0;
+    if (!GetTotalOctets(&in, &out)) {
+        g_downBps = 0.0;
+        g_upBps = 0.0;
+        g_lastTick = 0; // Reset baseline so reconnect doesn't understate next rate
+    } else {
+        ULONGLONG now = GetTickCount64();
+        if (g_lastTick != 0) {
+            double elapsedSec = (now - g_lastTick) / 1000.0;
+            if (elapsedSec > 0.05) {
+                g_downBps = (in >= g_lastIn) ? (in - g_lastIn) / elapsedSec : 0.0;
+                g_upBps = (out >= g_lastOut) ? (out - g_lastOut) / elapsedSec : 0.0;
+            }
         }
+        g_lastIn = in;
+        g_lastOut = out;
+        g_lastTick = now;
     }
-
-    g_lastIn = in;
-    g_lastOut = out;
-    g_lastTick = now;
 
     g_downHistory[g_historyIdx] = g_downBps;
     g_upHistory[g_historyIdx] = g_upBps;
     g_historyIdx = (g_historyIdx + 1) % kHistorySize;
 }
 
-void CheckTaskbarHooks() {
-    HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
-    if (!hTaskbar) return;
-    
-    DWORD pid = 0;
-    DWORD tid = GetWindowThreadProcessId(hTaskbar, &pid);
-    
-    if (pid != g_taskbarPid || tid != g_taskbarTid) {
-        if (g_hLocationHook) UnhookWinEvent(g_hLocationHook);
-        if (g_hDestroyHook) UnhookWinEvent(g_hDestroyHook);
-        
-        g_taskbarPid = pid;
-        g_taskbarTid = tid;
-        
-        g_hDestroyHook = SetWinEventHook(EVENT_OBJECT_DESTROY, EVENT_OBJECT_DESTROY, nullptr, 
-            [](HWINEVENTHOOK, DWORD e, HWND hwnd, LONG idObj, LONG, DWORD, DWORD) {
-                if (idObj == OBJID_WINDOW && hwnd == FindWindowW(L"Shell_TrayWnd", nullptr)) {
-                    HWND widget = g_hWnd.load();
-                    if (widget) ShowWindow(widget, SW_HIDE);
-                }
-            }, pid, tid, WINEVENT_OUTOFCONTEXT);
-
-        g_hLocationHook = SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_LOCATIONCHANGE, nullptr, 
-            [](HWINEVENTHOOK, DWORD e, HWND hwnd, LONG idObj, LONG, DWORD, DWORD) {
-                if (idObj == OBJID_WINDOW && hwnd == FindWindowW(L"Shell_TrayWnd", nullptr)) {
-                    HWND widget = g_hWnd.load();
-                    if (widget && !g_posUpdatePending.exchange(true)) {
-                        PostMessageW(widget, WM_UPDATE_POSITION, 0, 0);
-                    }
-                }
-            }, pid, tid, WINEVENT_OUTOFCONTEXT);
-    }
-}
-
 void RepositionWidget(HWND hWnd, const Settings& s) {
-    HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
-    if (!hTaskbar || !IsWindowVisible(hTaskbar)) {
+    if (!IsWindow(g_hCachedTaskbar) || !IsWindowVisible(g_hCachedTaskbar)) {
         if (IsWindowVisible(hWnd)) ShowWindow(hWnd, SW_HIDE);
         return;
     }
 
-    if (GetWindow(hWnd, GW_OWNER) != hTaskbar) {
-        SetWindowLongPtr(hWnd, GWLP_HWNDPARENT, (LONG_PTR)hTaskbar);
-    }
-
     RECT tbRect{};
-    GetWindowRect(hTaskbar, &tbRect);
+    if (!GetWindowRect(g_hCachedTaskbar, &tbRect)) return;
 
-    UINT dpi = GetDpiForWindow(hTaskbar);
+    UINT dpi = GetDpiForWindow(g_hCachedTaskbar);
     if (dpi == 0) dpi = 96;
     
-    if (dpi != g_currentDpi || !g_gdi) {
+    if (dpi != g_currentDpi || !g_gdi || !g_gdi->IsValid()) {
         g_currentDpi = dpi;
         RebuildGdiObjects(s.fontSize, s.theme, dpi);
     }
@@ -350,7 +321,11 @@ void RepositionWidget(HWND hWnd, const Settings& s) {
     UINT flags = SWP_NOACTIVATE | SWP_NOZORDER;
     if (!IsWindowVisible(hWnd)) flags |= SWP_SHOWWINDOW;
 
-    SetWindowPos(hWnd, nullptr, x, y, scaledWidth, scaledHeight, flags);
+    RECT newRect = {x, y, x + scaledWidth, y + scaledHeight};
+    if (memcmp(&g_lastWidgetRect, &newRect, sizeof(RECT)) != 0 || (flags & SWP_SHOWWINDOW)) {
+        SetWindowPos(hWnd, nullptr, x, y, scaledWidth, scaledHeight, flags);
+        g_lastWidgetRect = newRect;
+    }
 }
 
 void AddRoundRect(GraphicsPath& path, const RectF& r, float d) {
@@ -365,17 +340,16 @@ void DrawSparkline(Graphics& g, Pen* pen, const std::vector<double>& hist, size_
     double maxVal = 1024.0; 
     for (double v : hist) maxVal = std::max(maxVal, v);
     
-    std::vector<PointF> pts;
-    pts.reserve(hist.size());
-    float step = bounds.Width / (float)(hist.size() - 1);
+    PointF pts[kHistorySize];
+    float step = bounds.Width / (float)(kHistorySize - 1);
     
-    for (size_t i = 0; i < hist.size(); ++i) {
-        size_t idx = (head + i) % hist.size();
+    for (size_t i = 0; i < kHistorySize; ++i) {
+        size_t idx = (head + i) % kHistorySize;
         float x = bounds.X + (float)i * step;
         float y = bounds.Y + bounds.Height - (float)((hist[idx] / maxVal) * bounds.Height);
-        pts.push_back(PointF(x, y));
+        pts[i] = PointF(x, y);
     }
-    g.DrawLines(pen, pts.data(), pts.size());
+    g.DrawLines(pen, pts, kHistorySize);
 }
 
 void PaintWidget(HWND hWnd) {
@@ -389,7 +363,7 @@ void PaintWidget(HWND hWnd) {
     graphics.SetTextRenderingHint(TextRenderingHintClearTypeGridFit);
     graphics.Clear(Color(0, 0, 0, 0));
 
-    if (!g_gdi || !g_gdi->font || !g_gdi->largeFont || !g_gdi->bgBrush) {
+    if (!g_gdi || !g_gdi->IsValid()) {
         EndPaint(hWnd, &ps);
         return;
     }
@@ -477,6 +451,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         case WM_UPDATE_POSITION: {
             g_posUpdatePending.store(false);
             RepositionWidget(hWnd, GetSafeSettings());
+            InvalidateRect(hWnd, nullptr, TRUE);
             return 0;
         }
         case WM_PAINT:
@@ -485,9 +460,10 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         case WM_TIMER:
             if (wParam == kTimerId) {
                 UpdateSpeedSample();
-                CheckTaskbarHooks();
-                RepositionWidget(hWnd, GetSafeSettings());
-                InvalidateRect(hWnd, nullptr, FALSE);
+                if (g_hCachedTaskbar && IsWindow(g_hCachedTaskbar)) {
+                    RepositionWidget(hWnd, GetSafeSettings());
+                    InvalidateRect(hWnd, nullptr, FALSE);
+                }
             }
             return 0;
         case WM_ERASEBKGND:
@@ -496,6 +472,12 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             KillTimer(hWnd, kTimerId);
             DestroyWindow(hWnd);
             return 0;
+        case WM_NCDESTROY: {
+            std::lock_guard<std::mutex> lock(g_wndLifecycleMutex);
+            g_hWnd.store(nullptr);
+            PostQuitMessage(0);
+            return 0;
+        }
     }
     return DefWindowProc(hWnd, msg, wParam, lParam);
 }
@@ -508,72 +490,126 @@ DWORD WINAPI WidgetMessageLoop(LPVOID lpParam) {
     WNDCLASSW wc{};
     wc.lpfnWndProc = WndProc;
     wc.hInstance = GetCurrentModuleHandle();
-    wc.lpszClassName = kClassName;
     wc.hbrBackground = nullptr;
     
+    wchar_t szClassName[64];
+    swprintf_s(szClassName, L"WindhawkNetSpeed_%lu", GetCurrentThreadId());
+    wc.lpszClassName = szClassName;
+    
     if (!RegisterClassW(&wc)) {
-        if (GetLastError() != ERROR_CLASS_ALREADY_EXISTS) return 0;
+        return 0; 
     }
 
-    DWORD exStyle = WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT;
-    HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
-    
-    HWND hwnd = CreateWindowExW(exStyle, kClassName, L"", WS_POPUP, 0, 0,
-                               1, 1, hTaskbar, nullptr, wc.hInstance, nullptr);
+    while (!g_exiting.load()) {
+        HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
+        if (!hTaskbar) {
+            if (WaitForSingleObject(g_hExitEvent, 1000) == WAIT_OBJECT_0) break;
+            continue;
+        }
 
-    if (!hwnd) {
-        UnregisterClassW(kClassName, wc.hInstance);
-        return 0;
+        DWORD pid = 0;
+        DWORD tid = GetWindowThreadProcessId(hTaskbar, &pid);
+        
+        if (pid != GetCurrentProcessId()) {
+            if (WaitForSingleObject(g_hExitEvent, 2000) == WAIT_OBJECT_0) break;
+            continue;
+        }
+
+        g_hCachedTaskbar = hTaskbar;
+        g_taskbarPid = pid;
+        g_taskbarTid = tid;
+        memset(&g_lastWidgetRect, 0, sizeof(RECT));
+
+        DWORD exStyle = WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT;
+        
+        HWND hwnd = nullptr;
+        {
+            std::lock_guard<std::mutex> lock(g_wndLifecycleMutex);
+            if (g_exiting.load()) break;
+
+            hwnd = CreateWindowExW(exStyle, szClassName, L"", WS_POPUP, 0, 0,
+                                   1, 1, hTaskbar, nullptr, wc.hInstance, nullptr);
+            if (!hwnd) {
+                if (WaitForSingleObject(g_hExitEvent, 1000) == WAIT_OBJECT_0) break;
+                continue;
+            }
+            g_hWnd.store(hwnd);
+        }
+        
+        PostMessageW(hwnd, WM_UPDATE_SETTINGS, 0, 0);
+
+        g_hDestroyHook = SetWinEventHook(EVENT_OBJECT_DESTROY, EVENT_OBJECT_DESTROY, nullptr, 
+            [](HWINEVENTHOOK, DWORD, HWND hwndHook, LONG idObj, LONG, DWORD, DWORD) {
+                if (idObj == OBJID_WINDOW && hwndHook == g_hCachedTaskbar) {
+                    g_hCachedTaskbar = nullptr;
+                    HWND widget = g_hWnd.load();
+                    if (widget) {
+                        PostMessageW(widget, WM_CLOSE, 0, 0); 
+                    }
+                }
+            }, pid, tid, WINEVENT_OUTOFCONTEXT);
+
+        g_hLocationHook = SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_LOCATIONCHANGE, nullptr, 
+            [](HWINEVENTHOOK, DWORD, HWND hwndHook, LONG idObj, LONG, DWORD, DWORD) {
+                if (idObj == OBJID_WINDOW && hwndHook == g_hCachedTaskbar) {
+                    HWND widget = g_hWnd.load();
+                    if (widget && !g_posUpdatePending.exchange(true)) {
+                        PostMessageW(widget, WM_UPDATE_POSITION, 0, 0);
+                    }
+                }
+            }, pid, tid, WINEVENT_OUTOFCONTEXT);
+
+        while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+            TranslateMessage(&msg);
+            DispatchMessageW(&msg);
+        }
+        
+        if (g_hLocationHook) { UnhookWinEvent(g_hLocationHook); g_hLocationHook = nullptr; }
+        if (g_hDestroyHook) { UnhookWinEvent(g_hDestroyHook); g_hDestroyHook = nullptr; }
+        
+        g_hCachedTaskbar = nullptr;
     }
-    
-    g_hWnd.store(hwnd);
-    PostMessageW(hwnd, WM_UPDATE_SETTINGS, 0, 0);
-    CheckTaskbarHooks();
 
-    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
-        TranslateMessage(&msg);
-        DispatchMessageW(&msg);
-    }
-    
-    if (g_hLocationHook) UnhookWinEvent(g_hLocationHook);
-    if (g_hDestroyHook) UnhookWinEvent(g_hDestroyHook);
-    
-    HWND h = g_hWnd.exchange(nullptr);
-    if (h) DestroyWindow(h);
-
-    UnregisterClassW(kClassName, wc.hInstance);
+    UnregisterClassW(szClassName, wc.hInstance);
     return 0;
 }
 
 }  // namespace
 
 BOOL Wh_ModInit() {
-    HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
-    DWORD pid = 0;
-    if (!hTaskbar || !GetWindowThreadProcessId(hTaskbar, &pid) || pid != GetCurrentProcessId()) {
-        return FALSE; // Guarantee we only inject into the primary Explorer.exe process
-    }
-
-    g_hMutex = CreateMutexW(nullptr, FALSE, L"Windhawk_NetSpeedTaskbar_Mutex");
-    if (g_hMutex == nullptr || GetLastError() == ERROR_ALREADY_EXISTS) {
-        return FALSE; 
-    }
-
     LoadSettingsLocked();
 
     GdiplusStartupInput gdiplusStartupInput;
-    GdiplusStartup(&g_gdiplusToken, &gdiplusStartupInput, nullptr);
+    if (GdiplusStartup(&g_gdiplusToken, &gdiplusStartupInput, nullptr) != Ok) {
+        return FALSE;
+    }
 
+    g_exiting.store(false);
+    g_hExitEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
     g_hQueueReady = CreateEventW(nullptr, TRUE, FALSE, nullptr);
     g_hThread = CreateThread(nullptr, 0, WidgetMessageLoop, nullptr, 0, &g_threadId);
 
-    return TRUE;
+    return g_hThread != nullptr;
 }
 
 void Wh_ModUninit() {
+    g_exiting.store(true);
+    if (g_hExitEvent) {
+        SetEvent(g_hExitEvent);
+    }
+
     if (g_hThread) {
         WaitForSingleObject(g_hQueueReady, INFINITE); 
+        
+        {
+            std::lock_guard<std::mutex> lock(g_wndLifecycleMutex);
+            HWND hwnd = g_hWnd.load();
+            if (hwnd) {
+                PostMessageW(hwnd, WM_CLOSE, 0, 0);
+            }
+        }
         PostThreadMessageW(g_threadId, WM_QUIT, 0, 0); 
+        
         WaitForSingleObject(g_hThread, INFINITE);      
         CloseHandle(g_hThread);
         g_hThread = nullptr;
@@ -585,16 +621,16 @@ void Wh_ModUninit() {
         g_hQueueReady = nullptr;
     }
 
-    if (g_gdiplusToken) {
-        GdiplusShutdown(g_gdiplusToken);
-        g_gdiplusToken = 0;
+    if (g_hExitEvent) {
+        CloseHandle(g_hExitEvent);
+        g_hExitEvent = nullptr;
     }
 
     g_gdi.reset();
 
-    if (g_hMutex) {
-        CloseHandle(g_hMutex);
-        g_hMutex = nullptr;
+    if (g_gdiplusToken) {
+        GdiplusShutdown(g_gdiplusToken);
+        g_gdiplusToken = 0;
     }
 }
 

--- a/mods/net-speed-taskbar.wh.cpp
+++ b/mods/net-speed-taskbar.wh.cpp
@@ -2,7 +2,7 @@
 // @id          net-speed-taskbar
 // @name        Taskbar Network Speed Indicator
 // @description A free-floating network speed widget you can place anywhere along the taskbar, featuring a sparkline chart and multiple layouts.
-// @version     1.5
+// @version     1.6
 // @author      Narayan
 // @github      https://github.com/NarayanChetri
 // @homepage    https://narayanchetri.dev
@@ -253,14 +253,15 @@ void RebuildGdiObjects(int fontSize, const std::wstring& theme, UINT dpi) {
         upColor = Color(255, 200, 200, 200);
     }
 
+    float sc = dpi / 96.0f;
     newGdi->bgBrush = std::make_unique<Gdiplus::SolidBrush>(bgColor);
     newGdi->downBrush = std::make_unique<Gdiplus::SolidBrush>(downColor);
     newGdi->upBrush = std::make_unique<Gdiplus::SolidBrush>(upColor);
     newGdi->shadowBrush = std::make_unique<Gdiplus::SolidBrush>(Color(200, 0, 0, 0));
-    newGdi->borderPen = std::make_unique<Gdiplus::Pen>(Color(60, 255, 255, 255), 1.0f);
-    newGdi->dividerPen = std::make_unique<Gdiplus::Pen>(Color(40, 255, 255, 255), 1.0f);
-    newGdi->downChartPen = std::make_unique<Gdiplus::Pen>(downColor, 1.5f);
-    newGdi->upChartPen = std::make_unique<Gdiplus::Pen>(upColor, 1.5f);
+    newGdi->borderPen = std::make_unique<Gdiplus::Pen>(Color(60, 255, 255, 255), 1.0f * sc);
+    newGdi->dividerPen = std::make_unique<Gdiplus::Pen>(Color(40, 255, 255, 255), 1.0f * sc);
+    newGdi->downChartPen = std::make_unique<Gdiplus::Pen>(downColor, 1.5f * sc);
+    newGdi->upChartPen = std::make_unique<Gdiplus::Pen>(upColor, 1.5f * sc);
 
     newGdi->downChartPen->SetLineJoin(LineJoinRound);
     newGdi->upChartPen->SetLineJoin(LineJoinRound);
@@ -272,7 +273,7 @@ void RebuildGdiObjects(int fontSize, const std::wstring& theme, UINT dpi) {
     }
 }
 
-void GetThemeDimensions(const std::wstring& theme, int& width, int& height) {
+void GetThemeDimensions(const std::wstring& theme, int fontSize, int& width, int& height) {
     if (theme == L"Top-Down") {
         width = 75; height = 36;
     } else if (theme == L"Chart") {
@@ -282,6 +283,13 @@ void GetThemeDimensions(const std::wstring& theme, int& width, int& height) {
     } else {
         width = 140; height = 40;
     }
+
+    // Base dimensions above assume the default 13px font; widen/heighten
+    // proportionally so a larger "Font size" setting doesn't push text
+    // outside a fixed box.
+    float fontScale = fontSize / 13.0f;
+    width = (int)(width * fontScale);
+    height = (int)(height * fontScale);
 }
 
 // Uses GetIfEntry2 / MIB_IF_ROW2 (64-bit counters), so no 32-bit-wrap
@@ -397,7 +405,7 @@ void RepositionWidget(HWND hWnd, const Settings& s) {
     }
 
     int baseW, baseH;
-    GetThemeDimensions(s.theme, baseW, baseH);
+    GetThemeDimensions(s.theme, s.fontSize, baseW, baseH);
 
     int scaledWidth = MulDiv(baseW, dpi, 96);
     int scaledHeight = MulDiv(baseH, dpi, 96);
@@ -415,14 +423,18 @@ void RepositionWidget(HWND hWnd, const Settings& s) {
     if (!IsWindowVisible(hWnd)) flags |= SWP_SHOWWINDOW;
 
     RECT newRect = {x, y, x + scaledWidth, y + scaledHeight};
+    HWND zOrderTarget = g_usingBandedWindow.load() ? HWND_TOP : HWND_TOPMOST;
     if (memcmp(&g_lastWidgetRect, &newRect, sizeof(RECT)) != 0 || (flags & SWP_SHOWWINDOW)) {
-        HWND zOrderTarget = g_usingBandedWindow.load() ? HWND_TOP : HWND_TOPMOST;
         if (!SetWindowPos(hWnd, zOrderTarget, x, y, scaledWidth, scaledHeight, flags)) {
             Wh_Log(L"RepositionWidget: SetWindowPos failed, gle=%lu", GetLastError());
         }
         g_lastWidgetRect = newRect;
-    } else if (!g_usingBandedWindow.load()) {
-        SetWindowPos(hWnd, HWND_TOPMOST, 0, 0, 0, 0,
+    } else {
+        // Re-assert Z-order every tick even when the rect hasn't moved --
+        // Explorer raises Shell_TrayWnd within its own band on auto-hide
+        // reveal, ABM_ACTIVATE, and returning from full-screen, which would
+        // otherwise leave the widget stuck behind the taskbar.
+        SetWindowPos(hWnd, zOrderTarget, 0, 0, 0, 0,
                      SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
     }
 }
@@ -451,12 +463,13 @@ void DrawSparkline(Graphics& g, Pen* pen, const std::vector<double>& hist, size_
     g.DrawLines(pen, pts, kHistorySize);
 }
 
-void PaintWidgetContent(Graphics& graphics, int width, int height, const Settings& s) {
+void PaintWidgetContent(Graphics& graphics, int width, int height, const Settings& s, UINT dpi) {
     RectF bounds(0.0f, 0.0f, (float)width - 1.0f, (float)height - 1.0f);
+    float sc = dpi / 96.0f;
 
     if (s.theme != L"Minimal") {
         GraphicsPath path;
-        AddRoundRect(path, bounds, 8.0f);
+        AddRoundRect(path, bounds, 8.0f * sc);
         graphics.FillPath(g_gdi->bgBrush.get(), &path);
         if (g_gdi->borderPen) graphics.DrawPath(g_gdi->borderPen.get(), &path);
     }
@@ -473,22 +486,22 @@ void PaintWidgetContent(Graphics& graphics, int width, int height, const Setting
         float halfW = w / 2.0f;
         if (g_gdi->dividerPen) graphics.DrawLine(g_gdi->dividerPen.get(), halfW, h * 0.2f, halfW, h * 0.8f);
 
-        graphics.DrawString(L"\x2193", -1, g_gdi->largeFont.get(), RectF(0, 0, halfW, h / 2 + 4), &format, g_gdi->downBrush.get());
-        graphics.DrawString(strDown.c_str(), -1, g_gdi->font.get(), RectF(0, h / 2, halfW, h / 2 - 2), &format, g_gdi->downBrush.get());
+        graphics.DrawString(L"\x2193", -1, g_gdi->largeFont.get(), RectF(0, 0, halfW, h / 2 + 4 * sc), &format, g_gdi->downBrush.get());
+        graphics.DrawString(strDown.c_str(), -1, g_gdi->font.get(), RectF(0, h / 2, halfW, h / 2 - 2 * sc), &format, g_gdi->downBrush.get());
 
-        graphics.DrawString(L"\x2191", -1, g_gdi->largeFont.get(), RectF(halfW, 0, halfW, h / 2 + 4), &format, g_gdi->upBrush.get());
-        graphics.DrawString(strUp.c_str(), -1, g_gdi->font.get(), RectF(halfW, h / 2, halfW, h / 2 - 2), &format, g_gdi->upBrush.get());
+        graphics.DrawString(L"\x2191", -1, g_gdi->largeFont.get(), RectF(halfW, 0, halfW, h / 2 + 4 * sc), &format, g_gdi->upBrush.get());
+        graphics.DrawString(strUp.c_str(), -1, g_gdi->font.get(), RectF(halfW, h / 2, halfW, h / 2 - 2 * sc), &format, g_gdi->upBrush.get());
 
     } else if (s.theme == L"Top-Down") {
         format.SetAlignment(StringAlignmentNear);
         format.SetLineAlignment(StringAlignmentCenter);
         float halfH = h / 2.0f;
 
-        graphics.DrawString(L"\x2193", -1, g_gdi->font.get(), RectF(8, 0, 16, halfH), &format, g_gdi->downBrush.get());
-        graphics.DrawString(strDown.c_str(), -1, g_gdi->font.get(), RectF(22, 0, w - 22, halfH), &format, g_gdi->downBrush.get());
+        graphics.DrawString(L"\x2193", -1, g_gdi->font.get(), RectF(8 * sc, 0, 16 * sc, halfH), &format, g_gdi->downBrush.get());
+        graphics.DrawString(strDown.c_str(), -1, g_gdi->font.get(), RectF(22 * sc, 0, w - 22 * sc, halfH), &format, g_gdi->downBrush.get());
 
-        graphics.DrawString(L"\x2191", -1, g_gdi->font.get(), RectF(8, halfH, 16, halfH), &format, g_gdi->upBrush.get());
-        graphics.DrawString(strUp.c_str(), -1, g_gdi->font.get(), RectF(22, halfH, w - 22, halfH), &format, g_gdi->upBrush.get());
+        graphics.DrawString(L"\x2191", -1, g_gdi->font.get(), RectF(8 * sc, halfH, 16 * sc, halfH), &format, g_gdi->upBrush.get());
+        graphics.DrawString(strUp.c_str(), -1, g_gdi->font.get(), RectF(22 * sc, halfH, w - 22 * sc, halfH), &format, g_gdi->upBrush.get());
 
     } else if (s.theme == L"Chart") {
         format.SetAlignment(StringAlignmentNear);
@@ -496,23 +509,23 @@ void PaintWidgetContent(Graphics& graphics, int width, int height, const Setting
         float halfH = h / 2.0f;
         float chartW = w * 0.40f;
 
-        RectF chartDown(8.0f, 6.0f, chartW, halfH - 8.0f);
+        RectF chartDown(8.0f * sc, 6.0f * sc, chartW, halfH - 8.0f * sc);
         DrawSparkline(graphics, g_gdi->downChartPen.get(), g_downHistory, g_historyIdx, chartDown);
-        graphics.DrawString((L"\x2193 " + strDown).c_str(), -1, g_gdi->font.get(), RectF(chartW + 16, 0, w - chartW - 16, halfH), &format, g_gdi->downBrush.get());
+        graphics.DrawString((L"\x2193 " + strDown).c_str(), -1, g_gdi->font.get(), RectF(chartW + 16 * sc, 0, w - chartW - 16 * sc, halfH), &format, g_gdi->downBrush.get());
 
-        RectF chartUp(8.0f, halfH + 2.0f, chartW, halfH - 8.0f);
+        RectF chartUp(8.0f * sc, halfH + 2.0f * sc, chartW, halfH - 8.0f * sc);
         DrawSparkline(graphics, g_gdi->upChartPen.get(), g_upHistory, g_historyIdx, chartUp);
-        graphics.DrawString((L"\x2191 " + strUp).c_str(), -1, g_gdi->font.get(), RectF(chartW + 16, halfH, w - chartW - 16, halfH), &format, g_gdi->upBrush.get());
+        graphics.DrawString((L"\x2191 " + strUp).c_str(), -1, g_gdi->font.get(), RectF(chartW + 16 * sc, halfH, w - chartW - 16 * sc, halfH), &format, g_gdi->upBrush.get());
 
     } else if (s.theme == L"Minimal") {
         format.SetAlignment(StringAlignmentNear);
         format.SetLineAlignment(StringAlignmentCenter);
         float halfW = w / 2.0f;
 
-        graphics.DrawString((L"\x2193 " + strDown).c_str(), -1, g_gdi->font.get(), RectF(1, 1, halfW, h), &format, g_gdi->shadowBrush.get());
+        graphics.DrawString((L"\x2193 " + strDown).c_str(), -1, g_gdi->font.get(), RectF(1 * sc, 1 * sc, halfW, h), &format, g_gdi->shadowBrush.get());
         graphics.DrawString((L"\x2193 " + strDown).c_str(), -1, g_gdi->font.get(), RectF(0, 0, halfW, h), &format, g_gdi->downBrush.get());
 
-        graphics.DrawString((L"\x2191 " + strUp).c_str(), -1, g_gdi->font.get(), RectF(halfW + 1, 1, halfW, h), &format, g_gdi->shadowBrush.get());
+        graphics.DrawString((L"\x2191 " + strUp).c_str(), -1, g_gdi->font.get(), RectF(halfW + 1 * sc, 1 * sc, halfW, h), &format, g_gdi->shadowBrush.get());
         graphics.DrawString((L"\x2191 " + strUp).c_str(), -1, g_gdi->font.get(), RectF(halfW, 0, halfW, h), &format, g_gdi->upBrush.get());
     }
 }
@@ -548,7 +561,7 @@ void RenderWidget(HWND hWnd, int opacity) {
 
             if (g_gdi && g_gdi->IsValid()) {
                 Settings s = GetSafeSettings();
-                PaintWidgetContent(graphics, width, height, s);
+                PaintWidgetContent(graphics, width, height, s, g_currentDpi);
             }
         }
 

--- a/mods/net-speed-taskbar.wh.cpp
+++ b/mods/net-speed-taskbar.wh.cpp
@@ -7,7 +7,7 @@
 // @github      https://github.com/NarayanChetri
 // @homepage    https://narayanchetri.dev
 // @include     explorer.exe
-// @compilerOptions -lgdiplus -liphlpapi -lgdi32 -luser32 -DWIN32_LEAN_AND_MEAN -D_WIN32_WINNT=0x0A00
+// @compilerOptions -lgdiplus -liphlpapi -lgdi32 -luser32 -DWIN32_LEAN_AND_MEAN
 // @architecture    x86-64
 // @license         MIT
 // ==/WindhawkMod==

--- a/mods/net-speed-taskbar.wh.cpp
+++ b/mods/net-speed-taskbar.wh.cpp
@@ -7,7 +7,7 @@
 // @github      https://github.com/NarayanChetri
 // @homepage    https://narayanchetri.dev
 // @include     explorer.exe
-// @compilerOptions -lgdiplus -liphlpapi -lgdi32
+// @compilerOptions -lgdiplus -liphlpapi -lgdi32 -lshell32 -DWIN32_LEAN_AND_MEAN
 // @architecture    x86-64
 // @license         MIT
 // ==/WindhawkMod==
@@ -33,7 +33,6 @@ actually be an `explorer.exe` image.
 - Choose from different looks: Side-by-Side, Top-Down, Chart, or Minimal.
 - Move the widget anywhere along your taskbar using the Horizontal Position setting.
 - Click-through: it won't get in the way of your taskbar buttons.
-- Recovers automatically on an Explorer crash/restart, not just a clean shell exit.
 - Hides while a full-screen app or game covers the taskbar's monitor.
 
 Note: [Taskbar Clock Customization](https://windhawk.net) and
@@ -65,12 +64,19 @@ along the taskbar and the sparkline chart layouts.
 */
 // ==/WindhawkModSettings==
 
-// winsock2.h must come before windows.h so that iphlpapi.h pulls in the
-// netioapi.h declarations (GetIfEntry2 / MIB_IF_ROW2) instead of only the
-// legacy 32-bit-counter API.
+// iphlpapi.h only declares the netioapi APIs (GetIfEntry2 / MIB_IF_ROW2)
+// once winsock2 types are already in scope. -DWIN32_LEAN_AND_MEAN in
+// @compilerOptions stops windows.h from pulling in the legacy winsock.h,
+// which is what actually avoids the winsock2.h/windows.h ordering warning.
+// That flag also drops windows.h's normal auto-includes of shellapi.h
+// (CommandLineToArgvW) and ole2.h (PROPID, via wtypes.h), so both are
+// pulled in explicitly below.
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <windhawk_utils.h>
 #include <windows.h>
+#include <shellapi.h>
+#include <wtypes.h>
 #include <gdiplus.h>
 #include <iphlpapi.h>
 #include <string>
@@ -80,7 +86,6 @@ along the taskbar and the sparkline chart layouts.
 #include <memory>
 #include <mutex>
 #include <cstdio>
-#include <windhawk_utils.h>
 
 using namespace Gdiplus;
 

--- a/mods/net-speed-taskbar.wh.cpp
+++ b/mods/net-speed-taskbar.wh.cpp
@@ -2,7 +2,7 @@
 // @id          net-speed-taskbar
 // @name        Taskbar Network Speed Indicator
 // @description A free-floating network speed widget you can place anywhere along the taskbar, featuring a sparkline chart and multiple layouts.
-// @version     1.4
+// @version     1.5
 // @author      Narayan
 // @github      https://github.com/NarayanChetri
 // @homepage    https://narayanchetri.dev
@@ -33,12 +33,24 @@ actually be an `explorer.exe` image.
 - Choose from different looks: Side-by-Side, Top-Down, Chart, or Minimal.
 - Move the widget anywhere along your taskbar using the Horizontal Position setting.
 - Click-through: it won't get in the way of your taskbar buttons.
+- Recovers automatically on an Explorer crash/restart, not just a clean shell exit.
 - Hides while a full-screen app or game covers the taskbar's monitor.
 
-Note: [Taskbar Clock Customization](https://windhawk.net) and
-[taskbar-system-info](https://windhawk.net) both offer similar taskbar network
-readouts. This mod's differentiators are the free horizontal placement anywhere
-along the taskbar and the sparkline chart layouts.
+Note: [Taskbar Clock Customization](https://windhawk.net/mods/taskbar-clock-customization)
+and [Taskbar System Info](https://windhawk.net/mods/taskbar-system-info) both
+offer similar taskbar network readouts. This mod's differentiators are the
+free horizontal placement anywhere along the taskbar and the sparkline chart
+layouts.
+
+A few consequences of running as a dedicated `explorer.exe` helper process,
+worth knowing:
+
+- A second **"Windows Explorer"** entry appears in Task Manager. Ending it
+  won't relaunch the widget until the shell restarts or the mod is reloaded.
+- Any other mod you have enabled with `@include explorer.exe` gets injected
+  into this helper process too, since it genuinely is an `explorer.exe`. Most
+  mods no-op there, but it can make Windhawk's per-process mod list and crash
+  attribution look busier than expected.
 */
 // ==/WindhawkModReadme==
 
@@ -879,11 +891,6 @@ BOOL Wh_ModInit() {
         }
     }
 
-    // Only the shell instance (no arguments) should be treated as a
-    // candidate launcher; -Embedding COM servers, folder windows, etc.
-    // shouldn't spawn a tool-mod process of their own.
-    bool isPlainShellInstance = (argc == 1);
-
     LocalFree(argv);
 
     if (isExcluded) {
@@ -919,11 +926,17 @@ BOOL Wh_ModInit() {
         return TRUE;
     }
 
-    if (isToolModProcess) {
+    // Only the shell instance (no arguments) should be treated as a
+    // candidate launcher; -Embedding COM servers, folder windows, etc.
+    // shouldn't spawn a tool-mod process of their own, and must return
+    // FALSE here rather than fall through with g_isToolModProcessLauncher
+    // left false -- otherwise Wh_ModUninit's ExitProcess(0) (meant only
+    // for the -tool-mod process) would kill them when the mod unloads.
+    if (isToolModProcess || argc != 1) {
         return FALSE;
     }
 
-    g_isToolModProcessLauncher = isPlainShellInstance;
+    g_isToolModProcessLauncher = true;
     return TRUE;
 }
 

--- a/mods/net-speed-taskbar.wh.cpp
+++ b/mods/net-speed-taskbar.wh.cpp
@@ -7,7 +7,7 @@
 // @github      https://github.com/NarayanChetri
 // @homepage    https://narayanchetri.dev
 // @include     explorer.exe
-// @compilerOptions -lgdiplus -liphlpapi -lgdi32 -luser32 -lws2_32
+// @compilerOptions -lgdiplus -liphlpapi -lgdi32 -luser32 -lws2_32 -DWIN32_LEAN_AND_MEAN
 // @architecture    x86-64
 // @license         MIT
 // ==/WindhawkMod==
@@ -21,12 +21,11 @@ download and upload internet speed, refreshed every second.
 
 ![Demo](https://raw.githubusercontent.com/NarayanChetri/Files/main/taskbar-speed-indicator.gif)
 
+- Choose from different looks: Side-by-Side, Top-Down, Chart, or Minimal.
 - Move the widget anywhere along your taskbar using the Horizontal Position setting.
 - You can click right through it, so it won't get in the way of your taskbar buttons.
-- Smoothly follows your taskbar if you have auto-hide enabled.
-- Always stays visible on top of the taskbar.
 - Shows your actual internet speed, ignoring background virtual networks or VPN clutter.
-- Choose from different looks: Side-by-Side, Top-Down, Chart, or Minimal.
+
 */
 // ==/WindhawkModReadme==
 
@@ -67,6 +66,7 @@ download and upload internet speed, refreshed every second.
 #include <winsock2.h>
 #include <ws2ipdef.h>
 #include <windows.h>
+#include <objbase.h>
 #include <gdiplus.h>
 #include <iphlpapi.h>
 #include <netioapi.h>
@@ -174,7 +174,7 @@ void RebuildGdiObjects(int fontSize, const std::wstring& theme) {
     Color upColor = Color(255, 100, 230, 90);   
     
     if (theme == L"Minimal") {
-        bgColor = Color(0, 0, 0, 0);
+        bgColor = Color(0, 0, 0, 0); 
         downColor = Color(255, 255, 255, 255);
         upColor = Color(255, 200, 200, 200);
     }
@@ -432,10 +432,11 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             InvalidateRect(hWnd, nullptr, TRUE);
             return 0;
         }
-        case WM_UPDATE_POSITION:
+        case WM_UPDATE_POSITION: {
             g_posUpdatePending.store(false);
             RepositionWidget(hWnd, GetSafeSettings());
             return 0;
+        }
         case WM_PAINT:
             PaintWidget(hWnd);
             return 0;
@@ -533,7 +534,6 @@ BOOL Wh_ModInit() {
     GdiplusStartupInput gdiplusStartupInput;
     GdiplusStartup(&g_gdiplusToken, &gdiplusStartupInput, nullptr);
 
-    UpdateSpeedSample();
     g_hThread = CreateThread(nullptr, 0, WidgetMessageLoop, nullptr, 0, &g_threadId);
 
     return TRUE;

--- a/mods/net-speed-taskbar.wh.cpp
+++ b/mods/net-speed-taskbar.wh.cpp
@@ -2,12 +2,12 @@
 // @id          net-speed-taskbar
 // @name        Taskbar Network Speed Indicator
 // @description A free-floating network speed widget you can place anywhere along the taskbar, featuring a sparkline chart and multiple layouts.
-// @version     1.1
+// @version     1.3
 // @author      Narayan
 // @github      https://github.com/NarayanChetri
 // @homepage    https://narayanchetri.dev
 // @include     explorer.exe
-// @compilerOptions -lgdiplus -liphlpapi
+// @compilerOptions -lgdiplus -liphlpapi -lgdi32
 // @architecture    x86-64
 // @license         MIT
 // ==/WindhawkMod==
@@ -16,13 +16,23 @@
 /*
 # Taskbar Network Speed Indicator
 
-Unlike the existing "Taskbar Clock Customization" mod, this is a free-floating widget that can be placed anywhere along the taskbar, featuring a real-time sparkline chart and multiple distinct visual layouts. It shows your current download and upload internet speed, refreshed every second.
+A free-floating widget docked to the taskbar, featuring a real-time sparkline
+chart and multiple visual layouts. Shows current download/upload speed,
+refreshed every second.
 
-![Demo](https://raw.githubusercontent.com/NarayanChetri/Files/main/taskbar-speed-indicator.gif)
+Runs as a dedicated, isolated `explorer.exe` helper process (not the real
+shell) using the "mods as tools" pattern, so a bug in it can't take down your
+actual desktop. It targets `explorer.exe` rather than `windhawk.exe` because
+the taskbar's own content lives in DWM's immersive Z-band
+(`ZBID_IMMERSIVE_NOTIFICATION`), and `CreateWindowInBand` -- the only way to
+place a window in that band -- appears to require the calling process to
+actually be an `explorer.exe` image.
+
+![Demo](https://raw.githubusercontent.com/NarayanChetri/Files/main/taskbar-internet-speed-mod.gif)
 
 - Choose from different looks: Side-by-Side, Top-Down, Chart, or Minimal.
 - Move the widget anywhere along your taskbar using the Horizontal Position setting.
-- You can click right through it, so it won't get in the way of your taskbar buttons.
+- Click-through: it won't get in the way of your taskbar buttons.
 */
 // ==/WindhawkModReadme==
 
@@ -30,8 +40,6 @@ Unlike the existing "Taskbar Clock Customization" mod, this is a free-floating w
 /*
 - theme: Minimal
   $name: Visual Theme
-  $description: >-
-    Select the widget's structural layout and style.
   $options:
     - Side-by-Side: Side-by-Side
     - Top-Down: Top-Down (Compact)
@@ -39,25 +47,18 @@ Unlike the existing "Taskbar Clock Customization" mod, this is a free-floating w
     - Minimal: Minimal (Text Only)
 - horizontalPosition: 10
   $name: Horizontal position (%)
-  $description: >-
-    Where the widget sits along the taskbar's width. 0 = left edge, 100 =
-    right edge, 50 = centered. Enter any value 0-100.
 - verticalNudge: 0
   $name: Vertical nudge (px)
-  $description: Fine-tune vertical centering within the taskbar, in pixels. Positive moves down.
 - updateIntervalMs: 1000
   $name: Update interval (ms)
-  $description: How often the speed reading refreshes.
 - fontSize: 13
   $name: Font size
 - opacity: 235
   $name: Opacity (0-255)
-  $description: Overall widget transparency. 255 = fully opaque.
 */
 // ==/WindhawkModSettings==
 
 #include <windows.h>
-#include <objbase.h>
 #include <gdiplus.h>
 #include <iphlpapi.h>
 #include <string>
@@ -76,6 +77,42 @@ using namespace Gdiplus;
 
 namespace {
 
+// ----------------------------------------------------------------------
+// CreateWindowInBand: undocumented user32.dll export. Places a window in
+// a specific DWM composition Z-band. ZBID_IMMERSIVE_NOTIFICATION is the
+// band Shell_TrayWnd's own content lives in on Windows 11 -- plain
+// HWND_TOPMOST windows (even from a separate process) live in a lower
+// band and cannot render over the taskbar's own surface. This API is
+// undocumented and not guaranteed stable across builds, so it's loaded
+// dynamically with a safe fallback.
+// ----------------------------------------------------------------------
+enum ZBID {
+    ZBID_DEFAULT = 0,
+    ZBID_DESKTOP = 1,
+    ZBID_UIACCESS = 2,
+    ZBID_IMMERSIVE_IHM = 3,
+    ZBID_IMMERSIVE_NOTIFICATION = 4,
+    ZBID_IMMERSIVE_APPCHROME = 5,
+    ZBID_IMMERSIVE_MOGO = 6,
+    ZBID_IMMERSIVE_EDGY = 7,
+    ZBID_IMMERSIVE_INACTIVEMOBODY = 8,
+    ZBID_IMMERSIVE_INACTIVEDOCK = 9,
+    ZBID_IMMERSIVE_ACTIVEMOBODY = 10,
+    ZBID_IMMERSIVE_ACTIVEDOCK = 11,
+    ZBID_IMMERSIVE_BACKGROUND = 12,
+    ZBID_IMMERSIVE_SEARCH = 13,
+    ZBID_GENUINE_WINDOWS = 14,
+    ZBID_IMMERSIVE_RESTRICTED = 15,
+    ZBID_SYSTEM_TOOLS = 16,
+    ZBID_LOCK = 17,
+    ZBID_ABOVELOCK_UX = 18,
+};
+
+typedef HWND(WINAPI* CreateWindowInBand_t)(
+    DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle,
+    int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu,
+    HINSTANCE hInstance, LPVOID lpParam, DWORD dwBand);
+
 struct Settings {
     std::wstring theme;
     int horizontalPosition;
@@ -93,6 +130,7 @@ std::mutex g_wndLifecycleMutex;
 
 std::atomic<bool> g_posUpdatePending{false};
 std::atomic<bool> g_exiting{false};
+std::atomic<bool> g_usingBandedWindow{false};
 ULONG_PTR g_gdiplusToken = 0;
 constexpr UINT_PTR kTimerId = 1001;
 
@@ -103,15 +141,17 @@ HANDLE g_hExitEvent = nullptr;
 
 HWINEVENTHOOK g_hLocationHook = nullptr;
 HWINEVENTHOOK g_hDestroyHook = nullptr;
-DWORD g_taskbarPid = 0;
-DWORD g_taskbarTid = 0;
 HWND g_hCachedTaskbar = nullptr;
 
 RECT g_lastWidgetRect = {0, 0, 0, 0};
+int g_currentWidgetWidth = 0;
+int g_currentWidgetHeight = 0;
 
 ULONGLONG g_lastTick = 0;
 ULONG64 g_lastIn = 0;
 ULONG64 g_lastOut = 0;
+ULONG64 g_cumIn = 0;
+ULONG64 g_cumOut = 0;
 double g_downBps = 0.0;
 double g_upBps = 0.0;
 
@@ -136,7 +176,7 @@ struct GdiObjects {
     std::unique_ptr<Gdiplus::Pen> upChartPen;
 
     bool IsValid() const {
-        return font && largeFont && bgBrush && downBrush && upBrush && 
+        return font && largeFont && bgBrush && downBrush && upBrush &&
                shadowBrush && borderPen && dividerPen && downChartPen && upChartPen;
     }
 };
@@ -146,7 +186,7 @@ UINT g_currentDpi = 96;
 
 HINSTANCE GetCurrentModuleHandle() {
     HINSTANCE hInst = nullptr;
-    GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | 
+    GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
                        GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
                        (LPCWSTR)&GetCurrentModuleHandle, &hInst);
     return hInst;
@@ -157,7 +197,7 @@ Settings GetSafeSettings() {
     return g_settings;
 }
 
-void LoadSettingsLocked() {
+void LoadSettings() {
     std::lock_guard<std::mutex> lock(g_settingsMutex);
     g_settings.theme = WindhawkUtils::StringSetting::make(L"theme").get();
     g_settings.horizontalPosition = std::clamp((int)Wh_GetIntSetting(L"horizontalPosition"), 0, 100);
@@ -175,11 +215,11 @@ void RebuildGdiObjects(int fontSize, const std::wstring& theme, UINT dpi) {
 
     newGdi->font = std::make_unique<Gdiplus::Font>(&fontFamily, scaledFontSize, FontStyleRegular, UnitPixel);
     newGdi->largeFont = std::make_unique<Gdiplus::Font>(&fontFamily, scaledFontSize * 1.3f, FontStyleBold, UnitPixel);
-    
+
     Color bgColor = Color(240, 18, 20, 22);
-    Color downColor = Color(255, 64, 169, 255); 
-    Color upColor = Color(255, 100, 230, 90);   
-    
+    Color downColor = Color(255, 64, 169, 255);
+    Color upColor = Color(255, 100, 230, 90);
+
     if (theme == L"Minimal") {
         bgColor = Color(0, 0, 0, 0);
         downColor = Color(255, 255, 255, 255);
@@ -194,12 +234,14 @@ void RebuildGdiObjects(int fontSize, const std::wstring& theme, UINT dpi) {
     newGdi->dividerPen = std::make_unique<Gdiplus::Pen>(Color(40, 255, 255, 255), 1.0f);
     newGdi->downChartPen = std::make_unique<Gdiplus::Pen>(downColor, 1.5f);
     newGdi->upChartPen = std::make_unique<Gdiplus::Pen>(upColor, 1.5f);
-    
+
     newGdi->downChartPen->SetLineJoin(LineJoinRound);
     newGdi->upChartPen->SetLineJoin(LineJoinRound);
 
     if (newGdi->IsValid()) {
         g_gdi = std::move(newGdi);
+    } else {
+        Wh_Log(L"RebuildGdiObjects: one or more GDI+ objects failed to construct");
     }
 }
 
@@ -218,18 +260,22 @@ void GetThemeDimensions(const std::wstring& theme, int& width, int& height) {
 bool GetTotalOctets(ULONG64* inOctets, ULONG64* outOctets) {
     ULONGLONG now = GetTickCount64();
     if (g_bestIfIndex == 0 || (now - g_lastRouteCheck) > 10000) {
-        IPAddr destAddr = 0x08080808; 
+        IPAddr destAddr = 0x08080808;
         DWORD oldIndex = g_bestIfIndex;
         if (GetBestInterface(destAddr, &g_bestIfIndex) != NO_ERROR) {
             g_bestIfIndex = 0;
         } else if (oldIndex != 0 && oldIndex != g_bestIfIndex) {
-            g_lastTick = 0; 
+            g_lastTick = 0;
         }
         g_lastRouteCheck = now;
     }
 
     if (g_bestIfIndex == 0) return false;
 
+    // Windhawk's bundled mingw headers only declare the older MIB_IFROW /
+    // GetIfEntry (32-bit counters), not MIB_IF_ROW2 / GetIfEntry2. The
+    // 32-bit wrap (~34s on a gigabit link) is handled explicitly in
+    // UpdateSpeedSample via a 64-bit running total.
     MIB_IFROW row{};
     row.dwIndex = g_bestIfIndex;
     if (GetIfEntry(&row) != NO_ERROR) {
@@ -258,22 +304,38 @@ std::wstring FormatSpeed(double bytesPerSec) {
 }
 
 void UpdateSpeedSample() {
-    ULONG64 in = 0, out = 0;
-    if (!GetTotalOctets(&in, &out)) {
+    ULONG64 rawIn = 0, rawOut = 0;
+    if (!GetTotalOctets(&rawIn, &rawOut)) {
         g_downBps = 0.0;
         g_upBps = 0.0;
         g_lastTick = 0;
     } else {
         ULONGLONG now = GetTickCount64();
-        if (g_lastTick != 0) {
+        bool discontinuity = (g_lastTick == 0);
+
+        if (discontinuity) {
+            g_cumIn = rawIn;
+            g_cumOut = rawOut;
+        } else {
+            auto accumulate = [](ULONG64& cumulative, ULONG64 rawSample) {
+                ULONG64 prevLow = cumulative & 0xFFFFFFFFULL;
+                ULONG64 delta = (rawSample >= prevLow)
+                                     ? (rawSample - prevLow)
+                                     : (0x100000000ULL - prevLow + rawSample);
+                cumulative += delta;
+            };
+            accumulate(g_cumIn, rawIn);
+            accumulate(g_cumOut, rawOut);
+
             double elapsedSec = (now - g_lastTick) / 1000.0;
             if (elapsedSec > 0.05) {
-                g_downBps = (in >= g_lastIn) ? (in - g_lastIn) / elapsedSec : 0.0;
-                g_upBps = (out >= g_lastOut) ? (out - g_lastOut) / elapsedSec : 0.0;
+                g_downBps = (double)(g_cumIn - g_lastIn) / elapsedSec;
+                g_upBps = (double)(g_cumOut - g_lastOut) / elapsedSec;
             }
         }
-        g_lastIn = in;
-        g_lastOut = out;
+
+        g_lastIn = g_cumIn;
+        g_lastOut = g_cumOut;
         g_lastTick = now;
     }
 
@@ -289,11 +351,14 @@ void RepositionWidget(HWND hWnd, const Settings& s) {
     }
 
     RECT tbRect{};
-    if (!GetWindowRect(g_hCachedTaskbar, &tbRect)) return;
+    if (!GetWindowRect(g_hCachedTaskbar, &tbRect)) {
+        Wh_Log(L"RepositionWidget: GetWindowRect on taskbar failed, gle=%lu", GetLastError());
+        return;
+    }
 
     UINT dpi = GetDpiForWindow(g_hCachedTaskbar);
     if (dpi == 0) dpi = 96;
-    
+
     if (dpi != g_currentDpi || !g_gdi || !g_gdi->IsValid()) {
         g_currentDpi = dpi;
         RebuildGdiObjects(s.fontSize, s.theme, dpi);
@@ -304,6 +369,8 @@ void RepositionWidget(HWND hWnd, const Settings& s) {
 
     int scaledWidth = MulDiv(baseW, dpi, 96);
     int scaledHeight = MulDiv(baseH, dpi, 96);
+    g_currentWidgetWidth = scaledWidth;
+    g_currentWidgetHeight = scaledHeight;
 
     int tbWidth = tbRect.right - tbRect.left;
     int tbHeight = tbRect.bottom - tbRect.top;
@@ -312,13 +379,19 @@ void RepositionWidget(HWND hWnd, const Settings& s) {
     int x = tbRect.left + (int)((usableWidth * s.horizontalPosition) / 100.0);
     int y = tbRect.top + (tbHeight - scaledHeight) / 2 + s.verticalNudge;
 
-    UINT flags = SWP_NOACTIVATE | SWP_NOZORDER;
+    UINT flags = SWP_NOACTIVATE;
     if (!IsWindowVisible(hWnd)) flags |= SWP_SHOWWINDOW;
 
     RECT newRect = {x, y, x + scaledWidth, y + scaledHeight};
     if (memcmp(&g_lastWidgetRect, &newRect, sizeof(RECT)) != 0 || (flags & SWP_SHOWWINDOW)) {
-        SetWindowPos(hWnd, nullptr, x, y, scaledWidth, scaledHeight, flags);
+        HWND zOrderTarget = g_usingBandedWindow.load() ? HWND_TOP : HWND_TOPMOST;
+        if (!SetWindowPos(hWnd, zOrderTarget, x, y, scaledWidth, scaledHeight, flags)) {
+            Wh_Log(L"RepositionWidget: SetWindowPos failed, gle=%lu", GetLastError());
+        }
         g_lastWidgetRect = newRect;
+    } else if (!g_usingBandedWindow.load()) {
+        SetWindowPos(hWnd, HWND_TOPMOST, 0, 0, 0, 0,
+                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
     }
 }
 
@@ -331,12 +404,12 @@ void AddRoundRect(GraphicsPath& path, const RectF& r, float d) {
 }
 
 void DrawSparkline(Graphics& g, Pen* pen, const std::vector<double>& hist, size_t head, RectF bounds) {
-    double maxVal = 1024.0; 
+    double maxVal = 1024.0;
     for (double v : hist) maxVal = std::max(maxVal, v);
-    
+
     PointF pts[kHistorySize];
     float step = bounds.Width / (float)(kHistorySize - 1);
-    
+
     for (size_t i = 0; i < kHistorySize; ++i) {
         size_t idx = (head + i) % kHistorySize;
         float x = bounds.X + (float)i * step;
@@ -346,24 +419,8 @@ void DrawSparkline(Graphics& g, Pen* pen, const std::vector<double>& hist, size_
     g.DrawLines(pen, pts, kHistorySize);
 }
 
-void PaintWidget(HWND hWnd) {
-    PAINTSTRUCT ps;
-    HDC hdc = BeginPaint(hWnd, &ps);
-    RECT rc;
-    GetClientRect(hWnd, &rc);
-
-    Graphics graphics(hdc);
-    graphics.SetSmoothingMode(SmoothingModeAntiAlias);
-    graphics.SetTextRenderingHint(TextRenderingHintClearTypeGridFit);
-    graphics.Clear(Color(0, 0, 0, 0));
-
-    if (!g_gdi || !g_gdi->IsValid()) {
-        EndPaint(hWnd, &ps);
-        return;
-    }
-
-    Settings s = GetSafeSettings();
-    RectF bounds(0.0f, 0.0f, (float)rc.right - 1.0f, (float)rc.bottom - 1.0f);
+void PaintWidgetContent(Graphics& graphics, int width, int height, const Settings& s) {
+    RectF bounds(0.0f, 0.0f, (float)width - 1.0f, (float)height - 1.0f);
 
     if (s.theme != L"Minimal") {
         GraphicsPath path;
@@ -394,10 +451,10 @@ void PaintWidget(HWND hWnd) {
         format.SetAlignment(StringAlignmentNear);
         format.SetLineAlignment(StringAlignmentCenter);
         float halfH = h / 2.0f;
-        
+
         graphics.DrawString(L"\x2193", -1, g_gdi->font.get(), RectF(8, 0, 16, halfH), &format, g_gdi->downBrush.get());
         graphics.DrawString(strDown.c_str(), -1, g_gdi->font.get(), RectF(22, 0, w - 22, halfH), &format, g_gdi->downBrush.get());
-        
+
         graphics.DrawString(L"\x2191", -1, g_gdi->font.get(), RectF(8, halfH, 16, halfH), &format, g_gdi->upBrush.get());
         graphics.DrawString(strUp.c_str(), -1, g_gdi->font.get(), RectF(22, halfH, w - 22, halfH), &format, g_gdi->upBrush.get());
 
@@ -406,7 +463,7 @@ void PaintWidget(HWND hWnd) {
         format.SetLineAlignment(StringAlignmentCenter);
         float halfH = h / 2.0f;
         float chartW = w * 0.40f;
-        
+
         RectF chartDown(8.0f, 6.0f, chartW, halfH - 8.0f);
         DrawSparkline(graphics, g_gdi->downChartPen.get(), g_downHistory, g_historyIdx, chartDown);
         graphics.DrawString((L"\x2193 " + strDown).c_str(), -1, g_gdi->font.get(), RectF(chartW + 16, 0, w - chartW - 16, halfH), &format, g_gdi->downBrush.get());
@@ -426,8 +483,69 @@ void PaintWidget(HWND hWnd) {
         graphics.DrawString((L"\x2191 " + strUp).c_str(), -1, g_gdi->font.get(), RectF(halfW + 1, 1, halfW, h), &format, g_gdi->shadowBrush.get());
         graphics.DrawString((L"\x2191 " + strUp).c_str(), -1, g_gdi->font.get(), RectF(halfW, 0, halfW, h), &format, g_gdi->upBrush.get());
     }
+}
 
-    EndPaint(hWnd, &ps);
+void RenderWidget(HWND hWnd, int opacity) {
+    if (!IsWindowVisible(hWnd)) return;
+
+    int width = g_currentWidgetWidth;
+    int height = g_currentWidgetHeight;
+    if (width <= 0 || height <= 0 || !g_gdi || !g_gdi->IsValid()) return;
+
+    HDC hdcScreen = GetDC(nullptr);
+    HDC hdcMem = CreateCompatibleDC(hdcScreen);
+
+    BITMAPINFO bmi{};
+    bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    bmi.bmiHeader.biWidth = width;
+    bmi.bmiHeader.biHeight = -height;
+    bmi.bmiHeader.biPlanes = 1;
+    bmi.bmiHeader.biBitCount = 32;
+    bmi.bmiHeader.biCompression = BI_RGB;
+
+    void* pBits = nullptr;
+    HBITMAP hBitmap = CreateDIBSection(hdcScreen, &bmi, DIB_RGB_COLORS, &pBits, nullptr, 0);
+    if (hBitmap) {
+        HBITMAP hOldBitmap = (HBITMAP)SelectObject(hdcMem, hBitmap);
+
+        {
+            Graphics graphics(hdcMem);
+            graphics.SetSmoothingMode(SmoothingModeAntiAlias);
+            graphics.SetTextRenderingHint(TextRenderingHintAntiAlias);
+            graphics.Clear(Color(0, 0, 0, 0));
+
+            if (g_gdi && g_gdi->IsValid()) {
+                Settings s = GetSafeSettings();
+                PaintWidgetContent(graphics, width, height, s);
+            }
+        }
+
+        RECT rc{};
+        POINT ptDst{0, 0};
+        if (GetWindowRect(hWnd, &rc)) {
+            ptDst.x = rc.left;
+            ptDst.y = rc.top;
+        }
+        SIZE sizeWnd{width, height};
+        POINT ptSrc{0, 0};
+
+        BLENDFUNCTION blend{};
+        blend.BlendOp = AC_SRC_OVER;
+        blend.SourceConstantAlpha = (BYTE)std::clamp(opacity, 0, 255);
+        blend.AlphaFormat = AC_SRC_ALPHA;
+
+        if (!UpdateLayeredWindow(hWnd, hdcScreen, &ptDst, &sizeWnd, hdcMem, &ptSrc, 0, &blend, ULW_ALPHA)) {
+            Wh_Log(L"RenderWidget: UpdateLayeredWindow failed, gle=%lu", GetLastError());
+        }
+
+        SelectObject(hdcMem, hOldBitmap);
+        DeleteObject(hBitmap);
+    } else {
+        Wh_Log(L"RenderWidget: CreateDIBSection failed, gle=%lu", GetLastError());
+    }
+
+    DeleteDC(hdcMem);
+    ReleaseDC(nullptr, hdcScreen);
 }
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
@@ -437,26 +555,27 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             RebuildGdiObjects(s.fontSize, s.theme, g_currentDpi);
             KillTimer(hWnd, kTimerId);
             SetTimer(hWnd, kTimerId, s.updateIntervalMs, nullptr);
-            SetLayeredWindowAttributes(hWnd, 0, (BYTE)s.opacity, LWA_ALPHA);
             RepositionWidget(hWnd, s);
-            InvalidateRect(hWnd, nullptr, FALSE);
+            RenderWidget(hWnd, s.opacity);
             return 0;
         }
         case WM_UPDATE_POSITION: {
             g_posUpdatePending.store(false);
-            RepositionWidget(hWnd, GetSafeSettings());
-            InvalidateRect(hWnd, nullptr, TRUE);
+            Settings s = GetSafeSettings();
+            RepositionWidget(hWnd, s);
+            RenderWidget(hWnd, s.opacity);
             return 0;
         }
         case WM_PAINT:
-            PaintWidget(hWnd);
+            ValidateRect(hWnd, nullptr);
             return 0;
         case WM_TIMER:
             if (wParam == kTimerId) {
                 UpdateSpeedSample();
                 if (g_hCachedTaskbar && IsWindow(g_hCachedTaskbar)) {
-                    RepositionWidget(hWnd, GetSafeSettings());
-                    InvalidateRect(hWnd, nullptr, FALSE);
+                    Settings s = GetSafeSettings();
+                    RepositionWidget(hWnd, s);
+                    RenderWidget(hWnd, s.opacity);
                 }
             }
             return 0;
@@ -467,13 +586,43 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             DestroyWindow(hWnd);
             return 0;
         case WM_NCDESTROY: {
-            std::lock_guard<std::mutex> lock(g_wndLifecycleMutex);
-            g_hWnd.store(nullptr);
+            {
+                std::lock_guard<std::mutex> lock(g_wndLifecycleMutex);
+                g_hWnd.store(nullptr);
+                g_posUpdatePending.store(false);
+            }
             PostQuitMessage(0);
-            return 0;
+            break; // Let DefWindowProc handle cleanup
         }
     }
     return DefWindowProc(hWnd, msg, wParam, lParam);
+}
+
+HWND CreateBandedWidgetWindow(DWORD exStyle, LPCWSTR className, DWORD style,
+                               HINSTANCE hInstance) {
+    static CreateWindowInBand_t pCreateWindowInBand =
+        (CreateWindowInBand_t)GetProcAddress(GetModuleHandleW(L"user32.dll"),
+                                              "CreateWindowInBand");
+
+    if (pCreateWindowInBand) {
+        HWND hwnd = pCreateWindowInBand(exStyle, className, L"", style, 0, 0,
+                                         1, 1, nullptr, nullptr, hInstance,
+                                         nullptr, ZBID_IMMERSIVE_NOTIFICATION);
+        if (hwnd) {
+            Wh_Log(L"CreateWindowInBand succeeded (ZBID_IMMERSIVE_NOTIFICATION)");
+            g_usingBandedWindow.store(true);
+            return hwnd;
+        }
+        Wh_Log(L"CreateWindowInBand failed, gle=%lu -- falling back to a "
+               L"plain topmost window", GetLastError());
+    } else {
+        Wh_Log(L"CreateWindowInBand not exported by user32.dll on this "
+               L"build -- falling back to a plain topmost window");
+    }
+
+    g_usingBandedWindow.store(false);
+    return CreateWindowExW(exStyle | WS_EX_TOPMOST, className, L"", style, 0,
+                            0, 1, 1, nullptr, nullptr, hInstance, nullptr);
 }
 
 DWORD WINAPI WidgetMessageLoop(LPVOID lpParam) {
@@ -485,13 +634,12 @@ DWORD WINAPI WidgetMessageLoop(LPVOID lpParam) {
     wc.lpfnWndProc = WndProc;
     wc.hInstance = GetCurrentModuleHandle();
     wc.hbrBackground = nullptr;
-    
-    wchar_t szClassName[64];
-    swprintf_s(szClassName, L"WindhawkNetSpeed_%lu", GetCurrentThreadId());
+    LPCWSTR szClassName = L"WindhawkNetSpeedWidget";
     wc.lpszClassName = szClassName;
-    
+
     if (!RegisterClassW(&wc)) {
-        return 0; 
+        Wh_Log(L"RegisterClassW failed, gle=%lu", GetLastError());
+        return 0;
     }
 
     while (!g_exiting.load()) {
@@ -503,47 +651,46 @@ DWORD WINAPI WidgetMessageLoop(LPVOID lpParam) {
 
         DWORD pid = 0;
         DWORD tid = GetWindowThreadProcessId(hTaskbar, &pid);
-        
-        if (pid != GetCurrentProcessId()) {
-            if (WaitForSingleObject(g_hExitEvent, 2000) == WAIT_OBJECT_0) break;
-            continue;
-        }
 
         g_hCachedTaskbar = hTaskbar;
-        g_taskbarPid = pid;
-        g_taskbarTid = tid;
         memset(&g_lastWidgetRect, 0, sizeof(RECT));
+        g_posUpdatePending.store(false);
 
-        DWORD exStyle = WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT;
-        
+        DWORD exStyle = WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE |
+                         WS_EX_TRANSPARENT;
+
         HWND hwnd = nullptr;
         {
             std::lock_guard<std::mutex> lock(g_wndLifecycleMutex);
             if (g_exiting.load()) break;
 
-            hwnd = CreateWindowExW(exStyle, szClassName, L"", WS_POPUP, 0, 0,
-                                   1, 1, hTaskbar, nullptr, wc.hInstance, nullptr);
-            if (!hwnd) {
-                if (WaitForSingleObject(g_hExitEvent, 1000) == WAIT_OBJECT_0) break;
-                continue;
+            hwnd = CreateBandedWidgetWindow(exStyle, szClassName, WS_POPUP, wc.hInstance);
+            if (hwnd) {
+                g_hWnd.store(hwnd);
             }
-            g_hWnd.store(hwnd);
         }
-        
+        if (!hwnd) {
+            Wh_Log(L"CreateWindowExW failed, gle=%lu", GetLastError());
+            if (WaitForSingleObject(g_hExitEvent, 1000) == WAIT_OBJECT_0) break;
+            continue;
+        }
+
+        Wh_Log(L"Widget created (banded=%d), taskbar pid=%lu tid=%lu",
+               (int)g_usingBandedWindow.load(), pid, tid);
         PostMessageW(hwnd, WM_UPDATE_SETTINGS, 0, 0);
 
-        g_hDestroyHook = SetWinEventHook(EVENT_OBJECT_DESTROY, EVENT_OBJECT_DESTROY, nullptr, 
+        g_hDestroyHook = SetWinEventHook(EVENT_OBJECT_DESTROY, EVENT_OBJECT_DESTROY, nullptr,
             [](HWINEVENTHOOK, DWORD, HWND hwndHook, LONG idObj, LONG, DWORD, DWORD) {
                 if (idObj == OBJID_WINDOW && hwndHook == g_hCachedTaskbar) {
                     g_hCachedTaskbar = nullptr;
                     HWND widget = g_hWnd.load();
                     if (widget) {
-                        PostMessageW(widget, WM_CLOSE, 0, 0); 
+                        PostMessageW(widget, WM_CLOSE, 0, 0);
                     }
                 }
             }, pid, tid, WINEVENT_OUTOFCONTEXT);
 
-        g_hLocationHook = SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_LOCATIONCHANGE, nullptr, 
+        g_hLocationHook = SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_LOCATIONCHANGE, nullptr,
             [](HWINEVENTHOOK, DWORD, HWND hwndHook, LONG idObj, LONG, DWORD, DWORD) {
                 if (idObj == OBJID_WINDOW && hwndHook == g_hCachedTaskbar) {
                     HWND widget = g_hWnd.load();
@@ -557,11 +704,12 @@ DWORD WINAPI WidgetMessageLoop(LPVOID lpParam) {
             TranslateMessage(&msg);
             DispatchMessageW(&msg);
         }
-        
+
         if (g_hLocationHook) { UnhookWinEvent(g_hLocationHook); g_hLocationHook = nullptr; }
         if (g_hDestroyHook) { UnhookWinEvent(g_hDestroyHook); g_hDestroyHook = nullptr; }
-        
+
         g_hCachedTaskbar = nullptr;
+        Wh_Log(L"Widget message loop exited, will retry if not shutting down");
     }
 
     UnregisterClassW(szClassName, wc.hInstance);
@@ -570,31 +718,45 @@ DWORD WINAPI WidgetMessageLoop(LPVOID lpParam) {
 
 }  // namespace
 
-BOOL Wh_ModInit() {
-    LoadSettingsLocked();
+BOOL WhTool_ModInit() {
+    LoadSettings();
 
     GdiplusStartupInput gdiplusStartupInput;
-    if (GdiplusStartup(&g_gdiplusToken, &gdiplusStartupInput, nullptr) != Ok) {
+    Status gdiStatus = GdiplusStartup(&g_gdiplusToken, &gdiplusStartupInput, nullptr);
+    if (gdiStatus != Ok) {
+        Wh_Log(L"GdiplusStartup failed, status=%d", (int)gdiStatus);
         return FALSE;
     }
 
     g_exiting.store(false);
     g_hExitEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
     g_hQueueReady = CreateEventW(nullptr, TRUE, FALSE, nullptr);
-    g_hThread = CreateThread(nullptr, 0, WidgetMessageLoop, nullptr, 0, &g_threadId);
+    if (!g_hExitEvent || !g_hQueueReady) {
+        Wh_Log(L"CreateEventW failed, gle=%lu", GetLastError());
+        if (g_hExitEvent) { CloseHandle(g_hExitEvent); g_hExitEvent = nullptr; }
+        if (g_hQueueReady) { CloseHandle(g_hQueueReady); g_hQueueReady = nullptr; }
+        return FALSE;
+    }
 
-    return g_hThread != nullptr;
+    g_hThread = CreateThread(nullptr, 0, WidgetMessageLoop, nullptr, 0, &g_threadId);
+    if (!g_hThread) {
+        Wh_Log(L"CreateThread failed, gle=%lu", GetLastError());
+        return FALSE;
+    }
+
+    Wh_Log(L"WhTool_ModInit: worker thread started");
+    return TRUE;
 }
 
-void Wh_ModUninit() {
+void WhTool_ModUninit() {
     g_exiting.store(true);
     if (g_hExitEvent) {
         SetEvent(g_hExitEvent);
     }
 
     if (g_hThread) {
-        WaitForSingleObject(g_hQueueReady, INFINITE); 
-        
+        WaitForSingleObject(g_hQueueReady, INFINITE);
+
         {
             std::lock_guard<std::mutex> lock(g_wndLifecycleMutex);
             HWND hwnd = g_hWnd.load();
@@ -602,9 +764,9 @@ void Wh_ModUninit() {
                 PostMessageW(hwnd, WM_CLOSE, 0, 0);
             }
         }
-        PostThreadMessageW(g_threadId, WM_QUIT, 0, 0); 
-        
-        WaitForSingleObject(g_hThread, INFINITE);      
+        PostThreadMessageW(g_threadId, WM_QUIT, 0, 0);
+
+        WaitForSingleObject(g_hThread, INFINITE);
         CloseHandle(g_hThread);
         g_hThread = nullptr;
         g_threadId = 0;
@@ -620,6 +782,7 @@ void Wh_ModUninit() {
         g_hExitEvent = nullptr;
     }
 
+    // Released explicitly, BEFORE GdiplusShutdown.
     g_gdi.reset();
 
     if (g_gdiplusToken) {
@@ -628,8 +791,178 @@ void Wh_ModUninit() {
     }
 }
 
-void Wh_ModSettingsChanged() {
-    LoadSettingsLocked();
+void WhTool_ModSettingsChanged() {
+    LoadSettings();
     HWND hwnd = g_hWnd.load();
     if (hwnd) PostMessageW(hwnd, WM_UPDATE_SETTINGS, 0, 0);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Windhawk tool mod implementation for mods which don't need to inject to
+// other processes or hook other functions. Pasted verbatim from:
+// https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process
+
+bool g_isToolModProcessLauncher;
+HANDLE g_toolModProcessMutex;
+
+void WINAPI EntryPoint_Hook() {
+    Wh_Log(L">");
+    ExitThread(0);
+}
+
+BOOL Wh_ModInit() {
+    DWORD sessionId;
+    if (ProcessIdToSessionId(GetCurrentProcessId(), &sessionId) &&
+        sessionId == 0) {
+        return FALSE;
+    }
+
+    bool isExcluded = false;
+    bool isToolModProcess = false;
+    bool isCurrentToolModProcess = false;
+    int argc;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);
+    if (!argv) {
+        Wh_Log(L"CommandLineToArgvW failed");
+        return FALSE;
+    }
+
+    for (int i = 1; i < argc; i++) {
+        if (wcscmp(argv[i], L"-service") == 0 ||
+            wcscmp(argv[i], L"-service-start") == 0 ||
+            wcscmp(argv[i], L"-service-stop") == 0) {
+            isExcluded = true;
+            break;
+        }
+    }
+
+    for (int i = 1; i < argc - 1; i++) {
+        if (wcscmp(argv[i], L"-tool-mod") == 0) {
+            isToolModProcess = true;
+            if (wcscmp(argv[i + 1], WH_MOD_ID) == 0) {
+                isCurrentToolModProcess = true;
+            }
+            break;
+        }
+    }
+
+    LocalFree(argv);
+
+    if (isExcluded) {
+        return FALSE;
+    }
+
+    if (isCurrentToolModProcess) {
+        g_toolModProcessMutex =
+            CreateMutex(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
+        if (!g_toolModProcessMutex) {
+            Wh_Log(L"CreateMutex failed");
+            ExitProcess(1);
+        }
+
+        if (GetLastError() == ERROR_ALREADY_EXISTS) {
+            Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
+            ExitProcess(1);
+        }
+
+        if (!WhTool_ModInit()) {
+            ExitProcess(1);
+        }
+
+        IMAGE_DOS_HEADER* dosHeader =
+            (IMAGE_DOS_HEADER*)GetModuleHandle(nullptr);
+        IMAGE_NT_HEADERS* ntHeaders =
+            (IMAGE_NT_HEADERS*)((BYTE*)dosHeader + dosHeader->e_lfanew);
+
+        DWORD entryPointRVA = ntHeaders->OptionalHeader.AddressOfEntryPoint;
+        void* entryPoint = (BYTE*)dosHeader + entryPointRVA;
+
+        Wh_SetFunctionHook(entryPoint, (void*)EntryPoint_Hook, nullptr);
+        return TRUE;
+    }
+
+    if (isToolModProcess) {
+        return FALSE;
+    }
+
+    g_isToolModProcessLauncher = true;
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    if (!g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WCHAR currentProcessPath[MAX_PATH];
+    switch (GetModuleFileName(nullptr, currentProcessPath,
+                              ARRAYSIZE(currentProcessPath))) {
+        case 0:
+        case ARRAYSIZE(currentProcessPath):
+            Wh_Log(L"GetModuleFileName failed");
+            return;
+    }
+
+    WCHAR
+    commandLine[MAX_PATH + 2 +
+                (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
+    swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
+               WH_MOD_ID);
+
+    HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
+    if (!kernelModule) {
+        kernelModule = GetModuleHandle(L"kernel32.dll");
+        if (!kernelModule) {
+            Wh_Log(L"No kernelbase.dll/kernel32.dll");
+            return;
+        }
+    }
+
+    using CreateProcessInternalW_t = BOOL(WINAPI*)(
+        HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
+        LPSECURITY_ATTRIBUTES lpProcessAttributes,
+        LPSECURITY_ATTRIBUTES lpThreadAttributes, WINBOOL bInheritHandles,
+        DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory,
+        LPSTARTUPINFOW lpStartupInfo,
+        LPPROCESS_INFORMATION lpProcessInformation,
+        PHANDLE hRestrictedUserToken);
+    CreateProcessInternalW_t pCreateProcessInternalW =
+        (CreateProcessInternalW_t)GetProcAddress(kernelModule,
+                                                 "CreateProcessInternalW");
+    if (!pCreateProcessInternalW) {
+        Wh_Log(L"No CreateProcessInternalW");
+        return;
+    }
+
+    STARTUPINFO si{
+        .cb = sizeof(STARTUPINFO),
+        .dwFlags = STARTF_FORCEOFFFEEDBACK,
+    };
+    PROCESS_INFORMATION pi;
+    if (!pCreateProcessInternalW(nullptr, currentProcessPath, commandLine,
+                                 nullptr, nullptr, FALSE, NORMAL_PRIORITY_CLASS,
+                                 nullptr, nullptr, &si, &pi, nullptr)) {
+        Wh_Log(L"CreateProcess failed, gle=%lu", GetLastError());
+        return;
+    }
+
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+}
+
+void Wh_ModSettingsChanged() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModSettingsChanged();
+}
+
+void Wh_ModUninit() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModUninit();
+    ExitProcess(0);
 }

--- a/mods/net-speed-taskbar.wh.cpp
+++ b/mods/net-speed-taskbar.wh.cpp
@@ -23,7 +23,6 @@ Unlike the existing "Taskbar Clock Customization" mod, this is a free-floating w
 - Choose from different looks: Side-by-Side, Top-Down, Chart, or Minimal.
 - Move the widget anywhere along your taskbar using the Horizontal Position setting.
 - You can click right through it, so it won't get in the way of your taskbar buttons.
-
 */
 // ==/WindhawkModReadme==
 
@@ -57,17 +56,10 @@ Unlike the existing "Taskbar Clock Customization" mod, this is a free-floating w
 */
 // ==/WindhawkModSettings==
 
-#ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0A00
-#endif
-
-#include <winsock2.h>
-#include <ws2ipdef.h>
 #include <windows.h>
 #include <objbase.h>
 #include <gdiplus.h>
 #include <iphlpapi.h>
-#include <netioapi.h>
 #include <string>
 #include <algorithm>
 #include <atomic>
@@ -97,7 +89,7 @@ Settings g_settings;
 std::mutex g_settingsMutex;
 
 std::atomic<HWND> g_hWnd{nullptr};
-std::mutex g_wndLifecycleMutex; // Guards creation, publication, and teardown of g_hWnd
+std::mutex g_wndLifecycleMutex;
 
 std::atomic<bool> g_posUpdatePending{false};
 std::atomic<bool> g_exiting{false};
@@ -238,16 +230,18 @@ bool GetTotalOctets(ULONG64* inOctets, ULONG64* outOctets) {
 
     if (g_bestIfIndex == 0) return false;
 
-    MIB_IF_ROW2 row{};
-    row.InterfaceIndex = g_bestIfIndex;
-    if (GetIfEntry2(&row) != NO_ERROR) {
+    MIB_IFROW row{};
+    row.dwIndex = g_bestIfIndex;
+    if (GetIfEntry(&row) != NO_ERROR) {
         return false;
     }
 
-    if (row.OperStatus != IfOperStatusUp) return false;
+    if (row.dwOperStatus != MIB_IF_OPER_STATUS_OPERATIONAL && row.dwOperStatus != MIB_IF_OPER_STATUS_CONNECTED) {
+        return false;
+    }
 
-    *inOctets = row.InOctets;
-    *outOctets = row.OutOctets;
+    *inOctets = row.dwInOctets;
+    *outOctets = row.dwOutOctets;
     return true;
 }
 
@@ -268,7 +262,7 @@ void UpdateSpeedSample() {
     if (!GetTotalOctets(&in, &out)) {
         g_downBps = 0.0;
         g_upBps = 0.0;
-        g_lastTick = 0; // Reset baseline so reconnect doesn't understate next rate
+        g_lastTick = 0;
     } else {
         ULONGLONG now = GetTickCount64();
         if (g_lastTick != 0) {

--- a/mods/net-speed-taskbar.wh.cpp
+++ b/mods/net-speed-taskbar.wh.cpp
@@ -1,0 +1,566 @@
+// ==WindhawkMod==
+// @id          net-speed-taskbar
+// @name        Taskbar Network Speed Indicator
+// @description Shows live download/upload speed near the taskbar.
+// @version     1.0
+// @author      Narayan
+// @github      https://github.com/NarayanChetri
+// @homepage    https://narayanchetri.dev
+// @include     explorer.exe
+// @compilerOptions -lgdiplus -liphlpapi -lgdi32 -luser32 -lws2_32
+// @architecture    x86-64
+// @license         MIT
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Taskbar Network Speed Indicator
+
+Draws a small floating widget docked to the taskbar that shows your current
+download and upload internet speed, refreshed every second.
+
+![Demo](https://raw.githubusercontent.com/NarayanChetri/Files/main/taskbar-speed-indicator.gif)
+
+- Move the widget anywhere along your taskbar using the Horizontal Position setting.
+- You can click right through it, so it won't get in the way of your taskbar buttons.
+- Smoothly follows your taskbar if you have auto-hide enabled.
+- Always stays visible on top of the taskbar.
+- Shows your actual internet speed, ignoring background virtual networks or VPN clutter.
+- Choose from different looks: Side-by-Side, Top-Down, Chart, or Minimal.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- theme: Minimal
+  $name: Visual Theme
+  $description: >-
+    Select the widget's structural layout and style.
+  $options:
+    - Side-by-Side: Side-by-Side
+    - Top-Down: Top-Down (Compact)
+    - Chart: Chart (Sparklines)
+    - Minimal: Minimal (Text Only)
+- horizontalPosition: 7
+  $name: Horizontal position (%)
+  $description: >-
+    Where the widget sits along the taskbar's width. 0 = left edge, 100 =
+    right edge, 50 = centered. Enter any value 0-100.
+- verticalNudge: 0
+  $name: Vertical nudge (px)
+  $description: Fine-tune vertical centering within the taskbar, in pixels. Positive moves down.
+- updateIntervalMs: 1000
+  $name: Update interval (ms)
+  $description: How often the speed reading refreshes.
+- fontSize: 13
+  $name: Font size
+- opacity: 235
+  $name: Opacity (0-255)
+  $description: Overall widget transparency. 255 = fully opaque.
+*/
+// ==/WindhawkModSettings==
+
+#pragma comment(lib, "gdiplus.lib")
+#pragma comment(lib, "iphlpapi.lib")
+#pragma comment(lib, "ws2_32.lib")
+
+#include <winsock2.h>
+#include <ws2ipdef.h>
+#include <windows.h>
+#include <gdiplus.h>
+#include <iphlpapi.h>
+#include <netioapi.h>
+#include <string>
+#include <algorithm>
+#include <atomic>
+#include <vector>
+
+using namespace Gdiplus;
+
+#define WM_UPDATE_SETTINGS (WM_APP + 1)
+#define WM_UPDATE_POSITION (WM_APP + 2)
+
+namespace {
+
+struct Settings {
+    std::wstring theme;
+    int horizontalPosition;
+    int verticalNudge;
+    int updateIntervalMs;
+    int fontSize;
+    int opacity;
+};
+
+Settings g_settings;
+CRITICAL_SECTION g_settingsLock;
+
+std::atomic<HWND> g_hWnd{nullptr};
+std::atomic<bool> g_posUpdatePending{false};
+ULONG_PTR g_gdiplusToken = 0;
+UINT_PTR g_timerId = 1001;
+
+HANDLE g_hThread = nullptr;
+DWORD g_threadId = 0;
+HWINEVENTHOOK g_hLocationHook = nullptr;
+
+ULONGLONG g_lastTick = 0;
+ULONG64 g_lastIn = 0;
+ULONG64 g_lastOut = 0;
+double g_downBps = 0.0;
+double g_upBps = 0.0;
+
+DWORD g_bestIfIndex = 0;
+ULONGLONG g_lastRouteCheck = 0;
+
+const wchar_t* kClassName = L"WindhawkNetSpeedWidgetWnd";
+
+const size_t kHistorySize = 20;
+std::vector<double> g_downHistory(kHistorySize, 0.0);
+std::vector<double> g_upHistory(kHistorySize, 0.0);
+size_t g_historyIdx = 0;
+
+Gdiplus::Font* g_font = nullptr;
+Gdiplus::Font* g_largeFont = nullptr;
+Gdiplus::SolidBrush* g_bgBrush = nullptr;
+Gdiplus::SolidBrush* g_downBrush = nullptr;
+Gdiplus::SolidBrush* g_upBrush = nullptr;
+Gdiplus::SolidBrush* g_shadowBrush = nullptr;
+Gdiplus::Pen* g_borderPen = nullptr;
+Gdiplus::Pen* g_dividerPen = nullptr;
+Gdiplus::Pen* g_downChartPen = nullptr;
+Gdiplus::Pen* g_upChartPen = nullptr;
+
+Settings GetSafeSettings() {
+    Settings s;
+    EnterCriticalSection(&g_settingsLock);
+    s = g_settings;
+    LeaveCriticalSection(&g_settingsLock);
+    return s;
+}
+
+void LoadSettingsLocked() {
+    EnterCriticalSection(&g_settingsLock);
+    
+    PCWSTR pTheme = Wh_GetStringSetting(L"theme");
+    g_settings.theme = pTheme ? pTheme : L"Minimal";
+    if (pTheme) Wh_FreeStringSetting(pTheme);
+    
+    g_settings.horizontalPosition = std::clamp((int)Wh_GetIntSetting(L"horizontalPosition"), 0, 100);
+    g_settings.verticalNudge = (int)Wh_GetIntSetting(L"verticalNudge");
+    g_settings.updateIntervalMs = std::max((int)Wh_GetIntSetting(L"updateIntervalMs"), 200);
+    g_settings.fontSize = std::max((int)Wh_GetIntSetting(L"fontSize"), 6);
+    g_settings.opacity = std::clamp((int)Wh_GetIntSetting(L"opacity"), 0, 255);
+    LeaveCriticalSection(&g_settingsLock);
+}
+
+void RebuildGdiObjects(int fontSize, const std::wstring& theme) {
+    delete g_font;
+    delete g_largeFont;
+    delete g_bgBrush;
+    delete g_downBrush;
+    delete g_upBrush;
+    delete g_shadowBrush;
+    delete g_borderPen;
+    delete g_dividerPen;
+    delete g_downChartPen;
+    delete g_upChartPen;
+
+    Gdiplus::FontFamily fontFamily(L"Segoe UI");
+    g_font = new Gdiplus::Font(&fontFamily, (Gdiplus::REAL)fontSize, FontStyleRegular, UnitPixel);
+    g_largeFont = new Gdiplus::Font(&fontFamily, (Gdiplus::REAL)fontSize * 1.3f, FontStyleBold, UnitPixel);
+    
+    Color bgColor = Color(240, 18, 20, 22);
+    Color downColor = Color(255, 64, 169, 255); 
+    Color upColor = Color(255, 100, 230, 90);   
+    
+    if (theme == L"Minimal") {
+        bgColor = Color(0, 0, 0, 0);
+        downColor = Color(255, 255, 255, 255);
+        upColor = Color(255, 200, 200, 200);
+    }
+
+    g_bgBrush = new Gdiplus::SolidBrush(bgColor);
+    g_downBrush = new Gdiplus::SolidBrush(downColor);
+    g_upBrush = new Gdiplus::SolidBrush(upColor);
+    g_shadowBrush = new Gdiplus::SolidBrush(Color(200, 0, 0, 0));
+    g_borderPen = new Gdiplus::Pen(Color(60, 255, 255, 255), 1.0f);
+    g_dividerPen = new Gdiplus::Pen(Color(40, 255, 255, 255), 1.0f);
+    g_downChartPen = new Gdiplus::Pen(downColor, 1.5f);
+    g_upChartPen = new Gdiplus::Pen(upColor, 1.5f);
+    
+    g_downChartPen->SetLineJoin(LineJoinRound);
+    g_upChartPen->SetLineJoin(LineJoinRound);
+}
+
+void GetThemeDimensions(const std::wstring& theme, int& width, int& height) {
+    if (theme == L"Top-Down") {
+        width = 75; height = 36;
+    } else if (theme == L"Chart") {
+        width = 160; height = 44;
+    } else if (theme == L"Minimal") {
+        width = 130; height = 20;
+    } else {
+        width = 140; height = 40;
+    }
+}
+
+bool GetTotalOctets(ULONG64* inOctets, ULONG64* outOctets) {
+    ULONGLONG now = GetTickCount64();
+    if (g_bestIfIndex == 0 || (now - g_lastRouteCheck) > 10000) {
+        IPAddr destAddr = inet_addr("8.8.8.8");
+        GetBestInterface(destAddr, &g_bestIfIndex);
+        g_lastRouteCheck = now;
+    }
+
+    PMIB_IF_TABLE2 table = nullptr;
+    if (GetIfTable2(&table) != NO_ERROR) {
+        return false;
+    }
+
+    ULONG64 in = 0, out = 0;
+    for (ULONG i = 0; i < table->NumEntries; i++) {
+        const MIB_IF_ROW2& row = table->Table[i];
+        if (g_bestIfIndex != 0 && row.InterfaceIndex != g_bestIfIndex) continue;
+        if (row.Type == IF_TYPE_SOFTWARE_LOOPBACK || row.Type == IF_TYPE_TUNNEL) continue;
+        if (row.OperStatus != IfOperStatusUp) continue;
+        in += row.InOctets;
+        out += row.OutOctets;
+    }
+
+    FreeMibTable(table);
+    *inOctets = in;
+    *outOctets = out;
+    return true;
+}
+
+std::wstring FormatSpeed(double bytesPerSec) {
+    wchar_t buf[32];
+    if (bytesPerSec >= 1024.0 * 1024.0) {
+        swprintf_s(buf, L"%.1f MB/s", bytesPerSec / (1024.0 * 1024.0));
+    } else if (bytesPerSec >= 1024.0) {
+        swprintf_s(buf, L"%.0f KB/s", bytesPerSec / 1024.0);
+    } else {
+        swprintf_s(buf, L"%.0f B/s", bytesPerSec);
+    }
+    return buf;
+}
+
+void UpdateSpeedSample() {
+    ULONG64 in = 0, out = 0;
+    if (!GetTotalOctets(&in, &out)) return;
+
+    ULONGLONG now = GetTickCount64();
+    if (g_lastTick != 0) {
+        double elapsedSec = (now - g_lastTick) / 1000.0;
+        if (elapsedSec > 0.05) {
+            g_downBps = (in >= g_lastIn) ? (in - g_lastIn) / elapsedSec : 0.0;
+            g_upBps = (out >= g_lastOut) ? (out - g_lastOut) / elapsedSec : 0.0;
+        }
+    }
+
+    g_lastIn = in;
+    g_lastOut = out;
+    g_lastTick = now;
+
+    g_downHistory[g_historyIdx] = g_downBps;
+    g_upHistory[g_historyIdx] = g_upBps;
+    g_historyIdx = (g_historyIdx + 1) % kHistorySize;
+}
+
+void RepositionWidget(HWND hWnd, const Settings& s) {
+    static HWND hTaskbar = nullptr;
+    if (!hTaskbar || !IsWindow(hTaskbar)) {
+        hTaskbar = FindWindow(L"Shell_TrayWnd", nullptr);
+    }
+
+    if (!hTaskbar) {
+        if (IsWindowVisible(hWnd)) ShowWindow(hWnd, SW_HIDE);
+        return;
+    }
+
+    if (GetWindow(hWnd, GW_OWNER) != hTaskbar) {
+        SetWindowLongPtr(hWnd, GWLP_HWNDPARENT, (LONG_PTR)hTaskbar);
+    }
+
+    if (!IsWindowVisible(hTaskbar)) {
+        if (IsWindowVisible(hWnd)) ShowWindow(hWnd, SW_HIDE);
+        return;
+    }
+
+    RECT tbRect{};
+    GetWindowRect(hTaskbar, &tbRect);
+
+    int tbWidth = tbRect.right - tbRect.left;
+    int tbHeight = tbRect.bottom - tbRect.top;
+
+    int baseW, baseH;
+    GetThemeDimensions(s.theme, baseW, baseH);
+
+    UINT dpi = GetDpiForWindow(hTaskbar);
+    if (dpi == 0) dpi = 96;
+    int scaledWidth = MulDiv(baseW, dpi, 96);
+    int scaledHeight = MulDiv(baseH, dpi, 96);
+
+    int usableWidth = std::max(tbWidth - scaledWidth, 0);
+    int x = tbRect.left + (int)((usableWidth * s.horizontalPosition) / 100.0);
+    int y = tbRect.top + (tbHeight - scaledHeight) / 2 + s.verticalNudge;
+
+    UINT flags = SWP_NOACTIVATE | SWP_NOZORDER;
+    if (!IsWindowVisible(hWnd)) flags |= SWP_SHOWWINDOW;
+
+    SetWindowPos(hWnd, nullptr, x, y, scaledWidth, scaledHeight, flags);
+}
+
+void AddRoundRect(GraphicsPath& path, const RectF& r, float d) {
+    path.AddArc(r.X, r.Y, d, d, 180.0f, 90.0f);
+    path.AddArc(r.X + r.Width - d, r.Y, d, d, 270.0f, 90.0f);
+    path.AddArc(r.X + r.Width - d, r.Y + r.Height - d, d, d, 0.0f, 90.0f);
+    path.AddArc(r.X, r.Y + r.Height - d, d, d, 90.0f, 90.0f);
+    path.CloseFigure();
+}
+
+void DrawSparkline(Graphics& g, Pen* pen, const std::vector<double>& hist, size_t head, RectF bounds) {
+    double maxVal = 1024.0; 
+    for (double v : hist) maxVal = std::max(maxVal, v);
+    
+    std::vector<PointF> pts;
+    pts.reserve(hist.size());
+    float step = bounds.Width / (float)(hist.size() - 1);
+    
+    for (size_t i = 0; i < hist.size(); ++i) {
+        size_t idx = (head + i) % hist.size();
+        float x = bounds.X + (float)i * step;
+        float y = bounds.Y + bounds.Height - (float)((hist[idx] / maxVal) * bounds.Height);
+        pts.push_back(PointF(x, y));
+    }
+    g.DrawLines(pen, pts.data(), pts.size());
+}
+
+void PaintWidget(HWND hWnd) {
+    PAINTSTRUCT ps;
+    HDC hdc = BeginPaint(hWnd, &ps);
+    RECT rc;
+    GetClientRect(hWnd, &rc);
+
+    Graphics graphics(hdc);
+    graphics.SetSmoothingMode(SmoothingModeAntiAlias);
+    graphics.SetTextRenderingHint(TextRenderingHintClearTypeGridFit);
+    graphics.Clear(Color(0, 0, 0, 0));
+
+    if (!g_font || !g_largeFont || !g_bgBrush) {
+        EndPaint(hWnd, &ps);
+        return;
+    }
+
+    Settings s = GetSafeSettings();
+    RectF bounds(0.0f, 0.0f, (float)rc.right - 1.0f, (float)rc.bottom - 1.0f);
+
+    if (s.theme != L"Minimal") {
+        GraphicsPath path;
+        AddRoundRect(path, bounds, 8.0f);
+        graphics.FillPath(g_bgBrush, &path);
+        if (g_borderPen) graphics.DrawPath(g_borderPen, &path);
+    }
+
+    StringFormat format;
+    float w = bounds.Width;
+    float h = bounds.Height;
+    std::wstring strDown = FormatSpeed(g_downBps);
+    std::wstring strUp = FormatSpeed(g_upBps);
+
+    if (s.theme == L"Side-by-Side") {
+        format.SetAlignment(StringAlignmentCenter);
+        format.SetLineAlignment(StringAlignmentCenter);
+        float halfW = w / 2.0f;
+        if (g_dividerPen) graphics.DrawLine(g_dividerPen, halfW, h * 0.2f, halfW, h * 0.8f);
+
+        graphics.DrawString(L"\x2193", -1, g_largeFont, RectF(0, 0, halfW, h / 2 + 4), &format, g_downBrush);
+        graphics.DrawString(strDown.c_str(), -1, g_font, RectF(0, h / 2, halfW, h / 2 - 2), &format, g_downBrush);
+
+        graphics.DrawString(L"\x2191", -1, g_largeFont, RectF(halfW, 0, halfW, h / 2 + 4), &format, g_upBrush);
+        graphics.DrawString(strUp.c_str(), -1, g_font, RectF(halfW, h / 2, halfW, h / 2 - 2), &format, g_upBrush);
+
+    } else if (s.theme == L"Top-Down") {
+        format.SetAlignment(StringAlignmentNear);
+        format.SetLineAlignment(StringAlignmentCenter);
+        float halfH = h / 2.0f;
+        
+        graphics.DrawString(L"\x2193", -1, g_font, RectF(8, 0, 16, halfH), &format, g_downBrush);
+        graphics.DrawString(strDown.c_str(), -1, g_font, RectF(22, 0, w - 22, halfH), &format, g_downBrush);
+        
+        graphics.DrawString(L"\x2191", -1, g_font, RectF(8, halfH, 16, halfH), &format, g_upBrush);
+        graphics.DrawString(strUp.c_str(), -1, g_font, RectF(22, halfH, w - 22, halfH), &format, g_upBrush);
+
+    } else if (s.theme == L"Chart") {
+        format.SetAlignment(StringAlignmentNear);
+        format.SetLineAlignment(StringAlignmentCenter);
+        float halfH = h / 2.0f;
+        float chartW = w * 0.40f;
+        
+        RectF chartDown(8.0f, 6.0f, chartW, halfH - 8.0f);
+        DrawSparkline(graphics, g_downChartPen, g_downHistory, g_historyIdx, chartDown);
+        graphics.DrawString((L"\x2193 " + strDown).c_str(), -1, g_font, RectF(chartW + 16, 0, w - chartW - 16, halfH), &format, g_downBrush);
+
+        RectF chartUp(8.0f, halfH + 2.0f, chartW, halfH - 8.0f);
+        DrawSparkline(graphics, g_upChartPen, g_upHistory, g_historyIdx, chartUp);
+        graphics.DrawString((L"\x2191 " + strUp).c_str(), -1, g_font, RectF(chartW + 16, halfH, w - chartW - 16, halfH), &format, g_upBrush);
+
+    } else if (s.theme == L"Minimal") {
+        format.SetAlignment(StringAlignmentNear);
+        format.SetLineAlignment(StringAlignmentCenter);
+        float halfW = w / 2.0f;
+
+        graphics.DrawString((L"\x2193 " + strDown).c_str(), -1, g_font, RectF(1, 1, halfW, h), &format, g_shadowBrush);
+        graphics.DrawString((L"\x2193 " + strDown).c_str(), -1, g_font, RectF(0, 0, halfW, h), &format, g_downBrush);
+
+        graphics.DrawString((L"\x2191 " + strUp).c_str(), -1, g_font, RectF(halfW + 1, 1, halfW, h), &format, g_shadowBrush);
+        graphics.DrawString((L"\x2191 " + strUp).c_str(), -1, g_font, RectF(halfW, 0, halfW, h), &format, g_upBrush);
+    }
+
+    EndPaint(hWnd, &ps);
+}
+
+LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+    switch (msg) {
+        case WM_UPDATE_SETTINGS: {
+            Settings s = GetSafeSettings();
+            RebuildGdiObjects(s.fontSize, s.theme);
+            KillTimer(hWnd, g_timerId);
+            SetTimer(hWnd, g_timerId, s.updateIntervalMs, nullptr);
+            SetLayeredWindowAttributes(hWnd, 0, (BYTE)s.opacity, LWA_ALPHA);
+            RepositionWidget(hWnd, s);
+            InvalidateRect(hWnd, nullptr, TRUE);
+            return 0;
+        }
+        case WM_UPDATE_POSITION:
+            g_posUpdatePending.store(false);
+            RepositionWidget(hWnd, GetSafeSettings());
+            return 0;
+        case WM_PAINT:
+            PaintWidget(hWnd);
+            return 0;
+        case WM_TIMER:
+            if (wParam == g_timerId) {
+                UpdateSpeedSample();
+                RepositionWidget(hWnd, GetSafeSettings());
+                InvalidateRect(hWnd, nullptr, TRUE);
+            }
+            return 0;
+        case WM_ERASEBKGND:
+            return 1;
+        case WM_CLOSE:
+            KillTimer(hWnd, g_timerId);
+            DestroyWindow(hWnd);
+            return 0;
+        case WM_DESTROY:
+            delete g_font; delete g_largeFont; delete g_bgBrush;
+            delete g_downBrush; delete g_upBrush; delete g_shadowBrush;
+            delete g_borderPen; delete g_dividerPen;
+            delete g_downChartPen; delete g_upChartPen;
+            PostQuitMessage(0);
+            return 0;
+    }
+    return DefWindowProc(hWnd, msg, wParam, lParam);
+}
+
+void CALLBACK TaskbarEventProc(HWINEVENTHOOK hook, DWORD event, HWND hwnd, LONG idObj, LONG idChild, DWORD dwEventThread, DWORD dwmsEventTime) {
+    if (idObj == OBJID_WINDOW) {
+        static HWND hTaskbar = nullptr;
+        if (!hTaskbar || !IsWindow(hTaskbar)) {
+            hTaskbar = FindWindow(L"Shell_TrayWnd", nullptr);
+        }
+        if (hwnd == hTaskbar) {
+            if (event == EVENT_OBJECT_DESTROY) {
+                hTaskbar = nullptr;
+                HWND widget = g_hWnd.load();
+                if (widget) ShowWindow(widget, SW_HIDE);
+            } else if (event == EVENT_OBJECT_LOCATIONCHANGE) {
+                HWND widget = g_hWnd.load();
+                if (widget && !g_posUpdatePending.exchange(true)) {
+                    PostMessage(widget, WM_UPDATE_POSITION, 0, 0);
+                }
+            }
+        }
+    }
+}
+
+void CreateWidgetWindow() {
+    WNDCLASS wc{};
+    wc.lpfnWndProc = WndProc;
+    wc.hInstance = GetModuleHandle(nullptr);
+    wc.lpszClassName = kClassName;
+    wc.hbrBackground = nullptr;
+    
+    if (!RegisterClass(&wc) && GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
+        return;
+    }
+
+    DWORD exStyle = WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT;
+    HWND hTaskbar = FindWindow(L"Shell_TrayWnd", nullptr);
+
+    HWND hwnd = CreateWindowEx(exStyle, kClassName, L"", WS_POPUP, 0, 0,
+                               1, 1, hTaskbar, nullptr, GetModuleHandle(nullptr), nullptr);
+
+    if (!hwnd) return;
+    
+    g_hWnd.store(hwnd);
+    PostMessage(hwnd, WM_UPDATE_SETTINGS, 0, 0);
+}
+
+DWORD WINAPI WidgetMessageLoop(LPVOID lpParam) {
+    CreateWidgetWindow();
+
+    g_hLocationHook = SetWinEventHook(EVENT_OBJECT_DESTROY, EVENT_OBJECT_LOCATIONCHANGE,
+                                      nullptr, TaskbarEventProc, 0, 0, WINEVENT_OUTOFCONTEXT);
+
+    MSG msg;
+    while (GetMessage(&msg, nullptr, 0, 0) > 0) {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+    }
+    
+    if (g_hLocationHook) UnhookWinEvent(g_hLocationHook);
+    g_hWnd.store(nullptr);
+    return 0;
+}
+
+}  // namespace
+
+BOOL Wh_ModInit() {
+    InitializeCriticalSection(&g_settingsLock);
+    LoadSettingsLocked();
+
+    GdiplusStartupInput gdiplusStartupInput;
+    GdiplusStartup(&g_gdiplusToken, &gdiplusStartupInput, nullptr);
+
+    UpdateSpeedSample();
+    g_hThread = CreateThread(nullptr, 0, WidgetMessageLoop, nullptr, 0, &g_threadId);
+
+    return TRUE;
+}
+
+void Wh_ModUninit() {
+    if (g_threadId) PostThreadMessage(g_threadId, WM_QUIT, 0, 0);
+    
+    if (g_hThread) {
+        if (WaitForSingleObject(g_hThread, 2000) == WAIT_TIMEOUT) {
+            TerminateThread(g_hThread, 0);
+        }
+        CloseHandle(g_hThread);
+        g_hThread = nullptr;
+        g_threadId = 0;
+    }
+
+    UnregisterClass(kClassName, GetModuleHandle(nullptr));
+    if (g_gdiplusToken) {
+        GdiplusShutdown(g_gdiplusToken);
+        g_gdiplusToken = 0;
+    }
+    DeleteCriticalSection(&g_settingsLock);
+}
+
+void Wh_ModSettingsChanged() {
+    LoadSettingsLocked();
+    HWND hwnd = g_hWnd.load();
+    if (hwnd) PostMessage(hwnd, WM_UPDATE_SETTINGS, 0, 0);
+}

--- a/mods/net-speed-taskbar.wh.cpp
+++ b/mods/net-speed-taskbar.wh.cpp
@@ -1,13 +1,13 @@
 // ==WindhawkMod==
 // @id          net-speed-taskbar
 // @name        Taskbar Network Speed Indicator
-// @description Shows live download/upload speed near the taskbar.
+// @description A clean, lightweight tool that displays your live internet download and upload speeds right on the Windows taskbar.
 // @version     1.0
 // @author      Narayan
 // @github      https://github.com/NarayanChetri
 // @homepage    https://narayanchetri.dev
 // @include     explorer.exe
-// @compilerOptions -lgdiplus -liphlpapi -lgdi32 -luser32 -lws2_32 -DWIN32_LEAN_AND_MEAN
+// @compilerOptions -lgdiplus -liphlpapi -lgdi32 -luser32 -DWIN32_LEAN_AND_MEAN -D_WIN32_WINNT=0x0A00
 // @architecture    x86-64
 // @license         MIT
 // ==/WindhawkMod==
@@ -24,7 +24,6 @@ download and upload internet speed, refreshed every second.
 - Choose from different looks: Side-by-Side, Top-Down, Chart, or Minimal.
 - Move the widget anywhere along your taskbar using the Horizontal Position setting.
 - You can click right through it, so it won't get in the way of your taskbar buttons.
-- Shows your actual internet speed, ignoring background virtual networks or VPN clutter.
 
 */
 // ==/WindhawkModReadme==
@@ -40,7 +39,7 @@ download and upload internet speed, refreshed every second.
     - Top-Down: Top-Down (Compact)
     - Chart: Chart (Sparklines)
     - Minimal: Minimal (Text Only)
-- horizontalPosition: 7
+- horizontalPosition: 10
   $name: Horizontal position (%)
   $description: >-
     Where the widget sits along the taskbar's width. 0 = left edge, 100 =
@@ -59,10 +58,6 @@ download and upload internet speed, refreshed every second.
 */
 // ==/WindhawkModSettings==
 
-#pragma comment(lib, "gdiplus.lib")
-#pragma comment(lib, "iphlpapi.lib")
-#pragma comment(lib, "ws2_32.lib")
-
 #include <winsock2.h>
 #include <ws2ipdef.h>
 #include <windows.h>
@@ -74,6 +69,8 @@ download and upload internet speed, refreshed every second.
 #include <algorithm>
 #include <atomic>
 #include <vector>
+#include <memory>
+#include <mutex>
 
 using namespace Gdiplus;
 
@@ -92,16 +89,22 @@ struct Settings {
 };
 
 Settings g_settings;
-CRITICAL_SECTION g_settingsLock;
+std::mutex g_settingsMutex;
 
 std::atomic<HWND> g_hWnd{nullptr};
 std::atomic<bool> g_posUpdatePending{false};
 ULONG_PTR g_gdiplusToken = 0;
-UINT_PTR g_timerId = 1001;
+constexpr UINT_PTR kTimerId = 1001;
 
 HANDLE g_hThread = nullptr;
 DWORD g_threadId = 0;
+HANDLE g_hQueueReady = nullptr;
+HANDLE g_hMutex = nullptr;
+
 HWINEVENTHOOK g_hLocationHook = nullptr;
+HWINEVENTHOOK g_hDestroyHook = nullptr;
+DWORD g_taskbarPid = 0;
+DWORD g_taskbarTid = 0;
 
 ULONGLONG g_lastTick = 0;
 ULONG64 g_lastIn = 0;
@@ -119,77 +122,78 @@ std::vector<double> g_downHistory(kHistorySize, 0.0);
 std::vector<double> g_upHistory(kHistorySize, 0.0);
 size_t g_historyIdx = 0;
 
-Gdiplus::Font* g_font = nullptr;
-Gdiplus::Font* g_largeFont = nullptr;
-Gdiplus::SolidBrush* g_bgBrush = nullptr;
-Gdiplus::SolidBrush* g_downBrush = nullptr;
-Gdiplus::SolidBrush* g_upBrush = nullptr;
-Gdiplus::SolidBrush* g_shadowBrush = nullptr;
-Gdiplus::Pen* g_borderPen = nullptr;
-Gdiplus::Pen* g_dividerPen = nullptr;
-Gdiplus::Pen* g_downChartPen = nullptr;
-Gdiplus::Pen* g_upChartPen = nullptr;
+struct GdiObjects {
+    std::unique_ptr<Gdiplus::Font> font;
+    std::unique_ptr<Gdiplus::Font> largeFont;
+    std::unique_ptr<Gdiplus::SolidBrush> bgBrush;
+    std::unique_ptr<Gdiplus::SolidBrush> downBrush;
+    std::unique_ptr<Gdiplus::SolidBrush> upBrush;
+    std::unique_ptr<Gdiplus::SolidBrush> shadowBrush;
+    std::unique_ptr<Gdiplus::Pen> borderPen;
+    std::unique_ptr<Gdiplus::Pen> dividerPen;
+    std::unique_ptr<Gdiplus::Pen> downChartPen;
+    std::unique_ptr<Gdiplus::Pen> upChartPen;
+};
+std::unique_ptr<GdiObjects> g_gdi;
+UINT g_currentDpi = 96;
+
+HINSTANCE GetCurrentModuleHandle() {
+    HINSTANCE hInst = nullptr;
+    GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | 
+                       GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                       (LPCWSTR)&GetCurrentModuleHandle, &hInst);
+    return hInst;
+}
 
 Settings GetSafeSettings() {
-    Settings s;
-    EnterCriticalSection(&g_settingsLock);
-    s = g_settings;
-    LeaveCriticalSection(&g_settingsLock);
-    return s;
+    std::lock_guard<std::mutex> lock(g_settingsMutex);
+    return g_settings;
 }
 
 void LoadSettingsLocked() {
-    EnterCriticalSection(&g_settingsLock);
+    std::lock_guard<std::mutex> lock(g_settingsMutex);
     
     PCWSTR pTheme = Wh_GetStringSetting(L"theme");
     g_settings.theme = pTheme ? pTheme : L"Minimal";
     if (pTheme) Wh_FreeStringSetting(pTheme);
     
     g_settings.horizontalPosition = std::clamp((int)Wh_GetIntSetting(L"horizontalPosition"), 0, 100);
-    g_settings.verticalNudge = (int)Wh_GetIntSetting(L"verticalNudge");
+    g_settings.verticalNudge = std::clamp((int)Wh_GetIntSetting(L"verticalNudge"), -1000, 1000);
     g_settings.updateIntervalMs = std::max((int)Wh_GetIntSetting(L"updateIntervalMs"), 200);
     g_settings.fontSize = std::max((int)Wh_GetIntSetting(L"fontSize"), 6);
     g_settings.opacity = std::clamp((int)Wh_GetIntSetting(L"opacity"), 0, 255);
-    LeaveCriticalSection(&g_settingsLock);
 }
 
-void RebuildGdiObjects(int fontSize, const std::wstring& theme) {
-    delete g_font;
-    delete g_largeFont;
-    delete g_bgBrush;
-    delete g_downBrush;
-    delete g_upBrush;
-    delete g_shadowBrush;
-    delete g_borderPen;
-    delete g_dividerPen;
-    delete g_downChartPen;
-    delete g_upChartPen;
+void RebuildGdiObjects(int fontSize, const std::wstring& theme, UINT dpi) {
+    g_gdi = std::make_unique<GdiObjects>();
 
     Gdiplus::FontFamily fontFamily(L"Segoe UI");
-    g_font = new Gdiplus::Font(&fontFamily, (Gdiplus::REAL)fontSize, FontStyleRegular, UnitPixel);
-    g_largeFont = new Gdiplus::Font(&fontFamily, (Gdiplus::REAL)fontSize * 1.3f, FontStyleBold, UnitPixel);
+    float scaledFontSize = (float)MulDiv(fontSize, dpi, 96);
+
+    g_gdi->font = std::make_unique<Gdiplus::Font>(&fontFamily, scaledFontSize, FontStyleRegular, UnitPixel);
+    g_gdi->largeFont = std::make_unique<Gdiplus::Font>(&fontFamily, scaledFontSize * 1.3f, FontStyleBold, UnitPixel);
     
     Color bgColor = Color(240, 18, 20, 22);
     Color downColor = Color(255, 64, 169, 255); 
     Color upColor = Color(255, 100, 230, 90);   
     
     if (theme == L"Minimal") {
-        bgColor = Color(0, 0, 0, 0); 
+        bgColor = Color(0, 0, 0, 0);
         downColor = Color(255, 255, 255, 255);
         upColor = Color(255, 200, 200, 200);
     }
 
-    g_bgBrush = new Gdiplus::SolidBrush(bgColor);
-    g_downBrush = new Gdiplus::SolidBrush(downColor);
-    g_upBrush = new Gdiplus::SolidBrush(upColor);
-    g_shadowBrush = new Gdiplus::SolidBrush(Color(200, 0, 0, 0));
-    g_borderPen = new Gdiplus::Pen(Color(60, 255, 255, 255), 1.0f);
-    g_dividerPen = new Gdiplus::Pen(Color(40, 255, 255, 255), 1.0f);
-    g_downChartPen = new Gdiplus::Pen(downColor, 1.5f);
-    g_upChartPen = new Gdiplus::Pen(upColor, 1.5f);
+    g_gdi->bgBrush = std::make_unique<Gdiplus::SolidBrush>(bgColor);
+    g_gdi->downBrush = std::make_unique<Gdiplus::SolidBrush>(downColor);
+    g_gdi->upBrush = std::make_unique<Gdiplus::SolidBrush>(upColor);
+    g_gdi->shadowBrush = std::make_unique<Gdiplus::SolidBrush>(Color(200, 0, 0, 0));
+    g_gdi->borderPen = std::make_unique<Gdiplus::Pen>(Color(60, 255, 255, 255), 1.0f);
+    g_gdi->dividerPen = std::make_unique<Gdiplus::Pen>(Color(40, 255, 255, 255), 1.0f);
+    g_gdi->downChartPen = std::make_unique<Gdiplus::Pen>(downColor, 1.5f);
+    g_gdi->upChartPen = std::make_unique<Gdiplus::Pen>(upColor, 1.5f);
     
-    g_downChartPen->SetLineJoin(LineJoinRound);
-    g_upChartPen->SetLineJoin(LineJoinRound);
+    g_gdi->downChartPen->SetLineJoin(LineJoinRound);
+    g_gdi->upChartPen->SetLineJoin(LineJoinRound);
 }
 
 void GetThemeDimensions(const std::wstring& theme, int& width, int& height) {
@@ -207,10 +211,17 @@ void GetThemeDimensions(const std::wstring& theme, int& width, int& height) {
 bool GetTotalOctets(ULONG64* inOctets, ULONG64* outOctets) {
     ULONGLONG now = GetTickCount64();
     if (g_bestIfIndex == 0 || (now - g_lastRouteCheck) > 10000) {
-        IPAddr destAddr = inet_addr("8.8.8.8");
-        GetBestInterface(destAddr, &g_bestIfIndex);
+        IPAddr destAddr = 0x08080808; 
+        DWORD oldIndex = g_bestIfIndex;
+        if (GetBestInterface(destAddr, &g_bestIfIndex) != NO_ERROR) {
+            g_bestIfIndex = 0;
+        } else if (oldIndex != 0 && oldIndex != g_bestIfIndex) {
+            g_lastTick = 0; 
+        }
         g_lastRouteCheck = now;
     }
+
+    if (g_bestIfIndex == 0) return false;
 
     PMIB_IF_TABLE2 table = nullptr;
     if (GetIfTable2(&table) != NO_ERROR) {
@@ -220,7 +231,7 @@ bool GetTotalOctets(ULONG64* inOctets, ULONG64* outOctets) {
     ULONG64 in = 0, out = 0;
     for (ULONG i = 0; i < table->NumEntries; i++) {
         const MIB_IF_ROW2& row = table->Table[i];
-        if (g_bestIfIndex != 0 && row.InterfaceIndex != g_bestIfIndex) continue;
+        if (row.InterfaceIndex != g_bestIfIndex) continue;
         if (row.Type == IF_TYPE_SOFTWARE_LOOPBACK || row.Type == IF_TYPE_TUNNEL) continue;
         if (row.OperStatus != IfOperStatusUp) continue;
         in += row.InOctets;
@@ -267,13 +278,43 @@ void UpdateSpeedSample() {
     g_historyIdx = (g_historyIdx + 1) % kHistorySize;
 }
 
-void RepositionWidget(HWND hWnd, const Settings& s) {
-    static HWND hTaskbar = nullptr;
-    if (!hTaskbar || !IsWindow(hTaskbar)) {
-        hTaskbar = FindWindow(L"Shell_TrayWnd", nullptr);
-    }
+void CheckTaskbarHooks() {
+    HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
+    if (!hTaskbar) return;
+    
+    DWORD pid = 0;
+    DWORD tid = GetWindowThreadProcessId(hTaskbar, &pid);
+    
+    if (pid != g_taskbarPid || tid != g_taskbarTid) {
+        if (g_hLocationHook) UnhookWinEvent(g_hLocationHook);
+        if (g_hDestroyHook) UnhookWinEvent(g_hDestroyHook);
+        
+        g_taskbarPid = pid;
+        g_taskbarTid = tid;
+        
+        g_hDestroyHook = SetWinEventHook(EVENT_OBJECT_DESTROY, EVENT_OBJECT_DESTROY, nullptr, 
+            [](HWINEVENTHOOK, DWORD e, HWND hwnd, LONG idObj, LONG, DWORD, DWORD) {
+                if (idObj == OBJID_WINDOW && hwnd == FindWindowW(L"Shell_TrayWnd", nullptr)) {
+                    HWND widget = g_hWnd.load();
+                    if (widget) ShowWindow(widget, SW_HIDE);
+                }
+            }, pid, tid, WINEVENT_OUTOFCONTEXT);
 
-    if (!hTaskbar) {
+        g_hLocationHook = SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_LOCATIONCHANGE, nullptr, 
+            [](HWINEVENTHOOK, DWORD e, HWND hwnd, LONG idObj, LONG, DWORD, DWORD) {
+                if (idObj == OBJID_WINDOW && hwnd == FindWindowW(L"Shell_TrayWnd", nullptr)) {
+                    HWND widget = g_hWnd.load();
+                    if (widget && !g_posUpdatePending.exchange(true)) {
+                        PostMessageW(widget, WM_UPDATE_POSITION, 0, 0);
+                    }
+                }
+            }, pid, tid, WINEVENT_OUTOFCONTEXT);
+    }
+}
+
+void RepositionWidget(HWND hWnd, const Settings& s) {
+    HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
+    if (!hTaskbar || !IsWindowVisible(hTaskbar)) {
         if (IsWindowVisible(hWnd)) ShowWindow(hWnd, SW_HIDE);
         return;
     }
@@ -282,24 +323,25 @@ void RepositionWidget(HWND hWnd, const Settings& s) {
         SetWindowLongPtr(hWnd, GWLP_HWNDPARENT, (LONG_PTR)hTaskbar);
     }
 
-    if (!IsWindowVisible(hTaskbar)) {
-        if (IsWindowVisible(hWnd)) ShowWindow(hWnd, SW_HIDE);
-        return;
-    }
-
     RECT tbRect{};
     GetWindowRect(hTaskbar, &tbRect);
 
-    int tbWidth = tbRect.right - tbRect.left;
-    int tbHeight = tbRect.bottom - tbRect.top;
+    UINT dpi = GetDpiForWindow(hTaskbar);
+    if (dpi == 0) dpi = 96;
+    
+    if (dpi != g_currentDpi || !g_gdi) {
+        g_currentDpi = dpi;
+        RebuildGdiObjects(s.fontSize, s.theme, dpi);
+    }
 
     int baseW, baseH;
     GetThemeDimensions(s.theme, baseW, baseH);
 
-    UINT dpi = GetDpiForWindow(hTaskbar);
-    if (dpi == 0) dpi = 96;
     int scaledWidth = MulDiv(baseW, dpi, 96);
     int scaledHeight = MulDiv(baseH, dpi, 96);
+
+    int tbWidth = tbRect.right - tbRect.left;
+    int tbHeight = tbRect.bottom - tbRect.top;
 
     int usableWidth = std::max(tbWidth - scaledWidth, 0);
     int x = tbRect.left + (int)((usableWidth * s.horizontalPosition) / 100.0);
@@ -347,7 +389,7 @@ void PaintWidget(HWND hWnd) {
     graphics.SetTextRenderingHint(TextRenderingHintClearTypeGridFit);
     graphics.Clear(Color(0, 0, 0, 0));
 
-    if (!g_font || !g_largeFont || !g_bgBrush) {
+    if (!g_gdi || !g_gdi->font || !g_gdi->largeFont || !g_gdi->bgBrush) {
         EndPaint(hWnd, &ps);
         return;
     }
@@ -358,8 +400,8 @@ void PaintWidget(HWND hWnd) {
     if (s.theme != L"Minimal") {
         GraphicsPath path;
         AddRoundRect(path, bounds, 8.0f);
-        graphics.FillPath(g_bgBrush, &path);
-        if (g_borderPen) graphics.DrawPath(g_borderPen, &path);
+        graphics.FillPath(g_gdi->bgBrush.get(), &path);
+        if (g_gdi->borderPen) graphics.DrawPath(g_gdi->borderPen.get(), &path);
     }
 
     StringFormat format;
@@ -372,24 +414,24 @@ void PaintWidget(HWND hWnd) {
         format.SetAlignment(StringAlignmentCenter);
         format.SetLineAlignment(StringAlignmentCenter);
         float halfW = w / 2.0f;
-        if (g_dividerPen) graphics.DrawLine(g_dividerPen, halfW, h * 0.2f, halfW, h * 0.8f);
+        if (g_gdi->dividerPen) graphics.DrawLine(g_gdi->dividerPen.get(), halfW, h * 0.2f, halfW, h * 0.8f);
 
-        graphics.DrawString(L"\x2193", -1, g_largeFont, RectF(0, 0, halfW, h / 2 + 4), &format, g_downBrush);
-        graphics.DrawString(strDown.c_str(), -1, g_font, RectF(0, h / 2, halfW, h / 2 - 2), &format, g_downBrush);
+        graphics.DrawString(L"\x2193", -1, g_gdi->largeFont.get(), RectF(0, 0, halfW, h / 2 + 4), &format, g_gdi->downBrush.get());
+        graphics.DrawString(strDown.c_str(), -1, g_gdi->font.get(), RectF(0, h / 2, halfW, h / 2 - 2), &format, g_gdi->downBrush.get());
 
-        graphics.DrawString(L"\x2191", -1, g_largeFont, RectF(halfW, 0, halfW, h / 2 + 4), &format, g_upBrush);
-        graphics.DrawString(strUp.c_str(), -1, g_font, RectF(halfW, h / 2, halfW, h / 2 - 2), &format, g_upBrush);
+        graphics.DrawString(L"\x2191", -1, g_gdi->largeFont.get(), RectF(halfW, 0, halfW, h / 2 + 4), &format, g_gdi->upBrush.get());
+        graphics.DrawString(strUp.c_str(), -1, g_gdi->font.get(), RectF(halfW, h / 2, halfW, h / 2 - 2), &format, g_gdi->upBrush.get());
 
     } else if (s.theme == L"Top-Down") {
         format.SetAlignment(StringAlignmentNear);
         format.SetLineAlignment(StringAlignmentCenter);
         float halfH = h / 2.0f;
         
-        graphics.DrawString(L"\x2193", -1, g_font, RectF(8, 0, 16, halfH), &format, g_downBrush);
-        graphics.DrawString(strDown.c_str(), -1, g_font, RectF(22, 0, w - 22, halfH), &format, g_downBrush);
+        graphics.DrawString(L"\x2193", -1, g_gdi->font.get(), RectF(8, 0, 16, halfH), &format, g_gdi->downBrush.get());
+        graphics.DrawString(strDown.c_str(), -1, g_gdi->font.get(), RectF(22, 0, w - 22, halfH), &format, g_gdi->downBrush.get());
         
-        graphics.DrawString(L"\x2191", -1, g_font, RectF(8, halfH, 16, halfH), &format, g_upBrush);
-        graphics.DrawString(strUp.c_str(), -1, g_font, RectF(22, halfH, w - 22, halfH), &format, g_upBrush);
+        graphics.DrawString(L"\x2191", -1, g_gdi->font.get(), RectF(8, halfH, 16, halfH), &format, g_gdi->upBrush.get());
+        graphics.DrawString(strUp.c_str(), -1, g_gdi->font.get(), RectF(22, halfH, w - 22, halfH), &format, g_gdi->upBrush.get());
 
     } else if (s.theme == L"Chart") {
         format.SetAlignment(StringAlignmentNear);
@@ -398,23 +440,23 @@ void PaintWidget(HWND hWnd) {
         float chartW = w * 0.40f;
         
         RectF chartDown(8.0f, 6.0f, chartW, halfH - 8.0f);
-        DrawSparkline(graphics, g_downChartPen, g_downHistory, g_historyIdx, chartDown);
-        graphics.DrawString((L"\x2193 " + strDown).c_str(), -1, g_font, RectF(chartW + 16, 0, w - chartW - 16, halfH), &format, g_downBrush);
+        DrawSparkline(graphics, g_gdi->downChartPen.get(), g_downHistory, g_historyIdx, chartDown);
+        graphics.DrawString((L"\x2193 " + strDown).c_str(), -1, g_gdi->font.get(), RectF(chartW + 16, 0, w - chartW - 16, halfH), &format, g_gdi->downBrush.get());
 
         RectF chartUp(8.0f, halfH + 2.0f, chartW, halfH - 8.0f);
-        DrawSparkline(graphics, g_upChartPen, g_upHistory, g_historyIdx, chartUp);
-        graphics.DrawString((L"\x2191 " + strUp).c_str(), -1, g_font, RectF(chartW + 16, halfH, w - chartW - 16, halfH), &format, g_upBrush);
+        DrawSparkline(graphics, g_gdi->upChartPen.get(), g_upHistory, g_historyIdx, chartUp);
+        graphics.DrawString((L"\x2191 " + strUp).c_str(), -1, g_gdi->font.get(), RectF(chartW + 16, halfH, w - chartW - 16, halfH), &format, g_gdi->upBrush.get());
 
     } else if (s.theme == L"Minimal") {
         format.SetAlignment(StringAlignmentNear);
         format.SetLineAlignment(StringAlignmentCenter);
         float halfW = w / 2.0f;
 
-        graphics.DrawString((L"\x2193 " + strDown).c_str(), -1, g_font, RectF(1, 1, halfW, h), &format, g_shadowBrush);
-        graphics.DrawString((L"\x2193 " + strDown).c_str(), -1, g_font, RectF(0, 0, halfW, h), &format, g_downBrush);
+        graphics.DrawString((L"\x2193 " + strDown).c_str(), -1, g_gdi->font.get(), RectF(1, 1, halfW, h), &format, g_gdi->shadowBrush.get());
+        graphics.DrawString((L"\x2193 " + strDown).c_str(), -1, g_gdi->font.get(), RectF(0, 0, halfW, h), &format, g_gdi->downBrush.get());
 
-        graphics.DrawString((L"\x2191 " + strUp).c_str(), -1, g_font, RectF(halfW + 1, 1, halfW, h), &format, g_shadowBrush);
-        graphics.DrawString((L"\x2191 " + strUp).c_str(), -1, g_font, RectF(halfW, 0, halfW, h), &format, g_upBrush);
+        graphics.DrawString((L"\x2191 " + strUp).c_str(), -1, g_gdi->font.get(), RectF(halfW + 1, 1, halfW, h), &format, g_gdi->shadowBrush.get());
+        graphics.DrawString((L"\x2191 " + strUp).c_str(), -1, g_gdi->font.get(), RectF(halfW, 0, halfW, h), &format, g_gdi->upBrush.get());
     }
 
     EndPaint(hWnd, &ps);
@@ -424,12 +466,12 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     switch (msg) {
         case WM_UPDATE_SETTINGS: {
             Settings s = GetSafeSettings();
-            RebuildGdiObjects(s.fontSize, s.theme);
-            KillTimer(hWnd, g_timerId);
-            SetTimer(hWnd, g_timerId, s.updateIntervalMs, nullptr);
+            RebuildGdiObjects(s.fontSize, s.theme, g_currentDpi);
+            KillTimer(hWnd, kTimerId);
+            SetTimer(hWnd, kTimerId, s.updateIntervalMs, nullptr);
             SetLayeredWindowAttributes(hWnd, 0, (BYTE)s.opacity, LWA_ALPHA);
             RepositionWidget(hWnd, s);
-            InvalidateRect(hWnd, nullptr, TRUE);
+            InvalidateRect(hWnd, nullptr, FALSE);
             return 0;
         }
         case WM_UPDATE_POSITION: {
@@ -441,126 +483,123 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             PaintWidget(hWnd);
             return 0;
         case WM_TIMER:
-            if (wParam == g_timerId) {
+            if (wParam == kTimerId) {
                 UpdateSpeedSample();
+                CheckTaskbarHooks();
                 RepositionWidget(hWnd, GetSafeSettings());
-                InvalidateRect(hWnd, nullptr, TRUE);
+                InvalidateRect(hWnd, nullptr, FALSE);
             }
             return 0;
         case WM_ERASEBKGND:
             return 1;
         case WM_CLOSE:
-            KillTimer(hWnd, g_timerId);
+            KillTimer(hWnd, kTimerId);
             DestroyWindow(hWnd);
-            return 0;
-        case WM_DESTROY:
-            delete g_font; delete g_largeFont; delete g_bgBrush;
-            delete g_downBrush; delete g_upBrush; delete g_shadowBrush;
-            delete g_borderPen; delete g_dividerPen;
-            delete g_downChartPen; delete g_upChartPen;
-            PostQuitMessage(0);
             return 0;
     }
     return DefWindowProc(hWnd, msg, wParam, lParam);
 }
 
-void CALLBACK TaskbarEventProc(HWINEVENTHOOK hook, DWORD event, HWND hwnd, LONG idObj, LONG idChild, DWORD dwEventThread, DWORD dwmsEventTime) {
-    if (idObj == OBJID_WINDOW) {
-        static HWND hTaskbar = nullptr;
-        if (!hTaskbar || !IsWindow(hTaskbar)) {
-            hTaskbar = FindWindow(L"Shell_TrayWnd", nullptr);
-        }
-        if (hwnd == hTaskbar) {
-            if (event == EVENT_OBJECT_DESTROY) {
-                hTaskbar = nullptr;
-                HWND widget = g_hWnd.load();
-                if (widget) ShowWindow(widget, SW_HIDE);
-            } else if (event == EVENT_OBJECT_LOCATIONCHANGE) {
-                HWND widget = g_hWnd.load();
-                if (widget && !g_posUpdatePending.exchange(true)) {
-                    PostMessage(widget, WM_UPDATE_POSITION, 0, 0);
-                }
-            }
-        }
-    }
-}
+DWORD WINAPI WidgetMessageLoop(LPVOID lpParam) {
+    MSG msg;
+    PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+    SetEvent(g_hQueueReady);
 
-void CreateWidgetWindow() {
-    WNDCLASS wc{};
+    WNDCLASSW wc{};
     wc.lpfnWndProc = WndProc;
-    wc.hInstance = GetModuleHandle(nullptr);
+    wc.hInstance = GetCurrentModuleHandle();
     wc.lpszClassName = kClassName;
     wc.hbrBackground = nullptr;
     
-    if (!RegisterClass(&wc) && GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
-        return;
+    if (!RegisterClassW(&wc)) {
+        if (GetLastError() != ERROR_CLASS_ALREADY_EXISTS) return 0;
     }
 
     DWORD exStyle = WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT;
-    HWND hTaskbar = FindWindow(L"Shell_TrayWnd", nullptr);
+    HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
+    
+    HWND hwnd = CreateWindowExW(exStyle, kClassName, L"", WS_POPUP, 0, 0,
+                               1, 1, hTaskbar, nullptr, wc.hInstance, nullptr);
 
-    HWND hwnd = CreateWindowEx(exStyle, kClassName, L"", WS_POPUP, 0, 0,
-                               1, 1, hTaskbar, nullptr, GetModuleHandle(nullptr), nullptr);
-
-    if (!hwnd) return;
+    if (!hwnd) {
+        UnregisterClassW(kClassName, wc.hInstance);
+        return 0;
+    }
     
     g_hWnd.store(hwnd);
-    PostMessage(hwnd, WM_UPDATE_SETTINGS, 0, 0);
-}
+    PostMessageW(hwnd, WM_UPDATE_SETTINGS, 0, 0);
+    CheckTaskbarHooks();
 
-DWORD WINAPI WidgetMessageLoop(LPVOID lpParam) {
-    CreateWidgetWindow();
-
-    g_hLocationHook = SetWinEventHook(EVENT_OBJECT_DESTROY, EVENT_OBJECT_LOCATIONCHANGE,
-                                      nullptr, TaskbarEventProc, 0, 0, WINEVENT_OUTOFCONTEXT);
-
-    MSG msg;
-    while (GetMessage(&msg, nullptr, 0, 0) > 0) {
+    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
         TranslateMessage(&msg);
-        DispatchMessage(&msg);
+        DispatchMessageW(&msg);
     }
     
     if (g_hLocationHook) UnhookWinEvent(g_hLocationHook);
-    g_hWnd.store(nullptr);
+    if (g_hDestroyHook) UnhookWinEvent(g_hDestroyHook);
+    
+    HWND h = g_hWnd.exchange(nullptr);
+    if (h) DestroyWindow(h);
+
+    UnregisterClassW(kClassName, wc.hInstance);
     return 0;
 }
 
 }  // namespace
 
 BOOL Wh_ModInit() {
-    InitializeCriticalSection(&g_settingsLock);
+    HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
+    DWORD pid = 0;
+    if (!hTaskbar || !GetWindowThreadProcessId(hTaskbar, &pid) || pid != GetCurrentProcessId()) {
+        return FALSE; // Guarantee we only inject into the primary Explorer.exe process
+    }
+
+    g_hMutex = CreateMutexW(nullptr, FALSE, L"Windhawk_NetSpeedTaskbar_Mutex");
+    if (g_hMutex == nullptr || GetLastError() == ERROR_ALREADY_EXISTS) {
+        return FALSE; 
+    }
+
     LoadSettingsLocked();
 
     GdiplusStartupInput gdiplusStartupInput;
     GdiplusStartup(&g_gdiplusToken, &gdiplusStartupInput, nullptr);
 
+    g_hQueueReady = CreateEventW(nullptr, TRUE, FALSE, nullptr);
     g_hThread = CreateThread(nullptr, 0, WidgetMessageLoop, nullptr, 0, &g_threadId);
 
     return TRUE;
 }
 
 void Wh_ModUninit() {
-    if (g_threadId) PostThreadMessage(g_threadId, WM_QUIT, 0, 0);
-    
     if (g_hThread) {
-        if (WaitForSingleObject(g_hThread, 2000) == WAIT_TIMEOUT) {
-            TerminateThread(g_hThread, 0);
-        }
+        WaitForSingleObject(g_hQueueReady, INFINITE); 
+        PostThreadMessageW(g_threadId, WM_QUIT, 0, 0); 
+        WaitForSingleObject(g_hThread, INFINITE);      
         CloseHandle(g_hThread);
         g_hThread = nullptr;
         g_threadId = 0;
     }
 
-    UnregisterClass(kClassName, GetModuleHandle(nullptr));
+    if (g_hQueueReady) {
+        CloseHandle(g_hQueueReady);
+        g_hQueueReady = nullptr;
+    }
+
     if (g_gdiplusToken) {
         GdiplusShutdown(g_gdiplusToken);
         g_gdiplusToken = 0;
     }
-    DeleteCriticalSection(&g_settingsLock);
+
+    g_gdi.reset();
+
+    if (g_hMutex) {
+        CloseHandle(g_hMutex);
+        g_hMutex = nullptr;
+    }
 }
 
 void Wh_ModSettingsChanged() {
     LoadSettingsLocked();
     HWND hwnd = g_hWnd.load();
-    if (hwnd) PostMessage(hwnd, WM_UPDATE_SETTINGS, 0, 0);
+    if (hwnd) PostMessageW(hwnd, WM_UPDATE_SETTINGS, 0, 0);
 }


### PR DESCRIPTION
### Description
A clean, lightweight tool that displays your live internet download and upload speeds right on the Windows taskbar.

### Key Features
* **Accurate Speed Tracking:** Measures your true internet speed in real time while ignoring local background networks and VPN clutter.
* **Taskbar Auto-Hide Support:** Seamlessly slides and animates along with your taskbar if you use auto-hide.
* **Non-Intrusive:** Fully click-through, ensuring it never interferes with opening apps or clicking taskbar icons.
* **Multiple Themes:** Includes 4 built-in visual styles: **Minimal**, **Side-by-Side**, **Top-Down**, and **Chart** (live graph).
* **Smooth & Stable:** Runs independently without lagging the Windows Explorer interface or consuming high system resources.

### Visual Preview
![Demo](https://raw.githubusercontent.com/NarayanChetri/Files/main/taskbar-speed-indicator.gif)

### Tested Environment
* **OS:** Windows 11
* **Architecture:** x86-64
* **Target Application:** `explorer.exe`

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Initial release.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- [ ] The submitter, without AI assistance
- [x] The submitter, with AI assistance
- [ ] Claude
- [ ] ChatGPT
- [x] Gemini
- [ ] Another AI (please specify): 
- [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
