### PR TITLE
Fix dark outline in AllowDark mode for mod 'Dark mode context menus'

### DIFF
--- a/mods/dark-menus.wh.cpp
+++ b/mods/dark-menus.wh.cpp
@@ -413,9 +413,18 @@ LRESULT CALLBACK DefWindowProcA_Hook(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM
     return DefWindowProcA_Original(hWnd, uMsg, wParam, lParam);
 }
 
+bool ShouldMenusBeDark()
+{
+    return g_currentAppMode == AppMode::ForceDark ||
+           (g_currentAppMode == AppMode::AllowDark && ShouldAppsUseDarkMode());
+}
+
 decltype(&SetMenuInfo) SetMenuInfo_Original;
 WINBOOL WINAPI SetMenuInfo_Hook(HMENU hMenu, LPCMENUINFO lpInfo)
 {
+    if (!ShouldMenusBeDark())
+        return SetMenuInfo_Original(hMenu, lpInfo);
+
     //Disable custom menu backgrounds because they are broken in dark mode. (See https://github.com/MGGSK/DarkMenus/issues/16)
     alignas(MENUINFO) BYTE buffer[256];
     if (!(lpInfo->fMask & MIM_BACKGROUND) || lpInfo->cbSize > sizeof(buffer))


### PR DESCRIPTION
## Changelog
This PR updates the mod "Dark mode context menus"
This version fixes a bug reported on https://github.com/MGGSK/DarkMenus/issues/35 I tested it locally, the dark outline is gone when using light mode with AppMode: AllowDark


