### PR TITLE
Update Taskbar System Info to 1.5.0

### DIFF
--- a/mods/taskbar-system-info.wh.cpp
+++ b/mods/taskbar-system-info.wh.cpp
@@ -447,6 +447,10 @@ constexpr auto kGadgetRegistryPartialRescanInterval =
     std::chrono::seconds(5);
 constexpr auto kSharedMemoryRescanInterval = std::chrono::seconds(60);
 constexpr auto kSharedMemoryPartialRescanInterval = std::chrono::seconds(5);
+constexpr uint32_t kHwInfoFastPartialRescanLimit = 4;
+constexpr uint32_t kHwInfoCachedReadingFailureLimit = 2;
+constexpr auto kGpuAdapterCacheStaleGrace = std::chrono::minutes(5);
+constexpr uint32_t kGpuAdapterStaleFailureLimit = 5;
 constexpr wchar_t kDefaultGraphColor[] = L"#78A8FF";
 constexpr wchar_t kDefaultWarningColor[] = L"#FFFFB900";
 constexpr wchar_t kDefaultCriticalColor[] = L"#FFFF6B6B";
@@ -525,6 +529,15 @@ std::atomic<bool> g_taskbarViewDllLoaded;
 std::atomic<uint32_t> g_taskbarViewHookAttempts;
 std::atomic<HWND> g_taskbarWindow{nullptr};
 std::atomic<DWORD> g_taskbarThreadId{0};
+std::atomic<bool> g_placementApplyPending{false};
+std::atomic<bool> g_resetUnknownPlacementProbesPending{false};
+std::atomic<bool> g_taskbarCallbackCleanupFailed{false};
+std::atomic<bool> g_modulePinnedAfterFailedTeardown{false};
+std::mutex g_placementRetryWorkerMutex;
+std::atomic<bool> g_stopPlacementRetryWorker{false};
+std::atomic<bool> g_placementRetryWorkerRunning{false};
+HANDLE g_placementRetryWakeEvent = nullptr;
+[[clang::no_destroy]] std::optional<std::thread> g_placementRetryWorker;
 
 [[clang::no_destroy]] Grid g_widget{nullptr};
 [[clang::no_destroy]] Grid g_rootGrid{nullptr};
@@ -546,7 +559,6 @@ bool g_placementIsFallback = false;
 bool g_placementLocationUnknown = false;
 uint32_t g_unknownPlacementProbeFailures = 0;
 bool g_unknownPlacementProbesSuspended = false;
-int g_lastMonitorCount = -1;
 uint64_t g_lastDisplayTopologyFingerprint = 0;
 bool g_hasDisplayTopologyFingerprint = false;
 [[clang::no_destroy]]
@@ -600,14 +612,25 @@ std::chrono::steady_clock::time_point g_nextPdhCounterRetry{};
 std::chrono::steady_clock::time_point g_nextPdhRecovery{};
 std::chrono::steady_clock::time_point g_nextGpuIdentityCheck{};
 uint32_t g_consecutivePdhReadFailures = 0;
+uint32_t g_consecutivePdhEmptySamples = 0;
+uint32_t g_pdhEmptyRecoveries = 0;
+std::chrono::steady_clock::time_point g_nextPdhEmptyRecovery{};
 bool g_hwInfoInvalidUnitLogged = false;
 std::atomic<bool> g_hwInfoGpuAdapterMismatchLogged{false};
+
+struct HwInfoGadgetReadingIdentity {
+    std::wstring sensor;
+    std::wstring label;
+};
 
 struct HwInfoGadgetRegistryCache {
     std::optional<int> cpuIndex;
     std::optional<int> gpuIndex;
+    std::optional<HwInfoGadgetReadingIdentity> cpuIdentity;
+    std::optional<HwInfoGadgetReadingIdentity> gpuIdentity;
     bool fullScanCompleted = false;
     std::chrono::steady_clock::time_point nextFullScan{};
+    uint32_t consecutivePartialScans = 0;
     std::wstring cpuFilter;
     std::wstring gpuFilter;
     std::wstring gpuAdapter;
@@ -814,12 +837,15 @@ int CpuTemperatureScore(const std::wstring& sensorName,
 
     bool gpuSensor = Contains(sensor, L"gpu") || Contains(sensor, L"nvidia") ||
                      Contains(sensor, L"radeon");
+    bool platformSensor = Contains(sensor, L"pch") ||
+                          Contains(sensor, L"chipset");
     bool cpuSensor =
         Contains(sensor, L"cpu") || Contains(sensor, L"processor") ||
         Contains(sensor, L"ryzen") || Contains(sensor, L"threadripper") ||
         Contains(sensor, L"epyc") || Contains(sensor, L"xeon") ||
-        (Contains(sensor, L"intel") && !gpuSensor);
-    if (!cpuSensor) {
+        (Contains(sensor, L"intel") && Contains(sensor, L"core") &&
+         !gpuSensor);
+    if (!cpuSensor || platformSensor) {
         return -1;
     }
 
@@ -1099,13 +1125,7 @@ static_assert(sizeof(HwInfoSensorPrefix) == 264);
 static_assert(offsetof(HwInfoReadingPrefix, value) == 284);
 static_assert(sizeof(HwInfoReadingPrefix) == 292);
 
-struct HwInfoSharedMemoryCache {
-    std::optional<uint32_t> cpuReadingIndex;
-    std::optional<uint32_t> gpuReadingIndex;
-    std::chrono::steady_clock::time_point nextFullScan{};
-    std::wstring cpuFilter;
-    std::wstring gpuFilter;
-    std::wstring gpuAdapter;
+struct HwInfoLayoutKey {
     uint32_t version = 0;
     uint32_t revision = 0;
     uint32_t sensorOffset = 0;
@@ -1114,7 +1134,78 @@ struct HwInfoSharedMemoryCache {
     uint32_t readingOffset = 0;
     uint32_t readingStride = 0;
     uint32_t readingCount = 0;
-    bool layoutKnown = false;
+
+    bool operator==(const HwInfoLayoutKey&) const = default;
+};
+
+struct HwInfoReadingIdentity {
+    uint32_t sensorId = 0;
+    uint32_t sensorInstance = 0;
+    uint32_t readingId = 0;
+
+    bool operator==(const HwInfoReadingIdentity&) const = default;
+};
+
+HwInfoLayoutKey GetHwInfoLayoutKey(const HwInfoHeader& header) {
+    return {header.version,       header.revision,     header.sensorOffset,
+            header.sensorStride, header.sensorCount,  header.readingOffset,
+            header.readingStride, header.readingCount};
+}
+
+constexpr std::chrono::seconds GetHwInfoRescanInterval(
+    bool complete,
+    uint32_t& consecutivePartialScans,
+    std::chrono::seconds regularInterval,
+    std::chrono::seconds partialInterval) {
+    if (complete) {
+        consecutivePartialScans = 0;
+        return regularInterval;
+    }
+    if (consecutivePartialScans < kHwInfoFastPartialRescanLimit) {
+        consecutivePartialScans++;
+        return partialInterval;
+    }
+    return regularInterval;
+}
+
+constexpr bool HwInfoPartialRescanBackoffIsBounded() {
+    uint32_t partialScans = 0;
+    for (uint32_t i = 0; i < kHwInfoFastPartialRescanLimit; i++) {
+        if (GetHwInfoRescanInterval(false, partialScans,
+                                    std::chrono::seconds(60),
+                                    std::chrono::seconds(5)) !=
+            std::chrono::seconds(5)) {
+            return false;
+        }
+    }
+    if (GetHwInfoRescanInterval(false, partialScans,
+                                std::chrono::seconds(60),
+                                std::chrono::seconds(5)) !=
+        std::chrono::seconds(60)) {
+        return false;
+    }
+    return GetHwInfoRescanInterval(true, partialScans,
+                                   std::chrono::seconds(60),
+                                   std::chrono::seconds(5)) ==
+               std::chrono::seconds(60) &&
+           partialScans == 0;
+}
+
+static_assert(HwInfoPartialRescanBackoffIsBounded());
+
+struct HwInfoSharedMemoryCache {
+    std::optional<uint32_t> cpuReadingIndex;
+    std::optional<uint32_t> gpuReadingIndex;
+    std::optional<HwInfoReadingIdentity> cpuIdentity;
+    std::optional<HwInfoReadingIdentity> gpuIdentity;
+    std::chrono::steady_clock::time_point nextFullScan{};
+    uint32_t consecutivePartialScans = 0;
+    uint32_t cpuInvalidSamples = 0;
+    uint32_t gpuInvalidSamples = 0;
+    std::wstring cpuFilter;
+    std::wstring gpuFilter;
+    std::wstring gpuAdapter;
+    std::optional<HwInfoLayoutKey> layout;
 };
 
 struct HwInfoRawTemperatureReading {
@@ -1284,40 +1375,20 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
                              header.readingStride, header.readingCount,
                              sizeof(HwInfoReadingPrefix))) {
                 const auto* bytes = static_cast<const uint8_t*>(view);
+                HwInfoLayoutKey layout = GetHwInfoLayoutKey(header);
                 bool layoutChanged =
-                    !g_hwInfoSharedMemoryCache.layoutKnown ||
-                    g_hwInfoSharedMemoryCache.version != header.version ||
-                    g_hwInfoSharedMemoryCache.revision != header.revision ||
-                    g_hwInfoSharedMemoryCache.sensorOffset !=
-                        header.sensorOffset ||
-                    g_hwInfoSharedMemoryCache.sensorStride !=
-                        header.sensorStride ||
-                    g_hwInfoSharedMemoryCache.sensorCount !=
-                        header.sensorCount ||
-                    g_hwInfoSharedMemoryCache.readingOffset !=
-                        header.readingOffset ||
-                    g_hwInfoSharedMemoryCache.readingStride !=
-                        header.readingStride ||
-                    g_hwInfoSharedMemoryCache.readingCount !=
-                        header.readingCount;
+                    !g_hwInfoSharedMemoryCache.layout ||
+                    *g_hwInfoSharedMemoryCache.layout != layout;
                 if (layoutChanged) {
                     g_hwInfoSharedMemoryCache.cpuReadingIndex.reset();
                     g_hwInfoSharedMemoryCache.gpuReadingIndex.reset();
+                    g_hwInfoSharedMemoryCache.cpuIdentity.reset();
+                    g_hwInfoSharedMemoryCache.gpuIdentity.reset();
                     g_hwInfoSharedMemoryCache.nextFullScan = {};
-                    g_hwInfoSharedMemoryCache.version = header.version;
-                    g_hwInfoSharedMemoryCache.revision = header.revision;
-                    g_hwInfoSharedMemoryCache.sensorOffset =
-                        header.sensorOffset;
-                    g_hwInfoSharedMemoryCache.sensorStride =
-                        header.sensorStride;
-                    g_hwInfoSharedMemoryCache.sensorCount = header.sensorCount;
-                    g_hwInfoSharedMemoryCache.readingOffset =
-                        header.readingOffset;
-                    g_hwInfoSharedMemoryCache.readingStride =
-                        header.readingStride;
-                    g_hwInfoSharedMemoryCache.readingCount =
-                        header.readingCount;
-                    g_hwInfoSharedMemoryCache.layoutKnown = true;
+                    g_hwInfoSharedMemoryCache.consecutivePartialScans = 0;
+                    g_hwInfoSharedMemoryCache.cpuInvalidSamples = 0;
+                    g_hwInfoSharedMemoryCache.gpuInvalidSamples = 0;
+                    g_hwInfoSharedMemoryCache.layout = layout;
                 }
 
                 bool performFullScan =
@@ -1326,12 +1397,17 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
                     now >= g_hwInfoSharedMemoryCache.nextFullScan;
                 auto copyCachedReading =
                     [&](std::optional<uint32_t>& cachedIndex,
+                        std::optional<HwInfoReadingIdentity>& cachedIdentity,
                         std::optional<HwInfoRawTemperatureReading>& output) {
                         if (!cachedIndex || performFullScan) {
                             return;
                         }
-                        if (*cachedIndex >= header.readingCount) {
+                        if (!cachedIdentity ||
+                            *cachedIndex >= header.readingCount) {
                             cachedIndex.reset();
+                            cachedIdentity.reset();
+                            g_hwInfoSharedMemoryCache.nextFullScan = {};
+                            g_hwInfoSharedMemoryCache.consecutivePartialScans = 0;
                             performFullScan = true;
                             return;
                         }
@@ -1348,6 +1424,9 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
                                 kHwInfoTemperatureType ||
                             raw.reading.sensorIndex >= header.sensorCount) {
                             cachedIndex.reset();
+                            cachedIdentity.reset();
+                            g_hwInfoSharedMemoryCache.nextFullScan = {};
+                            g_hwInfoSharedMemoryCache.consecutivePartialScans = 0;
                             performFullScan = true;
                             return;
                         }
@@ -1357,14 +1436,27 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
                                 header.sensorStride;
                         std::memcpy(&raw.sensor, sensorAddress,
                                     sizeof(raw.sensor));
+                        HwInfoReadingIdentity identity{
+                            raw.sensor.sensorId, raw.sensor.sensorInstance,
+                            raw.reading.readingId};
+                        if (identity != *cachedIdentity) {
+                            cachedIndex.reset();
+                            cachedIdentity.reset();
+                            g_hwInfoSharedMemoryCache.nextFullScan = {};
+                            g_hwInfoSharedMemoryCache.consecutivePartialScans = 0;
+                            performFullScan = true;
+                            return;
+                        }
                         output = raw;
                     };
 
                 copyCachedReading(
                     g_hwInfoSharedMemoryCache.cpuReadingIndex,
+                    g_hwInfoSharedMemoryCache.cpuIdentity,
                     cachedCpuReading);
                 copyCachedReading(
                     g_hwInfoSharedMemoryCache.gpuReadingIndex,
+                    g_hwInfoSharedMemoryCache.gpuIdentity,
                     cachedGpuReading);
 
                 if (performFullScan) {
@@ -1471,14 +1563,36 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
 
         g_hwInfoSharedMemoryCache.cpuReadingIndex = bestCpuIndex;
         g_hwInfoSharedMemoryCache.gpuReadingIndex = bestGpuIndex;
+        auto getIdentity =
+            [&](const std::optional<uint32_t>& index)
+            -> std::optional<HwInfoReadingIdentity> {
+            if (!index || *index >= readings.size()) {
+                return std::nullopt;
+            }
+            const HwInfoReadingPrefix& reading = readings[*index];
+            if (reading.sensorIndex >= sensors.size()) {
+                return std::nullopt;
+            }
+            const HwInfoSensorPrefix& sensor = sensors[reading.sensorIndex];
+            return HwInfoReadingIdentity{sensor.sensorId, sensor.sensorInstance,
+                                         reading.readingId};
+        };
+        g_hwInfoSharedMemoryCache.cpuIdentity = getIdentity(bestCpuIndex);
+        g_hwInfoSharedMemoryCache.gpuIdentity = getIdentity(bestGpuIndex);
+        g_hwInfoSharedMemoryCache.cpuInvalidSamples = 0;
+        g_hwInfoSharedMemoryCache.gpuInvalidSamples = 0;
         g_hwInfoSharedMemoryCache.nextFullScan =
-            now + (bestCpuIndex && bestGpuIndex
-                       ? kSharedMemoryRescanInterval
-                       : kSharedMemoryPartialRescanInterval);
+            now + GetHwInfoRescanInterval(
+                      bestCpuIndex && bestGpuIndex,
+                      g_hwInfoSharedMemoryCache.consecutivePartialScans,
+                      kSharedMemoryRescanInterval,
+                      kSharedMemoryPartialRescanInterval);
     } else {
         auto applyCachedReading =
             [&](const std::optional<HwInfoRawTemperatureReading>& raw,
-                std::optional<uint32_t>& cachedIndex, bool cpu) {
+                std::optional<uint32_t>& cachedIndex,
+                std::optional<HwInfoReadingIdentity>& cachedIdentity,
+                uint32_t& invalidSamples, bool cpu) {
                 if (!raw) {
                     return;
                 }
@@ -1503,15 +1617,27 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
                                       gpuAdapterName);
                 if (score < 0) {
                     cachedIndex.reset();
+                    cachedIdentity.reset();
+                    invalidSamples = 0;
                     g_hwInfoSharedMemoryCache.nextFullScan = {};
+                    g_hwInfoSharedMemoryCache.consecutivePartialScans = 0;
                     return;
                 }
 
                 auto value = NormalizeHwInfoTemperature(
                     reading.value, reading.unit, std::size(reading.unit));
                 if (!value) {
+                    if (++invalidSamples >=
+                        kHwInfoCachedReadingFailureLimit) {
+                        cachedIndex.reset();
+                        cachedIdentity.reset();
+                        invalidSamples = 0;
+                        g_hwInfoSharedMemoryCache.nextFullScan = {};
+                        g_hwInfoSharedMemoryCache.consecutivePartialScans = 0;
+                    }
                     return;
                 }
+                invalidSamples = 0;
                 sawSupportedTemperatureUnit = true;
 
                 if (cpu) {
@@ -1526,9 +1652,13 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
             };
 
         applyCachedReading(cachedCpuReading,
-                           g_hwInfoSharedMemoryCache.cpuReadingIndex, true);
+                           g_hwInfoSharedMemoryCache.cpuReadingIndex,
+                           g_hwInfoSharedMemoryCache.cpuIdentity,
+                           g_hwInfoSharedMemoryCache.cpuInvalidSamples, true);
         applyCachedReading(cachedGpuReading,
-                           g_hwInfoSharedMemoryCache.gpuReadingIndex, false);
+                           g_hwInfoSharedMemoryCache.gpuReadingIndex,
+                           g_hwInfoSharedMemoryCache.gpuIdentity,
+                           g_hwInfoSharedMemoryCache.gpuInvalidSamples, false);
     }
 
     if (sawTemperatureReading && !sawSupportedTemperatureUnit &&
@@ -1634,20 +1764,45 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
                       KEY_QUERY_VALUE, &key) != ERROR_SUCCESS) {
         g_hwInfoGadgetRegistryCache.cpuIndex.reset();
         g_hwInfoGadgetRegistryCache.gpuIndex.reset();
+        g_hwInfoGadgetRegistryCache.cpuIdentity.reset();
+        g_hwInfoGadgetRegistryCache.gpuIdentity.reset();
         g_hwInfoGadgetRegistryCache.fullScanCompleted = true;
         g_hwInfoGadgetRegistryCache.nextFullScan =
-            now + kGadgetRegistryPartialRescanInterval;
+            now + GetHwInfoRescanInterval(
+                      false,
+                      g_hwInfoGadgetRegistryCache.consecutivePartialScans,
+                      kGadgetRegistryRescanInterval,
+                      kGadgetRegistryPartialRescanInterval);
         return;
     }
 
-    auto readCached = [&](std::optional<int>& cachedIndex, bool cpu) {
-        if (!cachedIndex) {
+    auto readCached =
+        [&](std::optional<int>& cachedIndex,
+            std::optional<HwInfoGadgetReadingIdentity>& cachedIdentity,
+            bool cpu, bool needed) {
+        if (!needed || !cachedIndex) {
+            return;
+        }
+        if (!cachedIdentity) {
+            cachedIndex.reset();
+            g_hwInfoGadgetRegistryCache.fullScanCompleted = false;
+            g_hwInfoGadgetRegistryCache.consecutivePartialScans = 0;
             return;
         }
         auto reading = ReadHwInfoGadgetReading(key, *cachedIndex);
         if (!reading) {
             cachedIndex.reset();
+            cachedIdentity.reset();
             g_hwInfoGadgetRegistryCache.fullScanCompleted = false;
+            g_hwInfoGadgetRegistryCache.consecutivePartialScans = 0;
+            return;
+        }
+        if (reading->sensor != cachedIdentity->sensor ||
+            reading->label != cachedIdentity->label) {
+            cachedIndex.reset();
+            cachedIdentity.reset();
+            g_hwInfoGadgetRegistryCache.fullScanCompleted = false;
+            g_hwInfoGadgetRegistryCache.consecutivePartialScans = 0;
             return;
         }
 
@@ -1660,7 +1815,9 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
                                               gpuAdapterName);
         if (score < 0) {
             cachedIndex.reset();
+            cachedIdentity.reset();
             g_hwInfoGadgetRegistryCache.fullScanCompleted = false;
+            g_hwInfoGadgetRegistryCache.consecutivePartialScans = 0;
             return;
         }
 
@@ -1675,9 +1832,12 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
         }
     };
 
-    readCached(g_hwInfoGadgetRegistryCache.cpuIndex, true);
-    readCached(g_hwInfoGadgetRegistryCache.gpuIndex, false);
-    if (snapshot.cpuTemp && snapshot.gpuTemp) {
+    readCached(g_hwInfoGadgetRegistryCache.cpuIndex,
+               g_hwInfoGadgetRegistryCache.cpuIdentity, true, needsCpu);
+    readCached(g_hwInfoGadgetRegistryCache.gpuIndex,
+               g_hwInfoGadgetRegistryCache.gpuIdentity, false, needsGpu);
+    if (snapshot.cpuTemp && snapshot.gpuTemp &&
+        now < g_hwInfoGadgetRegistryCache.nextFullScan) {
         RegCloseKey(key);
         return;
     }
@@ -1693,6 +1853,8 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
     std::optional<int> bestGpuIndex;
     std::optional<double> bestCpuValue;
     std::optional<double> bestGpuValue;
+    std::optional<HwInfoGadgetReadingIdentity> bestCpuIdentity;
+    std::optional<HwInfoGadgetReadingIdentity> bestGpuIdentity;
     int consecutiveMissing = 0;
     for (int i = 0; i < 1024; i++) {
         std::wstring suffix = std::to_wstring(i);
@@ -1724,6 +1886,7 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
             bestCpuScore = cpuScore;
             bestCpuIndex = i;
             bestCpuValue = *value;
+            bestCpuIdentity = HwInfoGadgetReadingIdentity{*sensor, *label};
         }
 
         int gpuScore =
@@ -1733,17 +1896,22 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
             bestGpuScore = gpuScore;
             bestGpuIndex = i;
             bestGpuValue = *value;
+            bestGpuIdentity = HwInfoGadgetReadingIdentity{*sensor, *label};
         }
     }
 
     RegCloseKey(key);
     g_hwInfoGadgetRegistryCache.cpuIndex = bestCpuIndex;
     g_hwInfoGadgetRegistryCache.gpuIndex = bestGpuIndex;
+    g_hwInfoGadgetRegistryCache.cpuIdentity = std::move(bestCpuIdentity);
+    g_hwInfoGadgetRegistryCache.gpuIdentity = std::move(bestGpuIdentity);
     g_hwInfoGadgetRegistryCache.fullScanCompleted = true;
     g_hwInfoGadgetRegistryCache.nextFullScan =
-        now + (bestCpuIndex && bestGpuIndex
-                   ? kGadgetRegistryRescanInterval
-                   : kGadgetRegistryPartialRescanInterval);
+        now + GetHwInfoRescanInterval(
+                  bestCpuIndex && bestGpuIndex,
+                  g_hwInfoGadgetRegistryCache.consecutivePartialScans,
+                  kGadgetRegistryRescanInterval,
+                  kGadgetRegistryPartialRescanInterval);
 
     if (!snapshot.cpuTemp && bestCpuValue) {
         snapshot.cpuTemp = *bestCpuValue;
@@ -2006,9 +2174,14 @@ struct GpuAdapterInfo {
 std::optional<std::wstring> g_cachedGpuAdapterFilter;
 std::optional<GpuAdapterInfo> g_cachedGpuAdapterInfo;
 bool g_cachedGpuAdapterResolved = false;
+std::chrono::steady_clock::time_point g_nextGpuAdapterResolve{};
+std::chrono::steady_clock::time_point g_lastSuccessfulGpuAdapterResolve{};
+uint32_t g_gpuAdapterResolveFailures = 0;
 D3DKMT_HANDLE g_cachedD3dkmtAdapterHandle = 0;
 LUID g_cachedD3dkmtAdapterLuid{};
 uint32_t g_unchangedGpuIdentityChecks = 0;
+uint32_t g_consecutiveD3dkmtFailures = 0;
+std::chrono::steady_clock::time_point g_nextD3dkmtRecovery{};
 
 bool SameLuid(const LUID& left, const LUID& right) {
     return left.HighPart == right.HighPart && left.LowPart == right.LowPart;
@@ -2028,8 +2201,13 @@ void InvalidateGpuAdapterCache() {
     g_cachedGpuAdapterFilter.reset();
     g_cachedGpuAdapterInfo.reset();
     g_cachedGpuAdapterResolved = false;
+    g_nextGpuAdapterResolve = {};
+    g_lastSuccessfulGpuAdapterResolve = {};
+    g_gpuAdapterResolveFailures = 0;
     g_nextGpuIdentityCheck = {};
     g_unchangedGpuIdentityChecks = 0;
+    g_consecutiveD3dkmtFailures = 0;
+    g_nextD3dkmtRecovery = {};
 }
 
 std::wstring FormatAdapterLuid(const LUID& luid) {
@@ -2208,33 +2386,82 @@ std::optional<GpuAdapterInfo> ResolveCurrentGpuAdapterInfo(
 std::optional<GpuAdapterInfo> GetGpuAdapterInfo(
     const std::wstring& adapterFilter) {
     std::wstring filterLower = ToLower(adapterFilter);
+    auto now = std::chrono::steady_clock::now();
     if (g_cachedGpuAdapterResolved &&
-        g_cachedGpuAdapterFilter == filterLower) {
+        g_cachedGpuAdapterFilter == filterLower &&
+        now < g_nextGpuAdapterResolve) {
         return g_cachedGpuAdapterInfo;
     }
 
+    std::optional<GpuAdapterInfo> previousAdapter;
     if (g_cachedGpuAdapterFilter &&
         *g_cachedGpuAdapterFilter != filterLower) {
         CloseCachedD3dkmtAdapterHandle();
+        g_cachedGpuAdapterInfo.reset();
+        g_cachedGpuAdapterResolved = false;
+        g_nextGpuAdapterResolve = {};
+        g_lastSuccessfulGpuAdapterResolve = {};
+        g_gpuAdapterResolveFailures = 0;
         g_nextGpuIdentityCheck = {};
         g_unchangedGpuIdentityChecks = 0;
+    } else {
+        previousAdapter = g_cachedGpuAdapterInfo;
     }
 
     g_cachedGpuAdapterFilter = filterLower;
     PCWSTR provider = nullptr;
-    g_cachedGpuAdapterInfo =
-        ResolveCurrentGpuAdapterInfo(filterLower, &provider);
+    auto resolvedAdapter = ResolveCurrentGpuAdapterInfo(filterLower, &provider);
     g_cachedGpuAdapterResolved = true;
 
-    if (!g_cachedGpuAdapterInfo) {
-        if (filterLower.empty()) {
-            Wh_Log(L"No GPU adapter found");
-        } else {
-            Wh_Log(L"No GPU adapter matched: %s", filterLower.c_str());
+    if (!resolvedAdapter) {
+        uint32_t exponent =
+            std::min<uint32_t>(g_gpuAdapterResolveFailures, 6);
+        auto delay = std::min(std::chrono::seconds(5u << exponent),
+                              std::chrono::seconds(300));
+        g_gpuAdapterResolveFailures++;
+        g_nextGpuAdapterResolve = now + delay;
+        bool previousAdapterIsFresh =
+            previousAdapter &&
+            g_lastSuccessfulGpuAdapterResolve !=
+                std::chrono::steady_clock::time_point{} &&
+            now - g_lastSuccessfulGpuAdapterResolve <=
+                kGpuAdapterCacheStaleGrace &&
+            g_gpuAdapterResolveFailures <= kGpuAdapterStaleFailureLimit;
+        if (!previousAdapterIsFresh) {
+            CloseCachedD3dkmtAdapterHandle();
+            previousAdapter.reset();
         }
-        return std::nullopt;
+        g_cachedGpuAdapterInfo = previousAdapter;
+        if (!previousAdapter && g_gpuAdapterResolveFailures == 1) {
+            if (filterLower.empty()) {
+                Wh_Log(L"No GPU adapter found; retrying automatically");
+            } else {
+                Wh_Log(L"No GPU adapter matched: %s; retrying automatically",
+                       filterLower.c_str());
+            }
+        }
+        return previousAdapter;
     }
 
+    bool adapterChanged =
+        !previousAdapter || previousAdapter->luid != resolvedAdapter->luid ||
+        previousAdapter->dedicatedVideoMemory !=
+            resolvedAdapter->dedicatedVideoMemory ||
+        previousAdapter->sharedSystemMemory !=
+            resolvedAdapter->sharedSystemMemory ||
+        previousAdapter->integrated != resolvedAdapter->integrated;
+    if (previousAdapter &&
+        !SameLuid(previousAdapter->luidValue, resolvedAdapter->luidValue)) {
+        CloseCachedD3dkmtAdapterHandle();
+    }
+    g_cachedGpuAdapterInfo = std::move(resolvedAdapter);
+    g_lastSuccessfulGpuAdapterResolve = now;
+    g_gpuAdapterResolveFailures = 0;
+    g_nextGpuAdapterResolve = now + std::chrono::seconds(60);
+
+    if (!adapterChanged) {
+        return g_cachedGpuAdapterInfo;
+    }
     Wh_Log(L"Selected GPU (%s): %s, LUID %s, dedicated %.1f GiB, shared %.1f "
            L"GiB, integrated=%d",
            provider, g_cachedGpuAdapterInfo->description.c_str(),
@@ -2245,6 +2472,20 @@ std::optional<GpuAdapterInfo> GetGpuAdapterInfo(
                kGiB,
            g_cachedGpuAdapterInfo->integrated);
     return g_cachedGpuAdapterInfo;
+}
+
+void RecordD3dkmtAdapterFailure() {
+    CloseCachedD3dkmtAdapterHandle();
+    g_consecutiveD3dkmtFailures =
+        std::min(g_consecutiveD3dkmtFailures + 1, 3u);
+    auto now = std::chrono::steady_clock::now();
+    if (g_consecutiveD3dkmtFailures < 3 || now < g_nextD3dkmtRecovery) {
+        return;
+    }
+    g_cachedGpuAdapterResolved = false;
+    g_nextGpuAdapterResolve = {};
+    g_nextD3dkmtRecovery = now + std::chrono::seconds(30);
+    g_consecutiveD3dkmtFailures = 0;
 }
 
 std::optional<std::wstring> ResolveGpuTemperatureAdapterName(
@@ -2299,6 +2540,7 @@ std::optional<D3DKMT_HANDLE> GetD3dkmtAdapterHandle(
     openAdapter.AdapterLuid = adapter.luidValue;
     if (g_d3dkmtOpenAdapterFromLuid(&openAdapter) != 0 ||
         !openAdapter.hAdapter) {
+        RecordD3dkmtAdapterFailure();
         return std::nullopt;
     }
     g_cachedD3dkmtAdapterHandle = openAdapter.hAdapter;
@@ -2332,8 +2574,12 @@ void ReadWindowsGpuTemperature(MetricsSnapshot& snapshot,
 
     LONG status = g_d3dkmtQueryAdapterInfo(&queryInfo);
     if (status != 0) {
-        // A driver restart invalidates KMT handles. Reopen on the next sample.
-        CloseCachedD3dkmtAdapterHandle();
+        // A driver restart can invalidate both the KMT handle and its LUID.
+        // Re-resolve the adapter after a bounded number of failures.
+        RecordD3dkmtAdapterFailure();
+    } else {
+        g_consecutiveD3dkmtFailures = 0;
+        g_nextD3dkmtRecovery = {};
     }
 
     // The driver reports tenths of a degree Celsius. Zero means unavailable;
@@ -2384,6 +2630,7 @@ void RecreatePdhSources(PCWSTR reason,
     ClosePdhQuery();
     InvalidateGpuAdapterCache();
     g_consecutivePdhReadFailures = 0;
+    g_consecutivePdhEmptySamples = 0;
     g_nextPdhCounterRetry = now + kPdhRecoveryRetryDelay;
     g_nextPdhRecovery = now + kPdhRecoveryCooldown;
 }
@@ -2409,6 +2656,30 @@ void RecoverFromGpuAdapterIdentityChange() {
         return;
     }
     RecreatePdhSources(L"confirmed adapter LUID change", ERROR_SUCCESS, now);
+}
+
+void RecordPdhEmptyAdapterSample(PDH_STATUS status) {
+    g_consecutivePdhReadFailures = 0;
+    g_consecutivePdhEmptySamples =
+        std::min(g_consecutivePdhEmptySamples + 1, 3u);
+    auto now = std::chrono::steady_clock::now();
+    if (g_consecutivePdhEmptySamples < 3 ||
+        now < g_nextPdhEmptyRecovery) {
+        return;
+    }
+
+    uint32_t exponent = std::min<uint32_t>(g_pdhEmptyRecoveries, 4);
+    auto delay = std::min(std::chrono::seconds(30u << exponent),
+                          std::chrono::seconds(300));
+    RecreatePdhSources(L"missing adapter VRAM sample", status, now);
+    g_pdhEmptyRecoveries++;
+    g_nextPdhEmptyRecovery = now + delay;
+}
+
+void ResetPdhEmptyAdapterRecovery() {
+    g_consecutivePdhEmptySamples = 0;
+    g_pdhEmptyRecoveries = 0;
+    g_nextPdhEmptyRecovery = {};
 }
 
 void RecordPdhReadSuccess() {
@@ -2728,9 +2999,9 @@ bool LooksLikeIntegratedGpu(const GpuAdapterInfo& adapter) {
 
     std::wstring name = NormalizeAdapterIdentity(adapter.description);
     bool radeonMobileModel = false;
-    if (Contains(name, L"radeon")) {
+    if (Contains(name, L"radeon") && !Contains(name, L"radeon hd")) {
         for (const std::wstring& token : IdentityTokens(name)) {
-            if (token.size() < 2 || token.back() != L'm') {
+            if (token.size() != 4 || token.back() != L'm') {
                 continue;
             }
             radeonMobileModel = std::all_of(
@@ -2742,13 +3013,13 @@ bool LooksLikeIntegratedGpu(const GpuAdapterInfo& adapter) {
         }
     }
 
-    bool intelArcGraphics = Contains(name, L"intel") &&
-                            Contains(name, L"arc") &&
-                            Contains(name, L"graphics");
-    return Contains(name, L"uhd graphics") || Contains(name, L"iris") ||
+    bool intelArc = Contains(name, L"intel") && Contains(name, L"arc");
+    return Contains(name, L"uhd graphics") ||
+           (Contains(name, L"intel") && Contains(name, L"hd graphics")) ||
+           Contains(name, L"iris") ||
            Contains(name, L"radeon graphics") || Contains(name, L"vega") ||
            Contains(name, L"integrated") || radeonMobileModel ||
-           intelArcGraphics;
+           intelArc;
 }
 
 bool UseSharedGpuMemory(const GpuAdapterInfo& adapter,
@@ -2840,11 +3111,14 @@ bool ReadPdhMetrics(MetricsSnapshot& snapshot, const ModSettings& settings) {
         // immediately instead of inheriting an old parked-GPU backoff window.
         g_unchangedGpuIdentityChecks = 0;
         g_nextGpuIdentityCheck = {};
+        ResetPdhEmptyAdapterRecovery();
     }
     if (hardReadFailure) {
         RecordPdhReadFailure(L"counter read");
     } else if (adapterIdentityChanged) {
         RecoverFromGpuAdapterIdentityChange();
+    } else if (adapterSampleMissing) {
+        RecordPdhEmptyAdapterSample(vramReadStatus);
     } else {
         RecordPdhReadSuccess();
     }
@@ -2985,6 +3259,8 @@ void MetricsWorkerProc() {
             // instead of publishing a synthetic near-zero sample.
             settings = CurrentSettings();
             ReadCpuUsage();
+            InvalidateGpuAdapterCache();
+            ResetPdhEmptyAdapterRecovery();
             EnsurePdhQuery(*settings);
             cpuTemperatureHoldover = {};
             gpuTemperatureHoldover = {};
@@ -3237,6 +3513,64 @@ void ApplyCachedBrushesToVisuals() {
     }
 }
 
+struct ThemeOpacityValues {
+    double label;
+    double value;
+    double graph;
+    double track;
+    double fill;
+};
+
+constexpr ThemeOpacityValues ResolveThemeOpacities(bool highContrast,
+                                                    int textOpacityPercent) {
+    double textOpacity =
+        static_cast<double>(textOpacityPercent) / 100.0;
+    return highContrast
+               ? ThemeOpacityValues{1.0, 1.0, 1.0, 0.45, 1.0}
+               : ThemeOpacityValues{textOpacity * 0.62, textOpacity, 0.78,
+                                    0.18, 0.76};
+}
+
+static_assert(ResolveThemeOpacities(true, 20).label == 1.0);
+static_assert(ResolveThemeOpacities(true, 20).track == 0.45);
+static_assert(ResolveThemeOpacities(false, 100).label > 0.61 &&
+              ResolveThemeOpacities(false, 100).label < 0.63);
+
+void ApplyThemeOpacities(const ModSettings& settings) {
+    bool highContrast = settings.adaptiveColors && g_cachedHighContrast;
+    ThemeOpacityValues opacities =
+        ResolveThemeOpacities(highContrast, settings.textOpacity);
+    for (TextBlock label :
+         {g_cpuLabel, g_gpuLabel, g_ramLabel, g_vramLabel}) {
+        if (label) {
+            label.Opacity(opacities.label);
+        }
+    }
+    for (TextBlock value : {g_cpuUsageText, g_cpuTempText, g_gpuUsageText,
+                            g_gpuTempText, g_ramPercentText,
+                            g_ramCapacityText, g_vramPercentText,
+                            g_vramCapacityText}) {
+        if (value) {
+            value.Opacity(opacities.value);
+        }
+    }
+    for (XamlPolyline graph : {g_cpuGraph, g_gpuGraph}) {
+        if (graph) {
+            graph.Opacity(opacities.graph);
+        }
+    }
+    for (XamlRectangle track : {g_ramTrack, g_vramTrack}) {
+        if (track) {
+            track.Opacity(opacities.track);
+        }
+    }
+    for (XamlRectangle fill : {g_ramFill, g_vramFill}) {
+        if (fill) {
+            fill.Opacity(opacities.fill);
+        }
+    }
+}
+
 void RefreshThemeBrushes(const ModSettings& settings) {
     ElementTheme theme = ResolveWidgetTheme();
     g_cachedWidgetTheme = theme;
@@ -3282,6 +3616,7 @@ void RefreshThemeBrushes(const ModSettings& settings) {
             settings.criticalColor, MakeColor(0xFF, 0xFF, 0x6B, 0x6B));
     }
     ApplyCachedBrushesToVisuals();
+    ApplyThemeOpacities(settings);
 }
 
 SolidColorBrush AlertBrush(AlertLevel alert) {
@@ -3327,14 +3662,58 @@ size_t HistoryCapacity(const ModSettings& settings) {
     return std::max<size_t>(2, static_cast<size_t>(intervals) + 1);
 }
 
-void AppendHistory(std::deque<double>& history,
-                   double value,
-                   size_t capacity) {
+template <typename History>
+constexpr void AppendHistory(History& history,
+                             double value,
+                             size_t capacity) {
     history.push_back(std::clamp(value, 0.0, 100.0));
     while (history.size() > capacity) {
         history.pop_front();
     }
 }
+
+template <typename History>
+constexpr void ApplyHistorySample(History& history,
+                                  bool available,
+                                  double value,
+                                  size_t capacity) {
+    if (!available) {
+        history.clear();
+        return;
+    }
+    AppendHistory(history, value, capacity);
+}
+
+struct HistoryTestBuffer {
+    double values[4]{};
+    size_t count = 0;
+
+    constexpr size_t size() const {
+        return count;
+    }
+    constexpr void clear() {
+        count = 0;
+    }
+    constexpr void push_back(double value) {
+        values[count++] = value;
+    }
+    constexpr void pop_front() {
+        for (size_t i = 1; i < count; i++) {
+            values[i - 1] = values[i];
+        }
+        count--;
+    }
+};
+
+constexpr bool HistoryGapResetIsDeterministic() {
+    HistoryTestBuffer history;
+    ApplyHistorySample(history, true, 10.0, 4);
+    ApplyHistorySample(history, false, 0.0, 4);
+    ApplyHistorySample(history, true, 20.0, 4);
+    return history.size() == 1 && history.values[0] == 20.0;
+}
+
+static_assert(HistoryGapResetIsDeterministic());
 
 void UpdateSparkline(XamlPolyline graph,
                      const std::deque<double>& history,
@@ -3427,8 +3806,10 @@ void ApplyTextStyle(TextBlock text,
     text.FontSize(settings.fontSize);
     text.FontWeight(label ? Text::FontWeights::SemiBold()
                           : Text::FontWeights::Normal());
-    double opacity = static_cast<double>(settings.textOpacity) / 100.0;
-    text.Opacity(label ? opacity * 0.62 : opacity);
+    bool highContrast = settings.adaptiveColors && g_cachedHighContrast;
+    ThemeOpacityValues opacities =
+        ResolveThemeOpacities(highContrast, settings.textOpacity);
+    text.Opacity(label ? opacities.label : opacities.value);
     text.TextWrapping(TextWrapping::NoWrap);
     text.TextTrimming(TextTrimming::CharacterEllipsis);
     SetTextForeground(text, AlertLevel::Normal);
@@ -3506,6 +3887,9 @@ void ApplyWidgetSettings() {
     }
     auto settingsSnapshot = CurrentSettings();
     const ModSettings& settings = *settingsSnapshot;
+    ThemeOpacityValues opacities = ResolveThemeOpacities(
+        settings.adaptiveColors && g_cachedHighContrast,
+        settings.textOpacity);
     RefreshThemeBrushes(settings);
     if (g_historyInterval != settings.updateInterval ||
         g_historyWindow != settings.historySeconds) {
@@ -3539,19 +3923,19 @@ void ApplyWidgetSettings() {
             graph.StrokeStartLineCap(PenLineCap::Round);
             graph.StrokeEndLineCap(PenLineCap::Round);
             graph.StrokeLineJoin(PenLineJoin::Round);
-            graph.Opacity(0.78);
+            graph.Opacity(opacities.graph);
         }
     }
     for (XamlRectangle track : {g_ramTrack, g_vramTrack}) {
         if (track) {
             track.Fill(g_graphBrush);
-            track.Opacity(0.18);
+            track.Opacity(opacities.track);
         }
     }
     for (XamlRectangle fill : {g_ramFill, g_vramFill}) {
         if (fill) {
             fill.Fill(g_graphBrush);
-            fill.Opacity(0.76);
+            fill.Opacity(opacities.fill);
         }
     }
 
@@ -3647,12 +4031,10 @@ void UpdateWidgetText(bool force = false) {
     if (hasNewSample) {
         size_t historyCapacity = HistoryCapacity(settings);
         for (const MetricsSnapshot& newSnapshot : newSnapshots) {
-            if (newSnapshot.cpuAvailable) {
-                AppendHistory(g_cpuHistory, newSnapshot.cpu, historyCapacity);
-            }
-            if (newSnapshot.gpuAvailable) {
-                AppendHistory(g_gpuHistory, newSnapshot.gpu, historyCapacity);
-            }
+            ApplyHistorySample(g_cpuHistory, newSnapshot.cpuAvailable,
+                               newSnapshot.cpu, historyCapacity);
+            ApplyHistorySample(g_gpuHistory, newSnapshot.gpuAvailable,
+                               newSnapshot.gpu, historyCapacity);
         }
         UpdateSparkline(g_cpuGraph, g_cpuHistory, historyCapacity);
         UpdateSparkline(g_gpuGraph, g_gpuHistory, historyCapacity);
@@ -3666,8 +4048,12 @@ void UpdateWidgetText(bool force = false) {
 void EnsureConfiguredTaskbarPlacement();
 
 void UpdateTimerInterval() {
-    if (g_timer) {
-        g_timer.Interval(std::chrono::milliseconds(g_widget ? 250 : 1000));
+    if (!g_timer) {
+        return;
+    }
+    auto interval = std::chrono::milliseconds(g_widget ? 250 : 1000);
+    if (g_timer.Interval() != interval) {
+        g_timer.Interval(interval);
     }
 }
 
@@ -3688,6 +4074,9 @@ void EnsureTimer() {
     g_nextTaskbarPlacementCheck = now + std::chrono::seconds(1);
     g_timerToken = g_timer.Tick([](IInspectable const&, IInspectable const&) {
         try {
+            if (g_unloading) {
+                return;
+            }
             bool force = false;
             auto now = std::chrono::steady_clock::now();
             if (g_widget && now >= g_nextSystemColorCheck) {
@@ -3711,15 +4100,29 @@ void EnsureTimer() {
     g_timer.Start();
 }
 
-void StopTimer() {
+bool StopTimer() {
+    bool succeeded = true;
     if (g_timer) {
-        g_timer.Stop();
-        g_timer.Tick(g_timerToken);
+        try {
+            g_timer.Stop();
+        } catch (...) {
+            Wh_Log(L"Stopping taskbar timer failed: %08X",
+                   static_cast<unsigned>(winrt::to_hresult()));
+            succeeded = false;
+        }
+        try {
+            g_timer.Tick(g_timerToken);
+        } catch (...) {
+            Wh_Log(L"Removing taskbar timer handler failed: %08X",
+                   static_cast<unsigned>(winrt::to_hresult()));
+            succeeded = false;
+        }
         g_timer = nullptr;
         g_timerToken = {};
     }
     g_nextSystemColorCheck = {};
     g_nextTaskbarPlacementCheck = {};
+    return succeeded;
 }
 
 ColumnDefinition PixelColumn(double width) {
@@ -3855,7 +4258,8 @@ Grid CreateMemoryRow(PCWSTR label,
     return row;
 }
 
-void RemoveWidget() {
+bool RemoveWidget() {
+    bool callbacksRevoked = true;
     g_nextSystemColorCheck = {};
 
     if (g_widget && g_actualThemeChangedToken.value) {
@@ -3865,6 +4269,7 @@ void RemoveWidget() {
             HRESULT error = winrt::to_hresult();
             Wh_Log(L"Removing taskbar theme handler failed: %08X",
                    static_cast<unsigned>(error));
+            callbacksRevoked = false;
         }
     }
     g_actualThemeChangedToken = {};
@@ -3932,6 +4337,7 @@ void RemoveWidget() {
     g_ramAlert = AlertLevel::Normal;
     g_vramAlert = AlertLevel::Normal;
     UpdateTimerInterval();
+    return callbacksRevoked;
 }
 
 bool InjectWidget(FrameworkElement taskbarFrame) {
@@ -4062,24 +4468,59 @@ bool InjectWidget(FrameworkElement taskbarFrame) {
 
 using RunFromWindowThreadProc = void (*)(void*);
 
+struct WindowThreadCallbackContext {
+    RunFromWindowThreadProc callback;
+    std::shared_ptr<void> context;
+    std::atomic<bool> invoked{false};
+
+    WindowThreadCallbackContext(RunFromWindowThreadProc callbackValue,
+                                std::shared_ptr<void> contextValue)
+        : callback(callbackValue), context(std::move(contextValue)) {}
+};
+
+std::mutex g_windowThreadDispatchMutex;
+std::mutex g_windowThreadCallbackRegistryMutex;
+[[clang::no_destroy]]
+std::unordered_map<ULONG_PTR, std::shared_ptr<WindowThreadCallbackContext>>
+    g_windowThreadCallbackRegistry;
+std::atomic<ULONG_PTR> g_nextWindowThreadCallbackToken{1};
+
 bool RunFromWindowThread(HWND window,
                          RunFromWindowThreadProc callback,
-                         void* context) {
+                         std::shared_ptr<void> context) {
     static const UINT message =
         RegisterWindowMessageW(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
-    struct CallbackContext {
-        RunFromWindowThreadProc callback;
-        void* context;
-        bool invoked;
-    };
-
     DWORD threadId = GetWindowThreadProcessId(window, nullptr);
-    if (!threadId) {
+    if (!threadId || g_taskbarCallbackCleanupFailed) {
         return false;
     }
     if (threadId == GetCurrentThreadId()) {
-        callback(context);
+        callback(context.get());
         return true;
+    }
+
+    std::lock_guard dispatchLock(g_windowThreadDispatchMutex);
+    if (g_taskbarCallbackCleanupFailed) {
+        return false;
+    }
+
+    std::shared_ptr<WindowThreadCallbackContext> callbackContext;
+    ULONG_PTR callbackToken = 0;
+    try {
+        callbackContext = std::make_shared<WindowThreadCallbackContext>(
+            callback, std::move(context));
+        std::lock_guard lock(g_windowThreadCallbackRegistryMutex);
+        do {
+            callbackToken = g_nextWindowThreadCallbackToken.fetch_add(
+                1, std::memory_order_relaxed);
+        } while (!callbackToken ||
+                 g_windowThreadCallbackRegistry.contains(callbackToken));
+        g_windowThreadCallbackRegistry.emplace(callbackToken,
+                                                callbackContext);
+    } catch (...) {
+        Wh_Log(L"Preparing taskbar thread dispatch failed: %08X",
+               static_cast<unsigned>(winrt::to_hresult()));
+        return false;
     }
 
     HHOOK hook = SetWindowsHookExW(
@@ -4089,29 +4530,69 @@ bool RunFromWindowThread(HWND window,
                 const auto* messageData =
                     reinterpret_cast<const CWPSTRUCT*>(lParam);
                 if (messageData->message == message) {
-                    auto* callbackContext =
-                        reinterpret_cast<CallbackContext*>(messageData->lParam);
-                    callbackContext->callback(callbackContext->context);
-                    callbackContext->invoked = true;
+                    std::shared_ptr<WindowThreadCallbackContext>
+                        callbackContext;
+                    {
+                        std::lock_guard lock(
+                            g_windowThreadCallbackRegistryMutex);
+                        auto callbackEntry =
+                            g_windowThreadCallbackRegistry.find(
+                                static_cast<ULONG_PTR>(messageData->lParam));
+                        if (callbackEntry !=
+                            g_windowThreadCallbackRegistry.end()) {
+                            callbackContext = callbackEntry->second;
+                            g_windowThreadCallbackRegistry.erase(
+                                callbackEntry);
+                        }
+                    }
+                    if (callbackContext) {
+                        try {
+                            callbackContext->callback(
+                                callbackContext->context.get());
+                        } catch (...) {
+                            Wh_Log(
+                                L"Unhandled taskbar dispatch callback error: %08X",
+                                static_cast<unsigned>(winrt::to_hresult()));
+                        }
+                        callbackContext->invoked.store(
+                            true, std::memory_order_release);
+                    }
                 }
             }
             return CallNextHookEx(nullptr, code, wParam, lParam);
         },
         nullptr, threadId);
     if (!hook) {
+        {
+            std::lock_guard lock(g_windowThreadCallbackRegistryMutex);
+            g_windowThreadCallbackRegistry.erase(callbackToken);
+        }
         Wh_Log(L"SetWindowsHookEx failed for taskbar thread %u: %u", threadId,
                GetLastError());
         return false;
     }
 
-    CallbackContext callbackContext{callback, context, false};
-    SendMessageW(window, message, 0,
-                 reinterpret_cast<LPARAM>(&callbackContext));
-    UnhookWindowsHookEx(hook);
-    if (!callbackContext.invoked) {
-        Wh_Log(L"Taskbar thread dispatch failed for thread %u", threadId);
+    DWORD_PTR messageResult = 0;
+    BOOL messageCompleted = SendMessageTimeoutW(
+        window, message, 0, static_cast<LPARAM>(callbackToken),
+        SMTO_ABORTIFHUNG | SMTO_BLOCK, 500, &messageResult);
+    BOOL hookRemoved = UnhookWindowsHookEx(hook);
+    if (!hookRemoved) {
+        g_taskbarCallbackCleanupFailed = true;
+        Wh_Log(L"UnhookWindowsHookEx failed for taskbar thread %u: %u",
+               threadId, GetLastError());
     }
-    return callbackContext.invoked;
+    {
+        std::lock_guard lock(g_windowThreadCallbackRegistryMutex);
+        g_windowThreadCallbackRegistry.erase(callbackToken);
+    }
+    bool invoked =
+        callbackContext->invoked.load(std::memory_order_acquire);
+    if (!messageCompleted || !invoked) {
+        Wh_Log(L"Taskbar thread dispatch timed out or failed for thread %u",
+               threadId);
+    }
+    return invoked && hookRemoved;
 }
 
 bool IsTaskbarWindowClass(HWND window, bool* secondary = nullptr) {
@@ -4450,10 +4931,15 @@ XamlRoot GetTaskbarXamlRoot(HWND taskbarWindow) {
 
     void* taskbarHostSharedPtr[2]{};
     getTaskbarHost(taskBandForSite, taskbarHostSharedPtr);
-    if (!taskbarHostSharedPtr[0] || !taskbarHostSharedPtr[1]) {
-        if (taskbarHostSharedPtr[1]) {
-            RefCountBase_Decref_Original(taskbarHostSharedPtr[1]);
+    struct TaskbarHostReferenceGuard {
+        void* reference;
+        ~TaskbarHostReferenceGuard() {
+            if (reference) {
+                RefCountBase_Decref_Original(reference);
+            }
         }
+    } referenceGuard{taskbarHostSharedPtr[1]};
+    if (!taskbarHostSharedPtr[0] || !taskbarHostSharedPtr[1]) {
         return nullptr;
     }
 
@@ -4468,7 +4954,6 @@ XamlRoot GetTaskbarXamlRoot(HWND taskbarWindow) {
         elementOffset = code[7];
     } else {
         Wh_Log(L"Unsupported TaskbarHost::FrameHeight pattern");
-        RefCountBase_Decref_Original(taskbarHostSharedPtr[1]);
         return nullptr;
     }
 #elif defined(_M_ARM64)
@@ -4482,7 +4967,6 @@ XamlRoot GetTaskbarXamlRoot(HWND taskbarWindow) {
         elementOffset = (code[3] >> 12) & 0xFF;
     } else {
         Wh_Log(L"Unsupported TaskbarHost::FrameHeight pattern");
-        RefCountBase_Decref_Original(taskbarHostSharedPtr[1]);
         return nullptr;
     }
 #else
@@ -4493,23 +4977,30 @@ XamlRoot GetTaskbarXamlRoot(HWND taskbarWindow) {
         static_cast<BYTE*>(taskbarHostSharedPtr[0]) + elementOffset;
     if (!IsReadableMemoryRange(elementAddress, sizeof(::IUnknown*))) {
         Wh_Log(L"Taskbar XAML element address is unreadable");
-        RefCountBase_Decref_Original(taskbarHostSharedPtr[1]);
         return nullptr;
     }
 
     auto* elementUnknown =
         *reinterpret_cast<::IUnknown**>(elementAddress);
     if (!elementUnknown) {
-        RefCountBase_Decref_Original(taskbarHostSharedPtr[1]);
         return nullptr;
     }
 
     FrameworkElement taskbarElement = nullptr;
     elementUnknown->QueryInterface(winrt::guid_of<FrameworkElement>(),
                                    winrt::put_abi(taskbarElement));
-    XamlRoot result = taskbarElement ? taskbarElement.XamlRoot() : nullptr;
-    RefCountBase_Decref_Original(taskbarHostSharedPtr[1]);
-    return result;
+    return taskbarElement ? taskbarElement.XamlRoot() : nullptr;
+}
+
+FrameworkElement FindTaskbarFrame(HWND taskbarWindow) {
+    XamlRoot xamlRoot = GetTaskbarXamlRoot(taskbarWindow);
+    if (!xamlRoot) {
+        return nullptr;
+    }
+    auto content = xamlRoot.Content().try_as<FrameworkElement>();
+    return FindChildRecursive(content, [](FrameworkElement child) {
+        return winrt::get_class_name(child) == L"Taskbar.TaskbarFrame";
+    });
 }
 
 struct ApplyWidgetContext {
@@ -4528,17 +5019,11 @@ void ApplyToTaskbarWindow(void* contextValue) {
     try {
         FrameworkElement taskbarFrame = context->taskbarFrame;
         if (!taskbarFrame) {
-            XamlRoot xamlRoot = GetTaskbarXamlRoot(taskbarWindow);
-            if (!xamlRoot) {
-                Wh_Log(L"GetTaskbarXamlRoot failed");
+            taskbarFrame = FindTaskbarFrame(taskbarWindow);
+            if (!taskbarFrame) {
+                Wh_Log(L"TaskbarFrame not found");
                 return;
             }
-            auto content = xamlRoot.Content().try_as<FrameworkElement>();
-            taskbarFrame =
-                FindChildRecursive(content, [](FrameworkElement child) {
-                    return winrt::get_class_name(child) ==
-                           L"Taskbar.TaskbarFrame";
-                });
         }
         if (taskbarFrame && InjectWidget(taskbarFrame)) {
             RememberTaskbarWindow(taskbarWindow);
@@ -4554,9 +5039,10 @@ void ApplyToTaskbarWindow(void* contextValue) {
 bool ApplyWidgetToTaskbarWindow(
     HWND taskbarWindow,
     FrameworkElement taskbarFrame = nullptr) {
-    ApplyWidgetContext context{taskbarWindow, taskbarFrame, false};
-    return RunFromWindowThread(taskbarWindow, ApplyToTaskbarWindow, &context) &&
-           context.succeeded;
+    auto context = std::make_shared<ApplyWidgetContext>(
+        ApplyWidgetContext{taskbarWindow, taskbarFrame, false});
+    return RunFromWindowThread(taskbarWindow, ApplyToTaskbarWindow, context) &&
+           context->succeeded;
 }
 
 struct TaskbarProbeContext {
@@ -4567,15 +5053,7 @@ struct TaskbarProbeContext {
 void ProbeTaskbarWindow(void* contextValue) {
     auto* context = reinterpret_cast<TaskbarProbeContext*>(contextValue);
     try {
-        XamlRoot xamlRoot = GetTaskbarXamlRoot(context->window);
-        if (!xamlRoot) {
-            return;
-        }
-        auto content = xamlRoot.Content().try_as<FrameworkElement>();
-        context->frame = FindChildRecursive(
-            content, [](FrameworkElement child) {
-                return winrt::get_class_name(child) == L"Taskbar.TaskbarFrame";
-            });
+        context->frame = FindTaskbarFrame(context->window);
     } catch (...) {
         HRESULT error = winrt::to_hresult();
         Wh_Log(L"Probing taskbar XAML failed: %08X",
@@ -4584,11 +5062,12 @@ void ProbeTaskbarWindow(void* contextValue) {
 }
 
 FrameworkElement FindReadyTaskbarFrame(HWND window) {
-    TaskbarProbeContext context{window, nullptr};
-    if (!RunFromWindowThread(window, ProbeTaskbarWindow, &context)) {
+    auto context = std::make_shared<TaskbarProbeContext>(
+        TaskbarProbeContext{window, nullptr});
+    if (!RunFromWindowThread(window, ProbeTaskbarWindow, context)) {
         return nullptr;
     }
-    return context.frame;
+    return context->frame;
 }
 
 struct RemoveWidgetForMoveContext {
@@ -4608,21 +5087,29 @@ void RemoveWidgetForMove(void* contextValue) {
     }
 }
 
-void RemoveFromCurrentTaskbar(void*) {
+struct RemoveTaskbarUiContext {
+    bool succeeded = false;
+};
+
+void RemoveFromCurrentTaskbar(void* contextValue) {
+    auto* context = reinterpret_cast<RemoveTaskbarUiContext*>(contextValue);
+    bool succeeded = true;
     try {
-        RemoveWidget();
+        succeeded = RemoveWidget() && succeeded;
     } catch (...) {
         HRESULT error = winrt::to_hresult();
         Wh_Log(L"Removing widget failed: %08X",
                static_cast<unsigned>(error));
+        succeeded = false;
     }
-    StopTimer();
+    succeeded = StopTimer() && succeeded;
     try {
         g_loadedRevokers.reset();
     } catch (...) {
         HRESULT error = winrt::to_hresult();
         Wh_Log(L"Removing taskbar Loaded handlers failed: %08X",
                static_cast<unsigned>(error));
+        succeeded = false;
     }
     g_taskbarWindow = nullptr;
     g_taskbarThreadId = 0;
@@ -4634,9 +5121,16 @@ void RemoveFromCurrentTaskbar(void*) {
     g_placementLocationUnknown = false;
     g_unknownPlacementProbeFailures = 0;
     g_unknownPlacementProbesSuspended = false;
-    g_lastMonitorCount = -1;
     g_lastDisplayTopologyFingerprint = 0;
     g_hasDisplayTopologyFingerprint = false;
+    g_placementApplyPending = false;
+    g_resetUnknownPlacementProbesPending = false;
+    if (!succeeded) {
+        g_taskbarCallbackCleanupFailed = true;
+    }
+    if (context) {
+        context->succeeded = succeeded;
+    }
 }
 
 void ResetPlacementRetryState() {
@@ -4690,6 +5184,7 @@ void MarkPlacementForRetry(HWND requestedWindow) {
 }
 
 void CompletePlacement(HWND requestedWindow, HWND actualWindow) {
+    g_placementApplyPending = false;
     g_placementLocationUnknown = false;
     ResetUnknownPlacementProbeState();
     if (requestedWindow == actualWindow) {
@@ -4751,7 +5246,10 @@ void ApplyOnTaskbarUiThreadImpl(void* contextValue) {
     if (g_unloading) {
         return;
     }
-    if (context->resetUnknownPlacementProbes) {
+    bool resetUnknownPlacementProbesPending =
+        g_resetUnknownPlacementProbesPending.exchange(false);
+    if (context->resetUnknownPlacementProbes ||
+        resetUnknownPlacementProbesPending) {
         ResetUnknownPlacementProbeState();
     }
 
@@ -4827,10 +5325,10 @@ void ApplyOnTaskbarUiThreadImpl(void* contextValue) {
     }
     bool widgetRemovedForMove = false;
     if (removalWindow && g_widget && currentWindow != targetWindow) {
-        RemoveWidgetForMoveContext removeContext;
+        auto removeContext = std::make_shared<RemoveWidgetForMoveContext>();
         if (!RunFromWindowThread(removalWindow, RemoveWidgetForMove,
-                                 &removeContext) ||
-            !removeContext.succeeded) {
+                                 removeContext) ||
+            !removeContext->succeeded) {
             Wh_Log(L"Removing widget from the previous monitor failed");
             MarkPlacementForRetry(requestedWindow);
             return;
@@ -4861,8 +5359,13 @@ void ApplyOnTaskbarUiThreadImpl(void* contextValue) {
 }
 
 void ApplyOnTaskbarUiThread(void* contextValue) {
+    auto* context =
+        reinterpret_cast<ApplyOnTaskbarThreadContext*>(contextValue);
     try {
         ApplyOnTaskbarUiThreadImpl(contextValue);
+        if (context->succeeded) {
+            g_placementApplyPending = false;
+        }
     } catch (...) {
         HRESULT error = winrt::to_hresult();
         Wh_Log(L"Taskbar placement update failed: %08X",
@@ -4871,36 +5374,165 @@ void ApplyOnTaskbarUiThread(void* contextValue) {
     }
 }
 
-void ApplyOnTaskbarThread(FrameworkElement fallbackFrame = nullptr,
+bool ApplyOnTaskbarThread(FrameworkElement fallbackFrame = nullptr,
                           bool refreshExistingWidget = true,
                           bool resetUnknownPlacementProbes = false,
                           HWND requestedWindow = nullptr) {
-    if (g_unloading) {
-        return;
+    if (g_unloading || g_taskbarCallbackCleanupFailed) {
+        return false;
     }
 
-    // Choose only a marshaling vehicle here. Monitor selection, widget state
-    // inspection and every mutation are serialized in ApplyOnTaskbarUiThread.
-    HWND dispatchWindow = FindPrimaryTaskbarWindow();
-    if (!dispatchWindow) {
+    if (resetUnknownPlacementProbes) {
+        g_resetUnknownPlacementProbesPending = true;
+    }
+    g_placementApplyPending = true;
+    constexpr int kMaximumDispatchAttempts = 3;
+    for (int attempt = 0; attempt < kMaximumDispatchAttempts; attempt++) {
+        DWORD attemptedThreadIds[3]{};
+        size_t attemptedThreadCount = 0;
         HWND rememberedWindow = g_taskbarWindow.load();
-        if (IsCurrentProcessTaskbarWindow(rememberedWindow)) {
-            dispatchWindow = rememberedWindow;
-        } else {
-            dispatchWindow = FindAnyWindowOnTaskbarThread(nullptr);
+        if (!IsCurrentProcessTaskbarWindow(rememberedWindow)) {
+            rememberedWindow = nullptr;
+        }
+        HWND primaryWindow = FindPrimaryTaskbarWindow();
+        HWND candidates[] = {
+            primaryWindow, rememberedWindow,
+            FindAnyWindowOnTaskbarThread(primaryWindow ? primaryWindow
+                                                       : rememberedWindow)};
+        for (size_t i = 0; i < std::size(candidates); i++) {
+            HWND dispatchWindow = candidates[i];
+            if (!dispatchWindow ||
+                std::find(candidates, candidates + i, dispatchWindow) !=
+                    candidates + i) {
+                continue;
+            }
+            DWORD dispatchThreadId =
+                GetWindowThreadProcessId(dispatchWindow, nullptr);
+            if (!dispatchThreadId ||
+                std::find(attemptedThreadIds,
+                          attemptedThreadIds + attemptedThreadCount,
+                          dispatchThreadId) !=
+                    attemptedThreadIds + attemptedThreadCount) {
+                continue;
+            }
+            attemptedThreadIds[attemptedThreadCount++] = dispatchThreadId;
+
+            auto context = std::make_shared<ApplyOnTaskbarThreadContext>(
+                ApplyOnTaskbarThreadContext{
+                    fallbackFrame, requestedWindow, refreshExistingWidget,
+                    resetUnknownPlacementProbes, false});
+            if (RunFromWindowThread(dispatchWindow, ApplyOnTaskbarUiThread,
+                                    context)) {
+                return true;
+            }
+        }
+        if (attempt + 1 < kMaximumDispatchAttempts) {
+            Sleep(25);
         }
     }
-    if (!dispatchWindow) {
-        Wh_Log(L"Taskbar UI thread is unavailable");
+    Wh_Log(L"Taskbar UI thread is unavailable; placement remains pending");
+    return false;
+}
+
+void StartPlacementRetryWorker() {
+    std::lock_guard lock(g_placementRetryWorkerMutex);
+    if (g_unloading || g_taskbarCallbackCleanupFailed) {
         return;
     }
-
-    ApplyOnTaskbarThreadContext context{fallbackFrame, requestedWindow,
-                                        refreshExistingWidget,
-                                        resetUnknownPlacementProbes, false};
-    if (!RunFromWindowThread(dispatchWindow, ApplyOnTaskbarUiThread, &context)) {
-        Wh_Log(L"Dispatching taskbar placement failed");
+    if (g_placementRetryWorker && g_placementRetryWorker->joinable()) {
+        if (g_placementRetryWorkerRunning) {
+            if (g_placementRetryWakeEvent) {
+                SetEvent(g_placementRetryWakeEvent);
+            }
+            return;
+        }
+        g_placementRetryWorker->join();
+        g_placementRetryWorker.reset();
     }
+
+    if (!g_placementRetryWakeEvent) {
+        g_placementRetryWakeEvent =
+            CreateEventW(nullptr, FALSE, FALSE, nullptr);
+        if (!g_placementRetryWakeEvent) {
+            Wh_Log(L"Creating taskbar placement retry event failed: %u",
+                   GetLastError());
+            return;
+        }
+    }
+
+    g_stopPlacementRetryWorker = false;
+    g_placementRetryWorkerRunning = true;
+    HANDLE retryWakeEvent = g_placementRetryWakeEvent;
+    try {
+        g_placementRetryWorker.emplace([retryWakeEvent] {
+            constexpr int kMaximumFastStartupRetryAttempts = 30;
+            int fastAttempts = 0;
+            bool slowBackoffLogged = false;
+            while (true) {
+                if (g_stopPlacementRetryWorker || g_unloading ||
+                    g_taskbarCallbackCleanupFailed ||
+                    !g_placementApplyPending) {
+                    break;
+                }
+                if (ApplyOnTaskbarThread()) {
+                    break;
+                }
+                bool slowBackoff =
+                    fastAttempts >= kMaximumFastStartupRetryAttempts;
+                if (slowBackoff && !slowBackoffLogged) {
+                    Wh_Log(L"Taskbar placement is still unavailable; retrying "
+                           L"every 30 seconds");
+                    slowBackoffLogged = true;
+                }
+                DWORD waitResult = WaitForSingleObject(
+                    retryWakeEvent, slowBackoff ? 30000 : 1000);
+                if (waitResult == WAIT_FAILED) {
+                    Wh_Log(L"Taskbar placement retry wait failed: %u",
+                           GetLastError());
+                    std::this_thread::sleep_for(std::chrono::seconds(1));
+                } else if (waitResult == WAIT_OBJECT_0) {
+                    fastAttempts = 0;
+                    slowBackoffLogged = false;
+                } else if (!slowBackoff) {
+                    fastAttempts++;
+                }
+            }
+            g_placementRetryWorkerRunning = false;
+        });
+    } catch (...) {
+        g_placementRetryWorkerRunning = false;
+        Wh_Log(L"Starting taskbar placement retry worker failed: %08X",
+               static_cast<unsigned>(winrt::to_hresult()));
+    }
+}
+
+void StopPlacementRetryWorker() {
+    std::optional<std::thread> worker;
+    HANDLE wakeEvent = nullptr;
+    {
+        std::lock_guard lock(g_placementRetryWorkerMutex);
+        g_stopPlacementRetryWorker = true;
+        if (g_placementRetryWakeEvent) {
+            SetEvent(g_placementRetryWakeEvent);
+        }
+        if (g_placementRetryWorker && g_placementRetryWorker->joinable()) {
+            worker.emplace(std::move(*g_placementRetryWorker));
+        }
+        g_placementRetryWorker.reset();
+        wakeEvent = g_placementRetryWakeEvent;
+        g_placementRetryWakeEvent = nullptr;
+    }
+    if (worker && worker->joinable()) {
+        if (worker->get_id() == std::this_thread::get_id()) {
+            worker->detach();
+        } else {
+            worker->join();
+        }
+    }
+    if (wakeEvent) {
+        CloseHandle(wakeEvent);
+    }
+    g_placementRetryWorkerRunning = false;
 }
 
 void EnsureConfiguredTaskbarPlacement() {
@@ -4909,14 +5541,11 @@ void EnsureConfiguredTaskbarPlacement() {
     }
 
     auto monitors = EnumerateDisplayMonitors();
-    int monitorCount = static_cast<int>(monitors.size());
     uint64_t topologyFingerprint = GetDisplayTopologyFingerprint(monitors);
     bool topologyChanged =
-        monitorCount != g_lastMonitorCount ||
         !g_hasDisplayTopologyFingerprint ||
         topologyFingerprint != g_lastDisplayTopologyFingerprint;
     if (topologyChanged) {
-        g_lastMonitorCount = monitorCount;
         g_lastDisplayTopologyFingerprint = topologyFingerprint;
         g_hasDisplayTopologyFingerprint = true;
         ResetPlacementRetryState();
@@ -4924,7 +5553,9 @@ void EnsureConfiguredTaskbarPlacement() {
     }
 
     HWND rememberedWindow = g_taskbarWindow.load();
-    if (!topologyChanged && !g_placementIsFallback &&
+    bool placementApplyPending = g_placementApplyPending.load();
+    if (!placementApplyPending && !topologyChanged &&
+        !g_placementIsFallback &&
         g_placementFailures == 0 && g_widget &&
         IsCurrentProcessTaskbarWindow(rememberedWindow)) {
         return;
@@ -4945,7 +5576,8 @@ void EnsureConfiguredTaskbarPlacement() {
         MarkPlacementForRetry(nullptr);
         return;
     }
-    if (g_widget && IsCurrentProcessTaskbarWindow(rememberedWindow) &&
+    if (!placementApplyPending && g_widget &&
+        IsCurrentProcessTaskbarWindow(rememberedWindow) &&
         rememberedWindow == targetWindow && !g_placementIsFallback) {
         ResetPlacementRetryState();
         return;
@@ -5000,34 +5632,47 @@ void* WINAPI TaskbarFrame_Constructor_Hook(void* pThis) {
         return result;
     }
 
-    FrameworkElement taskbarFrame = nullptr;
-    reinterpret_cast<::IUnknown**>(pThis)[1]->QueryInterface(
-        winrt::guid_of<FrameworkElement>(), winrt::put_abi(taskbarFrame));
-    if (!taskbarFrame) {
-        return result;
-    }
+    try {
+        FrameworkElement taskbarFrame = nullptr;
+        reinterpret_cast<::IUnknown**>(pThis)[1]->QueryInterface(
+            winrt::guid_of<FrameworkElement>(), winrt::put_abi(taskbarFrame));
+        if (!taskbarFrame) {
+            return result;
+        }
 
-    g_loadedRevokers->emplace_back();
-    auto revoker = std::prev(g_loadedRevokers->end());
-    *revoker = taskbarFrame.Loaded(
-        winrt::auto_revoke_t{},
-        [revoker](IInspectable const& sender, RoutedEventArgs const&) {
-            if (!g_loadedRevokers) {
-                return;
-            }
-            FrameworkElement loadedFrame = sender.try_as<FrameworkElement>();
+        g_loadedRevokers->emplace_back();
+        auto revoker = std::prev(g_loadedRevokers->end());
+        try {
+            *revoker = taskbarFrame.Loaded(
+                winrt::auto_revoke_t{},
+                [revoker](IInspectable const& sender,
+                          RoutedEventArgs const&) {
+                    if (!g_loadedRevokers) {
+                        return;
+                    }
+                    FrameworkElement loadedFrame =
+                        sender.try_as<FrameworkElement>();
+                    g_loadedRevokers->erase(revoker);
+                    if (g_unloading) {
+                        return;
+                    }
+                    try {
+                        ApplyLoadedTaskbarFrame(loadedFrame);
+                    } catch (...) {
+                        HRESULT error = winrt::to_hresult();
+                        Wh_Log(L"Loaded injection failed: %08X",
+                               static_cast<unsigned>(error));
+                    }
+                });
+        } catch (...) {
             g_loadedRevokers->erase(revoker);
-            if (g_unloading) {
-                return;
-            }
-            try {
-                ApplyLoadedTaskbarFrame(loadedFrame);
-            } catch (...) {
-                HRESULT error = winrt::to_hresult();
-                Wh_Log(L"Loaded injection failed: %08X",
-                       static_cast<unsigned>(error));
-            }
-        });
+            throw;
+        }
+    } catch (...) {
+        HRESULT error = winrt::to_hresult();
+        Wh_Log(L"Registering taskbar Loaded handler failed: %08X",
+               static_cast<unsigned>(error));
+    }
     return result;
 }
 
@@ -5121,35 +5766,79 @@ void CloseMetricSources() {
     g_nextPdhCounterRetry = {};
     g_nextPdhRecovery = {};
     g_consecutivePdhReadFailures = 0;
+    g_consecutivePdhEmptySamples = 0;
+    g_pdhEmptyRecoveries = 0;
+    g_nextPdhEmptyRecovery = {};
 }
 
 bool TearDownTaskbarUi() {
-    HWND taskbarWindow = FindRememberedTaskbarWindow();
-    if (taskbarWindow &&
-        RunFromWindowThread(taskbarWindow, RemoveFromCurrentTaskbar, nullptr)) {
+    if (g_taskbarCallbackCleanupFailed) {
+        return false;
+    }
+    constexpr int kMaximumTeardownAttempts = 3;
+    for (int attempt = 0; attempt < kMaximumTeardownAttempts; attempt++) {
+        DWORD attemptedThreadIds[3]{};
+        size_t attemptedThreadCount = 0;
+        HWND rememberedWindow = FindRememberedTaskbarWindow();
+        HWND candidates[] = {rememberedWindow,
+                             FindAnyWindowOnTaskbarThread(rememberedWindow),
+                             FindPrimaryTaskbarWindow()};
+        for (size_t i = 0; i < std::size(candidates); i++) {
+            HWND window = candidates[i];
+            if (!window ||
+                std::find(candidates, candidates + i, window) !=
+                    candidates + i) {
+                continue;
+            }
+            DWORD threadId = GetWindowThreadProcessId(window, nullptr);
+            if (!threadId ||
+                std::find(attemptedThreadIds,
+                          attemptedThreadIds + attemptedThreadCount,
+                          threadId) !=
+                    attemptedThreadIds + attemptedThreadCount) {
+                continue;
+            }
+            attemptedThreadIds[attemptedThreadCount++] = threadId;
+            auto context = std::make_shared<RemoveTaskbarUiContext>();
+            if (RunFromWindowThread(window, RemoveFromCurrentTaskbar,
+                                    context)) {
+                return context->succeeded;
+            }
+        }
+        if (attempt + 1 < kMaximumTeardownAttempts) {
+            Sleep(25);
+        }
+    }
+    return false;
+}
+
+bool PinModuleAfterFailedTaskbarTeardown() {
+    if (g_modulePinnedAfterFailedTeardown) {
         return true;
     }
-
-    // The Shell_TrayWnd can disappear during Explorer teardown. Any surviving
-    // window on its UI thread is sufficient: the WH_CALLWNDPROC hook runs the
-    // callback, while SendMessage only wakes that thread.
-    HWND fallbackWindow = FindAnyWindowOnTaskbarThread(taskbarWindow);
-    if (!fallbackWindow) {
-        // Injection can fail before g_taskbarWindow/g_taskbarThreadId are set,
-        // while TaskbarFrame Loaded revokers are already pending. Every taskbar
-        // shares Explorer's XAML UI thread, so the primary window is a safe
-        // final marshaling target for revoking them before the DLL unloads.
-        fallbackWindow = FindPrimaryTaskbarWindow();
+    HMODULE module = nullptr;
+    if (!GetModuleHandleExW(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                GET_MODULE_HANDLE_EX_FLAG_PIN,
+            reinterpret_cast<LPCWSTR>(&PinModuleAfterFailedTaskbarTeardown),
+            &module)) {
+        return false;
     }
-    return fallbackWindow && RunFromWindowThread(
-                                 fallbackWindow, RemoveFromCurrentTaskbar,
-                                 nullptr);
+    g_modulePinnedAfterFailedTeardown = true;
+    return true;
 }
 
 }  // namespace
 
 BOOL Wh_ModInit() {
     Wh_Log(L">");
+    if (g_modulePinnedAfterFailedTeardown) {
+        Wh_Log(L"The previous taskbar callbacks could not be revoked safely; "
+               L"restart Explorer before enabling the mod again");
+        return FALSE;
+    }
+    g_unloading = false;
+    g_taskbarCallbackCleanupFailed = false;
     g_uiTornDown = false;
     if (HMODULE gdi32 = GetModuleHandleW(L"gdi32.dll")) {
         g_d3dkmtEnumAdapters2 = reinterpret_cast<D3DKMTEnumAdapters2_t>(
@@ -5202,19 +5891,24 @@ void Wh_ModAfterInit() {
             TryHookTaskbarViewSymbols(module, true);
         }
     }
-    ApplyOnTaskbarThread();
+    if (!ApplyOnTaskbarThread()) {
+        StartPlacementRetryWorker();
+    }
 }
 
 void Wh_ModSettingsChanged() {
     Wh_Log(L">");
     LoadSettings();
     WakeMetricsWorker();
-    ApplyOnTaskbarThread(nullptr, true, true);
+    if (!ApplyOnTaskbarThread(nullptr, true, true)) {
+        StartPlacementRetryWorker();
+    }
 }
 
 void Wh_ModBeforeUninit() {
     Wh_Log(L">");
     g_unloading = true;
+    StopPlacementRetryWorker();
     StopMetricsWorker();
 
     g_uiTornDown = TearDownTaskbarUi();
@@ -5225,10 +5919,18 @@ void Wh_ModBeforeUninit() {
 
 void Wh_ModUninit() {
     Wh_Log(L">");
+    StopPlacementRetryWorker();
     if (!g_uiTornDown) {
         g_uiTornDown = TearDownTaskbarUi();
         if (!g_uiTornDown) {
             Wh_Log(L"Taskbar UI teardown retry failed");
+            if (PinModuleAfterFailedTaskbarTeardown()) {
+                Wh_Log(L"Keeping the mod image loaded because taskbar callbacks "
+                       L"could not be revoked safely");
+            } else {
+                Wh_Log(L"Keeping taskbar callbacks safe failed: %u",
+                       GetLastError());
+            }
         }
     }
     StopMetricsWorker();

--- a/mods/taskbar-system-info.wh.cpp
+++ b/mods/taskbar-system-info.wh.cpp
@@ -410,7 +410,6 @@ Released under GPL-3.0.
 
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
-#include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Text.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
@@ -420,7 +419,6 @@ Released under GPL-3.0.
 using namespace winrt;
 using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::UI;
-using namespace winrt::Windows::UI::Core;
 using namespace winrt::Windows::UI::Xaml;
 using namespace winrt::Windows::UI::Xaml::Controls;
 using namespace winrt::Windows::UI::Xaml::Media;
@@ -443,6 +441,8 @@ constexpr double kMemoryPercentWidth = 38.0;
 constexpr double kGraphHeight = 12.0;
 constexpr double kGiB = 1024.0 * 1024.0 * 1024.0;
 constexpr uint32_t kMaximumTaskbarViewHookAttempts = 3;
+constexpr uint32_t kMaximumUnknownPlacementProbeFailures = 3;
+constexpr auto kGadgetRegistryRescanInterval = std::chrono::seconds(30);
 constexpr wchar_t kDefaultGraphColor[] = L"#78A8FF";
 constexpr wchar_t kDefaultWarningColor[] = L"#FFFFB900";
 constexpr wchar_t kDefaultCriticalColor[] = L"#FFFF6B6B";
@@ -534,14 +534,14 @@ event_token g_timerToken{};
 event_token g_actualThemeChangedToken{};
 std::chrono::steady_clock::time_point g_nextSystemColorCheck{};
 std::chrono::steady_clock::time_point g_nextTaskbarPlacementCheck{};
-[[clang::no_destroy]] IAsyncAction g_placementApplyAction{nullptr};
-bool g_placementApplyQueued = false;
 HWND g_lastFailedPlacementTarget = nullptr;
 bool g_hasFailedPlacementTarget = false;
 std::chrono::steady_clock::time_point g_nextPlacementRetry{};
 uint32_t g_placementFailures = 0;
 bool g_placementIsFallback = false;
 bool g_placementLocationUnknown = false;
+uint32_t g_unknownPlacementProbeFailures = 0;
+bool g_unknownPlacementProbesSuspended = false;
 int g_lastMonitorCount = -1;
 uint64_t g_lastDisplayTopologyFingerprint = 0;
 bool g_hasDisplayTopologyFingerprint = false;
@@ -598,6 +598,18 @@ std::chrono::steady_clock::time_point g_nextGpuIdentityCheck{};
 uint32_t g_consecutivePdhReadFailures = 0;
 bool g_hwInfoInvalidUnitLogged = false;
 std::atomic<bool> g_hwInfoGpuAdapterMismatchLogged{false};
+
+struct HwInfoGadgetRegistryCache {
+    std::optional<int> cpuIndex;
+    std::optional<int> gpuIndex;
+    bool fullScanCompleted = false;
+    std::chrono::steady_clock::time_point nextFullScan{};
+    std::wstring cpuFilter;
+    std::wstring gpuFilter;
+    std::wstring gpuAdapter;
+};
+
+[[clang::no_destroy]] HwInfoGadgetRegistryCache g_hwInfoGadgetRegistryCache;
 
 struct MetricsSnapshot {
     double cpu = 0.0;
@@ -1364,18 +1376,120 @@ std::optional<double> NormalizeRegistryTemperature(
     return NormalizeTemperature(*value, formattedValue);
 }
 
+struct HwInfoGadgetReading {
+    std::wstring sensor;
+    std::wstring label;
+    double value = 0.0;
+};
+
+std::optional<HwInfoGadgetReading> ReadHwInfoGadgetReading(HKEY key,
+                                                           int index) {
+    std::wstring suffix = std::to_wstring(index);
+    auto sensor = ReadRegistryString(key, L"Sensor" + suffix);
+    auto label = ReadRegistryString(key, L"Label" + suffix);
+    auto rawValue = ReadRegistryString(key, L"ValueRaw" + suffix);
+    auto formattedValue = ReadRegistryString(key, L"Value" + suffix);
+    if (!sensor || !label || !rawValue || !formattedValue) {
+        return std::nullopt;
+    }
+
+    auto value = NormalizeRegistryTemperature(*rawValue, *formattedValue);
+    if (!value) {
+        return std::nullopt;
+    }
+    return HwInfoGadgetReading{std::move(*sensor), std::move(*label), *value};
+}
+
 void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
                               const ModSettings& settings,
                               const std::optional<std::wstring>& gpuAdapterName,
                               HwInfoTemperatureDiagnostics& diagnostics) {
-    HKEY key = nullptr;
-    if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\HWiNFO64\\VSB", 0,
-                      KEY_QUERY_VALUE, &key) != ERROR_SUCCESS) {
+    std::wstring gpuAdapter = gpuAdapterName.value_or(L"");
+    if (g_hwInfoGadgetRegistryCache.cpuFilter != settings.cpuTempSensor ||
+        g_hwInfoGadgetRegistryCache.gpuFilter != settings.gpuTempSensor ||
+        g_hwInfoGadgetRegistryCache.gpuAdapter != gpuAdapter) {
+        g_hwInfoGadgetRegistryCache = {};
+        g_hwInfoGadgetRegistryCache.cpuFilter = settings.cpuTempSensor;
+        g_hwInfoGadgetRegistryCache.gpuFilter = settings.gpuTempSensor;
+        g_hwInfoGadgetRegistryCache.gpuAdapter = std::move(gpuAdapter);
+    }
+
+    auto now = std::chrono::steady_clock::now();
+    bool needsCpu = !snapshot.cpuTemp;
+    bool needsGpu = !snapshot.gpuTemp;
+    bool hasCachedCandidate =
+        (needsCpu && g_hwInfoGadgetRegistryCache.cpuIndex) ||
+        (needsGpu && g_hwInfoGadgetRegistryCache.gpuIndex);
+    if (!hasCachedCandidate &&
+        g_hwInfoGadgetRegistryCache.fullScanCompleted &&
+        now < g_hwInfoGadgetRegistryCache.nextFullScan) {
         return;
     }
 
-    int bestCpuScore = snapshot.cpuTemp ? 10000 : -1;
-    int bestGpuScore = snapshot.gpuTemp ? 10000 : -1;
+    HKEY key = nullptr;
+    if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\HWiNFO64\\VSB", 0,
+                      KEY_QUERY_VALUE, &key) != ERROR_SUCCESS) {
+        g_hwInfoGadgetRegistryCache.cpuIndex.reset();
+        g_hwInfoGadgetRegistryCache.gpuIndex.reset();
+        g_hwInfoGadgetRegistryCache.fullScanCompleted = true;
+        g_hwInfoGadgetRegistryCache.nextFullScan =
+            now + kGadgetRegistryRescanInterval;
+        return;
+    }
+
+    auto readCached = [&](std::optional<int>& cachedIndex, bool cpu) {
+        if (!cachedIndex) {
+            return;
+        }
+        auto reading = ReadHwInfoGadgetReading(key, *cachedIndex);
+        if (!reading) {
+            cachedIndex.reset();
+            g_hwInfoGadgetRegistryCache.fullScanCompleted = false;
+            return;
+        }
+
+        RecordGpuTemperatureDiagnostic(diagnostics, reading->sensor,
+                                       reading->label, gpuAdapterName);
+        int score = cpu ? CpuTemperatureScore(reading->sensor, reading->label,
+                                              settings.cpuTempSensor)
+                        : GpuTemperatureScore(reading->sensor, reading->label,
+                                              settings.gpuTempSensor,
+                                              gpuAdapterName);
+        if (score < 0) {
+            cachedIndex.reset();
+            g_hwInfoGadgetRegistryCache.fullScanCompleted = false;
+            return;
+        }
+
+        if (cpu && !snapshot.cpuTemp) {
+            snapshot.cpuTemp = reading->value;
+            snapshot.cpuTempProvider =
+                TemperatureProvider::HwInfoGadgetRegistry;
+        } else if (!cpu && !snapshot.gpuTemp) {
+            snapshot.gpuTemp = reading->value;
+            snapshot.gpuTempProvider =
+                TemperatureProvider::HwInfoGadgetRegistry;
+        }
+    };
+
+    readCached(g_hwInfoGadgetRegistryCache.cpuIndex, true);
+    readCached(g_hwInfoGadgetRegistryCache.gpuIndex, false);
+    if (snapshot.cpuTemp && snapshot.gpuTemp) {
+        RegCloseKey(key);
+        return;
+    }
+    if (g_hwInfoGadgetRegistryCache.fullScanCompleted &&
+        now < g_hwInfoGadgetRegistryCache.nextFullScan) {
+        RegCloseKey(key);
+        return;
+    }
+
+    int bestCpuScore = -1;
+    int bestGpuScore = -1;
+    std::optional<int> bestCpuIndex;
+    std::optional<int> bestGpuIndex;
+    std::optional<double> bestCpuValue;
+    std::optional<double> bestGpuValue;
     int consecutiveMissing = 0;
     for (int i = 0; i < 1024; i++) {
         std::wstring suffix = std::to_wstring(i);
@@ -1405,9 +1519,8 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
             CpuTemperatureScore(*sensor, *label, settings.cpuTempSensor);
         if (cpuScore > bestCpuScore) {
             bestCpuScore = cpuScore;
-            snapshot.cpuTemp = *value;
-            snapshot.cpuTempProvider =
-                TemperatureProvider::HwInfoGadgetRegistry;
+            bestCpuIndex = i;
+            bestCpuValue = *value;
         }
 
         int gpuScore =
@@ -1415,13 +1528,26 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
                                 gpuAdapterName);
         if (gpuScore > bestGpuScore) {
             bestGpuScore = gpuScore;
-            snapshot.gpuTemp = *value;
-            snapshot.gpuTempProvider =
-                TemperatureProvider::HwInfoGadgetRegistry;
+            bestGpuIndex = i;
+            bestGpuValue = *value;
         }
     }
 
     RegCloseKey(key);
+    g_hwInfoGadgetRegistryCache.cpuIndex = bestCpuIndex;
+    g_hwInfoGadgetRegistryCache.gpuIndex = bestGpuIndex;
+    g_hwInfoGadgetRegistryCache.fullScanCompleted = true;
+    g_hwInfoGadgetRegistryCache.nextFullScan =
+        now + kGadgetRegistryRescanInterval;
+
+    if (!snapshot.cpuTemp && bestCpuValue) {
+        snapshot.cpuTemp = *bestCpuValue;
+        snapshot.cpuTempProvider = TemperatureProvider::HwInfoGadgetRegistry;
+    }
+    if (!snapshot.gpuTemp && bestGpuValue) {
+        snapshot.gpuTemp = *bestGpuValue;
+        snapshot.gpuTempProvider = TemperatureProvider::HwInfoGadgetRegistry;
+    }
 }
 
 void ReadWindowsThermalZones(MetricsSnapshot& snapshot,
@@ -2385,19 +2511,12 @@ bool LooksLikeIntegratedGpu(const GpuAdapterInfo& adapter) {
         return true;
     }
 
-    // Some WDDM drivers don't set HybridIntegrated but expose a small firmware
-    // carve-out. Restrict the fallback to familiar integrated-family names so
-    // an older low-memory discrete adapter isn't silently reclassified.
+    // Some WDDM drivers don't set HybridIntegrated for newer integrated parts
+    // such as Radeon 890M or Intel Arc iGPUs. Their small firmware carve-out
+    // plus usable shared memory is a more stable signal than marketing names.
     constexpr uint64_t kMaximumIntegratedCarveout = 512ull * 1024 * 1024;
-    if (adapter.dedicatedVideoMemory > kMaximumIntegratedCarveout ||
-        adapter.sharedSystemMemory == 0) {
-        return false;
-    }
-    std::wstring name = ToLower(adapter.description);
-    return Contains(name, L"uhd graphics") || Contains(name, L"iris") ||
-           Contains(name, L"radeon(tm) graphics") ||
-           Contains(name, L"radeon graphics") || Contains(name, L"vega") ||
-           Contains(name, L"integrated");
+    return adapter.dedicatedVideoMemory <= kMaximumIntegratedCarveout &&
+           adapter.sharedSystemMemory > 0;
 }
 
 bool UseSharedGpuMemory(const GpuAdapterInfo& adapter,
@@ -3314,8 +3433,15 @@ void UpdateWidgetText(bool force = false) {
 
 void EnsureConfiguredTaskbarPlacement();
 
+void UpdateTimerInterval() {
+    if (g_timer) {
+        g_timer.Interval(std::chrono::milliseconds(g_widget ? 250 : 1000));
+    }
+}
+
 void EnsureTimer() {
     if (g_timer) {
+        UpdateTimerInterval();
         return;
     }
     // The Tick delegate lives in this module, so teardown must always know
@@ -3351,6 +3477,17 @@ void EnsureTimer() {
         }
     });
     g_timer.Start();
+}
+
+void StopTimer() {
+    if (g_timer) {
+        g_timer.Stop();
+        g_timer.Tick(g_timerToken);
+        g_timer = nullptr;
+        g_timerToken = {};
+    }
+    g_nextSystemColorCheck = {};
+    g_nextTaskbarPlacementCheck = {};
 }
 
 ColumnDefinition PixelColumn(double width) {
@@ -3486,32 +3623,8 @@ Grid CreateMemoryRow(PCWSTR label,
     return row;
 }
 
-void CancelPendingPlacementApply() {
-    g_placementApplyQueued = false;
-    if (!g_placementApplyAction) {
-        return;
-    }
-
-    try {
-        g_placementApplyAction.Cancel();
-    } catch (...) {
-        HRESULT error = winrt::to_hresult();
-        Wh_Log(L"Cancelling deferred taskbar placement failed: %08X",
-               static_cast<unsigned>(error));
-    }
-    g_placementApplyAction = nullptr;
-}
-
 void RemoveWidget() {
-    CancelPendingPlacementApply();
-    if (g_timer) {
-        g_timer.Stop();
-        g_timer.Tick(g_timerToken);
-        g_timer = nullptr;
-        g_timerToken = {};
-    }
     g_nextSystemColorCheck = {};
-    g_nextTaskbarPlacementCheck = {};
 
     if (g_widget && g_actualThemeChangedToken.value) {
         try {
@@ -3586,6 +3699,7 @@ void RemoveWidget() {
     g_gpuTemperatureAlert = AlertLevel::Normal;
     g_ramAlert = AlertLevel::Normal;
     g_vramAlert = AlertLevel::Normal;
+    UpdateTimerInterval();
 }
 
 bool InjectWidget(FrameworkElement taskbarFrame) {
@@ -3784,11 +3898,11 @@ bool IsTaskbarWindowClass(HWND window, bool* secondary = nullptr) {
     return isPrimary || isSecondary;
 }
 
-bool IsCurrentProcessTaskbarWindow(HWND window) {
+bool IsCurrentProcessTaskbarWindow(HWND window, bool* secondary = nullptr) {
     DWORD processId = 0;
     return window && GetWindowThreadProcessId(window, &processId) != 0 &&
            processId == GetCurrentProcessId() &&
-           IsTaskbarWindowClass(window);
+           IsTaskbarWindowClass(window, secondary);
 }
 
 struct DisplayMonitor {
@@ -3837,45 +3951,24 @@ std::vector<DisplayMonitor> EnumerateDisplayMonitors() {
     return monitors;
 }
 
-uint64_t GetDisplayTopologyFingerprint() {
-    struct FingerprintContext {
-        uint64_t sum = 0;
-        uint64_t mixedXor = 0;
-        uint64_t count = 0;
-    } context;
+uint64_t GetDisplayTopologyFingerprint(
+    const std::vector<DisplayMonitor>& monitors) {
+    uint64_t hash = 1469598103934665603ull;
+    auto mix = [&hash](uint64_t value) {
+        hash ^= value;
+        hash *= 1099511628211ull;
+    };
 
-    EnumDisplayMonitors(
-        nullptr, nullptr,
-        [](HMONITOR monitor, HDC, LPRECT, LPARAM contextValue) -> BOOL {
-            MONITORINFO info{};
-            info.cbSize = sizeof(info);
-            if (!GetMonitorInfoW(monitor, &info)) {
-                return TRUE;
-            }
-
-            uint64_t entryHash = 1469598103934665603ull;
-            auto mix = [&entryHash](uint64_t value) {
-                entryHash ^= value;
-                entryHash *= 1099511628211ull;
-            };
-            mix(reinterpret_cast<uintptr_t>(monitor));
-            mix(static_cast<uint64_t>(static_cast<int64_t>(info.rcMonitor.left)));
-            mix(static_cast<uint64_t>(static_cast<int64_t>(info.rcMonitor.top)));
-            mix(static_cast<uint64_t>(static_cast<int64_t>(info.rcMonitor.right)));
-            mix(static_cast<uint64_t>(static_cast<int64_t>(info.rcMonitor.bottom)));
-            mix((info.dwFlags & MONITORINFOF_PRIMARY) != 0);
-
-            auto* context =
-                reinterpret_cast<FingerprintContext*>(contextValue);
-            context->sum += entryHash;
-            context->mixedXor ^= entryHash * 0x9E3779B185EBCA87ull;
-            context->count++;
-            return TRUE;
-        },
-        reinterpret_cast<LPARAM>(&context));
-
-    return context.sum ^ context.mixedXor ^
-           (context.count * 0xD6E8FEB86659FD93ull);
+    for (const DisplayMonitor& monitor : monitors) {
+        mix(reinterpret_cast<uintptr_t>(monitor.handle));
+        mix(static_cast<uint64_t>(static_cast<int64_t>(monitor.bounds.left)));
+        mix(static_cast<uint64_t>(static_cast<int64_t>(monitor.bounds.top)));
+        mix(static_cast<uint64_t>(static_cast<int64_t>(monitor.bounds.right)));
+        mix(static_cast<uint64_t>(static_cast<int64_t>(monitor.bounds.bottom)));
+        mix(monitor.primary);
+    }
+    mix(monitors.size());
+    return hash;
 }
 
 HWND FindTaskbarWindowForMonitor(HMONITOR monitor) {
@@ -3903,12 +3996,9 @@ HWND FindPrimaryTaskbarWindow() {
     HWND result = nullptr;
     EnumWindows(
         [](HWND window, LPARAM context) -> BOOL {
-            DWORD processId = 0;
-            WCHAR className[64];
-            if (GetWindowThreadProcessId(window, &processId) &&
-                processId == GetCurrentProcessId() &&
-                GetClassNameW(window, className, std::size(className)) &&
-                _wcsicmp(className, L"Shell_TrayWnd") == 0) {
+            bool secondary = false;
+            if (IsCurrentProcessTaskbarWindow(window, &secondary) &&
+                !secondary) {
                 *reinterpret_cast<HWND*>(context) = window;
                 return FALSE;
             }
@@ -3937,9 +4027,10 @@ HWND FindOnlyTaskbarWindow() {
     return context.count == 1 ? context.window : nullptr;
 }
 
-HWND FindConfiguredTaskbarWindow(bool logFallback = true) {
+HWND FindConfiguredTaskbarWindow(
+    const std::vector<DisplayMonitor>& monitors,
+    bool logFallback = true) {
     int monitorNumber = CurrentSettings()->monitor;
-    auto monitors = EnumerateDisplayMonitors();
     if (monitorNumber <= static_cast<int>(monitors.size())) {
         if (HWND window =
                 FindTaskbarWindowForMonitor(monitors[monitorNumber - 1].handle)) {
@@ -3958,6 +4049,15 @@ HWND FindConfiguredTaskbarWindow(bool logFallback = true) {
     return FindPrimaryTaskbarWindow();
 }
 
+HWND FindConfiguredTaskbarWindow(bool logFallback = true) {
+    return FindConfiguredTaskbarWindow(EnumerateDisplayMonitors(), logFallback);
+}
+
+void ResetUnknownPlacementProbeState() {
+    g_unknownPlacementProbeFailures = 0;
+    g_unknownPlacementProbesSuspended = false;
+}
+
 void RememberTaskbarWindow(HWND window) {
     if (!IsCurrentProcessTaskbarWindow(window)) {
         return;
@@ -3967,6 +4067,7 @@ void RememberTaskbarWindow(HWND window) {
         g_taskbarWindow = window;
         g_taskbarThreadId = threadId;
         g_placementLocationUnknown = false;
+        ResetUnknownPlacementProbeState();
     }
 }
 
@@ -4273,6 +4374,7 @@ void RemoveFromCurrentTaskbar(void*) {
         Wh_Log(L"Removing widget failed: %08X",
                static_cast<unsigned>(error));
     }
+    StopTimer();
     try {
         g_loadedRevokers.reset();
     } catch (...) {
@@ -4288,6 +4390,8 @@ void RemoveFromCurrentTaskbar(void*) {
     g_placementFailures = 0;
     g_placementIsFallback = false;
     g_placementLocationUnknown = false;
+    g_unknownPlacementProbeFailures = 0;
+    g_unknownPlacementProbesSuspended = false;
     g_lastMonitorCount = -1;
     g_lastDisplayTopologyFingerprint = 0;
     g_hasDisplayTopologyFingerprint = false;
@@ -4321,10 +4425,20 @@ void RecordPlacementFailure(HWND targetWindow) {
 void MarkPlacementForRetry(HWND requestedWindow) {
     g_placementIsFallback = true;
     RecordPlacementFailure(requestedWindow);
+    if (g_placementLocationUnknown && !g_unknownPlacementProbesSuspended) {
+        g_unknownPlacementProbeFailures++;
+        if (g_unknownPlacementProbeFailures >=
+            kMaximumUnknownPlacementProbeFailures) {
+            g_unknownPlacementProbesSuspended = true;
+            Wh_Log(L"Monitor lookup failed repeatedly; automatic XAML probes "
+                   L"are paused until taskbar topology or settings change");
+        }
+    }
 }
 
 void CompletePlacement(HWND requestedWindow, HWND actualWindow) {
     g_placementLocationUnknown = false;
+    ResetUnknownPlacementProbeState();
     if (requestedWindow == actualWindow) {
         g_placementIsFallback = false;
         ResetPlacementRetryState();
@@ -4373,6 +4487,7 @@ bool ApplyLoadedFrameFallback(FrameworkElement fallbackFrame,
 struct ApplyOnTaskbarThreadContext {
     FrameworkElement fallbackFrame{nullptr};
     bool refreshExistingWidget = true;
+    bool resetUnknownPlacementProbes = false;
     bool succeeded = false;
 };
 
@@ -4382,8 +4497,9 @@ void ApplyOnTaskbarUiThreadImpl(void* contextValue) {
     if (g_unloading) {
         return;
     }
-
-    CancelPendingPlacementApply();
+    if (context->resetUnknownPlacementProbes) {
+        ResetUnknownPlacementProbeState();
+    }
 
     // Keep a retry timer even before the first successful injection. All state
     // below is intentionally owned by Explorer's taskbar/XAML UI thread.
@@ -4396,9 +4512,11 @@ void ApplyOnTaskbarUiThreadImpl(void* contextValue) {
         return;
     }
 
-    HWND currentWindow = g_placementLocationUnknown
-                             ? nullptr
-                             : FindRememberedTaskbarWindow();
+    HWND currentWindow = g_taskbarWindow.load();
+    if (g_placementLocationUnknown ||
+        !IsCurrentProcessTaskbarWindow(currentWindow)) {
+        currentWindow = nullptr;
+    }
     if (currentWindow == requestedWindow && g_widget) {
         if (context->refreshExistingWidget) {
             RefreshExistingWidget();
@@ -4490,23 +4608,11 @@ void ApplyOnTaskbarUiThread(void* contextValue) {
                static_cast<unsigned>(error));
         MarkPlacementForRetry(nullptr);
     }
-
-    // A failed move can destroy the old widget and its timer before both the
-    // target injection and restoration fail. Keep the retry loop alive on
-    // every non-unload exit path.
-    if (!g_unloading) {
-        try {
-            EnsureTimer();
-        } catch (...) {
-            HRESULT error = winrt::to_hresult();
-            Wh_Log(L"Restoring the taskbar placement timer failed: %08X",
-                   static_cast<unsigned>(error));
-        }
-    }
 }
 
 void ApplyOnTaskbarThread(FrameworkElement fallbackFrame = nullptr,
-                          bool refreshExistingWidget = true) {
+                          bool refreshExistingWidget = true,
+                          bool resetUnknownPlacementProbes = false) {
     if (g_unloading) {
         return;
     }
@@ -4528,48 +4634,9 @@ void ApplyOnTaskbarThread(FrameworkElement fallbackFrame = nullptr,
     }
 
     ApplyOnTaskbarThreadContext context{fallbackFrame, refreshExistingWidget,
-                                        false};
+                                        resetUnknownPlacementProbes, false};
     if (!RunFromWindowThread(dispatchWindow, ApplyOnTaskbarUiThread, &context)) {
         Wh_Log(L"Dispatching taskbar placement failed");
-    }
-}
-
-void QueueConfiguredTaskbarPlacement() {
-    if (g_unloading || g_placementApplyQueued) {
-        return;
-    }
-
-    if (!g_widget) {
-        // The retry-only timer survives InjectWidget, so this path doesn't
-        // destroy the DispatcherTimer from inside its own Tick callback.
-        ApplyOnTaskbarThread(nullptr, false);
-        return;
-    }
-
-    try {
-        CoreDispatcher dispatcher = g_widget.Dispatcher();
-        if (!dispatcher) {
-            MarkPlacementForRetry(FindConfiguredTaskbarWindow(false));
-            return;
-        }
-
-        g_placementApplyQueued = true;
-        g_placementApplyAction = dispatcher.RunAsync(
-            CoreDispatcherPriority::Normal, [] {
-                bool shouldApply = g_placementApplyQueued;
-                g_placementApplyQueued = false;
-                g_placementApplyAction = nullptr;
-                if (shouldApply && !g_unloading) {
-                    ApplyOnTaskbarThread(nullptr, false);
-                }
-            });
-    } catch (...) {
-        HRESULT error = winrt::to_hresult();
-        g_placementApplyQueued = false;
-        g_placementApplyAction = nullptr;
-        Wh_Log(L"Deferring taskbar placement failed: %08X",
-               static_cast<unsigned>(error));
-        MarkPlacementForRetry(FindConfiguredTaskbarWindow(false));
     }
 }
 
@@ -4578,8 +4645,9 @@ void EnsureConfiguredTaskbarPlacement() {
         return;
     }
 
-    int monitorCount = GetSystemMetrics(SM_CMONITORS);
-    uint64_t topologyFingerprint = GetDisplayTopologyFingerprint();
+    auto monitors = EnumerateDisplayMonitors();
+    int monitorCount = static_cast<int>(monitors.size());
+    uint64_t topologyFingerprint = GetDisplayTopologyFingerprint(monitors);
     bool topologyChanged =
         monitorCount != g_lastMonitorCount ||
         !g_hasDisplayTopologyFingerprint ||
@@ -4589,6 +4657,7 @@ void EnsureConfiguredTaskbarPlacement() {
         g_lastDisplayTopologyFingerprint = topologyFingerprint;
         g_hasDisplayTopologyFingerprint = true;
         ResetPlacementRetryState();
+        ResetUnknownPlacementProbeState();
     }
 
     HWND rememberedWindow = g_taskbarWindow.load();
@@ -4603,8 +4672,12 @@ void EnsureConfiguredTaskbarPlacement() {
         now < g_nextPlacementRetry) {
         return;
     }
+    if (!topologyChanged && g_placementLocationUnknown &&
+        g_unknownPlacementProbesSuspended) {
+        return;
+    }
 
-    HWND targetWindow = FindConfiguredTaskbarWindow(false);
+    HWND targetWindow = FindConfiguredTaskbarWindow(monitors, false);
     if (!targetWindow) {
         MarkPlacementForRetry(nullptr);
         return;
@@ -4615,14 +4688,19 @@ void EnsureConfiguredTaskbarPlacement() {
         return;
     }
 
-    Wh_Log(L"Taskbar topology changed; moving the widget");
-    QueueConfiguredTaskbarPlacement();
+    if (topologyChanged) {
+        Wh_Log(L"Taskbar topology changed; moving the widget");
+    } else {
+        Wh_Log(L"Retrying taskbar placement");
+    }
+    ApplyOnTaskbarThread(nullptr, false);
 }
 
 void ApplyLoadedTaskbarFrame(FrameworkElement taskbarFrame) {
     if (g_unloading) {
         return;
     }
+    ResetUnknownPlacementProbeState();
     if (!taskbarFrame) {
         ApplyOnTaskbarThread();
         return;
@@ -4866,7 +4944,7 @@ void Wh_ModSettingsChanged() {
     Wh_Log(L">");
     LoadSettings();
     WakeMetricsWorker();
-    ApplyOnTaskbarThread();
+    ApplyOnTaskbarThread(nullptr, true, true);
 }
 
 void Wh_ModBeforeUninit() {

--- a/mods/taskbar-system-info.wh.cpp
+++ b/mods/taskbar-system-info.wh.cpp
@@ -628,8 +628,7 @@ std::atomic<HWND> g_taskbarWindow{nullptr};
 std::atomic<DWORD> g_taskbarThreadId{0};
 std::atomic<bool> g_placementApplyPending{false};
 std::atomic<bool> g_resetUnknownPlacementProbesPending{false};
-std::atomic<bool> g_taskbarCallbackCleanupFailed{false};
-std::atomic<bool> g_modulePinnedAfterFailedTeardown{false};
+std::atomic<bool> g_taskbarUiResourcesRegistered{false};
 std::mutex g_placementRetryWorkerMutex;
 std::atomic<bool> g_stopPlacementRetryWorker{false};
 std::atomic<bool> g_placementRetryWorkerRunning{false};
@@ -1264,31 +1263,6 @@ constexpr std::chrono::seconds GetHwInfoRescanInterval(
     }
     return regularInterval;
 }
-
-constexpr bool HwInfoPartialRescanBackoffIsBounded() {
-    uint32_t partialScans = 0;
-    for (uint32_t i = 0; i < kHwInfoFastPartialRescanLimit; i++) {
-        if (GetHwInfoRescanInterval(false, partialScans,
-                                    std::chrono::seconds(60),
-                                    std::chrono::seconds(5)) !=
-            std::chrono::seconds(5)) {
-            return false;
-        }
-    }
-    if (GetHwInfoRescanInterval(false, partialScans,
-                                std::chrono::seconds(60),
-                                std::chrono::seconds(5)) !=
-        std::chrono::seconds(60)) {
-        return false;
-    }
-    return GetHwInfoRescanInterval(true, partialScans,
-                                   std::chrono::seconds(60),
-                                   std::chrono::seconds(5)) ==
-               std::chrono::seconds(60) &&
-           partialScans == 0;
-}
-
-static_assert(HwInfoPartialRescanBackoffIsBounded());
 
 struct HwInfoSharedMemoryCache {
     std::optional<uint32_t> cpuReadingIndex;
@@ -3095,16 +3069,24 @@ bool LooksLikeIntegratedGpu(const GpuAdapterInfo& adapter) {
     }
 
     std::wstring name = NormalizeAdapterIdentity(adapter.description);
-    bool radeonMobileModel = false;
+    bool radeonIntegratedModel = false;
     if (Contains(name, L"radeon") && !Contains(name, L"radeon hd")) {
-        for (const std::wstring& token : IdentityTokens(name)) {
-            if (token.size() != 4 || token.back() != L'm') {
-                continue;
-            }
-            radeonMobileModel = std::all_of(
-                token.begin(), token.end() - 1,
-                [](wchar_t character) { return std::iswdigit(character) != 0; });
-            if (radeonMobileModel) {
+        auto tokens = IdentityTokens(name);
+        for (size_t i = 0; i < tokens.size(); i++) {
+            const std::wstring& token = tokens[i];
+            bool hasModelSuffix = token.size() > 1 &&
+                                  (token.back() == L'm' ||
+                                   token.back() == L's') &&
+                                  std::all_of(
+                                      token.begin(), token.end() - 1,
+                                      [](wchar_t character) {
+                                          return std::iswdigit(character) != 0;
+                                      });
+            bool followedByGraphics =
+                HasDigit(token) && i + 1 < tokens.size() &&
+                tokens[i + 1] == L"graphics";
+            if (hasModelSuffix || followedByGraphics) {
+                radeonIntegratedModel = true;
                 break;
             }
         }
@@ -3115,7 +3097,7 @@ bool LooksLikeIntegratedGpu(const GpuAdapterInfo& adapter) {
            (Contains(name, L"intel") && Contains(name, L"hd graphics")) ||
            Contains(name, L"iris") ||
            Contains(name, L"radeon graphics") || Contains(name, L"vega") ||
-           Contains(name, L"integrated") || radeonMobileModel ||
+           Contains(name, L"integrated") || radeonIntegratedModel ||
            intelArc;
 }
 
@@ -3628,11 +3610,6 @@ constexpr ThemeOpacityValues ResolveThemeOpacities(bool highContrast,
                                     0.18, 0.76};
 }
 
-static_assert(ResolveThemeOpacities(true, 20).label == 1.0);
-static_assert(ResolveThemeOpacities(true, 20).track == 0.45);
-static_assert(ResolveThemeOpacities(false, 100).label > 0.61 &&
-              ResolveThemeOpacities(false, 100).label < 0.63);
-
 void ApplyThemeOpacities(const ModSettings& settings) {
     bool highContrast = settings.adaptiveColors && g_cachedHighContrast;
     ThemeOpacityValues opacities =
@@ -3759,58 +3736,25 @@ size_t HistoryCapacity(const ModSettings& settings) {
     return std::max<size_t>(2, static_cast<size_t>(intervals) + 1);
 }
 
-template <typename History>
-constexpr void AppendHistory(History& history,
-                             double value,
-                             size_t capacity) {
+void AppendHistory(std::deque<double>& history,
+                   double value,
+                   size_t capacity) {
     history.push_back(std::clamp(value, 0.0, 100.0));
     while (history.size() > capacity) {
         history.pop_front();
     }
 }
 
-template <typename History>
-constexpr void ApplyHistorySample(History& history,
-                                  bool available,
-                                  double value,
-                                  size_t capacity) {
+void ApplyHistorySample(std::deque<double>& history,
+                        bool available,
+                        double value,
+                        size_t capacity) {
     if (!available) {
         history.clear();
         return;
     }
     AppendHistory(history, value, capacity);
 }
-
-struct HistoryTestBuffer {
-    double values[4]{};
-    size_t count = 0;
-
-    constexpr size_t size() const {
-        return count;
-    }
-    constexpr void clear() {
-        count = 0;
-    }
-    constexpr void push_back(double value) {
-        values[count++] = value;
-    }
-    constexpr void pop_front() {
-        for (size_t i = 1; i < count; i++) {
-            values[i - 1] = values[i];
-        }
-        count--;
-    }
-};
-
-constexpr bool HistoryGapResetIsDeterministic() {
-    HistoryTestBuffer history;
-    ApplyHistorySample(history, true, 10.0, 4);
-    ApplyHistorySample(history, false, 0.0, 4);
-    ApplyHistorySample(history, true, 20.0, 4);
-    return history.size() == 1 && history.values[0] == 20.0;
-}
-
-static_assert(HistoryGapResetIsDeterministic());
 
 void UpdateSparkline(XamlPolyline graph,
                      const std::deque<double>& history,
@@ -3984,9 +3928,6 @@ void ApplyWidgetSettings() {
     }
     auto settingsSnapshot = CurrentSettings();
     const ModSettings& settings = *settingsSnapshot;
-    ThemeOpacityValues opacities = ResolveThemeOpacities(
-        settings.adaptiveColors && g_cachedHighContrast,
-        settings.textOpacity);
     RefreshThemeBrushes(settings);
     if (g_historyInterval != settings.updateInterval ||
         g_historyWindow != settings.historySeconds) {
@@ -4020,19 +3961,16 @@ void ApplyWidgetSettings() {
             graph.StrokeStartLineCap(PenLineCap::Round);
             graph.StrokeEndLineCap(PenLineCap::Round);
             graph.StrokeLineJoin(PenLineJoin::Round);
-            graph.Opacity(opacities.graph);
         }
     }
     for (XamlRectangle track : {g_ramTrack, g_vramTrack}) {
         if (track) {
             track.Fill(g_graphBrush);
-            track.Opacity(opacities.track);
         }
     }
     for (XamlRectangle fill : {g_ramFill, g_vramFill}) {
         if (fill) {
             fill.Fill(g_graphBrush);
-            fill.Opacity(opacities.fill);
         }
     }
 
@@ -4165,6 +4103,7 @@ void EnsureTimer() {
         g_taskbarThreadId = GetCurrentThreadId();
     }
     g_timer = DispatcherTimer();
+    g_taskbarUiResourcesRegistered = true;
     UpdateTimerInterval();
     auto now = std::chrono::steady_clock::now();
     g_nextSystemColorCheck = now + std::chrono::seconds(1);
@@ -4198,28 +4137,27 @@ void EnsureTimer() {
 }
 
 bool StopTimer() {
-    bool succeeded = true;
     if (g_timer) {
         try {
             g_timer.Stop();
         } catch (...) {
             Wh_Log(L"Stopping taskbar timer failed: %08X",
                    static_cast<unsigned>(winrt::to_hresult()));
-            succeeded = false;
+            return false;
         }
         try {
             g_timer.Tick(g_timerToken);
         } catch (...) {
             Wh_Log(L"Removing taskbar timer handler failed: %08X",
                    static_cast<unsigned>(winrt::to_hresult()));
-            succeeded = false;
+            return false;
         }
         g_timer = nullptr;
         g_timerToken = {};
     }
     g_nextSystemColorCheck = {};
     g_nextTaskbarPlacementCheck = {};
-    return succeeded;
+    return true;
 }
 
 ColumnDefinition PixelColumn(double width) {
@@ -4356,7 +4294,6 @@ Grid CreateMemoryRow(PCWSTR label,
 }
 
 bool RemoveWidget() {
-    bool callbacksRevoked = true;
     g_nextSystemColorCheck = {};
 
     if (g_widget && g_actualThemeChangedToken.value) {
@@ -4366,7 +4303,7 @@ bool RemoveWidget() {
             HRESULT error = winrt::to_hresult();
             Wh_Log(L"Removing taskbar theme handler failed: %08X",
                    static_cast<unsigned>(error));
-            callbacksRevoked = false;
+            return false;
         }
     }
     g_actualThemeChangedToken = {};
@@ -4434,7 +4371,7 @@ bool RemoveWidget() {
     g_ramAlert = AlertLevel::Normal;
     g_vramAlert = AlertLevel::Normal;
     UpdateTimerInterval();
-    return callbacksRevoked;
+    return true;
 }
 
 bool InjectWidget(FrameworkElement taskbarFrame) {
@@ -4476,7 +4413,10 @@ bool InjectWidget(FrameworkElement taskbarFrame) {
     // it alive so an injection started by its Tick callback doesn't tear down
     // and recreate the very timer that's currently dispatching the callback.
     if (g_widget || g_rootGrid || g_taskItemsRepeater) {
-        RemoveWidget();
+        if (!RemoveWidget()) {
+            Wh_Log(L"Removing the previous widget before reinjection failed");
+            return false;
+        }
     }
 
     Grid widget;
@@ -4531,6 +4471,7 @@ bool InjectWidget(FrameworkElement taskbarFrame) {
     widget.Children().Append(leftPanel);
     widget.Children().Append(rightPanel);
     root.Children().Append(widget);
+    g_taskbarUiResourcesRegistered = true;
 
     g_rootGrid = root;
     g_widget = widget;
@@ -4578,8 +4519,9 @@ struct WindowThreadCallbackContext {
 std::mutex g_windowThreadDispatchMutex;
 std::mutex g_windowThreadCallbackRegistryMutex;
 [[clang::no_destroy]]
-std::unordered_map<ULONG_PTR, std::shared_ptr<WindowThreadCallbackContext>>
-    g_windowThreadCallbackRegistry;
+std::optional<std::unordered_map<
+    ULONG_PTR, std::shared_ptr<WindowThreadCallbackContext>>>
+    g_windowThreadCallbackRegistry{std::in_place};
 std::atomic<ULONG_PTR> g_nextWindowThreadCallbackToken{1};
 
 bool RunFromWindowThread(HWND window,
@@ -4588,7 +4530,7 @@ bool RunFromWindowThread(HWND window,
     static const UINT message =
         RegisterWindowMessageW(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
     DWORD threadId = GetWindowThreadProcessId(window, nullptr);
-    if (!threadId || g_taskbarCallbackCleanupFailed) {
+    if (!threadId) {
         return false;
     }
     if (threadId == GetCurrentThreadId()) {
@@ -4597,10 +4539,6 @@ bool RunFromWindowThread(HWND window,
     }
 
     std::lock_guard dispatchLock(g_windowThreadDispatchMutex);
-    if (g_taskbarCallbackCleanupFailed) {
-        return false;
-    }
-
     std::shared_ptr<WindowThreadCallbackContext> callbackContext;
     ULONG_PTR callbackToken = 0;
     try {
@@ -4611,9 +4549,9 @@ bool RunFromWindowThread(HWND window,
             callbackToken = g_nextWindowThreadCallbackToken.fetch_add(
                 1, std::memory_order_relaxed);
         } while (!callbackToken ||
-                 g_windowThreadCallbackRegistry.contains(callbackToken));
-        g_windowThreadCallbackRegistry.emplace(callbackToken,
-                                                callbackContext);
+                 g_windowThreadCallbackRegistry->contains(callbackToken));
+        g_windowThreadCallbackRegistry->emplace(callbackToken,
+                                                 callbackContext);
     } catch (...) {
         Wh_Log(L"Preparing taskbar thread dispatch failed: %08X",
                static_cast<unsigned>(winrt::to_hresult()));
@@ -4633,12 +4571,12 @@ bool RunFromWindowThread(HWND window,
                         std::lock_guard lock(
                             g_windowThreadCallbackRegistryMutex);
                         auto callbackEntry =
-                            g_windowThreadCallbackRegistry.find(
+                            g_windowThreadCallbackRegistry->find(
                                 static_cast<ULONG_PTR>(messageData->lParam));
                         if (callbackEntry !=
-                            g_windowThreadCallbackRegistry.end()) {
+                            g_windowThreadCallbackRegistry->end()) {
                             callbackContext = callbackEntry->second;
-                            g_windowThreadCallbackRegistry.erase(
+                            g_windowThreadCallbackRegistry->erase(
                                 callbackEntry);
                         }
                     }
@@ -4662,34 +4600,43 @@ bool RunFromWindowThread(HWND window,
     if (!hook) {
         {
             std::lock_guard lock(g_windowThreadCallbackRegistryMutex);
-            g_windowThreadCallbackRegistry.erase(callbackToken);
+            g_windowThreadCallbackRegistry->erase(callbackToken);
         }
         Wh_Log(L"SetWindowsHookEx failed for taskbar thread %u: %u", threadId,
                GetLastError());
         return false;
     }
 
-    DWORD_PTR messageResult = 0;
-    BOOL messageCompleted = SendMessageTimeoutW(
-        window, message, 0, static_cast<LPARAM>(callbackToken),
-        SMTO_ABORTIFHUNG | SMTO_BLOCK, 500, &messageResult);
-    BOOL hookRemoved = UnhookWindowsHookEx(hook);
-    if (!hookRemoved) {
-        g_taskbarCallbackCleanupFailed = true;
-        Wh_Log(L"UnhookWindowsHookEx failed for taskbar thread %u: %u",
-               threadId, GetLastError());
+    SendMessageW(window, message, 0, static_cast<LPARAM>(callbackToken));
+    DWORD unhookAttempts = 0;
+    while (true) {
+        if (UnhookWindowsHookEx(hook)) {
+            break;
+        }
+        DWORD unhookError = GetLastError();
+        if (unhookError == ERROR_INVALID_HOOK_HANDLE) {
+            Wh_Log(L"Taskbar thread hook was already removed for thread %u",
+                   threadId);
+            break;
+        }
+        unhookAttempts++;
+        if (unhookAttempts == 1 || unhookAttempts % 100 == 0) {
+            Wh_Log(L"UnhookWindowsHookEx failed for taskbar thread %u: %u; "
+                   L"retrying",
+                   threadId, unhookError);
+        }
+        Sleep(10);
     }
     {
         std::lock_guard lock(g_windowThreadCallbackRegistryMutex);
-        g_windowThreadCallbackRegistry.erase(callbackToken);
+        g_windowThreadCallbackRegistry->erase(callbackToken);
     }
     bool invoked =
         callbackContext->invoked.load(std::memory_order_acquire);
-    if (!messageCompleted || !invoked) {
-        Wh_Log(L"Taskbar thread dispatch timed out or failed for thread %u",
-               threadId);
+    if (!invoked) {
+        Wh_Log(L"Taskbar thread dispatch failed for thread %u", threadId);
     }
-    return invoked && hookRemoved;
+    return invoked;
 }
 
 bool IsTaskbarWindowClass(HWND window, bool* secondary = nullptr) {
@@ -5175,8 +5122,7 @@ void RemoveWidgetForMove(void* contextValue) {
     auto* context =
         reinterpret_cast<RemoveWidgetForMoveContext*>(contextValue);
     try {
-        RemoveWidget();
-        context->succeeded = true;
+        context->succeeded = RemoveWidget();
     } catch (...) {
         HRESULT error = winrt::to_hresult();
         Wh_Log(L"Removing widget before monitor switch failed: %08X",
@@ -5208,22 +5154,22 @@ void RemoveFromCurrentTaskbar(void* contextValue) {
                static_cast<unsigned>(error));
         succeeded = false;
     }
-    g_taskbarWindow = nullptr;
-    g_taskbarThreadId = 0;
-    g_lastFailedPlacementTarget = nullptr;
-    g_hasFailedPlacementTarget = false;
-    g_nextPlacementRetry = {};
-    g_placementFailures = 0;
-    g_placementIsFallback = false;
-    g_placementLocationUnknown = false;
-    g_unknownPlacementProbeFailures = 0;
-    g_unknownPlacementProbesSuspended = false;
-    g_lastDisplayTopologyFingerprint = 0;
-    g_hasDisplayTopologyFingerprint = false;
-    g_placementApplyPending = false;
-    g_resetUnknownPlacementProbesPending = false;
-    if (!succeeded) {
-        g_taskbarCallbackCleanupFailed = true;
+    if (succeeded) {
+        g_taskbarWindow = nullptr;
+        g_taskbarThreadId = 0;
+        g_lastFailedPlacementTarget = nullptr;
+        g_hasFailedPlacementTarget = false;
+        g_nextPlacementRetry = {};
+        g_placementFailures = 0;
+        g_placementIsFallback = false;
+        g_placementLocationUnknown = false;
+        g_unknownPlacementProbeFailures = 0;
+        g_unknownPlacementProbesSuspended = false;
+        g_lastDisplayTopologyFingerprint = 0;
+        g_hasDisplayTopologyFingerprint = false;
+        g_placementApplyPending = false;
+        g_resetUnknownPlacementProbesPending = false;
+        g_taskbarUiResourcesRegistered = false;
     }
     if (context) {
         context->succeeded = succeeded;
@@ -5475,7 +5421,7 @@ bool ApplyOnTaskbarThread(FrameworkElement fallbackFrame = nullptr,
                           bool refreshExistingWidget = true,
                           bool resetUnknownPlacementProbes = false,
                           HWND requestedWindow = nullptr) {
-    if (g_unloading || g_taskbarCallbackCleanupFailed) {
+    if (g_unloading) {
         return false;
     }
 
@@ -5533,7 +5479,7 @@ bool ApplyOnTaskbarThread(FrameworkElement fallbackFrame = nullptr,
 
 void StartPlacementRetryWorker() {
     std::lock_guard lock(g_placementRetryWorkerMutex);
-    if (g_unloading || g_taskbarCallbackCleanupFailed) {
+    if (g_unloading) {
         return;
     }
     if (g_placementRetryWorker && g_placementRetryWorker->joinable()) {
@@ -5567,7 +5513,6 @@ void StartPlacementRetryWorker() {
             bool slowBackoffLogged = false;
             while (true) {
                 if (g_stopPlacementRetryWorker || g_unloading ||
-                    g_taskbarCallbackCleanupFailed ||
                     !g_placementApplyPending) {
                     break;
                 }
@@ -5620,11 +5565,7 @@ void StopPlacementRetryWorker() {
         g_placementRetryWakeEvent = nullptr;
     }
     if (worker && worker->joinable()) {
-        if (worker->get_id() == std::this_thread::get_id()) {
-            worker->detach();
-        } else {
-            worker->join();
-        }
+        worker->join();
     }
     if (wakeEvent) {
         CloseHandle(wakeEvent);
@@ -5725,6 +5666,7 @@ TaskbarFrame_Constructor_t TaskbarFrame_Constructor_Original = nullptr;
 
 void* WINAPI TaskbarFrame_Constructor_Hook(void* pThis) {
     void* result = TaskbarFrame_Constructor_Original(pThis);
+    g_taskbarThreadId = GetCurrentThreadId();
     if (g_unloading || !g_loadedRevokers) {
         return result;
     }
@@ -5761,6 +5703,7 @@ void* WINAPI TaskbarFrame_Constructor_Hook(void* pThis) {
                                static_cast<unsigned>(error));
                     }
                 });
+            g_taskbarUiResourcesRegistered = true;
         } catch (...) {
             g_loadedRevokers->erase(revoker);
             throw;
@@ -5869,8 +5812,11 @@ void CloseMetricSources() {
 }
 
 bool TearDownTaskbarUi() {
-    if (g_taskbarCallbackCleanupFailed) {
-        return false;
+    if (!g_taskbarUiResourcesRegistered) {
+        g_loadedRevokers.reset();
+        g_taskbarWindow = nullptr;
+        g_taskbarThreadId = 0;
+        return true;
     }
     constexpr int kMaximumTeardownAttempts = 3;
     for (int attempt = 0; attempt < kMaximumTeardownAttempts; attempt++) {
@@ -5909,34 +5855,18 @@ bool TearDownTaskbarUi() {
     return false;
 }
 
-bool PinModuleAfterFailedTaskbarTeardown() {
-    if (g_modulePinnedAfterFailedTeardown) {
-        return true;
-    }
-    HMODULE module = nullptr;
-    if (!GetModuleHandleExW(
-            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
-                GET_MODULE_HANDLE_EX_FLAG_PIN,
-            reinterpret_cast<LPCWSTR>(&PinModuleAfterFailedTaskbarTeardown),
-            &module)) {
-        return false;
-    }
-    g_modulePinnedAfterFailedTeardown = true;
-    return true;
-}
-
 }  // namespace
 
 BOOL Wh_ModInit() {
     Wh_Log(L">");
-    if (g_modulePinnedAfterFailedTeardown) {
-        Wh_Log(L"The previous taskbar callbacks could not be revoked safely; "
-               L"restart Explorer before enabling the mod again");
-        return FALSE;
-    }
     g_unloading = false;
-    g_taskbarCallbackCleanupFailed = false;
+    g_taskbarUiResourcesRegistered = false;
     g_uiTornDown = false;
+    g_loadedRevokers.emplace();
+    {
+        std::lock_guard lock(g_windowThreadCallbackRegistryMutex);
+        g_windowThreadCallbackRegistry.emplace();
+    }
     if (HMODULE gdi32 = GetModuleHandleW(L"gdi32.dll")) {
         g_d3dkmtEnumAdapters2 = reinterpret_cast<D3DKMTEnumAdapters2_t>(
             GetProcAddress(gdi32, "D3DKMTEnumAdapters2"));
@@ -6021,15 +5951,12 @@ void Wh_ModUninit() {
         g_uiTornDown = TearDownTaskbarUi();
         if (!g_uiTornDown) {
             Wh_Log(L"Taskbar UI teardown retry failed");
-            if (PinModuleAfterFailedTaskbarTeardown()) {
-                Wh_Log(L"Keeping the mod image loaded because taskbar callbacks "
-                       L"could not be revoked safely");
-            } else {
-                Wh_Log(L"Keeping taskbar callbacks safe failed: %u",
-                       GetLastError());
-            }
         }
     }
     StopMetricsWorker();
     CloseMetricSources();
+    {
+        std::lock_guard lock(g_windowThreadCallbackRegistryMutex);
+        g_windowThreadCallbackRegistry.reset();
+    }
 }

--- a/mods/taskbar-system-info.wh.cpp
+++ b/mods/taskbar-system-info.wh.cpp
@@ -410,6 +410,7 @@ Released under GPL-3.0.
 
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Text.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
@@ -419,6 +420,7 @@ Released under GPL-3.0.
 using namespace winrt;
 using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::UI;
+using namespace winrt::Windows::UI::Core;
 using namespace winrt::Windows::UI::Xaml;
 using namespace winrt::Windows::UI::Xaml::Controls;
 using namespace winrt::Windows::UI::Xaml::Media;
@@ -532,6 +534,12 @@ event_token g_timerToken{};
 event_token g_actualThemeChangedToken{};
 std::chrono::steady_clock::time_point g_nextSystemColorCheck{};
 std::chrono::steady_clock::time_point g_nextTaskbarPlacementCheck{};
+[[clang::no_destroy]] IAsyncAction g_placementApplyAction{nullptr};
+bool g_placementApplyQueued = false;
+HWND g_lastFailedPlacementTarget = nullptr;
+std::chrono::steady_clock::time_point g_nextPlacementRetry{};
+uint32_t g_placementFailures = 0;
+int g_lastMonitorCount = -1;
 [[clang::no_destroy]]
 std::optional<std::list<FrameworkElement::Loaded_revoker>> g_loadedRevokers{
     std::in_place};
@@ -566,7 +574,7 @@ bool g_themeBrushesInitialized = false;
 bool g_cachedHighContrast = false;
 COLORREF g_cachedHighlightColor = CLR_INVALID;
 COLORREF g_cachedHotlightColor = CLR_INVALID;
-COLORREF g_cachedGrayTextColor = CLR_INVALID;
+COLORREF g_cachedWindowTextColor = CLR_INVALID;
 
 std::deque<double> g_cpuHistory;
 std::deque<double> g_gpuHistory;
@@ -2847,7 +2855,7 @@ bool SystemColorsChanged() {
            (highContrastEnabled &&
              (GetSysColor(COLOR_HIGHLIGHT) != g_cachedHighlightColor ||
               GetSysColor(COLOR_HOTLIGHT) != g_cachedHotlightColor ||
-              GetSysColor(COLOR_GRAYTEXT) != g_cachedGrayTextColor));
+              GetSysColor(COLOR_WINDOWTEXT) != g_cachedWindowTextColor));
 }
 
 Color ColorFromColorRef(COLORREF value) {
@@ -2885,13 +2893,13 @@ void RefreshThemeBrushes(const ModSettings& settings) {
         (highContrast.dwFlags & HCF_HIGHCONTRASTON) != 0;
     g_cachedHighlightColor = GetSysColor(COLOR_HIGHLIGHT);
     g_cachedHotlightColor = GetSysColor(COLOR_HOTLIGHT);
-    g_cachedGrayTextColor = GetSysColor(COLOR_GRAYTEXT);
+    g_cachedWindowTextColor = GetSysColor(COLOR_WINDOWTEXT);
     if (settings.adaptiveColors) {
         bool light = theme == ElementTheme::Light;
         g_textBrush = nullptr;
         if (g_cachedHighContrast) {
             g_graphBrush =
-                SolidColorBrush(ColorFromColorRef(g_cachedGrayTextColor));
+                SolidColorBrush(ColorFromColorRef(g_cachedWindowTextColor));
             g_warningBrush =
                 SolidColorBrush(ColorFromColorRef(g_cachedHotlightColor));
             g_criticalBrush =
@@ -3322,7 +3330,7 @@ void EnsureTimer() {
         try {
             bool force = false;
             auto now = std::chrono::steady_clock::now();
-            if (now >= g_nextSystemColorCheck) {
+            if (g_widget && now >= g_nextSystemColorCheck) {
                 g_nextSystemColorCheck = now + std::chrono::seconds(1);
                 if (SystemColorsChanged()) {
                     RefreshThemeBrushes(*CurrentSettings());
@@ -3476,7 +3484,24 @@ Grid CreateMemoryRow(PCWSTR label,
     return row;
 }
 
+void CancelPendingPlacementApply() {
+    g_placementApplyQueued = false;
+    if (!g_placementApplyAction) {
+        return;
+    }
+
+    try {
+        g_placementApplyAction.Cancel();
+    } catch (...) {
+        HRESULT error = winrt::to_hresult();
+        Wh_Log(L"Cancelling deferred taskbar placement failed: %08X",
+               static_cast<unsigned>(error));
+    }
+    g_placementApplyAction = nullptr;
+}
+
 void RemoveWidget() {
+    CancelPendingPlacementApply();
     if (g_timer) {
         g_timer.Stop();
         g_timer.Tick(g_timerToken);
@@ -3551,7 +3576,7 @@ void RemoveWidget() {
     g_cachedHighContrast = false;
     g_cachedHighlightColor = CLR_INVALID;
     g_cachedHotlightColor = CLR_INVALID;
-    g_cachedGrayTextColor = CLR_INVALID;
+    g_cachedWindowTextColor = CLR_INVALID;
     g_cpuHistory.clear();
     g_gpuHistory.clear();
     g_lastRenderedMetricsSequence = 0;
@@ -3596,7 +3621,12 @@ bool InjectWidget(FrameworkElement taskbarFrame) {
         children.RemoveAt(index);
     }
 
-    RemoveWidget();
+    // A retry-only timer can exist before the first successful injection. Keep
+    // it alive so an injection started by its Tick callback doesn't tear down
+    // and recreate the very timer that's currently dispatching the callback.
+    if (g_widget || g_rootGrid || g_taskItemsRepeater) {
+        RemoveWidget();
+    }
 
     Grid widget;
     widget.Name(kWidgetName);
@@ -4204,74 +4234,304 @@ void RemoveFromCurrentTaskbar(void*) {
     }
     g_taskbarWindow = nullptr;
     g_taskbarThreadId = 0;
+    g_lastFailedPlacementTarget = nullptr;
+    g_nextPlacementRetry = {};
+    g_placementFailures = 0;
+    g_lastMonitorCount = -1;
 }
 
-void ApplyOnTaskbarThread() {
-    HWND targetWindow = FindConfiguredTaskbarWindow();
-    if (!targetWindow) {
+void ResetPlacementRetryState() {
+    g_lastFailedPlacementTarget = nullptr;
+    g_nextPlacementRetry = {};
+    g_placementFailures = 0;
+}
+
+void RecordPlacementFailure(HWND targetWindow) {
+    if (targetWindow != g_lastFailedPlacementTarget) {
+        g_lastFailedPlacementTarget = targetWindow;
+        g_placementFailures = 0;
+    }
+
+    if (g_placementFailures < 7) {
+        g_placementFailures++;
+    }
+    uint32_t exponent = std::min(g_placementFailures - 1, 6u);
+    uint32_t retrySeconds = std::min(1u << exponent, 60u);
+    g_nextPlacementRetry =
+        std::chrono::steady_clock::now() + std::chrono::seconds(retrySeconds);
+    Wh_Log(L"Taskbar placement failed; retrying in %u seconds", retrySeconds);
+}
+
+bool ApplyExistingWidgetSettings(HWND logicalWindow,
+                                 bool placementSucceeded = true) {
+    if (!g_widget) {
+        return false;
+    }
+
+    ApplyWidgetSettings();
+    if (!StartMetricsWorker()) {
+        Wh_Log(L"Metrics worker unavailable");
+    }
+    EnsureTimer();
+    UpdateWidgetText(true);
+    if (placementSucceeded) {
+        if (IsCurrentProcessTaskbarWindow(logicalWindow)) {
+            RememberTaskbarWindow(logicalWindow);
+        }
+        ResetPlacementRetryState();
+    }
+    return true;
+}
+
+bool ApplyLoadedFrameFallback(FrameworkElement fallbackFrame,
+                              HWND logicalWindow) {
+    if (!fallbackFrame) {
+        return false;
+    }
+
+    Wh_Log(L"Taskbar XAML lookup unavailable; using the loaded frame directly");
+    if (!InjectWidget(fallbackFrame)) {
+        return false;
+    }
+
+    // The loaded frame is authoritative even when the private symbol path
+    // can't map it back to a specific HWND. Remember the requested/fallback
+    // window as the logical placement so the 1 Hz watchdog doesn't remove a
+    // working degraded injection on its next pass.
+    if (IsCurrentProcessTaskbarWindow(logicalWindow)) {
+        RememberTaskbarWindow(logicalWindow);
+    } else {
+        g_taskbarWindow = nullptr;
+        g_taskbarThreadId = GetCurrentThreadId();
+    }
+    ResetPlacementRetryState();
+    return true;
+}
+
+struct ApplyOnTaskbarThreadContext {
+    FrameworkElement fallbackFrame{nullptr};
+    bool succeeded = false;
+};
+
+void ApplyOnTaskbarUiThreadImpl(void* contextValue) {
+    auto* context =
+        reinterpret_cast<ApplyOnTaskbarThreadContext*>(contextValue);
+    if (g_unloading) {
+        return;
+    }
+
+    CancelPendingPlacementApply();
+
+    // Keep a retry timer even before the first successful injection. All state
+    // below is intentionally owned by Explorer's taskbar/XAML UI thread.
+    EnsureTimer();
+
+    HWND requestedWindow = FindConfiguredTaskbarWindow();
+    if (!requestedWindow) {
         Wh_Log(L"Taskbar window not found");
+        RecordPlacementFailure(nullptr);
         return;
     }
 
     HWND currentWindow = FindRememberedTaskbarWindow();
-    if (currentWindow != targetWindow && !IsTaskbarReady(targetWindow)) {
+    if (currentWindow == requestedWindow &&
+        ApplyExistingWidgetSettings(requestedWindow)) {
+        context->succeeded = true;
+        return;
+    }
+
+    HWND targetWindow = requestedWindow;
+    bool targetReady = IsTaskbarReady(targetWindow);
+    if (!targetReady) {
         HWND primaryWindow = FindPrimaryTaskbarWindow();
-        if (!primaryWindow) {
-            Wh_Log(L"Selected taskbar is not ready and no fallback exists");
+        if (primaryWindow && primaryWindow != targetWindow &&
+            IsTaskbarReady(primaryWindow)) {
+            Wh_Log(L"Selected taskbar is not ready; using the primary taskbar");
+            targetWindow = primaryWindow;
+            targetReady = true;
+        }
+    }
+
+    if (!targetReady) {
+        Wh_Log(L"No taskbar exposes a ready XAML root");
+        if (ApplyLoadedFrameFallback(context->fallbackFrame, targetWindow)) {
+            context->succeeded = true;
             return;
         }
-        if (targetWindow != primaryWindow) {
-            Wh_Log(L"Selected taskbar is not ready; using the primary taskbar");
+        if (ApplyExistingWidgetSettings(currentWindow, false)) {
+            Wh_Log(L"Keeping the existing widget until taskbar placement recovers");
         }
-        targetWindow = primaryWindow;
+        RecordPlacementFailure(requestedWindow);
+        return;
+    }
+
+    if (currentWindow == targetWindow &&
+        ApplyExistingWidgetSettings(targetWindow)) {
+        context->succeeded = true;
+        return;
     }
 
     HWND removalWindow = currentWindow;
-    if (!removalWindow && g_taskbarThreadId.load()) {
-        removalWindow = FindAnyWindowOnTaskbarThread(nullptr);
+    if (!removalWindow && g_widget && g_taskbarThreadId.load()) {
+        removalWindow = FindAnyWindowOnTaskbarThread(targetWindow);
     }
     bool widgetRemovedForMove = false;
-    if (removalWindow && currentWindow != targetWindow) {
+    if (removalWindow && g_widget && currentWindow != targetWindow) {
         RemoveWidgetForMoveContext removeContext;
         if (!RunFromWindowThread(removalWindow, RemoveWidgetForMove,
                                  &removeContext) ||
             !removeContext.succeeded) {
             Wh_Log(L"Removing widget from the previous monitor failed");
+            RecordPlacementFailure(requestedWindow);
             return;
         }
         widgetRemovedForMove = true;
     }
 
-    if (!ApplyWidgetToTaskbarWindow(targetWindow)) {
-        Wh_Log(L"Applying widget on taskbar thread failed");
-        if (widgetRemovedForMove &&
-            IsCurrentProcessTaskbarWindow(currentWindow)) {
-            Wh_Log(L"Restoring widget on the previous taskbar");
-            if (!ApplyWidgetToTaskbarWindow(currentWindow)) {
-                Wh_Log(L"Restoring widget on the previous taskbar failed");
-            }
+    if (ApplyWidgetToTaskbarWindow(targetWindow)) {
+        ResetPlacementRetryState();
+        context->succeeded = true;
+        return;
+    }
+
+    Wh_Log(L"Applying widget on taskbar thread failed");
+    if (ApplyLoadedFrameFallback(context->fallbackFrame, targetWindow)) {
+        context->succeeded = true;
+        return;
+    }
+
+    if (widgetRemovedForMove &&
+        IsCurrentProcessTaskbarWindow(currentWindow)) {
+        Wh_Log(L"Restoring widget on the previous taskbar");
+        if (!ApplyWidgetToTaskbarWindow(currentWindow)) {
+            Wh_Log(L"Restoring widget on the previous taskbar failed");
         }
+    }
+    RecordPlacementFailure(requestedWindow);
+}
+
+void ApplyOnTaskbarUiThread(void* contextValue) {
+    try {
+        ApplyOnTaskbarUiThreadImpl(contextValue);
+    } catch (...) {
+        HRESULT error = winrt::to_hresult();
+        Wh_Log(L"Taskbar placement update failed: %08X",
+               static_cast<unsigned>(error));
+        RecordPlacementFailure(nullptr);
+    }
+}
+
+void ApplyOnTaskbarThread(FrameworkElement fallbackFrame = nullptr) {
+    if (g_unloading) {
+        return;
+    }
+
+    // Choose only a marshaling vehicle here. Monitor selection, widget state
+    // inspection and every mutation are serialized in ApplyOnTaskbarUiThread.
+    HWND dispatchWindow = FindPrimaryTaskbarWindow();
+    if (!dispatchWindow) {
+        HWND rememberedWindow = g_taskbarWindow.load();
+        if (IsCurrentProcessTaskbarWindow(rememberedWindow)) {
+            dispatchWindow = rememberedWindow;
+        } else {
+            dispatchWindow = FindAnyWindowOnTaskbarThread(nullptr);
+        }
+    }
+    if (!dispatchWindow) {
+        Wh_Log(L"Taskbar UI thread is unavailable");
+        return;
+    }
+
+    ApplyOnTaskbarThreadContext context{fallbackFrame, false};
+    if (!RunFromWindowThread(dispatchWindow, ApplyOnTaskbarUiThread, &context)) {
+        Wh_Log(L"Dispatching taskbar placement failed");
+    }
+}
+
+void QueueConfiguredTaskbarPlacement() {
+    if (g_unloading || g_placementApplyQueued) {
+        return;
+    }
+
+    if (!g_widget) {
+        // The retry-only timer survives InjectWidget, so this path doesn't
+        // destroy the DispatcherTimer from inside its own Tick callback.
+        ApplyOnTaskbarThread();
+        return;
+    }
+
+    try {
+        CoreDispatcher dispatcher = g_widget.Dispatcher();
+        if (!dispatcher) {
+            RecordPlacementFailure(FindConfiguredTaskbarWindow(false));
+            return;
+        }
+
+        g_placementApplyQueued = true;
+        g_placementApplyAction = dispatcher.RunAsync(
+            CoreDispatcherPriority::Low, [] {
+                bool shouldApply = g_placementApplyQueued;
+                g_placementApplyQueued = false;
+                g_placementApplyAction = nullptr;
+                if (shouldApply && !g_unloading) {
+                    ApplyOnTaskbarThread();
+                }
+            });
+    } catch (...) {
+        HRESULT error = winrt::to_hresult();
+        g_placementApplyQueued = false;
+        g_placementApplyAction = nullptr;
+        Wh_Log(L"Deferring taskbar placement failed: %08X",
+               static_cast<unsigned>(error));
+        RecordPlacementFailure(FindConfiguredTaskbarWindow(false));
     }
 }
 
 void EnsureConfiguredTaskbarPlacement() {
-    if (!g_widget || g_unloading) {
+    if (g_unloading) {
         return;
     }
-    HWND targetWindow = FindConfiguredTaskbarWindow(false);
+
+    int monitorCount = GetSystemMetrics(SM_CMONITORS);
+    bool topologyChanged = monitorCount != g_lastMonitorCount;
+    if (topologyChanged) {
+        g_lastMonitorCount = monitorCount;
+        ResetPlacementRetryState();
+    }
+
     HWND rememberedWindow = g_taskbarWindow.load();
-    if (!targetWindow ||
-        (IsCurrentProcessTaskbarWindow(rememberedWindow) &&
-         rememberedWindow == targetWindow)) {
+    if (!topologyChanged && g_placementFailures == 0 && g_widget &&
+        IsCurrentProcessTaskbarWindow(rememberedWindow)) {
+        return;
+    }
+
+    auto now = std::chrono::steady_clock::now();
+    if (!topologyChanged && g_placementFailures != 0 &&
+        now < g_nextPlacementRetry) {
+        return;
+    }
+
+    HWND targetWindow = FindConfiguredTaskbarWindow(false);
+    if (!targetWindow) {
+        RecordPlacementFailure(nullptr);
+        return;
+    }
+    if (g_widget && IsCurrentProcessTaskbarWindow(rememberedWindow) &&
+        rememberedWindow == targetWindow) {
+        ResetPlacementRetryState();
         return;
     }
 
     Wh_Log(L"Taskbar topology changed; moving the widget");
-    ApplyOnTaskbarThread();
+    QueueConfiguredTaskbarPlacement();
 }
 
 void ApplyLoadedTaskbarFrame(FrameworkElement taskbarFrame) {
-    if (!taskbarFrame || g_unloading) {
+    if (g_unloading) {
+        return;
+    }
+    if (!taskbarFrame) {
+        ApplyOnTaskbarThread();
         return;
     }
 
@@ -4292,9 +4552,10 @@ void ApplyLoadedTaskbarFrame(FrameworkElement taskbarFrame) {
 
     if (directWindow && InjectWidget(taskbarFrame)) {
         RememberTaskbarWindow(directWindow);
+        ResetPlacementRetryState();
         return;
     }
-    ApplyOnTaskbarThread();
+    ApplyOnTaskbarThread(taskbarFrame);
 }
 
 using TaskbarFrame_Constructor_t = void*(WINAPI*)(void* pThis);

--- a/mods/taskbar-system-info.wh.cpp
+++ b/mods/taskbar-system-info.wh.cpp
@@ -4,7 +4,7 @@
 // @name:uk-UA      Системний монітор панелі завдань
 // @description     A quiet two-column CPU, GPU, RAM and VRAM monitor with 60-second history graphs for the Windows 11 taskbar.
 // @description:uk-UA Компактний монітор CPU, GPU, RAM і VRAM із 60-секундними графіками для панелі завдань Windows 11.
-// @version         1.3.3
+// @version         1.4.0
 // @author          Yevhenii Starychenko
 // @github          https://github.com/starychenko
 // @homepage        https://github.com/starychenko/windhawk-taskbar-system-info
@@ -20,7 +20,34 @@
 // Native GPU temperature collection via D3DKMT follows Taskbar Clock
 // Customization by Michael Maltsev (m417z):
 // https://github.com/m417z/my-windhawk-mods/commit/861920df6380f4c13abec5d9226362c4725e8362
-// Both projects are distributed under the GNU General Public License v3.0.
+// Secondary-taskbar discovery is adapted from Taskbar Fluent Media Player by
+// Salyts:
+// https://github.com/Salyts/Taskbar-Fluent-Media-Player
+// The first two projects are GPL-3.0; Taskbar Fluent Media Player is MIT.
+
+/*
+Taskbar Fluent Media Player MIT notice:
+
+Copyright (c) 2026 Salyts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
 
 // ==WindhawkModReadme==
 /*
@@ -43,7 +70,12 @@ GPU   4%  56°C  [60-second graph]    VRAM   9%   2.1/24G
 CPU and GPU history uses a fixed 0-100% scale. RAM and VRAM use thin capacity
 bars. Fixed-width fields prevent the layout from shifting as values change.
 Normal values remain monochrome; only warning and critical readings receive
-color. Network and disk activity are intentionally not collected.
+color. Adaptive colors are enabled by default: normal text follows the native
+taskbar foreground, while graphs and alerts switch between contrast-checked
+light and dark palettes as the taskbar theme changes. Windows high-contrast mode
+uses its system highlight colors. Disable the adaptive option to use the manual
+color settings exactly. Network and disk activity are intentionally not
+collected.
 
 Unlike the performance placeholders in
 [Taskbar Clock Customization](https://github.com/ramensoftware/windhawk-mods/blob/main/mods/taskbar-clock-customization.wh.cpp),
@@ -52,27 +84,35 @@ stable 2x2 dashboard with rolling graphs, capacity bars and temperature alerts.
 
 ## Metrics
 
-- CPU utilization from Windows system time counters.
+- CPU utilization from the Windows Processor Utility counter, matching the
+  frequency-aware value used by Task Manager when available. Windows system
+  time counters remain the compatibility fallback.
 - RAM usage and capacity from Windows memory status.
 - GPU utilization and dedicated or shared GPU-memory usage from Windows PDH
   counters.
 - GPU-memory capacity and adapter identity from live D3DKMT enumeration, with
-  DXGI as a compatibility fallback. Shared system memory is used when an
-  integrated adapter reports no dedicated video memory.
+  DXGI as a compatibility fallback. Automatic mode uses shared GPU memory for
+  integrated adapters, including common small dedicated carve-outs, and
+  dedicated VRAM for discrete adapters. The memory type can also be forced.
 - CPU and GPU temperatures from HWiNFO when available.
 - GPU fallback from the Windows display-driver interface (D3DKMT).
 - CPU fallback from Windows ACPI thermal zones exposed through PDH.
 
 Metric collection runs on a worker thread. The taskbar UI thread only renders
-the latest completed snapshot. If a display-driver restart changes an adapter
-LUID or invalidates the active performance counters, the mod refreshes the live
-adapter list and rebuilds the counters automatically. A missing VRAM instance
-alone does not trigger recovery unless fresh enumeration confirms a LUID change.
+completed snapshots and catches up with every sample that arrived while the UI
+was busy. If a display-driver restart changes an adapter LUID or invalidates the
+active performance counters, the mod refreshes the live adapter list and
+rebuilds the counters automatically. This also covers successful but empty VRAM
+results and uses exponential backoff while a parked GPU stays idle.
 
 The adapter with the most dedicated VRAM is selected automatically. A partial
 adapter-name filter is available for multi-GPU systems. GPU usage and VRAM are
 matched to the selected live adapter by LUID. Duplicate stale adapters without
 a driver name are ignored when a named adapter with the same capacity exists.
+For an integrated GPU, the displayed capacity is the Windows shared-memory
+limit rather than a physically reserved memory pool, so its percentage has
+different semantics from a discrete GPU's dedicated VRAM. Small and fractional
+capacity totals retain one decimal place.
 
 ## Temperature providers
 
@@ -104,13 +144,21 @@ interface. Configure it under **Sensor Settings > HWiNFO Gadget** by enabling
 selected source is unavailable, temperatures are shown as `--°C`; all other
 metrics continue to work. The active provider is written to the Windhawk log
 only when it changes, which makes fallback behavior diagnosable without adding
-noise every second.
+noise every second. Automatic HWiNFO GPU sensor selection is also matched to the
+selected Windows adapter, so a multi-GPU system doesn't show another card's
+temperature.
 
 ## Compatibility and placement
 
-- Windows 11 64-bit, primary taskbar. x64 is hardware-tested; ARM64 is
-  compilation-tested.
+- Windows 11 64-bit. The widget can be placed on the primary or a secondary
+  taskbar. x64 is hardware-tested; ARM64 is compilation-tested.
+- Monitor 1 is always the primary display. Other monitors are ordered by their
+  position in the virtual desktop and can differ from the numbers in Windows
+  Display Settings. An unavailable selection falls back to the primary taskbar.
 - Centered taskbar icons are recommended.
+- The widget uses the far-left taskbar area. Windows Widgets/weather or another
+  left-side taskbar extension can occupy the same space; adjust the offset or
+  disable the conflicting element if they overlap.
 - Enable **Reserve space before the Start button** if the widget overlaps
   left-aligned taskbar buttons.
 - The widget is native XAML inside the taskbar and can coexist with Taskbar
@@ -122,6 +170,9 @@ Taskbar discovery and window-thread marshaling follow techniques from
 [Multirow taskbar for Windows 11](https://github.com/ramensoftware/windhawk-mods/blob/main/mods/taskbar-multirow.wh.cpp)
 by Michael Maltsev (`m417z`). Native GPU temperature collection follows his
 [Taskbar Clock Customization implementation](https://github.com/m417z/my-windhawk-mods/commit/861920df6380f4c13abec5d9226362c4725e8362).
+Secondary-taskbar discovery is adapted from
+[Taskbar Fluent Media Player](https://github.com/Salyts/Taskbar-Fluent-Media-Player)
+by Salyts.
 Released under GPL-3.0.
 */
 // ==/WindhawkModReadme==
@@ -137,6 +188,14 @@ Released under GPL-3.0.
 - leftOffset: 10
   $name: Left offset
   $name:uk-UA: Відступ зліва
+  $description: "Distance from the left taskbar edge, from 0 to 1000 pixels."
+  $description:uk-UA: "Відстань від лівого краю панелі, від 0 до 1000 пікселів."
+
+- monitor: 1
+  $name: Taskbar monitor
+  $name:uk-UA: Монітор панелі завдань
+  $description: "Allowed range: 1-32. Monitor 1 is the primary display. Other monitors are ordered by their position in the virtual desktop and can differ from Windows Display Settings. An unavailable selection falls back to the primary taskbar."
+  $description:uk-UA: "Діапазон: 1-32. Монітор 1 - основний. Інші впорядковані за розташуванням у віртуальному робочому столі, тому номери можуть відрізнятися від параметрів дисплея Windows. Якщо вибраний монітор недоступний, використовується основна панель."
 
 - reserveSpace: false
   $name: Reserve space before the Start button
@@ -147,6 +206,8 @@ Released under GPL-3.0.
 - reserveGap: 8
   $name: Reserved space gap
   $name:uk-UA: Проміжок після блока
+  $description: "Additional gap after the reserved widget area, from 0 to 100 pixels."
+  $description:uk-UA: "Додатковий проміжок після зарезервованої області, від 0 до 100 пікселів."
 
 - updateInterval: 1
   $name: Update interval
@@ -173,22 +234,32 @@ Released under GPL-3.0.
 - textColor: ""
   $name: Text color
   $name:uk-UA: Колір тексту
-  $description: "#RRGGBB or #AARRGGBB. Leave empty to use the system color."
-  $description:uk-UA: "#RRGGBB або #AARRGGBB. Порожнє значення використовує системний колір."
+  $description: "#RRGGBB or #AARRGGBB. Leave empty to use the system color. Used when adaptive colors are disabled."
+  $description:uk-UA: "#RRGGBB або #AARRGGBB. Порожнє значення використовує системний колір. Застосовується, коли адаптивні кольори вимкнені."
+
+- adaptiveColors: true
+  $name: Adapt colors to the taskbar theme
+  $name:uk-UA: Адаптувати кольори до теми панелі
+  $description: "Automatically uses contrasting light, dark or Windows high-contrast colors for text, graphs and alerts. Disable to use the manual colors below exactly."
+  $description:uk-UA: "Автоматично добирає контрастні кольори тексту, графіків і попереджень для світлої, темної або висококонтрастної теми Windows. Вимкніть, щоб точно використовувати ручні кольори нижче."
 
 - graphColor: "#78A8FF"
   $name: Graph and bar color
   $name:uk-UA: Колір графіків і смуг
-  $description: "Accent color for CPU/GPU history and memory capacity bars."
-  $description:uk-UA: "Стриманий акцент для історії CPU/GPU та смуг памяті."
+  $description: "#RRGGBB or #AARRGGBB accent for CPU/GPU history and memory capacity bars. Used when adaptive colors are disabled. Invalid values use the default color."
+  $description:uk-UA: "Акцент #RRGGBB або #AARRGGBB для історії CPU/GPU та смуг памяті. Застосовується, коли адаптивні кольори вимкнені. Для некоректного значення використовується стандартний колір."
 
 - warningColor: "#FFFFB900"
   $name: Warning color
   $name:uk-UA: Колір попередження
+  $description: "#RRGGBB or #AARRGGBB. Used when adaptive colors are disabled. Invalid values use the default color."
+  $description:uk-UA: "#RRGGBB або #AARRGGBB. Застосовується, коли адаптивні кольори вимкнені. Для некоректного значення використовується стандартний колір."
 
 - criticalColor: "#FFFF6B6B"
   $name: Critical color
   $name:uk-UA: Критичний колір
+  $description: "#RRGGBB or #AARRGGBB. Used when adaptive colors are disabled. Invalid values use the default color."
+  $description:uk-UA: "#RRGGBB або #AARRGGBB. Застосовується, коли адаптивні кольори вимкнені. Для некоректного значення використовується стандартний колір."
 
 - textOpacity: 96
   $name: Text opacity
@@ -199,32 +270,58 @@ Released under GPL-3.0.
 - cpuWarningTemp: 75
   $name: CPU temperature warning
   $name:uk-UA: Попередження температури CPU
+  $description: "From 40 to 95 degrees Celsius."
+  $description:uk-UA: "Від 40 до 95 градусів Цельсія."
 
 - cpuCriticalTemp: 85
   $name: CPU critical temperature
   $name:uk-UA: Критична температура CPU
+  $description: "From one degree above the warning threshold to 105 degrees Celsius."
+  $description:uk-UA: "Від одного градуса вище порога попередження до 105 градусів Цельсія."
 
 - gpuWarningTemp: 80
   $name: GPU temperature warning
   $name:uk-UA: Попередження температури GPU
+  $description: "From 40 to 105 degrees Celsius."
+  $description:uk-UA: "Від 40 до 105 градусів Цельсія."
 
 - gpuCriticalTemp: 90
   $name: GPU critical temperature
   $name:uk-UA: Критична температура GPU
+  $description: "From one degree above the warning threshold to 115 degrees Celsius."
+  $description:uk-UA: "Від одного градуса вище порога попередження до 115 градусів Цельсія."
 
 - memoryWarningPercent: 80
   $name: Memory usage warning
   $name:uk-UA: Попередження заповнення памяті
+  $description: "From 50 to 98 percent."
+  $description:uk-UA: "Від 50 до 98 відсотків."
 
 - memoryCriticalPercent: 90
   $name: Critical memory usage
   $name:uk-UA: Критичне заповнення памяті
+  $description: "From one percent above the warning threshold to 100 percent."
+  $description:uk-UA: "Від одного відсотка вище порога попередження до 100 відсотків."
 
 - gpuAdapter: ""
   $name: GPU adapter filter
   $name:uk-UA: Відеокарта
   $description: "Optional partial adapter name. Empty selects the adapter with the most dedicated VRAM."
   $description:uk-UA: "Необовязкова частина назви. Порожнє значення вибирає адаптер з найбільшим обсягом VRAM."
+
+- gpuMemoryMode: auto
+  $name: GPU memory type
+  $name:uk-UA: Тип пам'яті GPU
+  $description: "Automatic uses shared GPU memory for an integrated adapter and dedicated VRAM for a discrete adapter. The explicit modes override automatic detection."
+  $description:uk-UA: "Автоматичний режим використовує спільну GPU-пам'ять для інтегрованого адаптера і виділену VRAM для дискретного. Явний режим перевизначає автоматичне визначення."
+  $options:
+  - auto: Automatic
+  - dedicated: Dedicated VRAM
+  - shared: Shared GPU memory
+  $options:uk-UA:
+  - auto: Автоматично
+  - dedicated: Виділена VRAM
+  - shared: Спільна GPU-пам'ять
 
 - temperatureSource: auto
   $name: Temperature source
@@ -297,9 +394,11 @@ Released under GPL-3.0.
 #include <deque>
 #include <iterator>
 #include <list>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -338,6 +437,13 @@ constexpr double kGraphLeftGap = 8.0;
 constexpr double kMemoryLabelWidth = 43.0;
 constexpr double kMemoryPercentWidth = 38.0;
 constexpr double kGraphHeight = 12.0;
+constexpr double kGiB = 1024.0 * 1024.0 * 1024.0;
+constexpr wchar_t kDefaultGraphColor[] = L"#78A8FF";
+constexpr wchar_t kDefaultWarningColor[] = L"#FFFFB900";
+constexpr wchar_t kDefaultCriticalColor[] = L"#FFFF6B6B";
+constexpr wchar_t kLightGraphColor[] = L"#FF005FB8";
+constexpr wchar_t kLightWarningColor[] = L"#FF8A4B00";
+constexpr wchar_t kLightCriticalColor[] = L"#FFC42B1C";
 constexpr uint32_t kHwInfoSignature = 0x53695748;  // "HWiS"
 constexpr uint32_t kHwInfoTemperatureType = 1;
 
@@ -353,6 +459,12 @@ enum class TemperatureSource {
 enum class ThermalZoneAggregation {
     Average,
     Hottest,
+};
+
+enum class GpuMemoryMode {
+    Auto,
+    Dedicated,
+    Shared,
 };
 
 enum class TemperatureProvider {
@@ -376,8 +488,11 @@ struct ModSettings {
     TemperatureSource temperatureSource = TemperatureSource::Auto;
     ThermalZoneAggregation windowsThermalZoneAggregation =
         ThermalZoneAggregation::Average;
+    GpuMemoryMode gpuMemoryMode = GpuMemoryMode::Auto;
     int width = 410;
     int leftOffset = 10;
+    int monitor = 1;
+    bool adaptiveColors = true;
     bool reserveSpace = false;
     int reserveGap = 8;
     int updateInterval = 1;
@@ -392,11 +507,13 @@ struct ModSettings {
     int memoryCriticalPercent = 90;
 };
 
-ModSettings g_settings;
+[[clang::no_destroy]] std::shared_ptr<const ModSettings> g_settings{
+    std::make_shared<ModSettings>()};
 std::mutex g_settingsMutex;
 std::atomic<bool> g_unloading;
 std::atomic<bool> g_uiTornDown;
 std::atomic<bool> g_taskbarViewDllLoaded;
+std::atomic<uint32_t> g_taskbarViewHookAttempts;
 std::atomic<HWND> g_taskbarWindow{nullptr};
 std::atomic<DWORD> g_taskbarThreadId{0};
 
@@ -404,6 +521,7 @@ std::atomic<DWORD> g_taskbarThreadId{0};
 [[clang::no_destroy]] Grid g_rootGrid{nullptr};
 [[clang::no_destroy]] FrameworkElement g_taskItemsRepeater{nullptr};
 double g_reservedMargin = 0.0;
+std::optional<double> g_lastAppliedRepeaterMarginLeft;
 double g_graphWidth = 96.0;
 double g_memoryBarWidth = 120.0;
 [[clang::no_destroy]] DispatcherTimer g_timer{nullptr};
@@ -433,6 +551,15 @@ std::optional<std::list<FrameworkElement::Loaded_revoker>> g_loadedRevokers{
 [[clang::no_destroy]] ColumnDefinition g_leftColumn{nullptr};
 [[clang::no_destroy]] ColumnDefinition g_gapColumn{nullptr};
 [[clang::no_destroy]] ColumnDefinition g_rightColumn{nullptr};
+[[clang::no_destroy]] SolidColorBrush g_textBrush{nullptr};
+[[clang::no_destroy]] SolidColorBrush g_graphBrush{nullptr};
+[[clang::no_destroy]] SolidColorBrush g_warningBrush{nullptr};
+[[clang::no_destroy]] SolidColorBrush g_criticalBrush{nullptr};
+ElementTheme g_cachedWidgetTheme = ElementTheme::Default;
+bool g_themeBrushesInitialized = false;
+bool g_cachedHighContrast = false;
+COLORREF g_cachedHighlightColor = CLR_INVALID;
+COLORREF g_cachedHotlightColor = CLR_INVALID;
 
 std::deque<double> g_cpuHistory;
 std::deque<double> g_gpuHistory;
@@ -440,6 +567,7 @@ int g_historyInterval = 0;
 int g_historyWindow = 0;
 
 PDH_HQUERY g_pdhQuery = nullptr;
+PDH_HCOUNTER g_cpuUtilityCounter = nullptr;
 PDH_HCOUNTER g_gpuCounter = nullptr;
 PDH_HCOUNTER g_vramCounter = nullptr;
 PDH_HCOUNTER g_sharedVramCounter = nullptr;
@@ -448,12 +576,15 @@ std::chrono::steady_clock::time_point g_nextPdhCounterRetry{};
 std::chrono::steady_clock::time_point g_nextPdhRecovery{};
 std::chrono::steady_clock::time_point g_nextGpuIdentityCheck{};
 uint32_t g_consecutivePdhReadFailures = 0;
+bool g_hwInfoInvalidUnitLogged = false;
 
 struct MetricsSnapshot {
     double cpu = 0.0;
+    bool cpuAvailable = false;
     double ram = 0.0;
     double ramUsedGb = 0.0;
     double ramTotalGb = 0.0;
+    bool ramAvailable = false;
     double gpu = 0.0;
     bool gpuAvailable = false;
     double vram = 0.0;
@@ -467,10 +598,14 @@ struct MetricsSnapshot {
 };
 
 std::mutex g_metricsMutex;
-MetricsSnapshot g_latestMetrics;
+struct PublishedMetricsSnapshot {
+    uint64_t sequence = 0;
+    MetricsSnapshot snapshot;
+};
+std::deque<PublishedMetricsSnapshot> g_publishedMetrics;
 uint64_t g_latestMetricsSequence = 0;
-bool g_latestMetricsAvailable = false;
 uint64_t g_lastRenderedMetricsSequence = 0;
+constexpr size_t kMaximumPublishedMetrics = 256;
 
 std::mutex g_metricsWorkerMutex;
 std::atomic<bool> g_stopMetricsWorker{false};
@@ -480,6 +615,8 @@ HANDLE g_metricsWorkerWakeEvent = nullptr;
 std::wstring GetStringSetting(PCWSTR name) {
     return WindhawkUtils::StringSetting::make(name).get();
 }
+
+std::optional<Color> ParseColor(const std::wstring& value);
 
 TemperatureSource ParseTemperatureSource(const std::wstring& value) {
     if (value == L"hwinfoAuto") {
@@ -491,7 +628,7 @@ TemperatureSource ParseTemperatureSource(const std::wstring& value) {
     if (value == L"gadgetRegistry") {
         return TemperatureSource::GadgetRegistry;
     }
-    if (value == L"windowsNative" || value == L"windowsThermalZones") {
+    if (value == L"windowsNative") {
         return TemperatureSource::WindowsNative;
     }
     if (value == L"disabled") {
@@ -506,6 +643,16 @@ ThermalZoneAggregation ParseThermalZoneAggregation(
                                 : ThermalZoneAggregation::Average;
 }
 
+GpuMemoryMode ParseGpuMemoryMode(const std::wstring& value) {
+    if (value == L"dedicated") {
+        return GpuMemoryMode::Dedicated;
+    }
+    if (value == L"shared") {
+        return GpuMemoryMode::Shared;
+    }
+    return GpuMemoryMode::Auto;
+}
+
 void LoadSettings() {
     ModSettings settings;
     settings.fontFamily = GetStringSetting(L"fontFamily");
@@ -514,6 +661,8 @@ void LoadSettings() {
     settings.warningColor = GetStringSetting(L"warningColor");
     settings.criticalColor = GetStringSetting(L"criticalColor");
     settings.gpuAdapter = GetStringSetting(L"gpuAdapter");
+    settings.gpuMemoryMode =
+        ParseGpuMemoryMode(GetStringSetting(L"gpuMemoryMode"));
     settings.temperatureSource =
         ParseTemperatureSource(GetStringSetting(L"temperatureSource"));
     settings.cpuTempSensor = GetStringSetting(L"cpuTempSensor");
@@ -524,6 +673,8 @@ void LoadSettings() {
         GetStringSetting(L"windowsThermalZoneAggregation"));
     settings.width = std::clamp(Wh_GetIntSetting(L"width"), 330, 800);
     settings.leftOffset = std::clamp(Wh_GetIntSetting(L"leftOffset"), 0, 1000);
+    settings.monitor = std::clamp(Wh_GetIntSetting(L"monitor"), 1, 32);
+    settings.adaptiveColors = Wh_GetIntSetting(L"adaptiveColors") != 0;
     settings.reserveSpace = Wh_GetIntSetting(L"reserveSpace") != 0;
     settings.reserveGap = std::clamp(Wh_GetIntSetting(L"reserveGap"), 0, 100);
     settings.updateInterval =
@@ -550,21 +701,28 @@ void LoadSettings() {
     if (settings.fontFamily.empty()) {
         settings.fontFamily = L"Segoe UI Variable Text";
     }
-    if (settings.graphColor.empty()) {
-        settings.graphColor = L"#78A8FF";
+    if (!settings.textColor.empty() && !ParseColor(settings.textColor)) {
+        Wh_Log(L"Invalid text color; using the system color");
+        settings.textColor.clear();
     }
-    if (settings.warningColor.empty()) {
-        settings.warningColor = L"#FFFFB900";
+    if (!ParseColor(settings.graphColor)) {
+        Wh_Log(L"Invalid graph color; using the default");
+        settings.graphColor = kDefaultGraphColor;
     }
-    if (settings.criticalColor.empty()) {
-        settings.criticalColor = L"#FFFF6B6B";
+    if (!ParseColor(settings.warningColor)) {
+        Wh_Log(L"Invalid warning color; using the default");
+        settings.warningColor = kDefaultWarningColor;
+    }
+    if (!ParseColor(settings.criticalColor)) {
+        Wh_Log(L"Invalid critical color; using the default");
+        settings.criticalColor = kDefaultCriticalColor;
     }
 
     std::lock_guard lock(g_settingsMutex);
-    g_settings = std::move(settings);
+    g_settings = std::make_shared<ModSettings>(std::move(settings));
 }
 
-ModSettings CurrentSettings() {
+std::shared_ptr<const ModSettings> CurrentSettings() {
     std::lock_guard lock(g_settingsMutex);
     return g_settings;
 }
@@ -579,6 +737,9 @@ std::wstring ToLower(std::wstring value) {
 bool Contains(const std::wstring& text, const std::wstring& needle) {
     return needle.empty() || text.find(needle) != std::wstring::npos;
 }
+
+std::optional<std::wstring> ResolveGpuTemperatureAdapterName(
+    const ModSettings& settings);
 
 std::wstring FixedAnsiToWide(const char* value, size_t capacity) {
     size_t length = 0;
@@ -659,9 +820,119 @@ int CpuTemperatureScore(const std::wstring& sensorName,
     return 100;
 }
 
+std::wstring NormalizeAdapterIdentity(std::wstring value) {
+    value = ToLower(std::move(value));
+    for (wchar_t& character : value) {
+        if (!std::iswalnum(character)) {
+            character = L' ';
+        }
+    }
+    std::wstring normalized;
+    bool previousSpace = true;
+    for (wchar_t character : value) {
+        bool space = std::iswspace(character) != 0;
+        if (space) {
+            if (!previousSpace) {
+                normalized.push_back(L' ');
+            }
+        } else {
+            normalized.push_back(character);
+        }
+        previousSpace = space;
+    }
+    if (!normalized.empty() && normalized.back() == L' ') {
+        normalized.pop_back();
+    }
+
+    // Windows adapter names often include trademark markers that HWiNFO omits
+    // (for example "Intel(R)" or "Radeon(TM)"). Remove only these standalone
+    // tokens so otherwise identical adapter names still match.
+    std::wstring filtered;
+    size_t start = 0;
+    while (start < normalized.size()) {
+        size_t end = normalized.find(L' ', start);
+        if (end == std::wstring::npos) {
+            end = normalized.size();
+        }
+        std::wstring_view token(normalized.data() + start, end - start);
+        if (token != L"r" && token != L"tm") {
+            if (!filtered.empty()) {
+                filtered.push_back(L' ');
+            }
+            filtered.append(token);
+        }
+        start = end + 1;
+    }
+    return filtered;
+}
+
+std::vector<std::wstring> IdentityTokens(const std::wstring& value) {
+    std::vector<std::wstring> tokens;
+    size_t start = 0;
+    while (start < value.size()) {
+        size_t end = value.find(L' ', start);
+        if (end == std::wstring::npos) {
+            end = value.size();
+        }
+        if (end > start) {
+            tokens.emplace_back(value.substr(start, end - start));
+        }
+        start = end + 1;
+    }
+    return tokens;
+}
+
+bool HasDigit(const std::wstring& value) {
+    return std::any_of(value.begin(), value.end(), [](wchar_t character) {
+        return std::iswdigit(character) != 0;
+    });
+}
+
+int GpuAdapterIdentityScore(const std::wstring& sensorName,
+                            const std::wstring& adapterName) {
+    if (adapterName.empty()) {
+        return 0;
+    }
+    std::wstring sensor = NormalizeAdapterIdentity(sensorName);
+    std::wstring adapter = NormalizeAdapterIdentity(adapterName);
+    if (adapter.empty()) {
+        return 0;
+    }
+    if (Contains(sensor, adapter)) {
+        return 5000;
+    }
+
+    auto sensorTokens = IdentityTokens(sensor);
+    auto adapterTokens = IdentityTokens(adapter);
+    int numericMatches = 0;
+    int distinctiveMatches = 0;
+    for (const std::wstring& token : adapterTokens) {
+        bool matched = std::find(sensorTokens.begin(), sensorTokens.end(),
+                                 token) != sensorTokens.end();
+        if (!matched) {
+            continue;
+        }
+        if (HasDigit(token)) {
+            numericMatches++;
+        } else if (token.size() >= 4 && token != L"graphics" &&
+                   token != L"radeon" && token != L"geforce" &&
+                   token != L"nvidia" && token != L"intel") {
+            distinctiveMatches++;
+        }
+    }
+    if (numericMatches) {
+        return 4000 + numericMatches * 100 + distinctiveMatches * 10;
+    }
+    if (distinctiveMatches >= 2) {
+        return 3000 + distinctiveMatches * 10;
+    }
+    return -1;
+}
+
 int GpuTemperatureScore(const std::wstring& sensorName,
                         const std::wstring& label,
-                        const std::wstring& preferred) {
+                        const std::wstring& preferred,
+                        const std::optional<std::wstring>& adapterName) {
     std::wstring sensor = ToLower(sensorName);
     std::wstring reading = ToLower(label);
     std::wstring combined = sensor + L" " + reading;
@@ -669,6 +940,15 @@ int GpuTemperatureScore(const std::wstring& sensorName,
 
     if (!preferredLower.empty()) {
         return Contains(combined, preferredLower) ? 10000 : -1;
+    }
+
+    if (!adapterName) {
+        return -1;
+    }
+
+    int adapterScore = GpuAdapterIdentityScore(sensorName, *adapterName);
+    if (adapterScore < 0) {
+        return -1;
     }
 
     if (!Contains(sensor, L"gpu") && !Contains(sensor, L"nvidia") &&
@@ -682,29 +962,29 @@ int GpuTemperatureScore(const std::wstring& sensorName,
     }
 
     if (reading == L"gpu temperature") {
-        return 1000;
+        return adapterScore + 1000;
     }
     if (Contains(reading, L"gpu temperature")) {
-        return 950;
+        return adapterScore + 950;
     }
     if (Contains(reading, L"gpu core")) {
-        return 900;
+        return adapterScore + 900;
     }
     if (Contains(reading, L"temperature")) {
-        return 500;
+        return adapterScore + 500;
     }
 
     // Prefer the shortest localized label containing the stable GPU acronym.
     // This normally selects labels such as "GPU Temperature" over longer
     // hotspot, junction, or memory-temperature labels.
     if (Contains(reading, L"gpu")) {
-        return 400 -
+        return adapterScore + 400 -
                static_cast<int>(std::min<size_t>(reading.size(), 200));
     }
 
     // As with CPU readings, the registry path validates the temperature unit
     // before this locale-independent fallback can be selected.
-    return 100;
+    return adapterScore + 100;
 }
 
 // HWiNFO's published shared-memory layout explicitly uses one-byte packing.
@@ -833,7 +1113,8 @@ std::optional<double> NormalizeHwInfoTemperature(double value,
 }
 
 void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
-                            const ModSettings& settings) {
+                            const ModSettings& settings,
+                            const std::optional<std::wstring>& gpuAdapterName) {
     HANDLE mapping = OpenFileMappingW(FILE_MAP_READ, FALSE,
                                       L"Global\\HWiNFO_SENS_SM2");
     if (!mapping) {
@@ -866,6 +1147,8 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
         return;
     }
 
+    std::vector<HwInfoSensorPrefix> sensors;
+    std::vector<HwInfoReadingPrefix> readings;
     MEMORY_BASIC_INFORMATION memoryInfo{};
     if (VirtualQuery(view, &memoryInfo, sizeof(memoryInfo))) {
         size_t viewOffset = static_cast<const uint8_t*>(view) -
@@ -888,58 +1171,32 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
                 IsRangeValid(mappedSize, header.readingOffset,
                              header.readingStride, header.readingCount,
                              sizeof(HwInfoReadingPrefix))) {
-                int bestCpuScore = -1;
-                int bestGpuScore = -1;
                 const auto* bytes = static_cast<const uint8_t*>(view);
-
+                sensors.resize(header.sensorCount);
+                readings.resize(header.readingCount);
+                for (uint32_t i = 0; i < header.sensorCount; i++) {
+                    const uint8_t* address =
+                        bytes + header.sensorOffset +
+                        static_cast<size_t>(i) * header.sensorStride;
+                    std::memcpy(&sensors[i], address, sizeof(sensors[i]));
+                }
                 for (uint32_t i = 0; i < header.readingCount; i++) {
-                    HwInfoReadingPrefix reading{};
-                    const uint8_t* readingAddress =
+                    const uint8_t* address =
                         bytes + header.readingOffset +
                         static_cast<size_t>(i) * header.readingStride;
-                    std::memcpy(&reading, readingAddress, sizeof(reading));
-
-                    if (reading.readingType != kHwInfoTemperatureType ||
-                        reading.sensorIndex >= header.sensorCount) {
-                        continue;
-                    }
-
-                    auto value = NormalizeHwInfoTemperature(
-                        reading.value, reading.unit, std::size(reading.unit));
-                    if (!value) {
-                        continue;
-                    }
-
-                    HwInfoSensorPrefix sensor{};
-                    const uint8_t* sensorAddress =
-                        bytes + header.sensorOffset +
-                        static_cast<size_t>(reading.sensorIndex) *
-                            header.sensorStride;
-                    std::memcpy(&sensor, sensorAddress, sizeof(sensor));
-
-                    std::wstring sensorName =
-                        FixedAnsiToWide(sensor.originalName,
-                                        std::size(sensor.originalName));
-                    std::wstring label =
-                        FixedAnsiToWide(reading.originalLabel,
-                                        std::size(reading.originalLabel));
-
-                    int cpuScore = CpuTemperatureScore(
-                        sensorName, label, settings.cpuTempSensor);
-                    if (cpuScore > bestCpuScore) {
-                        bestCpuScore = cpuScore;
-                        snapshot.cpuTemp = *value;
-                        snapshot.cpuTempProvider =
-                            TemperatureProvider::HwInfoSharedMemory;
-                    }
-
-                    int gpuScore = GpuTemperatureScore(
-                        sensorName, label, settings.gpuTempSensor);
-                    if (gpuScore > bestGpuScore) {
-                        bestGpuScore = gpuScore;
-                        snapshot.gpuTemp = *value;
-                        snapshot.gpuTempProvider =
-                            TemperatureProvider::HwInfoSharedMemory;
+                    std::memcpy(&readings[i], address, sizeof(readings[i]));
+                }
+                if (!mutexOwned) {
+                    HwInfoHeader verificationHeader{};
+                    std::memcpy(&verificationHeader, view,
+                                sizeof(verificationHeader));
+                    if (std::memcmp(&header, &verificationHeader,
+                                    sizeof(header)) != 0) {
+                        // Explorer can occasionally see the mapping without
+                        // access to HWiNFO's mutex. Discard a snapshot whose
+                        // generation changed while the raw records were copied.
+                        sensors.clear();
+                        readings.clear();
                     }
                 }
             }
@@ -954,6 +1211,58 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
         CloseHandle(mutex);
     }
     CloseHandle(mapping);
+
+    // Keep HWiNFO's shared mutex only while copying the validated raw records.
+    // String conversion, scoring and unit normalization don't need to block the
+    // producer from refreshing its shared memory.
+    int bestCpuScore = -1;
+    int bestGpuScore = -1;
+    bool sawTemperatureReading = false;
+    bool sawSupportedTemperatureUnit = false;
+    for (const HwInfoReadingPrefix& reading : readings) {
+        if (reading.readingType != kHwInfoTemperatureType ||
+            reading.sensorIndex >= sensors.size()) {
+            continue;
+        }
+        sawTemperatureReading = true;
+
+        auto value = NormalizeHwInfoTemperature(
+            reading.value, reading.unit, std::size(reading.unit));
+        if (!value) {
+            continue;
+        }
+        sawSupportedTemperatureUnit = true;
+
+        const HwInfoSensorPrefix& sensor = sensors[reading.sensorIndex];
+        std::wstring sensorName =
+            FixedAnsiToWide(sensor.originalName,
+                            std::size(sensor.originalName));
+        std::wstring label =
+            FixedAnsiToWide(reading.originalLabel,
+                            std::size(reading.originalLabel));
+
+        int cpuScore = CpuTemperatureScore(
+            sensorName, label, settings.cpuTempSensor);
+        if (cpuScore > bestCpuScore) {
+            bestCpuScore = cpuScore;
+            snapshot.cpuTemp = *value;
+            snapshot.cpuTempProvider = TemperatureProvider::HwInfoSharedMemory;
+        }
+
+        int gpuScore = GpuTemperatureScore(
+            sensorName, label, settings.gpuTempSensor, gpuAdapterName);
+        if (gpuScore > bestGpuScore) {
+            bestGpuScore = gpuScore;
+            snapshot.gpuTemp = *value;
+            snapshot.gpuTempProvider = TemperatureProvider::HwInfoSharedMemory;
+        }
+    }
+
+    if (sawTemperatureReading && !sawSupportedTemperatureUnit &&
+        !g_hwInfoInvalidUnitLogged) {
+        Wh_Log(L"HWiNFO temperature readings use an unsupported unit");
+        g_hwInfoInvalidUnitLogged = true;
+    }
 }
 
 std::optional<std::wstring> ReadRegistryString(HKEY key,
@@ -998,7 +1307,8 @@ std::optional<double> NormalizeRegistryTemperature(
 }
 
 void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
-                              const ModSettings& settings) {
+                              const ModSettings& settings,
+                              const std::optional<std::wstring>& gpuAdapterName) {
     HKEY key = nullptr;
     if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\HWiNFO64\\VSB", 0,
                       KEY_QUERY_VALUE, &key) != ERROR_SUCCESS) {
@@ -1040,7 +1350,8 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
         }
 
         int gpuScore =
-            GpuTemperatureScore(*sensor, *label, settings.gpuTempSensor);
+            GpuTemperatureScore(*sensor, *label, settings.gpuTempSensor,
+                                gpuAdapterName);
         if (gpuScore > bestGpuScore) {
             bestGpuScore = gpuScore;
             snapshot.gpuTemp = *value;
@@ -1058,22 +1369,28 @@ void ReadWindowsGpuTemperature(MetricsSnapshot& snapshot,
                                const ModSettings& settings);
 
 void ReadHwInfoTemperatures(MetricsSnapshot& snapshot,
-                            const ModSettings& settings) {
-    ReadHwInfoSharedMemory(snapshot, settings);
+                            const ModSettings& settings,
+                            const std::optional<std::wstring>& gpuAdapterName) {
+    ReadHwInfoSharedMemory(snapshot, settings, gpuAdapterName);
     if (!snapshot.cpuTemp || !snapshot.gpuTemp) {
-        ReadHwInfoGadgetRegistry(snapshot, settings);
+        ReadHwInfoGadgetRegistry(snapshot, settings, gpuAdapterName);
     }
 }
 
 void ReadTemperatures(MetricsSnapshot& snapshot,
                       const ModSettings& settings) {
+    std::optional<std::wstring> gpuAdapterName;
+    if (settings.temperatureSource != TemperatureSource::WindowsNative &&
+        settings.temperatureSource != TemperatureSource::Disabled) {
+        gpuAdapterName = ResolveGpuTemperatureAdapterName(settings);
+    }
     switch (settings.temperatureSource) {
         case TemperatureSource::SharedMemory:
-            ReadHwInfoSharedMemory(snapshot, settings);
+            ReadHwInfoSharedMemory(snapshot, settings, gpuAdapterName);
             break;
 
         case TemperatureSource::GadgetRegistry:
-            ReadHwInfoGadgetRegistry(snapshot, settings);
+            ReadHwInfoGadgetRegistry(snapshot, settings, gpuAdapterName);
             break;
 
         case TemperatureSource::WindowsNative:
@@ -1085,12 +1402,12 @@ void ReadTemperatures(MetricsSnapshot& snapshot,
             break;
 
         case TemperatureSource::HwInfoAuto:
-            ReadHwInfoTemperatures(snapshot, settings);
+            ReadHwInfoTemperatures(snapshot, settings, gpuAdapterName);
             break;
 
         case TemperatureSource::Auto:
         default:
-            ReadHwInfoTemperatures(snapshot, settings);
+            ReadHwInfoTemperatures(snapshot, settings, gpuAdapterName);
             if (!snapshot.gpuTemp) {
                 ReadWindowsGpuTemperature(snapshot, settings);
             }
@@ -1108,7 +1425,7 @@ uint64_t FileTimeValue(const FILETIME& value) {
     return result.QuadPart;
 }
 
-double ReadCpuUsage() {
+std::optional<double> ReadCpuUsage() {
     static bool initialized = false;
     static uint64_t previousIdle = 0;
     static uint64_t previousKernel = 0;
@@ -1118,7 +1435,7 @@ double ReadCpuUsage() {
     FILETIME kernelTime{};
     FILETIME userTime{};
     if (!GetSystemTimes(&idleTime, &kernelTime, &userTime)) {
-        return 0.0;
+        return std::nullopt;
     }
 
     uint64_t idle = FileTimeValue(idleTime);
@@ -1129,7 +1446,7 @@ double ReadCpuUsage() {
         previousIdle = idle;
         previousKernel = kernel;
         previousUser = user;
-        return 0.0;
+        return std::nullopt;
     }
 
     uint64_t idleDelta = idle - previousIdle;
@@ -1141,7 +1458,7 @@ double ReadCpuUsage() {
 
     uint64_t total = kernelDelta + userDelta;
     if (!total || idleDelta > total) {
-        return 0.0;
+        return std::nullopt;
     }
     return std::clamp(100.0 * static_cast<double>(total - idleDelta) /
                           static_cast<double>(total),
@@ -1155,14 +1472,12 @@ void ReadMemory(MetricsSnapshot& snapshot) {
         return;
     }
 
-    constexpr double gib = 1024.0 * 1024.0 * 1024.0;
     snapshot.ram = static_cast<double>(memory.dwMemoryLoad);
-    snapshot.ramTotalGb = static_cast<double>(memory.ullTotalPhys) / gib;
+    snapshot.ramTotalGb = static_cast<double>(memory.ullTotalPhys) / kGiB;
     snapshot.ramUsedGb =
-        static_cast<double>(memory.ullTotalPhys - memory.ullAvailPhys) / gib;
+        static_cast<double>(memory.ullTotalPhys - memory.ullAvailPhys) / kGiB;
+    snapshot.ramAvailable = true;
 }
-
-constexpr double kGiB = 1024.0 * 1024.0 * 1024.0;
 
 // D3DKMT exposes display-adapter performance data, including temperature,
 // without requiring a third-party monitoring application. The declarations are
@@ -1223,10 +1538,16 @@ struct D3DKMT_SEGMENTSIZEINFO {
     ULONGLONG SharedSystemMemorySize;
 };
 
+struct D3DKMT_ADAPTERTYPE {
+    UINT Value;
+};
+
 constexpr UINT kAdapterRegistryInfoQueryType = 8;
 constexpr UINT kAdapterSegmentSizeQueryType = 3;
+constexpr UINT kAdapterTypeQueryType = 15;
 constexpr UINT kAdapterPerfDataQueryType = 62;  // KMTQAITYPE_ADAPTERPERFDATA
 constexpr ULONG kMaxD3dkmtAdapters = 16;
+constexpr UINT kHybridIntegratedAdapterFlag = 1u << 5;
 
 using D3DKMTEnumAdapters2_t = LONG(WINAPI*)(D3DKMT_ENUMADAPTERS2*);
 using D3DKMTOpenAdapterFromLuid_t =
@@ -1247,17 +1568,36 @@ struct GpuAdapterInfo {
     LUID luidValue{};
     uint64_t dedicatedVideoMemory = 0;
     uint64_t sharedSystemMemory = 0;
+    bool integrated = false;
 };
 
 std::optional<std::wstring> g_cachedGpuAdapterFilter;
 std::optional<GpuAdapterInfo> g_cachedGpuAdapterInfo;
 bool g_cachedGpuAdapterResolved = false;
+D3DKMT_HANDLE g_cachedD3dkmtAdapterHandle = 0;
+LUID g_cachedD3dkmtAdapterLuid{};
+uint32_t g_unchangedGpuIdentityChecks = 0;
+
+bool SameLuid(const LUID& left, const LUID& right) {
+    return left.HighPart == right.HighPart && left.LowPart == right.LowPart;
+}
+
+void CloseCachedD3dkmtAdapterHandle() {
+    if (g_cachedD3dkmtAdapterHandle && g_d3dkmtCloseAdapter) {
+        D3DKMT_CLOSEADAPTER closeAdapter{g_cachedD3dkmtAdapterHandle};
+        g_d3dkmtCloseAdapter(&closeAdapter);
+    }
+    g_cachedD3dkmtAdapterHandle = 0;
+    g_cachedD3dkmtAdapterLuid = {};
+}
 
 void InvalidateGpuAdapterCache() {
+    CloseCachedD3dkmtAdapterHandle();
     g_cachedGpuAdapterFilter.reset();
     g_cachedGpuAdapterInfo.reset();
     g_cachedGpuAdapterResolved = false;
     g_nextGpuIdentityCheck = {};
+    g_unchangedGpuIdentityChecks = 0;
 }
 
 std::wstring FormatAdapterLuid(const LUID& luid) {
@@ -1314,6 +1654,15 @@ std::optional<GpuAdapterInfo> GetLiveD3dkmtAdapterInfo(
         bool segmentsAvailable =
             g_d3dkmtQueryAdapterInfo(&segmentQuery) == 0;
 
+        D3DKMT_ADAPTERTYPE adapterType{};
+        D3DKMT_QUERYADAPTERINFO adapterTypeQuery{};
+        adapterTypeQuery.hAdapter = adapter.hAdapter;
+        adapterTypeQuery.Type = kAdapterTypeQueryType;
+        adapterTypeQuery.pPrivateDriverData = &adapterType;
+        adapterTypeQuery.PrivateDriverDataSize = sizeof(adapterType);
+        bool adapterTypeAvailable =
+            g_d3dkmtQueryAdapterInfo(&adapterTypeQuery) == 0;
+
         std::wstring description =
             registryAvailable
                 ? FixedWideToString(registryInfo.AdapterString,
@@ -1325,6 +1674,8 @@ std::optional<GpuAdapterInfo> GetLiveD3dkmtAdapterInfo(
             adapter.AdapterLuid,
             segmentsAvailable ? segmentInfo.DedicatedVideoMemorySize : 0,
             segmentsAvailable ? segmentInfo.SharedSystemMemorySize : 0,
+            adapterTypeAvailable &&
+                (adapterType.Value & kHybridIntegratedAdapterFlag) != 0,
         };
 
         bool matchesFilter =
@@ -1404,7 +1755,7 @@ std::optional<GpuAdapterInfo> GetDxgiAdapterInfo(
     return GpuAdapterInfo{
         selected.Description, FormatAdapterLuid(selected.AdapterLuid),
         selected.AdapterLuid,
-        selected.DedicatedVideoMemory, selected.SharedSystemMemory};
+        selected.DedicatedVideoMemory, selected.SharedSystemMemory, false};
 }
 
 std::optional<GpuAdapterInfo> ResolveCurrentGpuAdapterInfo(
@@ -1430,6 +1781,13 @@ std::optional<GpuAdapterInfo> GetGpuAdapterInfo(
         return g_cachedGpuAdapterInfo;
     }
 
+    if (g_cachedGpuAdapterFilter &&
+        *g_cachedGpuAdapterFilter != filterLower) {
+        CloseCachedD3dkmtAdapterHandle();
+        g_nextGpuIdentityCheck = {};
+        g_unchangedGpuIdentityChecks = 0;
+    }
+
     g_cachedGpuAdapterFilter = filterLower;
     PCWSTR provider = nullptr;
     g_cachedGpuAdapterInfo =
@@ -1446,14 +1804,30 @@ std::optional<GpuAdapterInfo> GetGpuAdapterInfo(
     }
 
     Wh_Log(L"Selected GPU (%s): %s, LUID %s, dedicated %.1f GiB, shared %.1f "
-           L"GiB",
+           L"GiB, integrated=%d",
            provider, g_cachedGpuAdapterInfo->description.c_str(),
            g_cachedGpuAdapterInfo->luid.c_str(),
            static_cast<double>(g_cachedGpuAdapterInfo->dedicatedVideoMemory) /
                kGiB,
            static_cast<double>(g_cachedGpuAdapterInfo->sharedSystemMemory) /
-               kGiB);
+               kGiB,
+           g_cachedGpuAdapterInfo->integrated);
     return g_cachedGpuAdapterInfo;
+}
+
+std::optional<std::wstring> ResolveGpuTemperatureAdapterName(
+    const ModSettings& settings) {
+    auto adapter = GetGpuAdapterInfo(settings.gpuAdapter);
+    if (adapter) {
+        return adapter->description;
+    }
+    if (settings.gpuAdapter.empty()) {
+        // Preserve generic HWiNFO matching on systems where Windows adapter
+        // identity isn't available at all. An explicit filter miss is different
+        // and intentionally returns nullopt so another GPU isn't shown.
+        return std::wstring{};
+    }
+    return std::nullopt;
 }
 
 bool HasGpuAdapterIdentityChanged(const GpuAdapterInfo& cachedAdapter,
@@ -1462,11 +1836,42 @@ bool HasGpuAdapterIdentityChanged(const GpuAdapterInfo& cachedAdapter,
     if (now < g_nextGpuIdentityCheck) {
         return false;
     }
-    g_nextGpuIdentityCheck = now + std::chrono::seconds(5);
-
     auto currentAdapter =
         ResolveCurrentGpuAdapterInfo(ToLower(adapterFilter));
-    return currentAdapter && currentAdapter->luid != cachedAdapter.luid;
+    if (currentAdapter && currentAdapter->luid != cachedAdapter.luid) {
+        g_unchangedGpuIdentityChecks = 0;
+        g_nextGpuIdentityCheck = {};
+        return true;
+    }
+
+    // A parked or power-gated discrete GPU can temporarily resolve through a
+    // different enumeration path. Back off repeated identity probes while the
+    // cached adapter remains valid instead of re-enumerating every five seconds.
+    uint32_t exponent = std::min<uint32_t>(g_unchangedGpuIdentityChecks, 6);
+    auto delay = std::min(std::chrono::seconds(5u << exponent),
+                          std::chrono::seconds(300));
+    g_unchangedGpuIdentityChecks++;
+    g_nextGpuIdentityCheck = now + delay;
+    return false;
+}
+
+std::optional<D3DKMT_HANDLE> GetD3dkmtAdapterHandle(
+    const GpuAdapterInfo& adapter) {
+    if (g_cachedD3dkmtAdapterHandle &&
+        SameLuid(g_cachedD3dkmtAdapterLuid, adapter.luidValue)) {
+        return g_cachedD3dkmtAdapterHandle;
+    }
+
+    CloseCachedD3dkmtAdapterHandle();
+    D3DKMT_OPENADAPTERFROMLUID openAdapter{};
+    openAdapter.AdapterLuid = adapter.luidValue;
+    if (g_d3dkmtOpenAdapterFromLuid(&openAdapter) != 0 ||
+        !openAdapter.hAdapter) {
+        return std::nullopt;
+    }
+    g_cachedD3dkmtAdapterHandle = openAdapter.hAdapter;
+    g_cachedD3dkmtAdapterLuid = adapter.luidValue;
+    return g_cachedD3dkmtAdapterHandle;
 }
 
 void ReadWindowsGpuTemperature(MetricsSnapshot& snapshot,
@@ -1481,24 +1886,23 @@ void ReadWindowsGpuTemperature(MetricsSnapshot& snapshot,
         return;
     }
 
-    D3DKMT_OPENADAPTERFROMLUID openAdapter{};
-    openAdapter.AdapterLuid = adapter->luidValue;
-    if (g_d3dkmtOpenAdapterFromLuid(&openAdapter) != 0) {
+    auto adapterHandle = GetD3dkmtAdapterHandle(*adapter);
+    if (!adapterHandle) {
         return;
     }
 
     D3DKMT_ADAPTER_PERFDATA perfData{};
     D3DKMT_QUERYADAPTERINFO queryInfo{};
-    queryInfo.hAdapter = openAdapter.hAdapter;
+    queryInfo.hAdapter = *adapterHandle;
     queryInfo.Type = kAdapterPerfDataQueryType;
     queryInfo.pPrivateDriverData = &perfData;
     queryInfo.PrivateDriverDataSize = sizeof(perfData);
 
     LONG status = g_d3dkmtQueryAdapterInfo(&queryInfo);
-
-    D3DKMT_CLOSEADAPTER closeAdapter{};
-    closeAdapter.hAdapter = openAdapter.hAdapter;
-    g_d3dkmtCloseAdapter(&closeAdapter);
+    if (status != 0) {
+        // A driver restart invalidates KMT handles. Reopen on the next sample.
+        CloseCachedD3dkmtAdapterHandle();
+    }
 
     // The driver reports tenths of a degree Celsius. Zero means unavailable;
     // reject values above 200 C as invalid driver data.
@@ -1528,6 +1932,7 @@ void ClosePdhQuery() {
         PdhCloseQuery(g_pdhQuery);
         g_pdhQuery = nullptr;
     }
+    g_cpuUtilityCounter = nullptr;
     g_gpuCounter = nullptr;
     g_vramCounter = nullptr;
     g_sharedVramCounter = nullptr;
@@ -1602,7 +2007,7 @@ bool NeedsWindowsThermalZones(const ModSettings& settings) {
            settings.temperatureSource == TemperatureSource::WindowsNative;
 }
 
-void EnsurePdhQuery(const ModSettings& settings) {
+bool EnsurePdhQuery(const ModSettings& settings) {
     auto now = std::chrono::steady_clock::now();
     bool thermalZonesRequired = NeedsWindowsThermalZones(settings);
     if (!thermalZonesRequired && g_thermalZoneCounter) {
@@ -1613,24 +2018,29 @@ void EnsurePdhQuery(const ModSettings& settings) {
     bool queryCreated = false;
     if (!g_pdhQuery) {
         if (now < g_nextPdhCounterRetry) {
-            return;
+            return false;
         }
         if (PdhOpenQueryW(nullptr, 0, &g_pdhQuery) != ERROR_SUCCESS) {
             g_pdhQuery = nullptr;
             g_nextPdhCounterRetry = now + kPdhCounterRetryInterval;
-            return;
+            return false;
         }
         queryCreated = true;
-    } else if (g_gpuCounter && g_vramCounter && g_sharedVramCounter &&
+    } else if (g_cpuUtilityCounter && g_gpuCounter && g_vramCounter &&
+               g_sharedVramCounter &&
                (!thermalZonesRequired || g_thermalZoneCounter)) {
-        return;
+        return false;
     }
 
     if (!queryCreated && now < g_nextPdhCounterRetry) {
-        return;
+        return false;
     }
 
     bool counterAdded = false;
+    counterAdded |= AddPdhCounter(
+        g_cpuUtilityCounter,
+        L"\\Processor Information(_Total)\\% Processor Utility",
+        L"CPU utility");
     counterAdded |= AddPdhCounter(
         g_gpuCounter, L"\\GPU Engine(*)\\Utilization Percentage", L"GPU usage");
     counterAdded |= AddPdhCounter(
@@ -1646,15 +2056,17 @@ void EnsurePdhQuery(const ModSettings& settings) {
             L"Windows thermal-zone");
     }
 
-    if (!g_gpuCounter && !g_vramCounter && !g_sharedVramCounter &&
+    if (!g_cpuUtilityCounter && !g_gpuCounter && !g_vramCounter &&
+        !g_sharedVramCounter &&
         (!thermalZonesRequired || !g_thermalZoneCounter)) {
         PdhCloseQuery(g_pdhQuery);
         g_pdhQuery = nullptr;
         g_nextPdhCounterRetry = now + kPdhCounterRetryInterval;
-        return;
+        return false;
     }
 
-    if (!g_gpuCounter || !g_vramCounter || !g_sharedVramCounter ||
+    if (!g_cpuUtilityCounter || !g_gpuCounter || !g_vramCounter ||
+        !g_sharedVramCounter ||
         (thermalZonesRequired && !g_thermalZoneCounter)) {
         g_nextPdhCounterRetry = now + kPdhCounterRetryInterval;
     }
@@ -1666,6 +2078,7 @@ void EnsurePdhQuery(const ModSettings& settings) {
                    collectStatus);
         }
     }
+    return queryCreated || counterAdded;
 }
 
 PDH_STATUS ReadPdhArray(PDH_HCOUNTER counter,
@@ -1674,22 +2087,33 @@ PDH_STATUS ReadPdhArray(PDH_HCOUNTER counter,
     if (!counter) {
         return PDH_CSTATUS_NO_COUNTER;
     }
+    // GPU wildcard instances can appear or disappear between the sizing call
+    // and the data call. PDH_MORE_DATA on a later call is a normal resize race,
+    // not evidence that the provider or display driver is broken.
+    constexpr int kMaxArrayReadAttempts = 4;
     DWORD bufferSize = 0;
-    PDH_STATUS status = PdhGetFormattedCounterArrayW(
-        counter, PDH_FMT_DOUBLE, &bufferSize, &itemCount, nullptr);
-    if (status == ERROR_SUCCESS && !bufferSize) {
-        buffer.clear();
+    PDH_STATUS status = static_cast<PDH_STATUS>(PDH_MORE_DATA);
+    for (int attempt = 0; attempt < kMaxArrayReadAttempts; attempt++) {
         itemCount = 0;
-        return ERROR_SUCCESS;
+        auto* items = bufferSize
+                          ? reinterpret_cast<PDH_FMT_COUNTERVALUE_ITEM_W*>(
+                                buffer.data())
+                          : nullptr;
+        status = PdhGetFormattedCounterArrayW(
+            counter, PDH_FMT_DOUBLE, &bufferSize, &itemCount, items);
+        if (status == ERROR_SUCCESS) {
+            if (!bufferSize) {
+                buffer.clear();
+                itemCount = 0;
+            }
+            return ERROR_SUCCESS;
+        }
+        if (status != static_cast<PDH_STATUS>(PDH_MORE_DATA) || !bufferSize) {
+            return status;
+        }
+        buffer.resize(bufferSize);
     }
-    if (status != static_cast<PDH_STATUS>(PDH_MORE_DATA) || !bufferSize) {
-        return status;
-    }
-
-    buffer.resize(bufferSize);
-    auto* items = reinterpret_cast<PDH_FMT_COUNTERVALUE_ITEM_W*>(buffer.data());
-    return PdhGetFormattedCounterArrayW(counter, PDH_FMT_DOUBLE, &bufferSize,
-                                        &itemCount, items);
+    return status;
 }
 
 bool IsHardPdhArrayFailure(PDH_STATUS status) {
@@ -1799,13 +2223,34 @@ std::optional<double> ReadGpuUsage(
     for (const auto& [engine, usage] : engineTotals) {
         busiestEngine = std::max(busiestEngine, usage);
     }
-    return found ? std::clamp(busiestEngine, 0.0, 100.0) : 0.0;
+    if (found) {
+        return std::clamp(busiestEngine, 0.0, 100.0);
+    }
+    // A power-gated discrete GPU legitimately has no engine instances while an
+    // integrated adapter is active. Adapter identity recovery is handled from
+    // the memory counter below, so an otherwise healthy array means idle here.
+    return 0.0;
+}
+
+std::optional<double> ReadCpuUtility() {
+    if (!g_cpuUtilityCounter) {
+        return std::nullopt;
+    }
+    PDH_FMT_COUNTERVALUE value{};
+    PDH_STATUS status = PdhGetFormattedCounterValue(
+        g_cpuUtilityCounter, PDH_FMT_DOUBLE, nullptr, &value);
+    if (status != ERROR_SUCCESS ||
+        (value.CStatus != PDH_CSTATUS_VALID_DATA &&
+         value.CStatus != PDH_CSTATUS_NEW_DATA) ||
+        !std::isfinite(value.doubleValue) || value.doubleValue < 0.0) {
+        return std::nullopt;
+    }
+    return std::clamp(value.doubleValue, 0.0, 100.0);
 }
 
 std::optional<double> ReadVramUsedBytes(
     PDH_HCOUNTER counter,
     const std::optional<GpuAdapterInfo>& adapter,
-    bool& anyValidSample,
     PDH_STATUS& readStatus) {
     std::vector<uint8_t> buffer;
     DWORD itemCount = 0;
@@ -1824,8 +2269,6 @@ std::optional<double> ReadVramUsedBytes(
             !std::isfinite(value.doubleValue) || value.doubleValue < 0.0) {
             continue;
         }
-        anyValidSample = true;
-
         std::wstring instance = items[i].szName ? items[i].szName : L"";
         if (!MatchesGpuAdapter(instance, adapter)) {
             continue;
@@ -1836,21 +2279,74 @@ std::optional<double> ReadVramUsedBytes(
     return found ? std::optional<double>(total) : std::nullopt;
 }
 
-void ReadPdhMetrics(MetricsSnapshot& snapshot, const ModSettings& settings) {
-    EnsurePdhQuery(settings);
+bool LooksLikeIntegratedGpu(const GpuAdapterInfo& adapter) {
+    if (adapter.integrated || adapter.dedicatedVideoMemory == 0) {
+        return true;
+    }
+
+    // Some WDDM drivers don't set HybridIntegrated but expose a small firmware
+    // carve-out. Restrict the fallback to familiar integrated-family names so
+    // an older low-memory discrete adapter isn't silently reclassified.
+    constexpr uint64_t kMaximumIntegratedCarveout = 512ull * 1024 * 1024;
+    if (adapter.dedicatedVideoMemory > kMaximumIntegratedCarveout ||
+        adapter.sharedSystemMemory == 0) {
+        return false;
+    }
+    std::wstring name = ToLower(adapter.description);
+    return Contains(name, L"uhd graphics") || Contains(name, L"iris") ||
+           Contains(name, L"radeon(tm) graphics") ||
+           Contains(name, L"radeon graphics") || Contains(name, L"vega") ||
+           Contains(name, L"integrated");
+}
+
+bool UseSharedGpuMemory(const GpuAdapterInfo& adapter,
+                        const ModSettings& settings) {
+    switch (settings.gpuMemoryMode) {
+        case GpuMemoryMode::Dedicated:
+            return false;
+        case GpuMemoryMode::Shared:
+            return true;
+        case GpuMemoryMode::Auto:
+        default:
+            return adapter.sharedSystemMemory > 0 &&
+                   LooksLikeIntegratedGpu(adapter);
+    }
+}
+
+bool IsSoftPdhArrayAbsence(PDH_STATUS status) {
+    return status == ERROR_SUCCESS ||
+           status == static_cast<PDH_STATUS>(PDH_NO_DATA) ||
+           status == static_cast<PDH_STATUS>(PDH_CSTATUS_NO_INSTANCE);
+}
+
+bool ReadPdhMetrics(MetricsSnapshot& snapshot, const ModSettings& settings) {
+    if (EnsurePdhQuery(settings)) {
+        // Rate counters need two samples. EnsurePdhQuery just established the
+        // baseline, so publishing this same-tick snapshot would expose garbage
+        // or briefly replace valid GPU values with unavailable placeholders.
+        return false;
+    }
     if (!g_pdhQuery) {
-        return;
+        return true;
     }
 
     PDH_STATUS collectStatus = PdhCollectQueryData(g_pdhQuery);
     if (collectStatus != ERROR_SUCCESS) {
         RecordPdhReadFailure(L"collection", collectStatus);
-        return;
+        return true;
+    }
+
+    if (auto cpuUtility = ReadCpuUtility()) {
+        snapshot.cpu = *cpuUtility;
+        snapshot.cpuAvailable = true;
     }
 
     auto adapter = GetGpuAdapterInfo(settings.gpuAdapter);
+    bool explicitAdapterMissing = !settings.gpuAdapter.empty() && !adapter;
     PDH_STATUS gpuReadStatus = ERROR_SUCCESS;
-    auto gpuUsage = ReadGpuUsage(adapter, gpuReadStatus);
+    auto gpuUsage = explicitAdapterMissing
+                        ? std::optional<double>{}
+                        : ReadGpuUsage(adapter, gpuReadStatus);
     if (gpuUsage) {
         snapshot.gpu = *gpuUsage;
         snapshot.gpuAvailable = true;
@@ -1858,19 +2354,17 @@ void ReadPdhMetrics(MetricsSnapshot& snapshot, const ModSettings& settings) {
     uint64_t vramTotalBytes = 0;
     PDH_HCOUNTER vramCounter = nullptr;
     if (adapter) {
-        if (adapter->dedicatedVideoMemory > 0) {
-            vramTotalBytes = adapter->dedicatedVideoMemory;
-            vramCounter = g_vramCounter;
-        } else if (adapter->sharedSystemMemory > 0) {
+        if (UseSharedGpuMemory(*adapter, settings)) {
             vramTotalBytes = adapter->sharedSystemMemory;
             vramCounter = g_sharedVramCounter;
+        } else {
+            vramTotalBytes = adapter->dedicatedVideoMemory;
+            vramCounter = g_vramCounter;
         }
     }
-    bool vramCounterHasData = false;
     PDH_STATUS vramReadStatus = ERROR_SUCCESS;
-    auto vramUsedBytes =
-        ReadVramUsedBytes(vramCounter, adapter, vramCounterHasData,
-                          vramReadStatus);
+    auto vramUsedBytes = ReadVramUsedBytes(vramCounter, adapter,
+                                           vramReadStatus);
     bool vramAvailable = vramTotalBytes > 0 && vramUsedBytes.has_value();
     if (vramAvailable) {
         snapshot.vramUsedGb = *vramUsedBytes / kGiB;
@@ -1883,11 +2377,18 @@ void ReadPdhMetrics(MetricsSnapshot& snapshot, const ModSettings& settings) {
     bool hardReadFailure =
         (g_gpuCounter && IsHardPdhArrayFailure(gpuReadStatus)) ||
         (vramCounter && IsHardPdhArrayFailure(vramReadStatus));
-    bool adapterMismatch = adapter && vramReadStatus == ERROR_SUCCESS &&
-                           vramCounterHasData && !vramAvailable;
+    bool adapterSampleMissing = adapter && vramCounter && vramTotalBytes > 0 &&
+                                !vramAvailable &&
+                                IsSoftPdhArrayAbsence(vramReadStatus);
     bool adapterIdentityChanged =
-        adapterMismatch &&
+        adapterSampleMissing &&
         HasGpuAdapterIdentityChanged(*adapter, settings.gpuAdapter);
+    if (!adapterSampleMissing) {
+        // A healthy matching sample should make the next future mismatch probe
+        // immediately instead of inheriting an old parked-GPU backoff window.
+        g_unchangedGpuIdentityChecks = 0;
+        g_nextGpuIdentityCheck = {};
+    }
     if (hardReadFailure) {
         RecordPdhReadFailure(L"counter read");
     } else if (adapterIdentityChanged) {
@@ -1895,13 +2396,19 @@ void ReadPdhMetrics(MetricsSnapshot& snapshot, const ModSettings& settings) {
     } else {
         RecordPdhReadSuccess();
     }
+    return true;
 }
 
-MetricsSnapshot CollectMetrics(const ModSettings& settings) {
+std::optional<MetricsSnapshot> CollectMetrics(const ModSettings& settings) {
     MetricsSnapshot snapshot;
-    snapshot.cpu = ReadCpuUsage();
+    if (auto cpu = ReadCpuUsage()) {
+        snapshot.cpu = *cpu;
+        snapshot.cpuAvailable = true;
+    }
     ReadMemory(snapshot);
-    ReadPdhMetrics(snapshot, settings);
+    if (!ReadPdhMetrics(snapshot, settings)) {
+        return std::nullopt;
+    }
     ReadTemperatures(snapshot, settings);
     return snapshot;
 }
@@ -1924,33 +2431,47 @@ PCWSTR TemperatureProviderName(TemperatureProvider provider) {
 
 void PublishMetrics(MetricsSnapshot snapshot) {
     std::lock_guard lock(g_metricsMutex);
-    g_latestMetrics = std::move(snapshot);
     g_latestMetricsSequence++;
-    g_latestMetricsAvailable = true;
+    g_publishedMetrics.push_back(
+        {g_latestMetricsSequence, std::move(snapshot)});
+    while (g_publishedMetrics.size() > kMaximumPublishedMetrics) {
+        g_publishedMetrics.pop_front();
+    }
 }
 
-bool GetLatestMetrics(MetricsSnapshot& snapshot, uint64_t& sequence) {
+bool GetMetricsSince(uint64_t afterSequence,
+                     MetricsSnapshot& latestSnapshot,
+                     uint64_t& latestSequence,
+                     std::vector<MetricsSnapshot>& newSnapshots) {
     std::lock_guard lock(g_metricsMutex);
-    if (!g_latestMetricsAvailable) {
+    if (g_publishedMetrics.empty()) {
         return false;
     }
-    snapshot = g_latestMetrics;
-    sequence = g_latestMetricsSequence;
+    latestSnapshot = g_publishedMetrics.back().snapshot;
+    latestSequence = g_publishedMetrics.back().sequence;
+    for (const PublishedMetricsSnapshot& published : g_publishedMetrics) {
+        if (published.sequence > afterSequence) {
+            newSnapshots.push_back(published.snapshot);
+        }
+    }
     return true;
 }
 
 void MetricsWorkerProc() {
     ReadCpuUsage();
-    EnsurePdhQuery(CurrentSettings());
+    EnsurePdhQuery(*CurrentSettings());
 
     bool firstSample = true;
+    bool waitFailureLogged = false;
     bool providersLogged = false;
     TemperatureProvider lastCpuProvider = TemperatureProvider::None;
     TemperatureProvider lastGpuProvider = TemperatureProvider::None;
     while (!g_stopMetricsWorker) {
-        ModSettings settings = CurrentSettings();
+        auto settings = CurrentSettings();
         DWORD waitMilliseconds =
-            firstSample ? 250 : static_cast<DWORD>(settings.updateInterval) * 1000;
+            firstSample
+                ? 250
+                : static_cast<DWORD>(settings->updateInterval) * 1000;
         DWORD waitResult =
             WaitForSingleObject(g_metricsWorkerWakeEvent, waitMilliseconds);
         firstSample = false;
@@ -1959,23 +2480,42 @@ void MetricsWorkerProc() {
             break;
         }
         if (waitResult == WAIT_FAILED) {
-            Wh_Log(L"Metrics worker wait failed: %u", GetLastError());
-            break;
+            if (!waitFailureLogged) {
+                Wh_Log(L"Metrics worker wait failed: %u", GetLastError());
+                waitFailureLogged = true;
+            }
+            // Keep the monitor alive even if its wake handle becomes invalid.
+            // A short backoff prevents a hot loop; timeout-style collection can
+            // continue until Explorer recreates the mod.
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        } else if (waitResult == WAIT_OBJECT_0) {
+            // Settings changes wake the worker. Re-prime rate-based metrics and
+            // the CPU delta baseline, then wait for a real sampling interval
+            // instead of publishing a synthetic near-zero sample.
+            settings = CurrentSettings();
+            ReadCpuUsage();
+            EnsurePdhQuery(*settings);
+            continue;
+        } else {
+            waitFailureLogged = false;
         }
 
         settings = CurrentSettings();
-        MetricsSnapshot snapshot = CollectMetrics(settings);
+        auto snapshot = CollectMetrics(*settings);
+        if (!snapshot) {
+            continue;
+        }
         if (!providersLogged ||
-            snapshot.cpuTempProvider != lastCpuProvider ||
-            snapshot.gpuTempProvider != lastGpuProvider) {
+            snapshot->cpuTempProvider != lastCpuProvider ||
+            snapshot->gpuTempProvider != lastGpuProvider) {
             Wh_Log(L"Temperature providers: CPU=%s, GPU=%s",
-                   TemperatureProviderName(snapshot.cpuTempProvider),
-                   TemperatureProviderName(snapshot.gpuTempProvider));
-            lastCpuProvider = snapshot.cpuTempProvider;
-            lastGpuProvider = snapshot.gpuTempProvider;
+                   TemperatureProviderName(snapshot->cpuTempProvider),
+                   TemperatureProviderName(snapshot->gpuTempProvider));
+            lastCpuProvider = snapshot->cpuTempProvider;
+            lastGpuProvider = snapshot->gpuTempProvider;
             providersLogged = true;
         }
-        PublishMetrics(std::move(snapshot));
+        PublishMetrics(std::move(*snapshot));
     }
 
     CloseMetricSources();
@@ -1998,9 +2538,8 @@ bool StartMetricsWorker() {
 
     {
         std::lock_guard metricsLock(g_metricsMutex);
-        g_latestMetrics = {};
+        g_publishedMetrics.clear();
         g_latestMetricsSequence = 0;
-        g_latestMetricsAvailable = false;
     }
     g_stopMetricsWorker = false;
     try {
@@ -2039,9 +2578,8 @@ void StopMetricsWorker() {
     }
 
     std::lock_guard metricsLock(g_metricsMutex);
-    g_latestMetrics = {};
+    g_publishedMetrics.clear();
     g_latestMetricsSequence = 0;
-    g_latestMetricsAvailable = false;
 }
 
 std::wstring FormatFixed(double value, int decimals) {
@@ -2067,7 +2605,12 @@ std::wstring FormatCapacity(double usedGb, double totalGb, bool available) {
         totalGb <= 0.0) {
         return L"--/--G";
     }
-    int totalDecimals = totalGb < 1.0 ? 1 : 0;
+    double roundedTotalGb = std::round(totalGb);
+    int totalDecimals =
+        totalGb < 1.0 ||
+                (totalGb < 4.0 && std::abs(totalGb - roundedTotalGb) >= 0.05)
+            ? 1
+            : 0;
     return FormatFixed(usedGb, 1) + L"/" +
            FormatFixed(totalGb, totalDecimals) + L"G";
 }
@@ -2144,40 +2687,142 @@ SolidColorBrush BrushFromSetting(const std::wstring& value, Color fallback) {
     return SolidColorBrush(ParseColor(value).value_or(fallback));
 }
 
-void SetTextForeground(TextBlock text,
-                       AlertLevel alert,
-                       const ModSettings& settings) {
+ElementTheme ResolveWidgetTheme() {
+    if (g_widget) {
+        ElementTheme theme = g_widget.ActualTheme();
+        if (theme != ElementTheme::Default) {
+            return theme;
+        }
+    }
+    Application application = Application::Current();
+    return application && application.RequestedTheme() == ApplicationTheme::Light
+               ? ElementTheme::Light
+               : ElementTheme::Dark;
+}
+
+bool WidgetThemeChanged() {
+    HIGHCONTRASTW highContrast{};
+    highContrast.cbSize = sizeof(highContrast);
+    bool highContrastEnabled =
+        SystemParametersInfoW(SPI_GETHIGHCONTRAST, sizeof(highContrast),
+                              &highContrast, 0) &&
+        (highContrast.dwFlags & HCF_HIGHCONTRASTON) != 0;
+    return !g_themeBrushesInitialized ||
+           ResolveWidgetTheme() != g_cachedWidgetTheme ||
+           highContrastEnabled != g_cachedHighContrast ||
+           (highContrastEnabled &&
+            (GetSysColor(COLOR_HIGHLIGHT) != g_cachedHighlightColor ||
+             GetSysColor(COLOR_HOTLIGHT) != g_cachedHotlightColor));
+}
+
+Color ColorFromColorRef(COLORREF value) {
+    return MakeColor(0xFF, GetRValue(value), GetGValue(value),
+                     GetBValue(value));
+}
+
+void ApplyCachedBrushesToVisuals() {
+    for (XamlPolyline graph : {g_cpuGraph, g_gpuGraph}) {
+        if (graph) {
+            graph.Stroke(g_graphBrush);
+        }
+    }
+    for (XamlRectangle track : {g_ramTrack, g_vramTrack}) {
+        if (track) {
+            track.Fill(g_graphBrush);
+        }
+    }
+    for (XamlRectangle fill : {g_ramFill, g_vramFill}) {
+        if (fill) {
+            fill.Fill(g_graphBrush);
+        }
+    }
+}
+
+void RefreshThemeBrushes(const ModSettings& settings, bool force = false) {
+    ElementTheme theme = ResolveWidgetTheme();
+    if (!force && g_themeBrushesInitialized &&
+        theme == g_cachedWidgetTheme) {
+        return;
+    }
+
+    g_cachedWidgetTheme = theme;
+    g_themeBrushesInitialized = true;
+    HIGHCONTRASTW highContrast{};
+    highContrast.cbSize = sizeof(highContrast);
+    g_cachedHighContrast =
+        SystemParametersInfoW(SPI_GETHIGHCONTRAST, sizeof(highContrast),
+                              &highContrast, 0) &&
+        (highContrast.dwFlags & HCF_HIGHCONTRASTON) != 0;
+    g_cachedHighlightColor = GetSysColor(COLOR_HIGHLIGHT);
+    g_cachedHotlightColor = GetSysColor(COLOR_HOTLIGHT);
+    if (settings.adaptiveColors) {
+        bool light = theme == ElementTheme::Light;
+        g_textBrush = nullptr;
+        if (g_cachedHighContrast) {
+            g_graphBrush =
+                SolidColorBrush(ColorFromColorRef(g_cachedHighlightColor));
+            g_warningBrush =
+                SolidColorBrush(ColorFromColorRef(g_cachedHotlightColor));
+            g_criticalBrush =
+                SolidColorBrush(ColorFromColorRef(g_cachedHighlightColor));
+        } else {
+            g_graphBrush = BrushFromSetting(
+                light ? kLightGraphColor : kDefaultGraphColor,
+                MakeColor(0xFF, 0x78, 0xA8, 0xFF));
+            g_warningBrush = BrushFromSetting(
+                light ? kLightWarningColor : kDefaultWarningColor,
+                MakeColor(0xFF, 0xFF, 0xB9, 0x00));
+            g_criticalBrush = BrushFromSetting(
+                light ? kLightCriticalColor : kDefaultCriticalColor,
+                MakeColor(0xFF, 0xFF, 0x6B, 0x6B));
+        }
+    } else {
+        auto textColor = ParseColor(settings.textColor);
+        g_textBrush = textColor ? SolidColorBrush(*textColor) : nullptr;
+        g_graphBrush = BrushFromSetting(settings.graphColor,
+                                        MakeColor(0xFF, 0x78, 0xA8, 0xFF));
+        g_warningBrush = BrushFromSetting(settings.warningColor,
+                                          MakeColor(0xFF, 0xFF, 0xB9, 0x00));
+        g_criticalBrush = BrushFromSetting(
+            settings.criticalColor, MakeColor(0xFF, 0xFF, 0x6B, 0x6B));
+    }
+    ApplyCachedBrushesToVisuals();
+}
+
+SolidColorBrush AlertBrush(AlertLevel alert) {
+    if (alert == AlertLevel::Critical) {
+        return g_criticalBrush;
+    }
+    if (alert == AlertLevel::Warning) {
+        return g_warningBrush;
+    }
+    return g_graphBrush;
+}
+
+void SetTextForeground(TextBlock text, AlertLevel alert) {
     if (!text) {
         return;
     }
 
-    std::optional<Color> color;
-    if (alert == AlertLevel::Critical) {
-        color = ParseColor(settings.criticalColor);
-    } else if (alert == AlertLevel::Warning) {
-        color = ParseColor(settings.warningColor);
-    } else {
-        color = ParseColor(settings.textColor);
-    }
-
-    if (color) {
-        text.Foreground(SolidColorBrush(*color));
+    SolidColorBrush brush = alert == AlertLevel::Normal
+                                ? g_textBrush
+                                : AlertBrush(alert);
+    if (brush) {
+        text.Foreground(brush);
     } else {
         text.ClearValue(TextBlock::ForegroundProperty());
     }
 }
 
-SolidColorBrush AlertBrush(AlertLevel alert, const ModSettings& settings) {
-    if (alert == AlertLevel::Critical) {
-        return BrushFromSetting(settings.criticalColor,
-                                MakeColor(0xFF, 0xFF, 0x6B, 0x6B));
+void SetTextIfChanged(TextBlock text, const std::wstring& value) {
+    if (!text) {
+        return;
     }
-    if (alert == AlertLevel::Warning) {
-        return BrushFromSetting(settings.warningColor,
-                                MakeColor(0xFF, 0xFF, 0xB9, 0x00));
+    hstring current = text.Text();
+    if (current.size() != value.size() ||
+        !std::equal(value.begin(), value.end(), current.begin())) {
+        text.Text(value);
     }
-    return BrushFromSetting(settings.graphColor,
-                            MakeColor(0xFF, 0x78, 0xA8, 0xFF));
 }
 
 size_t HistoryCapacity(const ModSettings& settings) {
@@ -2228,15 +2873,14 @@ void UpdateSparkline(XamlPolyline graph,
 void UpdateMemoryBar(XamlRectangle fill,
                      double percent,
                      bool available,
-                     AlertLevel alert,
-                     const ModSettings& settings) {
+                     AlertLevel alert) {
     if (!fill) {
         return;
     }
     fill.Width(available ? g_memoryBarWidth *
                                std::clamp(percent, 0.0, 100.0) / 100.0
                          : 0.0);
-    fill.Fill(AlertBrush(alert, settings));
+    fill.Fill(AlertBrush(alert));
 }
 
 template <typename F>
@@ -2291,8 +2935,8 @@ void ApplyTextStyle(TextBlock text,
     double opacity = static_cast<double>(settings.textOpacity) / 100.0;
     text.Opacity(label ? opacity * 0.62 : opacity);
     text.TextWrapping(TextWrapping::NoWrap);
-    text.TextTrimming(TextTrimming::None);
-    SetTextForeground(text, AlertLevel::Normal, settings);
+    text.TextTrimming(TextTrimming::CharacterEllipsis);
+    SetTextForeground(text, AlertLevel::Normal);
 }
 
 void ApplyWidgetGeometry(const ModSettings& settings) {
@@ -2304,7 +2948,7 @@ void ApplyWidgetGeometry(const ModSettings& settings) {
         std::clamp(static_cast<double>(settings.width) * 0.38, 145.0, 170.0);
     double leftWidth = settings.width - kColumnGap - rightWidth;
     g_graphWidth = std::max(
-        48.0, leftWidth - kMetricLabelWidth - kMetricUsageWidth -
+        24.0, leftWidth - kMetricLabelWidth - kMetricUsageWidth -
                   kMetricTempWidth - kGraphLeftGap);
     g_memoryBarWidth = rightWidth;
 
@@ -2338,20 +2982,34 @@ void ApplyReservedSpace(const ModSettings& settings) {
     }
 
     Thickness margin = g_taskItemsRepeater.Margin();
-    margin.Left -= g_reservedMargin;
+    double baseLeft = margin.Left;
+    if (g_lastAppliedRepeaterMarginLeft &&
+        std::abs(margin.Left - *g_lastAppliedRepeaterMarginLeft) < 0.01) {
+        baseLeft -= g_reservedMargin;
+    } else if (g_reservedMargin != 0.0) {
+        Wh_Log(L"Taskbar repeater margin changed externally; adopting it as "
+               L"the new base");
+    }
     g_reservedMargin = settings.reserveSpace
                            ? settings.leftOffset + settings.width +
                                  settings.reserveGap
                            : 0.0;
-    margin.Left += g_reservedMargin;
+    margin.Left = baseLeft + g_reservedMargin;
     g_taskItemsRepeater.Margin(margin);
+    if (g_reservedMargin != 0.0) {
+        g_lastAppliedRepeaterMarginLeft = margin.Left;
+    } else {
+        g_lastAppliedRepeaterMarginLeft.reset();
+    }
 }
 
 void ApplyWidgetSettings() {
     if (!g_widget) {
         return;
     }
-    ModSettings settings = CurrentSettings();
+    auto settingsSnapshot = CurrentSettings();
+    const ModSettings& settings = *settingsSnapshot;
+    RefreshThemeBrushes(settings, true);
     if (g_historyInterval != settings.updateInterval ||
         g_historyWindow != settings.historySeconds) {
         g_cpuHistory.clear();
@@ -2377,10 +3035,9 @@ void ApplyWidgetSettings() {
         ApplyTextStyle(value, false, settings);
     }
 
-    SolidColorBrush graphBrush = AlertBrush(AlertLevel::Normal, settings);
     for (XamlPolyline graph : {g_cpuGraph, g_gpuGraph}) {
         if (graph) {
-            graph.Stroke(graphBrush);
+            graph.Stroke(g_graphBrush);
             graph.StrokeThickness(1.25);
             graph.StrokeStartLineCap(PenLineCap::Round);
             graph.StrokeEndLineCap(PenLineCap::Round);
@@ -2390,13 +3047,13 @@ void ApplyWidgetSettings() {
     }
     for (XamlRectangle track : {g_ramTrack, g_vramTrack}) {
         if (track) {
-            track.Fill(graphBrush);
+            track.Fill(g_graphBrush);
             track.Opacity(0.18);
         }
     }
     for (XamlRectangle fill : {g_ramFill, g_vramFill}) {
         if (fill) {
-            fill.Fill(graphBrush);
+            fill.Fill(g_graphBrush);
             fill.Opacity(0.76);
         }
     }
@@ -2413,20 +3070,38 @@ void ApplyWidgetSettings() {
     ApplyReservedSpace(settings);
 
     if (g_timer) {
-        g_timer.Interval(std::chrono::seconds(settings.updateInterval));
+        g_timer.Interval(std::chrono::milliseconds(250));
     }
 }
 
-void UpdateWidgetText() {
+void UpdateWidgetText(bool force = false) {
     if (!g_widget || g_unloading) {
         return;
     }
-    ModSettings settings = CurrentSettings();
+    bool themeChanged = WidgetThemeChanged();
+    std::shared_ptr<const ModSettings> settingsSnapshot;
+    if (themeChanged) {
+        settingsSnapshot = CurrentSettings();
+        // WidgetThemeChanged also observes high-contrast and system accent
+        // changes, which can occur without ActualTheme changing.
+        RefreshThemeBrushes(*settingsSnapshot, true);
+        force = true;
+    }
     MetricsSnapshot snapshot;
     uint64_t metricsSequence = 0;
-    if (!GetLatestMetrics(snapshot, metricsSequence)) {
+    std::vector<MetricsSnapshot> newSnapshots;
+    if (!GetMetricsSince(g_lastRenderedMetricsSequence, snapshot,
+                         metricsSequence, newSnapshots)) {
         return;
     }
+    bool hasNewSample = !newSnapshots.empty();
+    if (!force && !hasNewSample) {
+        return;
+    }
+    if (!settingsSnapshot) {
+        settingsSnapshot = CurrentSettings();
+    }
+    const ModSettings& settings = *settingsSnapshot;
 
     g_cpuTemperatureAlert = snapshot.cpuTemp
                                 ? EvaluateAlert(*snapshot.cpuTemp,
@@ -2440,72 +3115,76 @@ void UpdateWidgetText() {
                                                 settings.gpuCriticalTemp,
                                                 g_gpuTemperatureAlert, 3.0)
                                 : AlertLevel::Normal;
-    g_ramAlert = EvaluateAlert(snapshot.ram, settings.memoryWarningPercent,
-                               settings.memoryCriticalPercent, g_ramAlert, 3.0);
+    g_ramAlert = snapshot.ramAvailable
+                     ? EvaluateAlert(snapshot.ram,
+                                     settings.memoryWarningPercent,
+                                     settings.memoryCriticalPercent, g_ramAlert,
+                                     3.0)
+                     : AlertLevel::Normal;
     g_vramAlert =
         snapshot.vramAvailable
             ? EvaluateAlert(snapshot.vram, settings.memoryWarningPercent,
                             settings.memoryCriticalPercent, g_vramAlert, 3.0)
             : AlertLevel::Normal;
 
-    if (g_cpuUsageText) {
-        g_cpuUsageText.Text(FormatPercent(snapshot.cpu));
-    }
+    SetTextIfChanged(g_cpuUsageText,
+                     snapshot.cpuAvailable ? FormatPercent(snapshot.cpu)
+                                           : L"--%");
     if (g_cpuTempText) {
-        g_cpuTempText.Text(FormatTemperature(snapshot.cpuTemp));
-        SetTextForeground(g_cpuTempText, g_cpuTemperatureAlert, settings);
+        SetTextIfChanged(g_cpuTempText, FormatTemperature(snapshot.cpuTemp));
+        SetTextForeground(g_cpuTempText, g_cpuTemperatureAlert);
     }
-    if (g_gpuUsageText) {
-        g_gpuUsageText.Text(snapshot.gpuAvailable
-                                ? FormatPercent(snapshot.gpu)
-                                : L"--%");
-    }
+    SetTextIfChanged(g_gpuUsageText, snapshot.gpuAvailable
+                                         ? FormatPercent(snapshot.gpu)
+                                         : L"--%");
     if (g_gpuTempText) {
-        g_gpuTempText.Text(FormatTemperature(snapshot.gpuTemp));
-        SetTextForeground(g_gpuTempText, g_gpuTemperatureAlert, settings);
+        SetTextIfChanged(g_gpuTempText, FormatTemperature(snapshot.gpuTemp));
+        SetTextForeground(g_gpuTempText, g_gpuTemperatureAlert);
     }
     if (g_ramPercentText) {
-        g_ramPercentText.Text(FormatPercent(snapshot.ram));
-        SetTextForeground(g_ramPercentText, g_ramAlert, settings);
+        SetTextIfChanged(g_ramPercentText,
+                         snapshot.ramAvailable ? FormatPercent(snapshot.ram)
+                                               : L"--%");
+        SetTextForeground(g_ramPercentText, g_ramAlert);
     }
-    if (g_ramCapacityText) {
-        g_ramCapacityText.Text(FormatCapacity(snapshot.ramUsedGb,
-                                              snapshot.ramTotalGb, true));
-    }
+    SetTextIfChanged(g_ramCapacityText,
+                     FormatCapacity(snapshot.ramUsedGb, snapshot.ramTotalGb,
+                                    snapshot.ramAvailable));
     if (g_vramPercentText) {
-        g_vramPercentText.Text(snapshot.vramAvailable
-                                   ? FormatPercent(snapshot.vram)
-                                   : L"--%");
-        SetTextForeground(g_vramPercentText, g_vramAlert, settings);
+        SetTextIfChanged(g_vramPercentText, snapshot.vramAvailable
+                                                ? FormatPercent(snapshot.vram)
+                                                : L"--%");
+        SetTextForeground(g_vramPercentText, g_vramAlert);
     }
-    if (g_vramCapacityText) {
-        g_vramCapacityText.Text(
-            FormatCapacity(snapshot.vramUsedGb, snapshot.vramTotalGb,
-                           snapshot.vramAvailable));
-    }
+    SetTextIfChanged(g_vramCapacityText,
+                     FormatCapacity(snapshot.vramUsedGb, snapshot.vramTotalGb,
+                                    snapshot.vramAvailable));
 
-    if (metricsSequence != g_lastRenderedMetricsSequence) {
+    if (hasNewSample) {
         size_t historyCapacity = HistoryCapacity(settings);
-        AppendHistory(g_cpuHistory, snapshot.cpu, historyCapacity);
-        if (snapshot.gpuAvailable) {
-            AppendHistory(g_gpuHistory, snapshot.gpu, historyCapacity);
+        for (const MetricsSnapshot& newSnapshot : newSnapshots) {
+            if (newSnapshot.cpuAvailable) {
+                AppendHistory(g_cpuHistory, newSnapshot.cpu, historyCapacity);
+            }
+            if (newSnapshot.gpuAvailable) {
+                AppendHistory(g_gpuHistory, newSnapshot.gpu, historyCapacity);
+            }
         }
         UpdateSparkline(g_cpuGraph, g_cpuHistory, historyCapacity);
         UpdateSparkline(g_gpuGraph, g_gpuHistory, historyCapacity);
         g_lastRenderedMetricsSequence = metricsSequence;
     }
-    UpdateMemoryBar(g_ramFill, snapshot.ram, true, g_ramAlert, settings);
+    UpdateMemoryBar(g_ramFill, snapshot.ram, snapshot.ramAvailable, g_ramAlert);
     UpdateMemoryBar(g_vramFill, snapshot.vram, snapshot.vramAvailable,
-                    g_vramAlert, settings);
+                    g_vramAlert);
 }
 
 void EnsureTimer() {
     if (g_timer) {
         return;
     }
-    ModSettings settings = CurrentSettings();
     g_timer = DispatcherTimer();
-    g_timer.Interval(std::chrono::seconds(settings.updateInterval));
+    g_timer.Interval(std::chrono::milliseconds(250));
     g_timerToken = g_timer.Tick([](IInspectable const&, IInspectable const&) {
         try {
             UpdateWidgetText();
@@ -2537,7 +3216,7 @@ TextBlock CreateCellText(PCWSTR name, TextAlignment alignment) {
     text.VerticalAlignment(VerticalAlignment::Center);
     text.TextAlignment(alignment);
     text.TextWrapping(TextWrapping::NoWrap);
-    text.TextTrimming(TextTrimming::None);
+    text.TextTrimming(TextTrimming::CharacterEllipsis);
     text.IsHitTestVisible(false);
     return text;
 }
@@ -2661,10 +3340,17 @@ void RemoveWidget() {
 
     if (g_taskItemsRepeater && g_reservedMargin != 0.0) {
         Thickness margin = g_taskItemsRepeater.Margin();
-        margin.Left -= g_reservedMargin;
-        g_taskItemsRepeater.Margin(margin);
+        if (g_lastAppliedRepeaterMarginLeft &&
+            std::abs(margin.Left - *g_lastAppliedRepeaterMarginLeft) < 0.01) {
+            margin.Left -= g_reservedMargin;
+            g_taskItemsRepeater.Margin(margin);
+        } else {
+            Wh_Log(L"Taskbar repeater margin changed externally; leaving the "
+                   L"external value intact");
+        }
     }
     g_reservedMargin = 0.0;
+    g_lastAppliedRepeaterMarginLeft.reset();
 
     if (g_rootGrid && g_widget) {
         uint32_t index = 0;
@@ -2697,6 +3383,15 @@ void RemoveWidget() {
     g_leftColumn = nullptr;
     g_gapColumn = nullptr;
     g_rightColumn = nullptr;
+    g_textBrush = nullptr;
+    g_graphBrush = nullptr;
+    g_warningBrush = nullptr;
+    g_criticalBrush = nullptr;
+    g_cachedWidgetTheme = ElementTheme::Default;
+    g_themeBrushesInitialized = false;
+    g_cachedHighContrast = false;
+    g_cachedHighlightColor = CLR_INVALID;
+    g_cachedHotlightColor = CLR_INVALID;
     g_cpuHistory.clear();
     g_gpuHistory.clear();
     g_lastRenderedMetricsSequence = 0;
@@ -2733,7 +3428,7 @@ bool InjectWidget(FrameworkElement taskbarFrame) {
                 Wh_Log(L"Metrics worker unavailable");
             }
             EnsureTimer();
-            UpdateWidgetText();
+            UpdateWidgetText(true);
             return true;
         }
 
@@ -2801,6 +3496,7 @@ bool InjectWidget(FrameworkElement taskbarFrame) {
     g_taskItemsRepeater =
         FindDirectChildByName(root, L"TaskbarFrameRepeater");
     g_reservedMargin = 0.0;
+    g_lastAppliedRepeaterMarginLeft.reset();
 
     ApplyWidgetSettings();
     if (!StartMetricsWorker()) {
@@ -2866,7 +3562,97 @@ bool RunFromWindowThread(HWND window,
     return callbackContext.invoked;
 }
 
-HWND FindCurrentProcessTaskbarWindow() {
+bool IsTaskbarWindowClass(HWND window, bool* secondary = nullptr) {
+    WCHAR className[64];
+    if (!window ||
+        !GetClassNameW(window, className, std::size(className))) {
+        return false;
+    }
+
+    bool isPrimary = _wcsicmp(className, L"Shell_TrayWnd") == 0;
+    bool isSecondary =
+        _wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0;
+    if (secondary) {
+        *secondary = isSecondary;
+    }
+    return isPrimary || isSecondary;
+}
+
+bool IsCurrentProcessTaskbarWindow(HWND window) {
+    DWORD processId = 0;
+    return window && GetWindowThreadProcessId(window, &processId) != 0 &&
+           processId == GetCurrentProcessId() &&
+           IsTaskbarWindowClass(window);
+}
+
+struct DisplayMonitor {
+    HMONITOR handle = nullptr;
+    RECT bounds{};
+    bool primary = false;
+};
+
+std::vector<DisplayMonitor> EnumerateDisplayMonitors() {
+    std::vector<DisplayMonitor> monitors;
+    EnumDisplayMonitors(
+        nullptr, nullptr,
+        [](HMONITOR monitor, HDC, LPRECT, LPARAM context) -> BOOL {
+            MONITORINFO info{};
+            info.cbSize = sizeof(info);
+            if (GetMonitorInfoW(monitor, &info)) {
+                reinterpret_cast<std::vector<DisplayMonitor>*>(context)
+                    ->push_back({monitor, info.rcMonitor,
+                                 (info.dwFlags & MONITORINFOF_PRIMARY) != 0});
+            }
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&monitors));
+
+    std::stable_sort(
+        monitors.begin(), monitors.end(),
+        [](const DisplayMonitor& left, const DisplayMonitor& right) {
+            if (left.primary != right.primary) {
+                return left.primary;
+            }
+            if (left.bounds.left != right.bounds.left) {
+                return left.bounds.left < right.bounds.left;
+            }
+            if (left.bounds.top != right.bounds.top) {
+                return left.bounds.top < right.bounds.top;
+            }
+            if (left.bounds.right != right.bounds.right) {
+                return left.bounds.right < right.bounds.right;
+            }
+            if (left.bounds.bottom != right.bounds.bottom) {
+                return left.bounds.bottom < right.bounds.bottom;
+            }
+            return reinterpret_cast<uintptr_t>(left.handle) <
+                   reinterpret_cast<uintptr_t>(right.handle);
+        });
+    return monitors;
+}
+
+HWND FindTaskbarWindowForMonitor(HMONITOR monitor) {
+    struct SearchContext {
+        HMONITOR monitor;
+        HWND result;
+    } context{monitor, nullptr};
+
+    EnumWindows(
+        [](HWND window, LPARAM contextValue) -> BOOL {
+            auto* context = reinterpret_cast<SearchContext*>(contextValue);
+            if (IsCurrentProcessTaskbarWindow(window) &&
+                MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST) ==
+                    context->monitor) {
+                context->result = window;
+                return FALSE;
+            }
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&context));
+    return context.result;
+}
+
+HWND FindPrimaryTaskbarWindow() {
     HWND result = nullptr;
     EnumWindows(
         [](HWND window, LPARAM context) -> BOOL {
@@ -2885,18 +3671,25 @@ HWND FindCurrentProcessTaskbarWindow() {
     return result;
 }
 
-bool IsCurrentProcessWindow(HWND window) {
-    DWORD processId = 0;
-    WCHAR className[64];
-    return window && IsWindow(window) &&
-           GetWindowThreadProcessId(window, &processId) != 0 &&
-           processId == GetCurrentProcessId() &&
-           GetClassNameW(window, className, std::size(className)) != 0 &&
-           _wcsicmp(className, L"Shell_TrayWnd") == 0;
+HWND FindConfiguredTaskbarWindow() {
+    int monitorNumber = CurrentSettings()->monitor;
+    auto monitors = EnumerateDisplayMonitors();
+    if (monitorNumber <= static_cast<int>(monitors.size())) {
+        if (HWND window =
+                FindTaskbarWindowForMonitor(monitors[monitorNumber - 1].handle)) {
+            return window;
+        }
+        Wh_Log(L"Monitor %d has no taskbar; using the primary taskbar",
+               monitorNumber);
+    } else {
+        Wh_Log(L"Monitor %d is unavailable; using the primary taskbar",
+               monitorNumber);
+    }
+    return FindPrimaryTaskbarWindow();
 }
 
 void RememberTaskbarWindow(HWND window) {
-    if (!IsCurrentProcessWindow(window)) {
+    if (!IsCurrentProcessTaskbarWindow(window)) {
         return;
     }
     DWORD threadId = GetWindowThreadProcessId(window, nullptr);
@@ -2908,7 +3701,7 @@ void RememberTaskbarWindow(HWND window) {
 
 HWND FindRememberedTaskbarWindow() {
     HWND rememberedWindow = g_taskbarWindow.load();
-    if (IsCurrentProcessWindow(rememberedWindow)) {
+    if (IsCurrentProcessTaskbarWindow(rememberedWindow)) {
         return rememberedWindow;
     }
 
@@ -2918,26 +3711,19 @@ HWND FindRememberedTaskbarWindow() {
         EnumThreadWindows(
             rememberedThreadId,
             [](HWND window, LPARAM context) -> BOOL {
-                WCHAR className[64];
-                if (GetClassNameW(window, className, std::size(className)) &&
-                    _wcsicmp(className, L"Shell_TrayWnd") == 0) {
+                if (IsCurrentProcessTaskbarWindow(window)) {
                     *reinterpret_cast<HWND*>(context) = window;
                     return FALSE;
                 }
                 return TRUE;
             },
             reinterpret_cast<LPARAM>(&threadWindow));
-        if (IsCurrentProcessWindow(threadWindow)) {
+        if (IsCurrentProcessTaskbarWindow(threadWindow)) {
             RememberTaskbarWindow(threadWindow);
             return threadWindow;
         }
     }
-
-    HWND currentWindow = FindCurrentProcessTaskbarWindow();
-    if (currentWindow) {
-        RememberTaskbarWindow(currentWindow);
-    }
-    return currentWindow;
+    return nullptr;
 }
 
 HWND FindAnyWindowOnTaskbarThread(HWND excludedWindow) {
@@ -2971,6 +3757,11 @@ using CTaskBand_GetTaskbarHost_t =
     void*(WINAPI*)(void* pThis, void* taskbarHostSharedPtr);
 CTaskBand_GetTaskbarHost_t CTaskBand_GetTaskbarHost_Original = nullptr;
 
+using CSecondaryTaskBand_GetTaskbarHost_t =
+    void*(WINAPI*)(void* pThis, void* taskbarHostSharedPtr);
+CSecondaryTaskBand_GetTaskbarHost_t
+    CSecondaryTaskBand_GetTaskbarHost_Original = nullptr;
+
 using TaskbarHost_FrameHeight_t = int(WINAPI*)(void* pThis);
 TaskbarHost_FrameHeight_t TaskbarHost_FrameHeight_Original = nullptr;
 
@@ -2978,17 +3769,56 @@ using RefCountBase_Decref_t = void(WINAPI*)(void* pThis);
 RefCountBase_Decref_t RefCountBase_Decref_Original = nullptr;
 
 void* CTaskBand_ITaskListWndSite_vftable = nullptr;
+void* CSecondaryTaskBand_ITaskListWndSite_vftable = nullptr;
+
+bool IsReadableMemoryRange(const void* address, size_t size) {
+    if (!address || size == 0) {
+        return false;
+    }
+
+    MEMORY_BASIC_INFORMATION memory{};
+    if (!VirtualQuery(address, &memory, sizeof(memory)) ||
+        memory.State != MEM_COMMIT ||
+        (memory.Protect & (PAGE_GUARD | PAGE_NOACCESS))) {
+        return false;
+    }
+
+    uintptr_t start = reinterpret_cast<uintptr_t>(address);
+    uintptr_t regionStart =
+        reinterpret_cast<uintptr_t>(memory.BaseAddress);
+    uintptr_t regionEnd = regionStart + memory.RegionSize;
+    return start >= regionStart && start <= regionEnd &&
+           size <= regionEnd - start;
+}
 
 XamlRoot GetTaskbarXamlRoot(HWND taskbarWindow) {
-    if (!CTaskBand_GetTaskbarHost_Original ||
-        !TaskbarHost_FrameHeight_Original || !RefCountBase_Decref_Original ||
-        !CTaskBand_ITaskListWndSite_vftable) {
+    bool isSecondary = false;
+    if (!IsCurrentProcessTaskbarWindow(taskbarWindow) ||
+        !IsTaskbarWindowClass(taskbarWindow, &isSecondary) ||
+        !TaskbarHost_FrameHeight_Original || !RefCountBase_Decref_Original) {
         return nullptr;
     }
 
-    HWND taskBandWindow =
-        reinterpret_cast<HWND>(GetPropW(taskbarWindow, L"TaskbandHWND"));
+    auto getTaskbarHost = isSecondary
+                              ? CSecondaryTaskBand_GetTaskbarHost_Original
+                              : CTaskBand_GetTaskbarHost_Original;
+    void* expectedVftable =
+        isSecondary ? CSecondaryTaskBand_ITaskListWndSite_vftable
+                    : CTaskBand_ITaskListWndSite_vftable;
+    if (!getTaskbarHost || !expectedVftable) {
+        Wh_Log(L"%s taskbar symbols unavailable",
+               isSecondary ? L"Secondary" : L"Primary");
+        return nullptr;
+    }
+
+    HWND taskBandWindow = isSecondary
+                              ? FindWindowExW(taskbarWindow, nullptr, L"WorkerW",
+                                              nullptr)
+                              : reinterpret_cast<HWND>(GetPropW(
+                                    taskbarWindow, L"TaskbandHWND"));
     if (!taskBandWindow) {
+        Wh_Log(L"%s taskband host window not found",
+               isSecondary ? L"Secondary" : L"Primary");
         return nullptr;
     }
 
@@ -2999,18 +3829,23 @@ XamlRoot GetTaskbarXamlRoot(HWND taskbarWindow) {
     }
 
     void* taskBandForSite = taskBand;
-    for (int i = 0;
-         *reinterpret_cast<void**>(taskBandForSite) !=
-         CTaskBand_ITaskListWndSite_vftable;
-         i++) {
+    for (int i = 0;; i++) {
+        if (!IsReadableMemoryRange(taskBandForSite, sizeof(void*))) {
+            Wh_Log(L"Taskband site scan reached unreadable memory");
+            return nullptr;
+        }
+        if (*reinterpret_cast<void**>(taskBandForSite) == expectedVftable) {
+            break;
+        }
         if (i == 20) {
+            Wh_Log(L"Taskband site vftable not found");
             return nullptr;
         }
         taskBandForSite = reinterpret_cast<void**>(taskBandForSite) + 1;
     }
 
     void* taskbarHostSharedPtr[2]{};
-    CTaskBand_GetTaskbarHost_Original(taskBandForSite, taskbarHostSharedPtr);
+    getTaskbarHost(taskBandForSite, taskbarHostSharedPtr);
     if (!taskbarHostSharedPtr[0] || !taskbarHostSharedPtr[1]) {
         if (taskbarHostSharedPtr[1]) {
             RefCountBase_Decref_Original(taskbarHostSharedPtr[1]);
@@ -3022,7 +3857,8 @@ XamlRoot GetTaskbarXamlRoot(HWND taskbarWindow) {
 #if defined(_M_X64)
     const BYTE* code =
         reinterpret_cast<const BYTE*>(TaskbarHost_FrameHeight_Original);
-    if (code[0] == 0x48 && code[1] == 0x83 && code[2] == 0xEC &&
+    if (IsReadableMemoryRange(code, 8) && code[0] == 0x48 &&
+        code[1] == 0x83 && code[2] == 0xEC &&
         code[4] == 0x48 && code[5] == 0x83 && code[6] == 0xC1 &&
         code[7] <= 0x7F) {
         elementOffset = code[7];
@@ -3034,7 +3870,8 @@ XamlRoot GetTaskbarXamlRoot(HWND taskbarWindow) {
 #elif defined(_M_ARM64)
     const DWORD* code =
         reinterpret_cast<const DWORD*>(TaskbarHost_FrameHeight_Original);
-    if (code[0] == 0xD503237F &&
+    if (IsReadableMemoryRange(code, sizeof(DWORD) * 4) &&
+        code[0] == 0xD503237F &&
         (code[1] & 0xFFC07FFF) == 0xA9807BFD &&
         code[2] == 0x910003FD &&
         (code[3] & 0xFFF00FE0) == 0xF8400C00) {
@@ -3048,8 +3885,16 @@ XamlRoot GetTaskbarXamlRoot(HWND taskbarWindow) {
 #error "Unsupported architecture"
 #endif
 
-    auto* elementUnknown = *reinterpret_cast<::IUnknown**>(
-        static_cast<BYTE*>(taskbarHostSharedPtr[0]) + elementOffset);
+    auto* elementAddress =
+        static_cast<BYTE*>(taskbarHostSharedPtr[0]) + elementOffset;
+    if (!IsReadableMemoryRange(elementAddress, sizeof(::IUnknown*))) {
+        Wh_Log(L"Taskbar XAML element address is unreadable");
+        RefCountBase_Decref_Original(taskbarHostSharedPtr[1]);
+        return nullptr;
+    }
+
+    auto* elementUnknown =
+        *reinterpret_cast<::IUnknown**>(elementAddress);
     if (!elementUnknown) {
         RefCountBase_Decref_Original(taskbarHostSharedPtr[1]);
         return nullptr;
@@ -3063,9 +3908,9 @@ XamlRoot GetTaskbarXamlRoot(HWND taskbarWindow) {
     return result;
 }
 
-void ApplyToCurrentTaskbar(void*) {
-    HWND taskbarWindow = FindCurrentProcessTaskbarWindow();
-    if (!taskbarWindow) {
+void ApplyToTaskbarWindow(void* context) {
+    HWND taskbarWindow = reinterpret_cast<HWND>(context);
+    if (!IsCurrentProcessTaskbarWindow(taskbarWindow)) {
         return;
     }
 
@@ -3085,6 +3930,55 @@ void ApplyToCurrentTaskbar(void*) {
     } catch (...) {
         HRESULT error = winrt::to_hresult();
         Wh_Log(L"Applying widget failed: %08X",
+               static_cast<unsigned>(error));
+    }
+}
+
+struct TaskbarProbeContext {
+    HWND window = nullptr;
+    bool ready = false;
+};
+
+void ProbeTaskbarWindow(void* contextValue) {
+    auto* context = reinterpret_cast<TaskbarProbeContext*>(contextValue);
+    try {
+        XamlRoot xamlRoot = GetTaskbarXamlRoot(context->window);
+        if (!xamlRoot) {
+            return;
+        }
+        auto content = xamlRoot.Content().try_as<FrameworkElement>();
+        context->ready = static_cast<bool>(FindChildRecursive(
+            content, [](FrameworkElement child) {
+                return winrt::get_class_name(child) == L"Taskbar.TaskbarFrame";
+            }));
+    } catch (...) {
+        HRESULT error = winrt::to_hresult();
+        Wh_Log(L"Probing taskbar XAML failed: %08X",
+               static_cast<unsigned>(error));
+    }
+}
+
+bool IsTaskbarReady(HWND window) {
+    TaskbarProbeContext context{window, false};
+    return RunFromWindowThread(window, ProbeTaskbarWindow, &context) &&
+           context.ready;
+}
+
+struct RemoveWidgetForMoveContext {
+    bool succeeded = false;
+};
+
+void RemoveWidgetForMove(void* contextValue) {
+    auto* context =
+        reinterpret_cast<RemoveWidgetForMoveContext*>(contextValue);
+    try {
+        RemoveWidget();
+        context->succeeded = true;
+        g_taskbarWindow = nullptr;
+        g_taskbarThreadId = 0;
+    } catch (...) {
+        HRESULT error = winrt::to_hresult();
+        Wh_Log(L"Removing widget before monitor switch failed: %08X",
                static_cast<unsigned>(error));
     }
 }
@@ -3109,12 +4003,41 @@ void RemoveFromCurrentTaskbar(void*) {
 }
 
 void ApplyOnTaskbarThread() {
-    HWND taskbarWindow = FindRememberedTaskbarWindow();
-    if (!taskbarWindow) {
+    HWND targetWindow = FindConfiguredTaskbarWindow();
+    if (!targetWindow) {
         Wh_Log(L"Taskbar window not found");
         return;
     }
-    if (!RunFromWindowThread(taskbarWindow, ApplyToCurrentTaskbar, nullptr)) {
+
+    HWND currentWindow = FindRememberedTaskbarWindow();
+    if (currentWindow != targetWindow && !IsTaskbarReady(targetWindow)) {
+        HWND primaryWindow = FindPrimaryTaskbarWindow();
+        if (!primaryWindow) {
+            Wh_Log(L"Selected taskbar is not ready and no fallback exists");
+            return;
+        }
+        if (targetWindow != primaryWindow) {
+            Wh_Log(L"Selected taskbar is not ready; using the primary taskbar");
+        }
+        targetWindow = primaryWindow;
+    }
+
+    HWND removalWindow = currentWindow;
+    if (!removalWindow && g_taskbarThreadId.load()) {
+        removalWindow = FindAnyWindowOnTaskbarThread(nullptr);
+    }
+    if (removalWindow && currentWindow != targetWindow) {
+        RemoveWidgetForMoveContext removeContext;
+        if (!RunFromWindowThread(removalWindow, RemoveWidgetForMove,
+                                 &removeContext) ||
+            !removeContext.succeeded) {
+            Wh_Log(L"Removing widget from the previous monitor failed");
+            return;
+        }
+    }
+
+    if (!RunFromWindowThread(targetWindow, ApplyToTaskbarWindow,
+                             targetWindow)) {
         Wh_Log(L"Applying widget on taskbar thread failed");
     }
 }
@@ -3148,7 +4071,7 @@ void* WINAPI TaskbarFrame_Constructor_Hook(void* pThis) {
                 return;
             }
             try {
-                ApplyToCurrentTaskbar(nullptr);
+                ApplyOnTaskbarThread();
             } catch (...) {
                 HRESULT error = winrt::to_hresult();
                 Wh_Log(L"Loaded injection failed: %08X",
@@ -3168,8 +4091,12 @@ bool HookTaskbarDllSymbols() {
     WindhawkUtils::SYMBOL_HOOK taskbarDllHooks[] = {
         {{LR"(const CTaskBand::`vftable'{for `ITaskListWndSite'})"},
          &CTaskBand_ITaskListWndSite_vftable},
+        {{LR"(const CSecondaryTaskBand::`vftable'{for `ITaskListWndSite'})"},
+         &CSecondaryTaskBand_ITaskListWndSite_vftable},
         {{LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CTaskBand::GetTaskbarHost(void)const )"},
          &CTaskBand_GetTaskbarHost_Original},
+        {{LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CSecondaryTaskBand::GetTaskbarHost(void)const )"},
+         &CSecondaryTaskBand_GetTaskbarHost_Original},
         {{LR"(public: int __cdecl TaskbarHost::FrameHeight(void)const )"},
          &TaskbarHost_FrameHeight_Original},
         {{LR"(public: void __cdecl std::_Ref_count_base::_Decref(void))"},
@@ -3197,6 +4124,30 @@ HMODULE GetTaskbarViewModule() {
     return module;
 }
 
+bool TryHookTaskbarViewSymbols(HMODULE module, bool applyImmediately) {
+    if (!module || g_taskbarViewDllLoaded) {
+        return static_cast<bool>(g_taskbarViewDllLoaded);
+    }
+
+    constexpr uint32_t kMaximumHookAttempts = 3;
+    if (g_taskbarViewHookAttempts >= kMaximumHookAttempts ||
+        g_taskbarViewDllLoaded.exchange(true)) {
+        return static_cast<bool>(g_taskbarViewDllLoaded);
+    }
+
+    uint32_t attempt = ++g_taskbarViewHookAttempts;
+    if (!HookTaskbarViewSymbols(module)) {
+        Wh_Log(L"Taskbar.View symbol hook failed (attempt %u/%u)", attempt,
+               kMaximumHookAttempts);
+        g_taskbarViewDllLoaded = false;
+        return false;
+    }
+    if (applyImmediately) {
+        Wh_ApplyHookOperations();
+    }
+    return true;
+}
+
 using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 LoadLibraryExW_t LoadLibraryExW_Original = nullptr;
 
@@ -3204,11 +4155,8 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName,
                                    HANDLE file,
                                    DWORD flags) {
     HMODULE module = LoadLibraryExW_Original(fileName, file, flags);
-    if (module && !g_taskbarViewDllLoaded && GetTaskbarViewModule() == module &&
-        !g_taskbarViewDllLoaded.exchange(true)) {
-        if (HookTaskbarViewSymbols(module)) {
-            Wh_ApplyHookOperations();
-        }
+    if (HMODULE taskbarViewModule = GetTaskbarViewModule()) {
+        TryHookTaskbarViewSymbols(taskbarViewModule, true);
     }
     return module;
 }
@@ -3240,6 +4188,7 @@ bool TearDownTaskbarUi() {
 }  // namespace
 
 BOOL Wh_ModInit() {
+    Wh_Log(L">");
     g_uiTornDown = false;
     if (HMODULE gdi32 = GetModuleHandleW(L"gdi32.dll")) {
         g_d3dkmtEnumAdapters2 = reinterpret_cast<D3DKMTEnumAdapters2_t>(
@@ -3262,8 +4211,7 @@ BOOL Wh_ModInit() {
     }
 
     if (HMODULE module = GetTaskbarViewModule()) {
-        g_taskbarViewDllLoaded = true;
-        if (!HookTaskbarViewSymbols(module)) {
+        if (!TryHookTaskbarViewSymbols(module, false)) {
             Wh_Log(L"Taskbar.View symbols unavailable");
             return FALSE;
         }
@@ -3287,25 +4235,24 @@ BOOL Wh_ModInit() {
 }
 
 void Wh_ModAfterInit() {
+    Wh_Log(L">");
     if (!g_taskbarViewDllLoaded) {
         if (HMODULE module = GetTaskbarViewModule()) {
-            if (!g_taskbarViewDllLoaded.exchange(true)) {
-                if (HookTaskbarViewSymbols(module)) {
-                    Wh_ApplyHookOperations();
-                }
-            }
+            TryHookTaskbarViewSymbols(module, true);
         }
     }
     ApplyOnTaskbarThread();
 }
 
 void Wh_ModSettingsChanged() {
+    Wh_Log(L">");
     LoadSettings();
     WakeMetricsWorker();
     ApplyOnTaskbarThread();
 }
 
 void Wh_ModBeforeUninit() {
+    Wh_Log(L">");
     g_unloading = true;
     StopMetricsWorker();
 
@@ -3316,6 +4263,7 @@ void Wh_ModBeforeUninit() {
 }
 
 void Wh_ModUninit() {
+    Wh_Log(L">");
     if (!g_uiTornDown) {
         g_uiTornDown = TearDownTaskbarUi();
         if (!g_uiTornDown) {

--- a/mods/taskbar-system-info.wh.cpp
+++ b/mods/taskbar-system-info.wh.cpp
@@ -443,6 +443,10 @@ constexpr double kGiB = 1024.0 * 1024.0 * 1024.0;
 constexpr uint32_t kMaximumTaskbarViewHookAttempts = 3;
 constexpr uint32_t kMaximumUnknownPlacementProbeFailures = 3;
 constexpr auto kGadgetRegistryRescanInterval = std::chrono::seconds(30);
+constexpr auto kGadgetRegistryPartialRescanInterval =
+    std::chrono::seconds(5);
+constexpr auto kSharedMemoryRescanInterval = std::chrono::seconds(60);
+constexpr auto kSharedMemoryPartialRescanInterval = std::chrono::seconds(5);
 constexpr wchar_t kDefaultGraphColor[] = L"#78A8FF";
 constexpr wchar_t kDefaultWarningColor[] = L"#FFFFB900";
 constexpr wchar_t kDefaultCriticalColor[] = L"#FFFF6B6B";
@@ -609,7 +613,7 @@ struct HwInfoGadgetRegistryCache {
     std::wstring gpuAdapter;
 };
 
-[[clang::no_destroy]] HwInfoGadgetRegistryCache g_hwInfoGadgetRegistryCache;
+HwInfoGadgetRegistryCache g_hwInfoGadgetRegistryCache;
 
 struct MetricsSnapshot {
     double cpu = 0.0;
@@ -1095,6 +1099,32 @@ static_assert(sizeof(HwInfoSensorPrefix) == 264);
 static_assert(offsetof(HwInfoReadingPrefix, value) == 284);
 static_assert(sizeof(HwInfoReadingPrefix) == 292);
 
+struct HwInfoSharedMemoryCache {
+    std::optional<uint32_t> cpuReadingIndex;
+    std::optional<uint32_t> gpuReadingIndex;
+    std::chrono::steady_clock::time_point nextFullScan{};
+    std::wstring cpuFilter;
+    std::wstring gpuFilter;
+    std::wstring gpuAdapter;
+    uint32_t version = 0;
+    uint32_t revision = 0;
+    uint32_t sensorOffset = 0;
+    uint32_t sensorStride = 0;
+    uint32_t sensorCount = 0;
+    uint32_t readingOffset = 0;
+    uint32_t readingStride = 0;
+    uint32_t readingCount = 0;
+    bool layoutKnown = false;
+};
+
+struct HwInfoRawTemperatureReading {
+    uint32_t index = 0;
+    HwInfoSensorPrefix sensor{};
+    HwInfoReadingPrefix reading{};
+};
+
+HwInfoSharedMemoryCache g_hwInfoSharedMemoryCache;
+
 bool IsRangeValid(size_t totalSize,
                   uint32_t offset,
                   uint32_t stride,
@@ -1183,6 +1213,16 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
                             const ModSettings& settings,
                             const std::optional<std::wstring>& gpuAdapterName,
                             HwInfoTemperatureDiagnostics& diagnostics) {
+    std::wstring gpuAdapter = gpuAdapterName.value_or(L"");
+    if (g_hwInfoSharedMemoryCache.cpuFilter != settings.cpuTempSensor ||
+        g_hwInfoSharedMemoryCache.gpuFilter != settings.gpuTempSensor ||
+        g_hwInfoSharedMemoryCache.gpuAdapter != gpuAdapter) {
+        g_hwInfoSharedMemoryCache = {};
+        g_hwInfoSharedMemoryCache.cpuFilter = settings.cpuTempSensor;
+        g_hwInfoSharedMemoryCache.gpuFilter = settings.gpuTempSensor;
+        g_hwInfoSharedMemoryCache.gpuAdapter = std::move(gpuAdapter);
+    }
+
     HANDLE mapping = OpenFileMappingW(FILE_MAP_READ, FALSE,
                                       L"Global\\HWiNFO_SENS_SM2");
     if (!mapping) {
@@ -1217,6 +1257,10 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
 
     std::vector<HwInfoSensorPrefix> sensors;
     std::vector<HwInfoReadingPrefix> readings;
+    std::optional<HwInfoRawTemperatureReading> cachedCpuReading;
+    std::optional<HwInfoRawTemperatureReading> cachedGpuReading;
+    bool fullScanCopied = false;
+    auto now = std::chrono::steady_clock::now();
     MEMORY_BASIC_INFORMATION memoryInfo{};
     if (VirtualQuery(view, &memoryInfo, sizeof(memoryInfo))) {
         size_t viewOffset = static_cast<const uint8_t*>(view) -
@@ -1240,19 +1284,108 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
                              header.readingStride, header.readingCount,
                              sizeof(HwInfoReadingPrefix))) {
                 const auto* bytes = static_cast<const uint8_t*>(view);
-                sensors.resize(header.sensorCount);
-                readings.resize(header.readingCount);
-                for (uint32_t i = 0; i < header.sensorCount; i++) {
-                    const uint8_t* address =
-                        bytes + header.sensorOffset +
-                        static_cast<size_t>(i) * header.sensorStride;
-                    std::memcpy(&sensors[i], address, sizeof(sensors[i]));
+                bool layoutChanged =
+                    !g_hwInfoSharedMemoryCache.layoutKnown ||
+                    g_hwInfoSharedMemoryCache.version != header.version ||
+                    g_hwInfoSharedMemoryCache.revision != header.revision ||
+                    g_hwInfoSharedMemoryCache.sensorOffset !=
+                        header.sensorOffset ||
+                    g_hwInfoSharedMemoryCache.sensorStride !=
+                        header.sensorStride ||
+                    g_hwInfoSharedMemoryCache.sensorCount !=
+                        header.sensorCount ||
+                    g_hwInfoSharedMemoryCache.readingOffset !=
+                        header.readingOffset ||
+                    g_hwInfoSharedMemoryCache.readingStride !=
+                        header.readingStride ||
+                    g_hwInfoSharedMemoryCache.readingCount !=
+                        header.readingCount;
+                if (layoutChanged) {
+                    g_hwInfoSharedMemoryCache.cpuReadingIndex.reset();
+                    g_hwInfoSharedMemoryCache.gpuReadingIndex.reset();
+                    g_hwInfoSharedMemoryCache.nextFullScan = {};
+                    g_hwInfoSharedMemoryCache.version = header.version;
+                    g_hwInfoSharedMemoryCache.revision = header.revision;
+                    g_hwInfoSharedMemoryCache.sensorOffset =
+                        header.sensorOffset;
+                    g_hwInfoSharedMemoryCache.sensorStride =
+                        header.sensorStride;
+                    g_hwInfoSharedMemoryCache.sensorCount = header.sensorCount;
+                    g_hwInfoSharedMemoryCache.readingOffset =
+                        header.readingOffset;
+                    g_hwInfoSharedMemoryCache.readingStride =
+                        header.readingStride;
+                    g_hwInfoSharedMemoryCache.readingCount =
+                        header.readingCount;
+                    g_hwInfoSharedMemoryCache.layoutKnown = true;
                 }
-                for (uint32_t i = 0; i < header.readingCount; i++) {
-                    const uint8_t* address =
-                        bytes + header.readingOffset +
-                        static_cast<size_t>(i) * header.readingStride;
-                    std::memcpy(&readings[i], address, sizeof(readings[i]));
+
+                bool performFullScan =
+                    g_hwInfoSharedMemoryCache.nextFullScan ==
+                        std::chrono::steady_clock::time_point{} ||
+                    now >= g_hwInfoSharedMemoryCache.nextFullScan;
+                auto copyCachedReading =
+                    [&](std::optional<uint32_t>& cachedIndex,
+                        std::optional<HwInfoRawTemperatureReading>& output) {
+                        if (!cachedIndex || performFullScan) {
+                            return;
+                        }
+                        if (*cachedIndex >= header.readingCount) {
+                            cachedIndex.reset();
+                            performFullScan = true;
+                            return;
+                        }
+
+                        HwInfoRawTemperatureReading raw{};
+                        raw.index = *cachedIndex;
+                        const uint8_t* readingAddress =
+                            bytes + header.readingOffset +
+                            static_cast<size_t>(raw.index) *
+                                header.readingStride;
+                        std::memcpy(&raw.reading, readingAddress,
+                                    sizeof(raw.reading));
+                        if (raw.reading.readingType !=
+                                kHwInfoTemperatureType ||
+                            raw.reading.sensorIndex >= header.sensorCount) {
+                            cachedIndex.reset();
+                            performFullScan = true;
+                            return;
+                        }
+                        const uint8_t* sensorAddress =
+                            bytes + header.sensorOffset +
+                            static_cast<size_t>(raw.reading.sensorIndex) *
+                                header.sensorStride;
+                        std::memcpy(&raw.sensor, sensorAddress,
+                                    sizeof(raw.sensor));
+                        output = raw;
+                    };
+
+                copyCachedReading(
+                    g_hwInfoSharedMemoryCache.cpuReadingIndex,
+                    cachedCpuReading);
+                copyCachedReading(
+                    g_hwInfoSharedMemoryCache.gpuReadingIndex,
+                    cachedGpuReading);
+
+                if (performFullScan) {
+                    cachedCpuReading.reset();
+                    cachedGpuReading.reset();
+                    sensors.resize(header.sensorCount);
+                    readings.resize(header.readingCount);
+                    for (uint32_t i = 0; i < header.sensorCount; i++) {
+                        const uint8_t* address =
+                            bytes + header.sensorOffset +
+                            static_cast<size_t>(i) * header.sensorStride;
+                        std::memcpy(&sensors[i], address, sizeof(sensors[i]));
+                    }
+                    for (uint32_t i = 0; i < header.readingCount; i++) {
+                        const uint8_t* address =
+                            bytes + header.readingOffset +
+                            static_cast<size_t>(i) * header.readingStride;
+                        std::memcpy(&readings[i], address,
+                                    sizeof(readings[i]));
+                    }
+                    fullScanCopied = true;
                 }
                 if (!mutexOwned) {
                     HwInfoHeader verificationHeader{};
@@ -1265,6 +1398,9 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
                         // generation changed while the raw records were copied.
                         sensors.clear();
                         readings.clear();
+                        cachedCpuReading.reset();
+                        cachedGpuReading.reset();
+                        fullScanCopied = false;
                     }
                 }
             }
@@ -1280,52 +1416,119 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
     }
     CloseHandle(mapping);
 
-    // Keep HWiNFO's shared mutex only while copying the validated raw records.
-    // String conversion, scoring and unit normalization don't need to block the
-    // producer from refreshing its shared memory.
-    int bestCpuScore = -1;
-    int bestGpuScore = -1;
     bool sawTemperatureReading = false;
     bool sawSupportedTemperatureUnit = false;
-    for (const HwInfoReadingPrefix& reading : readings) {
-        if (reading.readingType != kHwInfoTemperatureType ||
-            reading.sensorIndex >= sensors.size()) {
-            continue;
-        }
-        sawTemperatureReading = true;
+    if (fullScanCopied) {
+        // The full table is copied only for discovery or periodic refresh.
+        // Normal samples below validate and read the two cached records.
+        int bestCpuScore = -1;
+        int bestGpuScore = -1;
+        std::optional<uint32_t> bestCpuIndex;
+        std::optional<uint32_t> bestGpuIndex;
+        for (uint32_t i = 0; i < readings.size(); i++) {
+            const HwInfoReadingPrefix& reading = readings[i];
+            if (reading.readingType != kHwInfoTemperatureType ||
+                reading.sensorIndex >= sensors.size()) {
+                continue;
+            }
+            sawTemperatureReading = true;
 
-        auto value = NormalizeHwInfoTemperature(
-            reading.value, reading.unit, std::size(reading.unit));
-        if (!value) {
-            continue;
-        }
-        sawSupportedTemperatureUnit = true;
+            auto value = NormalizeHwInfoTemperature(
+                reading.value, reading.unit, std::size(reading.unit));
+            if (!value) {
+                continue;
+            }
+            sawSupportedTemperatureUnit = true;
 
-        const HwInfoSensorPrefix& sensor = sensors[reading.sensorIndex];
-        std::wstring sensorName =
-            FixedAnsiToWide(sensor.originalName,
-                            std::size(sensor.originalName));
-        std::wstring label =
-            FixedAnsiToWide(reading.originalLabel,
-                            std::size(reading.originalLabel));
-        RecordGpuTemperatureDiagnostic(diagnostics, sensorName, label,
-                                       gpuAdapterName);
+            const HwInfoSensorPrefix& sensor = sensors[reading.sensorIndex];
+            std::wstring sensorName = FixedAnsiToWide(
+                sensor.originalName, std::size(sensor.originalName));
+            std::wstring label = FixedAnsiToWide(
+                reading.originalLabel, std::size(reading.originalLabel));
+            RecordGpuTemperatureDiagnostic(diagnostics, sensorName, label,
+                                           gpuAdapterName);
 
-        int cpuScore = CpuTemperatureScore(
-            sensorName, label, settings.cpuTempSensor);
-        if (cpuScore > bestCpuScore) {
-            bestCpuScore = cpuScore;
-            snapshot.cpuTemp = *value;
-            snapshot.cpuTempProvider = TemperatureProvider::HwInfoSharedMemory;
+            int cpuScore = CpuTemperatureScore(
+                sensorName, label, settings.cpuTempSensor);
+            if (cpuScore > bestCpuScore) {
+                bestCpuScore = cpuScore;
+                bestCpuIndex = i;
+                snapshot.cpuTemp = *value;
+                snapshot.cpuTempProvider =
+                    TemperatureProvider::HwInfoSharedMemory;
+            }
+
+            int gpuScore = GpuTemperatureScore(
+                sensorName, label, settings.gpuTempSensor, gpuAdapterName);
+            if (gpuScore > bestGpuScore) {
+                bestGpuScore = gpuScore;
+                bestGpuIndex = i;
+                snapshot.gpuTemp = *value;
+                snapshot.gpuTempProvider =
+                    TemperatureProvider::HwInfoSharedMemory;
+            }
         }
 
-        int gpuScore = GpuTemperatureScore(
-            sensorName, label, settings.gpuTempSensor, gpuAdapterName);
-        if (gpuScore > bestGpuScore) {
-            bestGpuScore = gpuScore;
-            snapshot.gpuTemp = *value;
-            snapshot.gpuTempProvider = TemperatureProvider::HwInfoSharedMemory;
-        }
+        g_hwInfoSharedMemoryCache.cpuReadingIndex = bestCpuIndex;
+        g_hwInfoSharedMemoryCache.gpuReadingIndex = bestGpuIndex;
+        g_hwInfoSharedMemoryCache.nextFullScan =
+            now + (bestCpuIndex && bestGpuIndex
+                       ? kSharedMemoryRescanInterval
+                       : kSharedMemoryPartialRescanInterval);
+    } else {
+        auto applyCachedReading =
+            [&](const std::optional<HwInfoRawTemperatureReading>& raw,
+                std::optional<uint32_t>& cachedIndex, bool cpu) {
+                if (!raw) {
+                    return;
+                }
+                sawTemperatureReading = true;
+
+                const HwInfoReadingPrefix& reading = raw->reading;
+                std::wstring sensorName = FixedAnsiToWide(
+                    raw->sensor.originalName,
+                    std::size(raw->sensor.originalName));
+                std::wstring label = FixedAnsiToWide(
+                    reading.originalLabel,
+                    std::size(reading.originalLabel));
+                RecordGpuTemperatureDiagnostic(diagnostics, sensorName, label,
+                                               gpuAdapterName);
+                int score = cpu
+                                ? CpuTemperatureScore(
+                                      sensorName, label,
+                                      settings.cpuTempSensor)
+                                : GpuTemperatureScore(
+                                      sensorName, label,
+                                      settings.gpuTempSensor,
+                                      gpuAdapterName);
+                if (score < 0) {
+                    cachedIndex.reset();
+                    g_hwInfoSharedMemoryCache.nextFullScan = {};
+                    return;
+                }
+
+                auto value = NormalizeHwInfoTemperature(
+                    reading.value, reading.unit, std::size(reading.unit));
+                if (!value) {
+                    return;
+                }
+                sawSupportedTemperatureUnit = true;
+
+                if (cpu) {
+                    snapshot.cpuTemp = *value;
+                    snapshot.cpuTempProvider =
+                        TemperatureProvider::HwInfoSharedMemory;
+                } else {
+                    snapshot.gpuTemp = *value;
+                    snapshot.gpuTempProvider =
+                        TemperatureProvider::HwInfoSharedMemory;
+                }
+            };
+
+        applyCachedReading(cachedCpuReading,
+                           g_hwInfoSharedMemoryCache.cpuReadingIndex, true);
+        applyCachedReading(cachedGpuReading,
+                           g_hwInfoSharedMemoryCache.gpuReadingIndex, false);
     }
 
     if (sawTemperatureReading && !sawSupportedTemperatureUnit &&
@@ -1433,7 +1636,7 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
         g_hwInfoGadgetRegistryCache.gpuIndex.reset();
         g_hwInfoGadgetRegistryCache.fullScanCompleted = true;
         g_hwInfoGadgetRegistryCache.nextFullScan =
-            now + kGadgetRegistryRescanInterval;
+            now + kGadgetRegistryPartialRescanInterval;
         return;
     }
 
@@ -1538,7 +1741,9 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
     g_hwInfoGadgetRegistryCache.gpuIndex = bestGpuIndex;
     g_hwInfoGadgetRegistryCache.fullScanCompleted = true;
     g_hwInfoGadgetRegistryCache.nextFullScan =
-        now + kGadgetRegistryRescanInterval;
+        now + (bestCpuIndex && bestGpuIndex
+                   ? kGadgetRegistryRescanInterval
+                   : kGadgetRegistryPartialRescanInterval);
 
     if (!snapshot.cpuTemp && bestCpuValue) {
         snapshot.cpuTemp = *bestCpuValue;
@@ -2512,11 +2717,38 @@ bool LooksLikeIntegratedGpu(const GpuAdapterInfo& adapter) {
     }
 
     // Some WDDM drivers don't set HybridIntegrated for newer integrated parts
-    // such as Radeon 890M or Intel Arc iGPUs. Their small firmware carve-out
-    // plus usable shared memory is a more stable signal than marketing names.
+    // such as Radeon 890M or Intel Arc iGPUs. Require both the characteristic
+    // memory shape and an integrated-family name so an old low-memory discrete
+    // adapter isn't silently switched to the shared-memory pool.
     constexpr uint64_t kMaximumIntegratedCarveout = 512ull * 1024 * 1024;
-    return adapter.dedicatedVideoMemory <= kMaximumIntegratedCarveout &&
-           adapter.sharedSystemMemory > 0;
+    if (adapter.dedicatedVideoMemory > kMaximumIntegratedCarveout ||
+        adapter.sharedSystemMemory == 0) {
+        return false;
+    }
+
+    std::wstring name = NormalizeAdapterIdentity(adapter.description);
+    bool radeonMobileModel = false;
+    if (Contains(name, L"radeon")) {
+        for (const std::wstring& token : IdentityTokens(name)) {
+            if (token.size() < 2 || token.back() != L'm') {
+                continue;
+            }
+            radeonMobileModel = std::all_of(
+                token.begin(), token.end() - 1,
+                [](wchar_t character) { return std::iswdigit(character) != 0; });
+            if (radeonMobileModel) {
+                break;
+            }
+        }
+    }
+
+    bool intelArcGraphics = Contains(name, L"intel") &&
+                            Contains(name, L"arc") &&
+                            Contains(name, L"graphics");
+    return Contains(name, L"uhd graphics") || Contains(name, L"iris") ||
+           Contains(name, L"radeon graphics") || Contains(name, L"vega") ||
+           Contains(name, L"integrated") || radeonMobileModel ||
+           intelArcGraphics;
 }
 
 bool UseSharedGpuMemory(const GpuAdapterInfo& adapter,
@@ -3266,6 +3498,8 @@ void ApplyReservedSpace(const ModSettings& settings) {
     }
 }
 
+void UpdateTimerInterval();
+
 void ApplyWidgetSettings() {
     if (!g_widget) {
         return;
@@ -3332,9 +3566,7 @@ void ApplyWidgetSettings() {
     UpdateSparkline(g_gpuGraph, g_gpuHistory, capacity);
     ApplyReservedSpace(settings);
 
-    if (g_timer) {
-        g_timer.Interval(std::chrono::milliseconds(250));
-    }
+    UpdateTimerInterval();
 }
 
 void UpdateWidgetText(bool force = false) {
@@ -3450,7 +3682,7 @@ void EnsureTimer() {
         g_taskbarThreadId = GetCurrentThreadId();
     }
     g_timer = DispatcherTimer();
-    g_timer.Interval(std::chrono::milliseconds(g_widget ? 250 : 1000));
+    UpdateTimerInterval();
     auto now = std::chrono::steady_clock::now();
     g_nextSystemColorCheck = now + std::chrono::seconds(1);
     g_nextTaskbarPlacementCheck = now + std::chrono::seconds(1);
@@ -4282,6 +4514,7 @@ XamlRoot GetTaskbarXamlRoot(HWND taskbarWindow) {
 
 struct ApplyWidgetContext {
     HWND taskbarWindow = nullptr;
+    FrameworkElement taskbarFrame{nullptr};
     bool succeeded = false;
 };
 
@@ -4293,15 +4526,20 @@ void ApplyToTaskbarWindow(void* contextValue) {
     }
 
     try {
-        XamlRoot xamlRoot = GetTaskbarXamlRoot(taskbarWindow);
-        if (!xamlRoot) {
-            Wh_Log(L"GetTaskbarXamlRoot failed");
-            return;
+        FrameworkElement taskbarFrame = context->taskbarFrame;
+        if (!taskbarFrame) {
+            XamlRoot xamlRoot = GetTaskbarXamlRoot(taskbarWindow);
+            if (!xamlRoot) {
+                Wh_Log(L"GetTaskbarXamlRoot failed");
+                return;
+            }
+            auto content = xamlRoot.Content().try_as<FrameworkElement>();
+            taskbarFrame =
+                FindChildRecursive(content, [](FrameworkElement child) {
+                    return winrt::get_class_name(child) ==
+                           L"Taskbar.TaskbarFrame";
+                });
         }
-        auto content = xamlRoot.Content().try_as<FrameworkElement>();
-        auto taskbarFrame = FindChildRecursive(content, [](FrameworkElement child) {
-            return winrt::get_class_name(child) == L"Taskbar.TaskbarFrame";
-        });
         if (taskbarFrame && InjectWidget(taskbarFrame)) {
             RememberTaskbarWindow(taskbarWindow);
             context->succeeded = true;
@@ -4313,15 +4551,17 @@ void ApplyToTaskbarWindow(void* contextValue) {
     }
 }
 
-bool ApplyWidgetToTaskbarWindow(HWND taskbarWindow) {
-    ApplyWidgetContext context{taskbarWindow, false};
+bool ApplyWidgetToTaskbarWindow(
+    HWND taskbarWindow,
+    FrameworkElement taskbarFrame = nullptr) {
+    ApplyWidgetContext context{taskbarWindow, taskbarFrame, false};
     return RunFromWindowThread(taskbarWindow, ApplyToTaskbarWindow, &context) &&
            context.succeeded;
 }
 
 struct TaskbarProbeContext {
     HWND window = nullptr;
-    bool ready = false;
+    FrameworkElement frame{nullptr};
 };
 
 void ProbeTaskbarWindow(void* contextValue) {
@@ -4332,10 +4572,10 @@ void ProbeTaskbarWindow(void* contextValue) {
             return;
         }
         auto content = xamlRoot.Content().try_as<FrameworkElement>();
-        context->ready = static_cast<bool>(FindChildRecursive(
+        context->frame = FindChildRecursive(
             content, [](FrameworkElement child) {
                 return winrt::get_class_name(child) == L"Taskbar.TaskbarFrame";
-            }));
+            });
     } catch (...) {
         HRESULT error = winrt::to_hresult();
         Wh_Log(L"Probing taskbar XAML failed: %08X",
@@ -4343,10 +4583,12 @@ void ProbeTaskbarWindow(void* contextValue) {
     }
 }
 
-bool IsTaskbarReady(HWND window) {
-    TaskbarProbeContext context{window, false};
-    return RunFromWindowThread(window, ProbeTaskbarWindow, &context) &&
-           context.ready;
+FrameworkElement FindReadyTaskbarFrame(HWND window) {
+    TaskbarProbeContext context{window, nullptr};
+    if (!RunFromWindowThread(window, ProbeTaskbarWindow, &context)) {
+        return nullptr;
+    }
+    return context.frame;
 }
 
 struct RemoveWidgetForMoveContext {
@@ -4404,7 +4646,7 @@ void ResetPlacementRetryState() {
     g_placementFailures = 0;
 }
 
-void RecordPlacementFailure(HWND targetWindow) {
+uint32_t SchedulePlacementRetry(HWND targetWindow) {
     if (!g_hasFailedPlacementTarget ||
         targetWindow != g_lastFailedPlacementTarget) {
         g_lastFailedPlacementTarget = targetWindow;
@@ -4419,7 +4661,18 @@ void RecordPlacementFailure(HWND targetWindow) {
     uint32_t retrySeconds = std::min(1u << exponent, 60u);
     g_nextPlacementRetry =
         std::chrono::steady_clock::now() + std::chrono::seconds(retrySeconds);
+    return retrySeconds;
+}
+
+void RecordPlacementFailure(HWND targetWindow) {
+    uint32_t retrySeconds = SchedulePlacementRetry(targetWindow);
     Wh_Log(L"Taskbar placement failed; retrying in %u seconds", retrySeconds);
+}
+
+void RecordPlacementFallback(HWND targetWindow) {
+    uint32_t retrySeconds = SchedulePlacementRetry(targetWindow);
+    Wh_Log(L"Taskbar placement fell back; re-checking in %u seconds",
+           retrySeconds);
 }
 
 void MarkPlacementForRetry(HWND requestedWindow) {
@@ -4444,7 +4697,7 @@ void CompletePlacement(HWND requestedWindow, HWND actualWindow) {
         ResetPlacementRetryState();
     } else {
         g_placementIsFallback = true;
-        RecordPlacementFailure(requestedWindow);
+        RecordPlacementFallback(requestedWindow);
     }
 }
 
@@ -4486,6 +4739,7 @@ bool ApplyLoadedFrameFallback(FrameworkElement fallbackFrame,
 
 struct ApplyOnTaskbarThreadContext {
     FrameworkElement fallbackFrame{nullptr};
+    HWND requestedWindow = nullptr;
     bool refreshExistingWidget = true;
     bool resetUnknownPlacementProbes = false;
     bool succeeded = false;
@@ -4505,7 +4759,10 @@ void ApplyOnTaskbarUiThreadImpl(void* contextValue) {
     // below is intentionally owned by Explorer's taskbar/XAML UI thread.
     EnsureTimer();
 
-    HWND requestedWindow = FindConfiguredTaskbarWindow();
+    HWND requestedWindow = context->requestedWindow;
+    if (!IsCurrentProcessTaskbarWindow(requestedWindow)) {
+        requestedWindow = FindConfiguredTaskbarWindow();
+    }
     if (!requestedWindow) {
         Wh_Log(L"Taskbar window not found");
         MarkPlacementForRetry(nullptr);
@@ -4527,18 +4784,22 @@ void ApplyOnTaskbarUiThreadImpl(void* contextValue) {
     }
 
     HWND targetWindow = requestedWindow;
-    bool targetReady = IsTaskbarReady(targetWindow);
-    if (!targetReady) {
+    FrameworkElement targetFrame = FindReadyTaskbarFrame(targetWindow);
+    if (!targetFrame) {
         HWND primaryWindow = FindPrimaryTaskbarWindow();
-        if (primaryWindow && primaryWindow != targetWindow &&
-            IsTaskbarReady(primaryWindow)) {
-            Wh_Log(L"Selected taskbar is not ready; using the primary taskbar");
-            targetWindow = primaryWindow;
-            targetReady = true;
+        if (primaryWindow && primaryWindow != targetWindow) {
+            FrameworkElement primaryFrame =
+                FindReadyTaskbarFrame(primaryWindow);
+            if (primaryFrame) {
+                Wh_Log(
+                    L"Selected taskbar is not ready; using the primary taskbar");
+                targetWindow = primaryWindow;
+                targetFrame = std::move(primaryFrame);
+            }
         }
     }
 
-    if (!targetReady) {
+    if (!targetFrame) {
         Wh_Log(L"No taskbar exposes a ready XAML root");
         if (ApplyLoadedFrameFallback(context->fallbackFrame, targetWindow)) {
             context->succeeded = true;
@@ -4577,7 +4838,7 @@ void ApplyOnTaskbarUiThreadImpl(void* contextValue) {
         widgetRemovedForMove = true;
     }
 
-    if (ApplyWidgetToTaskbarWindow(targetWindow)) {
+    if (ApplyWidgetToTaskbarWindow(targetWindow, targetFrame)) {
         CompletePlacement(requestedWindow, targetWindow);
         context->succeeded = true;
         return;
@@ -4612,7 +4873,8 @@ void ApplyOnTaskbarUiThread(void* contextValue) {
 
 void ApplyOnTaskbarThread(FrameworkElement fallbackFrame = nullptr,
                           bool refreshExistingWidget = true,
-                          bool resetUnknownPlacementProbes = false) {
+                          bool resetUnknownPlacementProbes = false,
+                          HWND requestedWindow = nullptr) {
     if (g_unloading) {
         return;
     }
@@ -4633,7 +4895,8 @@ void ApplyOnTaskbarThread(FrameworkElement fallbackFrame = nullptr,
         return;
     }
 
-    ApplyOnTaskbarThreadContext context{fallbackFrame, refreshExistingWidget,
+    ApplyOnTaskbarThreadContext context{fallbackFrame, requestedWindow,
+                                        refreshExistingWidget,
                                         resetUnknownPlacementProbes, false};
     if (!RunFromWindowThread(dispatchWindow, ApplyOnTaskbarUiThread, &context)) {
         Wh_Log(L"Dispatching taskbar placement failed");
@@ -4693,7 +4956,7 @@ void EnsureConfiguredTaskbarPlacement() {
     } else {
         Wh_Log(L"Retrying taskbar placement");
     }
-    ApplyOnTaskbarThread(nullptr, false);
+    ApplyOnTaskbarThread(nullptr, false, false, targetWindow);
 }
 
 void ApplyLoadedTaskbarFrame(FrameworkElement taskbarFrame) {
@@ -4853,6 +5116,8 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName,
 void CloseMetricSources() {
     ClosePdhQuery();
     InvalidateGpuAdapterCache();
+    g_hwInfoSharedMemoryCache = {};
+    g_hwInfoGadgetRegistryCache = {};
     g_nextPdhCounterRetry = {};
     g_nextPdhRecovery = {};
     g_consecutivePdhReadFailures = 0;

--- a/mods/taskbar-system-info.wh.cpp
+++ b/mods/taskbar-system-info.wh.cpp
@@ -537,9 +537,14 @@ std::chrono::steady_clock::time_point g_nextTaskbarPlacementCheck{};
 [[clang::no_destroy]] IAsyncAction g_placementApplyAction{nullptr};
 bool g_placementApplyQueued = false;
 HWND g_lastFailedPlacementTarget = nullptr;
+bool g_hasFailedPlacementTarget = false;
 std::chrono::steady_clock::time_point g_nextPlacementRetry{};
 uint32_t g_placementFailures = 0;
+bool g_placementIsFallback = false;
+bool g_placementLocationUnknown = false;
 int g_lastMonitorCount = -1;
+uint64_t g_lastDisplayTopologyFingerprint = 0;
+bool g_hasDisplayTopologyFingerprint = false;
 [[clang::no_destroy]]
 std::optional<std::list<FrameworkElement::Loaded_revoker>> g_loadedRevokers{
     std::in_place};
@@ -3321,8 +3326,13 @@ void EnsureTimer() {
     if (g_timer) {
         return;
     }
+    // The Tick delegate lives in this module, so teardown must always know
+    // which UI thread owns it even before the first injection succeeds.
+    if (!g_taskbarThreadId.load()) {
+        g_taskbarThreadId = GetCurrentThreadId();
+    }
     g_timer = DispatcherTimer();
-    g_timer.Interval(std::chrono::milliseconds(250));
+    g_timer.Interval(std::chrono::milliseconds(g_widget ? 250 : 1000));
     auto now = std::chrono::steady_clock::now();
     g_nextSystemColorCheck = now + std::chrono::seconds(1);
     g_nextTaskbarPlacementCheck = now + std::chrono::seconds(1);
@@ -3831,6 +3841,47 @@ std::vector<DisplayMonitor> EnumerateDisplayMonitors() {
     return monitors;
 }
 
+uint64_t GetDisplayTopologyFingerprint() {
+    struct FingerprintContext {
+        uint64_t sum = 0;
+        uint64_t mixedXor = 0;
+        uint64_t count = 0;
+    } context;
+
+    EnumDisplayMonitors(
+        nullptr, nullptr,
+        [](HMONITOR monitor, HDC, LPRECT, LPARAM contextValue) -> BOOL {
+            MONITORINFO info{};
+            info.cbSize = sizeof(info);
+            if (!GetMonitorInfoW(monitor, &info)) {
+                return TRUE;
+            }
+
+            uint64_t entryHash = 1469598103934665603ull;
+            auto mix = [&entryHash](uint64_t value) {
+                entryHash ^= value;
+                entryHash *= 1099511628211ull;
+            };
+            mix(reinterpret_cast<uintptr_t>(monitor));
+            mix(static_cast<uint64_t>(static_cast<int64_t>(info.rcMonitor.left)));
+            mix(static_cast<uint64_t>(static_cast<int64_t>(info.rcMonitor.top)));
+            mix(static_cast<uint64_t>(static_cast<int64_t>(info.rcMonitor.right)));
+            mix(static_cast<uint64_t>(static_cast<int64_t>(info.rcMonitor.bottom)));
+            mix((info.dwFlags & MONITORINFOF_PRIMARY) != 0);
+
+            auto* context =
+                reinterpret_cast<FingerprintContext*>(contextValue);
+            context->sum += entryHash;
+            context->mixedXor ^= entryHash * 0x9E3779B185EBCA87ull;
+            context->count++;
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&context));
+
+    return context.sum ^ context.mixedXor ^
+           (context.count * 0xD6E8FEB86659FD93ull);
+}
+
 HWND FindTaskbarWindowForMonitor(HMONITOR monitor) {
     struct SearchContext {
         HMONITOR monitor;
@@ -3919,6 +3970,7 @@ void RememberTaskbarWindow(HWND window) {
     if (threadId) {
         g_taskbarWindow = window;
         g_taskbarThreadId = threadId;
+        g_placementLocationUnknown = false;
     }
 }
 
@@ -4235,20 +4287,28 @@ void RemoveFromCurrentTaskbar(void*) {
     g_taskbarWindow = nullptr;
     g_taskbarThreadId = 0;
     g_lastFailedPlacementTarget = nullptr;
+    g_hasFailedPlacementTarget = false;
     g_nextPlacementRetry = {};
     g_placementFailures = 0;
+    g_placementIsFallback = false;
+    g_placementLocationUnknown = false;
     g_lastMonitorCount = -1;
+    g_lastDisplayTopologyFingerprint = 0;
+    g_hasDisplayTopologyFingerprint = false;
 }
 
 void ResetPlacementRetryState() {
     g_lastFailedPlacementTarget = nullptr;
+    g_hasFailedPlacementTarget = false;
     g_nextPlacementRetry = {};
     g_placementFailures = 0;
 }
 
 void RecordPlacementFailure(HWND targetWindow) {
-    if (targetWindow != g_lastFailedPlacementTarget) {
+    if (!g_hasFailedPlacementTarget ||
+        targetWindow != g_lastFailedPlacementTarget) {
         g_lastFailedPlacementTarget = targetWindow;
+        g_hasFailedPlacementTarget = true;
         g_placementFailures = 0;
     }
 
@@ -4262,8 +4322,23 @@ void RecordPlacementFailure(HWND targetWindow) {
     Wh_Log(L"Taskbar placement failed; retrying in %u seconds", retrySeconds);
 }
 
-bool ApplyExistingWidgetSettings(HWND logicalWindow,
-                                 bool placementSucceeded = true) {
+void MarkPlacementForRetry(HWND requestedWindow) {
+    g_placementIsFallback = true;
+    RecordPlacementFailure(requestedWindow);
+}
+
+void CompletePlacement(HWND requestedWindow, HWND actualWindow) {
+    g_placementLocationUnknown = false;
+    if (requestedWindow == actualWindow) {
+        g_placementIsFallback = false;
+        ResetPlacementRetryState();
+    } else {
+        g_placementIsFallback = true;
+        RecordPlacementFailure(requestedWindow);
+    }
+}
+
+bool RefreshExistingWidget() {
     if (!g_widget) {
         return false;
     }
@@ -4274,12 +4349,6 @@ bool ApplyExistingWidgetSettings(HWND logicalWindow,
     }
     EnsureTimer();
     UpdateWidgetText(true);
-    if (placementSucceeded) {
-        if (IsCurrentProcessTaskbarWindow(logicalWindow)) {
-            RememberTaskbarWindow(logicalWindow);
-        }
-        ResetPlacementRetryState();
-    }
     return true;
 }
 
@@ -4294,22 +4363,20 @@ bool ApplyLoadedFrameFallback(FrameworkElement fallbackFrame,
         return false;
     }
 
-    // The loaded frame is authoritative even when the private symbol path
-    // can't map it back to a specific HWND. Remember the requested/fallback
-    // window as the logical placement so the 1 Hz watchdog doesn't remove a
-    // working degraded injection on its next pass.
-    if (IsCurrentProcessTaskbarWindow(logicalWindow)) {
-        RememberTaskbarWindow(logicalWindow);
-    } else {
-        g_taskbarWindow = nullptr;
-        g_taskbarThreadId = GetCurrentThreadId();
-    }
-    ResetPlacementRetryState();
+    // On a multi-taskbar system the private XAML-root lookup is the only way to
+    // map this frame to an HWND. Don't claim a monitor we couldn't identify;
+    // keep the widget visible, mark its location unknown and retry with backoff.
+    g_taskbarWindow = nullptr;
+    g_taskbarThreadId = GetCurrentThreadId();
+    g_placementLocationUnknown = true;
+    Wh_Log(L"Monitor selection is unavailable for the direct-frame fallback");
+    MarkPlacementForRetry(logicalWindow);
     return true;
 }
 
 struct ApplyOnTaskbarThreadContext {
     FrameworkElement fallbackFrame{nullptr};
+    bool refreshExistingWidget = true;
     bool succeeded = false;
 };
 
@@ -4329,13 +4396,18 @@ void ApplyOnTaskbarUiThreadImpl(void* contextValue) {
     HWND requestedWindow = FindConfiguredTaskbarWindow();
     if (!requestedWindow) {
         Wh_Log(L"Taskbar window not found");
-        RecordPlacementFailure(nullptr);
+        MarkPlacementForRetry(nullptr);
         return;
     }
 
-    HWND currentWindow = FindRememberedTaskbarWindow();
-    if (currentWindow == requestedWindow &&
-        ApplyExistingWidgetSettings(requestedWindow)) {
+    HWND currentWindow = g_placementLocationUnknown
+                             ? nullptr
+                             : FindRememberedTaskbarWindow();
+    if (currentWindow == requestedWindow && g_widget) {
+        if (context->refreshExistingWidget) {
+            RefreshExistingWidget();
+        }
+        CompletePlacement(requestedWindow, currentWindow);
         context->succeeded = true;
         return;
     }
@@ -4358,22 +4430,25 @@ void ApplyOnTaskbarUiThreadImpl(void* contextValue) {
             context->succeeded = true;
             return;
         }
-        if (ApplyExistingWidgetSettings(currentWindow, false)) {
+        if (g_widget) {
             Wh_Log(L"Keeping the existing widget until taskbar placement recovers");
         }
-        RecordPlacementFailure(requestedWindow);
+        MarkPlacementForRetry(requestedWindow);
         return;
     }
 
-    if (currentWindow == targetWindow &&
-        ApplyExistingWidgetSettings(targetWindow)) {
+    if (currentWindow == targetWindow && g_widget) {
+        if (context->refreshExistingWidget) {
+            RefreshExistingWidget();
+        }
+        CompletePlacement(requestedWindow, targetWindow);
         context->succeeded = true;
         return;
     }
 
     HWND removalWindow = currentWindow;
     if (!removalWindow && g_widget && g_taskbarThreadId.load()) {
-        removalWindow = FindAnyWindowOnTaskbarThread(targetWindow);
+        removalWindow = FindAnyWindowOnTaskbarThread(nullptr);
     }
     bool widgetRemovedForMove = false;
     if (removalWindow && g_widget && currentWindow != targetWindow) {
@@ -4382,20 +4457,20 @@ void ApplyOnTaskbarUiThreadImpl(void* contextValue) {
                                  &removeContext) ||
             !removeContext.succeeded) {
             Wh_Log(L"Removing widget from the previous monitor failed");
-            RecordPlacementFailure(requestedWindow);
+            MarkPlacementForRetry(requestedWindow);
             return;
         }
         widgetRemovedForMove = true;
     }
 
     if (ApplyWidgetToTaskbarWindow(targetWindow)) {
-        ResetPlacementRetryState();
+        CompletePlacement(requestedWindow, targetWindow);
         context->succeeded = true;
         return;
     }
 
     Wh_Log(L"Applying widget on taskbar thread failed");
-    if (ApplyLoadedFrameFallback(context->fallbackFrame, targetWindow)) {
+    if (ApplyLoadedFrameFallback(context->fallbackFrame, requestedWindow)) {
         context->succeeded = true;
         return;
     }
@@ -4407,7 +4482,7 @@ void ApplyOnTaskbarUiThreadImpl(void* contextValue) {
             Wh_Log(L"Restoring widget on the previous taskbar failed");
         }
     }
-    RecordPlacementFailure(requestedWindow);
+    MarkPlacementForRetry(requestedWindow);
 }
 
 void ApplyOnTaskbarUiThread(void* contextValue) {
@@ -4417,11 +4492,25 @@ void ApplyOnTaskbarUiThread(void* contextValue) {
         HRESULT error = winrt::to_hresult();
         Wh_Log(L"Taskbar placement update failed: %08X",
                static_cast<unsigned>(error));
-        RecordPlacementFailure(nullptr);
+        MarkPlacementForRetry(nullptr);
+    }
+
+    // A failed move can destroy the old widget and its timer before both the
+    // target injection and restoration fail. Keep the retry loop alive on
+    // every non-unload exit path.
+    if (!g_unloading) {
+        try {
+            EnsureTimer();
+        } catch (...) {
+            HRESULT error = winrt::to_hresult();
+            Wh_Log(L"Restoring the taskbar placement timer failed: %08X",
+                   static_cast<unsigned>(error));
+        }
     }
 }
 
-void ApplyOnTaskbarThread(FrameworkElement fallbackFrame = nullptr) {
+void ApplyOnTaskbarThread(FrameworkElement fallbackFrame = nullptr,
+                          bool refreshExistingWidget = true) {
     if (g_unloading) {
         return;
     }
@@ -4442,7 +4531,8 @@ void ApplyOnTaskbarThread(FrameworkElement fallbackFrame = nullptr) {
         return;
     }
 
-    ApplyOnTaskbarThreadContext context{fallbackFrame, false};
+    ApplyOnTaskbarThreadContext context{fallbackFrame, refreshExistingWidget,
+                                        false};
     if (!RunFromWindowThread(dispatchWindow, ApplyOnTaskbarUiThread, &context)) {
         Wh_Log(L"Dispatching taskbar placement failed");
     }
@@ -4456,25 +4546,25 @@ void QueueConfiguredTaskbarPlacement() {
     if (!g_widget) {
         // The retry-only timer survives InjectWidget, so this path doesn't
         // destroy the DispatcherTimer from inside its own Tick callback.
-        ApplyOnTaskbarThread();
+        ApplyOnTaskbarThread(nullptr, false);
         return;
     }
 
     try {
         CoreDispatcher dispatcher = g_widget.Dispatcher();
         if (!dispatcher) {
-            RecordPlacementFailure(FindConfiguredTaskbarWindow(false));
+            MarkPlacementForRetry(FindConfiguredTaskbarWindow(false));
             return;
         }
 
         g_placementApplyQueued = true;
         g_placementApplyAction = dispatcher.RunAsync(
-            CoreDispatcherPriority::Low, [] {
+            CoreDispatcherPriority::Normal, [] {
                 bool shouldApply = g_placementApplyQueued;
                 g_placementApplyQueued = false;
                 g_placementApplyAction = nullptr;
                 if (shouldApply && !g_unloading) {
-                    ApplyOnTaskbarThread();
+                    ApplyOnTaskbarThread(nullptr, false);
                 }
             });
     } catch (...) {
@@ -4483,7 +4573,7 @@ void QueueConfiguredTaskbarPlacement() {
         g_placementApplyAction = nullptr;
         Wh_Log(L"Deferring taskbar placement failed: %08X",
                static_cast<unsigned>(error));
-        RecordPlacementFailure(FindConfiguredTaskbarWindow(false));
+        MarkPlacementForRetry(FindConfiguredTaskbarWindow(false));
     }
 }
 
@@ -4493,14 +4583,21 @@ void EnsureConfiguredTaskbarPlacement() {
     }
 
     int monitorCount = GetSystemMetrics(SM_CMONITORS);
-    bool topologyChanged = monitorCount != g_lastMonitorCount;
+    uint64_t topologyFingerprint = GetDisplayTopologyFingerprint();
+    bool topologyChanged =
+        monitorCount != g_lastMonitorCount ||
+        !g_hasDisplayTopologyFingerprint ||
+        topologyFingerprint != g_lastDisplayTopologyFingerprint;
     if (topologyChanged) {
         g_lastMonitorCount = monitorCount;
+        g_lastDisplayTopologyFingerprint = topologyFingerprint;
+        g_hasDisplayTopologyFingerprint = true;
         ResetPlacementRetryState();
     }
 
     HWND rememberedWindow = g_taskbarWindow.load();
-    if (!topologyChanged && g_placementFailures == 0 && g_widget &&
+    if (!topologyChanged && !g_placementIsFallback &&
+        g_placementFailures == 0 && g_widget &&
         IsCurrentProcessTaskbarWindow(rememberedWindow)) {
         return;
     }
@@ -4513,11 +4610,11 @@ void EnsureConfiguredTaskbarPlacement() {
 
     HWND targetWindow = FindConfiguredTaskbarWindow(false);
     if (!targetWindow) {
-        RecordPlacementFailure(nullptr);
+        MarkPlacementForRetry(nullptr);
         return;
     }
     if (g_widget && IsCurrentProcessTaskbarWindow(rememberedWindow) &&
-        rememberedWindow == targetWindow) {
+        rememberedWindow == targetWindow && !g_placementIsFallback) {
         ResetPlacementRetryState();
         return;
     }
@@ -4543,8 +4640,7 @@ void ApplyLoadedTaskbarFrame(FrameworkElement taskbarFrame) {
         XamlRoot loadedRoot = taskbarFrame.XamlRoot();
         XamlRoot widgetRoot = g_widget.XamlRoot();
         HWND rememberedWindow = g_taskbarWindow.load();
-        if (loadedRoot && widgetRoot &&
-            winrt::get_abi(loadedRoot) == winrt::get_abi(widgetRoot) &&
+        if (loadedRoot && widgetRoot && loadedRoot == widgetRoot &&
             IsCurrentProcessTaskbarWindow(rememberedWindow)) {
             directWindow = rememberedWindow;
         }
@@ -4552,7 +4648,7 @@ void ApplyLoadedTaskbarFrame(FrameworkElement taskbarFrame) {
 
     if (directWindow && InjectWidget(taskbarFrame)) {
         RememberTaskbarWindow(directWindow);
-        ResetPlacementRetryState();
+        CompletePlacement(directWindow, directWindow);
         return;
     }
     ApplyOnTaskbarThread(taskbarFrame);

--- a/mods/taskbar-system-info.wh.cpp
+++ b/mods/taskbar-system-info.wh.cpp
@@ -4,7 +4,7 @@
 // @name:uk-UA      Системний монітор панелі завдань
 // @description     A quiet two-column CPU, GPU, RAM and VRAM monitor with 60-second history graphs for the Windows 11 taskbar.
 // @description:uk-UA Компактний монітор CPU, GPU, RAM і VRAM із 60-секундними графіками для панелі завдань Windows 11.
-// @version         1.4.0
+// @version         1.5.0
 // @author          Yevhenii Starychenko
 // @github          https://github.com/starychenko
 // @homepage        https://github.com/starychenko/windhawk-taskbar-system-info
@@ -82,6 +82,23 @@ Unlike the performance placeholders in
 this mod does not alter the clock. It uses the free far-left taskbar area for a
 stable 2x2 dashboard with rolling graphs, capacity bars and temperature alerts.
 
+## Quick start
+
+1. Install and enable the mod. CPU, GPU, RAM and VRAM normally work without any
+   additional software.
+2. Keep **Temperature source** on **Automatic**. If a temperature stays at
+   `--°C`, Windows probably does not expose that sensor; configure HWiNFO as
+   described below.
+3. If the widget overlaps taskbar buttons, enable **Reserve space before the
+   Start button**. If Widgets/weather occupies the same area, increase **Left
+   offset** or disable the conflicting element.
+4. On a multi-monitor system, choose **Taskbar monitor**. Monitor 1 is always
+   the primary display.
+
+The mod is read-only. It does not control clocks, fans or power limits, does not
+collect network/disk activity, and does not send telemetry or make internet
+requests.
+
 ## Metrics
 
 - CPU utilization from the Windows Processor Utility counter, matching the
@@ -149,6 +166,84 @@ written to the Windhawk log only when it changes. Automatic HWiNFO GPU sensor
 selection is also matched to the selected Windows adapter; a one-time diagnostic
 explains when readings exist but no adapter name matches.
 
+## Setting up HWiNFO temperatures
+
+HWiNFO is only needed when Windows cannot expose the desired temperature. Keep
+HWiNFO running; **Sensors-only** mode is sufficient.
+
+### HWiNFO Shared Memory
+
+1. Open HWiNFO **Settings**.
+2. On **General / User Interface**, enable **Shared Memory Support**.
+3. Start or reopen the Sensors window.
+4. Keep this mod on **Automatic**, or select **HWiNFO Shared Memory** to use
+   only that interface.
+
+The free HWiNFO64 edition disables Shared Memory Support after 12 hours of
+continuous operation. This is an HWiNFO limitation, not a mod timer. Re-enable
+or restart it, use Gadget Registry, allow the Windows-native fallback, or use
+HWiNFO64 Pro. The mod does not bypass the limit.
+
+### HWiNFO Gadget Registry
+
+1. Open the HWiNFO Sensors window and **Sensor Settings**.
+2. Open the **HWiNFO Gadget** tab.
+3. Enable **Report to Gadget** for the required CPU and GPU temperature
+   readings.
+4. Run HWiNFO and Explorer/Windhawk as the same Windows user.
+5. Keep this mod on **Automatic**, or select **HWiNFO Gadget Registry**.
+
+If automatic selection chooses the wrong reading, enter a distinctive part of
+the HWiNFO sensor name in the CPU or GPU temperature sensor filter. Leave these
+filters empty unless a mismatch actually occurs.
+
+## Settings guide
+
+- **Widget width** and **Left offset** control the block size and its distance
+  from the far-left taskbar edge.
+- **Taskbar monitor** selects the display. An unavailable display falls back to
+  the primary taskbar and is retried automatically.
+- **Reserve space** prevents left-aligned taskbar buttons from overlapping the
+  widget; **Reserved space gap** adds padding after it.
+- **Update interval** controls collection frequency. One second is recommended.
+  **Graph history** controls how many seconds the CPU/GPU graphs represent.
+- **Adaptive colors** is recommended for automatic light, dark and Windows
+  high-contrast support. Manual text/graph/warning/critical colors are used when
+  it is disabled.
+- Temperature and memory warning/critical values only change alert colors; they
+  do not throttle hardware or close applications.
+- **GPU adapter filter** selects a card by a partial Windows adapter name.
+  Empty selects the adapter with the most dedicated VRAM.
+- **GPU memory type** should normally stay on Automatic. Shared memory is a
+  Windows allocation limit backed by system RAM, while dedicated VRAM is the
+  physical memory of a discrete GPU.
+- **Temperature source** should normally stay on Automatic. The HWiNFO-only,
+  Windows-native and Disabled modes are intended for diagnosis or explicit
+  control.
+- Windows thermal-zone settings only affect the Windows-native CPU fallback.
+  Firmware zones may describe a motherboard, chassis or skin sensor rather than
+  the CPU package.
+
+## Troubleshooting
+
+- **Temperature is `--°C`:** configure HWiNFO Shared Memory or Gadget Registry,
+  verify that HWiNFO is running, and keep Automatic mode enabled.
+- **HWiNFO stopped after about 12 hours:** the free Shared Memory period ended.
+  Re-enable it, use Gadget Registry/Windows-native fallback, or use HWiNFO Pro.
+- **Wrong GPU temperature:** set the GPU adapter filter, then the HWiNFO GPU
+  sensor filter only if necessary.
+- **VRAM is `--` after a driver update:** wait several samples while the mod
+  rebuilds its adapter and counters. If it remains unavailable, reload the mod
+  or restart Explorer and inspect the Windhawk log.
+- **Integrated-GPU memory looks too large:** Automatic mode shows the Windows
+  shared-memory limit. Force Dedicated only to display the reserved carve-out.
+- **Widget is missing, misplaced or overlapping:** verify monitor, width and
+  offset; reserve taskbar space or disable another element using the far-left
+  area.
+
+The Windhawk log records provider changes, adapter selection, counter recovery
+and HWiNFO sensor mismatches without logging every sample.
+
 ## Compatibility and placement
 
 - Windows 11 64-bit. The widget can be placed on the primary or a secondary
@@ -202,8 +297,8 @@ Released under GPL-3.0.
 - reserveSpace: false
   $name: Reserve space before the Start button
   $name:uk-UA: Резервувати місце перед кнопкою Пуск
-  $description: "Usually not needed when Windows 11 taskbar icons are centered."
-  $description:uk-UA: "Для центрованих значків Windows 11 зазвичай не потрібно."
+  $description: "Adds room before the Start button so left-aligned taskbar buttons don't overlap the widget. Usually unnecessary with centered buttons."
+  $description:uk-UA: "Додає місце перед кнопкою Пуск, щоб вирівняні ліворуч кнопки не перекривали блок. Для центрованих значків зазвичай не потрібно."
 
 - reserveGap: 8
   $name: Reserved space gap
@@ -214,14 +309,14 @@ Released under GPL-3.0.
 - updateInterval: 1
   $name: Update interval
   $name:uk-UA: Інтервал оновлення
-  $description: "Metric refresh interval, from 1 to 10 seconds."
-  $description:uk-UA: "Від 1 до 10 секунд."
+  $description: "Metric refresh interval, from 1 to 10 seconds. One second is recommended for quick monitoring; a longer interval reduces wakeups."
+  $description:uk-UA: "Інтервал від 1 до 10 секунд. Для оперативного моніторингу рекомендована 1 секунда; більший інтервал зменшує кількість оновлень."
 
 - historySeconds: 60
   $name: Graph history
   $name:uk-UA: Історія графіків
-  $description: "CPU and GPU history window, from 15 to 180 seconds."
-  $description:uk-UA: "Від 15 до 180 секунд."
+  $description: "CPU and GPU graph window, from 15 to 180 seconds. It is sampled at the configured update interval."
+  $description:uk-UA: "Проміжок історії графіків CPU і GPU від 15 до 180 секунд. Дані додаються із заданим інтервалом оновлення."
 
 - fontSize: 11
   $name: Font size
@@ -232,6 +327,8 @@ Released under GPL-3.0.
 - fontFamily: "Segoe UI Variable Text"
   $name: Font family
   $name:uk-UA: Шрифт
+  $description: "Installed Windows font-family name. The default is tuned for the compact taskbar layout."
+  $description:uk-UA: "Назва встановленого у Windows шрифту. Стандартний шрифт підібраний для компактного блока на панелі."
 
 - textColor: ""
   $name: Text color
@@ -266,8 +363,8 @@ Released under GPL-3.0.
 - textOpacity: 96
   $name: Text opacity
   $name:uk-UA: Прозорість тексту
-  $description: "From 0 to 100 percent."
-  $description:uk-UA: "Від 0 до 100."
+  $description: "From 0 to 100 percent. Metric labels are intentionally slightly dimmer; Windows high-contrast mode keeps important content fully visible."
+  $description:uk-UA: "Від 0 до 100 відсотків. Підписи показуються трохи тьмяніше; у висококонтрастному режимі важливі значення залишаються повністю видимими."
 
 - cpuWarningTemp: 75
   $name: CPU temperature warning
@@ -308,8 +405,8 @@ Released under GPL-3.0.
 - gpuAdapter: ""
   $name: GPU adapter filter
   $name:uk-UA: Відеокарта
-  $description: "Optional partial adapter name. Empty selects the adapter with the most dedicated VRAM."
-  $description:uk-UA: "Необовязкова частина назви. Порожнє значення вибирає адаптер з найбільшим обсягом VRAM."
+  $description: "Optional partial Windows adapter name for multi-GPU systems. Empty selects the adapter with the most dedicated VRAM. GPU usage, VRAM and automatic HWiNFO matching follow this adapter."
+  $description:uk-UA: "Необовязкова частина назви адаптера Windows для систем із кількома GPU. Порожнє значення вибирає адаптер з найбільшим обсягом VRAM. Навантаження, VRAM і автоматичний вибір HWiNFO привязуються до цього адаптера."
 
 - gpuMemoryMode: auto
   $name: GPU memory type
@@ -328,8 +425,8 @@ Released under GPL-3.0.
 - temperatureSource: auto
   $name: Temperature source
   $name:uk-UA: Джерело температури
-  $description: "Automatic tries both HWiNFO interfaces, then Windows D3DKMT for a missing GPU reading and Windows thermal zones for a missing CPU reading."
-  $description:uk-UA: "Автоматичний режим перевіряє обидва інтерфейси HWiNFO, а потім Windows D3DKMT для відсутньої температури GPU та системні термозони Windows для відсутньої температури CPU."
+  $description: "Automatic is recommended: it tries both HWiNFO interfaces, then Windows D3DKMT for a missing GPU reading and Windows thermal zones for a missing CPU reading. HWiNFO is optional but must be running and configured as explained on the Details page."
+  $description:uk-UA: "Рекомендовано Автоматично: режим перевіряє обидва інтерфейси HWiNFO, потім Windows D3DKMT для відсутньої температури GPU та термозони Windows для CPU. HWiNFO необовязковий, але має працювати й бути налаштований за інструкцією на сторінці Деталі."
   $options:
   - auto: Automatic
   - hwinfoAuto: HWiNFO automatic
@@ -366,14 +463,14 @@ Released under GPL-3.0.
 - cpuTempSensor: ""
   $name: CPU temperature sensor filter
   $name:uk-UA: Датчик температури CPU
-  $description: "Optional partial HWiNFO sensor name. Empty automatically selects CPU (Tctl/Tdie), CPU Die, or CPU Package."
-  $description:uk-UA: "Необов'язкова частина назви HWiNFO. Порожнє значення автоматично вибирає CPU (Tctl/Tdie), CPU Die або CPU Package."
+  $description: "Optional partial HWiNFO sensor name. Empty automatically selects CPU (Tctl/Tdie), CPU Die, or CPU Package. Set this only when automatic selection chooses the wrong sensor."
+  $description:uk-UA: "Необов'язкова частина назви датчика HWiNFO. Порожнє значення автоматично вибирає CPU (Tctl/Tdie), CPU Die або CPU Package. Заповнюйте лише коли автоматично вибрано не той датчик."
 
 - gpuTempSensor: ""
   $name: GPU temperature sensor filter
   $name:uk-UA: Датчик температури GPU
-  $description: "Optional partial HWiNFO sensor name. Empty automatically selects GPU Temperature."
-  $description:uk-UA: "Необов'язкова частина назви HWiNFO. Порожнє значення автоматично вибирає GPU Temperature."
+  $description: "Optional partial HWiNFO sensor name. Empty automatically selects GPU Temperature for the selected Windows adapter. Set this only when automatic selection chooses the wrong sensor."
+  $description:uk-UA: "Необов'язкова частина назви датчика HWiNFO. Порожнє значення автоматично вибирає GPU Temperature для вибраного адаптера Windows. Заповнюйте лише коли автоматично вибрано не той датчик."
 */
 // ==/WindhawkModSettings==
 

--- a/mods/taskbar-system-info.wh.cpp
+++ b/mods/taskbar-system-info.wh.cpp
@@ -3314,14 +3314,6 @@ void UpdateWidgetText(bool force = false) {
 
 void EnsureConfiguredTaskbarPlacement();
 
-void RefreshWidgetTheme() {
-    if (!g_widget || g_unloading) {
-        return;
-    }
-    RefreshThemeBrushes(*CurrentSettings());
-    UpdateWidgetText(true);
-}
-
 void EnsureTimer() {
     if (g_timer) {
         return;
@@ -3696,7 +3688,11 @@ bool InjectWidget(FrameworkElement taskbarFrame) {
     g_actualThemeChangedToken = g_widget.ActualThemeChanged(
         [](auto const&, auto const&) {
             try {
-                RefreshWidgetTheme();
+                if (!g_widget || g_unloading) {
+                    return;
+                }
+                RefreshThemeBrushes(*CurrentSettings());
+                UpdateWidgetText(true);
             } catch (...) {
                 HRESULT error = winrt::to_hresult();
                 Wh_Log(L"Taskbar theme update failed: %08X",

--- a/mods/taskbar-system-info.wh.cpp
+++ b/mods/taskbar-system-info.wh.cpp
@@ -142,11 +142,12 @@ use; HWiNFO64 Pro has no such limit. Gadget Registry is a separate HWiNFO
 interface. Configure it under **Sensor Settings > HWiNFO Gadget** by enabling
 **Report to Gadget** for the desired CPU and GPU temperature readings. If the
 selected source is unavailable, temperatures are shown as `--°C`; all other
-metrics continue to work. The active provider is written to the Windhawk log
-only when it changes, which makes fallback behavior diagnosable without adding
-noise every second. Automatic HWiNFO GPU sensor selection is also matched to the
-selected Windows adapter, so a multi-GPU system doesn't show another card's
-temperature.
+metrics continue to work. A single transient provider timeout keeps the last
+good temperature for at most two samples, avoiding a one-tick `--°C` flicker
+without hiding a provider that has actually disappeared. The active provider is
+written to the Windhawk log only when it changes. Automatic HWiNFO GPU sensor
+selection is also matched to the selected Windows adapter; a one-time diagnostic
+explains when readings exist but no adapter name matches.
 
 ## Compatibility and placement
 
@@ -154,7 +155,8 @@ temperature.
   taskbar. x64 is hardware-tested; ARM64 is compilation-tested.
 - Monitor 1 is always the primary display. Other monitors are ordered by their
   position in the virtual desktop and can differ from the numbers in Windows
-  Display Settings. An unavailable selection falls back to the primary taskbar.
+  Display Settings. An unavailable or disconnected selection falls back to the
+  primary taskbar automatically and moves back when the selected display returns.
 - Centered taskbar icons are recommended.
 - The widget uses the far-left taskbar area. Windows Widgets/weather or another
   left-side taskbar extension can occupy the same space; adjust the offset or
@@ -438,6 +440,7 @@ constexpr double kMemoryLabelWidth = 43.0;
 constexpr double kMemoryPercentWidth = 38.0;
 constexpr double kGraphHeight = 12.0;
 constexpr double kGiB = 1024.0 * 1024.0 * 1024.0;
+constexpr uint32_t kMaximumTaskbarViewHookAttempts = 3;
 constexpr wchar_t kDefaultGraphColor[] = L"#78A8FF";
 constexpr wchar_t kDefaultWarningColor[] = L"#FFFFB900";
 constexpr wchar_t kDefaultCriticalColor[] = L"#FFFF6B6B";
@@ -507,7 +510,7 @@ struct ModSettings {
     int memoryCriticalPercent = 90;
 };
 
-[[clang::no_destroy]] std::shared_ptr<const ModSettings> g_settings{
+std::shared_ptr<const ModSettings> g_settings{
     std::make_shared<ModSettings>()};
 std::mutex g_settingsMutex;
 std::atomic<bool> g_unloading;
@@ -526,6 +529,9 @@ double g_graphWidth = 96.0;
 double g_memoryBarWidth = 120.0;
 [[clang::no_destroy]] DispatcherTimer g_timer{nullptr};
 event_token g_timerToken{};
+event_token g_actualThemeChangedToken{};
+std::chrono::steady_clock::time_point g_nextSystemColorCheck{};
+std::chrono::steady_clock::time_point g_nextTaskbarPlacementCheck{};
 [[clang::no_destroy]]
 std::optional<std::list<FrameworkElement::Loaded_revoker>> g_loadedRevokers{
     std::in_place};
@@ -560,6 +566,7 @@ bool g_themeBrushesInitialized = false;
 bool g_cachedHighContrast = false;
 COLORREF g_cachedHighlightColor = CLR_INVALID;
 COLORREF g_cachedHotlightColor = CLR_INVALID;
+COLORREF g_cachedGrayTextColor = CLR_INVALID;
 
 std::deque<double> g_cpuHistory;
 std::deque<double> g_gpuHistory;
@@ -577,6 +584,7 @@ std::chrono::steady_clock::time_point g_nextPdhRecovery{};
 std::chrono::steady_clock::time_point g_nextGpuIdentityCheck{};
 uint32_t g_consecutivePdhReadFailures = 0;
 bool g_hwInfoInvalidUnitLogged = false;
+std::atomic<bool> g_hwInfoGpuAdapterMismatchLogged{false};
 
 struct MetricsSnapshot {
     double cpu = 0.0;
@@ -720,6 +728,7 @@ void LoadSettings() {
 
     std::lock_guard lock(g_settingsMutex);
     g_settings = std::make_shared<ModSettings>(std::move(settings));
+    g_hwInfoGpuAdapterMismatchLogged = false;
 }
 
 std::shared_ptr<const ModSettings> CurrentSettings() {
@@ -987,6 +996,39 @@ int GpuTemperatureScore(const std::wstring& sensorName,
     return adapterScore + 100;
 }
 
+struct HwInfoTemperatureDiagnostics {
+    bool gpuTemperatureReadingFound = false;
+    bool gpuAdapterMatched = false;
+};
+
+bool IsGpuTemperatureReadingCandidate(const std::wstring& sensorName,
+                                      const std::wstring& label) {
+    std::wstring sensor = ToLower(sensorName);
+    std::wstring reading = ToLower(label);
+    if (!Contains(sensor, L"gpu") && !Contains(sensor, L"nvidia") &&
+        !Contains(sensor, L"radeon")) {
+        return false;
+    }
+    return !Contains(reading, L"hot spot") &&
+           !Contains(reading, L"hotspot") &&
+           !Contains(reading, L"memory") && !Contains(reading, L"vram");
+}
+
+void RecordGpuTemperatureDiagnostic(
+    HwInfoTemperatureDiagnostics& diagnostics,
+    const std::wstring& sensorName,
+    const std::wstring& label,
+    const std::optional<std::wstring>& adapterName) {
+    if (!IsGpuTemperatureReadingCandidate(sensorName, label)) {
+        return;
+    }
+    diagnostics.gpuTemperatureReadingFound = true;
+    if (adapterName &&
+        GpuAdapterIdentityScore(sensorName, *adapterName) >= 0) {
+        diagnostics.gpuAdapterMatched = true;
+    }
+}
+
 // HWiNFO's published shared-memory layout explicitly uses one-byte packing.
 #pragma pack(push, 1)
 struct HwInfoHeader {
@@ -1114,7 +1156,8 @@ std::optional<double> NormalizeHwInfoTemperature(double value,
 
 void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
                             const ModSettings& settings,
-                            const std::optional<std::wstring>& gpuAdapterName) {
+                            const std::optional<std::wstring>& gpuAdapterName,
+                            HwInfoTemperatureDiagnostics& diagnostics) {
     HANDLE mapping = OpenFileMappingW(FILE_MAP_READ, FALSE,
                                       L"Global\\HWiNFO_SENS_SM2");
     if (!mapping) {
@@ -1240,6 +1283,8 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
         std::wstring label =
             FixedAnsiToWide(reading.originalLabel,
                             std::size(reading.originalLabel));
+        RecordGpuTemperatureDiagnostic(diagnostics, sensorName, label,
+                                       gpuAdapterName);
 
         int cpuScore = CpuTemperatureScore(
             sensorName, label, settings.cpuTempSensor);
@@ -1308,7 +1353,8 @@ std::optional<double> NormalizeRegistryTemperature(
 
 void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
                               const ModSettings& settings,
-                              const std::optional<std::wstring>& gpuAdapterName) {
+                              const std::optional<std::wstring>& gpuAdapterName,
+                              HwInfoTemperatureDiagnostics& diagnostics) {
     HKEY key = nullptr;
     if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\HWiNFO64\\VSB", 0,
                       KEY_QUERY_VALUE, &key) != ERROR_SUCCESS) {
@@ -1339,6 +1385,8 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
         if (!value) {
             continue;
         }
+        RecordGpuTemperatureDiagnostic(diagnostics, *sensor, *label,
+                                       gpuAdapterName);
 
         int cpuScore =
             CpuTemperatureScore(*sensor, *label, settings.cpuTempSensor);
@@ -1370,27 +1418,59 @@ void ReadWindowsGpuTemperature(MetricsSnapshot& snapshot,
 
 void ReadHwInfoTemperatures(MetricsSnapshot& snapshot,
                             const ModSettings& settings,
-                            const std::optional<std::wstring>& gpuAdapterName) {
-    ReadHwInfoSharedMemory(snapshot, settings, gpuAdapterName);
+                            const std::optional<std::wstring>& gpuAdapterName,
+                            HwInfoTemperatureDiagnostics& diagnostics) {
+    ReadHwInfoSharedMemory(snapshot, settings, gpuAdapterName, diagnostics);
     if (!snapshot.cpuTemp || !snapshot.gpuTemp) {
-        ReadHwInfoGadgetRegistry(snapshot, settings, gpuAdapterName);
+        ReadHwInfoGadgetRegistry(snapshot, settings, gpuAdapterName,
+                                 diagnostics);
+    }
+}
+
+void LogHwInfoGpuTemperatureMismatch(
+    const MetricsSnapshot& snapshot,
+    const ModSettings& settings,
+    const std::optional<std::wstring>& gpuAdapterName,
+    const HwInfoTemperatureDiagnostics& diagnostics) {
+    if (snapshot.gpuTemp || !settings.gpuTempSensor.empty() ||
+        !diagnostics.gpuTemperatureReadingFound ||
+        diagnostics.gpuAdapterMatched ||
+        g_hwInfoGpuAdapterMismatchLogged.exchange(true)) {
+        return;
+    }
+
+    if (gpuAdapterName) {
+        Wh_Log(L"HWiNFO GPU temperature readings found, but none matched "
+               L"adapter '%s'; set the GPU temperature sensor filter to "
+               L"select one explicitly",
+               gpuAdapterName->c_str());
+    } else {
+        Wh_Log(L"HWiNFO GPU temperature readings found, but the selected "
+               L"Windows GPU adapter could not be identified; set the GPU "
+               L"temperature sensor filter to select one explicitly");
     }
 }
 
 void ReadTemperatures(MetricsSnapshot& snapshot,
                       const ModSettings& settings) {
     std::optional<std::wstring> gpuAdapterName;
+    HwInfoTemperatureDiagnostics hwInfoDiagnostics;
+    bool usedHwInfo = false;
     if (settings.temperatureSource != TemperatureSource::WindowsNative &&
         settings.temperatureSource != TemperatureSource::Disabled) {
         gpuAdapterName = ResolveGpuTemperatureAdapterName(settings);
     }
     switch (settings.temperatureSource) {
         case TemperatureSource::SharedMemory:
-            ReadHwInfoSharedMemory(snapshot, settings, gpuAdapterName);
+            usedHwInfo = true;
+            ReadHwInfoSharedMemory(snapshot, settings, gpuAdapterName,
+                                   hwInfoDiagnostics);
             break;
 
         case TemperatureSource::GadgetRegistry:
-            ReadHwInfoGadgetRegistry(snapshot, settings, gpuAdapterName);
+            usedHwInfo = true;
+            ReadHwInfoGadgetRegistry(snapshot, settings, gpuAdapterName,
+                                     hwInfoDiagnostics);
             break;
 
         case TemperatureSource::WindowsNative:
@@ -1402,12 +1482,16 @@ void ReadTemperatures(MetricsSnapshot& snapshot,
             break;
 
         case TemperatureSource::HwInfoAuto:
-            ReadHwInfoTemperatures(snapshot, settings, gpuAdapterName);
+            usedHwInfo = true;
+            ReadHwInfoTemperatures(snapshot, settings, gpuAdapterName,
+                                   hwInfoDiagnostics);
             break;
 
         case TemperatureSource::Auto:
         default:
-            ReadHwInfoTemperatures(snapshot, settings, gpuAdapterName);
+            usedHwInfo = true;
+            ReadHwInfoTemperatures(snapshot, settings, gpuAdapterName,
+                                   hwInfoDiagnostics);
             if (!snapshot.gpuTemp) {
                 ReadWindowsGpuTemperature(snapshot, settings);
             }
@@ -1415,6 +1499,10 @@ void ReadTemperatures(MetricsSnapshot& snapshot,
                 ReadWindowsThermalZones(snapshot, settings);
             }
             break;
+    }
+    if (usedHwInfo) {
+        LogHwInfoGpuTemperatureMismatch(snapshot, settings, gpuAdapterName,
+                                        hwInfoDiagnostics);
     }
 }
 
@@ -2429,6 +2517,43 @@ PCWSTR TemperatureProviderName(TemperatureProvider provider) {
     }
 }
 
+constexpr uint32_t kTemperatureHoldoverSamples = 2;
+
+struct TemperatureHoldover {
+    std::optional<double> value;
+    TemperatureProvider provider = TemperatureProvider::None;
+    std::chrono::steady_clock::time_point capturedAt{};
+    uint32_t missedSamples = 0;
+};
+
+void ApplyTemperatureHoldover(std::optional<double>& value,
+                              TemperatureProvider& provider,
+                              TemperatureHoldover& holdover,
+                              const ModSettings& settings) {
+    auto now = std::chrono::steady_clock::now();
+    if (value) {
+        holdover.value = value;
+        holdover.provider = provider;
+        holdover.capturedAt = now;
+        holdover.missedSamples = 0;
+        return;
+    }
+
+    auto maximumAge = std::chrono::seconds(
+        settings.updateInterval * kTemperatureHoldoverSamples + 1);
+    if (settings.temperatureSource != TemperatureSource::Disabled &&
+        holdover.value &&
+        holdover.missedSamples < kTemperatureHoldoverSamples &&
+        now - holdover.capturedAt <= maximumAge) {
+        value = holdover.value;
+        provider = holdover.provider;
+        holdover.missedSamples++;
+        return;
+    }
+
+    holdover = {};
+}
+
 void PublishMetrics(MetricsSnapshot snapshot) {
     std::lock_guard lock(g_metricsMutex);
     g_latestMetricsSequence++;
@@ -2466,6 +2591,8 @@ void MetricsWorkerProc() {
     bool providersLogged = false;
     TemperatureProvider lastCpuProvider = TemperatureProvider::None;
     TemperatureProvider lastGpuProvider = TemperatureProvider::None;
+    TemperatureHoldover cpuTemperatureHoldover;
+    TemperatureHoldover gpuTemperatureHoldover;
     while (!g_stopMetricsWorker) {
         auto settings = CurrentSettings();
         DWORD waitMilliseconds =
@@ -2495,6 +2622,8 @@ void MetricsWorkerProc() {
             settings = CurrentSettings();
             ReadCpuUsage();
             EnsurePdhQuery(*settings);
+            cpuTemperatureHoldover = {};
+            gpuTemperatureHoldover = {};
             continue;
         } else {
             waitFailureLogged = false;
@@ -2505,6 +2634,12 @@ void MetricsWorkerProc() {
         if (!snapshot) {
             continue;
         }
+        ApplyTemperatureHoldover(snapshot->cpuTemp,
+                                 snapshot->cpuTempProvider,
+                                 cpuTemperatureHoldover, *settings);
+        ApplyTemperatureHoldover(snapshot->gpuTemp,
+                                 snapshot->gpuTempProvider,
+                                 gpuTemperatureHoldover, *settings);
         if (!providersLogged ||
             snapshot->cpuTempProvider != lastCpuProvider ||
             snapshot->gpuTempProvider != lastGpuProvider) {
@@ -2700,7 +2835,7 @@ ElementTheme ResolveWidgetTheme() {
                : ElementTheme::Dark;
 }
 
-bool WidgetThemeChanged() {
+bool SystemColorsChanged() {
     HIGHCONTRASTW highContrast{};
     highContrast.cbSize = sizeof(highContrast);
     bool highContrastEnabled =
@@ -2708,11 +2843,11 @@ bool WidgetThemeChanged() {
                               &highContrast, 0) &&
         (highContrast.dwFlags & HCF_HIGHCONTRASTON) != 0;
     return !g_themeBrushesInitialized ||
-           ResolveWidgetTheme() != g_cachedWidgetTheme ||
            highContrastEnabled != g_cachedHighContrast ||
            (highContrastEnabled &&
-            (GetSysColor(COLOR_HIGHLIGHT) != g_cachedHighlightColor ||
-             GetSysColor(COLOR_HOTLIGHT) != g_cachedHotlightColor));
+             (GetSysColor(COLOR_HIGHLIGHT) != g_cachedHighlightColor ||
+              GetSysColor(COLOR_HOTLIGHT) != g_cachedHotlightColor ||
+              GetSysColor(COLOR_GRAYTEXT) != g_cachedGrayTextColor));
 }
 
 Color ColorFromColorRef(COLORREF value) {
@@ -2738,13 +2873,8 @@ void ApplyCachedBrushesToVisuals() {
     }
 }
 
-void RefreshThemeBrushes(const ModSettings& settings, bool force = false) {
+void RefreshThemeBrushes(const ModSettings& settings) {
     ElementTheme theme = ResolveWidgetTheme();
-    if (!force && g_themeBrushesInitialized &&
-        theme == g_cachedWidgetTheme) {
-        return;
-    }
-
     g_cachedWidgetTheme = theme;
     g_themeBrushesInitialized = true;
     HIGHCONTRASTW highContrast{};
@@ -2755,12 +2885,13 @@ void RefreshThemeBrushes(const ModSettings& settings, bool force = false) {
         (highContrast.dwFlags & HCF_HIGHCONTRASTON) != 0;
     g_cachedHighlightColor = GetSysColor(COLOR_HIGHLIGHT);
     g_cachedHotlightColor = GetSysColor(COLOR_HOTLIGHT);
+    g_cachedGrayTextColor = GetSysColor(COLOR_GRAYTEXT);
     if (settings.adaptiveColors) {
         bool light = theme == ElementTheme::Light;
         g_textBrush = nullptr;
         if (g_cachedHighContrast) {
             g_graphBrush =
-                SolidColorBrush(ColorFromColorRef(g_cachedHighlightColor));
+                SolidColorBrush(ColorFromColorRef(g_cachedGrayTextColor));
             g_warningBrush =
                 SolidColorBrush(ColorFromColorRef(g_cachedHotlightColor));
             g_criticalBrush =
@@ -3009,7 +3140,7 @@ void ApplyWidgetSettings() {
     }
     auto settingsSnapshot = CurrentSettings();
     const ModSettings& settings = *settingsSnapshot;
-    RefreshThemeBrushes(settings, true);
+    RefreshThemeBrushes(settings);
     if (g_historyInterval != settings.updateInterval ||
         g_historyWindow != settings.historySeconds) {
         g_cpuHistory.clear();
@@ -3078,15 +3209,6 @@ void UpdateWidgetText(bool force = false) {
     if (!g_widget || g_unloading) {
         return;
     }
-    bool themeChanged = WidgetThemeChanged();
-    std::shared_ptr<const ModSettings> settingsSnapshot;
-    if (themeChanged) {
-        settingsSnapshot = CurrentSettings();
-        // WidgetThemeChanged also observes high-contrast and system accent
-        // changes, which can occur without ActualTheme changing.
-        RefreshThemeBrushes(*settingsSnapshot, true);
-        force = true;
-    }
     MetricsSnapshot snapshot;
     uint64_t metricsSequence = 0;
     std::vector<MetricsSnapshot> newSnapshots;
@@ -3098,9 +3220,7 @@ void UpdateWidgetText(bool force = false) {
     if (!force && !hasNewSample) {
         return;
     }
-    if (!settingsSnapshot) {
-        settingsSnapshot = CurrentSettings();
-    }
+    auto settingsSnapshot = CurrentSettings();
     const ModSettings& settings = *settingsSnapshot;
 
     g_cpuTemperatureAlert = snapshot.cpuTemp
@@ -3179,15 +3299,41 @@ void UpdateWidgetText(bool force = false) {
                     g_vramAlert);
 }
 
+void EnsureConfiguredTaskbarPlacement();
+
+void RefreshWidgetTheme() {
+    if (!g_widget || g_unloading) {
+        return;
+    }
+    RefreshThemeBrushes(*CurrentSettings());
+    UpdateWidgetText(true);
+}
+
 void EnsureTimer() {
     if (g_timer) {
         return;
     }
     g_timer = DispatcherTimer();
     g_timer.Interval(std::chrono::milliseconds(250));
+    auto now = std::chrono::steady_clock::now();
+    g_nextSystemColorCheck = now + std::chrono::seconds(1);
+    g_nextTaskbarPlacementCheck = now + std::chrono::seconds(1);
     g_timerToken = g_timer.Tick([](IInspectable const&, IInspectable const&) {
         try {
-            UpdateWidgetText();
+            bool force = false;
+            auto now = std::chrono::steady_clock::now();
+            if (now >= g_nextSystemColorCheck) {
+                g_nextSystemColorCheck = now + std::chrono::seconds(1);
+                if (SystemColorsChanged()) {
+                    RefreshThemeBrushes(*CurrentSettings());
+                    force = true;
+                }
+            }
+            if (now >= g_nextTaskbarPlacementCheck) {
+                g_nextTaskbarPlacementCheck = now + std::chrono::seconds(1);
+                EnsureConfiguredTaskbarPlacement();
+            }
+            UpdateWidgetText(force);
         } catch (...) {
             HRESULT error = winrt::to_hresult();
             Wh_Log(L"Metrics update failed: %08X",
@@ -3337,6 +3483,19 @@ void RemoveWidget() {
         g_timer = nullptr;
         g_timerToken = {};
     }
+    g_nextSystemColorCheck = {};
+    g_nextTaskbarPlacementCheck = {};
+
+    if (g_widget && g_actualThemeChangedToken.value) {
+        try {
+            g_widget.ActualThemeChanged(g_actualThemeChangedToken);
+        } catch (...) {
+            HRESULT error = winrt::to_hresult();
+            Wh_Log(L"Removing taskbar theme handler failed: %08X",
+                   static_cast<unsigned>(error));
+        }
+    }
+    g_actualThemeChangedToken = {};
 
     if (g_taskItemsRepeater && g_reservedMargin != 0.0) {
         Thickness margin = g_taskItemsRepeater.Margin();
@@ -3392,6 +3551,7 @@ void RemoveWidget() {
     g_cachedHighContrast = false;
     g_cachedHighlightColor = CLR_INVALID;
     g_cachedHotlightColor = CLR_INVALID;
+    g_cachedGrayTextColor = CLR_INVALID;
     g_cpuHistory.clear();
     g_gpuHistory.clear();
     g_lastRenderedMetricsSequence = 0;
@@ -3493,6 +3653,16 @@ bool InjectWidget(FrameworkElement taskbarFrame) {
 
     g_rootGrid = root;
     g_widget = widget;
+    g_actualThemeChangedToken = g_widget.ActualThemeChanged(
+        [](auto const&, auto const&) {
+            try {
+                RefreshWidgetTheme();
+            } catch (...) {
+                HRESULT error = winrt::to_hresult();
+                Wh_Log(L"Taskbar theme update failed: %08X",
+                       static_cast<unsigned>(error));
+            }
+        });
     g_taskItemsRepeater =
         FindDirectChildByName(root, L"TaskbarFrameRepeater");
     g_reservedMargin = 0.0;
@@ -3671,7 +3841,26 @@ HWND FindPrimaryTaskbarWindow() {
     return result;
 }
 
-HWND FindConfiguredTaskbarWindow() {
+HWND FindOnlyTaskbarWindow() {
+    struct SearchContext {
+        HWND window = nullptr;
+        uint32_t count = 0;
+    } context;
+    EnumWindows(
+        [](HWND window, LPARAM contextValue) -> BOOL {
+            auto* context = reinterpret_cast<SearchContext*>(contextValue);
+            if (!IsCurrentProcessTaskbarWindow(window)) {
+                return TRUE;
+            }
+            context->window = window;
+            context->count++;
+            return context->count < 2;
+        },
+        reinterpret_cast<LPARAM>(&context));
+    return context.count == 1 ? context.window : nullptr;
+}
+
+HWND FindConfiguredTaskbarWindow(bool logFallback = true) {
     int monitorNumber = CurrentSettings()->monitor;
     auto monitors = EnumerateDisplayMonitors();
     if (monitorNumber <= static_cast<int>(monitors.size())) {
@@ -3679,11 +3868,15 @@ HWND FindConfiguredTaskbarWindow() {
                 FindTaskbarWindowForMonitor(monitors[monitorNumber - 1].handle)) {
             return window;
         }
-        Wh_Log(L"Monitor %d has no taskbar; using the primary taskbar",
-               monitorNumber);
+        if (logFallback) {
+            Wh_Log(L"Monitor %d has no taskbar; using the primary taskbar",
+                   monitorNumber);
+        }
     } else {
-        Wh_Log(L"Monitor %d is unavailable; using the primary taskbar",
-               monitorNumber);
+        if (logFallback) {
+            Wh_Log(L"Monitor %d is unavailable; using the primary taskbar",
+                   monitorNumber);
+        }
     }
     return FindPrimaryTaskbarWindow();
 }
@@ -3908,8 +4101,14 @@ XamlRoot GetTaskbarXamlRoot(HWND taskbarWindow) {
     return result;
 }
 
-void ApplyToTaskbarWindow(void* context) {
-    HWND taskbarWindow = reinterpret_cast<HWND>(context);
+struct ApplyWidgetContext {
+    HWND taskbarWindow = nullptr;
+    bool succeeded = false;
+};
+
+void ApplyToTaskbarWindow(void* contextValue) {
+    auto* context = reinterpret_cast<ApplyWidgetContext*>(contextValue);
+    HWND taskbarWindow = context->taskbarWindow;
     if (!IsCurrentProcessTaskbarWindow(taskbarWindow)) {
         return;
     }
@@ -3926,12 +4125,19 @@ void ApplyToTaskbarWindow(void* context) {
         });
         if (taskbarFrame && InjectWidget(taskbarFrame)) {
             RememberTaskbarWindow(taskbarWindow);
+            context->succeeded = true;
         }
     } catch (...) {
         HRESULT error = winrt::to_hresult();
         Wh_Log(L"Applying widget failed: %08X",
                static_cast<unsigned>(error));
     }
+}
+
+bool ApplyWidgetToTaskbarWindow(HWND taskbarWindow) {
+    ApplyWidgetContext context{taskbarWindow, false};
+    return RunFromWindowThread(taskbarWindow, ApplyToTaskbarWindow, &context) &&
+           context.succeeded;
 }
 
 struct TaskbarProbeContext {
@@ -3974,8 +4180,6 @@ void RemoveWidgetForMove(void* contextValue) {
     try {
         RemoveWidget();
         context->succeeded = true;
-        g_taskbarWindow = nullptr;
-        g_taskbarThreadId = 0;
     } catch (...) {
         HRESULT error = winrt::to_hresult();
         Wh_Log(L"Removing widget before monitor switch failed: %08X",
@@ -4026,6 +4230,7 @@ void ApplyOnTaskbarThread() {
     if (!removalWindow && g_taskbarThreadId.load()) {
         removalWindow = FindAnyWindowOnTaskbarThread(nullptr);
     }
+    bool widgetRemovedForMove = false;
     if (removalWindow && currentWindow != targetWindow) {
         RemoveWidgetForMoveContext removeContext;
         if (!RunFromWindowThread(removalWindow, RemoveWidgetForMove,
@@ -4034,12 +4239,62 @@ void ApplyOnTaskbarThread() {
             Wh_Log(L"Removing widget from the previous monitor failed");
             return;
         }
+        widgetRemovedForMove = true;
     }
 
-    if (!RunFromWindowThread(targetWindow, ApplyToTaskbarWindow,
-                             targetWindow)) {
+    if (!ApplyWidgetToTaskbarWindow(targetWindow)) {
         Wh_Log(L"Applying widget on taskbar thread failed");
+        if (widgetRemovedForMove &&
+            IsCurrentProcessTaskbarWindow(currentWindow)) {
+            Wh_Log(L"Restoring widget on the previous taskbar");
+            if (!ApplyWidgetToTaskbarWindow(currentWindow)) {
+                Wh_Log(L"Restoring widget on the previous taskbar failed");
+            }
+        }
     }
+}
+
+void EnsureConfiguredTaskbarPlacement() {
+    if (!g_widget || g_unloading) {
+        return;
+    }
+    HWND targetWindow = FindConfiguredTaskbarWindow(false);
+    HWND rememberedWindow = g_taskbarWindow.load();
+    if (!targetWindow ||
+        (IsCurrentProcessTaskbarWindow(rememberedWindow) &&
+         rememberedWindow == targetWindow)) {
+        return;
+    }
+
+    Wh_Log(L"Taskbar topology changed; moving the widget");
+    ApplyOnTaskbarThread();
+}
+
+void ApplyLoadedTaskbarFrame(FrameworkElement taskbarFrame) {
+    if (!taskbarFrame || g_unloading) {
+        return;
+    }
+
+    // The constructor hook already gives us the stable XAML element. Use it
+    // directly whenever its taskbar is unambiguous, and keep the symbol-based
+    // XAML-root lookup only for choosing between multiple monitor taskbars.
+    HWND directWindow = FindOnlyTaskbarWindow();
+    if (!directWindow && g_widget) {
+        XamlRoot loadedRoot = taskbarFrame.XamlRoot();
+        XamlRoot widgetRoot = g_widget.XamlRoot();
+        HWND rememberedWindow = g_taskbarWindow.load();
+        if (loadedRoot && widgetRoot &&
+            winrt::get_abi(loadedRoot) == winrt::get_abi(widgetRoot) &&
+            IsCurrentProcessTaskbarWindow(rememberedWindow)) {
+            directWindow = rememberedWindow;
+        }
+    }
+
+    if (directWindow && InjectWidget(taskbarFrame)) {
+        RememberTaskbarWindow(directWindow);
+        return;
+    }
+    ApplyOnTaskbarThread();
 }
 
 using TaskbarFrame_Constructor_t = void*(WINAPI*)(void* pThis);
@@ -4062,16 +4317,17 @@ void* WINAPI TaskbarFrame_Constructor_Hook(void* pThis) {
     auto revoker = std::prev(g_loadedRevokers->end());
     *revoker = taskbarFrame.Loaded(
         winrt::auto_revoke_t{},
-        [revoker](IInspectable const&, RoutedEventArgs const&) {
+        [revoker](IInspectable const& sender, RoutedEventArgs const&) {
             if (!g_loadedRevokers) {
                 return;
             }
+            FrameworkElement loadedFrame = sender.try_as<FrameworkElement>();
             g_loadedRevokers->erase(revoker);
             if (g_unloading) {
                 return;
             }
             try {
-                ApplyOnTaskbarThread();
+                ApplyLoadedTaskbarFrame(loadedFrame);
             } catch (...) {
                 HRESULT error = winrt::to_hresult();
                 Wh_Log(L"Loaded injection failed: %08X",
@@ -4129,8 +4385,7 @@ bool TryHookTaskbarViewSymbols(HMODULE module, bool applyImmediately) {
         return static_cast<bool>(g_taskbarViewDllLoaded);
     }
 
-    constexpr uint32_t kMaximumHookAttempts = 3;
-    if (g_taskbarViewHookAttempts >= kMaximumHookAttempts ||
+    if (g_taskbarViewHookAttempts >= kMaximumTaskbarViewHookAttempts ||
         g_taskbarViewDllLoaded.exchange(true)) {
         return static_cast<bool>(g_taskbarViewDllLoaded);
     }
@@ -4138,7 +4393,7 @@ bool TryHookTaskbarViewSymbols(HMODULE module, bool applyImmediately) {
     uint32_t attempt = ++g_taskbarViewHookAttempts;
     if (!HookTaskbarViewSymbols(module)) {
         Wh_Log(L"Taskbar.View symbol hook failed (attempt %u/%u)", attempt,
-               kMaximumHookAttempts);
+               kMaximumTaskbarViewHookAttempts);
         g_taskbarViewDllLoaded = false;
         return false;
     }
@@ -4155,8 +4410,11 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName,
                                    HANDLE file,
                                    DWORD flags) {
     HMODULE module = LoadLibraryExW_Original(fileName, file, flags);
-    if (HMODULE taskbarViewModule = GetTaskbarViewModule()) {
-        TryHookTaskbarViewSymbols(taskbarViewModule, true);
+    if (!g_taskbarViewDllLoaded &&
+        g_taskbarViewHookAttempts < kMaximumTaskbarViewHookAttempts) {
+        if (HMODULE taskbarViewModule = GetTaskbarViewModule()) {
+            TryHookTaskbarViewSymbols(taskbarViewModule, true);
+        }
     }
     return module;
 }
@@ -4180,9 +4438,16 @@ bool TearDownTaskbarUi() {
     // window on its UI thread is sufficient: the WH_CALLWNDPROC hook runs the
     // callback, while SendMessage only wakes that thread.
     HWND fallbackWindow = FindAnyWindowOnTaskbarThread(taskbarWindow);
-    return fallbackWindow &&
-           RunFromWindowThread(fallbackWindow, RemoveFromCurrentTaskbar,
-                               nullptr);
+    if (!fallbackWindow) {
+        // Injection can fail before g_taskbarWindow/g_taskbarThreadId are set,
+        // while TaskbarFrame Loaded revokers are already pending. Every taskbar
+        // shares Explorer's XAML UI thread, so the primary window is a safe
+        // final marshaling target for revoking them before the DLL unloads.
+        fallbackWindow = FindPrimaryTaskbarWindow();
+    }
+    return fallbackWindow && RunFromWindowThread(
+                                 fallbackWindow, RemoveFromCurrentTaskbar,
+                                 nullptr);
 }
 
 }  // namespace

--- a/mods/taskbar-system-info.wh.cpp
+++ b/mods/taskbar-system-info.wh.cpp
@@ -117,10 +117,10 @@ requests.
 
 Metric collection runs on a worker thread. The taskbar UI thread only renders
 completed snapshots and catches up with every sample that arrived while the UI
-was busy. If a display-driver restart changes an adapter LUID or invalidates the
-active performance counters, the mod refreshes the live adapter list and
-rebuilds the counters automatically. This also covers successful but empty VRAM
-results and uses exponential backoff while a parked GPU stays idle.
+was busy. If a display-driver restart assigns the adapter a new LUID, the mod
+detects it during the normal adapter refresh and rebuilds the GPU performance
+counters once. Hard counter failures use the same bounded recovery path and
+fixed cooldown.
 
 The adapter with the most dedicated VRAM is selected automatically. A partial
 adapter-name filter is available for multi-GPU systems. GPU usage and VRAM are
@@ -159,12 +159,11 @@ use; HWiNFO64 Pro has no such limit. Gadget Registry is a separate HWiNFO
 interface. Configure it under **Sensor Settings > HWiNFO Gadget** by enabling
 **Report to Gadget** for the desired CPU and GPU temperature readings. If the
 selected source is unavailable, temperatures are shown as `--°C`; all other
-metrics continue to work. A single transient provider timeout keeps the last
-good temperature for at most two samples, avoiding a one-tick `--°C` flicker
-without hiding a provider that has actually disappeared. The active provider is
-written to the Windhawk log only when it changes. Automatic HWiNFO GPU sensor
-selection is also matched to the selected Windows adapter; a one-time diagnostic
-explains when readings exist but no adapter name matches.
+  metrics continue to work. The active provider is written to the Windhawk log
+  only when it changes. When Windows adapter identity is available, automatic
+  HWiNFO GPU selection is matched to it. If adapter enumeration has never been
+  available and no adapter filter is set, HWiNFO uses its generic GPU match; on
+  multi-GPU systems, configure the adapter and sensor filters explicitly.
 
 ## Setting up HWiNFO temperatures
 
@@ -232,11 +231,14 @@ filters empty unless a mismatch actually occurs.
   Re-enable it, use Gadget Registry/Windows-native fallback, or use HWiNFO Pro.
 - **Wrong GPU temperature:** set the GPU adapter filter, then the HWiNFO GPU
   sensor filter only if necessary.
-- **VRAM is `--` after a driver update:** wait several samples while the mod
-  rebuilds its adapter and counters. If it remains unavailable, reload the mod
-  or restart Explorer and inspect the Windhawk log.
+- **VRAM is `--` after a driver update:** a changed adapter LUID triggers an
+  automatic counter rebuild. Wait several samples; if it remains unavailable,
+  reload the mod or restart Explorer and inspect the Windhawk log.
 - **Integrated-GPU memory looks too large:** Automatic mode shows the Windows
   shared-memory limit. Force Dedicated only to display the reserved carve-out.
+- **A legacy 512 MB discrete GPU is shown as shared:** force Dedicated VRAM.
+  The automatic memory-shape signal cannot always distinguish it from an
+  integrated carve-out.
 - **Widget is missing, misplaced or overlapping:** verify monitor, width and
   offset; reserve taskbar space or disable another element using the far-left
   area.
@@ -537,17 +539,9 @@ constexpr double kMemoryLabelWidth = 43.0;
 constexpr double kMemoryPercentWidth = 38.0;
 constexpr double kGraphHeight = 12.0;
 constexpr double kGiB = 1024.0 * 1024.0 * 1024.0;
-constexpr uint32_t kMaximumTaskbarViewHookAttempts = 3;
-constexpr uint32_t kMaximumUnknownPlacementProbeFailures = 3;
 constexpr auto kGadgetRegistryRescanInterval = std::chrono::seconds(30);
-constexpr auto kGadgetRegistryPartialRescanInterval =
-    std::chrono::seconds(5);
 constexpr auto kSharedMemoryRescanInterval = std::chrono::seconds(60);
-constexpr auto kSharedMemoryPartialRescanInterval = std::chrono::seconds(5);
-constexpr uint32_t kHwInfoFastPartialRescanLimit = 4;
-constexpr uint32_t kHwInfoCachedReadingFailureLimit = 2;
-constexpr auto kGpuAdapterCacheStaleGrace = std::chrono::minutes(5);
-constexpr uint32_t kGpuAdapterStaleFailureLimit = 5;
+constexpr auto kHwInfoUnavailableRetryInterval = std::chrono::seconds(5);
 constexpr wchar_t kDefaultGraphColor[] = L"#78A8FF";
 constexpr wchar_t kDefaultWarningColor[] = L"#FFFFB900";
 constexpr wchar_t kDefaultCriticalColor[] = L"#FFFF6B6B";
@@ -623,11 +617,10 @@ std::mutex g_settingsMutex;
 std::atomic<bool> g_unloading;
 std::atomic<bool> g_uiTornDown;
 std::atomic<bool> g_taskbarViewDllLoaded;
-std::atomic<uint32_t> g_taskbarViewHookAttempts;
+std::atomic<bool> g_taskbarViewHookAttempted;
 std::atomic<HWND> g_taskbarWindow{nullptr};
 std::atomic<DWORD> g_taskbarThreadId{0};
 std::atomic<bool> g_placementApplyPending{false};
-std::atomic<bool> g_resetUnknownPlacementProbesPending{false};
 std::atomic<bool> g_taskbarUiResourcesRegistered{false};
 std::mutex g_placementRetryWorkerMutex;
 std::atomic<bool> g_stopPlacementRetryWorker{false};
@@ -645,18 +638,12 @@ double g_memoryBarWidth = 120.0;
 [[clang::no_destroy]] DispatcherTimer g_timer{nullptr};
 event_token g_timerToken{};
 event_token g_actualThemeChangedToken{};
-std::chrono::steady_clock::time_point g_nextSystemColorCheck{};
-std::chrono::steady_clock::time_point g_nextTaskbarPlacementCheck{};
 HWND g_lastFailedPlacementTarget = nullptr;
 bool g_hasFailedPlacementTarget = false;
 std::chrono::steady_clock::time_point g_nextPlacementRetry{};
 uint32_t g_placementFailures = 0;
 bool g_placementIsFallback = false;
 bool g_placementLocationUnknown = false;
-uint32_t g_unknownPlacementProbeFailures = 0;
-bool g_unknownPlacementProbesSuspended = false;
-uint64_t g_lastDisplayTopologyFingerprint = 0;
-bool g_hasDisplayTopologyFingerprint = false;
 [[clang::no_destroy]]
 std::optional<std::list<FrameworkElement::Loaded_revoker>> g_loadedRevokers{
     std::in_place};
@@ -706,27 +693,14 @@ PDH_HCOUNTER g_sharedVramCounter = nullptr;
 PDH_HCOUNTER g_thermalZoneCounter = nullptr;
 std::chrono::steady_clock::time_point g_nextPdhCounterRetry{};
 std::chrono::steady_clock::time_point g_nextPdhRecovery{};
-std::chrono::steady_clock::time_point g_nextGpuIdentityCheck{};
 uint32_t g_consecutivePdhReadFailures = 0;
-uint32_t g_consecutivePdhEmptySamples = 0;
-uint32_t g_pdhEmptyRecoveries = 0;
-std::chrono::steady_clock::time_point g_nextPdhEmptyRecovery{};
 bool g_hwInfoInvalidUnitLogged = false;
 std::atomic<bool> g_hwInfoGpuAdapterMismatchLogged{false};
-
-struct HwInfoGadgetReadingIdentity {
-    std::wstring sensor;
-    std::wstring label;
-};
 
 struct HwInfoGadgetRegistryCache {
     std::optional<int> cpuIndex;
     std::optional<int> gpuIndex;
-    std::optional<HwInfoGadgetReadingIdentity> cpuIdentity;
-    std::optional<HwInfoGadgetReadingIdentity> gpuIdentity;
-    bool fullScanCompleted = false;
     std::chrono::steady_clock::time_point nextFullScan{};
-    uint32_t consecutivePartialScans = 0;
     std::wstring cpuFilter;
     std::wstring gpuFilter;
     std::wstring gpuAdapter;
@@ -1221,62 +1195,13 @@ static_assert(sizeof(HwInfoSensorPrefix) == 264);
 static_assert(offsetof(HwInfoReadingPrefix, value) == 284);
 static_assert(sizeof(HwInfoReadingPrefix) == 292);
 
-struct HwInfoLayoutKey {
-    uint32_t version = 0;
-    uint32_t revision = 0;
-    uint32_t sensorOffset = 0;
-    uint32_t sensorStride = 0;
-    uint32_t sensorCount = 0;
-    uint32_t readingOffset = 0;
-    uint32_t readingStride = 0;
-    uint32_t readingCount = 0;
-
-    bool operator==(const HwInfoLayoutKey&) const = default;
-};
-
-struct HwInfoReadingIdentity {
-    uint32_t sensorId = 0;
-    uint32_t sensorInstance = 0;
-    uint32_t readingId = 0;
-
-    bool operator==(const HwInfoReadingIdentity&) const = default;
-};
-
-HwInfoLayoutKey GetHwInfoLayoutKey(const HwInfoHeader& header) {
-    return {header.version,       header.revision,     header.sensorOffset,
-            header.sensorStride, header.sensorCount,  header.readingOffset,
-            header.readingStride, header.readingCount};
-}
-
-constexpr std::chrono::seconds GetHwInfoRescanInterval(
-    bool complete,
-    uint32_t& consecutivePartialScans,
-    std::chrono::seconds regularInterval,
-    std::chrono::seconds partialInterval) {
-    if (complete) {
-        consecutivePartialScans = 0;
-        return regularInterval;
-    }
-    if (consecutivePartialScans < kHwInfoFastPartialRescanLimit) {
-        consecutivePartialScans++;
-        return partialInterval;
-    }
-    return regularInterval;
-}
-
 struct HwInfoSharedMemoryCache {
     std::optional<uint32_t> cpuReadingIndex;
     std::optional<uint32_t> gpuReadingIndex;
-    std::optional<HwInfoReadingIdentity> cpuIdentity;
-    std::optional<HwInfoReadingIdentity> gpuIdentity;
     std::chrono::steady_clock::time_point nextFullScan{};
-    uint32_t consecutivePartialScans = 0;
-    uint32_t cpuInvalidSamples = 0;
-    uint32_t gpuInvalidSamples = 0;
     std::wstring cpuFilter;
     std::wstring gpuFilter;
     std::wstring gpuAdapter;
-    std::optional<HwInfoLayoutKey> layout;
 };
 
 struct HwInfoRawTemperatureReading {
@@ -1431,13 +1356,8 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
                                 ? memoryInfo.RegionSize - viewOffset
                                 : 0;
         if (mappedSize >= sizeof(HwInfoHeader)) {
-            // HWiNFO updates this mapping in place. Snapshot the range metadata
-            // so every address below uses the same values that passed
-            // validation even when the shared mutex isn't accessible from
-            // Explorer.
             HwInfoHeader header{};
             std::memcpy(&header, view, sizeof(header));
-
             if (header.signature == kHwInfoSignature &&
                 IsRangeValid(mappedSize, header.sensorOffset,
                              header.sensorStride, header.sensorCount,
@@ -1446,39 +1366,20 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
                              header.readingStride, header.readingCount,
                              sizeof(HwInfoReadingPrefix))) {
                 const auto* bytes = static_cast<const uint8_t*>(view);
-                HwInfoLayoutKey layout = GetHwInfoLayoutKey(header);
-                bool layoutChanged =
-                    !g_hwInfoSharedMemoryCache.layout ||
-                    *g_hwInfoSharedMemoryCache.layout != layout;
-                if (layoutChanged) {
-                    g_hwInfoSharedMemoryCache.cpuReadingIndex.reset();
-                    g_hwInfoSharedMemoryCache.gpuReadingIndex.reset();
-                    g_hwInfoSharedMemoryCache.cpuIdentity.reset();
-                    g_hwInfoSharedMemoryCache.gpuIdentity.reset();
-                    g_hwInfoSharedMemoryCache.nextFullScan = {};
-                    g_hwInfoSharedMemoryCache.consecutivePartialScans = 0;
-                    g_hwInfoSharedMemoryCache.cpuInvalidSamples = 0;
-                    g_hwInfoSharedMemoryCache.gpuInvalidSamples = 0;
-                    g_hwInfoSharedMemoryCache.layout = layout;
-                }
-
                 bool performFullScan =
                     g_hwInfoSharedMemoryCache.nextFullScan ==
                         std::chrono::steady_clock::time_point{} ||
                     now >= g_hwInfoSharedMemoryCache.nextFullScan;
+
                 auto copyCachedReading =
                     [&](std::optional<uint32_t>& cachedIndex,
-                        std::optional<HwInfoReadingIdentity>& cachedIdentity,
                         std::optional<HwInfoRawTemperatureReading>& output) {
                         if (!cachedIndex || performFullScan) {
                             return;
                         }
-                        if (!cachedIdentity ||
-                            *cachedIndex >= header.readingCount) {
+                        if (*cachedIndex >= header.readingCount) {
                             cachedIndex.reset();
-                            cachedIdentity.reset();
                             g_hwInfoSharedMemoryCache.nextFullScan = {};
-                            g_hwInfoSharedMemoryCache.consecutivePartialScans = 0;
                             performFullScan = true;
                             return;
                         }
@@ -1495,9 +1396,7 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
                                 kHwInfoTemperatureType ||
                             raw.reading.sensorIndex >= header.sensorCount) {
                             cachedIndex.reset();
-                            cachedIdentity.reset();
                             g_hwInfoSharedMemoryCache.nextFullScan = {};
-                            g_hwInfoSharedMemoryCache.consecutivePartialScans = 0;
                             performFullScan = true;
                             return;
                         }
@@ -1507,27 +1406,14 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
                                 header.sensorStride;
                         std::memcpy(&raw.sensor, sensorAddress,
                                     sizeof(raw.sensor));
-                        HwInfoReadingIdentity identity{
-                            raw.sensor.sensorId, raw.sensor.sensorInstance,
-                            raw.reading.readingId};
-                        if (identity != *cachedIdentity) {
-                            cachedIndex.reset();
-                            cachedIdentity.reset();
-                            g_hwInfoSharedMemoryCache.nextFullScan = {};
-                            g_hwInfoSharedMemoryCache.consecutivePartialScans = 0;
-                            performFullScan = true;
-                            return;
-                        }
                         output = raw;
                     };
 
                 copyCachedReading(
                     g_hwInfoSharedMemoryCache.cpuReadingIndex,
-                    g_hwInfoSharedMemoryCache.cpuIdentity,
                     cachedCpuReading);
                 copyCachedReading(
                     g_hwInfoSharedMemoryCache.gpuReadingIndex,
-                    g_hwInfoSharedMemoryCache.gpuIdentity,
                     cachedGpuReading);
 
                 if (performFullScan) {
@@ -1550,15 +1436,13 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
                     }
                     fullScanCopied = true;
                 }
+
                 if (!mutexOwned) {
                     HwInfoHeader verificationHeader{};
                     std::memcpy(&verificationHeader, view,
                                 sizeof(verificationHeader));
                     if (std::memcmp(&header, &verificationHeader,
                                     sizeof(header)) != 0) {
-                        // Explorer can occasionally see the mapping without
-                        // access to HWiNFO's mutex. Discard a snapshot whose
-                        // generation changed while the raw records were copied.
                         sensors.clear();
                         readings.clear();
                         cachedCpuReading.reset();
@@ -1634,36 +1518,15 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
 
         g_hwInfoSharedMemoryCache.cpuReadingIndex = bestCpuIndex;
         g_hwInfoSharedMemoryCache.gpuReadingIndex = bestGpuIndex;
-        auto getIdentity =
-            [&](const std::optional<uint32_t>& index)
-            -> std::optional<HwInfoReadingIdentity> {
-            if (!index || *index >= readings.size()) {
-                return std::nullopt;
-            }
-            const HwInfoReadingPrefix& reading = readings[*index];
-            if (reading.sensorIndex >= sensors.size()) {
-                return std::nullopt;
-            }
-            const HwInfoSensorPrefix& sensor = sensors[reading.sensorIndex];
-            return HwInfoReadingIdentity{sensor.sensorId, sensor.sensorInstance,
-                                         reading.readingId};
-        };
-        g_hwInfoSharedMemoryCache.cpuIdentity = getIdentity(bestCpuIndex);
-        g_hwInfoSharedMemoryCache.gpuIdentity = getIdentity(bestGpuIndex);
-        g_hwInfoSharedMemoryCache.cpuInvalidSamples = 0;
-        g_hwInfoSharedMemoryCache.gpuInvalidSamples = 0;
+        bool anyReadingFound = bestCpuIndex || bestGpuIndex;
         g_hwInfoSharedMemoryCache.nextFullScan =
-            now + GetHwInfoRescanInterval(
-                      bestCpuIndex && bestGpuIndex,
-                      g_hwInfoSharedMemoryCache.consecutivePartialScans,
-                      kSharedMemoryRescanInterval,
-                      kSharedMemoryPartialRescanInterval);
+            now + (anyReadingFound
+                       ? kSharedMemoryRescanInterval
+                       : kHwInfoUnavailableRetryInterval);
     } else {
         auto applyCachedReading =
             [&](const std::optional<HwInfoRawTemperatureReading>& raw,
-                std::optional<uint32_t>& cachedIndex,
-                std::optional<HwInfoReadingIdentity>& cachedIdentity,
-                uint32_t& invalidSamples, bool cpu) {
+                std::optional<uint32_t>& cachedIndex, bool cpu) {
                 if (!raw) {
                     return;
                 }
@@ -1688,27 +1551,17 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
                                       gpuAdapterName);
                 if (score < 0) {
                     cachedIndex.reset();
-                    cachedIdentity.reset();
-                    invalidSamples = 0;
                     g_hwInfoSharedMemoryCache.nextFullScan = {};
-                    g_hwInfoSharedMemoryCache.consecutivePartialScans = 0;
                     return;
                 }
 
                 auto value = NormalizeHwInfoTemperature(
                     reading.value, reading.unit, std::size(reading.unit));
                 if (!value) {
-                    if (++invalidSamples >=
-                        kHwInfoCachedReadingFailureLimit) {
-                        cachedIndex.reset();
-                        cachedIdentity.reset();
-                        invalidSamples = 0;
-                        g_hwInfoSharedMemoryCache.nextFullScan = {};
-                        g_hwInfoSharedMemoryCache.consecutivePartialScans = 0;
-                    }
+                    cachedIndex.reset();
+                    g_hwInfoSharedMemoryCache.nextFullScan = {};
                     return;
                 }
-                invalidSamples = 0;
                 sawSupportedTemperatureUnit = true;
 
                 if (cpu) {
@@ -1724,12 +1577,10 @@ void ReadHwInfoSharedMemory(MetricsSnapshot& snapshot,
 
         applyCachedReading(cachedCpuReading,
                            g_hwInfoSharedMemoryCache.cpuReadingIndex,
-                           g_hwInfoSharedMemoryCache.cpuIdentity,
-                           g_hwInfoSharedMemoryCache.cpuInvalidSamples, true);
+                           true);
         applyCachedReading(cachedGpuReading,
                            g_hwInfoSharedMemoryCache.gpuReadingIndex,
-                           g_hwInfoSharedMemoryCache.gpuIdentity,
-                           g_hwInfoSharedMemoryCache.gpuInvalidSamples, false);
+                           false);
     }
 
     if (sawTemperatureReading && !sawSupportedTemperatureUnit &&
@@ -1821,59 +1672,30 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
     auto now = std::chrono::steady_clock::now();
     bool needsCpu = !snapshot.cpuTemp;
     bool needsGpu = !snapshot.gpuTemp;
-    bool hasCachedCandidate =
-        (needsCpu && g_hwInfoGadgetRegistryCache.cpuIndex) ||
-        (needsGpu && g_hwInfoGadgetRegistryCache.gpuIndex);
-    if (!hasCachedCandidate &&
-        g_hwInfoGadgetRegistryCache.fullScanCompleted &&
-        now < g_hwInfoGadgetRegistryCache.nextFullScan) {
-        return;
-    }
+    bool performFullScan =
+        g_hwInfoGadgetRegistryCache.nextFullScan ==
+            std::chrono::steady_clock::time_point{} ||
+        now >= g_hwInfoGadgetRegistryCache.nextFullScan;
 
     HKEY key = nullptr;
     if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\HWiNFO64\\VSB", 0,
                       KEY_QUERY_VALUE, &key) != ERROR_SUCCESS) {
         g_hwInfoGadgetRegistryCache.cpuIndex.reset();
         g_hwInfoGadgetRegistryCache.gpuIndex.reset();
-        g_hwInfoGadgetRegistryCache.cpuIdentity.reset();
-        g_hwInfoGadgetRegistryCache.gpuIdentity.reset();
-        g_hwInfoGadgetRegistryCache.fullScanCompleted = true;
         g_hwInfoGadgetRegistryCache.nextFullScan =
-            now + GetHwInfoRescanInterval(
-                      false,
-                      g_hwInfoGadgetRegistryCache.consecutivePartialScans,
-                      kGadgetRegistryRescanInterval,
-                      kGadgetRegistryPartialRescanInterval);
+            now + kHwInfoUnavailableRetryInterval;
         return;
     }
 
     auto readCached =
-        [&](std::optional<int>& cachedIndex,
-            std::optional<HwInfoGadgetReadingIdentity>& cachedIdentity,
-            bool cpu, bool needed) {
-        if (!needed || !cachedIndex) {
-            return;
-        }
-        if (!cachedIdentity) {
-            cachedIndex.reset();
-            g_hwInfoGadgetRegistryCache.fullScanCompleted = false;
-            g_hwInfoGadgetRegistryCache.consecutivePartialScans = 0;
+        [&](std::optional<int>& cachedIndex, bool cpu, bool needed) {
+        if (!needed || !cachedIndex || performFullScan) {
             return;
         }
         auto reading = ReadHwInfoGadgetReading(key, *cachedIndex);
         if (!reading) {
             cachedIndex.reset();
-            cachedIdentity.reset();
-            g_hwInfoGadgetRegistryCache.fullScanCompleted = false;
-            g_hwInfoGadgetRegistryCache.consecutivePartialScans = 0;
-            return;
-        }
-        if (reading->sensor != cachedIdentity->sensor ||
-            reading->label != cachedIdentity->label) {
-            cachedIndex.reset();
-            cachedIdentity.reset();
-            g_hwInfoGadgetRegistryCache.fullScanCompleted = false;
-            g_hwInfoGadgetRegistryCache.consecutivePartialScans = 0;
+            performFullScan = true;
             return;
         }
 
@@ -1886,9 +1708,7 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
                                               gpuAdapterName);
         if (score < 0) {
             cachedIndex.reset();
-            cachedIdentity.reset();
-            g_hwInfoGadgetRegistryCache.fullScanCompleted = false;
-            g_hwInfoGadgetRegistryCache.consecutivePartialScans = 0;
+            performFullScan = true;
             return;
         }
 
@@ -1903,17 +1723,9 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
         }
     };
 
-    readCached(g_hwInfoGadgetRegistryCache.cpuIndex,
-               g_hwInfoGadgetRegistryCache.cpuIdentity, true, needsCpu);
-    readCached(g_hwInfoGadgetRegistryCache.gpuIndex,
-               g_hwInfoGadgetRegistryCache.gpuIdentity, false, needsGpu);
-    if (snapshot.cpuTemp && snapshot.gpuTemp &&
-        now < g_hwInfoGadgetRegistryCache.nextFullScan) {
-        RegCloseKey(key);
-        return;
-    }
-    if (g_hwInfoGadgetRegistryCache.fullScanCompleted &&
-        now < g_hwInfoGadgetRegistryCache.nextFullScan) {
+    readCached(g_hwInfoGadgetRegistryCache.cpuIndex, true, needsCpu);
+    readCached(g_hwInfoGadgetRegistryCache.gpuIndex, false, needsGpu);
+    if (!performFullScan) {
         RegCloseKey(key);
         return;
     }
@@ -1924,8 +1736,6 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
     std::optional<int> bestGpuIndex;
     std::optional<double> bestCpuValue;
     std::optional<double> bestGpuValue;
-    std::optional<HwInfoGadgetReadingIdentity> bestCpuIdentity;
-    std::optional<HwInfoGadgetReadingIdentity> bestGpuIdentity;
     int consecutiveMissing = 0;
     for (int i = 0; i < 1024; i++) {
         std::wstring suffix = std::to_wstring(i);
@@ -1957,7 +1767,6 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
             bestCpuScore = cpuScore;
             bestCpuIndex = i;
             bestCpuValue = *value;
-            bestCpuIdentity = HwInfoGadgetReadingIdentity{*sensor, *label};
         }
 
         int gpuScore =
@@ -1967,22 +1776,17 @@ void ReadHwInfoGadgetRegistry(MetricsSnapshot& snapshot,
             bestGpuScore = gpuScore;
             bestGpuIndex = i;
             bestGpuValue = *value;
-            bestGpuIdentity = HwInfoGadgetReadingIdentity{*sensor, *label};
         }
     }
 
     RegCloseKey(key);
     g_hwInfoGadgetRegistryCache.cpuIndex = bestCpuIndex;
     g_hwInfoGadgetRegistryCache.gpuIndex = bestGpuIndex;
-    g_hwInfoGadgetRegistryCache.cpuIdentity = std::move(bestCpuIdentity);
-    g_hwInfoGadgetRegistryCache.gpuIdentity = std::move(bestGpuIdentity);
-    g_hwInfoGadgetRegistryCache.fullScanCompleted = true;
+    bool anyReadingFound = bestCpuIndex || bestGpuIndex;
     g_hwInfoGadgetRegistryCache.nextFullScan =
-        now + GetHwInfoRescanInterval(
-                  bestCpuIndex && bestGpuIndex,
-                  g_hwInfoGadgetRegistryCache.consecutivePartialScans,
-                  kGadgetRegistryRescanInterval,
-                  kGadgetRegistryPartialRescanInterval);
+        now + (anyReadingFound
+                   ? kGadgetRegistryRescanInterval
+                   : kHwInfoUnavailableRetryInterval);
 
     if (!snapshot.cpuTemp && bestCpuValue) {
         snapshot.cpuTemp = *bestCpuValue;
@@ -2246,13 +2050,12 @@ std::optional<std::wstring> g_cachedGpuAdapterFilter;
 std::optional<GpuAdapterInfo> g_cachedGpuAdapterInfo;
 bool g_cachedGpuAdapterResolved = false;
 std::chrono::steady_clock::time_point g_nextGpuAdapterResolve{};
-std::chrono::steady_clock::time_point g_lastSuccessfulGpuAdapterResolve{};
-uint32_t g_gpuAdapterResolveFailures = 0;
+std::optional<std::wstring> g_lastResolvedGpuAdapterFilter;
+std::optional<LUID> g_lastResolvedGpuAdapterLuid;
+bool g_gpuAdapterIdentityChanged = false;
+bool g_hasResolvedGpuAdapterIdentity = false;
 D3DKMT_HANDLE g_cachedD3dkmtAdapterHandle = 0;
 LUID g_cachedD3dkmtAdapterLuid{};
-uint32_t g_unchangedGpuIdentityChecks = 0;
-uint32_t g_consecutiveD3dkmtFailures = 0;
-std::chrono::steady_clock::time_point g_nextD3dkmtRecovery{};
 
 bool SameLuid(const LUID& left, const LUID& right) {
     return left.HighPart == right.HighPart && left.LowPart == right.LowPart;
@@ -2273,12 +2076,6 @@ void InvalidateGpuAdapterCache() {
     g_cachedGpuAdapterInfo.reset();
     g_cachedGpuAdapterResolved = false;
     g_nextGpuAdapterResolve = {};
-    g_lastSuccessfulGpuAdapterResolve = {};
-    g_gpuAdapterResolveFailures = 0;
-    g_nextGpuIdentityCheck = {};
-    g_unchangedGpuIdentityChecks = 0;
-    g_consecutiveD3dkmtFailures = 0;
-    g_nextD3dkmtRecovery = {};
 }
 
 std::wstring FormatAdapterLuid(const LUID& luid) {
@@ -2468,13 +2265,6 @@ std::optional<GpuAdapterInfo> GetGpuAdapterInfo(
     if (g_cachedGpuAdapterFilter &&
         *g_cachedGpuAdapterFilter != filterLower) {
         CloseCachedD3dkmtAdapterHandle();
-        g_cachedGpuAdapterInfo.reset();
-        g_cachedGpuAdapterResolved = false;
-        g_nextGpuAdapterResolve = {};
-        g_lastSuccessfulGpuAdapterResolve = {};
-        g_gpuAdapterResolveFailures = 0;
-        g_nextGpuIdentityCheck = {};
-        g_unchangedGpuIdentityChecks = 0;
     } else {
         previousAdapter = g_cachedGpuAdapterInfo;
     }
@@ -2485,25 +2275,10 @@ std::optional<GpuAdapterInfo> GetGpuAdapterInfo(
     g_cachedGpuAdapterResolved = true;
 
     if (!resolvedAdapter) {
-        uint32_t exponent =
-            std::min<uint32_t>(g_gpuAdapterResolveFailures, 6);
-        auto delay = std::min(std::chrono::seconds(5u << exponent),
-                              std::chrono::seconds(300));
-        g_gpuAdapterResolveFailures++;
-        g_nextGpuAdapterResolve = now + delay;
-        bool previousAdapterIsFresh =
-            previousAdapter &&
-            g_lastSuccessfulGpuAdapterResolve !=
-                std::chrono::steady_clock::time_point{} &&
-            now - g_lastSuccessfulGpuAdapterResolve <=
-                kGpuAdapterCacheStaleGrace &&
-            g_gpuAdapterResolveFailures <= kGpuAdapterStaleFailureLimit;
-        if (!previousAdapterIsFresh) {
-            CloseCachedD3dkmtAdapterHandle();
-            previousAdapter.reset();
-        }
-        g_cachedGpuAdapterInfo = previousAdapter;
-        if (!previousAdapter && g_gpuAdapterResolveFailures == 1) {
+        CloseCachedD3dkmtAdapterHandle();
+        g_cachedGpuAdapterInfo.reset();
+        g_nextGpuAdapterResolve = now + std::chrono::seconds(5);
+        if (!previousAdapter) {
             if (filterLower.empty()) {
                 Wh_Log(L"No GPU adapter found; retrying automatically");
             } else {
@@ -2511,7 +2286,7 @@ std::optional<GpuAdapterInfo> GetGpuAdapterInfo(
                        filterLower.c_str());
             }
         }
-        return previousAdapter;
+        return std::nullopt;
     }
 
     bool adapterChanged =
@@ -2525,9 +2300,19 @@ std::optional<GpuAdapterInfo> GetGpuAdapterInfo(
         !SameLuid(previousAdapter->luidValue, resolvedAdapter->luidValue)) {
         CloseCachedD3dkmtAdapterHandle();
     }
+    if (g_lastResolvedGpuAdapterLuid && g_lastResolvedGpuAdapterFilter &&
+        *g_lastResolvedGpuAdapterFilter == filterLower &&
+        !SameLuid(*g_lastResolvedGpuAdapterLuid,
+                  resolvedAdapter->luidValue)) {
+        // A driver restart can preserve the adapter name while assigning a new
+        // LUID. Existing PDH wildcard counters may keep the old instances, so
+        // request one rebuild when the normal adapter refresh confirms it.
+        g_gpuAdapterIdentityChanged = true;
+    }
+    g_lastResolvedGpuAdapterFilter = filterLower;
+    g_lastResolvedGpuAdapterLuid = resolvedAdapter->luidValue;
+    g_hasResolvedGpuAdapterIdentity = true;
     g_cachedGpuAdapterInfo = std::move(resolvedAdapter);
-    g_lastSuccessfulGpuAdapterResolve = now;
-    g_gpuAdapterResolveFailures = 0;
     g_nextGpuAdapterResolve = now + std::chrono::seconds(60);
 
     if (!adapterChanged) {
@@ -2545,58 +2330,22 @@ std::optional<GpuAdapterInfo> GetGpuAdapterInfo(
     return g_cachedGpuAdapterInfo;
 }
 
-void RecordD3dkmtAdapterFailure() {
-    CloseCachedD3dkmtAdapterHandle();
-    g_consecutiveD3dkmtFailures =
-        std::min(g_consecutiveD3dkmtFailures + 1, 3u);
-    auto now = std::chrono::steady_clock::now();
-    if (g_consecutiveD3dkmtFailures < 3 || now < g_nextD3dkmtRecovery) {
-        return;
-    }
-    g_cachedGpuAdapterResolved = false;
-    g_nextGpuAdapterResolve = {};
-    g_nextD3dkmtRecovery = now + std::chrono::seconds(30);
-    g_consecutiveD3dkmtFailures = 0;
-}
-
 std::optional<std::wstring> ResolveGpuTemperatureAdapterName(
     const ModSettings& settings) {
     auto adapter = GetGpuAdapterInfo(settings.gpuAdapter);
     if (adapter) {
         return adapter->description;
     }
-    if (settings.gpuAdapter.empty()) {
-        // Preserve generic HWiNFO matching on systems where Windows adapter
-        // identity isn't available at all. An explicit filter miss is different
-        // and intentionally returns nullopt so another GPU isn't shown.
+    if (settings.gpuAdapter.empty() && !g_hasResolvedGpuAdapterIdentity) {
+        // Preserve HWiNFO-only operation when Windows adapter enumeration has
+        // never been available. Once an adapter was resolved, a later failure
+        // is treated as transient to avoid selecting another GPU.
         return std::wstring{};
     }
+    // Without a resolved Windows adapter identity, generic HWiNFO matching can
+    // select another GPU on multi-adapter systems. Leave the temperature
+    // unavailable until the short adapter retry succeeds instead.
     return std::nullopt;
-}
-
-bool HasGpuAdapterIdentityChanged(const GpuAdapterInfo& cachedAdapter,
-                                  const std::wstring& adapterFilter) {
-    auto now = std::chrono::steady_clock::now();
-    if (now < g_nextGpuIdentityCheck) {
-        return false;
-    }
-    auto currentAdapter =
-        ResolveCurrentGpuAdapterInfo(ToLower(adapterFilter));
-    if (currentAdapter && currentAdapter->luid != cachedAdapter.luid) {
-        g_unchangedGpuIdentityChecks = 0;
-        g_nextGpuIdentityCheck = {};
-        return true;
-    }
-
-    // A parked or power-gated discrete GPU can temporarily resolve through a
-    // different enumeration path. Back off repeated identity probes while the
-    // cached adapter remains valid instead of re-enumerating every five seconds.
-    uint32_t exponent = std::min<uint32_t>(g_unchangedGpuIdentityChecks, 6);
-    auto delay = std::min(std::chrono::seconds(5u << exponent),
-                          std::chrono::seconds(300));
-    g_unchangedGpuIdentityChecks++;
-    g_nextGpuIdentityCheck = now + delay;
-    return false;
 }
 
 std::optional<D3DKMT_HANDLE> GetD3dkmtAdapterHandle(
@@ -2611,7 +2360,7 @@ std::optional<D3DKMT_HANDLE> GetD3dkmtAdapterHandle(
     openAdapter.AdapterLuid = adapter.luidValue;
     if (g_d3dkmtOpenAdapterFromLuid(&openAdapter) != 0 ||
         !openAdapter.hAdapter) {
-        RecordD3dkmtAdapterFailure();
+        InvalidateGpuAdapterCache();
         return std::nullopt;
     }
     g_cachedD3dkmtAdapterHandle = openAdapter.hAdapter;
@@ -2646,11 +2395,8 @@ void ReadWindowsGpuTemperature(MetricsSnapshot& snapshot,
     LONG status = g_d3dkmtQueryAdapterInfo(&queryInfo);
     if (status != 0) {
         // A driver restart can invalidate both the KMT handle and its LUID.
-        // Re-resolve the adapter after a bounded number of failures.
-        RecordD3dkmtAdapterFailure();
-    } else {
-        g_consecutiveD3dkmtFailures = 0;
-        g_nextD3dkmtRecovery = {};
+        // Drop the cached identity and let the next sample resolve it again.
+        InvalidateGpuAdapterCache();
     }
 
     // The driver reports tenths of a degree Celsius. Zero means unavailable;
@@ -2673,7 +2419,7 @@ void CloseMetricSources();
 
 constexpr auto kPdhCounterRetryInterval = std::chrono::seconds(30);
 constexpr auto kPdhRecoveryRetryDelay = std::chrono::seconds(1);
-constexpr auto kPdhRecoveryCooldown = std::chrono::seconds(30);
+constexpr auto kPdhRecoveryCooldown = std::chrono::seconds(60);
 constexpr uint32_t kPdhReadFailureThreshold = 3;
 
 void ClosePdhQuery() {
@@ -2701,7 +2447,6 @@ void RecreatePdhSources(PCWSTR reason,
     ClosePdhQuery();
     InvalidateGpuAdapterCache();
     g_consecutivePdhReadFailures = 0;
-    g_consecutivePdhEmptySamples = 0;
     g_nextPdhCounterRetry = now + kPdhRecoveryRetryDelay;
     g_nextPdhRecovery = now + kPdhRecoveryCooldown;
 }
@@ -2721,36 +2466,12 @@ void RecordPdhReadFailure(PCWSTR reason,
     RecreatePdhSources(reason, status, now);
 }
 
-void RecoverFromGpuAdapterIdentityChange() {
+void RecoverFromMissingGpuSample(PDH_STATUS status) {
     auto now = std::chrono::steady_clock::now();
     if (now < g_nextPdhRecovery) {
         return;
     }
-    RecreatePdhSources(L"confirmed adapter LUID change", ERROR_SUCCESS, now);
-}
-
-void RecordPdhEmptyAdapterSample(PDH_STATUS status) {
-    g_consecutivePdhReadFailures = 0;
-    g_consecutivePdhEmptySamples =
-        std::min(g_consecutivePdhEmptySamples + 1, 3u);
-    auto now = std::chrono::steady_clock::now();
-    if (g_consecutivePdhEmptySamples < 3 ||
-        now < g_nextPdhEmptyRecovery) {
-        return;
-    }
-
-    uint32_t exponent = std::min<uint32_t>(g_pdhEmptyRecoveries, 4);
-    auto delay = std::min(std::chrono::seconds(30u << exponent),
-                          std::chrono::seconds(300));
     RecreatePdhSources(L"missing adapter VRAM sample", status, now);
-    g_pdhEmptyRecoveries++;
-    g_nextPdhEmptyRecovery = now + delay;
-}
-
-void ResetPdhEmptyAdapterRecovery() {
-    g_consecutivePdhEmptySamples = 0;
-    g_pdhEmptyRecoveries = 0;
-    g_nextPdhEmptyRecovery = {};
 }
 
 void RecordPdhReadSuccess() {
@@ -2959,7 +2680,9 @@ void ReadWindowsThermalZones(MetricsSnapshot& snapshot,
 
 std::optional<double> ReadGpuUsage(
     const std::optional<GpuAdapterInfo>& adapter,
-    PDH_STATUS& readStatus) {
+    PDH_STATUS& readStatus,
+    bool& adapterInstanceFound) {
+    adapterInstanceFound = false;
     std::vector<uint8_t> buffer;
     DWORD itemCount = 0;
     readStatus = ReadPdhArray(g_gpuCounter, buffer, itemCount);
@@ -2985,6 +2708,7 @@ std::optional<double> ReadGpuUsage(
         if (!MatchesGpuAdapter(instance, adapter)) {
             continue;
         }
+        adapterInstanceFound = true;
         size_t luidPosition = instance.find(L"luid_");
         std::wstring engineKey =
             luidPosition == std::wstring::npos ? instance
@@ -3001,8 +2725,7 @@ std::optional<double> ReadGpuUsage(
         return std::clamp(busiestEngine, 0.0, 100.0);
     }
     // A power-gated discrete GPU legitimately has no engine instances while an
-    // integrated adapter is active. Adapter identity recovery is handled from
-    // the memory counter below, so an otherwise healthy array means idle here.
+    // integrated adapter is active, so an otherwise healthy array means idle.
     return 0.0;
 }
 
@@ -3058,47 +2781,12 @@ bool LooksLikeIntegratedGpu(const GpuAdapterInfo& adapter) {
         return true;
     }
 
-    // Some WDDM drivers don't set HybridIntegrated for newer integrated parts
-    // such as Radeon 890M or Intel Arc iGPUs. Require both the characteristic
-    // memory shape and an integrated-family name so an old low-memory discrete
-    // adapter isn't silently switched to the shared-memory pool.
+    // Some WDDM drivers don't set HybridIntegrated. A small hardware carve-out
+    // plus a larger shared pool is the stable signal; the explicit setting is
+    // available for unusual adapters instead of maintaining a GPU name list.
     constexpr uint64_t kMaximumIntegratedCarveout = 512ull * 1024 * 1024;
-    if (adapter.dedicatedVideoMemory > kMaximumIntegratedCarveout ||
-        adapter.sharedSystemMemory == 0) {
-        return false;
-    }
-
-    std::wstring name = NormalizeAdapterIdentity(adapter.description);
-    bool radeonIntegratedModel = false;
-    if (Contains(name, L"radeon") && !Contains(name, L"radeon hd")) {
-        auto tokens = IdentityTokens(name);
-        for (size_t i = 0; i < tokens.size(); i++) {
-            const std::wstring& token = tokens[i];
-            bool hasModelSuffix = token.size() > 1 &&
-                                  (token.back() == L'm' ||
-                                   token.back() == L's') &&
-                                  std::all_of(
-                                      token.begin(), token.end() - 1,
-                                      [](wchar_t character) {
-                                          return std::iswdigit(character) != 0;
-                                      });
-            bool followedByGraphics =
-                HasDigit(token) && i + 1 < tokens.size() &&
-                tokens[i + 1] == L"graphics";
-            if (hasModelSuffix || followedByGraphics) {
-                radeonIntegratedModel = true;
-                break;
-            }
-        }
-    }
-
-    bool intelArc = Contains(name, L"intel") && Contains(name, L"arc");
-    return Contains(name, L"uhd graphics") ||
-           (Contains(name, L"intel") && Contains(name, L"hd graphics")) ||
-           Contains(name, L"iris") ||
-           Contains(name, L"radeon graphics") || Contains(name, L"vega") ||
-           Contains(name, L"integrated") || radeonIntegratedModel ||
-           intelArc;
+    return adapter.dedicatedVideoMemory <= kMaximumIntegratedCarveout &&
+           adapter.sharedSystemMemory > adapter.dedicatedVideoMemory;
 }
 
 bool UseSharedGpuMemory(const GpuAdapterInfo& adapter,
@@ -3144,11 +2832,17 @@ bool ReadPdhMetrics(MetricsSnapshot& snapshot, const ModSettings& settings) {
     }
 
     auto adapter = GetGpuAdapterInfo(settings.gpuAdapter);
-    bool explicitAdapterMissing = !settings.gpuAdapter.empty() && !adapter;
+    if (std::exchange(g_gpuAdapterIdentityChanged, false)) {
+        RecreatePdhSources(L"confirmed GPU adapter LUID change", ERROR_SUCCESS,
+                           std::chrono::steady_clock::now());
+        return false;
+    }
     PDH_STATUS gpuReadStatus = ERROR_SUCCESS;
-    auto gpuUsage = explicitAdapterMissing
-                        ? std::optional<double>{}
-                        : ReadGpuUsage(adapter, gpuReadStatus);
+    bool gpuAdapterInstanceFound = false;
+    auto gpuUsage = adapter
+                        ? ReadGpuUsage(adapter, gpuReadStatus,
+                                       gpuAdapterInstanceFound)
+                        : std::optional<double>{};
     if (gpuUsage) {
         snapshot.gpu = *gpuUsage;
         snapshot.gpuAvailable = true;
@@ -3179,25 +2873,14 @@ bool ReadPdhMetrics(MetricsSnapshot& snapshot, const ModSettings& settings) {
     bool hardReadFailure =
         (g_gpuCounter && IsHardPdhArrayFailure(gpuReadStatus)) ||
         (vramCounter && IsHardPdhArrayFailure(vramReadStatus));
-    bool adapterSampleMissing = adapter && vramCounter && vramTotalBytes > 0 &&
-                                !vramAvailable &&
-                                IsSoftPdhArrayAbsence(vramReadStatus);
-    bool adapterIdentityChanged =
-        adapterSampleMissing &&
-        HasGpuAdapterIdentityChanged(*adapter, settings.gpuAdapter);
-    if (!adapterSampleMissing) {
-        // A healthy matching sample should make the next future mismatch probe
-        // immediately instead of inheriting an old parked-GPU backoff window.
-        g_unchangedGpuIdentityChecks = 0;
-        g_nextGpuIdentityCheck = {};
-        ResetPdhEmptyAdapterRecovery();
-    }
+    bool adapterSampleMissing = adapter && gpuAdapterInstanceFound &&
+                                 vramCounter && vramTotalBytes > 0 &&
+                                 !vramAvailable &&
+                                 IsSoftPdhArrayAbsence(vramReadStatus);
     if (hardReadFailure) {
         RecordPdhReadFailure(L"counter read");
-    } else if (adapterIdentityChanged) {
-        RecoverFromGpuAdapterIdentityChange();
     } else if (adapterSampleMissing) {
-        RecordPdhEmptyAdapterSample(vramReadStatus);
+        RecoverFromMissingGpuSample(vramReadStatus);
     } else {
         RecordPdhReadSuccess();
     }
@@ -3232,43 +2915,6 @@ PCWSTR TemperatureProviderName(TemperatureProvider provider) {
         default:
             return L"unavailable";
     }
-}
-
-constexpr uint32_t kTemperatureHoldoverSamples = 2;
-
-struct TemperatureHoldover {
-    std::optional<double> value;
-    TemperatureProvider provider = TemperatureProvider::None;
-    std::chrono::steady_clock::time_point capturedAt{};
-    uint32_t missedSamples = 0;
-};
-
-void ApplyTemperatureHoldover(std::optional<double>& value,
-                              TemperatureProvider& provider,
-                              TemperatureHoldover& holdover,
-                              const ModSettings& settings) {
-    auto now = std::chrono::steady_clock::now();
-    if (value) {
-        holdover.value = value;
-        holdover.provider = provider;
-        holdover.capturedAt = now;
-        holdover.missedSamples = 0;
-        return;
-    }
-
-    auto maximumAge = std::chrono::seconds(
-        settings.updateInterval * kTemperatureHoldoverSamples + 1);
-    if (settings.temperatureSource != TemperatureSource::Disabled &&
-        holdover.value &&
-        holdover.missedSamples < kTemperatureHoldoverSamples &&
-        now - holdover.capturedAt <= maximumAge) {
-        value = holdover.value;
-        provider = holdover.provider;
-        holdover.missedSamples++;
-        return;
-    }
-
-    holdover = {};
 }
 
 void PublishMetrics(MetricsSnapshot snapshot) {
@@ -3308,8 +2954,6 @@ void MetricsWorkerProc() {
     bool providersLogged = false;
     TemperatureProvider lastCpuProvider = TemperatureProvider::None;
     TemperatureProvider lastGpuProvider = TemperatureProvider::None;
-    TemperatureHoldover cpuTemperatureHoldover;
-    TemperatureHoldover gpuTemperatureHoldover;
     while (!g_stopMetricsWorker) {
         auto settings = CurrentSettings();
         DWORD waitMilliseconds =
@@ -3339,10 +2983,7 @@ void MetricsWorkerProc() {
             settings = CurrentSettings();
             ReadCpuUsage();
             InvalidateGpuAdapterCache();
-            ResetPdhEmptyAdapterRecovery();
             EnsurePdhQuery(*settings);
-            cpuTemperatureHoldover = {};
-            gpuTemperatureHoldover = {};
             continue;
         } else {
             waitFailureLogged = false;
@@ -3353,12 +2994,6 @@ void MetricsWorkerProc() {
         if (!snapshot) {
             continue;
         }
-        ApplyTemperatureHoldover(snapshot->cpuTemp,
-                                 snapshot->cpuTempProvider,
-                                 cpuTemperatureHoldover, *settings);
-        ApplyTemperatureHoldover(snapshot->gpuTemp,
-                                 snapshot->gpuTempProvider,
-                                 gpuTemperatureHoldover, *settings);
         if (!providersLogged ||
             snapshot->cpuTempProvider != lastCpuProvider ||
             snapshot->gpuTempProvider != lastGpuProvider) {
@@ -4074,6 +3709,7 @@ void UpdateWidgetText(bool force = false) {
         UpdateSparkline(g_cpuGraph, g_cpuHistory, historyCapacity);
         UpdateSparkline(g_gpuGraph, g_gpuHistory, historyCapacity);
         g_lastRenderedMetricsSequence = metricsSequence;
+        UpdateTimerInterval();
     }
     UpdateMemoryBar(g_ramFill, snapshot.ram, snapshot.ramAvailable, g_ramAlert);
     UpdateMemoryBar(g_vramFill, snapshot.vram, snapshot.vramAvailable,
@@ -4086,7 +3722,9 @@ void UpdateTimerInterval() {
     if (!g_timer) {
         return;
     }
-    auto interval = std::chrono::milliseconds(g_widget ? 250 : 1000);
+    auto interval = g_widget && !g_lastRenderedMetricsSequence
+                        ? std::chrono::milliseconds(250)
+                        : std::chrono::milliseconds(1000);
     if (g_timer.Interval() != interval) {
         g_timer.Interval(interval);
     }
@@ -4105,27 +3743,17 @@ void EnsureTimer() {
     g_timer = DispatcherTimer();
     g_taskbarUiResourcesRegistered = true;
     UpdateTimerInterval();
-    auto now = std::chrono::steady_clock::now();
-    g_nextSystemColorCheck = now + std::chrono::seconds(1);
-    g_nextTaskbarPlacementCheck = now + std::chrono::seconds(1);
     g_timerToken = g_timer.Tick([](IInspectable const&, IInspectable const&) {
         try {
             if (g_unloading) {
                 return;
             }
             bool force = false;
-            auto now = std::chrono::steady_clock::now();
-            if (g_widget && now >= g_nextSystemColorCheck) {
-                g_nextSystemColorCheck = now + std::chrono::seconds(1);
-                if (SystemColorsChanged()) {
-                    RefreshThemeBrushes(*CurrentSettings());
-                    force = true;
-                }
+            if (g_widget && SystemColorsChanged()) {
+                RefreshThemeBrushes(*CurrentSettings());
+                force = true;
             }
-            if (now >= g_nextTaskbarPlacementCheck) {
-                g_nextTaskbarPlacementCheck = now + std::chrono::seconds(1);
-                EnsureConfiguredTaskbarPlacement();
-            }
+            EnsureConfiguredTaskbarPlacement();
             UpdateWidgetText(force);
         } catch (...) {
             HRESULT error = winrt::to_hresult();
@@ -4155,8 +3783,6 @@ bool StopTimer() {
         g_timer = nullptr;
         g_timerToken = {};
     }
-    g_nextSystemColorCheck = {};
-    g_nextTaskbarPlacementCheck = {};
     return true;
 }
 
@@ -4294,8 +3920,6 @@ Grid CreateMemoryRow(PCWSTR label,
 }
 
 bool RemoveWidget() {
-    g_nextSystemColorCheck = {};
-
     if (g_widget && g_actualThemeChangedToken.value) {
         try {
             g_widget.ActualThemeChanged(g_actualThemeChangedToken);
@@ -4508,25 +4132,20 @@ using RunFromWindowThreadProc = void (*)(void*);
 
 struct WindowThreadCallbackContext {
     RunFromWindowThreadProc callback;
-    std::shared_ptr<void> context;
+    void* context;
     std::atomic<bool> invoked{false};
-
-    WindowThreadCallbackContext(RunFromWindowThreadProc callbackValue,
-                                std::shared_ptr<void> contextValue)
-        : callback(callbackValue), context(std::move(contextValue)) {}
 };
 
-std::mutex g_windowThreadDispatchMutex;
 std::mutex g_windowThreadCallbackRegistryMutex;
 [[clang::no_destroy]]
-std::optional<std::unordered_map<
-    ULONG_PTR, std::shared_ptr<WindowThreadCallbackContext>>>
+std::optional<
+    std::unordered_map<ULONG_PTR, WindowThreadCallbackContext*>>
     g_windowThreadCallbackRegistry{std::in_place};
 std::atomic<ULONG_PTR> g_nextWindowThreadCallbackToken{1};
 
 bool RunFromWindowThread(HWND window,
                          RunFromWindowThreadProc callback,
-                         std::shared_ptr<void> context) {
+                         void* context) {
     static const UINT message =
         RegisterWindowMessageW(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
     DWORD threadId = GetWindowThreadProcessId(window, nullptr);
@@ -4534,24 +4153,24 @@ bool RunFromWindowThread(HWND window,
         return false;
     }
     if (threadId == GetCurrentThreadId()) {
-        callback(context.get());
+        callback(context);
         return true;
     }
 
-    std::lock_guard dispatchLock(g_windowThreadDispatchMutex);
-    std::shared_ptr<WindowThreadCallbackContext> callbackContext;
+    WindowThreadCallbackContext callbackContext{callback, context};
     ULONG_PTR callbackToken = 0;
     try {
-        callbackContext = std::make_shared<WindowThreadCallbackContext>(
-            callback, std::move(context));
         std::lock_guard lock(g_windowThreadCallbackRegistryMutex);
+        if (!g_windowThreadCallbackRegistry) {
+            return false;
+        }
         do {
             callbackToken = g_nextWindowThreadCallbackToken.fetch_add(
                 1, std::memory_order_relaxed);
         } while (!callbackToken ||
                  g_windowThreadCallbackRegistry->contains(callbackToken));
         g_windowThreadCallbackRegistry->emplace(callbackToken,
-                                                 callbackContext);
+                                                 &callbackContext);
     } catch (...) {
         Wh_Log(L"Preparing taskbar thread dispatch failed: %08X",
                static_cast<unsigned>(winrt::to_hresult()));
@@ -4565,32 +4184,24 @@ bool RunFromWindowThread(HWND window,
                 const auto* messageData =
                     reinterpret_cast<const CWPSTRUCT*>(lParam);
                 if (messageData->message == message) {
-                    std::shared_ptr<WindowThreadCallbackContext>
-                        callbackContext;
+                    WindowThreadCallbackContext* callbackContext = nullptr;
                     {
                         std::lock_guard lock(
                             g_windowThreadCallbackRegistryMutex);
-                        auto callbackEntry =
-                            g_windowThreadCallbackRegistry->find(
+                        if (g_windowThreadCallbackRegistry) {
+                            auto entry = g_windowThreadCallbackRegistry->find(
                                 static_cast<ULONG_PTR>(messageData->lParam));
-                        if (callbackEntry !=
-                            g_windowThreadCallbackRegistry->end()) {
-                            callbackContext = callbackEntry->second;
-                            g_windowThreadCallbackRegistry->erase(
-                                callbackEntry);
+                            if (entry !=
+                                g_windowThreadCallbackRegistry->end()) {
+                                callbackContext = entry->second;
+                                g_windowThreadCallbackRegistry->erase(entry);
+                            }
                         }
                     }
                     if (callbackContext) {
-                        try {
-                            callbackContext->callback(
-                                callbackContext->context.get());
-                        } catch (...) {
-                            Wh_Log(
-                                L"Unhandled taskbar dispatch callback error: %08X",
-                                static_cast<unsigned>(winrt::to_hresult()));
-                        }
-                        callbackContext->invoked.store(
-                            true, std::memory_order_release);
+                        callbackContext->callback(callbackContext->context);
+                        callbackContext->invoked.store(true,
+                                                       std::memory_order_release);
                     }
                 }
             }
@@ -4598,8 +4209,8 @@ bool RunFromWindowThread(HWND window,
         },
         nullptr, threadId);
     if (!hook) {
-        {
-            std::lock_guard lock(g_windowThreadCallbackRegistryMutex);
+        std::lock_guard lock(g_windowThreadCallbackRegistryMutex);
+        if (g_windowThreadCallbackRegistry) {
             g_windowThreadCallbackRegistry->erase(callbackToken);
         }
         Wh_Log(L"SetWindowsHookEx failed for taskbar thread %u: %u", threadId,
@@ -4608,35 +4219,37 @@ bool RunFromWindowThread(HWND window,
     }
 
     SendMessageW(window, message, 0, static_cast<LPARAM>(callbackToken));
-    DWORD unhookAttempts = 0;
-    while (true) {
+    bool unhooked = false;
+    DWORD unhookError = ERROR_SUCCESS;
+    for (int attempt = 0; attempt < 3; attempt++) {
         if (UnhookWindowsHookEx(hook)) {
+            unhooked = true;
             break;
         }
-        DWORD unhookError = GetLastError();
+        unhookError = GetLastError();
         if (unhookError == ERROR_INVALID_HOOK_HANDLE) {
-            Wh_Log(L"Taskbar thread hook was already removed for thread %u",
-                   threadId);
+            unhooked = true;
             break;
         }
-        unhookAttempts++;
-        if (unhookAttempts == 1 || unhookAttempts % 100 == 0) {
-            Wh_Log(L"UnhookWindowsHookEx failed for taskbar thread %u: %u; "
-                   L"retrying",
-                   threadId, unhookError);
+        if (attempt < 2) {
+            Sleep(10);
         }
-        Sleep(10);
     }
     {
         std::lock_guard lock(g_windowThreadCallbackRegistryMutex);
-        g_windowThreadCallbackRegistry->erase(callbackToken);
+        if (g_windowThreadCallbackRegistry) {
+            g_windowThreadCallbackRegistry->erase(callbackToken);
+        }
     }
-    bool invoked =
-        callbackContext->invoked.load(std::memory_order_acquire);
+    if (!unhooked) {
+        Wh_Log(L"UnhookWindowsHookEx failed for taskbar thread %u: %u",
+               threadId, unhookError);
+    }
+    bool invoked = callbackContext.invoked.load(std::memory_order_acquire);
     if (!invoked) {
         Wh_Log(L"Taskbar thread dispatch failed for thread %u", threadId);
     }
-    return invoked;
+    return invoked && unhooked;
 }
 
 bool IsTaskbarWindowClass(HWND window, bool* secondary = nullptr) {
@@ -4706,26 +4319,6 @@ std::vector<DisplayMonitor> EnumerateDisplayMonitors() {
                    reinterpret_cast<uintptr_t>(right.handle);
         });
     return monitors;
-}
-
-uint64_t GetDisplayTopologyFingerprint(
-    const std::vector<DisplayMonitor>& monitors) {
-    uint64_t hash = 1469598103934665603ull;
-    auto mix = [&hash](uint64_t value) {
-        hash ^= value;
-        hash *= 1099511628211ull;
-    };
-
-    for (const DisplayMonitor& monitor : monitors) {
-        mix(reinterpret_cast<uintptr_t>(monitor.handle));
-        mix(static_cast<uint64_t>(static_cast<int64_t>(monitor.bounds.left)));
-        mix(static_cast<uint64_t>(static_cast<int64_t>(monitor.bounds.top)));
-        mix(static_cast<uint64_t>(static_cast<int64_t>(monitor.bounds.right)));
-        mix(static_cast<uint64_t>(static_cast<int64_t>(monitor.bounds.bottom)));
-        mix(monitor.primary);
-    }
-    mix(monitors.size());
-    return hash;
 }
 
 HWND FindTaskbarWindowForMonitor(HMONITOR monitor) {
@@ -4810,11 +4403,6 @@ HWND FindConfiguredTaskbarWindow(bool logFallback = true) {
     return FindConfiguredTaskbarWindow(EnumerateDisplayMonitors(), logFallback);
 }
 
-void ResetUnknownPlacementProbeState() {
-    g_unknownPlacementProbeFailures = 0;
-    g_unknownPlacementProbesSuspended = false;
-}
-
 void RememberTaskbarWindow(HWND window) {
     if (!IsCurrentProcessTaskbarWindow(window)) {
         return;
@@ -4824,7 +4412,6 @@ void RememberTaskbarWindow(HWND window) {
         g_taskbarWindow = window;
         g_taskbarThreadId = threadId;
         g_placementLocationUnknown = false;
-        ResetUnknownPlacementProbeState();
     }
 }
 
@@ -4900,26 +4487,6 @@ RefCountBase_Decref_t RefCountBase_Decref_Original = nullptr;
 void* CTaskBand_ITaskListWndSite_vftable = nullptr;
 void* CSecondaryTaskBand_ITaskListWndSite_vftable = nullptr;
 
-bool IsReadableMemoryRange(const void* address, size_t size) {
-    if (!address || size == 0) {
-        return false;
-    }
-
-    MEMORY_BASIC_INFORMATION memory{};
-    if (!VirtualQuery(address, &memory, sizeof(memory)) ||
-        memory.State != MEM_COMMIT ||
-        (memory.Protect & (PAGE_GUARD | PAGE_NOACCESS))) {
-        return false;
-    }
-
-    uintptr_t start = reinterpret_cast<uintptr_t>(address);
-    uintptr_t regionStart =
-        reinterpret_cast<uintptr_t>(memory.BaseAddress);
-    uintptr_t regionEnd = regionStart + memory.RegionSize;
-    return start >= regionStart && start <= regionEnd &&
-           size <= regionEnd - start;
-}
-
 XamlRoot GetTaskbarXamlRoot(HWND taskbarWindow) {
     bool isSecondary = false;
     if (!IsCurrentProcessTaskbarWindow(taskbarWindow) ||
@@ -4959,10 +4526,6 @@ XamlRoot GetTaskbarXamlRoot(HWND taskbarWindow) {
 
     void* taskBandForSite = taskBand;
     for (int i = 0;; i++) {
-        if (!IsReadableMemoryRange(taskBandForSite, sizeof(void*))) {
-            Wh_Log(L"Taskband site scan reached unreadable memory");
-            return nullptr;
-        }
         if (*reinterpret_cast<void**>(taskBandForSite) == expectedVftable) {
             break;
         }
@@ -4991,8 +4554,7 @@ XamlRoot GetTaskbarXamlRoot(HWND taskbarWindow) {
 #if defined(_M_X64)
     const BYTE* code =
         reinterpret_cast<const BYTE*>(TaskbarHost_FrameHeight_Original);
-    if (IsReadableMemoryRange(code, 8) && code[0] == 0x48 &&
-        code[1] == 0x83 && code[2] == 0xEC &&
+    if (code[0] == 0x48 && code[1] == 0x83 && code[2] == 0xEC &&
         code[4] == 0x48 && code[5] == 0x83 && code[6] == 0xC1 &&
         code[7] <= 0x7F) {
         elementOffset = code[7];
@@ -5003,8 +4565,7 @@ XamlRoot GetTaskbarXamlRoot(HWND taskbarWindow) {
 #elif defined(_M_ARM64)
     const DWORD* code =
         reinterpret_cast<const DWORD*>(TaskbarHost_FrameHeight_Original);
-    if (IsReadableMemoryRange(code, sizeof(DWORD) * 4) &&
-        code[0] == 0xD503237F &&
+    if (code[0] == 0xD503237F &&
         (code[1] & 0xFFC07FFF) == 0xA9807BFD &&
         code[2] == 0x910003FD &&
         (code[3] & 0xFFF00FE0) == 0xF8400C00) {
@@ -5019,11 +4580,6 @@ XamlRoot GetTaskbarXamlRoot(HWND taskbarWindow) {
 
     auto* elementAddress =
         static_cast<BYTE*>(taskbarHostSharedPtr[0]) + elementOffset;
-    if (!IsReadableMemoryRange(elementAddress, sizeof(::IUnknown*))) {
-        Wh_Log(L"Taskbar XAML element address is unreadable");
-        return nullptr;
-    }
-
     auto* elementUnknown =
         *reinterpret_cast<::IUnknown**>(elementAddress);
     if (!elementUnknown) {
@@ -5083,10 +4639,10 @@ void ApplyToTaskbarWindow(void* contextValue) {
 bool ApplyWidgetToTaskbarWindow(
     HWND taskbarWindow,
     FrameworkElement taskbarFrame = nullptr) {
-    auto context = std::make_shared<ApplyWidgetContext>(
-        ApplyWidgetContext{taskbarWindow, taskbarFrame, false});
-    return RunFromWindowThread(taskbarWindow, ApplyToTaskbarWindow, context) &&
-           context->succeeded;
+    ApplyWidgetContext context{taskbarWindow, taskbarFrame, false};
+    return RunFromWindowThread(taskbarWindow, ApplyToTaskbarWindow,
+                               &context) &&
+           context.succeeded;
 }
 
 struct TaskbarProbeContext {
@@ -5106,12 +4662,11 @@ void ProbeTaskbarWindow(void* contextValue) {
 }
 
 FrameworkElement FindReadyTaskbarFrame(HWND window) {
-    auto context = std::make_shared<TaskbarProbeContext>(
-        TaskbarProbeContext{window, nullptr});
-    if (!RunFromWindowThread(window, ProbeTaskbarWindow, context)) {
+    TaskbarProbeContext context{window, nullptr};
+    if (!RunFromWindowThread(window, ProbeTaskbarWindow, &context)) {
         return nullptr;
     }
-    return context->frame;
+    return context.frame;
 }
 
 struct RemoveWidgetForMoveContext {
@@ -5163,12 +4718,7 @@ void RemoveFromCurrentTaskbar(void* contextValue) {
         g_placementFailures = 0;
         g_placementIsFallback = false;
         g_placementLocationUnknown = false;
-        g_unknownPlacementProbeFailures = 0;
-        g_unknownPlacementProbesSuspended = false;
-        g_lastDisplayTopologyFingerprint = 0;
-        g_hasDisplayTopologyFingerprint = false;
         g_placementApplyPending = false;
-        g_resetUnknownPlacementProbesPending = false;
         g_taskbarUiResourcesRegistered = false;
     }
     if (context) {
@@ -5215,21 +4765,11 @@ void RecordPlacementFallback(HWND targetWindow) {
 void MarkPlacementForRetry(HWND requestedWindow) {
     g_placementIsFallback = true;
     RecordPlacementFailure(requestedWindow);
-    if (g_placementLocationUnknown && !g_unknownPlacementProbesSuspended) {
-        g_unknownPlacementProbeFailures++;
-        if (g_unknownPlacementProbeFailures >=
-            kMaximumUnknownPlacementProbeFailures) {
-            g_unknownPlacementProbesSuspended = true;
-            Wh_Log(L"Monitor lookup failed repeatedly; automatic XAML probes "
-                   L"are paused until taskbar topology or settings change");
-        }
-    }
 }
 
 void CompletePlacement(HWND requestedWindow, HWND actualWindow) {
     g_placementApplyPending = false;
     g_placementLocationUnknown = false;
-    ResetUnknownPlacementProbeState();
     if (requestedWindow == actualWindow) {
         g_placementIsFallback = false;
         ResetPlacementRetryState();
@@ -5279,7 +4819,6 @@ struct ApplyOnTaskbarThreadContext {
     FrameworkElement fallbackFrame{nullptr};
     HWND requestedWindow = nullptr;
     bool refreshExistingWidget = true;
-    bool resetUnknownPlacementProbes = false;
     bool succeeded = false;
 };
 
@@ -5289,13 +4828,6 @@ void ApplyOnTaskbarUiThreadImpl(void* contextValue) {
     if (g_unloading) {
         return;
     }
-    bool resetUnknownPlacementProbesPending =
-        g_resetUnknownPlacementProbesPending.exchange(false);
-    if (context->resetUnknownPlacementProbes ||
-        resetUnknownPlacementProbesPending) {
-        ResetUnknownPlacementProbeState();
-    }
-
     // Keep a retry timer even before the first successful injection. All state
     // below is intentionally owned by Explorer's taskbar/XAML UI thread.
     EnsureTimer();
@@ -5368,10 +4900,10 @@ void ApplyOnTaskbarUiThreadImpl(void* contextValue) {
     }
     bool widgetRemovedForMove = false;
     if (removalWindow && g_widget && currentWindow != targetWindow) {
-        auto removeContext = std::make_shared<RemoveWidgetForMoveContext>();
+        RemoveWidgetForMoveContext removeContext;
         if (!RunFromWindowThread(removalWindow, RemoveWidgetForMove,
-                                 removeContext) ||
-            !removeContext->succeeded) {
+                                 &removeContext) ||
+            !removeContext.succeeded) {
             Wh_Log(L"Removing widget from the previous monitor failed");
             MarkPlacementForRetry(requestedWindow);
             return;
@@ -5419,15 +4951,11 @@ void ApplyOnTaskbarUiThread(void* contextValue) {
 
 bool ApplyOnTaskbarThread(FrameworkElement fallbackFrame = nullptr,
                           bool refreshExistingWidget = true,
-                          bool resetUnknownPlacementProbes = false,
                           HWND requestedWindow = nullptr) {
     if (g_unloading) {
         return false;
     }
 
-    if (resetUnknownPlacementProbes) {
-        g_resetUnknownPlacementProbesPending = true;
-    }
     g_placementApplyPending = true;
     constexpr int kMaximumDispatchAttempts = 3;
     for (int attempt = 0; attempt < kMaximumDispatchAttempts; attempt++) {
@@ -5460,13 +4988,11 @@ bool ApplyOnTaskbarThread(FrameworkElement fallbackFrame = nullptr,
             }
             attemptedThreadIds[attemptedThreadCount++] = dispatchThreadId;
 
-            auto context = std::make_shared<ApplyOnTaskbarThreadContext>(
-                ApplyOnTaskbarThreadContext{
-                    fallbackFrame, requestedWindow, refreshExistingWidget,
-                    resetUnknownPlacementProbes, false});
+            ApplyOnTaskbarThreadContext context{
+                fallbackFrame, requestedWindow, refreshExistingWidget, false};
             if (RunFromWindowThread(dispatchWindow, ApplyOnTaskbarUiThread,
-                                    context)) {
-                return true;
+                                    &context)) {
+                return context.succeeded;
             }
         }
         if (attempt + 1 < kMaximumDispatchAttempts) {
@@ -5578,37 +5104,20 @@ void EnsureConfiguredTaskbarPlacement() {
         return;
     }
 
-    auto monitors = EnumerateDisplayMonitors();
-    uint64_t topologyFingerprint = GetDisplayTopologyFingerprint(monitors);
-    bool topologyChanged =
-        !g_hasDisplayTopologyFingerprint ||
-        topologyFingerprint != g_lastDisplayTopologyFingerprint;
-    if (topologyChanged) {
-        g_lastDisplayTopologyFingerprint = topologyFingerprint;
-        g_hasDisplayTopologyFingerprint = true;
-        ResetPlacementRetryState();
-        ResetUnknownPlacementProbeState();
-    }
-
     HWND rememberedWindow = g_taskbarWindow.load();
     bool placementApplyPending = g_placementApplyPending.load();
-    if (!placementApplyPending && !topologyChanged &&
-        !g_placementIsFallback &&
+    if (!placementApplyPending && !g_placementIsFallback &&
         g_placementFailures == 0 && g_widget &&
         IsCurrentProcessTaskbarWindow(rememberedWindow)) {
         return;
     }
 
     auto now = std::chrono::steady_clock::now();
-    if (!topologyChanged && g_placementFailures != 0 &&
-        now < g_nextPlacementRetry) {
-        return;
-    }
-    if (!topologyChanged && g_placementLocationUnknown &&
-        g_unknownPlacementProbesSuspended) {
+    if (g_placementFailures != 0 && now < g_nextPlacementRetry) {
         return;
     }
 
+    auto monitors = EnumerateDisplayMonitors();
     HWND targetWindow = FindConfiguredTaskbarWindow(monitors, false);
     if (!targetWindow) {
         MarkPlacementForRetry(nullptr);
@@ -5621,19 +5130,15 @@ void EnsureConfiguredTaskbarPlacement() {
         return;
     }
 
-    if (topologyChanged) {
-        Wh_Log(L"Taskbar topology changed; moving the widget");
-    } else {
-        Wh_Log(L"Retrying taskbar placement");
-    }
-    ApplyOnTaskbarThread(nullptr, false, false, targetWindow);
+    Wh_Log(L"Retrying taskbar placement");
+    ApplyOnTaskbarThread(nullptr, false, targetWindow);
 }
 
 void ApplyLoadedTaskbarFrame(FrameworkElement taskbarFrame) {
     if (g_unloading) {
         return;
     }
-    ResetUnknownPlacementProbeState();
+    ResetPlacementRetryState();
     if (!taskbarFrame) {
         ApplyOnTaskbarThread();
         return;
@@ -5759,23 +5264,23 @@ HMODULE GetTaskbarViewModule() {
     return module;
 }
 
-bool TryHookTaskbarViewSymbols(HMODULE module, bool applyImmediately) {
-    if (!module || g_taskbarViewDllLoaded) {
-        return static_cast<bool>(g_taskbarViewDllLoaded);
-    }
-
-    if (g_taskbarViewHookAttempts >= kMaximumTaskbarViewHookAttempts ||
-        g_taskbarViewDllLoaded.exchange(true)) {
-        return static_cast<bool>(g_taskbarViewDllLoaded);
-    }
-
-    uint32_t attempt = ++g_taskbarViewHookAttempts;
-    if (!HookTaskbarViewSymbols(module)) {
-        Wh_Log(L"Taskbar.View symbol hook failed (attempt %u/%u)", attempt,
-               kMaximumTaskbarViewHookAttempts);
-        g_taskbarViewDllLoaded = false;
+bool HandleLoadedModuleIfTaskbarView(HMODULE module,
+                                     LPCWSTR fileName,
+                                     bool applyImmediately) {
+    if (!module || GetTaskbarViewModule() != module) {
         return false;
     }
+    if (g_taskbarViewHookAttempted.exchange(true)) {
+        return static_cast<bool>(g_taskbarViewDllLoaded);
+    }
+
+    Wh_Log(L"Taskbar view module loaded: %s",
+           fileName ? fileName : L"<already loaded>");
+    if (!HookTaskbarViewSymbols(module)) {
+        Wh_Log(L"Taskbar.View symbol hook failed");
+        return false;
+    }
+    g_taskbarViewDllLoaded = true;
     if (applyImmediately) {
         Wh_ApplyHookOperations();
     }
@@ -5789,12 +5294,11 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName,
                                    HANDLE file,
                                    DWORD flags) {
     HMODULE module = LoadLibraryExW_Original(fileName, file, flags);
-    if (!g_taskbarViewDllLoaded &&
-        g_taskbarViewHookAttempts < kMaximumTaskbarViewHookAttempts) {
-        if (HMODULE taskbarViewModule = GetTaskbarViewModule()) {
-            TryHookTaskbarViewSymbols(taskbarViewModule, true);
-        }
+    DWORD lastError = GetLastError();
+    if (module && !g_taskbarViewHookAttempted) {
+        HandleLoadedModuleIfTaskbarView(module, fileName, true);
     }
+    SetLastError(lastError);
     return module;
 }
 
@@ -5806,9 +5310,12 @@ void CloseMetricSources() {
     g_nextPdhCounterRetry = {};
     g_nextPdhRecovery = {};
     g_consecutivePdhReadFailures = 0;
-    g_consecutivePdhEmptySamples = 0;
-    g_pdhEmptyRecoveries = 0;
-    g_nextPdhEmptyRecovery = {};
+    g_lastResolvedGpuAdapterFilter.reset();
+    g_lastResolvedGpuAdapterLuid.reset();
+    g_gpuAdapterIdentityChanged = false;
+    g_hasResolvedGpuAdapterIdentity = false;
+    g_hwInfoInvalidUnitLogged = false;
+    g_hwInfoGpuAdapterMismatchLogged = false;
 }
 
 bool TearDownTaskbarUi() {
@@ -5818,38 +5325,29 @@ bool TearDownTaskbarUi() {
         g_taskbarThreadId = 0;
         return true;
     }
-    constexpr int kMaximumTeardownAttempts = 3;
-    for (int attempt = 0; attempt < kMaximumTeardownAttempts; attempt++) {
-        DWORD attemptedThreadIds[3]{};
-        size_t attemptedThreadCount = 0;
-        HWND rememberedWindow = FindRememberedTaskbarWindow();
-        HWND candidates[] = {rememberedWindow,
-                             FindAnyWindowOnTaskbarThread(rememberedWindow),
-                             FindPrimaryTaskbarWindow()};
-        for (size_t i = 0; i < std::size(candidates); i++) {
-            HWND window = candidates[i];
-            if (!window ||
-                std::find(candidates, candidates + i, window) !=
-                    candidates + i) {
-                continue;
-            }
-            DWORD threadId = GetWindowThreadProcessId(window, nullptr);
-            if (!threadId ||
-                std::find(attemptedThreadIds,
-                          attemptedThreadIds + attemptedThreadCount,
-                          threadId) !=
-                    attemptedThreadIds + attemptedThreadCount) {
-                continue;
-            }
-            attemptedThreadIds[attemptedThreadCount++] = threadId;
-            auto context = std::make_shared<RemoveTaskbarUiContext>();
-            if (RunFromWindowThread(window, RemoveFromCurrentTaskbar,
-                                    context)) {
-                return context->succeeded;
-            }
+    DWORD attemptedThreadIds[3]{};
+    size_t attemptedThreadCount = 0;
+    HWND rememberedWindow = FindRememberedTaskbarWindow();
+    HWND candidates[] = {rememberedWindow,
+                         FindAnyWindowOnTaskbarThread(rememberedWindow),
+                         FindPrimaryTaskbarWindow()};
+    for (size_t i = 0; i < std::size(candidates); i++) {
+        HWND window = candidates[i];
+        if (!window || std::find(candidates, candidates + i, window) !=
+                           candidates + i) {
+            continue;
         }
-        if (attempt + 1 < kMaximumTeardownAttempts) {
-            Sleep(25);
+        DWORD threadId = GetWindowThreadProcessId(window, nullptr);
+        if (!threadId ||
+            std::find(attemptedThreadIds,
+                      attemptedThreadIds + attemptedThreadCount,
+                      threadId) != attemptedThreadIds + attemptedThreadCount) {
+            continue;
+        }
+        attemptedThreadIds[attemptedThreadCount++] = threadId;
+        RemoveTaskbarUiContext context;
+        if (RunFromWindowThread(window, RemoveFromCurrentTaskbar, &context)) {
+            return context.succeeded;
         }
     }
     return false;
@@ -5888,7 +5386,7 @@ BOOL Wh_ModInit() {
     }
 
     if (HMODULE module = GetTaskbarViewModule()) {
-        if (!TryHookTaskbarViewSymbols(module, false)) {
+        if (!HandleLoadedModuleIfTaskbarView(module, nullptr, false)) {
             Wh_Log(L"Taskbar.View symbols unavailable");
             return FALSE;
         }
@@ -5913,9 +5411,9 @@ BOOL Wh_ModInit() {
 
 void Wh_ModAfterInit() {
     Wh_Log(L">");
-    if (!g_taskbarViewDllLoaded) {
+    if (!g_taskbarViewHookAttempted) {
         if (HMODULE module = GetTaskbarViewModule()) {
-            TryHookTaskbarViewSymbols(module, true);
+            HandleLoadedModuleIfTaskbarView(module, nullptr, true);
         }
     }
     if (!ApplyOnTaskbarThread()) {
@@ -5927,7 +5425,7 @@ void Wh_ModSettingsChanged() {
     Wh_Log(L">");
     LoadSettings();
     WakeMetricsWorker();
-    if (!ApplyOnTaskbarThread(nullptr, true, true)) {
+    if (!ApplyOnTaskbarThread(nullptr, true)) {
         StartPlacementRetryWorker();
     }
 }


### PR DESCRIPTION
## Changelog

Update Taskbar System Info from 1.3.3 to 1.5.0.

- Add a **Taskbar monitor** setting to place the widget on the primary or a secondary display. If the selected display is unavailable, use the primary taskbar and retry the selected display automatically.
- Add **adaptive colors** for light, dark and Windows high-contrast themes, while retaining manual color settings.
- Scale the widget down on short taskbars so its two rows fit without clipping.
- Use the Windows Processor Utility counter for CPU usage when available, aligning the reading with Task Manager's frequency-aware measurement. Keep the existing CPU counter as a fallback.
- Add **Automatic / Dedicated / Shared** GPU-memory selection and improve automatic handling of integrated GPUs with a small dedicated-memory reservation.
- Improve recovery when GPU/VRAM counters stop returning data, while keeping CPU and RAM readings visible. Show unavailable GPU readings as `--%` instead of treating them as idle.
- Keep CPU/GPU graph history when samples are missing, show gaps for unavailable data, and use measurement timestamps to preserve the selected history duration.
- Improve HWiNFO temperature-sensor matching when sensor records change, and fix temperature parsing with comma decimal separators.
- Expand the built-in guide with a quick start, explanations of each setting, HWiNFO setup instructions and troubleshooting for missing temperatures.

<details>
<summary>Implementation notes and verification</summary>

### Implementation notes

- CPU and GPU performance queries are separate. A fresh GPU-memory reading is used to confirm stale counters before rebuilding; an unavailable or parked GPU does not by itself trigger repeated counter resets.
- HWiNFO cached readings are checked against sensor identity rather than only their position in the sensor list.
- New metric snapshots and Windows display/theme notifications trigger UI updates. A fallback timer follows the configured update interval.
- Window-thread dispatch uses bounded hook-removal attempts, and no mutex is held across the synchronous window message. Taskbar symbols are hooked once per module, and the loader hook preserves the original error result.

### Verification recorded for this revision

- Source, settings and documentation validation passed: 28 settings.
- Windhawk x64 and ARM64 cross-builds passed without compiler warnings. ARM64 hardware was not tested.
- **70 behavioral checks** exercise the production code with synthetic provider data, including stale and unavailable GPU counters, HWiNFO sensor reordering, decimal parsing, graph gaps and sampling deadlines.
- Native hidden-window tests cover display notifications and handler cleanup.
- Six isolated XAML renders were checked: dark/light themes, short taskbar, minimum width, large font and unavailable readings.
- A healthy live smoke test on an RX 7900 XTX confirmed CPU usage, GPU usage, VRAM and native GPU temperature.

Driver restart/TDR, actual adapter-identity changes, live HWiNFO table replacement, physical monitor rearrangement, mixed-DPI transitions and live high-contrast switching were not physically reproduced in that verification pass. Synthetic tests and isolated renders do not establish those end-to-end scenarios.

The source in this PR at `d2b4a11c1b7b9f5db5ca310cc7372d32c1775b57` matches standalone commit [`664f929`](https://github.com/starychenko/windhawk-taskbar-system-info/commit/664f9293fe01ec6ab5a2b5e7ee1f2868127e619c), which contains the tests and the [detailed verification record](https://github.com/starychenko/windhawk-taskbar-system-info/blob/664f9293fe01ec6ab5a2b5e7ee1f2868127e619c/docs/review-resolution-2026-09-17.md).

The standalone release and tag are unchanged. This description update does not change the PR code or resolve outstanding code-review findings.

</details>
