### PR TITLE
Add Explorer Title Bar Label mod

### DIFF
--- a/mods/explorer-title-bar-label.wh.cpp
+++ b/mods/explorer-title-bar-label.wh.cpp
@@ -1,0 +1,1587 @@
+// ==WindhawkMod==
+// @id              explorer-title-bar-label
+// @name            Explorer Title Bar Label
+// @description     Add custom text, date and time to the Windows 11 File Explorer title bar.
+// @version         1.0.0
+// @author          digitalART
+// @github          https://github.com/digart11
+// @license         GPL-3.0
+// @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject
+// ==/WindhawkMod==
+
+// Source code is published under the GNU General Public License v3.0.
+
+// ==WindhawkModReadme==
+/*
+# Explorer Title Bar Label
+
+Add custom text, date and time to the right side of the Windows 11 File Explorer title bar.
+
+![Explorer Title Bar Label](https://raw.githubusercontent.com/digart11/explorer-title-bar-label/main/images/screenshot.png)
+
+## Features
+
+- Custom text, date and time
+- Flexible date display
+- 12-hour or 24-hour time with optional seconds
+- Font, size, weight and color
+- Opacity and spacing
+- Live updates
+
+## Date and time
+
+Choose the date parts and order you prefer:
+
+- **Weekday:** None, Mon, Monday
+- **Day number:** 1, 01
+- **Month:** 8, 08, Aug, August
+- **Year:** None, 26, 2026
+- **Date order:** Month-Day-Year, Day-Month-Year, Year-Month-Day
+- **Numeric separator:** `/`, `-`, `.`
+
+Time can use **12-hour or 24-hour format**, with optional seconds.
+
+## Compatibility
+
+This mod uses XAML diagnostics and may conflict with other File Explorer mods that also use XAML diagnostics.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- customText: ""
+  $name: Custom text
+  $description: "Optional text displayed before the date and time."
+
+- showDate: true
+  $name: Show date
+
+- dateWeekday: short
+  $name: Weekday
+  $options:
+  - none: None
+  - short: Mon
+  - long: Monday
+
+- dateDay: number
+  $name: Day number
+  $options:
+  - number: "1"
+  - twoDigit: "01"
+
+- dateMonth: short
+  $name: Month
+  $options:
+  - number: "8"
+  - twoDigit: "08"
+  - short: Aug
+  - long: August
+
+- dateYear: none
+  $name: Year
+  $options:
+  - none: None
+  - short: "26"
+  - long: "2026"
+
+- dateOrder: mdy
+  $name: Date order
+  $options:
+  - mdy: Month - Day - Year
+  - dmy: Day - Month - Year
+  - ymd: Year - Month - Day
+
+- numericDateSeparator: slash
+  $name: Numeric date separator
+  $options:
+  - slash: "/"
+  - dash: "-"
+  - dot: "."
+
+- showTime: true
+  $name: Show time
+
+- use24Hour: false
+  $name: 24-hour time
+
+- showSeconds: false
+  $name: Show seconds
+
+- separator: "   |   "
+  $name: Label separator
+
+- fontPreset: segoeVariable
+  $name: Font family
+  $options:
+  - segoeVariable: Segoe UI Variable Text
+  - segoe: Segoe UI
+  - arial: Arial
+  - calibri: Calibri
+  - consolas: Consolas
+  - tahoma: Tahoma
+  - verdana: Verdana
+  - custom: Custom
+
+- customFontFamily: ""
+  $name: Custom font family
+  $description: "Used only when Font family is set to Custom."
+
+- fontSize: 12
+  $name: Font size
+
+- fontWeight: normal
+  $name: Font weight
+  $options:
+  - normal: Normal
+  - semibold: Semibold
+  - bold: Bold
+
+- italic: false
+  $name: Italic
+
+- textColor: "#FFFFFF"
+  $name: Text color
+  $description: "Hex color such as #FFFFFF or #A0A0A0."
+
+- opacity: 100
+  $name: Opacity
+  $description: "0 to 100."
+
+- leftMargin: 12
+  $name: Left spacing
+
+- rightMargin: 12
+  $name: Right spacing
+
+- verticalOffset: 0
+  $name: Vertical offset
+  $description: "Positive values move the label down. Negative values move it up."
+*/
+// ==/WindhawkModSettings==
+
+#include <windows.h>
+
+#undef GetCurrentTime
+
+#include <xamlom.h>
+#include <Unknwn.h>
+#include <ocidl.h>
+
+#include <winrt/base.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.UI.h>
+#include <winrt/Windows.UI.Text.h>
+
+#include <winrt/Microsoft.UI.Xaml.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <winrt/Microsoft.UI.Xaml.Media.h>
+
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cwctype>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace wf = winrt::Windows::Foundation;
+namespace mux = winrt::Microsoft::UI::Xaml;
+namespace muxc = winrt::Microsoft::UI::Xaml::Controls;
+namespace muxm = winrt::Microsoft::UI::Xaml::Media;
+
+// ============================================================================
+// Settings
+// ============================================================================
+
+enum class WeekdayStyle {
+    None,
+    Short,
+    Long,
+};
+
+enum class DayStyle {
+    Number,
+    TwoDigit,
+};
+
+enum class MonthStyle {
+    Number,
+    TwoDigit,
+    Short,
+    Long,
+};
+
+enum class YearStyle {
+    None,
+    Short,
+    Long,
+};
+
+enum class DateOrder {
+    MDY,
+    DMY,
+    YMD,
+};
+
+enum class NumericDateSeparator {
+    Slash,
+    Dash,
+    Dot,
+};
+
+enum class FontPreset {
+    SegoeVariable,
+    Segoe,
+    Arial,
+    Calibri,
+    Consolas,
+    Tahoma,
+    Verdana,
+    Custom,
+};
+
+enum class FontWeightSetting {
+    Normal,
+    Semibold,
+    Bold,
+};
+
+struct Settings {
+    std::wstring customText;
+    bool showDate = true;
+    WeekdayStyle dateWeekday = WeekdayStyle::Short;
+    DayStyle dateDay = DayStyle::Number;
+    MonthStyle dateMonth = MonthStyle::Short;
+    YearStyle dateYear = YearStyle::None;
+    DateOrder dateOrder = DateOrder::MDY;
+    NumericDateSeparator numericDateSeparator = NumericDateSeparator::Slash;
+
+    bool showTime = true;
+    bool use24Hour = false;
+    bool showSeconds = false;
+
+    std::wstring separator = L"   |   ";
+
+    FontPreset fontPreset = FontPreset::SegoeVariable;
+    std::wstring customFontFamily;
+    int fontSize = 12;
+    FontWeightSetting fontWeight = FontWeightSetting::Normal;
+    bool italic = false;
+    std::wstring textColor = L"#FFFFFF";
+    int opacity = 100;
+
+    int leftMargin = 12;
+    int rightMargin = 12;
+    int verticalOffset = 0;
+};
+
+struct SettingsSnapshot {
+    Settings settings;
+    uint64_t generation = 0;
+};
+
+static Settings g_settings;
+static std::atomic<uint64_t> g_settingsGeneration{1};
+static std::mutex g_settingsMutex;
+
+static std::atomic<bool> g_unloading{false};
+static std::atomic<int> g_activeTextBlocks{0};
+static HANDLE g_connectorThread = nullptr;
+
+// ============================================================================
+// Settings helpers
+// ============================================================================
+
+static std::wstring ReadStringSetting(PCWSTR name, PCWSTR fallback) {
+    PCWSTR value = Wh_GetStringSetting(name);
+    if (!value) {
+        return fallback;
+    }
+
+    std::wstring result = value;
+    Wh_FreeStringSetting(value);
+    return result;
+}
+
+static Settings ReadSettingsFromWindhawk() {
+    Settings settings;
+
+    settings.customText = ReadStringSetting(L"customText", L"");
+    settings.showDate = Wh_GetIntSetting(L"showDate") != 0;
+
+    {
+        std::wstring value = ReadStringSetting(L"dateWeekday", L"short");
+        if (value == L"none") {
+            settings.dateWeekday = WeekdayStyle::None;
+        } else if (value == L"long") {
+            settings.dateWeekday = WeekdayStyle::Long;
+        } else {
+            settings.dateWeekday = WeekdayStyle::Short;
+        }
+    }
+
+    {
+        std::wstring value = ReadStringSetting(L"dateDay", L"number");
+        settings.dateDay = value == L"twoDigit" ? DayStyle::TwoDigit
+                                                 : DayStyle::Number;
+    }
+
+    {
+        std::wstring value = ReadStringSetting(L"dateMonth", L"short");
+        if (value == L"number") {
+            settings.dateMonth = MonthStyle::Number;
+        } else if (value == L"twoDigit") {
+            settings.dateMonth = MonthStyle::TwoDigit;
+        } else if (value == L"long") {
+            settings.dateMonth = MonthStyle::Long;
+        } else {
+            settings.dateMonth = MonthStyle::Short;
+        }
+    }
+
+    {
+        std::wstring value = ReadStringSetting(L"dateYear", L"none");
+        if (value == L"short") {
+            settings.dateYear = YearStyle::Short;
+        } else if (value == L"long") {
+            settings.dateYear = YearStyle::Long;
+        } else {
+            settings.dateYear = YearStyle::None;
+        }
+    }
+
+    {
+        std::wstring value = ReadStringSetting(L"dateOrder", L"mdy");
+        if (value == L"dmy") {
+            settings.dateOrder = DateOrder::DMY;
+        } else if (value == L"ymd") {
+            settings.dateOrder = DateOrder::YMD;
+        } else {
+            settings.dateOrder = DateOrder::MDY;
+        }
+    }
+
+    {
+        std::wstring value =
+            ReadStringSetting(L"numericDateSeparator", L"slash");
+        if (value == L"dash") {
+            settings.numericDateSeparator = NumericDateSeparator::Dash;
+        } else if (value == L"dot") {
+            settings.numericDateSeparator = NumericDateSeparator::Dot;
+        } else {
+            settings.numericDateSeparator = NumericDateSeparator::Slash;
+        }
+    }
+
+    settings.showTime = Wh_GetIntSetting(L"showTime") != 0;
+    settings.use24Hour = Wh_GetIntSetting(L"use24Hour") != 0;
+    settings.showSeconds = Wh_GetIntSetting(L"showSeconds") != 0;
+    settings.separator = ReadStringSetting(L"separator", L"   |   ");
+
+    {
+        std::wstring value = ReadStringSetting(L"fontPreset", L"segoeVariable");
+        if (value == L"segoe") {
+            settings.fontPreset = FontPreset::Segoe;
+        } else if (value == L"arial") {
+            settings.fontPreset = FontPreset::Arial;
+        } else if (value == L"calibri") {
+            settings.fontPreset = FontPreset::Calibri;
+        } else if (value == L"consolas") {
+            settings.fontPreset = FontPreset::Consolas;
+        } else if (value == L"tahoma") {
+            settings.fontPreset = FontPreset::Tahoma;
+        } else if (value == L"verdana") {
+            settings.fontPreset = FontPreset::Verdana;
+        } else if (value == L"custom") {
+            settings.fontPreset = FontPreset::Custom;
+        } else {
+            settings.fontPreset = FontPreset::SegoeVariable;
+        }
+    }
+
+    settings.customFontFamily = ReadStringSetting(L"customFontFamily", L"");
+    settings.fontSize = Wh_GetIntSetting(L"fontSize");
+
+    {
+        std::wstring value = ReadStringSetting(L"fontWeight", L"normal");
+        if (value == L"bold") {
+            settings.fontWeight = FontWeightSetting::Bold;
+        } else if (value == L"semibold") {
+            settings.fontWeight = FontWeightSetting::Semibold;
+        } else {
+            settings.fontWeight = FontWeightSetting::Normal;
+        }
+    }
+
+    settings.italic = Wh_GetIntSetting(L"italic") != 0;
+    settings.textColor = ReadStringSetting(L"textColor", L"#FFFFFF");
+    settings.opacity = Wh_GetIntSetting(L"opacity");
+    settings.leftMargin = Wh_GetIntSetting(L"leftMargin");
+    settings.rightMargin = Wh_GetIntSetting(L"rightMargin");
+    settings.verticalOffset = Wh_GetIntSetting(L"verticalOffset");
+
+    if (settings.fontSize < 6) {
+        settings.fontSize = 6;
+    } else if (settings.fontSize > 72) {
+        settings.fontSize = 72;
+    }
+
+    if (settings.opacity < 0) {
+        settings.opacity = 0;
+    } else if (settings.opacity > 100) {
+        settings.opacity = 100;
+    }
+
+    if (settings.leftMargin < 0) {
+        settings.leftMargin = 0;
+    } else if (settings.leftMargin > 500) {
+        settings.leftMargin = 500;
+    }
+
+    if (settings.rightMargin < 0) {
+        settings.rightMargin = 0;
+    } else if (settings.rightMargin > 500) {
+        settings.rightMargin = 500;
+    }
+
+    if (settings.verticalOffset < -50) {
+        settings.verticalOffset = -50;
+    } else if (settings.verticalOffset > 50) {
+        settings.verticalOffset = 50;
+    }
+
+    return settings;
+}
+
+static void LoadSettings(bool incrementGeneration) {
+    Settings settings = ReadSettingsFromWindhawk();
+
+    {
+        std::lock_guard<std::mutex> lock(g_settingsMutex);
+        g_settings = std::move(settings);
+    }
+
+    if (incrementGeneration) {
+        g_settingsGeneration.fetch_add(1, std::memory_order_release);
+    }
+}
+
+static SettingsSnapshot GetSettingsSnapshot() {
+    std::lock_guard<std::mutex> lock(g_settingsMutex);
+    return {g_settings,
+            g_settingsGeneration.load(std::memory_order_acquire)};
+}
+
+static std::wstring GetSelectedFontFamily(const Settings& settings) {
+    switch (settings.fontPreset) {
+        case FontPreset::Segoe:
+            return L"Segoe UI";
+        case FontPreset::Arial:
+            return L"Arial";
+        case FontPreset::Calibri:
+            return L"Calibri";
+        case FontPreset::Consolas:
+            return L"Consolas";
+        case FontPreset::Tahoma:
+            return L"Tahoma";
+        case FontPreset::Verdana:
+            return L"Verdana";
+        case FontPreset::Custom:
+            return settings.customFontFamily.empty()
+                       ? L"Segoe UI Variable Text"
+                       : settings.customFontFamily;
+        case FontPreset::SegoeVariable:
+        default:
+            return L"Segoe UI Variable Text";
+    }
+}
+
+// ============================================================================
+// Color parsing
+// ============================================================================
+
+static int HexDigit(wchar_t c) {
+    if (c >= L'0' && c <= L'9') {
+        return c - L'0';
+    }
+
+    c = towupper(c);
+    if (c >= L'A' && c <= L'F') {
+        return 10 + c - L'A';
+    }
+
+    return -1;
+}
+
+static bool ParseHexByte(wchar_t a, wchar_t b, uint8_t* result) {
+    int hi = HexDigit(a);
+    int lo = HexDigit(b);
+    if (hi < 0 || lo < 0) {
+        return false;
+    }
+
+    *result = static_cast<uint8_t>((hi << 4) | lo);
+    return true;
+}
+
+static winrt::Windows::UI::Color ParseColor(const std::wstring& input) {
+    winrt::Windows::UI::Color color{255, 255, 255, 255};
+    std::wstring text = input;
+
+    if (!text.empty() && text.front() == L'#') {
+        text.erase(text.begin());
+    }
+
+    if (text.length() == 6) {
+        uint8_t r{};
+        uint8_t g{};
+        uint8_t b{};
+
+        if (ParseHexByte(text[0], text[1], &r) &&
+            ParseHexByte(text[2], text[3], &g) &&
+            ParseHexByte(text[4], text[5], &b)) {
+            color.A = 255;
+            color.R = r;
+            color.G = g;
+            color.B = b;
+        }
+    } else if (text.length() == 8) {
+        uint8_t a{};
+        uint8_t r{};
+        uint8_t g{};
+        uint8_t b{};
+
+        if (ParseHexByte(text[0], text[1], &a) &&
+            ParseHexByte(text[2], text[3], &r) &&
+            ParseHexByte(text[4], text[5], &g) &&
+            ParseHexByte(text[6], text[7], &b)) {
+            color.A = a;
+            color.R = r;
+            color.G = g;
+            color.B = b;
+        }
+    }
+
+    return color;
+}
+
+// ============================================================================
+// Date and time formatting
+// ============================================================================
+
+static std::wstring FormatLocaleDatePart(const SYSTEMTIME& st, PCWSTR format) {
+    wchar_t buffer[128]{};
+
+    if (!GetDateFormatEx(LOCALE_NAME_USER_DEFAULT, 0, &st, format, buffer,
+                         ARRAYSIZE(buffer), nullptr)) {
+        return L"";
+    }
+
+    return buffer;
+}
+
+static std::wstring BuildWeekdayText(const SYSTEMTIME& st,
+                                     const Settings& settings) {
+    switch (settings.dateWeekday) {
+        case WeekdayStyle::Short:
+            return FormatLocaleDatePart(st, L"ddd");
+        case WeekdayStyle::Long:
+            return FormatLocaleDatePart(st, L"dddd");
+        case WeekdayStyle::None:
+        default:
+            return L"";
+    }
+}
+
+static std::wstring BuildDayText(const SYSTEMTIME& st,
+                                 const Settings& settings) {
+    wchar_t buffer[16]{};
+    if (settings.dateDay == DayStyle::TwoDigit) {
+        swprintf_s(buffer, L"%02u", st.wDay);
+    } else {
+        swprintf_s(buffer, L"%u", st.wDay);
+    }
+    return buffer;
+}
+
+static std::wstring BuildMonthText(const SYSTEMTIME& st,
+                                   const Settings& settings) {
+    wchar_t buffer[32]{};
+
+    switch (settings.dateMonth) {
+        case MonthStyle::Number:
+            swprintf_s(buffer, L"%u", st.wMonth);
+            return buffer;
+        case MonthStyle::TwoDigit:
+            swprintf_s(buffer, L"%02u", st.wMonth);
+            return buffer;
+        case MonthStyle::Long:
+            return FormatLocaleDatePart(st, L"MMMM");
+        case MonthStyle::Short:
+        default:
+            return FormatLocaleDatePart(st, L"MMM");
+    }
+}
+
+static std::wstring BuildYearText(const SYSTEMTIME& st,
+                                  const Settings& settings) {
+    wchar_t buffer[16]{};
+
+    switch (settings.dateYear) {
+        case YearStyle::Short:
+            swprintf_s(buffer, L"%02u", st.wYear % 100);
+            return buffer;
+        case YearStyle::Long:
+            swprintf_s(buffer, L"%04u", st.wYear);
+            return buffer;
+        case YearStyle::None:
+        default:
+            return L"";
+    }
+}
+
+static bool IsNumericMonth(const Settings& settings) {
+    return settings.dateMonth == MonthStyle::Number ||
+           settings.dateMonth == MonthStyle::TwoDigit;
+}
+
+static wchar_t GetNumericDateSeparator(const Settings& settings) {
+    switch (settings.numericDateSeparator) {
+        case NumericDateSeparator::Dash:
+            return L'-';
+        case NumericDateSeparator::Dot:
+            return L'.';
+        case NumericDateSeparator::Slash:
+        default:
+            return L'/';
+    }
+}
+
+static std::wstring BuildDateText(const SYSTEMTIME& st,
+                                  const Settings& settings) {
+    std::wstring weekday = BuildWeekdayText(st, settings);
+    std::wstring day = BuildDayText(st, settings);
+    std::wstring month = BuildMonthText(st, settings);
+    std::wstring year = BuildYearText(st, settings);
+    std::wstring date;
+
+    if (IsNumericMonth(settings)) {
+        wchar_t separator = GetNumericDateSeparator(settings);
+
+        auto appendPart = [&date, separator](const std::wstring& part) {
+            if (part.empty()) {
+                return;
+            }
+            if (!date.empty()) {
+                date += separator;
+            }
+            date += part;
+        };
+
+        switch (settings.dateOrder) {
+            case DateOrder::DMY:
+                appendPart(day);
+                appendPart(month);
+                appendPart(year);
+                break;
+            case DateOrder::YMD:
+                appendPart(year);
+                appendPart(month);
+                appendPart(day);
+                break;
+            case DateOrder::MDY:
+            default:
+                appendPart(month);
+                appendPart(day);
+                appendPart(year);
+                break;
+        }
+    } else {
+        switch (settings.dateOrder) {
+            case DateOrder::DMY:
+                date = day + L" " + month;
+                if (!year.empty()) {
+                    date += L" " + year;
+                }
+                break;
+
+            case DateOrder::YMD:
+                if (!year.empty()) {
+                    date = year + L" ";
+                }
+                date += month + L" " + day;
+                break;
+
+            case DateOrder::MDY:
+            default:
+                date = month + L" " + day;
+                if (!year.empty()) {
+                    date += L", " + year;
+                }
+                break;
+        }
+    }
+
+    if (!weekday.empty()) {
+        date = weekday + L", " + date;
+    }
+
+    return date;
+}
+
+static std::wstring BuildTimeText(const SYSTEMTIME& st,
+                                  const Settings& settings) {
+    wchar_t buffer[128]{};
+
+    if (settings.use24Hour) {
+        if (settings.showSeconds) {
+            swprintf_s(buffer, L"%02u:%02u:%02u", st.wHour, st.wMinute,
+                       st.wSecond);
+        } else {
+            swprintf_s(buffer, L"%02u:%02u", st.wHour, st.wMinute);
+        }
+    } else {
+        unsigned hour = st.wHour % 12;
+        if (hour == 0) {
+            hour = 12;
+        }
+
+        if (settings.showSeconds) {
+            swprintf_s(buffer, L"%u:%02u:%02u %s", hour, st.wMinute,
+                       st.wSecond, st.wHour >= 12 ? L"PM" : L"AM");
+        } else {
+            swprintf_s(buffer, L"%u:%02u %s", hour, st.wMinute,
+                       st.wHour >= 12 ? L"PM" : L"AM");
+        }
+    }
+
+    return buffer;
+}
+
+static std::wstring BuildDisplayText(const Settings& settings) {
+    SYSTEMTIME st{};
+    GetLocalTime(&st);
+
+    std::vector<std::wstring> parts;
+
+    if (!settings.customText.empty()) {
+        parts.emplace_back(settings.customText);
+    }
+
+    if (settings.showDate) {
+        std::wstring date = BuildDateText(st, settings);
+        if (!date.empty()) {
+            parts.emplace_back(std::move(date));
+        }
+    }
+
+    if (settings.showTime) {
+        std::wstring time = BuildTimeText(st, settings);
+        if (!time.empty()) {
+            parts.emplace_back(std::move(time));
+        }
+    }
+
+    std::wstring result;
+    for (size_t i = 0; i < parts.size(); ++i) {
+        if (i != 0) {
+            result += settings.separator;
+        }
+        result += parts[i];
+    }
+
+    return result;
+}
+
+// ============================================================================
+// Explorer HWND matching
+// ============================================================================
+
+struct ExplorerWindowMatchContext {
+    double targetWidthDip = 0.0;
+    double targetHeightDip = 0.0;
+    HWND bestHwnd = nullptr;
+    double bestScore = std::numeric_limits<double>::max();
+};
+
+static BOOL CALLBACK EnumExplorerWindowProc(HWND hwnd, LPARAM lParam) {
+    auto* context =
+        reinterpret_cast<ExplorerWindowMatchContext*>(lParam);
+    if (!context) {
+        return TRUE;
+    }
+
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hwnd, &pid);
+    if (pid != GetCurrentProcessId()) {
+        return TRUE;
+    }
+
+    wchar_t className[128]{};
+    if (!GetClassNameW(hwnd, className, ARRAYSIZE(className)) ||
+        wcscmp(className, L"CabinetWClass") != 0 || !IsWindowVisible(hwnd)) {
+        return TRUE;
+    }
+
+    RECT clientRect{};
+    if (!GetClientRect(hwnd, &clientRect)) {
+        return TRUE;
+    }
+
+    UINT dpi = GetDpiForWindow(hwnd);
+    if (dpi == 0) {
+        dpi = 96;
+    }
+
+    double widthPx = static_cast<double>(clientRect.right - clientRect.left);
+    double heightPx = static_cast<double>(clientRect.bottom - clientRect.top);
+    double widthDip = widthPx * 96.0 / static_cast<double>(dpi);
+    double heightDip = heightPx * 96.0 / static_cast<double>(dpi);
+
+    double widthDiff = std::abs(widthDip - context->targetWidthDip);
+    double heightDiff = std::abs(heightDip - context->targetHeightDip);
+    double score = widthDiff + heightDiff * 0.25;
+
+    if (score < context->bestScore) {
+        context->bestScore = score;
+        context->bestHwnd = hwnd;
+    }
+
+    return TRUE;
+}
+
+static HWND FindExplorerWindowForGrid(muxc::Grid const& grid) {
+    try {
+        auto xamlRoot = grid.XamlRoot();
+        if (!xamlRoot) {
+            return nullptr;
+        }
+
+        auto rootSize = xamlRoot.Size();
+        ExplorerWindowMatchContext context;
+        context.targetWidthDip = rootSize.Width;
+        context.targetHeightDip = rootSize.Height;
+
+        EnumWindows(EnumExplorerWindowProc,
+                    reinterpret_cast<LPARAM>(&context));
+        return context.bestHwnd;
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+// ============================================================================
+// Vertical positioning
+// ============================================================================
+
+static void UpdateVerticalPosition(muxc::TextBlock const& text,
+                                   muxc::Grid const& grid,
+                                   int verticalOffset) {
+    double automaticCorrection = 0.0;
+
+    try {
+        HWND hwnd = FindExplorerWindowForGrid(grid);
+
+        if (hwnd && IsZoomed(hwnd)) {
+            auto transform = grid.TransformToVisual(nullptr);
+            wf::Point origin{0.0f, 0.0f};
+            wf::Point position = transform.TransformPoint(origin);
+
+            if (position.Y < 0.0f) {
+                // Explorer's maximized title grid sits slightly above the
+                // client origin. The extra 1.5 DIP matches the restored and
+                // maximized visual center on current Windows 11 builds.
+                automaticCorrection =
+                    -static_cast<double>(position.Y) + 1.5;
+            }
+        }
+
+        auto currentTransform =
+            text.RenderTransform().try_as<muxm::TranslateTransform>();
+
+        muxm::TranslateTransform translate{nullptr};
+        if (currentTransform) {
+            translate = currentTransform;
+        } else {
+            translate = muxm::TranslateTransform();
+            text.RenderTransform(translate);
+        }
+
+        translate.Y(static_cast<double>(verticalOffset) + automaticCorrection);
+    } catch (...) {
+        Wh_Log(L"UpdateVerticalPosition exception hr=0x%08X",
+               winrt::to_hresult());
+    }
+}
+
+// ============================================================================
+// Appearance
+// ============================================================================
+
+static void ApplyTextSettings(muxc::TextBlock const& text,
+                              const Settings& settings) {
+    text.Text(BuildDisplayText(settings));
+
+    try {
+        muxm::FontFamily family(GetSelectedFontFamily(settings));
+        text.FontFamily(family);
+    } catch (...) {
+        Wh_Log(L"Invalid font family, using Segoe UI Variable Text");
+        try {
+            text.FontFamily(muxm::FontFamily(L"Segoe UI Variable Text"));
+        } catch (...) {
+        }
+    }
+
+    text.FontSize(static_cast<double>(settings.fontSize));
+
+    winrt::Windows::UI::Text::FontWeight weight{};
+    switch (settings.fontWeight) {
+        case FontWeightSetting::Bold:
+            weight.Weight = 700;
+            break;
+        case FontWeightSetting::Semibold:
+            weight.Weight = 600;
+            break;
+        case FontWeightSetting::Normal:
+        default:
+            weight.Weight = 400;
+            break;
+    }
+    text.FontWeight(weight);
+
+    text.FontStyle(settings.italic
+                       ? winrt::Windows::UI::Text::FontStyle::Italic
+                       : winrt::Windows::UI::Text::FontStyle::Normal);
+
+    // Apply opacity through the foreground brush instead of compositing the
+    // entire TextBlock. This keeps low-opacity glyph edges cleaner.
+    auto color = ParseColor(settings.textColor);
+    color.A = static_cast<uint8_t>(
+        (static_cast<unsigned>(color.A) *
+             static_cast<unsigned>(settings.opacity) +
+         50u) /
+        100u);
+
+    muxm::SolidColorBrush brush;
+    brush.Color(color);
+    text.Foreground(brush);
+    text.Opacity(1.0);
+    text.HorizontalAlignment(mux::HorizontalAlignment::Right);
+    text.VerticalAlignment(mux::VerticalAlignment::Center);
+    text.Margin(mux::Thickness{static_cast<double>(settings.leftMargin), 0.0,
+                               static_cast<double>(settings.rightMargin), 0.0});
+    text.IsHitTestVisible(false);
+}
+
+// ============================================================================
+// Module helper
+// ============================================================================
+
+static HMODULE GetCurrentModuleHandle() {
+    HMODULE module = nullptr;
+
+    if (!GetModuleHandleExW(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            reinterpret_cast<LPCWSTR>(&GetCurrentModuleHandle), &module)) {
+        return nullptr;
+    }
+
+    return module;
+}
+
+// Keep the active-label count accurate even when an Explorer window is closed
+// before mod unload. The timer owns one shared instance of this helper, so the
+// counter is released when that timer/delegate is destroyed.
+struct ActiveLabelLifetime {
+    ActiveLabelLifetime() {
+        g_activeTextBlocks.fetch_add(1);
+    }
+
+    ~ActiveLabelLifetime() {
+        g_activeTextBlocks.fetch_sub(1);
+    }
+};
+
+// ============================================================================
+// Visual Tree Watcher
+// ============================================================================
+
+class VisualTreeWatcher
+    : public winrt::implements<VisualTreeWatcher, IVisualTreeServiceCallback2,
+                               winrt::non_agile> {
+public:
+    explicit VisualTreeWatcher(winrt::com_ptr<IUnknown> site)
+        : m_xamlDiagnostics(site.as<IXamlDiagnostics>()),
+          m_visualTreeService(site.as<IVisualTreeService3>()) {
+        // AdviseVisualTreeChange must be made from a separate thread in
+        // Explorer. Keep the handle so shutdown can wait for it safely.
+        AddRef();
+        m_adviseThread = CreateThread(
+            nullptr, 0,
+            [](LPVOID parameter) -> DWORD {
+                auto watcher = static_cast<VisualTreeWatcher*>(parameter);
+                HRESULT hr =
+                    watcher->m_visualTreeService->AdviseVisualTreeChange(watcher);
+                if (FAILED(hr)) {
+                    Wh_Log(L"AdviseVisualTreeChange failed hr=0x%08X", hr);
+                }
+                watcher->Release();
+                return 0;
+            },
+            this, 0, nullptr);
+
+        if (!m_adviseThread) {
+            Wh_Log(L"CreateThread for XAML visual tree watcher failed: %u",
+                   GetLastError());
+            Release();
+        }
+    }
+
+    ~VisualTreeWatcher() {
+        // Normally Disconnect() has already joined and closed this handle. If
+        // destruction happens on the advise thread itself, only close it here.
+        if (m_adviseThread) {
+            CloseHandle(m_adviseThread);
+            m_adviseThread = nullptr;
+        }
+    }
+
+    void Disconnect() {
+        if (m_disconnected) {
+            return;
+        }
+        m_disconnected = true;
+
+        WaitForAdviseThread();
+
+        if (!m_visualTreeService) {
+            return;
+        }
+
+        HRESULT hr = m_visualTreeService->UnadviseVisualTreeChange(this);
+        if (FAILED(hr)) {
+            Wh_Log(L"UnadviseVisualTreeChange failed hr=0x%08X", hr);
+        }
+    }
+
+private:
+    void WaitForAdviseThread() {
+        if (!m_adviseThread) {
+            return;
+        }
+
+        DWORD threadId = GetThreadId(m_adviseThread);
+        if (threadId != 0 && threadId != GetCurrentThreadId()) {
+            WaitForSingleObject(m_adviseThread, INFINITE);
+        }
+
+        CloseHandle(m_adviseThread);
+        m_adviseThread = nullptr;
+    }
+
+    wf::IInspectable FromHandle(InstanceHandle handle) {
+        wf::IInspectable object{nullptr};
+
+        HRESULT hr = m_xamlDiagnostics->GetIInspectableFromHandle(
+            handle, reinterpret_cast<::IInspectable**>(winrt::put_abi(object)));
+        if (FAILED(hr)) {
+            return nullptr;
+        }
+
+        return object;
+    }
+
+    void TryInsertTitleText(InstanceHandle handle) {
+        auto inspectable = FromHandle(handle);
+        if (!inspectable) {
+            return;
+        }
+
+        auto frameworkElement = inspectable.try_as<mux::FrameworkElement>();
+        if (!frameworkElement || frameworkElement.Name() != L"TabContainerGrid") {
+            return;
+        }
+
+        auto grid = inspectable.try_as<muxc::Grid>();
+        if (!grid) {
+            return;
+        }
+
+        auto children = grid.Children();
+        mux::FrameworkElement rightAnchor{nullptr};
+
+        for (uint32_t i = 0; i < children.Size(); ++i) {
+            auto child = children.GetAt(i).try_as<mux::FrameworkElement>();
+            if (!child) {
+                continue;
+            }
+
+            if (child.Name() == L"WindhawkExplorerTitleBarLabel") {
+                return;
+            }
+
+            if (child.Name() == L"RightContentPresenter") {
+                rightAnchor = child;
+            }
+        }
+
+        if (!rightAnchor) {
+            Wh_Log(L"RightContentPresenter not found");
+            return;
+        }
+
+        int32_t targetColumn = muxc::Grid::GetColumn(rightAnchor);
+        int32_t targetRow = muxc::Grid::GetRow(rightAnchor);
+
+        SettingsSnapshot initialSnapshot = GetSettingsSnapshot();
+
+        muxc::TextBlock text;
+        text.Name(L"WindhawkExplorerTitleBarLabel");
+        ApplyTextSettings(text, initialSnapshot.settings);
+        muxc::Grid::SetColumn(text, targetColumn);
+        muxc::Grid::SetRow(text, targetRow);
+        muxc::Canvas::SetZIndex(text, 100);
+        children.Append(text);
+
+        UpdateVerticalPosition(text, grid,
+                               initialSnapshot.settings.verticalOffset);
+
+        auto weakSizeText = winrt::make_weak(text);
+        auto weakSizeGrid = winrt::make_weak(grid);
+
+        winrt::event_token sizeChangedToken = grid.SizeChanged(
+            [weakSizeText, weakSizeGrid](
+                auto const&, mux::SizeChangedEventArgs const&) {
+                auto text = weakSizeText.get();
+                auto grid = weakSizeGrid.get();
+
+                if (!text || !grid || g_unloading.load()) {
+                    return;
+                }
+
+                SettingsSnapshot snapshot = GetSettingsSnapshot();
+                UpdateVerticalPosition(text, grid,
+                                       snapshot.settings.verticalOffset);
+            });
+
+        auto sizeChangedTokenHolder =
+            std::make_shared<winrt::event_token>(sizeChangedToken);
+
+        mux::DispatcherTimer timer;
+
+        // Poll unload quickly so disabling the mod removes the injected label
+        // almost immediately. Normal date/time rendering is still throttled to
+        // once per second below, so the faster timer doesn't rebuild the label
+        // text ten times per second.
+        timer.Interval(std::chrono::milliseconds(100));
+
+        auto weakText = winrt::make_weak(text);
+        auto weakGrid = winrt::make_weak(grid);
+        auto weakTimer = winrt::make_weak(timer);
+        auto seenGeneration =
+            std::make_shared<uint64_t>(initialSnapshot.generation);
+        auto currentSettings =
+            std::make_shared<Settings>(initialSnapshot.settings);
+        auto lastText = std::make_shared<std::wstring>(
+            BuildDisplayText(initialSnapshot.settings));
+        auto lastClockSecond = std::make_shared<ULONGLONG>(
+            GetTickCount64() / 1000);
+        auto activeLifetime = std::make_shared<ActiveLabelLifetime>();
+
+        timer.Tick([weakText, weakGrid, weakTimer, seenGeneration,
+                    currentSettings, lastText, lastClockSecond,
+                    activeLifetime, sizeChangedTokenHolder](auto const&,
+                                                            auto const&) {
+            // The capture itself owns the active-label lifetime token.
+            (void)activeLifetime;
+
+            auto text = weakText.get();
+            auto grid = weakGrid.get();
+            auto timer = weakTimer.get();
+
+            if (!text) {
+                if (timer) {
+                    timer.Stop();
+                }
+                return;
+            }
+
+            if (g_unloading.load()) {
+                if (timer) {
+                    timer.Stop();
+                }
+
+                if (grid) {
+                    try {
+                        grid.SizeChanged(*sizeChangedTokenHolder);
+                    } catch (...) {
+                    }
+
+                    try {
+                        auto children = grid.Children();
+                        uint32_t index{};
+                        if (children.IndexOf(text, index)) {
+                            children.RemoveAt(index);
+                        }
+                    } catch (...) {
+                    }
+                }
+
+                try {
+                    text.Tag(nullptr);
+                } catch (...) {
+                }
+
+                return;
+            }
+
+            uint64_t generation =
+                g_settingsGeneration.load(std::memory_order_acquire);
+            bool settingsChanged = generation != *seenGeneration;
+
+            if (settingsChanged) {
+                SettingsSnapshot snapshot = GetSettingsSnapshot();
+                *seenGeneration = snapshot.generation;
+                *currentSettings = snapshot.settings;
+
+                ApplyTextSettings(text, *currentSettings);
+                *lastText = BuildDisplayText(*currentSettings);
+
+                if (grid) {
+                    UpdateVerticalPosition(
+                        text, grid, currentSettings->verticalOffset);
+                }
+            }
+
+            ULONGLONG clockSecond = GetTickCount64() / 1000;
+            if (clockSecond == *lastClockSecond && !settingsChanged) {
+                return;
+            }
+            *lastClockSecond = clockSecond;
+
+            std::wstring current = BuildDisplayText(*currentSettings);
+            if (current != *lastText) {
+                text.Text(current);
+                *lastText = std::move(current);
+            }
+        });
+
+        timer.Start();
+
+        // Keep the DispatcherTimer alive for as long as the injected label is
+        // alive. The Tick handler only keeps weak references back to the XAML
+        // objects, avoiding a strong reference cycle.
+        text.Tag(timer);
+    }
+
+    HRESULT STDMETHODCALLTYPE OnVisualTreeChange(
+        ParentChildRelation,
+        VisualElement element,
+        VisualMutationType mutationType) override {
+        try {
+            if (!g_unloading.load() && mutationType == Add) {
+                TryInsertTitleText(element.Handle);
+            }
+        } catch (...) {
+            Wh_Log(L"OnVisualTreeChange exception hr=0x%08X",
+                   winrt::to_hresult());
+        }
+
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE OnElementStateChanged(InstanceHandle,
+                                                    VisualElementState,
+                                                    LPCWSTR) noexcept override {
+        return S_OK;
+    }
+
+    winrt::com_ptr<IXamlDiagnostics> m_xamlDiagnostics;
+    winrt::com_ptr<IVisualTreeService3> m_visualTreeService;
+    HANDLE m_adviseThread = nullptr;
+    bool m_disconnected = false;
+};
+
+static winrt::com_ptr<VisualTreeWatcher> g_visualTreeWatcher;
+
+// ============================================================================
+// TAP
+// ============================================================================
+
+static constexpr CLSID CLSID_WindhawkTitleBarLabelTAP = {
+    0x48b7eb40,
+    0xd62d,
+    0x49c0,
+    {0x9f, 0x13, 0x27, 0x41, 0xa7, 0x9b, 0xb4, 0x11},
+};
+
+class WindhawkTAP
+    : public winrt::implements<WindhawkTAP, IObjectWithSite,
+                               winrt::non_agile> {
+public:
+    HRESULT STDMETHODCALLTYPE SetSite(IUnknown* site) override {
+        try {
+            if (g_visualTreeWatcher) {
+                g_visualTreeWatcher->Disconnect();
+                g_visualTreeWatcher = nullptr;
+            }
+
+            m_site.copy_from(site);
+
+            if (m_site) {
+                HMODULE module = GetCurrentModuleHandle();
+                if (module) {
+                    FreeLibrary(module);
+                }
+
+                g_visualTreeWatcher =
+                    winrt::make_self<VisualTreeWatcher>(m_site);
+            }
+
+            return S_OK;
+        } catch (...) {
+            HRESULT hr = winrt::to_hresult();
+            Wh_Log(L"SetSite exception hr=0x%08X", hr);
+            return hr;
+        }
+    }
+
+    HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void** result) noexcept override {
+        if (!result) {
+            return E_POINTER;
+        }
+
+        *result = nullptr;
+        if (!m_site) {
+            return E_FAIL;
+        }
+
+        return m_site.as(riid, result);
+    }
+
+private:
+    winrt::com_ptr<IUnknown> m_site;
+};
+
+// ============================================================================
+// COM factory and exports
+// ============================================================================
+
+template <typename T>
+struct SimpleFactory
+    : winrt::implements<SimpleFactory<T>, IClassFactory, winrt::non_agile> {
+    HRESULT STDMETHODCALLTYPE CreateInstance(IUnknown* outer,
+                                             REFIID riid,
+                                             void** object) override {
+        if (!object) {
+            return E_POINTER;
+        }
+
+        *object = nullptr;
+        if (outer) {
+            return CLASS_E_NOAGGREGATION;
+        }
+
+        try {
+            return winrt::make<T>().as(riid, object);
+        } catch (...) {
+            return winrt::to_hresult();
+        }
+    }
+
+    HRESULT STDMETHODCALLTYPE LockServer(BOOL) noexcept override {
+        return S_OK;
+    }
+};
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdll-attribute-on-redeclaration"
+
+extern "C" __declspec(dllexport) HRESULT __stdcall DllGetClassObject(
+    REFCLSID clsid,
+    REFIID riid,
+    LPVOID* result) {
+    if (!result) {
+        return E_POINTER;
+    }
+
+    *result = nullptr;
+    if (clsid != CLSID_WindhawkTitleBarLabelTAP) {
+        return CLASS_E_CLASSNOTAVAILABLE;
+    }
+
+    try {
+        return winrt::make<SimpleFactory<WindhawkTAP>>().as(riid, result);
+    } catch (...) {
+        return winrt::to_hresult();
+    }
+}
+
+extern "C" __declspec(dllexport) HRESULT __stdcall DllCanUnloadNow() {
+    return winrt::get_module_lock() ? S_FALSE : S_OK;
+}
+
+#pragma clang diagnostic pop
+
+// ============================================================================
+// XAML diagnostics connection
+// ============================================================================
+
+using InitializeXamlDiagnosticsEx_t = decltype(&InitializeXamlDiagnosticsEx);
+
+static HRESULT ConnectToExplorerXaml() {
+    HMODULE self = GetCurrentModuleHandle();
+    if (!self) {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    wchar_t modulePath[MAX_PATH]{};
+    DWORD length =
+        GetModuleFileNameW(self, modulePath, ARRAYSIZE(modulePath));
+    if (!length || length >= ARRAYSIZE(modulePath)) {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    HMODULE framework =
+        GetModuleHandleW(L"Microsoft.Internal.FrameworkUdk.dll");
+    if (!framework) {
+        return HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND);
+    }
+
+    auto initialize = reinterpret_cast<InitializeXamlDiagnosticsEx_t>(
+        GetProcAddress(framework, "InitializeXamlDiagnosticsEx"));
+    if (!initialize) {
+        return HRESULT_FROM_WIN32(ERROR_PROC_NOT_FOUND);
+    }
+
+    HRESULT hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
+
+    for (int i = 1; i <= 10000 && !g_unloading.load(); ++i) {
+        wchar_t connection[128]{};
+        swprintf_s(connection, L"WinUIVisualDiagConnection%d", i);
+
+        hr = initialize(connection, GetCurrentProcessId(), L"", modulePath,
+                        CLSID_WindhawkTitleBarLabelTAP, nullptr);
+
+        if (hr != HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
+            break;
+        }
+    }
+
+    return hr;
+}
+
+// ============================================================================
+// Connector thread
+// ============================================================================
+
+static bool SleepWhileLoaded(DWORD milliseconds) {
+    constexpr DWORD kSliceMs = 50;
+
+    while (milliseconds > 0 && !g_unloading.load()) {
+        DWORD slice = milliseconds < kSliceMs ? milliseconds : kSliceMs;
+        Sleep(slice);
+        milliseconds -= slice;
+    }
+
+    return !g_unloading.load();
+}
+
+static DWORD WINAPI ConnectorThread(LPVOID) {
+    for (int attempt = 1; attempt <= 60 && !g_unloading.load(); ++attempt) {
+        HMODULE framework =
+            GetModuleHandleW(L"Microsoft.Internal.FrameworkUdk.dll");
+
+        if (!framework) {
+            if (!SleepWhileLoaded(500)) {
+                break;
+            }
+            continue;
+        }
+
+        HRESULT hr = ConnectToExplorerXaml();
+        if (SUCCEEDED(hr)) {
+            Wh_Log(L"Connected to Explorer XAML diagnostics");
+            return 0;
+        }
+
+        if (g_unloading.load()) {
+            break;
+        }
+
+        if (hr == HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
+            if (!SleepWhileLoaded(500)) {
+                break;
+            }
+            continue;
+        }
+
+        Wh_Log(L"Diagnostics connection failed hr=0x%08X", hr);
+        if (!SleepWhileLoaded(1000)) {
+            break;
+        }
+    }
+
+    return 0;
+}
+
+// ============================================================================
+// Windhawk
+// ============================================================================
+
+BOOL Wh_ModInit() {
+    Wh_Log(L"Explorer Title Bar Label 1.0.0 init");
+
+    g_unloading.store(false);
+    g_activeTextBlocks.store(0);
+    LoadSettings(false);
+
+    g_connectorThread =
+        CreateThread(nullptr, 0, ConnectorThread, nullptr, 0, nullptr);
+    if (!g_connectorThread) {
+        Wh_Log(L"CreateThread failed: %u", GetLastError());
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+void Wh_ModSettingsChanged() {
+    LoadSettings(true);
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L"Explorer Title Bar Label 1.0.0 uninit");
+
+    g_unloading.store(true);
+
+    // Do not let the connector continue executing mod code after unload.
+    if (g_connectorThread) {
+        WaitForSingleObject(g_connectorThread, INFINITE);
+        CloseHandle(g_connectorThread);
+        g_connectorThread = nullptr;
+    }
+
+    // The UI timer checks unload every 100 ms, so labels normally disappear
+    // within a fraction of a second. Keep a bounded wait as a safety margin
+    // before disconnecting XAML diagnostics.
+    for (int i = 0; i < 15; ++i) {
+        if (g_activeTextBlocks.load() <= 0) {
+            break;
+        }
+        Sleep(100);
+    }
+
+    if (g_visualTreeWatcher) {
+        g_visualTreeWatcher->Disconnect();
+        g_visualTreeWatcher = nullptr;
+    }
+}

--- a/mods/explorer-title-bar-label.wh.cpp
+++ b/mods/explorer-title-bar-label.wh.cpp
@@ -3,7 +3,7 @@
 // @name            Explorer Title Bar Label
 // @description     Add custom text, date and time to the Windows 11 File Explorer title bar.
 // @version         1.0.0
-// @author          digitalART
+// @author          digART
 // @github          https://github.com/digart11
 // @license         GPL-3.0
 // @include         explorer.exe

--- a/mods/explorer-title-bar-label.wh.cpp
+++ b/mods/explorer-title-bar-label.wh.cpp
@@ -45,7 +45,7 @@ Time can use **12-hour or 24-hour format**, with optional seconds.
 
 ## Compatibility
 
-This mod uses XAML diagnostics and may conflict with other File Explorer mods that also use XAML diagnostics.
+This mod uses XAML diagnostics, which allows only one diagnostics consumer per Explorer process. Known conflicts include **Windows 11 File Explorer Styler**, **ExplorerBlurMica**, **TranslucentTB**, and other tools/mods that attach to File Explorer XAML diagnostics. If another consumer blocks the connection, the label will not appear.
 */
 // ==/WindhawkModReadme==
 
@@ -178,12 +178,12 @@ This mod uses XAML diagnostics and may conflict with other File Explorer mods th
 #include <winrt/Microsoft.UI.Xaml.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.Media.h>
+#include <winrt/Microsoft.UI.h>
+#include <winrt/Microsoft.UI.Content.h>
 
 #include <atomic>
 #include <chrono>
-#include <cmath>
 #include <cwctype>
-#include <limits>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -291,8 +291,9 @@ static std::atomic<uint64_t> g_settingsGeneration{1};
 static std::mutex g_settingsMutex;
 
 static std::atomic<bool> g_unloading{false};
-static std::atomic<int> g_activeTextBlocks{0};
+static std::mutex g_connectorMutex;
 static HANDLE g_connectorThread = nullptr;
+static HANDLE g_tapReadyEvent = nullptr;
 
 // ============================================================================
 // Settings helpers
@@ -800,80 +801,23 @@ static std::wstring BuildDisplayText(const Settings& settings) {
 }
 
 // ============================================================================
-// Explorer HWND matching
+// Explorer HWND
 // ============================================================================
 
-struct ExplorerWindowMatchContext {
-    double targetWidthDip = 0.0;
-    double targetHeightDip = 0.0;
-    HWND bestHwnd = nullptr;
-    double bestScore = std::numeric_limits<double>::max();
-};
-
-static BOOL CALLBACK EnumExplorerWindowProc(HWND hwnd, LPARAM lParam) {
-    auto* context =
-        reinterpret_cast<ExplorerWindowMatchContext*>(lParam);
-    if (!context) {
-        return TRUE;
-    }
-
-    DWORD pid = 0;
-    GetWindowThreadProcessId(hwnd, &pid);
-    if (pid != GetCurrentProcessId()) {
-        return TRUE;
-    }
-
-    wchar_t className[128]{};
-    if (!GetClassNameW(hwnd, className, ARRAYSIZE(className)) ||
-        wcscmp(className, L"CabinetWClass") != 0 || !IsWindowVisible(hwnd)) {
-        return TRUE;
-    }
-
-    RECT clientRect{};
-    if (!GetClientRect(hwnd, &clientRect)) {
-        return TRUE;
-    }
-
-    UINT dpi = GetDpiForWindow(hwnd);
-    if (dpi == 0) {
-        dpi = 96;
-    }
-
-    double widthPx = static_cast<double>(clientRect.right - clientRect.left);
-    double heightPx = static_cast<double>(clientRect.bottom - clientRect.top);
-    double widthDip = widthPx * 96.0 / static_cast<double>(dpi);
-    double heightDip = heightPx * 96.0 / static_cast<double>(dpi);
-
-    double widthDiff = std::abs(widthDip - context->targetWidthDip);
-    double heightDiff = std::abs(heightDip - context->targetHeightDip);
-    double score = widthDiff + heightDiff * 0.25;
-
-    if (score < context->bestScore) {
-        context->bestScore = score;
-        context->bestHwnd = hwnd;
-    }
-
-    return TRUE;
-}
-
-static HWND FindExplorerWindowForGrid(muxc::Grid const& grid) {
+static HWND GetExplorerWindowForElement(mux::FrameworkElement const& element) {
     try {
-        auto xamlRoot = grid.XamlRoot();
-        if (!xamlRoot) {
-            return nullptr;
+        if (auto xamlRoot = element.XamlRoot()) {
+            if (auto environment = xamlRoot.ContentIslandEnvironment()) {
+                return reinterpret_cast<HWND>(
+                    static_cast<uintptr_t>(environment.AppWindowId().Value));
+            }
         }
-
-        auto rootSize = xamlRoot.Size();
-        ExplorerWindowMatchContext context;
-        context.targetWidthDip = rootSize.Width;
-        context.targetHeightDip = rootSize.Height;
-
-        EnumWindows(EnumExplorerWindowProc,
-                    reinterpret_cast<LPARAM>(&context));
-        return context.bestHwnd;
     } catch (...) {
-        return nullptr;
+        Wh_Log(L"Failed to get Explorer window from XamlRoot hr=0x%08X",
+               winrt::to_hresult());
     }
+
+    return nullptr;
 }
 
 // ============================================================================
@@ -886,7 +830,7 @@ static void UpdateVerticalPosition(muxc::TextBlock const& text,
     double automaticCorrection = 0.0;
 
     try {
-        HWND hwnd = FindExplorerWindowForGrid(grid);
+        HWND hwnd = GetExplorerWindowForElement(grid);
 
         if (hwnd && IsZoomed(hwnd)) {
             auto transform = grid.TransformToVisual(nullptr);
@@ -894,11 +838,8 @@ static void UpdateVerticalPosition(muxc::TextBlock const& text,
             wf::Point position = transform.TransformPoint(origin);
 
             if (position.Y < 0.0f) {
-                // Explorer's maximized title grid sits slightly above the
-                // client origin. The extra 1.5 DIP matches the restored and
-                // maximized visual center on current Windows 11 builds.
                 automaticCorrection =
-                    -static_cast<double>(position.Y) + 1.5;
+                    -static_cast<double>(position.Y) + 0.0;
             }
         }
 
@@ -997,18 +938,214 @@ static HMODULE GetCurrentModuleHandle() {
     return module;
 }
 
-// Keep the active-label count accurate even when an Explorer window is closed
-// before mod unload. The timer owns one shared instance of this helper, so the
-// counter is released when that timer/delegate is destroyed.
-struct ActiveLabelLifetime {
-    ActiveLabelLifetime() {
-        g_activeTextBlocks.fetch_add(1);
+// DispatcherTimer is rooted by the dispatcher queue while running, and its Tick
+// handler lives in this DLL. Keep each timer and every XAML event token in
+// thread-local state so teardown can stop and revoke them on the owning UI
+// thread before the mod is unloaded.
+struct LabelEntry {
+    winrt::weak_ref<muxc::TextBlock> text;
+    winrt::weak_ref<muxc::Grid> grid;
+    mux::DispatcherTimer timer{nullptr};
+    winrt::event_token tickToken{};
+    winrt::event_token sizeChangedToken{};
+    bool tickRegistered = false;
+    bool sizeChangedRegistered = false;
+    bool cleaned = false;
+
+    uint64_t seenGeneration = 0;
+    Settings currentSettings;
+    std::wstring lastText;
+};
+
+thread_local std::vector<std::shared_ptr<LabelEntry>> g_labelEntries;
+
+static void ReleaseLabelEntry(const std::shared_ptr<LabelEntry>& entry,
+                              bool removeElement) {
+    if (!entry || entry->cleaned) {
+        return;
     }
 
-    ~ActiveLabelLifetime() {
-        g_activeTextBlocks.fetch_sub(1);
+    entry->cleaned = true;
+
+    try {
+        if (entry->timer) {
+            entry->timer.Stop();
+            if (entry->tickRegistered) {
+                entry->timer.Tick(entry->tickToken);
+                entry->tickRegistered = false;
+            }
+        }
+    } catch (...) {
+        Wh_Log(L"Failed to release title-bar timer hr=0x%08X",
+               winrt::to_hresult());
     }
-};
+
+    auto grid = entry->grid.get();
+    if (grid && entry->sizeChangedRegistered) {
+        try {
+            grid.SizeChanged(entry->sizeChangedToken);
+            entry->sizeChangedRegistered = false;
+        } catch (...) {
+            Wh_Log(L"Failed to revoke SizeChanged hr=0x%08X",
+                   winrt::to_hresult());
+        }
+    }
+
+    if (removeElement) {
+        auto text = entry->text.get();
+        if (grid && text) {
+            try {
+                auto children = grid.Children();
+                uint32_t index{};
+                if (children.IndexOf(text, index)) {
+                    children.RemoveAt(index);
+                }
+            } catch (...) {
+                Wh_Log(L"Failed to remove title-bar label hr=0x%08X",
+                       winrt::to_hresult());
+            }
+        }
+    }
+
+}
+
+static void PruneReleasedLabelEntries() {
+    for (auto it = g_labelEntries.begin(); it != g_labelEntries.end();) {
+        auto& entry = *it;
+
+        if (!entry->cleaned && !entry->text.get()) {
+            ReleaseLabelEntry(entry, false);
+        }
+
+        if (entry->cleaned) {
+            it = g_labelEntries.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+static void RemoveLabelsForCurrentThread() {
+    std::vector<std::shared_ptr<LabelEntry>> taken;
+    taken.swap(g_labelEntries);
+
+    for (auto& entry : taken) {
+        ReleaseLabelEntry(entry, true);
+    }
+}
+
+static bool IsFileExplorerWindow(HWND hwnd) {
+    if (!hwnd) {
+        return false;
+    }
+
+    DWORD processId = 0;
+    if (!GetWindowThreadProcessId(hwnd, &processId) ||
+        processId != GetCurrentProcessId()) {
+        return false;
+    }
+
+    wchar_t className[64]{};
+    return GetClassNameW(hwnd, className, ARRAYSIZE(className)) &&
+           _wcsicmp(className, L"CabinetWClass") == 0;
+}
+
+static std::vector<HWND> GetFileExplorerWindows() {
+    std::vector<HWND> windows;
+
+    EnumWindows(
+        [](HWND hwnd, LPARAM lParam) -> BOOL {
+            auto& windows =
+                *reinterpret_cast<std::vector<HWND>*>(lParam);
+            if (IsFileExplorerWindow(hwnd)) {
+                windows.push_back(hwnd);
+            }
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&windows));
+
+    return windows;
+}
+
+using RunFromWindowThreadProc_t = void(WINAPI*)(PVOID parameter);
+
+static bool RunFromWindowThread(HWND hwnd,
+                                RunFromWindowThreadProc_t proc,
+                                PVOID procParam) {
+    static const UINT message =
+        RegisterWindowMessageW(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
+
+    struct RunParam {
+        RunFromWindowThreadProc_t proc;
+        PVOID procParam;
+    };
+
+    DWORD threadId = GetWindowThreadProcessId(hwnd, nullptr);
+    if (!threadId) {
+        return false;
+    }
+
+    if (threadId == GetCurrentThreadId()) {
+        proc(procParam);
+        return true;
+    }
+
+    HHOOK hook = SetWindowsHookExW(
+        WH_CALLWNDPROC,
+        [](int code, WPARAM wParam, LPARAM lParam) -> LRESULT {
+            if (code == HC_ACTION) {
+                const auto* cwp = reinterpret_cast<const CWPSTRUCT*>(lParam);
+                if (cwp->message == message) {
+                    auto* param =
+                        reinterpret_cast<RunParam*>(cwp->lParam);
+                    param->proc(param->procParam);
+                }
+            }
+
+            return CallNextHookEx(nullptr, code, wParam, lParam);
+        },
+        nullptr, threadId);
+    if (!hook) {
+        return false;
+    }
+
+    RunParam param{proc, procParam};
+    SendMessageW(hwnd, message, 0, reinterpret_cast<LPARAM>(&param));
+    UnhookWindowsHookEx(hook);
+
+    return true;
+}
+
+static void EnsureConnectorStarted();
+
+// Connect only after a real File Explorer top-level window exists. This avoids
+// occupying the XAML diagnostics slot in shell-only explorer.exe processes and
+// means a File Explorer window opened long after login still triggers setup.
+using CreateWindowExW_t = decltype(&CreateWindowExW);
+static CreateWindowExW_t CreateWindowExW_Original = nullptr;
+
+static HWND WINAPI CreateWindowExW_Hook(DWORD exStyle,
+                                        LPCWSTR className,
+                                        LPCWSTR windowName,
+                                        DWORD style,
+                                        int x,
+                                        int y,
+                                        int width,
+                                        int height,
+                                        HWND parent,
+                                        HMENU menu,
+                                        HINSTANCE instance,
+                                        PVOID param) {
+    HWND hwnd = CreateWindowExW_Original(
+        exStyle, className, windowName, style, x, y, width, height, parent,
+        menu, instance, param);
+
+    if (hwnd && !g_unloading.load() && IsFileExplorerWindow(hwnd)) {
+        EnsureConnectorStarted();
+    }
+
+    return hwnd;
+}
 
 // ============================================================================
 // Visual Tree Watcher
@@ -1106,7 +1243,8 @@ private:
         }
 
         auto frameworkElement = inspectable.try_as<mux::FrameworkElement>();
-        if (!frameworkElement || frameworkElement.Name() != L"TabContainerGrid") {
+        if (!frameworkElement ||
+            frameworkElement.Name() != L"TabContainerGrid") {
             return;
         }
 
@@ -1138,6 +1276,8 @@ private:
             return;
         }
 
+        PruneReleasedLabelEntries();
+
         int32_t targetColumn = muxc::Grid::GetColumn(rightAnchor);
         int32_t targetRow = muxc::Grid::GetRow(rightAnchor);
 
@@ -1154,16 +1294,25 @@ private:
         UpdateVerticalPosition(text, grid,
                                initialSnapshot.settings.verticalOffset);
 
-        auto weakSizeText = winrt::make_weak(text);
-        auto weakSizeGrid = winrt::make_weak(grid);
+        auto entry = std::make_shared<LabelEntry>();
+        entry->text = winrt::make_weak(text);
+        entry->grid = winrt::make_weak(grid);
+        entry->seenGeneration = initialSnapshot.generation;
+        entry->currentSettings = initialSnapshot.settings;
+        entry->lastText = BuildDisplayText(initialSnapshot.settings);
 
-        winrt::event_token sizeChangedToken = grid.SizeChanged(
-            [weakSizeText, weakSizeGrid](
-                auto const&, mux::SizeChangedEventArgs const&) {
-                auto text = weakSizeText.get();
-                auto grid = weakSizeGrid.get();
+        std::weak_ptr<LabelEntry> weakEntry = entry;
 
-                if (!text || !grid || g_unloading.load()) {
+        entry->sizeChangedToken = grid.SizeChanged(
+            [weakEntry](auto const&, mux::SizeChangedEventArgs const&) {
+                auto entry = weakEntry.lock();
+                if (!entry || entry->cleaned || g_unloading.load()) {
+                    return;
+                }
+
+                auto text = entry->text.get();
+                auto grid = entry->grid.get();
+                if (!text || !grid) {
                     return;
                 }
 
@@ -1171,115 +1320,62 @@ private:
                 UpdateVerticalPosition(text, grid,
                                        snapshot.settings.verticalOffset);
             });
-
-        auto sizeChangedTokenHolder =
-            std::make_shared<winrt::event_token>(sizeChangedToken);
+        entry->sizeChangedRegistered = true;
 
         mux::DispatcherTimer timer;
+        timer.Interval(std::chrono::seconds(1));
 
-        // Poll unload quickly so disabling the mod removes the injected label
-        // almost immediately. Normal date/time rendering is still throttled to
-        // once per second below, so the faster timer doesn't rebuild the label
-        // text ten times per second.
-        timer.Interval(std::chrono::milliseconds(100));
-
-        auto weakText = winrt::make_weak(text);
-        auto weakGrid = winrt::make_weak(grid);
-        auto weakTimer = winrt::make_weak(timer);
-        auto seenGeneration =
-            std::make_shared<uint64_t>(initialSnapshot.generation);
-        auto currentSettings =
-            std::make_shared<Settings>(initialSnapshot.settings);
-        auto lastText = std::make_shared<std::wstring>(
-            BuildDisplayText(initialSnapshot.settings));
-        auto lastClockSecond = std::make_shared<ULONGLONG>(
-            GetTickCount64() / 1000);
-        auto activeLifetime = std::make_shared<ActiveLabelLifetime>();
-
-        timer.Tick([weakText, weakGrid, weakTimer, seenGeneration,
-                    currentSettings, lastText, lastClockSecond,
-                    activeLifetime, sizeChangedTokenHolder](auto const&,
-                                                            auto const&) {
-            // The capture itself owns the active-label lifetime token.
-            (void)activeLifetime;
-
-            auto text = weakText.get();
-            auto grid = weakGrid.get();
-            auto timer = weakTimer.get();
-
-            if (!text) {
-                if (timer) {
-                    timer.Stop();
-                }
-                return;
-            }
-
-            if (g_unloading.load()) {
-                if (timer) {
-                    timer.Stop();
+        entry->timer = timer;
+        entry->tickToken = timer.Tick(
+            [weakEntry](auto const&, auto const&) {
+                auto entry = weakEntry.lock();
+                if (!entry || entry->cleaned) {
+                    return;
                 }
 
-                if (grid) {
-                    try {
-                        grid.SizeChanged(*sizeChangedTokenHolder);
-                    } catch (...) {
-                    }
+                auto text = entry->text.get();
+                if (!text) {
+                    ReleaseLabelEntry(entry, false);
+                    return;
+                }
 
-                    try {
-                        auto children = grid.Children();
-                        uint32_t index{};
-                        if (children.IndexOf(text, index)) {
-                            children.RemoveAt(index);
-                        }
-                    } catch (...) {
+                if (g_unloading.load()) {
+                    ReleaseLabelEntry(entry, true);
+                    return;
+                }
+
+                uint64_t generation =
+                    g_settingsGeneration.load(std::memory_order_acquire);
+                bool settingsChanged =
+                    generation != entry->seenGeneration;
+
+                if (settingsChanged) {
+                    SettingsSnapshot snapshot = GetSettingsSnapshot();
+                    entry->seenGeneration = snapshot.generation;
+                    entry->currentSettings = snapshot.settings;
+
+                    ApplyTextSettings(text, entry->currentSettings);
+                    entry->lastText =
+                        BuildDisplayText(entry->currentSettings);
+
+                    if (auto grid = entry->grid.get()) {
+                        UpdateVerticalPosition(
+                            text, grid,
+                            entry->currentSettings.verticalOffset);
                     }
                 }
 
-                try {
-                    text.Tag(nullptr);
-                } catch (...) {
+                std::wstring current =
+                    BuildDisplayText(entry->currentSettings);
+                if (current != entry->lastText) {
+                    text.Text(current);
+                    entry->lastText = std::move(current);
                 }
+            });
+        entry->tickRegistered = true;
 
-                return;
-            }
-
-            uint64_t generation =
-                g_settingsGeneration.load(std::memory_order_acquire);
-            bool settingsChanged = generation != *seenGeneration;
-
-            if (settingsChanged) {
-                SettingsSnapshot snapshot = GetSettingsSnapshot();
-                *seenGeneration = snapshot.generation;
-                *currentSettings = snapshot.settings;
-
-                ApplyTextSettings(text, *currentSettings);
-                *lastText = BuildDisplayText(*currentSettings);
-
-                if (grid) {
-                    UpdateVerticalPosition(
-                        text, grid, currentSettings->verticalOffset);
-                }
-            }
-
-            ULONGLONG clockSecond = GetTickCount64() / 1000;
-            if (clockSecond == *lastClockSecond && !settingsChanged) {
-                return;
-            }
-            *lastClockSecond = clockSecond;
-
-            std::wstring current = BuildDisplayText(*currentSettings);
-            if (current != *lastText) {
-                text.Text(current);
-                *lastText = std::move(current);
-            }
-        });
-
+        g_labelEntries.push_back(entry);
         timer.Start();
-
-        // Keep the DispatcherTimer alive for as long as the injected label is
-        // alive. The Tick handler only keeps weak references back to the XAML
-        // objects, avoiding a strong reference cycle.
-        text.Tag(timer);
     }
 
     HRESULT STDMETHODCALLTYPE OnVisualTreeChange(
@@ -1336,7 +1432,7 @@ public:
 
             m_site.copy_from(site);
 
-            if (m_site) {
+            if (m_site && !g_unloading.load()) {
                 HMODULE module = GetCurrentModuleHandle();
                 if (module) {
                     FreeLibrary(module);
@@ -1344,6 +1440,10 @@ public:
 
                 g_visualTreeWatcher =
                     winrt::make_self<VisualTreeWatcher>(m_site);
+
+                if (g_tapReadyEvent) {
+                    SetEvent(g_tapReadyEvent);
+                }
             }
 
             return S_OK;
@@ -1496,41 +1596,103 @@ static bool SleepWhileLoaded(DWORD milliseconds) {
 }
 
 static DWORD WINAPI ConnectorThread(LPVOID) {
-    for (int attempt = 1; attempt <= 60 && !g_unloading.load(); ++attempt) {
+    // This thread is created only after a real File Explorer window exists.
+    // Wait as long as needed for WinUI to load instead of giving up a fixed
+    // number of seconds after explorer.exe starts.
+    while (!g_unloading.load()) {
         HMODULE framework =
             GetModuleHandleW(L"Microsoft.Internal.FrameworkUdk.dll");
 
         if (!framework) {
-            if (!SleepWhileLoaded(500)) {
-                break;
+            if (!SleepWhileLoaded(100)) {
+                return 0;
             }
             continue;
         }
 
         HRESULT hr = ConnectToExplorerXaml();
         if (SUCCEEDED(hr)) {
-            Wh_Log(L"Connected to Explorer XAML diagnostics");
+            // Some XAML-diagnostics consumers intentionally return S_OK while
+            // blocking the caller. Only report success after our TAP's SetSite
+            // actually runs.
+            DWORD waitResult =
+                g_tapReadyEvent
+                    ? WaitForSingleObject(g_tapReadyEvent, 2000)
+                    : WAIT_FAILED;
+
+            if (waitResult == WAIT_OBJECT_0) {
+                Wh_Log(L"Connected to Explorer XAML diagnostics");
+            } else if (!g_unloading.load()) {
+                Wh_Log(
+                    L"XAML diagnostics returned success, but the title-bar "
+                    L"TAP was not initialized. Another XAML diagnostics "
+                    L"consumer may have blocked the connection.");
+            }
+
             return 0;
         }
 
         if (g_unloading.load()) {
-            break;
+            return 0;
         }
 
-        if (hr == HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
-            if (!SleepWhileLoaded(500)) {
-                break;
+        if (hr == HRESULT_FROM_WIN32(ERROR_NOT_FOUND) ||
+            hr == HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND)) {
+            if (!SleepWhileLoaded(250)) {
+                return 0;
             }
             continue;
         }
 
         Wh_Log(L"Diagnostics connection failed hr=0x%08X", hr);
-        if (!SleepWhileLoaded(1000)) {
-            break;
-        }
+        return 0;
     }
 
     return 0;
+}
+
+static void EnsureConnectorStarted() {
+    if (g_unloading.load()) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(g_connectorMutex);
+    if (g_unloading.load() || g_connectorThread) {
+        return;
+    }
+
+    if (g_tapReadyEvent) {
+        ResetEvent(g_tapReadyEvent);
+    }
+
+    g_connectorThread =
+        CreateThread(nullptr, 0, ConnectorThread, nullptr, 0, nullptr);
+    if (!g_connectorThread) {
+        Wh_Log(L"CreateThread failed: %u", GetLastError());
+    }
+}
+
+static void StopConnectorThread() {
+    HANDLE thread = nullptr;
+
+    {
+        std::lock_guard<std::mutex> lock(g_connectorMutex);
+        thread = g_connectorThread;
+    }
+
+    if (!thread) {
+        return;
+    }
+
+    if (GetThreadId(thread) != GetCurrentThreadId()) {
+        WaitForSingleObject(thread, INFINITE);
+    }
+
+    std::lock_guard<std::mutex> lock(g_connectorMutex);
+    if (g_connectorThread == thread) {
+        CloseHandle(g_connectorThread);
+        g_connectorThread = nullptr;
+    }
 }
 
 // ============================================================================
@@ -1541,21 +1703,44 @@ BOOL Wh_ModInit() {
     Wh_Log(L"Explorer Title Bar Label 1.0.0 init");
 
     g_unloading.store(false);
-    g_activeTextBlocks.store(0);
     LoadSettings(false);
 
-    g_connectorThread =
-        CreateThread(nullptr, 0, ConnectorThread, nullptr, 0, nullptr);
-    if (!g_connectorThread) {
-        Wh_Log(L"CreateThread failed: %u", GetLastError());
+    g_tapReadyEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    if (!g_tapReadyEvent) {
+        Wh_Log(L"CreateEvent failed: %u", GetLastError());
+        return FALSE;
+    }
+
+    if (!Wh_SetFunctionHook(
+            reinterpret_cast<void*>(CreateWindowExW),
+            reinterpret_cast<void*>(CreateWindowExW_Hook),
+            reinterpret_cast<void**>(&CreateWindowExW_Original))) {
+        Wh_Log(L"Failed to hook CreateWindowExW");
+        CloseHandle(g_tapReadyEvent);
+        g_tapReadyEvent = nullptr;
         return FALSE;
     }
 
     return TRUE;
 }
 
+void Wh_ModAfterInit() {
+    // Hooks become active after Wh_ModInit. Handle windows which were already
+    // open before that point.
+    if (!GetFileExplorerWindows().empty()) {
+        EnsureConnectorStarted();
+    }
+}
+
 void Wh_ModSettingsChanged() {
     LoadSettings(true);
+}
+
+// Function hooks are removed before Wh_ModUninit, but XAML delegates can still
+// be alive until explicit UI-thread teardown below. Stop them from doing new
+// work as early as Windhawk allows.
+void Wh_ModBeforeUninit() {
+    g_unloading.store(true);
 }
 
 void Wh_ModUninit() {
@@ -1563,25 +1748,26 @@ void Wh_ModUninit() {
 
     g_unloading.store(true);
 
-    // Do not let the connector continue executing mod code after unload.
-    if (g_connectorThread) {
-        WaitForSingleObject(g_connectorThread, INFINITE);
-        CloseHandle(g_connectorThread);
-        g_connectorThread = nullptr;
-    }
+    StopConnectorThread();
 
-    // The UI timer checks unload every 100 ms, so labels normally disappear
-    // within a fraction of a second. Keep a bounded wait as a safety margin
-    // before disconnecting XAML diagnostics.
-    for (int i = 0; i < 15; ++i) {
-        if (g_activeTextBlocks.load() <= 0) {
-            break;
+    // Every XAML delegate is revoked synchronously on the thread which owns it
+    // before this DLL can be unloaded.
+    for (HWND hwnd : GetFileExplorerWindows()) {
+        if (!RunFromWindowThread(
+                hwnd, [](PVOID) { RemoveLabelsForCurrentThread(); },
+                nullptr)) {
+            Wh_Log(L"Couldn't reach Explorer UI thread for window %08X",
+                   static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(hwnd)));
         }
-        Sleep(100);
     }
 
     if (g_visualTreeWatcher) {
         g_visualTreeWatcher->Disconnect();
         g_visualTreeWatcher = nullptr;
+    }
+
+    if (g_tapReadyEvent) {
+        CloseHandle(g_tapReadyEvent);
+        g_tapReadyEvent = nullptr;
     }
 }

--- a/mods/explorer-title-bar-label.wh.cpp
+++ b/mods/explorer-title-bar-label.wh.cpp
@@ -8,7 +8,7 @@
 // @license         GPL-3.0
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lole32 -loleaut32 -lruntimeobject
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -ldwmapi
 // ==/WindhawkMod==
 
 // Source code is published under the GNU General Public License v3.0.
@@ -141,9 +141,9 @@ This mod uses XAML diagnostics, which allows only one diagnostics consumer per E
 - italic: false
   $name: Italic
 
-- textColor: "#FFFFFF"
+- textColor: ""
   $name: Text color
-  $description: "Hex color such as #FFFFFF or #A0A0A0."
+  $description: "Hex color such as #FFFFFF or #A0A0A0. Leave empty to follow the system theme."
 
 - opacity: 100
   $name: Opacity
@@ -162,6 +162,7 @@ This mod uses XAML diagnostics, which allows only one diagnostics consumer per E
 // ==/WindhawkModSettings==
 
 #include <windows.h>
+#include <dwmapi.h>
 
 #undef GetCurrentTime
 
@@ -175,11 +176,11 @@ This mod uses XAML diagnostics, which allows only one diagnostics consumer per E
 #include <winrt/Windows.UI.h>
 #include <winrt/Windows.UI.Text.h>
 
+#include <winrt/Microsoft.UI.h>
+#include <winrt/Microsoft.UI.Content.h>
 #include <winrt/Microsoft.UI.Xaml.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.Media.h>
-#include <winrt/Microsoft.UI.h>
-#include <winrt/Microsoft.UI.Content.h>
 
 #include <atomic>
 #include <chrono>
@@ -199,43 +200,50 @@ namespace muxm = winrt::Microsoft::UI::Xaml::Media;
 // Settings
 // ============================================================================
 
-enum class WeekdayStyle {
+enum class WeekdayStyle
+{
     None,
     Short,
     Long,
 };
 
-enum class DayStyle {
+enum class DayStyle
+{
     Number,
     TwoDigit,
 };
 
-enum class MonthStyle {
+enum class MonthStyle
+{
     Number,
     TwoDigit,
     Short,
     Long,
 };
 
-enum class YearStyle {
+enum class YearStyle
+{
     None,
     Short,
     Long,
 };
 
-enum class DateOrder {
+enum class DateOrder
+{
     MDY,
     DMY,
     YMD,
 };
 
-enum class NumericDateSeparator {
+enum class NumericDateSeparator
+{
     Slash,
     Dash,
     Dot,
 };
 
-enum class FontPreset {
+enum class FontPreset
+{
     SegoeVariable,
     Segoe,
     Arial,
@@ -246,13 +254,15 @@ enum class FontPreset {
     Custom,
 };
 
-enum class FontWeightSetting {
+enum class FontWeightSetting
+{
     Normal,
     Semibold,
     Bold,
 };
 
-struct Settings {
+struct Settings
+{
     std::wstring customText;
     bool showDate = true;
     WeekdayStyle dateWeekday = WeekdayStyle::Short;
@@ -273,7 +283,7 @@ struct Settings {
     int fontSize = 12;
     FontWeightSetting fontWeight = FontWeightSetting::Normal;
     bool italic = false;
-    std::wstring textColor = L"#FFFFFF";
+    std::wstring textColor;
     int opacity = 100;
 
     int leftMargin = 12;
@@ -281,7 +291,8 @@ struct Settings {
     int verticalOffset = 0;
 };
 
-struct SettingsSnapshot {
+struct SettingsSnapshot
+{
     Settings settings;
     uint64_t generation = 0;
 };
@@ -291,6 +302,7 @@ static std::atomic<uint64_t> g_settingsGeneration{1};
 static std::mutex g_settingsMutex;
 
 static std::atomic<bool> g_unloading{false};
+static std::atomic<bool> g_diagnosticsConnected{false};
 static std::mutex g_connectorMutex;
 static HANDLE g_connectorThread = nullptr;
 static HANDLE g_tapReadyEvent = nullptr;
@@ -299,9 +311,11 @@ static HANDLE g_tapReadyEvent = nullptr;
 // Settings helpers
 // ============================================================================
 
-static std::wstring ReadStringSetting(PCWSTR name, PCWSTR fallback) {
+static std::wstring ReadStringSetting(PCWSTR name, PCWSTR fallback)
+{
     PCWSTR value = Wh_GetStringSetting(name);
-    if (!value) {
+    if (!value)
+    {
         return fallback;
     }
 
@@ -310,7 +324,8 @@ static std::wstring ReadStringSetting(PCWSTR name, PCWSTR fallback) {
     return result;
 }
 
-static Settings ReadSettingsFromWindhawk() {
+static Settings ReadSettingsFromWindhawk()
+{
     Settings settings;
 
     settings.customText = ReadStringSetting(L"customText", L"");
@@ -318,11 +333,16 @@ static Settings ReadSettingsFromWindhawk() {
 
     {
         std::wstring value = ReadStringSetting(L"dateWeekday", L"short");
-        if (value == L"none") {
+        if (value == L"none")
+        {
             settings.dateWeekday = WeekdayStyle::None;
-        } else if (value == L"long") {
+        }
+        else if (value == L"long")
+        {
             settings.dateWeekday = WeekdayStyle::Long;
-        } else {
+        }
+        else
+        {
             settings.dateWeekday = WeekdayStyle::Short;
         }
     }
@@ -330,40 +350,57 @@ static Settings ReadSettingsFromWindhawk() {
     {
         std::wstring value = ReadStringSetting(L"dateDay", L"number");
         settings.dateDay = value == L"twoDigit" ? DayStyle::TwoDigit
-                                                 : DayStyle::Number;
+                                                : DayStyle::Number;
     }
 
     {
         std::wstring value = ReadStringSetting(L"dateMonth", L"short");
-        if (value == L"number") {
+        if (value == L"number")
+        {
             settings.dateMonth = MonthStyle::Number;
-        } else if (value == L"twoDigit") {
+        }
+        else if (value == L"twoDigit")
+        {
             settings.dateMonth = MonthStyle::TwoDigit;
-        } else if (value == L"long") {
+        }
+        else if (value == L"long")
+        {
             settings.dateMonth = MonthStyle::Long;
-        } else {
+        }
+        else
+        {
             settings.dateMonth = MonthStyle::Short;
         }
     }
 
     {
         std::wstring value = ReadStringSetting(L"dateYear", L"none");
-        if (value == L"short") {
+        if (value == L"short")
+        {
             settings.dateYear = YearStyle::Short;
-        } else if (value == L"long") {
+        }
+        else if (value == L"long")
+        {
             settings.dateYear = YearStyle::Long;
-        } else {
+        }
+        else
+        {
             settings.dateYear = YearStyle::None;
         }
     }
 
     {
         std::wstring value = ReadStringSetting(L"dateOrder", L"mdy");
-        if (value == L"dmy") {
+        if (value == L"dmy")
+        {
             settings.dateOrder = DateOrder::DMY;
-        } else if (value == L"ymd") {
+        }
+        else if (value == L"ymd")
+        {
             settings.dateOrder = DateOrder::YMD;
-        } else {
+        }
+        else
+        {
             settings.dateOrder = DateOrder::MDY;
         }
     }
@@ -371,11 +408,16 @@ static Settings ReadSettingsFromWindhawk() {
     {
         std::wstring value =
             ReadStringSetting(L"numericDateSeparator", L"slash");
-        if (value == L"dash") {
+        if (value == L"dash")
+        {
             settings.numericDateSeparator = NumericDateSeparator::Dash;
-        } else if (value == L"dot") {
+        }
+        else if (value == L"dot")
+        {
             settings.numericDateSeparator = NumericDateSeparator::Dot;
-        } else {
+        }
+        else
+        {
             settings.numericDateSeparator = NumericDateSeparator::Slash;
         }
     }
@@ -387,21 +429,36 @@ static Settings ReadSettingsFromWindhawk() {
 
     {
         std::wstring value = ReadStringSetting(L"fontPreset", L"segoeVariable");
-        if (value == L"segoe") {
+        if (value == L"segoe")
+        {
             settings.fontPreset = FontPreset::Segoe;
-        } else if (value == L"arial") {
+        }
+        else if (value == L"arial")
+        {
             settings.fontPreset = FontPreset::Arial;
-        } else if (value == L"calibri") {
+        }
+        else if (value == L"calibri")
+        {
             settings.fontPreset = FontPreset::Calibri;
-        } else if (value == L"consolas") {
+        }
+        else if (value == L"consolas")
+        {
             settings.fontPreset = FontPreset::Consolas;
-        } else if (value == L"tahoma") {
+        }
+        else if (value == L"tahoma")
+        {
             settings.fontPreset = FontPreset::Tahoma;
-        } else if (value == L"verdana") {
+        }
+        else if (value == L"verdana")
+        {
             settings.fontPreset = FontPreset::Verdana;
-        } else if (value == L"custom") {
+        }
+        else if (value == L"custom")
+        {
             settings.fontPreset = FontPreset::Custom;
-        } else {
+        }
+        else
+        {
             settings.fontPreset = FontPreset::SegoeVariable;
         }
     }
@@ -411,56 +468,77 @@ static Settings ReadSettingsFromWindhawk() {
 
     {
         std::wstring value = ReadStringSetting(L"fontWeight", L"normal");
-        if (value == L"bold") {
+        if (value == L"bold")
+        {
             settings.fontWeight = FontWeightSetting::Bold;
-        } else if (value == L"semibold") {
+        }
+        else if (value == L"semibold")
+        {
             settings.fontWeight = FontWeightSetting::Semibold;
-        } else {
+        }
+        else
+        {
             settings.fontWeight = FontWeightSetting::Normal;
         }
     }
 
     settings.italic = Wh_GetIntSetting(L"italic") != 0;
-    settings.textColor = ReadStringSetting(L"textColor", L"#FFFFFF");
+    settings.textColor = ReadStringSetting(L"textColor", L"");
     settings.opacity = Wh_GetIntSetting(L"opacity");
     settings.leftMargin = Wh_GetIntSetting(L"leftMargin");
     settings.rightMargin = Wh_GetIntSetting(L"rightMargin");
     settings.verticalOffset = Wh_GetIntSetting(L"verticalOffset");
 
-    if (settings.fontSize < 6) {
+    if (settings.fontSize < 6)
+    {
         settings.fontSize = 6;
-    } else if (settings.fontSize > 72) {
+    }
+    else if (settings.fontSize > 72)
+    {
         settings.fontSize = 72;
     }
 
-    if (settings.opacity < 0) {
+    if (settings.opacity < 0)
+    {
         settings.opacity = 0;
-    } else if (settings.opacity > 100) {
+    }
+    else if (settings.opacity > 100)
+    {
         settings.opacity = 100;
     }
 
-    if (settings.leftMargin < 0) {
+    if (settings.leftMargin < 0)
+    {
         settings.leftMargin = 0;
-    } else if (settings.leftMargin > 500) {
+    }
+    else if (settings.leftMargin > 500)
+    {
         settings.leftMargin = 500;
     }
 
-    if (settings.rightMargin < 0) {
+    if (settings.rightMargin < 0)
+    {
         settings.rightMargin = 0;
-    } else if (settings.rightMargin > 500) {
+    }
+    else if (settings.rightMargin > 500)
+    {
         settings.rightMargin = 500;
     }
 
-    if (settings.verticalOffset < -50) {
+    if (settings.verticalOffset < -50)
+    {
         settings.verticalOffset = -50;
-    } else if (settings.verticalOffset > 50) {
+    }
+    else if (settings.verticalOffset > 50)
+    {
         settings.verticalOffset = 50;
     }
 
     return settings;
 }
 
-static void LoadSettings(bool incrementGeneration) {
+static void LoadSettings(bool incrementGeneration)
+{
     Settings settings = ReadSettingsFromWindhawk();
 
     {
@@ -468,38 +546,42 @@ static void LoadSettings(bool incrementGeneration) {
         g_settings = std::move(settings);
     }
 
-    if (incrementGeneration) {
+    if (incrementGeneration)
+    {
         g_settingsGeneration.fetch_add(1, std::memory_order_release);
     }
 }
 
-static SettingsSnapshot GetSettingsSnapshot() {
+static SettingsSnapshot GetSettingsSnapshot()
+{
     std::lock_guard<std::mutex> lock(g_settingsMutex);
     return {g_settings,
             g_settingsGeneration.load(std::memory_order_acquire)};
 }
 
-static std::wstring GetSelectedFontFamily(const Settings& settings) {
-    switch (settings.fontPreset) {
-        case FontPreset::Segoe:
-            return L"Segoe UI";
-        case FontPreset::Arial:
-            return L"Arial";
-        case FontPreset::Calibri:
-            return L"Calibri";
-        case FontPreset::Consolas:
-            return L"Consolas";
-        case FontPreset::Tahoma:
-            return L"Tahoma";
-        case FontPreset::Verdana:
-            return L"Verdana";
-        case FontPreset::Custom:
-            return settings.customFontFamily.empty()
-                       ? L"Segoe UI Variable Text"
-                       : settings.customFontFamily;
-        case FontPreset::SegoeVariable:
-        default:
-            return L"Segoe UI Variable Text";
+static std::wstring GetSelectedFontFamily(const Settings &settings)
+{
+    switch (settings.fontPreset)
+    {
+    case FontPreset::Segoe:
+        return L"Segoe UI";
+    case FontPreset::Arial:
+        return L"Arial";
+    case FontPreset::Calibri:
+        return L"Calibri";
+    case FontPreset::Consolas:
+        return L"Consolas";
+    case FontPreset::Tahoma:
+        return L"Tahoma";
+    case FontPreset::Verdana:
+        return L"Verdana";
+    case FontPreset::Custom:
+        return settings.customFontFamily.empty()
+                   ? L"Segoe UI Variable Text"
+                   : settings.customFontFamily;
+    case FontPreset::SegoeVariable:
+    default:
+        return L"Segoe UI Variable Text";
     }
 }
 
@@ -507,23 +589,28 @@ static std::wstring GetSelectedFontFamily(const Settings& settings) {
 // Color parsing
 // ============================================================================
 
-static int HexDigit(wchar_t c) {
-    if (c >= L'0' && c <= L'9') {
+static int HexDigit(wchar_t c)
+{
+    if (c >= L'0' && c <= L'9')
+    {
         return c - L'0';
     }
 
     c = towupper(c);
-    if (c >= L'A' && c <= L'F') {
+    if (c >= L'A' && c <= L'F')
+    {
         return 10 + c - L'A';
     }
 
     return -1;
 }
 
-static bool ParseHexByte(wchar_t a, wchar_t b, uint8_t* result) {
+static bool ParseHexByte(wchar_t a, wchar_t b, uint8_t *result)
+{
     int hi = HexDigit(a);
     int lo = HexDigit(b);
-    if (hi < 0 || lo < 0) {
+    if (hi < 0 || lo < 0)
+    {
         return false;
     }
 
@@ -531,28 +618,34 @@ static bool ParseHexByte(wchar_t a, wchar_t b, uint8_t* result) {
     return true;
 }
 
-static winrt::Windows::UI::Color ParseColor(const std::wstring& input) {
+static winrt::Windows::UI::Color ParseColor(const std::wstring &input)
+{
     winrt::Windows::UI::Color color{255, 255, 255, 255};
     std::wstring text = input;
 
-    if (!text.empty() && text.front() == L'#') {
+    if (!text.empty() && text.front() == L'#')
+    {
         text.erase(text.begin());
     }
 
-    if (text.length() == 6) {
+    if (text.length() == 6)
+    {
         uint8_t r{};
         uint8_t g{};
         uint8_t b{};
 
         if (ParseHexByte(text[0], text[1], &r) &&
             ParseHexByte(text[2], text[3], &g) &&
-            ParseHexByte(text[4], text[5], &b)) {
+            ParseHexByte(text[4], text[5], &b))
+        {
             color.A = 255;
             color.R = r;
             color.G = g;
             color.B = b;
         }
-    } else if (text.length() == 8) {
+    }
+    else if (text.length() == 8)
+    {
         uint8_t a{};
         uint8_t r{};
         uint8_t g{};
@@ -561,7 +654,8 @@ static winrt::Windows::UI::Color ParseColor(const std::wstring& input) {
         if (ParseHexByte(text[0], text[1], &a) &&
             ParseHexByte(text[2], text[3], &r) &&
             ParseHexByte(text[4], text[5], &g) &&
-            ParseHexByte(text[6], text[7], &b)) {
+            ParseHexByte(text[6], text[7], &b))
+        {
             color.A = a;
             color.R = r;
             color.G = g;
@@ -576,187 +670,226 @@ static winrt::Windows::UI::Color ParseColor(const std::wstring& input) {
 // Date and time formatting
 // ============================================================================
 
-static std::wstring FormatLocaleDatePart(const SYSTEMTIME& st, PCWSTR format) {
+static std::wstring FormatLocaleDatePart(const SYSTEMTIME &st, PCWSTR format)
+{
     wchar_t buffer[128]{};
 
     if (!GetDateFormatEx(LOCALE_NAME_USER_DEFAULT, 0, &st, format, buffer,
-                         ARRAYSIZE(buffer), nullptr)) {
+                         ARRAYSIZE(buffer), nullptr))
+    {
         return L"";
     }
 
     return buffer;
 }
 
-static std::wstring BuildWeekdayText(const SYSTEMTIME& st,
-                                     const Settings& settings) {
-    switch (settings.dateWeekday) {
-        case WeekdayStyle::Short:
-            return FormatLocaleDatePart(st, L"ddd");
-        case WeekdayStyle::Long:
-            return FormatLocaleDatePart(st, L"dddd");
-        case WeekdayStyle::None:
-        default:
-            return L"";
+static std::wstring BuildWeekdayText(const SYSTEMTIME &st,
+                                     const Settings &settings)
+{
+    switch (settings.dateWeekday)
+    {
+    case WeekdayStyle::Short:
+        return FormatLocaleDatePart(st, L"ddd");
+    case WeekdayStyle::Long:
+        return FormatLocaleDatePart(st, L"dddd");
+    case WeekdayStyle::None:
+    default:
+        return L"";
     }
 }
 
-static std::wstring BuildDayText(const SYSTEMTIME& st,
-                                 const Settings& settings) {
+static std::wstring BuildDayText(const SYSTEMTIME &st,
+                                 const Settings &settings)
+{
     wchar_t buffer[16]{};
-    if (settings.dateDay == DayStyle::TwoDigit) {
+    if (settings.dateDay == DayStyle::TwoDigit)
+    {
         swprintf_s(buffer, L"%02u", st.wDay);
-    } else {
+    }
+    else
+    {
         swprintf_s(buffer, L"%u", st.wDay);
     }
     return buffer;
 }
 
-static std::wstring BuildMonthText(const SYSTEMTIME& st,
-                                   const Settings& settings) {
+static std::wstring BuildMonthText(const SYSTEMTIME &st,
+                                   const Settings &settings)
+{
     wchar_t buffer[32]{};
 
-    switch (settings.dateMonth) {
-        case MonthStyle::Number:
-            swprintf_s(buffer, L"%u", st.wMonth);
-            return buffer;
-        case MonthStyle::TwoDigit:
-            swprintf_s(buffer, L"%02u", st.wMonth);
-            return buffer;
-        case MonthStyle::Long:
-            return FormatLocaleDatePart(st, L"MMMM");
-        case MonthStyle::Short:
-        default:
-            return FormatLocaleDatePart(st, L"MMM");
+    switch (settings.dateMonth)
+    {
+    case MonthStyle::Number:
+        swprintf_s(buffer, L"%u", st.wMonth);
+        return buffer;
+    case MonthStyle::TwoDigit:
+        swprintf_s(buffer, L"%02u", st.wMonth);
+        return buffer;
+    case MonthStyle::Long:
+        return FormatLocaleDatePart(st, L"MMMM");
+    case MonthStyle::Short:
+    default:
+        return FormatLocaleDatePart(st, L"MMM");
     }
 }
 
-static std::wstring BuildYearText(const SYSTEMTIME& st,
-                                  const Settings& settings) {
+static std::wstring BuildYearText(const SYSTEMTIME &st,
+                                  const Settings &settings)
+{
     wchar_t buffer[16]{};
 
-    switch (settings.dateYear) {
-        case YearStyle::Short:
-            swprintf_s(buffer, L"%02u", st.wYear % 100);
-            return buffer;
-        case YearStyle::Long:
-            swprintf_s(buffer, L"%04u", st.wYear);
-            return buffer;
-        case YearStyle::None:
-        default:
-            return L"";
+    switch (settings.dateYear)
+    {
+    case YearStyle::Short:
+        swprintf_s(buffer, L"%02u", st.wYear % 100);
+        return buffer;
+    case YearStyle::Long:
+        swprintf_s(buffer, L"%04u", st.wYear);
+        return buffer;
+    case YearStyle::None:
+    default:
+        return L"";
     }
 }
 
-static bool IsNumericMonth(const Settings& settings) {
+static bool IsNumericMonth(const Settings &settings)
+{
     return settings.dateMonth == MonthStyle::Number ||
            settings.dateMonth == MonthStyle::TwoDigit;
 }
 
-static wchar_t GetNumericDateSeparator(const Settings& settings) {
-    switch (settings.numericDateSeparator) {
-        case NumericDateSeparator::Dash:
-            return L'-';
-        case NumericDateSeparator::Dot:
-            return L'.';
-        case NumericDateSeparator::Slash:
-        default:
-            return L'/';
+static wchar_t GetNumericDateSeparator(const Settings &settings)
+{
+    switch (settings.numericDateSeparator)
+    {
+    case NumericDateSeparator::Dash:
+        return L'-';
+    case NumericDateSeparator::Dot:
+        return L'.';
+    case NumericDateSeparator::Slash:
+    default:
+        return L'/';
     }
 }
 
-static std::wstring BuildDateText(const SYSTEMTIME& st,
-                                  const Settings& settings) {
+static std::wstring BuildDateText(const SYSTEMTIME &st,
+                                  const Settings &settings)
+{
     std::wstring weekday = BuildWeekdayText(st, settings);
     std::wstring day = BuildDayText(st, settings);
     std::wstring month = BuildMonthText(st, settings);
     std::wstring year = BuildYearText(st, settings);
     std::wstring date;
 
-    if (IsNumericMonth(settings)) {
+    if (IsNumericMonth(settings))
+    {
         wchar_t separator = GetNumericDateSeparator(settings);
 
-        auto appendPart = [&date, separator](const std::wstring& part) {
-            if (part.empty()) {
+        auto appendPart = [&date, separator](const std::wstring &part)
+        {
+            if (part.empty())
+            {
                 return;
             }
-            if (!date.empty()) {
+            if (!date.empty())
+            {
                 date += separator;
             }
             date += part;
         };
 
-        switch (settings.dateOrder) {
-            case DateOrder::DMY:
-                appendPart(day);
-                appendPart(month);
-                appendPart(year);
-                break;
-            case DateOrder::YMD:
-                appendPart(year);
-                appendPart(month);
-                appendPart(day);
-                break;
-            case DateOrder::MDY:
-            default:
-                appendPart(month);
-                appendPart(day);
-                appendPart(year);
-                break;
+        switch (settings.dateOrder)
+        {
+        case DateOrder::DMY:
+            appendPart(day);
+            appendPart(month);
+            appendPart(year);
+            break;
+        case DateOrder::YMD:
+            appendPart(year);
+            appendPart(month);
+            appendPart(day);
+            break;
+        case DateOrder::MDY:
+        default:
+            appendPart(month);
+            appendPart(day);
+            appendPart(year);
+            break;
         }
-    } else {
-        switch (settings.dateOrder) {
-            case DateOrder::DMY:
-                date = day + L" " + month;
-                if (!year.empty()) {
-                    date += L" " + year;
-                }
-                break;
+    }
+    else
+    {
+        switch (settings.dateOrder)
+        {
+        case DateOrder::DMY:
+            date = day + L" " + month;
+            if (!year.empty())
+            {
+                date += L" " + year;
+            }
+            break;
 
-            case DateOrder::YMD:
-                if (!year.empty()) {
-                    date = year + L" ";
-                }
-                date += month + L" " + day;
-                break;
+        case DateOrder::YMD:
+            if (!year.empty())
+            {
+                date = year + L" ";
+            }
+            date += month + L" " + day;
+            break;
 
-            case DateOrder::MDY:
-            default:
-                date = month + L" " + day;
-                if (!year.empty()) {
-                    date += L", " + year;
-                }
-                break;
+        case DateOrder::MDY:
+        default:
+            date = month + L" " + day;
+            if (!year.empty())
+            {
+                date += L", " + year;
+            }
+            break;
         }
     }
 
-    if (!weekday.empty()) {
+    if (!weekday.empty())
+    {
         date = weekday + L", " + date;
     }
 
     return date;
 }
 
-static std::wstring BuildTimeText(const SYSTEMTIME& st,
-                                  const Settings& settings) {
+static std::wstring BuildTimeText(const SYSTEMTIME &st,
+                                  const Settings &settings)
+{
     wchar_t buffer[128]{};
 
-    if (settings.use24Hour) {
-        if (settings.showSeconds) {
+    if (settings.use24Hour)
+    {
+        if (settings.showSeconds)
+        {
             swprintf_s(buffer, L"%02u:%02u:%02u", st.wHour, st.wMinute,
                        st.wSecond);
-        } else {
+        }
+        else
+        {
             swprintf_s(buffer, L"%02u:%02u", st.wHour, st.wMinute);
         }
-    } else {
+    }
+    else
+    {
         unsigned hour = st.wHour % 12;
-        if (hour == 0) {
+        if (hour == 0)
+        {
             hour = 12;
         }
 
-        if (settings.showSeconds) {
+        if (settings.showSeconds)
+        {
             swprintf_s(buffer, L"%u:%02u:%02u %s", hour, st.wMinute,
                        st.wSecond, st.wHour >= 12 ? L"PM" : L"AM");
-        } else {
+        }
+        else
+        {
             swprintf_s(buffer, L"%u:%02u %s", hour, st.wMinute,
                        st.wHour >= 12 ? L"PM" : L"AM");
         }
@@ -765,33 +898,41 @@ static std::wstring BuildTimeText(const SYSTEMTIME& st,
     return buffer;
 }
 
-static std::wstring BuildDisplayText(const Settings& settings) {
+static std::wstring BuildDisplayText(const Settings &settings)
+{
     SYSTEMTIME st{};
     GetLocalTime(&st);
 
     std::vector<std::wstring> parts;
 
-    if (!settings.customText.empty()) {
+    if (!settings.customText.empty())
+    {
         parts.emplace_back(settings.customText);
     }
 
-    if (settings.showDate) {
+    if (settings.showDate)
+    {
         std::wstring date = BuildDateText(st, settings);
-        if (!date.empty()) {
+        if (!date.empty())
+        {
             parts.emplace_back(std::move(date));
         }
     }
 
-    if (settings.showTime) {
+    if (settings.showTime)
+    {
         std::wstring time = BuildTimeText(st, settings);
-        if (!time.empty()) {
+        if (!time.empty())
+        {
             parts.emplace_back(std::move(time));
         }
     }
 
     std::wstring result;
-    for (size_t i = 0; i < parts.size(); ++i) {
-        if (i != 0) {
+    for (size_t i = 0; i < parts.size(); ++i)
+    {
+        if (i != 0)
+        {
             result += settings.separator;
         }
         result += parts[i];
@@ -804,15 +945,21 @@ static std::wstring BuildDisplayText(const Settings& settings) {
 // Explorer HWND
 // ============================================================================
 
-static HWND GetExplorerWindowForElement(mux::FrameworkElement const& element) {
-    try {
-        if (auto xamlRoot = element.XamlRoot()) {
-            if (auto environment = xamlRoot.ContentIslandEnvironment()) {
+static HWND GetExplorerWindowForElement(mux::FrameworkElement const &element)
+{
+    try
+    {
+        if (auto xamlRoot = element.XamlRoot())
+        {
+            if (auto environment = xamlRoot.ContentIslandEnvironment())
+            {
                 return reinterpret_cast<HWND>(
                     static_cast<uintptr_t>(environment.AppWindowId().Value));
             }
         }
-    } catch (...) {
+    }
+    catch (...)
+    {
         Wh_Log(L"Failed to get Explorer window from XamlRoot hr=0x%08X",
                winrt::to_hresult());
     }
@@ -824,39 +971,122 @@ static HWND GetExplorerWindowForElement(mux::FrameworkElement const& element) {
 // Vertical positioning
 // ============================================================================
 
-static void UpdateVerticalPosition(muxc::TextBlock const& text,
-                                   muxc::Grid const& grid,
-                                   int verticalOffset) {
-    double automaticCorrection = 0.0;
+static double GetCaptionButtonsWidthDip(HWND hwnd)
+{
+    if (!hwnd)
+    {
+        return 0.0;
+    }
 
-    try {
-        HWND hwnd = GetExplorerWindowForElement(grid);
+    RECT captionBounds{};
+    HRESULT hr = DwmGetWindowAttribute(
+        hwnd, DWMWA_CAPTION_BUTTON_BOUNDS,
+        &captionBounds, sizeof(captionBounds));
+    if (FAILED(hr))
+    {
+        return 0.0;
+    }
 
-        if (hwnd && IsZoomed(hwnd)) {
-            auto transform = grid.TransformToVisual(nullptr);
-            wf::Point origin{0.0f, 0.0f};
-            wf::Point position = transform.TransformPoint(origin);
+    LONG widthPx = captionBounds.right - captionBounds.left;
+    if (widthPx <= 0)
+    {
+        return 0.0;
+    }
 
-            if (position.Y < 0.0f) {
-                automaticCorrection =
-                    -static_cast<double>(position.Y) + 0.0;
-            }
-        }
+    UINT dpi = GetDpiForWindow(hwnd);
+    if (!dpi)
+    {
+        dpi = 96;
+    }
 
+    return static_cast<double>(widthPx) * 96.0 /
+           static_cast<double>(dpi);
+}
+
+static void UpdateLabelPosition(muxc::TextBlock const &text,
+                                muxc::Grid const &grid,
+                                int verticalOffset)
+{
+    double automaticHorizontalCorrection = 0.0;
+    double automaticVerticalCorrection = 0.0;
+
+    try
+    {
         auto currentTransform =
             text.RenderTransform().try_as<muxm::TranslateTransform>();
 
         muxm::TranslateTransform translate{nullptr};
-        if (currentTransform) {
+        if (currentTransform)
+        {
             translate = currentTransform;
-        } else {
+        }
+        else
+        {
             translate = muxm::TranslateTransform();
             text.RenderTransform(translate);
         }
 
-        translate.Y(static_cast<double>(verticalOffset) + automaticCorrection);
-    } catch (...) {
-        Wh_Log(L"UpdateVerticalPosition exception hr=0x%08X",
+        // Always measure from the native XAML position.
+        translate.X(0.0);
+
+        HWND hwnd = GetExplorerWindowForElement(grid);
+
+        if (hwnd && text.ActualWidth() > 0.0)
+        {
+            auto xamlRoot = text.XamlRoot();
+            if (xamlRoot)
+            {
+                double captionButtonsWidth =
+                    GetCaptionButtonsWidthDip(hwnd);
+
+                if (captionButtonsWidth > 0.0)
+                {
+                    wf::Point origin{0.0f, 0.0f};
+                    auto textTransform = text.TransformToVisual(nullptr);
+                    wf::Point textPosition =
+                        textTransform.TransformPoint(origin);
+
+                    double textRight =
+                        static_cast<double>(textPosition.X) +
+                        text.ActualWidth();
+
+                    double safeRight =
+                        static_cast<double>(xamlRoot.Size().Width) -
+                        captionButtonsWidth;
+
+                    // Explorer builds differ in whether this XAML region
+                    // already excludes the native caption buttons. Only shift
+                    // when the label actually enters the DWM-reported button
+                    // bounds.
+                    if (textRight > safeRight)
+                    {
+                        automaticHorizontalCorrection =
+                            safeRight - textRight;
+                    }
+                }
+            }
+        }
+
+        if (hwnd && IsZoomed(hwnd))
+        {
+            auto transform = grid.TransformToVisual(nullptr);
+            wf::Point origin{0.0f, 0.0f};
+            wf::Point position = transform.TransformPoint(origin);
+
+            if (position.Y < 0.0f)
+            {
+                automaticVerticalCorrection =
+                    -static_cast<double>(position.Y) + 0.0;
+            }
+        }
+
+        translate.X(automaticHorizontalCorrection);
+        translate.Y(static_cast<double>(verticalOffset) +
+                    automaticVerticalCorrection);
+    }
+    catch (...)
+    {
+        Wh_Log(L"UpdateLabelPosition exception hr=0x%08X",
                winrt::to_hresult());
     }
 }
@@ -865,35 +1095,43 @@ static void UpdateVerticalPosition(muxc::TextBlock const& text,
 // Appearance
 // ============================================================================
 
-static void ApplyTextSettings(muxc::TextBlock const& text,
-                              const Settings& settings) {
+static void ApplyTextSettings(muxc::TextBlock const &text,
+                              const Settings &settings)
+{
     text.Text(BuildDisplayText(settings));
 
-    try {
+    try
+    {
         muxm::FontFamily family(GetSelectedFontFamily(settings));
         text.FontFamily(family);
-    } catch (...) {
+    }
+    catch (...)
+    {
         Wh_Log(L"Invalid font family, using Segoe UI Variable Text");
-        try {
+        try
+        {
             text.FontFamily(muxm::FontFamily(L"Segoe UI Variable Text"));
-        } catch (...) {
+        }
+        catch (...)
+        {
         }
     }
 
     text.FontSize(static_cast<double>(settings.fontSize));
 
     winrt::Windows::UI::Text::FontWeight weight{};
-    switch (settings.fontWeight) {
-        case FontWeightSetting::Bold:
-            weight.Weight = 700;
-            break;
-        case FontWeightSetting::Semibold:
-            weight.Weight = 600;
-            break;
-        case FontWeightSetting::Normal:
-        default:
-            weight.Weight = 400;
-            break;
+    switch (settings.fontWeight)
+    {
+    case FontWeightSetting::Bold:
+        weight.Weight = 700;
+        break;
+    case FontWeightSetting::Semibold:
+        weight.Weight = 600;
+        break;
+    case FontWeightSetting::Normal:
+    default:
+        weight.Weight = 400;
+        break;
     }
     text.FontWeight(weight);
 
@@ -901,19 +1139,28 @@ static void ApplyTextSettings(muxc::TextBlock const& text,
                        ? winrt::Windows::UI::Text::FontStyle::Italic
                        : winrt::Windows::UI::Text::FontStyle::Normal);
 
-    // Apply opacity through the foreground brush instead of compositing the
-    // entire TextBlock. This keeps low-opacity glyph edges cleaner.
-    auto color = ParseColor(settings.textColor);
-    color.A = static_cast<uint8_t>(
-        (static_cast<unsigned>(color.A) *
-             static_cast<unsigned>(settings.opacity) +
-         50u) /
-        100u);
+    if (settings.textColor.empty())
+    {
+        // Follow Explorer's theme foreground when no custom color is set.
+        text.ClearValue(muxc::TextBlock::ForegroundProperty());
+        text.Opacity(static_cast<double>(settings.opacity) / 100.0);
+    }
+    else
+    {
+        // Apply opacity through the custom foreground brush instead of
+        // compositing the entire TextBlock.
+        auto color = ParseColor(settings.textColor);
+        color.A = static_cast<uint8_t>(
+            (static_cast<unsigned>(color.A) *
+                 static_cast<unsigned>(settings.opacity) +
+             50u) /
+            100u);
 
-    muxm::SolidColorBrush brush;
-    brush.Color(color);
-    text.Foreground(brush);
-    text.Opacity(1.0);
+        muxm::SolidColorBrush brush;
+        brush.Color(color);
+        text.Foreground(brush);
+        text.Opacity(1.0);
+    }
     text.HorizontalAlignment(mux::HorizontalAlignment::Right);
     text.VerticalAlignment(mux::VerticalAlignment::Center);
     text.Margin(mux::Thickness{static_cast<double>(settings.leftMargin), 0.0,
@@ -925,13 +1172,15 @@ static void ApplyTextSettings(muxc::TextBlock const& text,
 // Module helper
 // ============================================================================
 
-static HMODULE GetCurrentModuleHandle() {
+static HMODULE GetCurrentModuleHandle()
+{
     HMODULE module = nullptr;
 
     if (!GetModuleHandleExW(
             GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
                 GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-            reinterpret_cast<LPCWSTR>(&GetCurrentModuleHandle), &module)) {
+            reinterpret_cast<LPCWSTR>(&GetCurrentModuleHandle), &module))
+    {
         return nullptr;
     }
 
@@ -942,7 +1191,8 @@ static HMODULE GetCurrentModuleHandle() {
 // handler lives in this DLL. Keep each timer and every XAML event token in
 // thread-local state so teardown can stop and revoke them on the owning UI
 // thread before the mod is unloaded.
-struct LabelEntry {
+struct LabelEntry
+{
     winrt::weak_ref<muxc::TextBlock> text;
     winrt::weak_ref<muxc::Grid> grid;
     mux::DispatcherTimer timer{nullptr};
@@ -959,89 +1209,116 @@ struct LabelEntry {
 
 thread_local std::vector<std::shared_ptr<LabelEntry>> g_labelEntries;
 
-static void ReleaseLabelEntry(const std::shared_ptr<LabelEntry>& entry,
-                              bool removeElement) {
-    if (!entry || entry->cleaned) {
+static void ReleaseLabelEntry(const std::shared_ptr<LabelEntry> &entry,
+                              bool removeElement)
+{
+    if (!entry || entry->cleaned)
+    {
         return;
     }
 
     entry->cleaned = true;
 
-    try {
-        if (entry->timer) {
+    try
+    {
+        if (entry->timer)
+        {
             entry->timer.Stop();
-            if (entry->tickRegistered) {
+            if (entry->tickRegistered)
+            {
                 entry->timer.Tick(entry->tickToken);
                 entry->tickRegistered = false;
             }
         }
-    } catch (...) {
+    }
+    catch (...)
+    {
         Wh_Log(L"Failed to release title-bar timer hr=0x%08X",
                winrt::to_hresult());
     }
 
     auto grid = entry->grid.get();
-    if (grid && entry->sizeChangedRegistered) {
-        try {
+    if (grid && entry->sizeChangedRegistered)
+    {
+        try
+        {
             grid.SizeChanged(entry->sizeChangedToken);
             entry->sizeChangedRegistered = false;
-        } catch (...) {
+        }
+        catch (...)
+        {
             Wh_Log(L"Failed to revoke SizeChanged hr=0x%08X",
                    winrt::to_hresult());
         }
     }
 
-    if (removeElement) {
+    if (removeElement)
+    {
         auto text = entry->text.get();
-        if (grid && text) {
-            try {
+        if (grid && text)
+        {
+            try
+            {
                 auto children = grid.Children();
                 uint32_t index{};
-                if (children.IndexOf(text, index)) {
+                if (children.IndexOf(text, index))
+                {
                     children.RemoveAt(index);
                 }
-            } catch (...) {
+            }
+            catch (...)
+            {
                 Wh_Log(L"Failed to remove title-bar label hr=0x%08X",
                        winrt::to_hresult());
             }
         }
     }
-
 }
 
-static void PruneReleasedLabelEntries() {
-    for (auto it = g_labelEntries.begin(); it != g_labelEntries.end();) {
-        auto& entry = *it;
+static void PruneReleasedLabelEntries()
+{
+    for (auto it = g_labelEntries.begin(); it != g_labelEntries.end();)
+    {
+        auto &entry = *it;
 
-        if (!entry->cleaned && !entry->text.get()) {
+        if (!entry->cleaned && !entry->text.get())
+        {
             ReleaseLabelEntry(entry, false);
         }
 
-        if (entry->cleaned) {
+        if (entry->cleaned)
+        {
             it = g_labelEntries.erase(it);
-        } else {
+        }
+        else
+        {
             ++it;
         }
     }
 }
 
-static void RemoveLabelsForCurrentThread() {
+static void RemoveLabelsForCurrentThread()
+{
     std::vector<std::shared_ptr<LabelEntry>> taken;
     taken.swap(g_labelEntries);
 
-    for (auto& entry : taken) {
+    for (auto &entry : taken)
+    {
         ReleaseLabelEntry(entry, true);
     }
 }
 
-static bool IsFileExplorerWindow(HWND hwnd) {
-    if (!hwnd) {
+static bool IsFileExplorerWindow(HWND hwnd)
+{
+    if (!hwnd)
+    {
         return false;
     }
 
     DWORD processId = 0;
     if (!GetWindowThreadProcessId(hwnd, &processId) ||
-        processId != GetCurrentProcessId()) {
+        processId != GetCurrentProcessId())
+    {
         return false;
     }
 
@@ -1050,14 +1327,17 @@ static bool IsFileExplorerWindow(HWND hwnd) {
            _wcsicmp(className, L"CabinetWClass") == 0;
 }
 
-static std::vector<HWND> GetFileExplorerWindows() {
+static std::vector<HWND> GetFileExplorerWindows()
+{
     std::vector<HWND> windows;
 
     EnumWindows(
-        [](HWND hwnd, LPARAM lParam) -> BOOL {
-            auto& windows =
-                *reinterpret_cast<std::vector<HWND>*>(lParam);
-            if (IsFileExplorerWindow(hwnd)) {
+        [](HWND hwnd, LPARAM lParam) -> BOOL
+        {
+            auto &windows =
+                *reinterpret_cast<std::vector<HWND> *>(lParam);
+            if (IsFileExplorerWindow(hwnd))
+            {
                 windows.push_back(hwnd);
             }
             return TRUE;
@@ -1067,37 +1347,44 @@ static std::vector<HWND> GetFileExplorerWindows() {
     return windows;
 }
 
-using RunFromWindowThreadProc_t = void(WINAPI*)(PVOID parameter);
+using RunFromWindowThreadProc_t = void(WINAPI *)(PVOID parameter);
 
 static bool RunFromWindowThread(HWND hwnd,
                                 RunFromWindowThreadProc_t proc,
-                                PVOID procParam) {
+                                PVOID procParam)
+{
     static const UINT message =
         RegisterWindowMessageW(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
 
-    struct RunParam {
+    struct RunParam
+    {
         RunFromWindowThreadProc_t proc;
         PVOID procParam;
     };
 
     DWORD threadId = GetWindowThreadProcessId(hwnd, nullptr);
-    if (!threadId) {
+    if (!threadId)
+    {
         return false;
     }
 
-    if (threadId == GetCurrentThreadId()) {
+    if (threadId == GetCurrentThreadId())
+    {
         proc(procParam);
         return true;
     }
 
     HHOOK hook = SetWindowsHookExW(
         WH_CALLWNDPROC,
-        [](int code, WPARAM wParam, LPARAM lParam) -> LRESULT {
-            if (code == HC_ACTION) {
-                const auto* cwp = reinterpret_cast<const CWPSTRUCT*>(lParam);
-                if (cwp->message == message) {
-                    auto* param =
-                        reinterpret_cast<RunParam*>(cwp->lParam);
+        [](int code, WPARAM wParam, LPARAM lParam) -> LRESULT
+        {
+            if (code == HC_ACTION)
+            {
+                const auto *cwp = reinterpret_cast<const CWPSTRUCT *>(lParam);
+                if (cwp->message == message)
+                {
+                    auto *param =
+                        reinterpret_cast<RunParam *>(cwp->lParam);
                     param->proc(param->procParam);
                 }
             }
@@ -1105,7 +1392,8 @@ static bool RunFromWindowThread(HWND hwnd,
             return CallNextHookEx(nullptr, code, wParam, lParam);
         },
         nullptr, threadId);
-    if (!hook) {
+    if (!hook)
+    {
         return false;
     }
 
@@ -1135,12 +1423,14 @@ static HWND WINAPI CreateWindowExW_Hook(DWORD exStyle,
                                         HWND parent,
                                         HMENU menu,
                                         HINSTANCE instance,
-                                        PVOID param) {
+                                        PVOID param)
+{
     HWND hwnd = CreateWindowExW_Original(
         exStyle, className, windowName, style, x, y, width, height, parent,
         menu, instance, param);
 
-    if (hwnd && !g_unloading.load() && IsFileExplorerWindow(hwnd)) {
+    if (hwnd && !g_unloading.load() && IsFileExplorerWindow(hwnd))
+    {
         EnsureConnectorStarted();
     }
 
@@ -1153,21 +1443,25 @@ static HWND WINAPI CreateWindowExW_Hook(DWORD exStyle,
 
 class VisualTreeWatcher
     : public winrt::implements<VisualTreeWatcher, IVisualTreeServiceCallback2,
-                               winrt::non_agile> {
+                               winrt::non_agile>
+{
 public:
     explicit VisualTreeWatcher(winrt::com_ptr<IUnknown> site)
         : m_xamlDiagnostics(site.as<IXamlDiagnostics>()),
-          m_visualTreeService(site.as<IVisualTreeService3>()) {
+          m_visualTreeService(site.as<IVisualTreeService3>())
+    {
         // AdviseVisualTreeChange must be made from a separate thread in
         // Explorer. Keep the handle so shutdown can wait for it safely.
         AddRef();
         m_adviseThread = CreateThread(
             nullptr, 0,
-            [](LPVOID parameter) -> DWORD {
-                auto watcher = static_cast<VisualTreeWatcher*>(parameter);
+            [](LPVOID parameter) -> DWORD
+            {
+                auto watcher = static_cast<VisualTreeWatcher *>(parameter);
                 HRESULT hr =
                     watcher->m_visualTreeService->AdviseVisualTreeChange(watcher);
-                if (FAILED(hr)) {
+                if (FAILED(hr))
+                {
                     Wh_Log(L"AdviseVisualTreeChange failed hr=0x%08X", hr);
                 }
                 watcher->Release();
@@ -1175,48 +1469,58 @@ public:
             },
             this, 0, nullptr);
 
-        if (!m_adviseThread) {
+        if (!m_adviseThread)
+        {
             Wh_Log(L"CreateThread for XAML visual tree watcher failed: %u",
                    GetLastError());
             Release();
         }
     }
 
-    ~VisualTreeWatcher() {
+    ~VisualTreeWatcher()
+    {
         // Normally Disconnect() has already joined and closed this handle. If
         // destruction happens on the advise thread itself, only close it here.
-        if (m_adviseThread) {
+        if (m_adviseThread)
+        {
             CloseHandle(m_adviseThread);
             m_adviseThread = nullptr;
         }
     }
 
-    void Disconnect() {
-        if (m_disconnected) {
+    void Disconnect()
+    {
+        if (m_disconnected)
+        {
             return;
         }
         m_disconnected = true;
 
         WaitForAdviseThread();
 
-        if (!m_visualTreeService) {
+        if (!m_visualTreeService)
+        {
             return;
         }
 
         HRESULT hr = m_visualTreeService->UnadviseVisualTreeChange(this);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Wh_Log(L"UnadviseVisualTreeChange failed hr=0x%08X", hr);
         }
     }
 
 private:
-    void WaitForAdviseThread() {
-        if (!m_adviseThread) {
+    void WaitForAdviseThread()
+    {
+        if (!m_adviseThread)
+        {
             return;
         }
 
         DWORD threadId = GetThreadId(m_adviseThread);
-        if (threadId != 0 && threadId != GetCurrentThreadId()) {
+        if (threadId != 0 && threadId != GetCurrentThreadId())
+        {
             WaitForSingleObject(m_adviseThread, INFINITE);
         }
 
@@ -1224,54 +1528,65 @@ private:
         m_adviseThread = nullptr;
     }
 
-    wf::IInspectable FromHandle(InstanceHandle handle) {
+    wf::IInspectable FromHandle(InstanceHandle handle)
+    {
         wf::IInspectable object{nullptr};
 
         HRESULT hr = m_xamlDiagnostics->GetIInspectableFromHandle(
-            handle, reinterpret_cast<::IInspectable**>(winrt::put_abi(object)));
-        if (FAILED(hr)) {
+            handle, reinterpret_cast<::IInspectable **>(winrt::put_abi(object)));
+        if (FAILED(hr))
+        {
             return nullptr;
         }
 
         return object;
     }
 
-    void TryInsertTitleText(InstanceHandle handle) {
+    void TryInsertTitleText(InstanceHandle handle)
+    {
         auto inspectable = FromHandle(handle);
-        if (!inspectable) {
+        if (!inspectable)
+        {
             return;
         }
 
         auto frameworkElement = inspectable.try_as<mux::FrameworkElement>();
         if (!frameworkElement ||
-            frameworkElement.Name() != L"TabContainerGrid") {
+            frameworkElement.Name() != L"TabContainerGrid")
+        {
             return;
         }
 
         auto grid = inspectable.try_as<muxc::Grid>();
-        if (!grid) {
+        if (!grid)
+        {
             return;
         }
 
         auto children = grid.Children();
         mux::FrameworkElement rightAnchor{nullptr};
 
-        for (uint32_t i = 0; i < children.Size(); ++i) {
+        for (uint32_t i = 0; i < children.Size(); ++i)
+        {
             auto child = children.GetAt(i).try_as<mux::FrameworkElement>();
-            if (!child) {
+            if (!child)
+            {
                 continue;
             }
 
-            if (child.Name() == L"WindhawkExplorerTitleBarLabel") {
+            if (child.Name() == L"WindhawkExplorerTitleBarLabel")
+            {
                 return;
             }
 
-            if (child.Name() == L"RightContentPresenter") {
+            if (child.Name() == L"RightContentPresenter")
+            {
                 rightAnchor = child;
             }
         }
 
-        if (!rightAnchor) {
+        if (!rightAnchor)
+        {
             Wh_Log(L"RightContentPresenter not found");
             return;
         }
@@ -1291,8 +1606,18 @@ private:
         muxc::Canvas::SetZIndex(text, 100);
         children.Append(text);
 
-        UpdateVerticalPosition(text, grid,
-                               initialSnapshot.settings.verticalOffset);
+        try
+        {
+            grid.UpdateLayout();
+        }
+        catch (...)
+        {
+            Wh_Log(L"Initial title-bar layout update failed hr=0x%08X",
+                   winrt::to_hresult());
+        }
+
+        UpdateLabelPosition(text, grid,
+                            initialSnapshot.settings.verticalOffset);
 
         auto entry = std::make_shared<LabelEntry>();
         entry->text = winrt::make_weak(text);
@@ -1301,92 +1626,126 @@ private:
         entry->currentSettings = initialSnapshot.settings;
         entry->lastText = BuildDisplayText(initialSnapshot.settings);
 
+        // Track the entry before registering any delegate whose callback lives
+        // in this DLL, so shutdown can always revoke partially initialized
+        // handlers.
+        g_labelEntries.push_back(entry);
         std::weak_ptr<LabelEntry> weakEntry = entry;
 
-        entry->sizeChangedToken = grid.SizeChanged(
-            [weakEntry](auto const&, mux::SizeChangedEventArgs const&) {
-                auto entry = weakEntry.lock();
-                if (!entry || entry->cleaned || g_unloading.load()) {
-                    return;
-                }
-
-                auto text = entry->text.get();
-                auto grid = entry->grid.get();
-                if (!text || !grid) {
-                    return;
-                }
-
-                SettingsSnapshot snapshot = GetSettingsSnapshot();
-                UpdateVerticalPosition(text, grid,
-                                       snapshot.settings.verticalOffset);
-            });
-        entry->sizeChangedRegistered = true;
-
-        mux::DispatcherTimer timer;
-        timer.Interval(std::chrono::seconds(1));
-
-        entry->timer = timer;
-        entry->tickToken = timer.Tick(
-            [weakEntry](auto const&, auto const&) {
-                auto entry = weakEntry.lock();
-                if (!entry || entry->cleaned) {
-                    return;
-                }
-
-                auto text = entry->text.get();
-                if (!text) {
-                    ReleaseLabelEntry(entry, false);
-                    return;
-                }
-
-                if (g_unloading.load()) {
-                    ReleaseLabelEntry(entry, true);
-                    return;
-                }
-
-                uint64_t generation =
-                    g_settingsGeneration.load(std::memory_order_acquire);
-                bool settingsChanged =
-                    generation != entry->seenGeneration;
-
-                if (settingsChanged) {
-                    SettingsSnapshot snapshot = GetSettingsSnapshot();
-                    entry->seenGeneration = snapshot.generation;
-                    entry->currentSettings = snapshot.settings;
-
-                    ApplyTextSettings(text, entry->currentSettings);
-                    entry->lastText =
-                        BuildDisplayText(entry->currentSettings);
-
-                    if (auto grid = entry->grid.get()) {
-                        UpdateVerticalPosition(
-                            text, grid,
-                            entry->currentSettings.verticalOffset);
+        try
+        {
+            entry->sizeChangedToken = grid.SizeChanged(
+                [weakEntry](auto const &, mux::SizeChangedEventArgs const &)
+                {
+                    auto entry = weakEntry.lock();
+                    if (!entry || entry->cleaned || g_unloading.load())
+                    {
+                        return;
                     }
-                }
 
-                std::wstring current =
-                    BuildDisplayText(entry->currentSettings);
-                if (current != entry->lastText) {
-                    text.Text(current);
-                    entry->lastText = std::move(current);
-                }
-            });
-        entry->tickRegistered = true;
+                    auto text = entry->text.get();
+                    auto grid = entry->grid.get();
+                    if (!text || !grid)
+                    {
+                        return;
+                    }
 
-        g_labelEntries.push_back(entry);
-        timer.Start();
+                    SettingsSnapshot snapshot = GetSettingsSnapshot();
+                    UpdateLabelPosition(text, grid,
+                                        snapshot.settings.verticalOffset);
+                });
+            entry->sizeChangedRegistered = true;
+
+            mux::DispatcherTimer timer;
+            timer.Interval(std::chrono::seconds(1));
+
+            entry->timer = timer;
+            entry->tickToken = timer.Tick(
+                [weakEntry](auto const &, auto const &)
+                {
+                    auto entry = weakEntry.lock();
+                    if (!entry || entry->cleaned)
+                    {
+                        return;
+                    }
+
+                    auto text = entry->text.get();
+                    if (!text)
+                    {
+                        ReleaseLabelEntry(entry, false);
+                        return;
+                    }
+
+                    if (g_unloading.load())
+                    {
+                        ReleaseLabelEntry(entry, true);
+                        return;
+                    }
+
+                    uint64_t generation =
+                        g_settingsGeneration.load(std::memory_order_acquire);
+                    bool settingsChanged =
+                        generation != entry->seenGeneration;
+
+                    if (settingsChanged)
+                    {
+                        SettingsSnapshot snapshot = GetSettingsSnapshot();
+                        entry->seenGeneration = snapshot.generation;
+                        entry->currentSettings = snapshot.settings;
+
+                        ApplyTextSettings(text, entry->currentSettings);
+                        entry->lastText =
+                            BuildDisplayText(entry->currentSettings);
+
+                        if (auto grid = entry->grid.get())
+                        {
+                            UpdateLabelPosition(
+                                text, grid,
+                                entry->currentSettings.verticalOffset);
+                        }
+                    }
+
+                    std::wstring current =
+                        BuildDisplayText(entry->currentSettings);
+                    if (current != entry->lastText)
+                    {
+                        text.Text(current);
+                        entry->lastText = std::move(current);
+
+                        if (auto grid = entry->grid.get())
+                        {
+                            UpdateLabelPosition(
+                                text, grid,
+                                entry->currentSettings.verticalOffset);
+                        }
+                    }
+                });
+            entry->tickRegistered = true;
+
+            timer.Start();
+        }
+        catch (...)
+        {
+            ReleaseLabelEntry(entry, true);
+            PruneReleasedLabelEntries();
+            throw;
+        }
     }
 
     HRESULT STDMETHODCALLTYPE OnVisualTreeChange(
         ParentChildRelation,
         VisualElement element,
-        VisualMutationType mutationType) override {
-        try {
-            if (!g_unloading.load() && mutationType == Add) {
+        VisualMutationType mutationType) override
+    {
+        try
+        {
+            if (!g_unloading.load() && mutationType == Add)
+            {
                 TryInsertTitleText(element.Handle);
             }
-        } catch (...) {
+        }
+        catch (...)
+        {
             Wh_Log(L"OnVisualTreeChange exception hr=0x%08X",
                    winrt::to_hresult());
         }
@@ -1396,7 +1755,8 @@ private:
 
     HRESULT STDMETHODCALLTYPE OnElementStateChanged(InstanceHandle,
                                                     VisualElementState,
-                                                    LPCWSTR) noexcept override {
+                                                    LPCWSTR) noexcept override
+    {
         return S_OK;
     }
 
@@ -1421,46 +1781,66 @@ static constexpr CLSID CLSID_WindhawkTitleBarLabelTAP = {
 
 class WindhawkTAP
     : public winrt::implements<WindhawkTAP, IObjectWithSite,
-                               winrt::non_agile> {
+                               winrt::non_agile>
+{
 public:
-    HRESULT STDMETHODCALLTYPE SetSite(IUnknown* site) override {
-        try {
-            if (g_visualTreeWatcher) {
+    HRESULT STDMETHODCALLTYPE SetSite(IUnknown *site) override
+    {
+        try
+        {
+            if (g_visualTreeWatcher)
+            {
                 g_visualTreeWatcher->Disconnect();
                 g_visualTreeWatcher = nullptr;
             }
+            g_diagnosticsConnected.store(false, std::memory_order_release);
 
             m_site.copy_from(site);
 
-            if (m_site && !g_unloading.load()) {
+            if (m_site)
+            {
+                // Balance the module reference added by
+                // InitializeXamlDiagnosticsEx even during shutdown.
                 HMODULE module = GetCurrentModuleHandle();
-                if (module) {
+                if (module)
+                {
                     FreeLibrary(module);
                 }
 
-                g_visualTreeWatcher =
-                    winrt::make_self<VisualTreeWatcher>(m_site);
+                if (!g_unloading.load())
+                {
+                    g_visualTreeWatcher =
+                        winrt::make_self<VisualTreeWatcher>(m_site);
+                    g_diagnosticsConnected.store(
+                        true, std::memory_order_release);
 
-                if (g_tapReadyEvent) {
-                    SetEvent(g_tapReadyEvent);
+                    if (g_tapReadyEvent)
+                    {
+                        SetEvent(g_tapReadyEvent);
+                    }
                 }
             }
 
             return S_OK;
-        } catch (...) {
+        }
+        catch (...)
+        {
             HRESULT hr = winrt::to_hresult();
             Wh_Log(L"SetSite exception hr=0x%08X", hr);
             return hr;
         }
     }
 
-    HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void** result) noexcept override {
-        if (!result) {
+    HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void **result) noexcept override
+    {
+        if (!result)
+        {
             return E_POINTER;
         }
 
         *result = nullptr;
-        if (!m_site) {
+        if (!m_site)
+        {
             return E_FAIL;
         }
 
@@ -1477,27 +1857,35 @@ private:
 
 template <typename T>
 struct SimpleFactory
-    : winrt::implements<SimpleFactory<T>, IClassFactory, winrt::non_agile> {
-    HRESULT STDMETHODCALLTYPE CreateInstance(IUnknown* outer,
+    : winrt::implements<SimpleFactory<T>, IClassFactory, winrt::non_agile>
+{
+    HRESULT STDMETHODCALLTYPE CreateInstance(IUnknown *outer,
                                              REFIID riid,
-                                             void** object) override {
-        if (!object) {
+                                             void **object) override
+    {
+        if (!object)
+        {
             return E_POINTER;
         }
 
         *object = nullptr;
-        if (outer) {
+        if (outer)
+        {
             return CLASS_E_NOAGGREGATION;
         }
 
-        try {
+        try
+        {
             return winrt::make<T>().as(riid, object);
-        } catch (...) {
+        }
+        catch (...)
+        {
             return winrt::to_hresult();
         }
     }
 
-    HRESULT STDMETHODCALLTYPE LockServer(BOOL) noexcept override {
+    HRESULT STDMETHODCALLTYPE LockServer(BOOL) noexcept override
+    {
         return S_OK;
     }
 };
@@ -1508,24 +1896,31 @@ struct SimpleFactory
 extern "C" __declspec(dllexport) HRESULT __stdcall DllGetClassObject(
     REFCLSID clsid,
     REFIID riid,
-    LPVOID* result) {
-    if (!result) {
+    LPVOID *result)
+{
+    if (!result)
+    {
         return E_POINTER;
     }
 
     *result = nullptr;
-    if (clsid != CLSID_WindhawkTitleBarLabelTAP) {
+    if (clsid != CLSID_WindhawkTitleBarLabelTAP)
+    {
         return CLASS_E_CLASSNOTAVAILABLE;
     }
 
-    try {
+    try
+    {
         return winrt::make<SimpleFactory<WindhawkTAP>>().as(riid, result);
-    } catch (...) {
+    }
+    catch (...)
+    {
         return winrt::to_hresult();
     }
 }
 
-extern "C" __declspec(dllexport) HRESULT __stdcall DllCanUnloadNow() {
+extern "C" __declspec(dllexport) HRESULT __stdcall DllCanUnloadNow()
+{
     return winrt::get_module_lock() ? S_FALSE : S_OK;
 }
 
@@ -1537,41 +1932,48 @@ extern "C" __declspec(dllexport) HRESULT __stdcall DllCanUnloadNow() {
 
 using InitializeXamlDiagnosticsEx_t = decltype(&InitializeXamlDiagnosticsEx);
 
-static HRESULT ConnectToExplorerXaml() {
+static HRESULT ConnectToExplorerXaml()
+{
     HMODULE self = GetCurrentModuleHandle();
-    if (!self) {
+    if (!self)
+    {
         return HRESULT_FROM_WIN32(GetLastError());
     }
 
     wchar_t modulePath[MAX_PATH]{};
     DWORD length =
         GetModuleFileNameW(self, modulePath, ARRAYSIZE(modulePath));
-    if (!length || length >= ARRAYSIZE(modulePath)) {
+    if (!length || length >= ARRAYSIZE(modulePath))
+    {
         return HRESULT_FROM_WIN32(GetLastError());
     }
 
     HMODULE framework =
         GetModuleHandleW(L"Microsoft.Internal.FrameworkUdk.dll");
-    if (!framework) {
+    if (!framework)
+    {
         return HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND);
     }
 
     auto initialize = reinterpret_cast<InitializeXamlDiagnosticsEx_t>(
         GetProcAddress(framework, "InitializeXamlDiagnosticsEx"));
-    if (!initialize) {
+    if (!initialize)
+    {
         return HRESULT_FROM_WIN32(ERROR_PROC_NOT_FOUND);
     }
 
     HRESULT hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
 
-    for (int i = 1; i <= 10000 && !g_unloading.load(); ++i) {
+    for (int i = 1; i <= 10000 && !g_unloading.load(); ++i)
+    {
         wchar_t connection[128]{};
         swprintf_s(connection, L"WinUIVisualDiagConnection%d", i);
 
         hr = initialize(connection, GetCurrentProcessId(), L"", modulePath,
                         CLSID_WindhawkTitleBarLabelTAP, nullptr);
 
-        if (hr != HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
+        if (hr != HRESULT_FROM_WIN32(ERROR_NOT_FOUND))
+        {
             break;
         }
     }
@@ -1583,10 +1985,12 @@ static HRESULT ConnectToExplorerXaml() {
 // Connector thread
 // ============================================================================
 
-static bool SleepWhileLoaded(DWORD milliseconds) {
+static bool SleepWhileLoaded(DWORD milliseconds)
+{
     constexpr DWORD kSliceMs = 50;
 
-    while (milliseconds > 0 && !g_unloading.load()) {
+    while (milliseconds > 0 && !g_unloading.load())
+    {
         DWORD slice = milliseconds < kSliceMs ? milliseconds : kSliceMs;
         Sleep(slice);
         milliseconds -= slice;
@@ -1595,84 +1999,119 @@ static bool SleepWhileLoaded(DWORD milliseconds) {
     return !g_unloading.load();
 }
 
-static DWORD WINAPI ConnectorThread(LPVOID) {
-    // This thread is created only after a real File Explorer window exists.
-    // Wait as long as needed for WinUI to load instead of giving up a fixed
-    // number of seconds after explorer.exe starts.
-    while (!g_unloading.load()) {
+static DWORD WINAPI ConnectorThread(LPVOID)
+{
+    // This thread starts only after a real File Explorer window exists. Give
+    // WinUI a bounded startup window instead of polling forever in unsupported
+    // Explorer processes.
+    constexpr int kMaxAttempts = 120;
+    constexpr DWORD kRetryDelayMs = 500;
+
+    for (int attempt = 0;
+         attempt < kMaxAttempts && !g_unloading.load();
+         ++attempt)
+    {
         HMODULE framework =
             GetModuleHandleW(L"Microsoft.Internal.FrameworkUdk.dll");
 
-        if (!framework) {
-            if (!SleepWhileLoaded(100)) {
+        if (framework)
+        {
+            HRESULT hr = ConnectToExplorerXaml();
+            if (SUCCEEDED(hr))
+            {
+                // Some XAML-diagnostics consumers intentionally return S_OK
+                // while blocking the caller. Only report success after our
+                // TAP's SetSite actually runs.
+                DWORD waitResult =
+                    g_tapReadyEvent
+                        ? WaitForSingleObject(g_tapReadyEvent, 2000)
+                        : WAIT_FAILED;
+
+                if (waitResult == WAIT_OBJECT_0)
+                {
+                    Wh_Log(L"Connected to Explorer XAML diagnostics");
+                }
+                else if (!g_unloading.load())
+                {
+                    Wh_Log(
+                        L"XAML diagnostics returned success, but the title-bar "
+                        L"TAP was not initialized. Another XAML diagnostics "
+                        L"consumer may have blocked the connection.");
+                }
+
                 return 0;
             }
-            continue;
-        }
 
-        HRESULT hr = ConnectToExplorerXaml();
-        if (SUCCEEDED(hr)) {
-            // Some XAML-diagnostics consumers intentionally return S_OK while
-            // blocking the caller. Only report success after our TAP's SetSite
-            // actually runs.
-            DWORD waitResult =
-                g_tapReadyEvent
-                    ? WaitForSingleObject(g_tapReadyEvent, 2000)
-                    : WAIT_FAILED;
-
-            if (waitResult == WAIT_OBJECT_0) {
-                Wh_Log(L"Connected to Explorer XAML diagnostics");
-            } else if (!g_unloading.load()) {
-                Wh_Log(
-                    L"XAML diagnostics returned success, but the title-bar "
-                    L"TAP was not initialized. Another XAML diagnostics "
-                    L"consumer may have blocked the connection.");
-            }
-
-            return 0;
-        }
-
-        if (g_unloading.load()) {
-            return 0;
-        }
-
-        if (hr == HRESULT_FROM_WIN32(ERROR_NOT_FOUND) ||
-            hr == HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND)) {
-            if (!SleepWhileLoaded(250)) {
+            if (g_unloading.load())
+            {
                 return 0;
             }
-            continue;
+
+            if (hr != HRESULT_FROM_WIN32(ERROR_NOT_FOUND) &&
+                hr != HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND))
+            {
+                Wh_Log(L"Diagnostics connection failed hr=0x%08X", hr);
+                return 0;
+            }
         }
 
-        Wh_Log(L"Diagnostics connection failed hr=0x%08X", hr);
-        return 0;
+        if (!SleepWhileLoaded(kRetryDelayMs))
+        {
+            return 0;
+        }
+    }
+
+    if (!g_unloading.load())
+    {
+        Wh_Log(L"Explorer WinUI diagnostics did not become available");
     }
 
     return 0;
 }
 
-static void EnsureConnectorStarted() {
-    if (g_unloading.load()) {
+static void EnsureConnectorStarted()
+{
+    if (g_unloading.load() ||
+        g_diagnosticsConnected.load(std::memory_order_acquire))
+    {
         return;
     }
 
     std::lock_guard<std::mutex> lock(g_connectorMutex);
-    if (g_unloading.load() || g_connectorThread) {
+    if (g_unloading.load() ||
+        g_diagnosticsConnected.load(std::memory_order_acquire))
+    {
         return;
     }
 
-    if (g_tapReadyEvent) {
+    if (g_connectorThread)
+    {
+        if (WaitForSingleObject(g_connectorThread, 0) == WAIT_OBJECT_0)
+        {
+            CloseHandle(g_connectorThread);
+            g_connectorThread = nullptr;
+        }
+        else
+        {
+            return;
+        }
+    }
+
+    if (g_tapReadyEvent)
+    {
         ResetEvent(g_tapReadyEvent);
     }
 
     g_connectorThread =
         CreateThread(nullptr, 0, ConnectorThread, nullptr, 0, nullptr);
-    if (!g_connectorThread) {
+    if (!g_connectorThread)
+    {
         Wh_Log(L"CreateThread failed: %u", GetLastError());
     }
 }
 
-static void StopConnectorThread() {
+static void StopConnectorThread()
+{
     HANDLE thread = nullptr;
 
     {
@@ -1680,16 +2119,19 @@ static void StopConnectorThread() {
         thread = g_connectorThread;
     }
 
-    if (!thread) {
+    if (!thread)
+    {
         return;
     }
 
-    if (GetThreadId(thread) != GetCurrentThreadId()) {
+    if (GetThreadId(thread) != GetCurrentThreadId())
+    {
         WaitForSingleObject(thread, INFINITE);
     }
 
     std::lock_guard<std::mutex> lock(g_connectorMutex);
-    if (g_connectorThread == thread) {
+    if (g_connectorThread == thread)
+    {
         CloseHandle(g_connectorThread);
         g_connectorThread = nullptr;
     }
@@ -1699,22 +2141,26 @@ static void StopConnectorThread() {
 // Windhawk
 // ============================================================================
 
-BOOL Wh_ModInit() {
+BOOL Wh_ModInit()
+{
     Wh_Log(L"Explorer Title Bar Label 1.0.0 init");
 
     g_unloading.store(false);
+    g_diagnosticsConnected.store(false, std::memory_order_release);
     LoadSettings(false);
 
     g_tapReadyEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
-    if (!g_tapReadyEvent) {
+    if (!g_tapReadyEvent)
+    {
         Wh_Log(L"CreateEvent failed: %u", GetLastError());
         return FALSE;
     }
 
     if (!Wh_SetFunctionHook(
-            reinterpret_cast<void*>(CreateWindowExW),
-            reinterpret_cast<void*>(CreateWindowExW_Hook),
-            reinterpret_cast<void**>(&CreateWindowExW_Original))) {
+            reinterpret_cast<void *>(CreateWindowExW),
+            reinterpret_cast<void *>(CreateWindowExW_Hook),
+            reinterpret_cast<void **>(&CreateWindowExW_Original)))
+    {
         Wh_Log(L"Failed to hook CreateWindowExW");
         CloseHandle(g_tapReadyEvent);
         g_tapReadyEvent = nullptr;
@@ -1724,26 +2170,32 @@ BOOL Wh_ModInit() {
     return TRUE;
 }
 
-void Wh_ModAfterInit() {
+void Wh_ModAfterInit()
+{
     // Hooks become active after Wh_ModInit. Handle windows which were already
     // open before that point.
-    if (!GetFileExplorerWindows().empty()) {
+    if (!GetFileExplorerWindows().empty())
+    {
         EnsureConnectorStarted();
     }
 }
 
-void Wh_ModSettingsChanged() {
+void Wh_ModSettingsChanged()
+{
     LoadSettings(true);
 }
 
 // Function hooks are removed before Wh_ModUninit, but XAML delegates can still
 // be alive until explicit UI-thread teardown below. Stop them from doing new
 // work as early as Windhawk allows.
-void Wh_ModBeforeUninit() {
+void Wh_ModBeforeUninit()
+{
     g_unloading.store(true);
+    g_diagnosticsConnected.store(false, std::memory_order_release);
 }
 
-void Wh_ModUninit() {
+void Wh_ModUninit()
+{
     Wh_Log(L"Explorer Title Bar Label 1.0.0 uninit");
 
     g_unloading.store(true);
@@ -1752,21 +2204,27 @@ void Wh_ModUninit() {
 
     // Every XAML delegate is revoked synchronously on the thread which owns it
     // before this DLL can be unloaded.
-    for (HWND hwnd : GetFileExplorerWindows()) {
+    for (HWND hwnd : GetFileExplorerWindows())
+    {
         if (!RunFromWindowThread(
-                hwnd, [](PVOID) { RemoveLabelsForCurrentThread(); },
-                nullptr)) {
+                hwnd, [](PVOID)
+                { RemoveLabelsForCurrentThread(); },
+                nullptr))
+        {
             Wh_Log(L"Couldn't reach Explorer UI thread for window %08X",
                    static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(hwnd)));
         }
     }
 
-    if (g_visualTreeWatcher) {
+    if (g_visualTreeWatcher)
+    {
         g_visualTreeWatcher->Disconnect();
         g_visualTreeWatcher = nullptr;
     }
+    g_diagnosticsConnected.store(false, std::memory_order_release);
 
-    if (g_tapReadyEvent) {
+    if (g_tapReadyEvent)
+    {
         CloseHandle(g_tapReadyEvent);
         g_tapReadyEvent = nullptr;
     }

--- a/mods/explorer-title-bar-label.wh.cpp
+++ b/mods/explorer-title-bar-label.wh.cpp
@@ -1407,7 +1407,6 @@ static LRESULT CALLBACK ExplorerWindowSubclassProc(
     UINT message,
     WPARAM wParam,
     LPARAM lParam,
-    UINT_PTR,
     DWORD_PTR)
 {
     if (message == WM_NCDESTROY)

--- a/mods/explorer-title-bar-label.wh.cpp
+++ b/mods/explorer-title-bar-label.wh.cpp
@@ -317,6 +317,7 @@ static Settings g_settings;
 static std::mutex g_settingsMutex;
 
 static std::atomic<bool> g_unloading{false};
+static std::atomic<int> g_pendingScans{0};
 
 // ============================================================================
 // Settings helpers
@@ -1211,6 +1212,7 @@ struct LabelEntry
 };
 
 thread_local std::vector<std::shared_ptr<LabelEntry>> g_labelEntries;
+thread_local bool g_threadScanned = false;
 
 static void ReleaseLabelEntry(const std::shared_ptr<LabelEntry> &entry,
                               bool removeElement)
@@ -1300,8 +1302,30 @@ static void PruneReleasedLabelEntries()
     }
 }
 
+static bool HasLiveLabelForCurrentThread()
+{
+    PruneReleasedLabelEntries();
+
+    for (auto const &entry : g_labelEntries)
+    {
+        if (!entry || entry->cleaned)
+        {
+            continue;
+        }
+
+        if (entry->text.get() && entry->grid.get())
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 static void RemoveLabelsForCurrentThread()
 {
+    g_threadScanned = false;
+
     std::vector<std::shared_ptr<LabelEntry>> taken;
     taken.swap(g_labelEntries);
 
@@ -1636,7 +1660,14 @@ try
     std::vector<muxc::Grid> grids;
     CollectTitleBarGrids(content, 0, &grids);
     for (auto const &grid : grids)
+    {
         TryInsertTitleText(grid);
+    }
+
+    if (!grids.empty())
+    {
+        g_threadScanned = true;
+    }
 }
 catch (...)
 {
@@ -1644,22 +1675,46 @@ catch (...)
 }
 
 static void ScheduleXamlRootScan(mux::UIElement const &element)
-try
 {
     if (g_unloading.load() || !element)
-        return;
-    auto queue = winrt::Microsoft::UI::Dispatching::DispatcherQueue::GetForCurrentThread();
-    if (!queue)
     {
-        ScanXamlRootForTitleBars(element);
         return;
     }
-    queue.TryEnqueue([weak = winrt::make_weak(element)]()
-                     {
-        if (auto element = weak.get()) ScanXamlRootForTitleBars(element); });
-}
-catch (...)
-{
+
+    bool pendingAdded = false;
+
+    try
+    {
+        auto queue =
+            winrt::Microsoft::UI::Dispatching::DispatcherQueue::GetForCurrentThread();
+        if (!queue)
+        {
+            ScanXamlRootForTitleBars(element);
+            return;
+        }
+
+        g_pendingScans.fetch_add(1, std::memory_order_acq_rel);
+        pendingAdded = true;
+
+        if (!queue.TryEnqueue([weak = winrt::make_weak(element)]()
+                              {
+                if (auto element = weak.get()) {
+                    ScanXamlRootForTitleBars(element);
+                }
+
+                g_pendingScans.fetch_sub(1, std::memory_order_acq_rel); }))
+        {
+            g_pendingScans.fetch_sub(1, std::memory_order_acq_rel);
+            pendingAdded = false;
+        }
+    }
+    catch (...)
+    {
+        if (pendingAdded)
+        {
+            g_pendingScans.fetch_sub(1, std::memory_order_acq_rel);
+        }
+    }
 }
 
 static void ScanCurrentThreadForTitleBars()
@@ -1687,21 +1742,43 @@ catch (...)
 }
 
 static void ScheduleCurrentThreadScan()
-try
 {
     if (g_unloading.load())
-        return;
-    auto queue = winrt::Microsoft::UI::Dispatching::DispatcherQueue::GetForCurrentThread();
-    if (!queue)
     {
-        ScanCurrentThreadForTitleBars();
         return;
     }
-    queue.TryEnqueue([]()
-                     { ScanCurrentThreadForTitleBars(); });
-}
-catch (...)
-{
+
+    bool pendingAdded = false;
+
+    try
+    {
+        auto queue =
+            winrt::Microsoft::UI::Dispatching::DispatcherQueue::GetForCurrentThread();
+        if (!queue)
+        {
+            ScanCurrentThreadForTitleBars();
+            return;
+        }
+
+        g_pendingScans.fetch_add(1, std::memory_order_acq_rel);
+        pendingAdded = true;
+
+        if (!queue.TryEnqueue([]()
+                              {
+                ScanCurrentThreadForTitleBars();
+                g_pendingScans.fetch_sub(1, std::memory_order_acq_rel); }))
+        {
+            g_pendingScans.fetch_sub(1, std::memory_order_acq_rel);
+            pendingAdded = false;
+        }
+    }
+    catch (...)
+    {
+        if (pendingAdded)
+        {
+            g_pendingScans.fetch_sub(1, std::memory_order_acq_rel);
+        }
+    }
 }
 
 static void DiscoverFromElement(mux::UIElement const &element)
@@ -1783,6 +1860,11 @@ static void WINAPI CommandBarControl_GotFocusHandler_Hook(
         return;
     }
 
+    if (g_threadScanned && HasLiveLabelForCurrentThread())
+    {
+        return;
+    }
+
     try
     {
         auto const &inspectable =
@@ -1826,6 +1908,12 @@ static void WINAPI FileExplorerTabControl_TabView_GotFocus_Hook(
     void *pThis, void *sender, void *args)
 {
     FileExplorerTabControl_TabView_GotFocus_Original(pThis, sender, args);
+
+    if (g_threadScanned && HasLiveLabelForCurrentThread())
+    {
+        return;
+    }
+
     DiscoverFromInspectableParameter(sender);
 }
 
@@ -2058,13 +2146,50 @@ void Wh_ModUninit()
 {
     Wh_Log(L"Explorer Title Bar Label 1.0.0 uninit");
     g_unloading.store(true);
-    for (HWND hwnd : GetFileExplorerWindows())
+
+    auto windows = GetFileExplorerWindows();
+    for (HWND hwnd : windows)
     {
-        if (!RunFromWindowThread(hwnd, [](PVOID)
-                                 { RemoveLabelsForCurrentThread(); }, nullptr))
+        bool cleaned = false;
+
+        // A live Explorer window normally succeeds immediately. Retry briefly
+        // to cover a transient hook/setup failure during shell activity.
+        for (int attempt = 0; attempt < 3 && IsWindow(hwnd); ++attempt)
+        {
+            if (RunFromWindowThread(
+                    hwnd,
+                    [](PVOID)
+                    { RemoveLabelsForCurrentThread(); },
+                    nullptr))
+            {
+                cleaned = true;
+                break;
+            }
+
+            Sleep(10);
+        }
+
+        if (!cleaned && IsWindow(hwnd))
         {
             Wh_Log(L"Couldn't reach Explorer UI thread for window %08X",
                    static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(hwnd)));
         }
+    }
+
+    // DispatcherQueue callbacks contain code from this module. Wait briefly for
+    // all callbacks that were queued before g_unloading became true to finish
+    // before Windhawk is allowed to unmap the DLL.
+    for (int i = 0;
+         i < 200 &&
+         g_pendingScans.load(std::memory_order_acquire) > 0;
+         ++i)
+    {
+        Sleep(10);
+    }
+
+    if (g_pendingScans.load(std::memory_order_acquire) > 0)
+    {
+        Wh_Log(L"Timed out waiting for %d pending XAML scan callback(s)",
+               g_pendingScans.load(std::memory_order_relaxed));
     }
 }

--- a/mods/explorer-title-bar-label.wh.cpp
+++ b/mods/explorer-title-bar-label.wh.cpp
@@ -1373,7 +1373,9 @@ static void PruneReleasedLabelEntries()
 
         if (!entry->cleaned && !entry->text.get())
         {
-            ReleaseLabelEntry(entry, removeElement);
+            // The XAML element is already gone, so there's nothing left to
+            // remove from the tree. Just release delegates/timer state.
+            ReleaseLabelEntry(entry, false);
         }
 
         if (entry->cleaned)
@@ -1430,10 +1432,10 @@ static void RemoveLabelsForWindowOnCurrentThread(HWND hwnd, bool removeElement)
 
         if (entry && entry->hwnd == hwnd)
         {
-            // The native window is already going away, so there's no reason
-            // to mutate the XAML children collection. Just revoke delegates
-            // and release the strong DispatcherTimer reference.
-            ReleaseLabelEntry(entry, false);
+            // WM_NCDESTROY passes false because the native window is already
+            // going away. Explicit mod unload passes true so the visible XAML
+            // element is removed from a still-live Explorer window.
+            ReleaseLabelEntry(entry, removeElement);
             it = g_labelEntries.erase(it);
         }
         else

--- a/mods/explorer-title-bar-label.wh.cpp
+++ b/mods/explorer-title-bar-label.wh.cpp
@@ -206,7 +206,6 @@ Parts of the File Explorer hook and XAML discovery plumbing are adapted from **E
 
 #include <winrt/Microsoft.UI.h>
 #include <winrt/Microsoft.UI.Content.h>
-#include <winrt/Microsoft.UI.Dispatching.h>
 #include <winrt/Microsoft.UI.Xaml.Input.h>
 #include <winrt/Microsoft.UI.Xaml.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
@@ -219,6 +218,8 @@ Parts of the File Explorer hook and XAML discovery plumbing are adapted from **E
 #include <mutex>
 #include <string>
 #include <utility>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <windhawk_utils.h>
@@ -327,23 +328,9 @@ static Settings g_settings;
 static std::mutex g_settingsMutex;
 
 static std::atomic<bool> g_unloading{false};
-static std::atomic<int> g_pendingScans{0};
 
-struct PendingScan
-{
-    PendingScan()
-    {
-        g_pendingScans.fetch_add(1, std::memory_order_acq_rel);
-    }
-
-    PendingScan(const PendingScan &) = delete;
-    PendingScan &operator=(const PendingScan &) = delete;
-
-    ~PendingScan()
-    {
-        g_pendingScans.fetch_sub(1, std::memory_order_acq_rel);
-    }
-};
+static std::mutex g_subclassedWindowsMutex;
+static std::unordered_set<HWND> g_subclassedWindows;
 
 // ============================================================================
 // Settings helpers
@@ -1240,6 +1227,63 @@ struct LabelEntry
 
 thread_local std::vector<std::shared_ptr<LabelEntry>> g_labelEntries;
 thread_local bool g_threadScanned = false;
+thread_local std::unordered_map<HWND, winrt::weak_ref<mux::UIElement>>
+    g_pendingScanElements;
+
+static void ScanXamlRootForTitleBars(mux::UIElement const &element);
+static LRESULT CALLBACK ExplorerWindowSubclassProc(
+    HWND hwnd,
+    UINT message,
+    WPARAM wParam,
+    LPARAM lParam,
+    DWORD_PTR refData);
+
+static UINT GetScanMessage()
+{
+    static const UINT message =
+        RegisterWindowMessageW(L"Windhawk_ExplorerTitleBarLabel_Scan_" WH_MOD_ID);
+    return message;
+}
+
+static bool EnsureExplorerWindowSubclassed(HWND hwnd)
+{
+    if (!hwnd || g_unloading.load())
+    {
+        return false;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_subclassedWindowsMutex);
+        if (g_subclassedWindows.find(hwnd) != g_subclassedWindows.end())
+        {
+            return true;
+        }
+    }
+
+    if (!WindhawkUtils::SetWindowSubclassFromAnyThread(
+            hwnd, ExplorerWindowSubclassProc, 1))
+    {
+        return false;
+    }
+
+    bool keepSubclass = false;
+    {
+        std::lock_guard<std::mutex> lock(g_subclassedWindowsMutex);
+        if (!g_unloading.load())
+        {
+            g_subclassedWindows.insert(hwnd);
+            keepSubclass = true;
+        }
+    }
+
+    if (!keepSubclass)
+    {
+        WindhawkUtils::RemoveWindowSubclassFromAnyThread(
+            hwnd, ExplorerWindowSubclassProc);
+    }
+
+    return keepSubclass;
+}
 
 static void ReleaseLabelEntry(const std::shared_ptr<LabelEntry> &entry,
                               bool removeElement)
@@ -1378,6 +1422,8 @@ static void RemoveLabelsForCurrentThread()
 
 static void RemoveLabelsForWindowOnCurrentThread(HWND hwnd)
 {
+    g_pendingScanElements.erase(hwnd);
+
     for (auto it = g_labelEntries.begin(); it != g_labelEntries.end();)
     {
         auto entry = *it;
@@ -1409,9 +1455,35 @@ static LRESULT CALLBACK ExplorerWindowSubclassProc(
     LPARAM lParam,
     DWORD_PTR)
 {
+    if (message == GetScanMessage())
+    {
+        auto it = g_pendingScanElements.find(hwnd);
+        if (it != g_pendingScanElements.end())
+        {
+            auto weakElement = it->second;
+            g_pendingScanElements.erase(it);
+
+            if (!g_unloading.load())
+            {
+                if (auto element = weakElement.get())
+                {
+                    ScanXamlRootForTitleBars(element);
+                }
+            }
+        }
+
+        return 0;
+    }
+
     if (message == WM_NCDESTROY)
     {
         RemoveLabelsForWindowOnCurrentThread(hwnd);
+
+        {
+            std::lock_guard<std::mutex> lock(g_subclassedWindowsMutex);
+            g_subclassedWindows.erase(hwnd);
+        }
+
         WindhawkUtils::RemoveWindowSubclassFromAnyThread(
             hwnd, ExplorerWindowSubclassProc);
     }
@@ -1626,11 +1698,9 @@ static void TryInsertTitleText(muxc::Grid const &grid)
         return;
     }
 
-    // Install the native-window teardown hook before creating XAML delegates.
-    // If the window closes, WM_NCDESTROY will synchronously release this
-    // window's entries on the same UI thread.
-    if (!WindhawkUtils::SetWindowSubclassFromAnyThread(
-            hwnd, ExplorerWindowSubclassProc, 1))
+    // The scan path normally installs this before insertion. Keep this check
+    // here as a safety net for any synchronous discovery path.
+    if (!EnsureExplorerWindowSubclassed(hwnd))
     {
         Wh_Log(L"Failed to subclass Explorer window %08X",
                static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(hwnd)));
@@ -1785,27 +1855,44 @@ static void ScheduleXamlRootScan(mux::UIElement const &element)
 
     try
     {
-        auto queue =
-            winrt::Microsoft::UI::Dispatching::DispatcherQueue::GetForCurrentThread();
-        if (!queue)
+        auto frameworkElement = element.try_as<mux::FrameworkElement>();
+        HWND hwnd = frameworkElement
+                        ? GetExplorerWindowForElement(frameworkElement)
+                        : nullptr;
+
+        if (!hwnd)
         {
+            // No native host to post to. Scan synchronously so no callback can
+            // outlive the mod.
             ScanXamlRootForTitleBars(element);
             return;
         }
 
-        auto pending = std::make_shared<PendingScan>();
+        // Install the subclass on first discovery, before posting any message.
+        if (!EnsureExplorerWindowSubclassed(hwnd))
+        {
+            Wh_Log(L"Failed to subclass Explorer window %08X for scan",
+                   static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(hwnd)));
+            return;
+        }
 
-        queue.TryEnqueue(
-            [pending, weak = winrt::make_weak(element)]()
-            {
-                if (auto element = weak.get())
-                {
-                    ScanXamlRootForTitleBars(element);
-                }
-            });
+        // Keep only a weak XAML reference in thread-local state. Multiple
+        // requests for the same window coalesce naturally to the newest root.
+        g_pendingScanElements[hwnd] = winrt::make_weak(element);
+
+        if (!PostMessageW(hwnd, GetScanMessage(), 0, 0))
+        {
+            g_pendingScanElements.erase(hwnd);
+
+            // Posting failed, so run synchronously rather than leaving work
+            // outstanding.
+            ScanXamlRootForTitleBars(element);
+        }
     }
     catch (...)
     {
+        Wh_Log(L"Failed to schedule XAML scan hr=0x%08X",
+               winrt::to_hresult());
     }
 }
 
@@ -1831,36 +1918,6 @@ try
 }
 catch (...)
 {
-}
-
-static void ScheduleCurrentThreadScan()
-{
-    if (g_unloading.load())
-    {
-        return;
-    }
-
-    try
-    {
-        auto queue =
-            winrt::Microsoft::UI::Dispatching::DispatcherQueue::GetForCurrentThread();
-        if (!queue)
-        {
-            ScanCurrentThreadForTitleBars();
-            return;
-        }
-
-        auto pending = std::make_shared<PendingScan>();
-
-        queue.TryEnqueue(
-            [pending]()
-            {
-                ScanCurrentThreadForTitleBars();
-            });
-    }
-    catch (...)
-    {
-    }
 }
 
 static void DiscoverFromElement(mux::UIElement const &element)
@@ -2226,20 +2283,37 @@ void Wh_ModUninit()
     Wh_Log(L"Explorer Title Bar Label 1.0.0 uninit");
     g_unloading.store(true);
 
-    auto windows = GetFileExplorerWindows();
-    for (HWND hwnd : windows)
+    // Tear down only windows that this mod actually subclassed. Copy and clear
+    // under the lock, then release it before any cross-thread SendMessage-based
+    // helper calls.
+    std::vector<HWND> subclassedWindows;
     {
+        std::lock_guard<std::mutex> lock(g_subclassedWindowsMutex);
+        subclassedWindows.assign(g_subclassedWindows.begin(),
+                                 g_subclassedWindows.end());
+        g_subclassedWindows.clear();
+    }
+
+    for (HWND hwnd : subclassedWindows)
+    {
+        if (!IsWindow(hwnd))
+        {
+            continue;
+        }
+
         bool cleaned = false;
 
-        // A live Explorer window normally succeeds immediately. Retry briefly
-        // to cover a transient hook/setup failure during shell activity.
+        // Release this window's XAML objects on its owning UI thread.
         for (int attempt = 0; attempt < 3 && IsWindow(hwnd); ++attempt)
         {
             if (RunFromWindowThread(
                     hwnd,
-                    [](PVOID)
-                    { RemoveLabelsForCurrentThread(); },
-                    nullptr))
+                    [](PVOID parameter)
+                    {
+                        RemoveLabelsForWindowOnCurrentThread(
+                            reinterpret_cast<HWND>(parameter));
+                    },
+                    hwnd))
             {
                 cleaned = true;
                 break;
@@ -2254,26 +2328,9 @@ void Wh_ModUninit()
                    static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(hwnd)));
         }
 
-        // The subclass callback lives in this DLL, so it must be removed before
-        // Windhawk can unmap the mod.
+        // Remove synchronously. Any already-posted scan message then becomes a
+        // normal unhandled window message and can no longer call into this DLL.
         WindhawkUtils::RemoveWindowSubclassFromAnyThread(
             hwnd, ExplorerWindowSubclassProc);
-    }
-
-    // DispatcherQueue callbacks contain code from this module. Wait briefly for
-    // all callbacks that were queued before g_unloading became true to finish
-    // or be discarded. PendingScan decrements in either case.
-    for (int i = 0;
-         i < 200 &&
-         g_pendingScans.load(std::memory_order_acquire) > 0;
-         ++i)
-    {
-        Sleep(10);
-    }
-
-    if (g_pendingScans.load(std::memory_order_acquire) > 0)
-    {
-        Wh_Log(L"Timed out waiting for %d pending XAML scan callback(s)",
-               g_pendingScans.load(std::memory_order_relaxed));
     }
 }

--- a/mods/explorer-title-bar-label.wh.cpp
+++ b/mods/explorer-title-bar-label.wh.cpp
@@ -1790,7 +1790,7 @@ enum class SymbolHookResult
 
 static SymbolHookResult HookFileExplorerExtensionsSymbols(HMODULE module)
 {
-    WindhawkUtils::SYMBOL_HOOK hooks[] = {
+    WindhawkUtils::SYMBOL_HOOK fileExplorerExtensionsDllHooks[] = {
         {
             {
                 LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarManager::CommandBar(struct winrt::Microsoft::UI::Xaml::Controls::CommandBar const &))",
@@ -1849,7 +1849,7 @@ static SymbolHookResult HookFileExplorerExtensionsSymbols(HMODULE module)
 
     Wh_Log(L"Resolving FileExplorerExtensions hooks");
 
-    if (!WindhawkUtils::HookSymbols(module, hooks, ARRAYSIZE(hooks)))
+    if (!WindhawkUtils::HookSymbols(module, fileExplorerExtensionsDllHooks, ARRAYSIZE(fileExplorerExtensionsDllHooks)))
     {
         Wh_Log(L"HookSymbols(FileExplorerExtensions.dll) failed");
         return SymbolHookResult::ResolutionFailed;
@@ -1970,3 +1970,4 @@ void Wh_ModUninit()
         }
     }
 }
+

--- a/mods/explorer-title-bar-label.wh.cpp
+++ b/mods/explorer-title-bar-label.wh.cpp
@@ -12,6 +12,27 @@
 // ==/WindhawkMod==
 
 // Source code is published under the GNU General Public License v3.0.
+// Portions of the File Explorer hook and XAML discovery code are adapted
+// from Explorer Command Bar by DanRotaru, licensed under the MIT License.
+//
+// Copyright (c) DanRotaru
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE.
 
 // ==WindhawkModReadme==
 /*
@@ -53,18 +74,6 @@ If the mod is enabled while File Explorer windows are already open, the label ma
 
 Parts of the File Explorer hook and XAML discovery plumbing are adapted from **Explorer Command Bar** by **DanRotaru**, licensed under the MIT License.
 
-<details>
-<summary>MIT license notice for reused code</summary>
-
-Copyright (c) DanRotaru
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE.
-
-</details>
 */
 // ==/WindhawkModReadme==
 
@@ -1964,61 +1973,55 @@ enum class SymbolHookResult
 static SymbolHookResult HookFileExplorerExtensionsSymbols(HMODULE module)
 {
     WindhawkUtils::SYMBOL_HOOK fileExplorerExtensionsDllHooks[] = {
+    {
         {
-            {
-                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarManager::CommandBar(struct winrt::Microsoft::UI::Xaml::Controls::CommandBar const &))",
-                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarManager::CommandBar(struct winrt::Microsoft::UI::Xaml::Controls::CommandBar const & __ptr64) __ptr64)",
-            },
-            &CommandBarManager_CommandBar_Original,
-            CommandBarManager_CommandBar_Hook,
-            true,
+            LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarManager::CommandBar(struct winrt::Microsoft::UI::Xaml::Controls::CommandBar const &))",
         },
+        &CommandBarManager_CommandBar_Original,
+        CommandBarManager_CommandBar_Hook,
+        true,
+    },
+    {
         {
-            {
-                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_Loaded(struct winrt::Windows::Foundation::IInspectable const &,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const &))",
-                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_Loaded(struct winrt::Windows::Foundation::IInspectable const & __ptr64,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const & __ptr64) __ptr64)",
-            },
-            &FileExplorerTabControl_TabView_Loaded_Original,
-            FileExplorerTabControl_TabView_Loaded_Hook,
-            true,
+            LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_Loaded(struct winrt::Windows::Foundation::IInspectable const &,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const &))",
         },
+        &FileExplorerTabControl_TabView_Loaded_Original,
+        FileExplorerTabControl_TabView_Loaded_Hook,
+        true,
+    },
+    {
         {
-            {
-                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_GotFocus(struct winrt::Windows::Foundation::IInspectable const &,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const &))",
-                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_GotFocus(struct winrt::Windows::Foundation::IInspectable const & __ptr64,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const & __ptr64) __ptr64)",
-            },
-            &FileExplorerTabControl_TabView_GotFocus_Original,
-            FileExplorerTabControl_TabView_GotFocus_Hook,
-            true,
+            LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_GotFocus(struct winrt::Windows::Foundation::IInspectable const &,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const &))",
         },
+        &FileExplorerTabControl_TabView_GotFocus_Original,
+        FileExplorerTabControl_TabView_GotFocus_Hook,
+        true,
+    },
+    {
         {
-            {
-                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_SelectionChanged(struct winrt::Windows::Foundation::IInspectable const &,struct winrt::Microsoft::UI::Xaml::Controls::SelectionChangedEventArgs const &))",
-                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_SelectionChanged(struct winrt::Windows::Foundation::IInspectable const & __ptr64,struct winrt::Microsoft::UI::Xaml::Controls::SelectionChangedEventArgs const & __ptr64) __ptr64)",
-            },
-            &FileExplorerTabControl_TabView_SelectionChanged_Original,
-            FileExplorerTabControl_TabView_SelectionChanged_Hook,
-            true,
+            LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_SelectionChanged(struct winrt::Windows::Foundation::IInspectable const &,struct winrt::Microsoft::UI::Xaml::Controls::SelectionChangedEventArgs const &))",
         },
+        &FileExplorerTabControl_TabView_SelectionChanged_Original,
+        FileExplorerTabControl_TabView_SelectionChanged_Hook,
+        true,
+    },
+    {
         {
-            {
-                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_TabItemsChanged(struct winrt::Microsoft::UI::Xaml::Controls::TabView const &,struct winrt::Windows::Foundation::Collections::IVectorChangedEventArgs const &))",
-                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_TabItemsChanged(struct winrt::Microsoft::UI::Xaml::Controls::TabView const & __ptr64,struct winrt::Windows::Foundation::Collections::IVectorChangedEventArgs const & __ptr64) __ptr64)",
-            },
-            &FileExplorerTabControl_TabView_TabItemsChanged_Original,
-            FileExplorerTabControl_TabView_TabItemsChanged_Hook,
-            true,
+            LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_TabItemsChanged(struct winrt::Microsoft::UI::Xaml::Controls::TabView const &,struct winrt::Windows::Foundation::Collections::IVectorChangedEventArgs const &))",
         },
+        &FileExplorerTabControl_TabView_TabItemsChanged_Original,
+        FileExplorerTabControl_TabView_TabItemsChanged_Hook,
+        true,
+    },
+    {
         {
-            {
-                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarControl::CommandBarControlGotFocusHandler(struct winrt::Windows::Foundation::IInspectable const &,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const &))",
-                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarControl::CommandBarControlGotFocusHandler(struct winrt::Windows::Foundation::IInspectable const & __ptr64,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const & __ptr64) __ptr64)",
-            },
-            &CommandBarControl_GotFocusHandler_Original,
-            CommandBarControl_GotFocusHandler_Hook,
-            true,
+            LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarControl::CommandBarControlGotFocusHandler(struct winrt::Windows::Foundation::IInspectable const &,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const &))",
         },
-    };
+        &CommandBarControl_GotFocusHandler_Original,
+        CommandBarControl_GotFocusHandler_Hook,
+        true,
+    },
+};
 
     Wh_Log(L"Resolving FileExplorerExtensions hooks");
 

--- a/mods/explorer-title-bar-label.wh.cpp
+++ b/mods/explorer-title-bar-label.wh.cpp
@@ -45,7 +45,9 @@ Time can use **12-hour or 24-hour format**, with optional seconds.
 
 ## Compatibility
 
-This mod uses XAML diagnostics, which allows only one diagnostics consumer per Explorer process. Known conflicts include **Windows 11 File Explorer Styler**, **ExplorerBlurMica**, **TranslucentTB**, and other tools/mods that attach to File Explorer XAML diagnostics. If another consumer blocks the connection, the label will not appear.
+This mod does not use XAML Diagnostics, so it can be used together with **Windows 11 File Explorer Styler** and other tools/mods that consume File Explorer XAML diagnostics.
+
+If the mod is enabled while File Explorer windows are already open, the label may only appear in newly opened windows or after Explorer rebuilds the relevant tab UI (for example, after tab activity). This is a limitation of avoiding XAML Diagnostics.
 */
 // ==/WindhawkModReadme==
 
@@ -166,9 +168,7 @@ This mod uses XAML diagnostics, which allows only one diagnostics consumer per E
 
 #undef GetCurrentTime
 
-#include <xamlom.h>
 #include <Unknwn.h>
-#include <ocidl.h>
 
 #include <winrt/base.h>
 #include <winrt/Windows.Foundation.h>
@@ -178,6 +178,8 @@ This mod uses XAML diagnostics, which allows only one diagnostics consumer per E
 
 #include <winrt/Microsoft.UI.h>
 #include <winrt/Microsoft.UI.Content.h>
+#include <winrt/Microsoft.UI.Dispatching.h>
+#include <winrt/Microsoft.UI.Xaml.Input.h>
 #include <winrt/Microsoft.UI.Xaml.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.Media.h>
@@ -190,6 +192,8 @@ This mod uses XAML diagnostics, which allows only one diagnostics consumer per E
 #include <string>
 #include <utility>
 #include <vector>
+
+#include <windhawk_utils.h>
 
 namespace wf = winrt::Windows::Foundation;
 namespace mux = winrt::Microsoft::UI::Xaml;
@@ -302,10 +306,6 @@ static std::atomic<uint64_t> g_settingsGeneration{1};
 static std::mutex g_settingsMutex;
 
 static std::atomic<bool> g_unloading{false};
-static std::atomic<bool> g_diagnosticsConnected{false};
-static std::mutex g_connectorMutex;
-static HANDLE g_connectorThread = nullptr;
-static HANDLE g_tapReadyEvent = nullptr;
 
 // ============================================================================
 // Settings helpers
@@ -1404,737 +1404,512 @@ static bool RunFromWindowThread(HWND hwnd,
     return true;
 }
 
-static void EnsureConnectorStarted();
+// ============================================================================
+// Title-bar discovery without XAML Diagnostics
+// ============================================================================
 
-// Connect only after a real File Explorer top-level window exists. This avoids
-// occupying the XAML diagnostics slot in shell-only explorer.exe processes and
-// means a File Explorer window opened long after login still triggers setup.
-using CreateWindowExW_t = decltype(&CreateWindowExW);
-static CreateWindowExW_t CreateWindowExW_Original = nullptr;
-
-static HWND WINAPI CreateWindowExW_Hook(DWORD exStyle,
-                                        LPCWSTR className,
-                                        LPCWSTR windowName,
-                                        DWORD style,
-                                        int x,
-                                        int y,
-                                        int width,
-                                        int height,
-                                        HWND parent,
-                                        HMENU menu,
-                                        HINSTANCE instance,
-                                        PVOID param)
+static void TryInsertTitleText(muxc::Grid const &grid)
 {
-    HWND hwnd = CreateWindowExW_Original(
-        exStyle, className, windowName, style, x, y, width, height, parent,
-        menu, instance, param);
+    if (!grid || g_unloading.load())
+        return;
 
-    if (hwnd && !g_unloading.load() && IsFileExplorerWindow(hwnd))
+    auto children = grid.Children();
+    mux::FrameworkElement rightAnchor{nullptr};
+    for (uint32_t i = 0; i < children.Size(); ++i)
     {
-        EnsureConnectorStarted();
+        auto child = children.GetAt(i).try_as<mux::FrameworkElement>();
+        if (!child)
+            continue;
+        if (child.Name() == L"WindhawkExplorerTitleBarLabel")
+            return;
+        if (child.Name() == L"RightContentPresenter")
+            rightAnchor = child;
     }
+    if (!rightAnchor)
+        return;
 
-    return hwnd;
+    PruneReleasedLabelEntries();
+    SettingsSnapshot initialSnapshot = GetSettingsSnapshot();
+
+    muxc::TextBlock text;
+    text.Name(L"WindhawkExplorerTitleBarLabel");
+    ApplyTextSettings(text, initialSnapshot.settings);
+    muxc::Grid::SetColumn(text, muxc::Grid::GetColumn(rightAnchor));
+    muxc::Grid::SetRow(text, muxc::Grid::GetRow(rightAnchor));
+    muxc::Canvas::SetZIndex(text, 100);
+    children.Append(text);
+
+    try
+    {
+        grid.UpdateLayout();
+    }
+    catch (...)
+    {
+    }
+    UpdateLabelPosition(text, grid, initialSnapshot.settings.verticalOffset);
+
+    auto entry = std::make_shared<LabelEntry>();
+    entry->text = winrt::make_weak(text);
+    entry->grid = winrt::make_weak(grid);
+    entry->seenGeneration = initialSnapshot.generation;
+    entry->currentSettings = initialSnapshot.settings;
+    entry->lastText = BuildDisplayText(initialSnapshot.settings);
+    g_labelEntries.push_back(entry);
+    std::weak_ptr<LabelEntry> weakEntry = entry;
+
+    try
+    {
+        entry->sizeChangedToken = grid.SizeChanged(
+            [weakEntry](auto const &, mux::SizeChangedEventArgs const &)
+            {
+                auto entry = weakEntry.lock();
+                if (!entry || entry->cleaned || g_unloading.load())
+                    return;
+                auto text = entry->text.get();
+                auto grid = entry->grid.get();
+                if (!text || !grid)
+                    return;
+                SettingsSnapshot snapshot = GetSettingsSnapshot();
+                UpdateLabelPosition(text, grid, snapshot.settings.verticalOffset);
+            });
+        entry->sizeChangedRegistered = true;
+
+        mux::DispatcherTimer timer;
+        timer.Interval(std::chrono::seconds(1));
+        entry->timer = timer;
+        entry->tickToken = timer.Tick([weakEntry](auto const &, auto const &)
+                                      {
+            auto entry = weakEntry.lock();
+            if (!entry || entry->cleaned) return;
+            auto text = entry->text.get();
+            if (!text) { ReleaseLabelEntry(entry, false); return; }
+            if (g_unloading.load()) { ReleaseLabelEntry(entry, true); return; }
+
+            uint64_t generation = g_settingsGeneration.load(std::memory_order_acquire);
+            if (generation != entry->seenGeneration) {
+                SettingsSnapshot snapshot = GetSettingsSnapshot();
+                entry->seenGeneration = snapshot.generation;
+                entry->currentSettings = snapshot.settings;
+                ApplyTextSettings(text, entry->currentSettings);
+                entry->lastText = BuildDisplayText(entry->currentSettings);
+                if (auto grid = entry->grid.get())
+                    UpdateLabelPosition(text, grid, entry->currentSettings.verticalOffset);
+            }
+
+            std::wstring current = BuildDisplayText(entry->currentSettings);
+            if (current != entry->lastText) {
+                text.Text(current);
+                entry->lastText = std::move(current);
+                if (auto grid = entry->grid.get())
+                    UpdateLabelPosition(text, grid, entry->currentSettings.verticalOffset);
+            } });
+        entry->tickRegistered = true;
+        timer.Start();
+        Wh_Log(L"Title-bar label attached");
+    }
+    catch (...)
+    {
+        ReleaseLabelEntry(entry, true);
+        PruneReleasedLabelEntries();
+        throw;
+    }
 }
 
-// ============================================================================
-// Visual Tree Watcher
-// ============================================================================
-
-class VisualTreeWatcher
-    : public winrt::implements<VisualTreeWatcher, IVisualTreeServiceCallback2,
-                               winrt::non_agile>
+static void CollectTitleBarGrids(mux::DependencyObject const &root, int depth,
+                                 std::vector<muxc::Grid> *grids)
 {
-public:
-    explicit VisualTreeWatcher(winrt::com_ptr<IUnknown> site)
-        : m_xamlDiagnostics(site.as<IXamlDiagnostics>()),
-          m_visualTreeService(site.as<IVisualTreeService3>())
+    if (!root || depth > 64)
+        return;
+    int count = muxm::VisualTreeHelper::GetChildrenCount(root);
+    for (int i = 0; i < count; ++i)
     {
-        // AdviseVisualTreeChange must be made from a separate thread in
-        // Explorer. Keep the handle so shutdown can wait for it safely.
-        AddRef();
-        m_adviseThread = CreateThread(
-            nullptr, 0,
-            [](LPVOID parameter) -> DWORD
+        auto child = muxm::VisualTreeHelper::GetChild(root, i);
+        if (auto element = child.try_as<mux::FrameworkElement>();
+            element && element.Name() == L"TabContainerGrid")
+        {
+            if (auto grid = child.try_as<muxc::Grid>())
             {
-                auto watcher = static_cast<VisualTreeWatcher *>(parameter);
-                HRESULT hr =
-                    watcher->m_visualTreeService->AdviseVisualTreeChange(watcher);
-                if (FAILED(hr))
-                {
-                    Wh_Log(L"AdviseVisualTreeChange failed hr=0x%08X", hr);
-                }
-                watcher->Release();
-                return 0;
-            },
-            this, 0, nullptr);
-
-        if (!m_adviseThread)
-        {
-            Wh_Log(L"CreateThread for XAML visual tree watcher failed: %u",
-                   GetLastError());
-            Release();
-        }
-    }
-
-    ~VisualTreeWatcher()
-    {
-        // Normally Disconnect() has already joined and closed this handle. If
-        // destruction happens on the advise thread itself, only close it here.
-        if (m_adviseThread)
-        {
-            CloseHandle(m_adviseThread);
-            m_adviseThread = nullptr;
-        }
-    }
-
-    void Disconnect()
-    {
-        if (m_disconnected)
-        {
-            return;
-        }
-        m_disconnected = true;
-
-        WaitForAdviseThread();
-
-        if (!m_visualTreeService)
-        {
-            return;
-        }
-
-        HRESULT hr = m_visualTreeService->UnadviseVisualTreeChange(this);
-        if (FAILED(hr))
-        {
-            Wh_Log(L"UnadviseVisualTreeChange failed hr=0x%08X", hr);
-        }
-    }
-
-private:
-    void WaitForAdviseThread()
-    {
-        if (!m_adviseThread)
-        {
-            return;
-        }
-
-        DWORD threadId = GetThreadId(m_adviseThread);
-        if (threadId != 0 && threadId != GetCurrentThreadId())
-        {
-            WaitForSingleObject(m_adviseThread, INFINITE);
-        }
-
-        CloseHandle(m_adviseThread);
-        m_adviseThread = nullptr;
-    }
-
-    wf::IInspectable FromHandle(InstanceHandle handle)
-    {
-        wf::IInspectable object{nullptr};
-
-        HRESULT hr = m_xamlDiagnostics->GetIInspectableFromHandle(
-            handle, reinterpret_cast<::IInspectable **>(winrt::put_abi(object)));
-        if (FAILED(hr))
-        {
-            return nullptr;
-        }
-
-        return object;
-    }
-
-    void TryInsertTitleText(InstanceHandle handle)
-    {
-        auto inspectable = FromHandle(handle);
-        if (!inspectable)
-        {
-            return;
-        }
-
-        auto frameworkElement = inspectable.try_as<mux::FrameworkElement>();
-        if (!frameworkElement ||
-            frameworkElement.Name() != L"TabContainerGrid")
-        {
-            return;
-        }
-
-        auto grid = inspectable.try_as<muxc::Grid>();
-        if (!grid)
-        {
-            return;
-        }
-
-        auto children = grid.Children();
-        mux::FrameworkElement rightAnchor{nullptr};
-
-        for (uint32_t i = 0; i < children.Size(); ++i)
-        {
-            auto child = children.GetAt(i).try_as<mux::FrameworkElement>();
-            if (!child)
-            {
+                grids->push_back(std::move(grid));
                 continue;
             }
+        }
+        CollectTitleBarGrids(child, depth + 1, grids);
+    }
+}
 
-            if (child.Name() == L"WindhawkExplorerTitleBarLabel")
+static void ScanXamlRootForTitleBars(mux::UIElement const &element)
+try
+{
+    if (g_unloading.load() || !element)
+        return;
+    auto xamlRoot = element.XamlRoot();
+    if (!xamlRoot)
+        return;
+    auto content = xamlRoot.Content();
+    if (!content)
+        return;
+    std::vector<muxc::Grid> grids;
+    CollectTitleBarGrids(content, 0, &grids);
+    for (auto const &grid : grids)
+        TryInsertTitleText(grid);
+}
+catch (...)
+{
+    Wh_Log(L"ScanXamlRootForTitleBars exception hr=0x%08X", winrt::to_hresult());
+}
+
+static void ScheduleXamlRootScan(mux::UIElement const &element)
+try
+{
+    if (g_unloading.load() || !element)
+        return;
+    auto queue = winrt::Microsoft::UI::Dispatching::DispatcherQueue::GetForCurrentThread();
+    if (!queue)
+    {
+        ScanXamlRootForTitleBars(element);
+        return;
+    }
+    queue.TryEnqueue([weak = winrt::make_weak(element)]()
+                     {
+        if (auto element = weak.get()) ScanXamlRootForTitleBars(element); });
+}
+catch (...)
+{
+}
+
+static void ScanCurrentThreadForTitleBars()
+try
+{
+    if (g_unloading.load())
+        return;
+    for (auto const &entry : g_labelEntries)
+    {
+        if (entry && !entry->cleaned)
+        {
+            if (auto grid = entry->grid.get())
             {
+                ScanXamlRootForTitleBars(grid);
                 return;
             }
-
-            if (child.Name() == L"RightContentPresenter")
-            {
-                rightAnchor = child;
-            }
-        }
-
-        if (!rightAnchor)
-        {
-            Wh_Log(L"RightContentPresenter not found");
-            return;
-        }
-
-        PruneReleasedLabelEntries();
-
-        int32_t targetColumn = muxc::Grid::GetColumn(rightAnchor);
-        int32_t targetRow = muxc::Grid::GetRow(rightAnchor);
-
-        SettingsSnapshot initialSnapshot = GetSettingsSnapshot();
-
-        muxc::TextBlock text;
-        text.Name(L"WindhawkExplorerTitleBarLabel");
-        ApplyTextSettings(text, initialSnapshot.settings);
-        muxc::Grid::SetColumn(text, targetColumn);
-        muxc::Grid::SetRow(text, targetRow);
-        muxc::Canvas::SetZIndex(text, 100);
-        children.Append(text);
-
-        try
-        {
-            grid.UpdateLayout();
-        }
-        catch (...)
-        {
-            Wh_Log(L"Initial title-bar layout update failed hr=0x%08X",
-                   winrt::to_hresult());
-        }
-
-        UpdateLabelPosition(text, grid,
-                            initialSnapshot.settings.verticalOffset);
-
-        auto entry = std::make_shared<LabelEntry>();
-        entry->text = winrt::make_weak(text);
-        entry->grid = winrt::make_weak(grid);
-        entry->seenGeneration = initialSnapshot.generation;
-        entry->currentSettings = initialSnapshot.settings;
-        entry->lastText = BuildDisplayText(initialSnapshot.settings);
-
-        // Track the entry before registering any delegate whose callback lives
-        // in this DLL, so shutdown can always revoke partially initialized
-        // handlers.
-        g_labelEntries.push_back(entry);
-        std::weak_ptr<LabelEntry> weakEntry = entry;
-
-        try
-        {
-            entry->sizeChangedToken = grid.SizeChanged(
-                [weakEntry](auto const &, mux::SizeChangedEventArgs const &)
-                {
-                    auto entry = weakEntry.lock();
-                    if (!entry || entry->cleaned || g_unloading.load())
-                    {
-                        return;
-                    }
-
-                    auto text = entry->text.get();
-                    auto grid = entry->grid.get();
-                    if (!text || !grid)
-                    {
-                        return;
-                    }
-
-                    SettingsSnapshot snapshot = GetSettingsSnapshot();
-                    UpdateLabelPosition(text, grid,
-                                        snapshot.settings.verticalOffset);
-                });
-            entry->sizeChangedRegistered = true;
-
-            mux::DispatcherTimer timer;
-            timer.Interval(std::chrono::seconds(1));
-
-            entry->timer = timer;
-            entry->tickToken = timer.Tick(
-                [weakEntry](auto const &, auto const &)
-                {
-                    auto entry = weakEntry.lock();
-                    if (!entry || entry->cleaned)
-                    {
-                        return;
-                    }
-
-                    auto text = entry->text.get();
-                    if (!text)
-                    {
-                        ReleaseLabelEntry(entry, false);
-                        return;
-                    }
-
-                    if (g_unloading.load())
-                    {
-                        ReleaseLabelEntry(entry, true);
-                        return;
-                    }
-
-                    uint64_t generation =
-                        g_settingsGeneration.load(std::memory_order_acquire);
-                    bool settingsChanged =
-                        generation != entry->seenGeneration;
-
-                    if (settingsChanged)
-                    {
-                        SettingsSnapshot snapshot = GetSettingsSnapshot();
-                        entry->seenGeneration = snapshot.generation;
-                        entry->currentSettings = snapshot.settings;
-
-                        ApplyTextSettings(text, entry->currentSettings);
-                        entry->lastText =
-                            BuildDisplayText(entry->currentSettings);
-
-                        if (auto grid = entry->grid.get())
-                        {
-                            UpdateLabelPosition(
-                                text, grid,
-                                entry->currentSettings.verticalOffset);
-                        }
-                    }
-
-                    std::wstring current =
-                        BuildDisplayText(entry->currentSettings);
-                    if (current != entry->lastText)
-                    {
-                        text.Text(current);
-                        entry->lastText = std::move(current);
-
-                        if (auto grid = entry->grid.get())
-                        {
-                            UpdateLabelPosition(
-                                text, grid,
-                                entry->currentSettings.verticalOffset);
-                        }
-                    }
-                });
-            entry->tickRegistered = true;
-
-            timer.Start();
-        }
-        catch (...)
-        {
-            ReleaseLabelEntry(entry, true);
-            PruneReleasedLabelEntries();
-            throw;
         }
     }
-
-    HRESULT STDMETHODCALLTYPE OnVisualTreeChange(
-        ParentChildRelation,
-        VisualElement element,
-        VisualMutationType mutationType) override
-    {
-        try
-        {
-            if (!g_unloading.load() && mutationType == Add)
-            {
-                TryInsertTitleText(element.Handle);
-            }
-        }
-        catch (...)
-        {
-            Wh_Log(L"OnVisualTreeChange exception hr=0x%08X",
-                   winrt::to_hresult());
-        }
-
-        return S_OK;
-    }
-
-    HRESULT STDMETHODCALLTYPE OnElementStateChanged(InstanceHandle,
-                                                    VisualElementState,
-                                                    LPCWSTR) noexcept override
-    {
-        return S_OK;
-    }
-
-    winrt::com_ptr<IXamlDiagnostics> m_xamlDiagnostics;
-    winrt::com_ptr<IVisualTreeService3> m_visualTreeService;
-    HANDLE m_adviseThread = nullptr;
-    bool m_disconnected = false;
-};
-
-static winrt::com_ptr<VisualTreeWatcher> g_visualTreeWatcher;
-
-// ============================================================================
-// TAP
-// ============================================================================
-
-static constexpr CLSID CLSID_WindhawkTitleBarLabelTAP = {
-    0x48b7eb40,
-    0xd62d,
-    0x49c0,
-    {0x9f, 0x13, 0x27, 0x41, 0xa7, 0x9b, 0xb4, 0x11},
-};
-
-class WindhawkTAP
-    : public winrt::implements<WindhawkTAP, IObjectWithSite,
-                               winrt::non_agile>
+    auto focused = mux::Input::FocusManager::GetFocusedElement();
+    if (auto element = focused ? focused.try_as<mux::UIElement>() : nullptr)
+        ScanXamlRootForTitleBars(element);
+}
+catch (...)
 {
-public:
-    HRESULT STDMETHODCALLTYPE SetSite(IUnknown *site) override
-    {
-        try
-        {
-            if (g_visualTreeWatcher)
-            {
-                g_visualTreeWatcher->Disconnect();
-                g_visualTreeWatcher = nullptr;
-            }
-            g_diagnosticsConnected.store(false, std::memory_order_release);
+}
 
-            m_site.copy_from(site);
-
-            if (m_site)
-            {
-                // Balance the module reference added by
-                // InitializeXamlDiagnosticsEx even during shutdown.
-                HMODULE module = GetCurrentModuleHandle();
-                if (module)
-                {
-                    FreeLibrary(module);
-                }
-
-                if (!g_unloading.load())
-                {
-                    g_visualTreeWatcher =
-                        winrt::make_self<VisualTreeWatcher>(m_site);
-                    g_diagnosticsConnected.store(
-                        true, std::memory_order_release);
-
-                    if (g_tapReadyEvent)
-                    {
-                        SetEvent(g_tapReadyEvent);
-                    }
-                }
-            }
-
-            return S_OK;
-        }
-        catch (...)
-        {
-            HRESULT hr = winrt::to_hresult();
-            Wh_Log(L"SetSite exception hr=0x%08X", hr);
-            return hr;
-        }
-    }
-
-    HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void **result) noexcept override
-    {
-        if (!result)
-        {
-            return E_POINTER;
-        }
-
-        *result = nullptr;
-        if (!m_site)
-        {
-            return E_FAIL;
-        }
-
-        return m_site.as(riid, result);
-    }
-
-private:
-    winrt::com_ptr<IUnknown> m_site;
-};
-
-// ============================================================================
-// COM factory and exports
-// ============================================================================
-
-template <typename T>
-struct SimpleFactory
-    : winrt::implements<SimpleFactory<T>, IClassFactory, winrt::non_agile>
+static void ScheduleCurrentThreadScan()
+try
 {
-    HRESULT STDMETHODCALLTYPE CreateInstance(IUnknown *outer,
-                                             REFIID riid,
-                                             void **object) override
+    if (g_unloading.load())
+        return;
+    auto queue = winrt::Microsoft::UI::Dispatching::DispatcherQueue::GetForCurrentThread();
+    if (!queue)
     {
-        if (!object)
-        {
-            return E_POINTER;
-        }
-
-        *object = nullptr;
-        if (outer)
-        {
-            return CLASS_E_NOAGGREGATION;
-        }
-
-        try
-        {
-            return winrt::make<T>().as(riid, object);
-        }
-        catch (...)
-        {
-            return winrt::to_hresult();
-        }
+        ScanCurrentThreadForTitleBars();
+        return;
     }
-
-    HRESULT STDMETHODCALLTYPE LockServer(BOOL) noexcept override
-    {
-        return S_OK;
-    }
-};
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdll-attribute-on-redeclaration"
-
-extern "C" __declspec(dllexport) HRESULT __stdcall DllGetClassObject(
-    REFCLSID clsid,
-    REFIID riid,
-    LPVOID *result)
+    queue.TryEnqueue([]()
+                     { ScanCurrentThreadForTitleBars(); });
+}
+catch (...)
 {
-    if (!result)
-    {
-        return E_POINTER;
-    }
+}
 
-    *result = nullptr;
-    if (clsid != CLSID_WindhawkTitleBarLabelTAP)
+static void DiscoverFromElement(mux::UIElement const &element)
+{
+    if (!g_unloading.load() && element)
     {
-        return CLASS_E_CLASSNOTAVAILABLE;
+        ScheduleXamlRootScan(element);
+    }
+}
+
+static void DiscoverFromInspectableParameter(void *parameter)
+{
+    if (g_unloading.load() || !parameter)
+    {
+        return;
     }
 
     try
     {
-        return winrt::make<SimpleFactory<WindhawkTAP>>().as(riid, result);
+        auto const &inspectable =
+            *reinterpret_cast<wf::IInspectable const *>(parameter);
+
+        if (auto element =
+                inspectable ? inspectable.try_as<mux::UIElement>() : nullptr)
+        {
+            DiscoverFromElement(element);
+        }
     }
     catch (...)
     {
-        return winrt::to_hresult();
+        Wh_Log(L"XAML discovery failed hr=0x%08X",
+               winrt::to_hresult());
     }
 }
 
-extern "C" __declspec(dllexport) HRESULT __stdcall DllCanUnloadNow()
+using CommandBarManager_CommandBar_t =
+    void(WINAPI *)(void *pThis, void *commandBar);
+static CommandBarManager_CommandBar_t CommandBarManager_CommandBar_Original;
+
+static void WINAPI CommandBarManager_CommandBar_Hook(void *pThis,
+                                                     void *commandBar)
 {
-    return winrt::get_module_lock() ? S_FALSE : S_OK;
-}
+    CommandBarManager_CommandBar_Original(pThis, commandBar);
 
-#pragma clang diagnostic pop
-
-// ============================================================================
-// XAML diagnostics connection
-// ============================================================================
-
-using InitializeXamlDiagnosticsEx_t = decltype(&InitializeXamlDiagnosticsEx);
-
-static HRESULT ConnectToExplorerXaml()
-{
-    HMODULE self = GetCurrentModuleHandle();
-    if (!self)
-    {
-        return HRESULT_FROM_WIN32(GetLastError());
-    }
-
-    wchar_t modulePath[MAX_PATH]{};
-    DWORD length =
-        GetModuleFileNameW(self, modulePath, ARRAYSIZE(modulePath));
-    if (!length || length >= ARRAYSIZE(modulePath))
-    {
-        return HRESULT_FROM_WIN32(GetLastError());
-    }
-
-    HMODULE framework =
-        GetModuleHandleW(L"Microsoft.Internal.FrameworkUdk.dll");
-    if (!framework)
-    {
-        return HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND);
-    }
-
-    auto initialize = reinterpret_cast<InitializeXamlDiagnosticsEx_t>(
-        GetProcAddress(framework, "InitializeXamlDiagnosticsEx"));
-    if (!initialize)
-    {
-        return HRESULT_FROM_WIN32(ERROR_PROC_NOT_FOUND);
-    }
-
-    HRESULT hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
-
-    for (int i = 1; i <= 10000 && !g_unloading.load(); ++i)
-    {
-        wchar_t connection[128]{};
-        swprintf_s(connection, L"WinUIVisualDiagConnection%d", i);
-
-        hr = initialize(connection, GetCurrentProcessId(), L"", modulePath,
-                        CLSID_WindhawkTitleBarLabelTAP, nullptr);
-
-        if (hr != HRESULT_FROM_WIN32(ERROR_NOT_FOUND))
-        {
-            break;
-        }
-    }
-
-    return hr;
-}
-
-// ============================================================================
-// Connector thread
-// ============================================================================
-
-static bool SleepWhileLoaded(DWORD milliseconds)
-{
-    constexpr DWORD kSliceMs = 50;
-
-    while (milliseconds > 0 && !g_unloading.load())
-    {
-        DWORD slice = milliseconds < kSliceMs ? milliseconds : kSliceMs;
-        Sleep(slice);
-        milliseconds -= slice;
-    }
-
-    return !g_unloading.load();
-}
-
-static DWORD WINAPI ConnectorThread(LPVOID)
-{
-    // This thread starts only after a real File Explorer window exists. Give
-    // WinUI a bounded startup window instead of polling forever in unsupported
-    // Explorer processes.
-    constexpr int kMaxAttempts = 120;
-    constexpr DWORD kRetryDelayMs = 500;
-
-    for (int attempt = 0;
-         attempt < kMaxAttempts && !g_unloading.load();
-         ++attempt)
-    {
-        HMODULE framework =
-            GetModuleHandleW(L"Microsoft.Internal.FrameworkUdk.dll");
-
-        if (framework)
-        {
-            HRESULT hr = ConnectToExplorerXaml();
-            if (SUCCEEDED(hr))
-            {
-                // Some XAML-diagnostics consumers intentionally return S_OK
-                // while blocking the caller. Only report success after our
-                // TAP's SetSite actually runs.
-                DWORD waitResult =
-                    g_tapReadyEvent
-                        ? WaitForSingleObject(g_tapReadyEvent, 2000)
-                        : WAIT_FAILED;
-
-                if (waitResult == WAIT_OBJECT_0)
-                {
-                    Wh_Log(L"Connected to Explorer XAML diagnostics");
-                }
-                else if (!g_unloading.load())
-                {
-                    Wh_Log(
-                        L"XAML diagnostics returned success, but the title-bar "
-                        L"TAP was not initialized. Another XAML diagnostics "
-                        L"consumer may have blocked the connection.");
-                }
-
-                return 0;
-            }
-
-            if (g_unloading.load())
-            {
-                return 0;
-            }
-
-            if (hr != HRESULT_FROM_WIN32(ERROR_NOT_FOUND) &&
-                hr != HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND))
-            {
-                Wh_Log(L"Diagnostics connection failed hr=0x%08X", hr);
-                return 0;
-            }
-        }
-
-        if (!SleepWhileLoaded(kRetryDelayMs))
-        {
-            return 0;
-        }
-    }
-
-    if (!g_unloading.load())
-    {
-        Wh_Log(L"Explorer WinUI diagnostics did not become available");
-    }
-
-    return 0;
-}
-
-static void EnsureConnectorStarted()
-{
-    if (g_unloading.load() ||
-        g_diagnosticsConnected.load(std::memory_order_acquire))
+    if (g_unloading.load() || !commandBar)
     {
         return;
     }
 
-    std::lock_guard<std::mutex> lock(g_connectorMutex);
-    if (g_unloading.load() ||
-        g_diagnosticsConnected.load(std::memory_order_acquire))
+    try
     {
-        return;
-    }
+        auto const &element =
+            *reinterpret_cast<muxc::CommandBar const *>(commandBar);
 
-    if (g_connectorThread)
-    {
-        if (WaitForSingleObject(g_connectorThread, 0) == WAIT_OBJECT_0)
+        if (element)
         {
-            CloseHandle(g_connectorThread);
-            g_connectorThread = nullptr;
-        }
-        else
-        {
-            return;
+            DiscoverFromElement(element);
         }
     }
-
-    if (g_tapReadyEvent)
+    catch (...)
     {
-        ResetEvent(g_tapReadyEvent);
-    }
-
-    g_connectorThread =
-        CreateThread(nullptr, 0, ConnectorThread, nullptr, 0, nullptr);
-    if (!g_connectorThread)
-    {
-        Wh_Log(L"CreateThread failed: %u", GetLastError());
+        Wh_Log(L"CommandBar discovery failed hr=0x%08X",
+               winrt::to_hresult());
     }
 }
 
-static void StopConnectorThread()
+using CommandBarControl_GotFocusHandler_t =
+    void(WINAPI *)(void *pThis, void *sender, void *args);
+static CommandBarControl_GotFocusHandler_t
+    CommandBarControl_GotFocusHandler_Original;
+
+static void WINAPI CommandBarControl_GotFocusHandler_Hook(
+    void *pThis, void *sender, void *args)
 {
-    HANDLE thread = nullptr;
+    CommandBarControl_GotFocusHandler_Original(pThis, sender, args);
 
-    {
-        std::lock_guard<std::mutex> lock(g_connectorMutex);
-        thread = g_connectorThread;
-    }
-
-    if (!thread)
+    if (g_unloading.load() || !sender)
     {
         return;
     }
 
-    if (GetThreadId(thread) != GetCurrentThreadId())
+    try
     {
-        WaitForSingleObject(thread, INFINITE);
+        auto const &inspectable =
+            *reinterpret_cast<wf::IInspectable const *>(sender);
+
+        if (auto element =
+                inspectable ? inspectable.try_as<mux::UIElement>() : nullptr)
+        {
+            Wh_Log(L"GotFocus fired, thread=%u",
+                   GetCurrentThreadId());
+            ScheduleXamlRootScan(element);
+        }
+    }
+    catch (...)
+    {
+        Wh_Log(L"GotFocus access failed hr=0x%08X",
+               winrt::to_hresult());
+    }
+}
+
+using ThreeParameterEvent_t =
+    void(WINAPI *)(void *pThis, void *sender, void *args);
+
+static ThreeParameterEvent_t
+    FileExplorerTabControl_TabView_Loaded_Original;
+static ThreeParameterEvent_t
+    FileExplorerTabControl_TabView_GotFocus_Original;
+static ThreeParameterEvent_t
+    FileExplorerTabControl_TabView_SelectionChanged_Original;
+static ThreeParameterEvent_t
+    FileExplorerTabControl_TabView_TabItemsChanged_Original;
+
+static void WINAPI FileExplorerTabControl_TabView_Loaded_Hook(
+    void *pThis, void *sender, void *args)
+{
+    FileExplorerTabControl_TabView_Loaded_Original(pThis, sender, args);
+    DiscoverFromInspectableParameter(sender);
+}
+
+static void WINAPI FileExplorerTabControl_TabView_GotFocus_Hook(
+    void *pThis, void *sender, void *args)
+{
+    FileExplorerTabControl_TabView_GotFocus_Original(pThis, sender, args);
+    DiscoverFromInspectableParameter(sender);
+}
+
+static void WINAPI FileExplorerTabControl_TabView_SelectionChanged_Hook(
+    void *pThis, void *sender, void *args)
+{
+    FileExplorerTabControl_TabView_SelectionChanged_Original(
+        pThis, sender, args);
+    DiscoverFromInspectableParameter(sender);
+}
+
+static void WINAPI FileExplorerTabControl_TabView_TabItemsChanged_Hook(
+    void *pThis, void *tabView, void *args)
+{
+    FileExplorerTabControl_TabView_TabItemsChanged_Original(
+        pThis, tabView, args);
+
+    if (g_unloading.load() || !tabView)
+    {
+        return;
     }
 
-    std::lock_guard<std::mutex> lock(g_connectorMutex);
-    if (g_connectorThread == thread)
+    try
     {
-        CloseHandle(g_connectorThread);
-        g_connectorThread = nullptr;
+        auto const &typedTabView =
+            *reinterpret_cast<muxc::TabView const *>(tabView);
+
+        if (typedTabView)
+        {
+            DiscoverFromElement(typedTabView);
+        }
     }
+    catch (...)
+    {
+        Wh_Log(L"TabView items discovery failed hr=0x%08X",
+               winrt::to_hresult());
+    }
+}
+
+static std::atomic<bool> g_symbolsHooked{false};
+enum class SymbolHookResult
+{
+    Success,
+    ResolutionFailed,
+    NoSymbolFound
+};
+
+static SymbolHookResult HookFileExplorerExtensionsSymbols(HMODULE module)
+{
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {
+        {
+            {
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarManager::CommandBar(struct winrt::Microsoft::UI::Xaml::Controls::CommandBar const &))",
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarManager::CommandBar(struct winrt::Microsoft::UI::Xaml::Controls::CommandBar const & __ptr64) __ptr64)",
+            },
+            &CommandBarManager_CommandBar_Original,
+            CommandBarManager_CommandBar_Hook,
+            true,
+        },
+        {
+            {
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_Loaded(struct winrt::Windows::Foundation::IInspectable const &,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const &))",
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_Loaded(struct winrt::Windows::Foundation::IInspectable const & __ptr64,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const & __ptr64) __ptr64)",
+            },
+            &FileExplorerTabControl_TabView_Loaded_Original,
+            FileExplorerTabControl_TabView_Loaded_Hook,
+            true,
+        },
+        {
+            {
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_GotFocus(struct winrt::Windows::Foundation::IInspectable const &,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const &))",
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_GotFocus(struct winrt::Windows::Foundation::IInspectable const & __ptr64,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const & __ptr64) __ptr64)",
+            },
+            &FileExplorerTabControl_TabView_GotFocus_Original,
+            FileExplorerTabControl_TabView_GotFocus_Hook,
+            true,
+        },
+        {
+            {
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_SelectionChanged(struct winrt::Windows::Foundation::IInspectable const &,struct winrt::Microsoft::UI::Xaml::Controls::SelectionChangedEventArgs const &))",
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_SelectionChanged(struct winrt::Windows::Foundation::IInspectable const & __ptr64,struct winrt::Microsoft::UI::Xaml::Controls::SelectionChangedEventArgs const & __ptr64) __ptr64)",
+            },
+            &FileExplorerTabControl_TabView_SelectionChanged_Original,
+            FileExplorerTabControl_TabView_SelectionChanged_Hook,
+            true,
+        },
+        {
+            {
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_TabItemsChanged(struct winrt::Microsoft::UI::Xaml::Controls::TabView const &,struct winrt::Windows::Foundation::Collections::IVectorChangedEventArgs const &))",
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::FileExplorerTabControl::TabView_TabItemsChanged(struct winrt::Microsoft::UI::Xaml::Controls::TabView const & __ptr64,struct winrt::Windows::Foundation::Collections::IVectorChangedEventArgs const & __ptr64) __ptr64)",
+            },
+            &FileExplorerTabControl_TabView_TabItemsChanged_Original,
+            FileExplorerTabControl_TabView_TabItemsChanged_Hook,
+            true,
+        },
+        {
+            {
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarControl::CommandBarControlGotFocusHandler(struct winrt::Windows::Foundation::IInspectable const &,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const &))",
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarControl::CommandBarControlGotFocusHandler(struct winrt::Windows::Foundation::IInspectable const & __ptr64,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const & __ptr64) __ptr64)",
+            },
+            &CommandBarControl_GotFocusHandler_Original,
+            CommandBarControl_GotFocusHandler_Hook,
+            true,
+        },
+    };
+
+    Wh_Log(L"Resolving FileExplorerExtensions hooks");
+
+    if (!WindhawkUtils::HookSymbols(module, hooks, ARRAYSIZE(hooks)))
+    {
+        Wh_Log(L"HookSymbols(FileExplorerExtensions.dll) failed");
+        return SymbolHookResult::ResolutionFailed;
+    }
+
+    if (!CommandBarManager_CommandBar_Original &&
+        !FileExplorerTabControl_TabView_Loaded_Original &&
+        !FileExplorerTabControl_TabView_GotFocus_Original &&
+        !FileExplorerTabControl_TabView_SelectionChanged_Original &&
+        !FileExplorerTabControl_TabView_TabItemsChanged_Original)
+    {
+        Wh_Log(L"No typed File Explorer discovery hook was found");
+        return SymbolHookResult::NoSymbolFound;
+    }
+
+    Wh_Log(L"FileExplorerExtensions hooks registered");
+    return SymbolHookResult::Success;
+}
+
+static HMODULE GetFileExplorerExtensionsModuleHandle() { return GetModuleHandleW(L"FileExplorerExtensions.dll"); }
+static bool HookFileExplorerExtensionsIfLoaded(bool applyHooks)
+{
+    if (g_symbolsHooked.load())
+        return true;
+    HMODULE module = GetFileExplorerExtensionsModuleHandle();
+    if (!module)
+        return true;
+    if (g_symbolsHooked.exchange(true))
+        return true;
+    Wh_Log(L"Hooking FileExplorerExtensions.dll");
+    switch (HookFileExplorerExtensionsSymbols(module))
+    {
+    case SymbolHookResult::Success:
+        break;
+    case SymbolHookResult::ResolutionFailed:
+        g_symbolsHooked.store(false);
+        return false;
+    case SymbolHookResult::NoSymbolFound:
+        return false;
+    }
+    if (applyHooks)
+        Wh_ApplyHookOperations();
+    return true;
+}
+
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+static LoadLibraryExW_t LoadLibraryExW_Original;
+static HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName, HANDLE file, DWORD flags)
+{
+    HMODULE module = LoadLibraryExW_Original(fileName, file, flags);
+    if (!module || g_unloading.load() || !fileName)
+        return module;
+    PCWSTR baseName = fileName;
+    for (PCWSTR p = fileName; *p; ++p)
+        if (*p == L'\\' || *p == L'/')
+            baseName = p + 1;
+    if (_wcsicmp(baseName, L"FileExplorerExtensions.dll") == 0 ||
+        _wcsicmp(baseName, L"FileExplorerExtensions") == 0)
+        HookFileExplorerExtensionsIfLoaded(true);
+    return module;
 }
 
 // ============================================================================
@@ -2144,88 +1919,54 @@ static void StopConnectorThread()
 BOOL Wh_ModInit()
 {
     Wh_Log(L"Explorer Title Bar Label 1.0.0 init");
-
     g_unloading.store(false);
-    g_diagnosticsConnected.store(false, std::memory_order_release);
+    g_symbolsHooked.store(false);
     LoadSettings(false);
 
-    g_tapReadyEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
-    if (!g_tapReadyEvent)
+    if (GetFileExplorerExtensionsModuleHandle())
     {
-        Wh_Log(L"CreateEvent failed: %u", GetLastError());
-        return FALSE;
+        if (!HookFileExplorerExtensionsIfLoaded(false))
+            return FALSE;
     }
-
-    if (!Wh_SetFunctionHook(
-            reinterpret_cast<void *>(CreateWindowExW),
-            reinterpret_cast<void *>(CreateWindowExW_Hook),
-            reinterpret_cast<void **>(&CreateWindowExW_Original)))
+    else
     {
-        Wh_Log(L"Failed to hook CreateWindowExW");
-        CloseHandle(g_tapReadyEvent);
-        g_tapReadyEvent = nullptr;
-        return FALSE;
+        Wh_Log(L"FileExplorerExtensions.dll isn't loaded yet");
+        HMODULE kernelBase = GetModuleHandleW(L"kernelbase.dll");
+        auto loadLibraryExW = reinterpret_cast<decltype(&LoadLibraryExW)>(
+            GetProcAddress(kernelBase, "LoadLibraryExW"));
+        if (!loadLibraryExW)
+            return FALSE;
+        if (!WindhawkUtils::SetFunctionHook(loadLibraryExW, LoadLibraryExW_Hook,
+                                            &LoadLibraryExW_Original))
+            return FALSE;
     }
-
     return TRUE;
 }
 
 void Wh_ModAfterInit()
 {
-    // Hooks become active after Wh_ModInit. Handle windows which were already
-    // open before that point.
-    if (!GetFileExplorerWindows().empty())
+    HookFileExplorerExtensionsIfLoaded(true);
+    for (HWND hwnd : GetFileExplorerWindows())
     {
-        EnsureConnectorStarted();
+        RunFromWindowThread(hwnd, [](PVOID)
+                            { ScanCurrentThreadForTitleBars(); }, nullptr);
     }
 }
 
-void Wh_ModSettingsChanged()
-{
-    LoadSettings(true);
-}
-
-// Function hooks are removed before Wh_ModUninit, but XAML delegates can still
-// be alive until explicit UI-thread teardown below. Stop them from doing new
-// work as early as Windhawk allows.
-void Wh_ModBeforeUninit()
-{
-    g_unloading.store(true);
-    g_diagnosticsConnected.store(false, std::memory_order_release);
-}
+void Wh_ModSettingsChanged() { LoadSettings(true); }
+void Wh_ModBeforeUninit() { g_unloading.store(true); }
 
 void Wh_ModUninit()
 {
     Wh_Log(L"Explorer Title Bar Label 1.0.0 uninit");
-
     g_unloading.store(true);
-
-    StopConnectorThread();
-
-    // Every XAML delegate is revoked synchronously on the thread which owns it
-    // before this DLL can be unloaded.
     for (HWND hwnd : GetFileExplorerWindows())
     {
-        if (!RunFromWindowThread(
-                hwnd, [](PVOID)
-                { RemoveLabelsForCurrentThread(); },
-                nullptr))
+        if (!RunFromWindowThread(hwnd, [](PVOID)
+                                 { RemoveLabelsForCurrentThread(); }, nullptr))
         {
             Wh_Log(L"Couldn't reach Explorer UI thread for window %08X",
                    static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(hwnd)));
         }
-    }
-
-    if (g_visualTreeWatcher)
-    {
-        g_visualTreeWatcher->Disconnect();
-        g_visualTreeWatcher = nullptr;
-    }
-    g_diagnosticsConnected.store(false, std::memory_order_release);
-
-    if (g_tapReadyEvent)
-    {
-        CloseHandle(g_tapReadyEvent);
-        g_tapReadyEvent = nullptr;
     }
 }

--- a/mods/explorer-title-bar-label.wh.cpp
+++ b/mods/explorer-title-bar-label.wh.cpp
@@ -1689,33 +1689,68 @@ static void TryInsertTitleText(muxc::Grid const &grid)
 
     auto children = grid.Children();
     mux::FrameworkElement rightAnchor{nullptr};
-    for (uint32_t i = 0; i < children.Size();)
+    mux::FrameworkElement existingLabel{nullptr};
+    uint32_t existingLabelIndex = 0;
+
+    for (uint32_t i = 0; i < children.Size(); ++i)
     {
         auto child = children.GetAt(i).try_as<mux::FrameworkElement>();
         if (!child)
         {
-            ++i;
             continue;
         }
 
         if (child.Name() == L"WindhawkExplorerTitleBarLabel")
         {
-            // Recover from a stale label left by an earlier instance that
-            // couldn't remove its XAML element during teardown. Don't advance
-            // the index because the next child shifts into this slot.
-            children.RemoveAt(i);
-            continue;
+            existingLabel = child;
+            existingLabelIndex = i;
         }
-
-        if (child.Name() == L"RightContentPresenter")
+        else if (child.Name() == L"RightContentPresenter")
         {
             rightAnchor = child;
         }
-
-        ++i;
     }
+
     if (!rightAnchor)
+    {
         return;
+    }
+
+    PruneReleasedLabelEntries();
+
+    if (existingLabel)
+    {
+        for (auto const &entry : g_labelEntries)
+        {
+            if (!entry || entry->cleaned)
+            {
+                continue;
+            }
+
+            auto entryGrid = entry->grid.get();
+            auto entryText = entry->text.get();
+
+            if (entryGrid == grid && entryText == existingLabel)
+            {
+                try
+                {
+                    RefreshLabelEntry(entry, GetSettings());
+                }
+                catch (...)
+                {
+                    Wh_Log(L"Refresh existing label failed hr=0x%08X",
+                           winrt::to_hresult());
+                }
+
+                return;
+            }
+        }
+
+        // The XAML element exists but no live LabelEntry owns it. This can
+        // happen if a previous mod instance couldn't remove its element during
+        // teardown. Remove only that orphaned child, then recreate it below.
+        children.RemoveAt(existingLabelIndex);
+    }
 
     HWND hwnd = GetExplorerWindowForElement(grid);
     if (!hwnd)
@@ -1732,7 +1767,6 @@ static void TryInsertTitleText(muxc::Grid const &grid)
         return;
     }
 
-    PruneReleasedLabelEntries();
     Settings initialSettings = GetSettings();
 
     muxc::TextBlock text;

--- a/mods/explorer-title-bar-label.wh.cpp
+++ b/mods/explorer-title-bar-label.wh.cpp
@@ -8,7 +8,7 @@
 // @license         GPL-3.0
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lole32 -loleaut32 -lruntimeobject -ldwmapi
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -ldwmapi -lcomctl32
 // ==/WindhawkMod==
 
 // Source code is published under the GNU General Public License v3.0.
@@ -191,6 +191,7 @@ Parts of the File Explorer hook and XAML discovery plumbing are adapted from **E
 // ==/WindhawkModSettings==
 
 #include <windows.h>
+#include <commctrl.h>
 #include <dwmapi.h>
 
 #undef GetCurrentTime
@@ -327,6 +328,22 @@ static std::mutex g_settingsMutex;
 
 static std::atomic<bool> g_unloading{false};
 static std::atomic<int> g_pendingScans{0};
+
+struct PendingScan
+{
+    PendingScan()
+    {
+        g_pendingScans.fetch_add(1, std::memory_order_acq_rel);
+    }
+
+    PendingScan(const PendingScan &) = delete;
+    PendingScan &operator=(const PendingScan &) = delete;
+
+    ~PendingScan()
+    {
+        g_pendingScans.fetch_sub(1, std::memory_order_acq_rel);
+    }
+};
 
 // ============================================================================
 // Settings helpers
@@ -1210,6 +1227,7 @@ struct LabelEntry
     winrt::weak_ref<muxc::TextBlock> text;
     winrt::weak_ref<muxc::Grid> grid;
     mux::DispatcherTimer timer{nullptr};
+    HWND hwnd = nullptr;
     winrt::event_token tickToken{};
     winrt::event_token sizeChangedToken{};
     bool tickRegistered = false;
@@ -1233,22 +1251,36 @@ static void ReleaseLabelEntry(const std::shared_ptr<LabelEntry> &entry,
 
     entry->cleaned = true;
 
-    try
+    if (entry->timer)
     {
-        if (entry->timer)
+        try
         {
             entry->timer.Stop();
-            if (entry->tickRegistered)
+        }
+        catch (...)
+        {
+            Wh_Log(L"Failed to stop title-bar timer hr=0x%08X",
+                   winrt::to_hresult());
+        }
+
+        if (entry->tickRegistered)
+        {
+            try
             {
                 entry->timer.Tick(entry->tickToken);
                 entry->tickRegistered = false;
             }
+            catch (...)
+            {
+                Wh_Log(L"Failed to revoke title-bar timer hr=0x%08X",
+                       winrt::to_hresult());
+            }
         }
-    }
-    catch (...)
-    {
-        Wh_Log(L"Failed to release title-bar timer hr=0x%08X",
-               winrt::to_hresult());
+
+        // Drop the final strong XAML reference while still on the owning UI
+        // thread. The thread_local container can then safely outlive the XAML
+        // object itself.
+        entry->timer = nullptr;
     }
 
     auto grid = entry->grid.get();
@@ -1342,6 +1374,50 @@ static void RemoveLabelsForCurrentThread()
     {
         ReleaseLabelEntry(entry, true);
     }
+}
+
+static void RemoveLabelsForWindowOnCurrentThread(HWND hwnd)
+{
+    for (auto it = g_labelEntries.begin(); it != g_labelEntries.end();)
+    {
+        auto entry = *it;
+
+        if (entry && entry->hwnd == hwnd)
+        {
+            // The native window is already going away, so there's no reason
+            // to mutate the XAML children collection. Just revoke delegates
+            // and release the strong DispatcherTimer reference.
+            ReleaseLabelEntry(entry, false);
+            it = g_labelEntries.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    if (g_labelEntries.empty())
+    {
+        g_threadScanned = false;
+    }
+}
+
+static LRESULT CALLBACK ExplorerWindowSubclassProc(
+    HWND hwnd,
+    UINT message,
+    WPARAM wParam,
+    LPARAM lParam,
+    UINT_PTR,
+    DWORD_PTR)
+{
+    if (message == WM_NCDESTROY)
+    {
+        RemoveLabelsForWindowOnCurrentThread(hwnd);
+        WindhawkUtils::RemoveWindowSubclassFromAnyThread(
+            hwnd, ExplorerWindowSubclassProc);
+    }
+
+    return DefSubclassProc(hwnd, message, wParam, lParam);
 }
 
 static bool IsFileExplorerWindow(HWND hwnd)
@@ -1545,6 +1621,23 @@ static void TryInsertTitleText(muxc::Grid const &grid)
     if (!rightAnchor)
         return;
 
+    HWND hwnd = GetExplorerWindowForElement(grid);
+    if (!hwnd)
+    {
+        return;
+    }
+
+    // Install the native-window teardown hook before creating XAML delegates.
+    // If the window closes, WM_NCDESTROY will synchronously release this
+    // window's entries on the same UI thread.
+    if (!WindhawkUtils::SetWindowSubclassFromAnyThread(
+            hwnd, ExplorerWindowSubclassProc, 1))
+    {
+        Wh_Log(L"Failed to subclass Explorer window %08X",
+               static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(hwnd)));
+        return;
+    }
+
     PruneReleasedLabelEntries();
     Settings initialSettings = GetSettings();
 
@@ -1569,6 +1662,7 @@ static void TryInsertTitleText(muxc::Grid const &grid)
     auto entry = std::make_shared<LabelEntry>();
     entry->text = winrt::make_weak(text);
     entry->grid = winrt::make_weak(grid);
+    entry->hwnd = hwnd;
     entry->currentSettings = initialSettings;
     entry->lastText = BuildDisplayText(initialSettings);
     g_labelEntries.push_back(entry);
@@ -1690,8 +1784,6 @@ static void ScheduleXamlRootScan(mux::UIElement const &element)
         return;
     }
 
-    bool pendingAdded = false;
-
     try
     {
         auto queue =
@@ -1702,27 +1794,19 @@ static void ScheduleXamlRootScan(mux::UIElement const &element)
             return;
         }
 
-        g_pendingScans.fetch_add(1, std::memory_order_acq_rel);
-        pendingAdded = true;
+        auto pending = std::make_shared<PendingScan>();
 
-        if (!queue.TryEnqueue([weak = winrt::make_weak(element)]()
-                              {
-                if (auto element = weak.get()) {
+        queue.TryEnqueue(
+            [pending, weak = winrt::make_weak(element)]()
+            {
+                if (auto element = weak.get())
+                {
                     ScanXamlRootForTitleBars(element);
                 }
-
-                g_pendingScans.fetch_sub(1, std::memory_order_acq_rel); }))
-        {
-            g_pendingScans.fetch_sub(1, std::memory_order_acq_rel);
-            pendingAdded = false;
-        }
+            });
     }
     catch (...)
     {
-        if (pendingAdded)
-        {
-            g_pendingScans.fetch_sub(1, std::memory_order_acq_rel);
-        }
     }
 }
 
@@ -1757,8 +1841,6 @@ static void ScheduleCurrentThreadScan()
         return;
     }
 
-    bool pendingAdded = false;
-
     try
     {
         auto queue =
@@ -1769,24 +1851,16 @@ static void ScheduleCurrentThreadScan()
             return;
         }
 
-        g_pendingScans.fetch_add(1, std::memory_order_acq_rel);
-        pendingAdded = true;
+        auto pending = std::make_shared<PendingScan>();
 
-        if (!queue.TryEnqueue([]()
-                              {
+        queue.TryEnqueue(
+            [pending]()
+            {
                 ScanCurrentThreadForTitleBars();
-                g_pendingScans.fetch_sub(1, std::memory_order_acq_rel); }))
-        {
-            g_pendingScans.fetch_sub(1, std::memory_order_acq_rel);
-            pendingAdded = false;
-        }
+            });
     }
     catch (...)
     {
-        if (pendingAdded)
-        {
-            g_pendingScans.fetch_sub(1, std::memory_order_acq_rel);
-        }
     }
 }
 
@@ -2047,6 +2121,7 @@ static SymbolHookResult HookFileExplorerExtensionsSymbols(HMODULE module)
 }
 
 static HMODULE GetFileExplorerExtensionsModuleHandle() { return GetModuleHandleW(L"FileExplorerExtensions.dll"); }
+
 static bool HookFileExplorerExtensionsIfLoaded(bool applyHooks)
 {
     if (g_symbolsHooked.load())
@@ -2074,6 +2149,7 @@ static bool HookFileExplorerExtensionsIfLoaded(bool applyHooks)
 
 using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 static LoadLibraryExW_t LoadLibraryExW_Original;
+
 static HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName, HANDLE file, DWORD flags)
 {
     HMODULE module = LoadLibraryExW_Original(fileName, file, flags);
@@ -2143,6 +2219,7 @@ void Wh_ModSettingsChanged()
             nullptr);
     }
 }
+
 void Wh_ModBeforeUninit() { g_unloading.store(true); }
 
 void Wh_ModUninit()
@@ -2177,11 +2254,16 @@ void Wh_ModUninit()
             Wh_Log(L"Couldn't reach Explorer UI thread for window %08X",
                    static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(hwnd)));
         }
+
+        // The subclass callback lives in this DLL, so it must be removed before
+        // Windhawk can unmap the mod.
+        WindhawkUtils::RemoveWindowSubclassFromAnyThread(
+            hwnd, ExplorerWindowSubclassProc);
     }
 
     // DispatcherQueue callbacks contain code from this module. Wait briefly for
     // all callbacks that were queued before g_unloading became true to finish
-    // before Windhawk is allowed to unmap the DLL.
+    // or be discarded. PendingScan decrements in either case.
     for (int i = 0;
          i < 200 &&
          g_pendingScans.load(std::memory_order_acquire) > 0;

--- a/mods/explorer-title-bar-label.wh.cpp
+++ b/mods/explorer-title-bar-label.wh.cpp
@@ -1373,7 +1373,7 @@ static void PruneReleasedLabelEntries()
 
         if (!entry->cleaned && !entry->text.get())
         {
-            ReleaseLabelEntry(entry, false);
+            ReleaseLabelEntry(entry, removeElement);
         }
 
         if (entry->cleaned)
@@ -1420,7 +1420,7 @@ static void RemoveLabelsForCurrentThread()
     }
 }
 
-static void RemoveLabelsForWindowOnCurrentThread(HWND hwnd)
+static void RemoveLabelsForWindowOnCurrentThread(HWND hwnd, bool removeElement)
 {
     g_pendingScanElements.erase(hwnd);
 
@@ -1477,7 +1477,7 @@ static LRESULT CALLBACK ExplorerWindowSubclassProc(
 
     if (message == WM_NCDESTROY)
     {
-        RemoveLabelsForWindowOnCurrentThread(hwnd);
+        RemoveLabelsForWindowOnCurrentThread(hwnd, false);
 
         {
             std::lock_guard<std::mutex> lock(g_subclassedWindowsMutex);
@@ -1666,7 +1666,15 @@ static void RefreshLabelsForCurrentThread()
 
     for (auto const &entry : g_labelEntries)
     {
-        RefreshLabelEntry(entry, settings);
+        try
+        {
+            RefreshLabelEntry(entry, settings);
+        }
+        catch (...)
+        {
+            Wh_Log(L"RefreshLabelEntry failed hr=0x%08X",
+                   winrt::to_hresult());
+        }
     }
 
     PruneReleasedLabelEntries();
@@ -1679,15 +1687,30 @@ static void TryInsertTitleText(muxc::Grid const &grid)
 
     auto children = grid.Children();
     mux::FrameworkElement rightAnchor{nullptr};
-    for (uint32_t i = 0; i < children.Size(); ++i)
+    for (uint32_t i = 0; i < children.Size();)
     {
         auto child = children.GetAt(i).try_as<mux::FrameworkElement>();
         if (!child)
+        {
+            ++i;
             continue;
+        }
+
         if (child.Name() == L"WindhawkExplorerTitleBarLabel")
-            return;
+        {
+            // Recover from a stale label left by an earlier instance that
+            // couldn't remove its XAML element during teardown. Don't advance
+            // the index because the next child shifts into this slot.
+            children.RemoveAt(i);
+            continue;
+        }
+
         if (child.Name() == L"RightContentPresenter")
+        {
             rightAnchor = child;
+        }
+
+        ++i;
     }
     if (!rightAnchor)
         return;
@@ -2311,7 +2334,7 @@ void Wh_ModUninit()
                     [](PVOID parameter)
                     {
                         RemoveLabelsForWindowOnCurrentThread(
-                            reinterpret_cast<HWND>(parameter));
+                            reinterpret_cast<HWND>(parameter), true);
                     },
                     hwnd))
             {

--- a/mods/explorer-title-bar-label.wh.cpp
+++ b/mods/explorer-title-bar-label.wh.cpp
@@ -48,6 +48,23 @@ Time can use **12-hour or 24-hour format**, with optional seconds.
 This mod does not use XAML Diagnostics, so it can be used together with **Windows 11 File Explorer Styler** and other tools/mods that consume File Explorer XAML diagnostics.
 
 If the mod is enabled while File Explorer windows are already open, the label may only appear in newly opened windows or after Explorer rebuilds the relevant tab UI (for example, after tab activity). This is a limitation of avoiding XAML Diagnostics.
+
+## Credits
+
+Parts of the File Explorer hook and XAML discovery plumbing are adapted from **Explorer Command Bar** by **DanRotaru**, licensed under the MIT License.
+
+<details>
+<summary>MIT license notice for reused code</summary>
+
+Copyright (c) DanRotaru
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE.
+
+</details>
 */
 // ==/WindhawkModReadme==
 
@@ -152,7 +169,8 @@ If the mod is enabled while File Explorer windows are already open, the label ma
   $description: "0 to 100."
 
 - leftMargin: 12
-  $name: Left spacing
+  $name: Left offset
+  $description: "Positive values move the label to the left."
 
 - rightMargin: 12
   $name: Right spacing
@@ -295,14 +313,7 @@ struct Settings
     int verticalOffset = 0;
 };
 
-struct SettingsSnapshot
-{
-    Settings settings;
-    uint64_t generation = 0;
-};
-
 static Settings g_settings;
-static std::atomic<uint64_t> g_settingsGeneration{1};
 static std::mutex g_settingsMutex;
 
 static std::atomic<bool> g_unloading{false};
@@ -537,26 +548,18 @@ static Settings ReadSettingsFromWindhawk()
     return settings;
 }
 
-static void LoadSettings(bool incrementGeneration)
+static void LoadSettings()
 {
     Settings settings = ReadSettingsFromWindhawk();
 
-    {
-        std::lock_guard<std::mutex> lock(g_settingsMutex);
-        g_settings = std::move(settings);
-    }
-
-    if (incrementGeneration)
-    {
-        g_settingsGeneration.fetch_add(1, std::memory_order_release);
-    }
+    std::lock_guard<std::mutex> lock(g_settingsMutex);
+    g_settings = std::move(settings);
 }
 
-static SettingsSnapshot GetSettingsSnapshot()
+static Settings GetSettings()
 {
     std::lock_guard<std::mutex> lock(g_settingsMutex);
-    return {g_settings,
-            g_settingsGeneration.load(std::memory_order_acquire)};
+    return g_settings;
 }
 
 static std::wstring GetSelectedFontFamily(const Settings &settings)
@@ -1005,6 +1008,7 @@ static double GetCaptionButtonsWidthDip(HWND hwnd)
 
 static void UpdateLabelPosition(muxc::TextBlock const &text,
                                 muxc::Grid const &grid,
+                                int leftOffset,
                                 int verticalOffset)
 {
     double automaticHorizontalCorrection = 0.0;
@@ -1080,7 +1084,7 @@ static void UpdateLabelPosition(muxc::TextBlock const &text,
             }
         }
 
-        translate.X(automaticHorizontalCorrection);
+        translate.X(automaticHorizontalCorrection - static_cast<double>(leftOffset));
         translate.Y(static_cast<double>(verticalOffset) +
                     automaticVerticalCorrection);
     }
@@ -1163,7 +1167,7 @@ static void ApplyTextSettings(muxc::TextBlock const &text,
     }
     text.HorizontalAlignment(mux::HorizontalAlignment::Right);
     text.VerticalAlignment(mux::VerticalAlignment::Center);
-    text.Margin(mux::Thickness{static_cast<double>(settings.leftMargin), 0.0,
+    text.Margin(mux::Thickness{0.0, 0.0,
                                static_cast<double>(settings.rightMargin), 0.0});
     text.IsHitTestVisible(false);
 }
@@ -1202,7 +1206,6 @@ struct LabelEntry
     bool sizeChangedRegistered = false;
     bool cleaned = false;
 
-    uint64_t seenGeneration = 0;
     Settings currentSettings;
     std::wstring lastText;
 };
@@ -1408,6 +1411,87 @@ static bool RunFromWindowThread(HWND hwnd,
 // Title-bar discovery without XAML Diagnostics
 // ============================================================================
 
+static std::chrono::milliseconds GetLabelTimerInterval(
+    const Settings &settings)
+{
+    if (settings.showTime && settings.showSeconds)
+    {
+        return std::chrono::seconds(1);
+    }
+
+    SYSTEMTIME st{};
+    GetLocalTime(&st);
+    DWORD elapsedMs =
+        static_cast<DWORD>(st.wSecond) * 1000u + st.wMilliseconds;
+    DWORD untilNextMinuteMs = 60000u - elapsedMs;
+    if (untilNextMinuteMs == 0)
+    {
+        untilNextMinuteMs = 60000u;
+    }
+
+    return std::chrono::milliseconds(untilNextMinuteMs);
+}
+
+static void ConfigureLabelTimer(const std::shared_ptr<LabelEntry> &entry)
+{
+    if (!entry || entry->cleaned || !entry->timer)
+    {
+        return;
+    }
+
+    entry->timer.Stop();
+
+    if (!entry->currentSettings.showDate &&
+        !entry->currentSettings.showTime)
+    {
+        return;
+    }
+
+    entry->timer.Interval(GetLabelTimerInterval(entry->currentSettings));
+    entry->timer.Start();
+}
+
+static void RefreshLabelEntry(const std::shared_ptr<LabelEntry> &entry,
+                              const Settings &settings)
+{
+    if (!entry || entry->cleaned)
+    {
+        return;
+    }
+
+    auto text = entry->text.get();
+    if (!text)
+    {
+        ReleaseLabelEntry(entry, false);
+        return;
+    }
+
+    entry->currentSettings = settings;
+    ApplyTextSettings(text, entry->currentSettings);
+    entry->lastText = BuildDisplayText(entry->currentSettings);
+
+    if (auto grid = entry->grid.get())
+    {
+        UpdateLabelPosition(text, grid, entry->currentSettings.leftMargin,
+                            entry->currentSettings.verticalOffset);
+    }
+
+    ConfigureLabelTimer(entry);
+}
+
+static void RefreshLabelsForCurrentThread()
+{
+    PruneReleasedLabelEntries();
+    Settings settings = GetSettings();
+
+    for (auto const &entry : g_labelEntries)
+    {
+        RefreshLabelEntry(entry, settings);
+    }
+
+    PruneReleasedLabelEntries();
+}
+
 static void TryInsertTitleText(muxc::Grid const &grid)
 {
     if (!grid || g_unloading.load())
@@ -1429,11 +1513,11 @@ static void TryInsertTitleText(muxc::Grid const &grid)
         return;
 
     PruneReleasedLabelEntries();
-    SettingsSnapshot initialSnapshot = GetSettingsSnapshot();
+    Settings initialSettings = GetSettings();
 
     muxc::TextBlock text;
     text.Name(L"WindhawkExplorerTitleBarLabel");
-    ApplyTextSettings(text, initialSnapshot.settings);
+    ApplyTextSettings(text, initialSettings);
     muxc::Grid::SetColumn(text, muxc::Grid::GetColumn(rightAnchor));
     muxc::Grid::SetRow(text, muxc::Grid::GetRow(rightAnchor));
     muxc::Canvas::SetZIndex(text, 100);
@@ -1446,14 +1530,14 @@ static void TryInsertTitleText(muxc::Grid const &grid)
     catch (...)
     {
     }
-    UpdateLabelPosition(text, grid, initialSnapshot.settings.verticalOffset);
+    UpdateLabelPosition(text, grid, initialSettings.leftMargin,
+                        initialSettings.verticalOffset);
 
     auto entry = std::make_shared<LabelEntry>();
     entry->text = winrt::make_weak(text);
     entry->grid = winrt::make_weak(grid);
-    entry->seenGeneration = initialSnapshot.generation;
-    entry->currentSettings = initialSnapshot.settings;
-    entry->lastText = BuildDisplayText(initialSnapshot.settings);
+    entry->currentSettings = initialSettings;
+    entry->lastText = BuildDisplayText(initialSettings);
     g_labelEntries.push_back(entry);
     std::weak_ptr<LabelEntry> weakEntry = entry;
 
@@ -1469,13 +1553,13 @@ static void TryInsertTitleText(muxc::Grid const &grid)
                 auto grid = entry->grid.get();
                 if (!text || !grid)
                     return;
-                SettingsSnapshot snapshot = GetSettingsSnapshot();
-                UpdateLabelPosition(text, grid, snapshot.settings.verticalOffset);
+                UpdateLabelPosition(text, grid,
+                                    entry->currentSettings.leftMargin,
+                                    entry->currentSettings.verticalOffset);
             });
         entry->sizeChangedRegistered = true;
 
         mux::DispatcherTimer timer;
-        timer.Interval(std::chrono::seconds(1));
         entry->timer = timer;
         entry->tickToken = timer.Tick([weakEntry](auto const &, auto const &)
                                       {
@@ -1485,26 +1569,25 @@ static void TryInsertTitleText(muxc::Grid const &grid)
             if (!text) { ReleaseLabelEntry(entry, false); return; }
             if (g_unloading.load()) { ReleaseLabelEntry(entry, true); return; }
 
-            uint64_t generation = g_settingsGeneration.load(std::memory_order_acquire);
-            if (generation != entry->seenGeneration) {
-                SettingsSnapshot snapshot = GetSettingsSnapshot();
-                entry->seenGeneration = snapshot.generation;
-                entry->currentSettings = snapshot.settings;
-                ApplyTextSettings(text, entry->currentSettings);
-                entry->lastText = BuildDisplayText(entry->currentSettings);
-                if (auto grid = entry->grid.get())
-                    UpdateLabelPosition(text, grid, entry->currentSettings.verticalOffset);
-            }
-
             std::wstring current = BuildDisplayText(entry->currentSettings);
             if (current != entry->lastText) {
                 text.Text(current);
                 entry->lastText = std::move(current);
-                if (auto grid = entry->grid.get())
-                    UpdateLabelPosition(text, grid, entry->currentSettings.verticalOffset);
+                if (auto grid = entry->grid.get()) {
+                    UpdateLabelPosition(text, grid,
+                                        entry->currentSettings.leftMargin,
+                                        entry->currentSettings.verticalOffset);
+                }
+            }
+
+            // Re-align minute-based updates after each tick. Seconds mode
+            // remains a regular one-second timer.
+            if (!(entry->currentSettings.showTime &&
+                  entry->currentSettings.showSeconds)) {
+                ConfigureLabelTimer(entry);
             } });
         entry->tickRegistered = true;
-        timer.Start();
+        ConfigureLabelTimer(entry);
         Wh_Log(L"Title-bar label attached");
     }
     catch (...)
@@ -1518,10 +1601,11 @@ static void TryInsertTitleText(muxc::Grid const &grid)
 static void CollectTitleBarGrids(mux::DependencyObject const &root, int depth,
                                  std::vector<muxc::Grid> *grids)
 {
-    if (!root || depth > 64)
+    if (!root || depth > 64 || !grids || !grids->empty())
         return;
+
     int count = muxm::VisualTreeHelper::GetChildrenCount(root);
-    for (int i = 0; i < count; ++i)
+    for (int i = 0; i < count && grids->empty(); ++i)
     {
         auto child = muxm::VisualTreeHelper::GetChild(root, i);
         if (auto element = child.try_as<mux::FrameworkElement>();
@@ -1530,9 +1614,10 @@ static void CollectTitleBarGrids(mux::DependencyObject const &root, int depth,
             if (auto grid = child.try_as<muxc::Grid>())
             {
                 grids->push_back(std::move(grid));
-                continue;
+                return;
             }
         }
+
         CollectTitleBarGrids(child, depth + 1, grids);
     }
 }
@@ -1849,7 +1934,8 @@ static SymbolHookResult HookFileExplorerExtensionsSymbols(HMODULE module)
 
     Wh_Log(L"Resolving FileExplorerExtensions hooks");
 
-    if (!WindhawkUtils::HookSymbols(module, fileExplorerExtensionsDllHooks, ARRAYSIZE(fileExplorerExtensionsDllHooks)))
+    if (!WindhawkUtils::HookSymbols(module, fileExplorerExtensionsDllHooks,
+                                    ARRAYSIZE(fileExplorerExtensionsDllHooks)))
     {
         Wh_Log(L"HookSymbols(FileExplorerExtensions.dll) failed");
         return SymbolHookResult::ResolutionFailed;
@@ -1921,7 +2007,7 @@ BOOL Wh_ModInit()
     Wh_Log(L"Explorer Title Bar Label 1.0.0 init");
     g_unloading.store(false);
     g_symbolsHooked.store(false);
-    LoadSettings(false);
+    LoadSettings();
 
     if (GetFileExplorerExtensionsModuleHandle())
     {
@@ -1953,7 +2039,19 @@ void Wh_ModAfterInit()
     }
 }
 
-void Wh_ModSettingsChanged() { LoadSettings(true); }
+void Wh_ModSettingsChanged()
+{
+    LoadSettings();
+
+    for (HWND hwnd : GetFileExplorerWindows())
+    {
+        RunFromWindowThread(
+            hwnd,
+            [](PVOID)
+            { RefreshLabelsForCurrentThread(); },
+            nullptr);
+    }
+}
 void Wh_ModBeforeUninit() { g_unloading.store(true); }
 
 void Wh_ModUninit()
@@ -1970,4 +2068,3 @@ void Wh_ModUninit()
         }
     }
 }
-


### PR DESCRIPTION
Adds a new Windhawk mod that displays customizable text, date and time in the Windows 11 File Explorer title bar.

The label is inserted as a native WinUI/XAML `TextBlock` next to Explorer's title-bar controls. It supports configurable date components and order, 12/24-hour time with optional seconds, font family/size/weight/style, text color, opacity, spacing, and live settings updates.

Tested on Windows 11 with multiple Explorer windows, maximize/restore, resizing, live settings changes, enable/disable, and Explorer restart.

## Changelog
If this pull request updates an existing mod, describe the changes below:

* Initial release.

## Mod authorship
If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- [ ] The submitter, without AI assistance
- [x] The submitter, with AI assistance
- [ ] Claude
- [x] ChatGPT
- [ ] Gemini
- [ ] Another AI (please specify):
- [ ] Other (please specify):


<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
