### PR TITLE
Add Hide Scrollbars mod

### DIFF
--- a/mods/hide-scrollbars.wh.cpp
+++ b/mods/hide-scrollbars.wh.cpp
@@ -5,7 +5,7 @@
 // @version         1.0.0
 // @author          AmazingBodilyFluids
 // @github          https://github.com/AmazingBodilyFluids
-// @include         *
+// @include         explorer.exe
 // @license         MIT
 // ==/WindhawkMod==
 
@@ -13,22 +13,42 @@
 /*
 # Hide Scrollbars
 
-Removes the vertical and/or horizontal scrollbars from windows in the
-processes you choose. By default it targets `explorer.exe`, so the File
-Explorer file list loses its scrollbar and the freed strip is used by the
-content instead of sitting empty.
+Shrinks the vertical and/or horizontal scrollbars away in the target
+process. By default it targets `explorer.exe`, so the File Explorer file
+list loses its scrollbar and the freed strip is used by the content
+instead of sitting empty.
+
+To apply it to other programs, add them to the mod's **Custom process
+inclusion list** under the mod's Advanced settings in Windhawk.
 
 Mouse-wheel and keyboard scrolling keep working. Precision-touchpad
 two-finger scrolling keeps working at the default scrollbar size of 1px;
 setting the size to 0 breaks it (see the limitation below).
 
+## Screenshots
+
+Windows default (slim scrollbar in its own gutter):
+
+![Default](https://raw.githubusercontent.com/AmazingBodilyFluids/windhawk-mods/assets/hide-scrollbars-default.png)
+
+Scrollbar size 1 (1px sliver, gutter reclaimed):
+
+![Size 1](https://raw.githubusercontent.com/AmazingBodilyFluids/windhawk-mods/assets/hide-scrollbars-1px.png)
+
+Scrollbar size 0 (fully hidden):
+
+![Size 0](https://raw.githubusercontent.com/AmazingBodilyFluids/windhawk-mods/assets/hide-scrollbars-0px.png)
+
 ## How it works
 
 The mod hooks `GetSystemMetrics`, `GetSystemMetricsForDpi` and
 `GetThemeSysSize`, and reports a reduced size for `SM_CXVSCROLL` /
-`SM_CYHSCROLL` (the vertical/horizontal scrollbar thickness). Controls
-that lay themselves out from the scrollbar size then shrink it
-accordingly.
+`SM_CYHSCROLL` (the vertical/horizontal scrollbar thickness). Code that
+lays itself out from that metric - such as Explorer's DirectUI file list
+- then shrinks the scrollbar accordingly. Plain Win32 windows that draw
+standard non-client scrollbars are mostly unaffected, because user32
+lays those out from an internal metric table rather than the exported
+function.
 
 ## Known limitation: precision-touchpad scrolling
 
@@ -46,17 +66,15 @@ The **Scrollbar size** setting lets you choose:
 - `1` (default) - touchpad-safe, 1px sliver remains.
 - `0` - fully hidden, breaks precision-touchpad two-finger scroll.
 
-## Notes and limitations
+## Notes
 
-- The metric override is process-wide. Every classic control in a
-  targeted process loses its scrollbar, not only Explorer's file list.
-- Apps rendered with newer UI frameworks (WinUI/XAML) that do not read
-  these metrics are unaffected.
-- With the default size of `1`, a 1px sliver remains where the scrollbar
-  was. Set **Scrollbar size** to `0` for full removal (see the touchpad
-  limitation above).
-- If a control in a targeted process misbehaves, remove that process
-  from the list.
+- The override is process-wide. Other mods running in the same process
+  that read `SM_CXVSCROLL` / `SM_CYHSCROLL` (for example to hit-test the
+  scrollbar strip) will see the reduced value too.
+- The scrollbar *arrow button* metrics (`SM_CXHSCROLL` / `SM_CYVSCROLL`)
+  and `SPI_GETNONCLIENTMETRICS` are left untouched, so a control that
+  mixes those with `SM_CXVSCROLL` may lay out slightly oddly.
+- If a targeted process misbehaves, remove it from the inclusion list.
 
 ## Settings
 
@@ -65,8 +83,6 @@ The **Scrollbar size** setting lets you choose:
 - **Scrollbar size** - reported thickness in pixels. `1` (default) keeps
   precision-touchpad scrolling working; `0` hides the bar fully but
   breaks two-finger touchpad scroll.
-- **Processes** - executable names the mod applies to, one per line. The
-  mod is loaded into every process but stays inactive outside this list.
 */
 // ==/WindhawkModReadme==
 
@@ -83,17 +99,12 @@ The **Scrollbar size** setting lets you choose:
     precision-touchpad two-finger scrolling working while leaving only a
     1px sliver. 0 hides the scrollbar completely but breaks
     precision-touchpad scrolling (mouse wheel and keyboard still work).
-- processList:
-  - explorer.exe
-  $name: Processes
-  $description: Executable names (with .exe) the mod applies to, one per line.
 */
 // ==/WindhawkModSettings==
 
-#include <uxtheme.h>
+#include <windhawk_utils.h>
 
-#include <string>
-#include <vector>
+#include <uxtheme.h>
 
 struct {
     bool hideVertical;
@@ -101,11 +112,9 @@ struct {
     int scrollbarSize;
 } g_settings;
 
-std::vector<std::wstring> g_processList;
-
 // --- hooks ----------------------------------------------------------------
 
-using GetSystemMetrics_t = int(WINAPI*)(int);
+using GetSystemMetrics_t = decltype(&GetSystemMetrics);
 GetSystemMetrics_t GetSystemMetrics_Original;
 
 int WINAPI GetSystemMetrics_Hook(int nIndex) {
@@ -118,7 +127,7 @@ int WINAPI GetSystemMetrics_Hook(int nIndex) {
     return GetSystemMetrics_Original(nIndex);
 }
 
-using GetSystemMetricsForDpi_t = int(WINAPI*)(int, UINT);
+using GetSystemMetricsForDpi_t = decltype(&GetSystemMetricsForDpi);
 GetSystemMetricsForDpi_t GetSystemMetricsForDpi_Original;
 
 int WINAPI GetSystemMetricsForDpi_Hook(int nIndex, UINT dpi) {
@@ -131,7 +140,7 @@ int WINAPI GetSystemMetricsForDpi_Hook(int nIndex, UINT dpi) {
     return GetSystemMetricsForDpi_Original(nIndex, dpi);
 }
 
-using GetThemeSysSize_t = int(WINAPI*)(HTHEME, int);
+using GetThemeSysSize_t = decltype(&GetThemeSysSize);
 GetThemeSysSize_t GetThemeSysSize_Original;
 
 int WINAPI GetThemeSysSize_Hook(HTHEME hTheme, int iSizeId) {
@@ -153,64 +162,17 @@ void LoadSettings() {
     if (g_settings.scrollbarSize < 0) {
         g_settings.scrollbarSize = 0;
     }
-
-    g_processList.clear();
-    for (int i = 0;; i++) {
-        PCWSTR value = Wh_GetStringSetting(L"processList[%d]", i);
-        bool done = !*value;
-        if (!done) {
-            std::wstring s = value;
-            size_t a = s.find_first_not_of(L" \t");
-            size_t b = s.find_last_not_of(L" \t");
-            if (a != std::wstring::npos) {
-                g_processList.push_back(s.substr(a, b - a + 1));
-            }
-        }
-        Wh_FreeStringSetting(value);
-        if (done) {
-            break;
-        }
-    }
-}
-
-bool IsTargetProcess() {
-    WCHAR path[MAX_PATH];
-    DWORD n = GetModuleFileName(nullptr, path, ARRAYSIZE(path));
-    if (n == 0 || n >= ARRAYSIZE(path)) {
-        return false;
-    }
-
-    PCWSTR base = wcsrchr(path, L'\\');
-    base = base ? base + 1 : path;
-
-    for (const auto& name : g_processList) {
-        if (_wcsicmp(base, name.c_str()) == 0) {
-            return true;
-        }
-    }
-    return false;
-}
-
-BOOL CALLBACK RefreshChildProc(HWND hChild, LPARAM) {
-    SetWindowPos(hChild, nullptr, 0, 0, 0, 0,
-                 SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER |
-                     SWP_NOACTIVATE);
-    return TRUE;
 }
 
 BOOL CALLBACK RefreshTopProc(HWND hWnd, LPARAM) {
     DWORD pid = 0;
     GetWindowThreadProcessId(hWnd, &pid);
-    if (pid != GetCurrentProcessId()) {
-        return TRUE;
+    if (pid == GetCurrentProcessId()) {
+        // WM_THEMECHANGED makes themed controls re-read the metric. Guarded
+        // so a wedged window thread can't stall an enable/disable.
+        SendMessageTimeoutW(hWnd, WM_THEMECHANGED, 0, 0, SMTO_ABORTIFHUNG, 200,
+                            nullptr);
     }
-
-    SendMessageTimeout(hWnd, WM_THEMECHANGED, 0, 0, SMTO_ABORTIFHUNG, 200,
-                       nullptr);
-    SetWindowPos(hWnd, nullptr, 0, 0, 0, 0,
-                 SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER |
-                     SWP_NOACTIVATE | SWP_NOOWNERZORDER);
-    EnumChildWindows(hWnd, RefreshChildProc, 0);
     return TRUE;
 }
 
@@ -223,25 +185,30 @@ void RefreshWindows() {
 BOOL Wh_ModInit() {
     LoadSettings();
 
-    if (!IsTargetProcess()) {
-        Wh_Log(L"hide-scrollbars: process not targeted, staying inactive");
-        return FALSE;
-    }
+    WindhawkUtils::SetFunctionHook(GetSystemMetrics, GetSystemMetrics_Hook,
+                                   &GetSystemMetrics_Original);
 
-    Wh_SetFunctionHook((void*)GetSystemMetrics, (void*)GetSystemMetrics_Hook,
-                       (void**)&GetSystemMetrics_Original);
-
-    if (HMODULE user32 = GetModuleHandle(L"user32.dll")) {
-        if (void* p = (void*)GetProcAddress(user32, "GetSystemMetricsForDpi")) {
-            Wh_SetFunctionHook(p, (void*)GetSystemMetricsForDpi_Hook,
-                               (void**)&GetSystemMetricsForDpi_Original);
+    if (HMODULE user32 = GetModuleHandleW(L"user32.dll")) {
+        auto pGetSystemMetricsForDpi = (GetSystemMetricsForDpi_t)GetProcAddress(
+            user32, "GetSystemMetricsForDpi");
+        if (pGetSystemMetricsForDpi) {
+            WindhawkUtils::SetFunctionHook(pGetSystemMetricsForDpi,
+                                          GetSystemMetricsForDpi_Hook,
+                                          &GetSystemMetricsForDpi_Original);
         }
     }
 
-    if (HMODULE uxtheme = LoadLibrary(L"uxtheme.dll")) {
-        if (void* p = (void*)GetProcAddress(uxtheme, "GetThemeSysSize")) {
-            Wh_SetFunctionHook(p, (void*)GetThemeSysSize_Hook,
-                               (void**)&GetThemeSysSize_Original);
+    HMODULE uxtheme = GetModuleHandleW(L"uxtheme.dll");
+    if (!uxtheme) {
+        uxtheme = LoadLibraryExW(L"uxtheme.dll", nullptr,
+                                 LOAD_LIBRARY_SEARCH_SYSTEM32);
+    }
+    if (uxtheme) {
+        auto pGetThemeSysSize =
+            (GetThemeSysSize_t)GetProcAddress(uxtheme, "GetThemeSysSize");
+        if (pGetThemeSysSize) {
+            WindhawkUtils::SetFunctionHook(pGetThemeSysSize, GetThemeSysSize_Hook,
+                                          &GetThemeSysSize_Original);
         }
     }
 
@@ -253,15 +220,12 @@ void Wh_ModAfterInit() {
 }
 
 void Wh_ModUninit() {
-    // Neutralise the hooks before Windhawk removes them, then relayout so
-    // the scrollbars come back.
-    g_settings.hideVertical = false;
-    g_settings.hideHorizontal = false;
+    // Hooks are already removed by the time this runs, so the windows
+    // relayout against the real metrics.
     RefreshWindows();
 }
 
-void Wh_ModSettingsChanged(BOOL* bReload) {
-    // A processList change alters which processes should load the mod, so
-    // ask Windhawk for a full reload rather than a live settings swap.
-    *bReload = TRUE;
+void Wh_ModSettingsChanged() {
+    LoadSettings();
+    RefreshWindows();
 }

--- a/mods/hide-scrollbars.wh.cpp
+++ b/mods/hide-scrollbars.wh.cpp
@@ -1,0 +1,267 @@
+// ==WindhawkMod==
+// @id              hide-scrollbars
+// @name            Hide Scrollbars
+// @description     Hide vertical/horizontal scrollbars in selected processes (default: File Explorer) and reclaim the gutter space
+// @version         1.0.0
+// @author          AmazingBodilyFluids
+// @github          https://github.com/AmazingBodilyFluids
+// @include         *
+// @license         MIT
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Hide Scrollbars
+
+Removes the vertical and/or horizontal scrollbars from windows in the
+processes you choose. By default it targets `explorer.exe`, so the File
+Explorer file list loses its scrollbar and the freed strip is used by the
+content instead of sitting empty.
+
+Mouse-wheel and keyboard scrolling keep working. Precision-touchpad
+two-finger scrolling keeps working at the default scrollbar size of 1px;
+setting the size to 0 breaks it (see the limitation below).
+
+## How it works
+
+The mod hooks `GetSystemMetrics`, `GetSystemMetricsForDpi` and
+`GetThemeSysSize`, and reports a reduced size for `SM_CXVSCROLL` /
+`SM_CYHSCROLL` (the vertical/horizontal scrollbar thickness). Controls
+that lay themselves out from the scrollbar size then shrink it
+accordingly.
+
+## Known limitation: precision-touchpad scrolling
+
+Reporting a size of **0** makes the scrollbar vanish completely, but a
+0-width scrollbar reads as "not scrollable" to the Windows
+precision-touchpad pan handler, so **two-finger scrolling stops working**
+in affected windows. Mouse wheel and keyboard scrolling (arrows,
+PageUp/PageDown, Home/End) are unaffected.
+
+Reporting **1** leaves a 1px sliver that is visually negligible and keeps
+two-finger scrolling working.
+
+The **Scrollbar size** setting lets you choose:
+
+- `1` (default) - touchpad-safe, 1px sliver remains.
+- `0` - fully hidden, breaks precision-touchpad two-finger scroll.
+
+## Notes and limitations
+
+- The metric override is process-wide. Every classic control in a
+  targeted process loses its scrollbar, not only Explorer's file list.
+- Apps rendered with newer UI frameworks (WinUI/XAML) that do not read
+  these metrics are unaffected.
+- With the default size of `1`, a 1px sliver remains where the scrollbar
+  was. Set **Scrollbar size** to `0` for full removal (see the touchpad
+  limitation above).
+- If a control in a targeted process misbehaves, remove that process
+  from the list.
+
+## Settings
+
+- **Hide vertical scrollbars** - toggle the vertical bar.
+- **Hide horizontal scrollbars** - toggle the horizontal bar.
+- **Scrollbar size** - reported thickness in pixels. `1` (default) keeps
+  precision-touchpad scrolling working; `0` hides the bar fully but
+  breaks two-finger touchpad scroll.
+- **Processes** - executable names the mod applies to, one per line. The
+  mod is loaded into every process but stays inactive outside this list.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- hideVertical: true
+  $name: Hide vertical scrollbars
+- hideHorizontal: true
+  $name: Hide horizontal scrollbars
+- scrollbarSize: 1
+  $name: Scrollbar size
+  $description: >-
+    Reported scrollbar thickness in pixels. 1 (default) keeps
+    precision-touchpad two-finger scrolling working while leaving only a
+    1px sliver. 0 hides the scrollbar completely but breaks
+    precision-touchpad scrolling (mouse wheel and keyboard still work).
+- processList:
+  - explorer.exe
+  $name: Processes
+  $description: Executable names (with .exe) the mod applies to, one per line.
+*/
+// ==/WindhawkModSettings==
+
+#include <uxtheme.h>
+
+#include <string>
+#include <vector>
+
+struct {
+    bool hideVertical;
+    bool hideHorizontal;
+    int scrollbarSize;
+} g_settings;
+
+std::vector<std::wstring> g_processList;
+
+// --- hooks ----------------------------------------------------------------
+
+using GetSystemMetrics_t = int(WINAPI*)(int);
+GetSystemMetrics_t GetSystemMetrics_Original;
+
+int WINAPI GetSystemMetrics_Hook(int nIndex) {
+    if (nIndex == SM_CXVSCROLL && g_settings.hideVertical) {
+        return g_settings.scrollbarSize;
+    }
+    if (nIndex == SM_CYHSCROLL && g_settings.hideHorizontal) {
+        return g_settings.scrollbarSize;
+    }
+    return GetSystemMetrics_Original(nIndex);
+}
+
+using GetSystemMetricsForDpi_t = int(WINAPI*)(int, UINT);
+GetSystemMetricsForDpi_t GetSystemMetricsForDpi_Original;
+
+int WINAPI GetSystemMetricsForDpi_Hook(int nIndex, UINT dpi) {
+    if (nIndex == SM_CXVSCROLL && g_settings.hideVertical) {
+        return g_settings.scrollbarSize;
+    }
+    if (nIndex == SM_CYHSCROLL && g_settings.hideHorizontal) {
+        return g_settings.scrollbarSize;
+    }
+    return GetSystemMetricsForDpi_Original(nIndex, dpi);
+}
+
+using GetThemeSysSize_t = int(WINAPI*)(HTHEME, int);
+GetThemeSysSize_t GetThemeSysSize_Original;
+
+int WINAPI GetThemeSysSize_Hook(HTHEME hTheme, int iSizeId) {
+    if (iSizeId == SM_CXVSCROLL && g_settings.hideVertical) {
+        return g_settings.scrollbarSize;
+    }
+    if (iSizeId == SM_CYHSCROLL && g_settings.hideHorizontal) {
+        return g_settings.scrollbarSize;
+    }
+    return GetThemeSysSize_Original(hTheme, iSizeId);
+}
+
+// --- helpers ------------------------------------------------------------
+
+void LoadSettings() {
+    g_settings.hideVertical = Wh_GetIntSetting(L"hideVertical");
+    g_settings.hideHorizontal = Wh_GetIntSetting(L"hideHorizontal");
+    g_settings.scrollbarSize = Wh_GetIntSetting(L"scrollbarSize");
+    if (g_settings.scrollbarSize < 0) {
+        g_settings.scrollbarSize = 0;
+    }
+
+    g_processList.clear();
+    for (int i = 0;; i++) {
+        PCWSTR value = Wh_GetStringSetting(L"processList[%d]", i);
+        bool done = !*value;
+        if (!done) {
+            std::wstring s = value;
+            size_t a = s.find_first_not_of(L" \t");
+            size_t b = s.find_last_not_of(L" \t");
+            if (a != std::wstring::npos) {
+                g_processList.push_back(s.substr(a, b - a + 1));
+            }
+        }
+        Wh_FreeStringSetting(value);
+        if (done) {
+            break;
+        }
+    }
+}
+
+bool IsTargetProcess() {
+    WCHAR path[MAX_PATH];
+    DWORD n = GetModuleFileName(nullptr, path, ARRAYSIZE(path));
+    if (n == 0 || n >= ARRAYSIZE(path)) {
+        return false;
+    }
+
+    PCWSTR base = wcsrchr(path, L'\\');
+    base = base ? base + 1 : path;
+
+    for (const auto& name : g_processList) {
+        if (_wcsicmp(base, name.c_str()) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+BOOL CALLBACK RefreshChildProc(HWND hChild, LPARAM) {
+    SetWindowPos(hChild, nullptr, 0, 0, 0, 0,
+                 SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER |
+                     SWP_NOACTIVATE);
+    return TRUE;
+}
+
+BOOL CALLBACK RefreshTopProc(HWND hWnd, LPARAM) {
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hWnd, &pid);
+    if (pid != GetCurrentProcessId()) {
+        return TRUE;
+    }
+
+    SendMessageTimeout(hWnd, WM_THEMECHANGED, 0, 0, SMTO_ABORTIFHUNG, 200,
+                       nullptr);
+    SetWindowPos(hWnd, nullptr, 0, 0, 0, 0,
+                 SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER |
+                     SWP_NOACTIVATE | SWP_NOOWNERZORDER);
+    EnumChildWindows(hWnd, RefreshChildProc, 0);
+    return TRUE;
+}
+
+void RefreshWindows() {
+    EnumWindows(RefreshTopProc, 0);
+}
+
+// --- mod entry points -------------------------------------------------
+
+BOOL Wh_ModInit() {
+    LoadSettings();
+
+    if (!IsTargetProcess()) {
+        Wh_Log(L"hide-scrollbars: process not targeted, staying inactive");
+        return FALSE;
+    }
+
+    Wh_SetFunctionHook((void*)GetSystemMetrics, (void*)GetSystemMetrics_Hook,
+                       (void**)&GetSystemMetrics_Original);
+
+    if (HMODULE user32 = GetModuleHandle(L"user32.dll")) {
+        if (void* p = (void*)GetProcAddress(user32, "GetSystemMetricsForDpi")) {
+            Wh_SetFunctionHook(p, (void*)GetSystemMetricsForDpi_Hook,
+                               (void**)&GetSystemMetricsForDpi_Original);
+        }
+    }
+
+    if (HMODULE uxtheme = LoadLibrary(L"uxtheme.dll")) {
+        if (void* p = (void*)GetProcAddress(uxtheme, "GetThemeSysSize")) {
+            Wh_SetFunctionHook(p, (void*)GetThemeSysSize_Hook,
+                               (void**)&GetThemeSysSize_Original);
+        }
+    }
+
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    RefreshWindows();
+}
+
+void Wh_ModUninit() {
+    // Neutralise the hooks before Windhawk removes them, then relayout so
+    // the scrollbars come back.
+    g_settings.hideVertical = false;
+    g_settings.hideHorizontal = false;
+    RefreshWindows();
+}
+
+void Wh_ModSettingsChanged(BOOL* bReload) {
+    // A processList change alters which processes should load the mod, so
+    // ask Windhawk for a full reload rather than a live settings swap.
+    *bReload = TRUE;
+}

--- a/mods/hide-scrollbars.wh.cpp
+++ b/mods/hide-scrollbars.wh.cpp
@@ -21,9 +21,7 @@ instead of sitting empty.
 To apply it to other programs, add them to the mod's **Custom process
 inclusion list** under the mod's Advanced settings in Windhawk.
 
-Mouse-wheel and keyboard scrolling keep working. Precision-touchpad
-two-finger scrolling keeps working at the default scrollbar size of 1px;
-setting the size to 0 breaks it (see the limitation below).
+Mouse-wheel and keyboard scrolling are unaffected.
 
 ## Screenshots
 
@@ -31,40 +29,30 @@ Windows default (slim scrollbar in its own gutter):
 
 ![Default](https://raw.githubusercontent.com/AmazingBodilyFluids/windhawk-mods/assets/hide-scrollbars-default.png)
 
-Scrollbar size 1 px:
+With the mod (1px sliver, gutter reclaimed):
 
-![Size 1](https://raw.githubusercontent.com/AmazingBodilyFluids/windhawk-mods/assets/hide-scrollbars-1px.png)
-
-Scrollbar size 0 px (fully hidden):
-
-![Size 0](https://raw.githubusercontent.com/AmazingBodilyFluids/windhawk-mods/assets/hide-scrollbars-0px.png)
+![With the mod](https://raw.githubusercontent.com/AmazingBodilyFluids/windhawk-mods/assets/hide-scrollbars-1px.png)
 
 ## How it works
 
 The mod hooks `GetSystemMetrics`, `GetSystemMetricsForDpi` and
-`GetThemeSysSize`, and reports a reduced size for `SM_CXVSCROLL` /
+`GetThemeSysSize`, and reports a size of 1px for `SM_CXVSCROLL` /
 `SM_CYHSCROLL` (the vertical/horizontal scrollbar thickness). Code that
 lays itself out from that metric - such as Explorer's DirectUI file list
-- then shrinks the scrollbar accordingly. Plain Win32 windows that draw
-standard non-client scrollbars are mostly unaffected, because user32
-lays those out from an internal metric table rather than the exported
-function.
+- then shrinks the scrollbar to a 1px sliver. Plain Win32 windows that
+draw standard non-client scrollbars are mostly unaffected, because
+user32 lays those out from an internal metric table rather than the
+exported function.
 
-## Known limitation: precision-touchpad scrolling
+## Why 1px and not 0
 
-Reporting a size of **0** makes the scrollbar vanish completely, but a
-0-width scrollbar reads as "not scrollable" to the Windows
-precision-touchpad pan handler, so **two-finger scrolling stops working**
-in affected windows. Mouse wheel and keyboard scrolling (arrows,
-PageUp/PageDown, Home/End) are unaffected.
-
-Reporting **1** leaves a 1px sliver that is visually negligible and keeps
-two-finger scrolling working.
-
-The **Scrollbar size** setting lets you choose:
-
-- `1` (default) - touchpad-safe, 1px sliver remains.
-- `0` - fully hidden, breaks precision-touchpad two-finger scroll.
+Reporting 0 makes the scrollbar disappear entirely, but a 0-width
+scrollbar reads as "not scrollable" to the Windows precision-touchpad
+pan handler, so two-finger scrolling stops working in the affected
+windows. A 1px sliver is visually negligible and keeps precision-touchpad
+scrolling working, so the mod uses 1px and does not expose a 0 option.
+Mouse wheel and keyboard scrolling (arrows, PageUp/PageDown, Home/End)
+work either way.
 
 ## Notes
 
@@ -83,9 +71,6 @@ The **Scrollbar size** setting lets you choose:
 
 - **Hide vertical scrollbars** - toggle the vertical bar.
 - **Hide horizontal scrollbars** - toggle the horizontal bar.
-- **Scrollbar size** - reported thickness in pixels; use `0` or `1`.
-  `1` (default) keeps precision-touchpad scrolling working; `0` hides
-  the bar fully but breaks two-finger touchpad scroll.
 */
 // ==/WindhawkModReadme==
 
@@ -95,13 +80,6 @@ The **Scrollbar size** setting lets you choose:
   $name: Hide vertical scrollbars
 - hideHorizontal: true
   $name: Hide horizontal scrollbars
-- scrollbarSize: 1
-  $name: Scrollbar size
-  $description: >-
-    Reported scrollbar thickness in pixels; use 0 or 1. 1 (default)
-    keeps precision-touchpad two-finger scrolling working while leaving
-    only a 1px sliver. 0 hides the scrollbar completely but breaks
-    precision-touchpad scrolling (mouse wheel and keyboard still work).
 */
 // ==/WindhawkModSettings==
 
@@ -109,16 +87,24 @@ The **Scrollbar size** setting lets you choose:
 
 #include <atomic>
 
+#include <string.h>
 #include <uxtheme.h>
+
+// A 1px sliver rather than 0: a 0-width scrollbar reads as "not
+// scrollable" to the Windows precision-touchpad pan handler, which breaks
+// two-finger scrolling. 1px is visually negligible.
+constexpr int kScrollbarSize = 1;
 
 struct {
     std::atomic<bool> hideVertical;
     std::atomic<bool> hideHorizontal;
-    std::atomic<int> scrollbarSize;
 } g_settings;
 
 // Non-null only if this mod (rather than the process) loaded uxtheme.dll.
 HMODULE g_loadedUxtheme;
+
+// Whether the host process is explorer.exe (set in Wh_ModInit).
+bool g_isExplorer;
 
 // --- hooks ----------------------------------------------------------------
 
@@ -127,10 +113,10 @@ GetSystemMetrics_t GetSystemMetrics_Original;
 
 int WINAPI GetSystemMetrics_Hook(int nIndex) {
     if (nIndex == SM_CXVSCROLL && g_settings.hideVertical) {
-        return g_settings.scrollbarSize;
+        return kScrollbarSize;
     }
     if (nIndex == SM_CYHSCROLL && g_settings.hideHorizontal) {
-        return g_settings.scrollbarSize;
+        return kScrollbarSize;
     }
     return GetSystemMetrics_Original(nIndex);
 }
@@ -140,10 +126,10 @@ GetSystemMetricsForDpi_t GetSystemMetricsForDpi_Original;
 
 int WINAPI GetSystemMetricsForDpi_Hook(int nIndex, UINT dpi) {
     if (nIndex == SM_CXVSCROLL && g_settings.hideVertical) {
-        return g_settings.scrollbarSize;
+        return kScrollbarSize;
     }
     if (nIndex == SM_CYHSCROLL && g_settings.hideHorizontal) {
-        return g_settings.scrollbarSize;
+        return kScrollbarSize;
     }
     return GetSystemMetricsForDpi_Original(nIndex, dpi);
 }
@@ -153,10 +139,10 @@ GetThemeSysSize_t GetThemeSysSize_Original;
 
 int WINAPI GetThemeSysSize_Hook(HTHEME hTheme, int iSizeId) {
     if (iSizeId == SM_CXVSCROLL && g_settings.hideVertical) {
-        return g_settings.scrollbarSize;
+        return kScrollbarSize;
     }
     if (iSizeId == SM_CYHSCROLL && g_settings.hideHorizontal) {
-        return g_settings.scrollbarSize;
+        return kScrollbarSize;
     }
     return GetThemeSysSize_Original(hTheme, iSizeId);
 }
@@ -166,13 +152,12 @@ int WINAPI GetThemeSysSize_Hook(HTHEME hTheme, int iSizeId) {
 void LoadSettings() {
     g_settings.hideVertical = Wh_GetIntSetting(L"hideVertical") != 0;
     g_settings.hideHorizontal = Wh_GetIntSetting(L"hideHorizontal") != 0;
-    int size = Wh_GetIntSetting(L"scrollbarSize");
-    g_settings.scrollbarSize = size < 0 ? 0 : size;
 }
 
 BOOL CALLBACK RefreshChildProc(HWND hChild, LPARAM) {
-    SendMessageTimeoutW(hChild, WM_THEMECHANGED, 0, 0, SMTO_ABORTIFHUNG, 200,
-                        nullptr);
+    // Async: we run on the Windhawk engine thread, the target windows
+    // belong to other threads, and we don't need to wait for the relayout.
+    SendNotifyMessageW(hChild, WM_THEMECHANGED, 0, 0);
     return TRUE;
 }
 
@@ -183,18 +168,21 @@ BOOL CALLBACK RefreshTopProc(HWND hWnd, LPARAM) {
         return TRUE;
     }
 
-    // Only Explorer browser windows host the file-list scrollbar. Don't
-    // re-theme the shell (tray, desktop, flyouts) over a scrollbar metric.
-    WCHAR className[64];
-    if (GetClassNameW(hWnd, className, ARRAYSIZE(className)) == 0 ||
-        _wcsicmp(className, L"CabinetWClass") != 0) {
-        return TRUE;
+    // In Explorer only the browser windows host the affected scrollbars,
+    // so don't re-theme the shell (tray, desktop, flyouts). In a process
+    // added via the inclusion list we have no such knowledge - refresh
+    // everything the process owns.
+    if (g_isExplorer) {
+        WCHAR className[64];
+        if (GetClassNameW(hWnd, className, ARRAYSIZE(className)) == 0 ||
+            _wcsicmp(className, L"CabinetWClass") != 0) {
+            return TRUE;
+        }
     }
 
     // WM_THEMECHANGED doesn't forward to children on its own, so walk them
-    // too. Guarded because each CabinetWClass window runs on its own thread.
-    SendMessageTimeoutW(hWnd, WM_THEMECHANGED, 0, 0, SMTO_ABORTIFHUNG, 200,
-                        nullptr);
+    // too.
+    SendNotifyMessageW(hWnd, WM_THEMECHANGED, 0, 0);
     EnumChildWindows(hWnd, RefreshChildProc, 0);
     return TRUE;
 }
@@ -211,6 +199,12 @@ BOOL Wh_ModInit() {
     if (!g_settings.hideVertical && !g_settings.hideHorizontal) {
         Wh_Log(L"Nothing to hide, staying inactive");
         return FALSE;
+    }
+
+    WCHAR exePath[MAX_PATH];
+    if (GetModuleFileNameW(nullptr, exePath, ARRAYSIZE(exePath))) {
+        const WCHAR* exeName = wcsrchr(exePath, L'\\');
+        g_isExplorer = exeName && _wcsicmp(exeName + 1, L"explorer.exe") == 0;
     }
 
     WindhawkUtils::SetFunctionHook(GetSystemMetrics, GetSystemMetrics_Hook,
@@ -259,16 +253,24 @@ void Wh_ModUninit() {
     }
 }
 
-void Wh_ModSettingsChanged() {
+BOOL Wh_ModSettingsChanged(BOOL* bReload) {
     bool prevVertical = g_settings.hideVertical;
     bool prevHorizontal = g_settings.hideHorizontal;
-    int prevSize = g_settings.scrollbarSize;
 
     LoadSettings();
 
+    // Nothing left to hide: reload so Wh_ModInit can return FALSE and the
+    // pass-through hooks go away. Wh_ModUninit's RefreshWindows() restores
+    // the layout on the way out.
+    if (!g_settings.hideVertical && !g_settings.hideHorizontal) {
+        *bReload = TRUE;
+        return TRUE;
+    }
+
     if (g_settings.hideVertical != prevVertical ||
-        g_settings.hideHorizontal != prevHorizontal ||
-        g_settings.scrollbarSize != prevSize) {
+        g_settings.hideHorizontal != prevHorizontal) {
         RefreshWindows();
     }
+
+    return TRUE;
 }

--- a/mods/hide-scrollbars.wh.cpp
+++ b/mods/hide-scrollbars.wh.cpp
@@ -31,11 +31,11 @@ Windows default (slim scrollbar in its own gutter):
 
 ![Default](https://raw.githubusercontent.com/AmazingBodilyFluids/windhawk-mods/assets/hide-scrollbars-default.png)
 
-Scrollbar size 1 (1px sliver, gutter reclaimed):
+Scrollbar size 1 px:
 
 ![Size 1](https://raw.githubusercontent.com/AmazingBodilyFluids/windhawk-mods/assets/hide-scrollbars-1px.png)
 
-Scrollbar size 0 (fully hidden):
+Scrollbar size 0 px (fully hidden):
 
 ![Size 0](https://raw.githubusercontent.com/AmazingBodilyFluids/windhawk-mods/assets/hide-scrollbars-0px.png)
 
@@ -71,6 +71,9 @@ The **Scrollbar size** setting lets you choose:
 - The override is process-wide. Other mods running in the same process
   that read `SM_CXVSCROLL` / `SM_CYHSCROLL` (for example to hit-test the
   scrollbar strip) will see the reduced value too.
+- `SM_CXVSCROLL` also drives the width of combo-box drop-down buttons
+  and the status-bar sizing grip. Code that reads the exported metric
+  (rather than user32's internal table) shrinks those too.
 - The scrollbar *arrow button* metrics (`SM_CXHSCROLL` / `SM_CYVSCROLL`)
   and `SPI_GETNONCLIENTMETRICS` are left untouched, so a control that
   mixes those with `SM_CXVSCROLL` may lay out slightly oddly.
@@ -80,9 +83,9 @@ The **Scrollbar size** setting lets you choose:
 
 - **Hide vertical scrollbars** - toggle the vertical bar.
 - **Hide horizontal scrollbars** - toggle the horizontal bar.
-- **Scrollbar size** - reported thickness in pixels. `1` (default) keeps
-  precision-touchpad scrolling working; `0` hides the bar fully but
-  breaks two-finger touchpad scroll.
+- **Scrollbar size** - reported thickness in pixels; use `0` or `1`.
+  `1` (default) keeps precision-touchpad scrolling working; `0` hides
+  the bar fully but breaks two-finger touchpad scroll.
 */
 // ==/WindhawkModReadme==
 
@@ -95,22 +98,27 @@ The **Scrollbar size** setting lets you choose:
 - scrollbarSize: 1
   $name: Scrollbar size
   $description: >-
-    Reported scrollbar thickness in pixels. 1 (default) keeps
-    precision-touchpad two-finger scrolling working while leaving only a
-    1px sliver. 0 hides the scrollbar completely but breaks
+    Reported scrollbar thickness in pixels; use 0 or 1. 1 (default)
+    keeps precision-touchpad two-finger scrolling working while leaving
+    only a 1px sliver. 0 hides the scrollbar completely but breaks
     precision-touchpad scrolling (mouse wheel and keyboard still work).
 */
 // ==/WindhawkModSettings==
 
 #include <windhawk_utils.h>
 
+#include <atomic>
+
 #include <uxtheme.h>
 
 struct {
-    bool hideVertical;
-    bool hideHorizontal;
-    int scrollbarSize;
+    std::atomic<bool> hideVertical;
+    std::atomic<bool> hideHorizontal;
+    std::atomic<int> scrollbarSize;
 } g_settings;
+
+// Non-null only if this mod (rather than the process) loaded uxtheme.dll.
+HMODULE g_loadedUxtheme;
 
 // --- hooks ----------------------------------------------------------------
 
@@ -156,23 +164,38 @@ int WINAPI GetThemeSysSize_Hook(HTHEME hTheme, int iSizeId) {
 // --- helpers ------------------------------------------------------------
 
 void LoadSettings() {
-    g_settings.hideVertical = Wh_GetIntSetting(L"hideVertical");
-    g_settings.hideHorizontal = Wh_GetIntSetting(L"hideHorizontal");
-    g_settings.scrollbarSize = Wh_GetIntSetting(L"scrollbarSize");
-    if (g_settings.scrollbarSize < 0) {
-        g_settings.scrollbarSize = 0;
-    }
+    g_settings.hideVertical = Wh_GetIntSetting(L"hideVertical") != 0;
+    g_settings.hideHorizontal = Wh_GetIntSetting(L"hideHorizontal") != 0;
+    int size = Wh_GetIntSetting(L"scrollbarSize");
+    g_settings.scrollbarSize = size < 0 ? 0 : size;
+}
+
+BOOL CALLBACK RefreshChildProc(HWND hChild, LPARAM) {
+    SendMessageTimeoutW(hChild, WM_THEMECHANGED, 0, 0, SMTO_ABORTIFHUNG, 200,
+                        nullptr);
+    return TRUE;
 }
 
 BOOL CALLBACK RefreshTopProc(HWND hWnd, LPARAM) {
     DWORD pid = 0;
     GetWindowThreadProcessId(hWnd, &pid);
-    if (pid == GetCurrentProcessId()) {
-        // WM_THEMECHANGED makes themed controls re-read the metric. Guarded
-        // so a wedged window thread can't stall an enable/disable.
-        SendMessageTimeoutW(hWnd, WM_THEMECHANGED, 0, 0, SMTO_ABORTIFHUNG, 200,
-                            nullptr);
+    if (pid != GetCurrentProcessId()) {
+        return TRUE;
     }
+
+    // Only Explorer browser windows host the file-list scrollbar. Don't
+    // re-theme the shell (tray, desktop, flyouts) over a scrollbar metric.
+    WCHAR className[64];
+    if (GetClassNameW(hWnd, className, ARRAYSIZE(className)) == 0 ||
+        _wcsicmp(className, L"CabinetWClass") != 0) {
+        return TRUE;
+    }
+
+    // WM_THEMECHANGED doesn't forward to children on its own, so walk them
+    // too. Guarded because each CabinetWClass window runs on its own thread.
+    SendMessageTimeoutW(hWnd, WM_THEMECHANGED, 0, 0, SMTO_ABORTIFHUNG, 200,
+                        nullptr);
+    EnumChildWindows(hWnd, RefreshChildProc, 0);
     return TRUE;
 }
 
@@ -184,6 +207,11 @@ void RefreshWindows() {
 
 BOOL Wh_ModInit() {
     LoadSettings();
+
+    if (!g_settings.hideVertical && !g_settings.hideHorizontal) {
+        Wh_Log(L"Nothing to hide, staying inactive");
+        return FALSE;
+    }
 
     WindhawkUtils::SetFunctionHook(GetSystemMetrics, GetSystemMetrics_Hook,
                                    &GetSystemMetrics_Original);
@@ -202,6 +230,7 @@ BOOL Wh_ModInit() {
     if (!uxtheme) {
         uxtheme = LoadLibraryExW(L"uxtheme.dll", nullptr,
                                  LOAD_LIBRARY_SEARCH_SYSTEM32);
+        g_loadedUxtheme = uxtheme;
     }
     if (uxtheme) {
         auto pGetThemeSysSize =
@@ -223,9 +252,23 @@ void Wh_ModUninit() {
     // Hooks are already removed by the time this runs, so the windows
     // relayout against the real metrics.
     RefreshWindows();
+
+    if (g_loadedUxtheme) {
+        FreeLibrary(g_loadedUxtheme);
+        g_loadedUxtheme = nullptr;
+    }
 }
 
 void Wh_ModSettingsChanged() {
+    bool prevVertical = g_settings.hideVertical;
+    bool prevHorizontal = g_settings.hideHorizontal;
+    int prevSize = g_settings.scrollbarSize;
+
     LoadSettings();
-    RefreshWindows();
+
+    if (g_settings.hideVertical != prevVertical ||
+        g_settings.hideHorizontal != prevHorizontal ||
+        g_settings.scrollbarSize != prevSize) {
+        RefreshWindows();
+    }
 }


### PR DESCRIPTION
This pull request adds a new mod, **Hide Scrollbars**.

It hides the vertical and/or horizontal scrollbars in a configurable list of processes (default: `explorer.exe`) by hooking `GetSystemMetrics`, `GetSystemMetricsForDpi` and `GetThemeSysSize` and returning a reduced size for `SM_CXVSCROLL` / `SM_CYHSCROLL`. Affected controls then reflow their content into the reclaimed gutter.

Mouse-wheel and keyboard scrolling are unaffected. A **Scrollbar size** setting (default `1`) leaves a 1px sliver so that precision-touchpad two-finger scrolling keeps working; setting it to `0` removes the scrollbar entirely at the cost of touchpad panning in the affected windows. This trade-off is documented in the mod's readme.

**Note on `@include *`:** the mod is injected into every process but returns `FALSE` from `Wh_ModInit` unless the process is in the user-configurable list, so it is inert everywhere else. This follows the same pattern used by other mods that expose a runtime-configurable process list.

## Changelog

* Initial release.

## Mod authorship

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify):
- - [ ] Other (please specify):
