### PR TITLE
Add mod: Always hide all taskbar tray icons in overflow (taskbar-tray-icons-in-overflow)

### DIFF
--- a/mods/taskbar-tray-icons-in-overflow.wh.cpp
+++ b/mods/taskbar-tray-icons-in-overflow.wh.cpp
@@ -1,0 +1,312 @@
+// ==WindhawkMod==
+// @id              taskbar-tray-icons-in-overflow
+// @name            Always hide all taskbar tray icons in overflow
+// @description     Forces all notification area (tray) icons inside the overflow chevron arrow (Windows 11 only)
+// @version         1.0
+// @author          Hubert
+// @github          https://github.com/hlsitechio
+// @include         explorer.exe
+// @architecture    x86-64
+// @license         MIT
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Always hide all taskbar tray icons in overflow
+
+Keep your Windows 11 taskbar minimal, clean, and distraction-free by automatically collapsing
+all notification area (system tray) icons into the overflow arrow (the `^` chevron flyout).
+
+![Demonstration](https://raw.githubusercontent.com/hlsitechio/windhawk-tray-icons-in-overflow/main/assets/tray-icons-after.png)
+
+### Features
+- **All icons inside the arrow**: Ensures every third-party notification tray icon stays inside the overflow flyout rather than cluttering the main taskbar.
+- **Configurable modes**:
+  - `hideAll` (Default): All notification icons are forced into the overflow flyout.
+  - `hideNew`: New notification icons are sent to the overflow flyout by default, leaving existing configurations intact.
+- **Zero background overhead**: Hooks the Windows registry queries (`NotifyIconSettings\IsPromoted`) directly inside Explorer without running persistent polling loops.
+
+### Supported Windows Versions
+- Windows 11 only (including 22H2, 23H2, and 24H2).
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- mode: hideAll
+  $name: Mode
+  $options:
+  - hideAll: All icons are hidden inside the overflow arrow
+  - hideNew: New icons are hidden inside the overflow arrow, existing icons are unaffected
+*/
+// ==/WindhawkModSettings==
+
+#include <ntstatus.h>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+enum class Mode {
+    hideAll,
+    hideNew,
+};
+
+struct {
+    Mode mode;
+} g_settings;
+
+std::wstring GetPathFromHKEY(HKEY key) {
+    std::wstring keyPath;
+    if (key) {
+        HMODULE dll = GetModuleHandleW(L"ntdll.dll");
+        if (dll) {
+            typedef NTSTATUS(__stdcall * NtQueryKeyType)(
+                HANDLE KeyHandle, int KeyInformationClass, PVOID KeyInformation,
+                ULONG Length, PULONG ResultLength);
+            NtQueryKeyType func =
+                (NtQueryKeyType)GetProcAddress(dll, "NtQueryKey");
+            if (func) {
+                ULONG size = 0;
+                NTSTATUS result = func(key, 3, nullptr, 0, &size);
+                if (result == STATUS_BUFFER_TOO_SMALL) {
+                    size = size + 2;
+                    wchar_t* buffer = new (std::nothrow)
+                        wchar_t[size / sizeof(wchar_t)];
+                    if (buffer) {
+                        result = func(key, 3, buffer, size, &size);
+                        if (result == STATUS_SUCCESS) {
+                            buffer[size / sizeof(wchar_t)] = L'\0';
+                            keyPath = std::wstring(buffer + 2);
+                        }
+                        delete[] buffer;
+                    }
+                }
+            }
+        }
+    }
+    return keyPath;
+}
+
+std::vector<std::wstring> SplitStringView(std::wstring_view s,
+                                          WCHAR delimiter) {
+    size_t pos_start = 0, pos_end;
+    std::wstring token;
+    std::vector<std::wstring> res;
+
+    while ((pos_end = s.find(delimiter, pos_start)) !=
+           std::wstring_view::npos) {
+        token = s.substr(pos_start, pos_end - pos_start);
+        pos_start = pos_end + 1;
+        res.push_back(std::move(token));
+    }
+
+    token = s.substr(pos_start);
+    res.push_back(std::move(token));
+    return res;
+}
+
+std::wstring GetNotifyIconSettingsNameFromRegKey(HKEY hKey) {
+    // Expected path:
+    // \REGISTRY\USER\S-1-5-...\Control Panel\NotifyIconSettings\<entry_id>
+    auto path = SplitStringView(GetPathFromHKEY(hKey), L'\\');
+    if (path.size() == 7 && path[0].size() == 0 &&
+        _wcsicmp(path[1].c_str(), L"REGISTRY") == 0 &&
+        _wcsicmp(path[2].c_str(), L"USER") == 0 &&
+        _wcsicmp(path[4].c_str(), L"Control Panel") == 0 &&
+        _wcsicmp(path[5].c_str(), L"NotifyIconSettings") == 0) {
+        return path[6];
+    }
+
+    return L"";
+}
+
+using RegSetValueExW_t = decltype(&RegSetValueExW);
+RegSetValueExW_t RegSetValueExW_Original;
+LONG WINAPI RegSetValueExW_Hook(HKEY hKey,
+                                LPCWSTR lpValueName,
+                                DWORD Reserved,
+                                DWORD dwType,
+                                CONST BYTE* lpData,
+                                DWORD cbData) {
+    if (g_settings.mode == Mode::hideAll && lpValueName &&
+        _wcsicmp(lpValueName, L"IsPromoted") == 0) {
+        auto entry = GetNotifyIconSettingsNameFromRegKey(hKey);
+        if (!entry.empty()) {
+            Wh_Log(L"Suppressing promotion for %s, keeping inside overflow", entry.c_str());
+            return ERROR_SUCCESS;
+        }
+    }
+
+    return RegSetValueExW_Original(hKey, lpValueName, Reserved, dwType, lpData,
+                                   cbData);
+}
+
+bool SetIsPromoted(PCWSTR entry, DWORD isPromoted) {
+    Wh_Log(L"Writing IsPromoted=%u for %s", isPromoted, entry);
+
+    std::wstring subKey = L"Control Panel\\NotifyIconSettings\\";
+    subKey += entry;
+
+    HKEY key;
+    LONG result =
+        RegOpenKeyEx(HKEY_CURRENT_USER, subKey.c_str(), 0, KEY_SET_VALUE, &key);
+    if (result != ERROR_SUCCESS) {
+        Wh_Log(L"Failed to open %s: %d", subKey.c_str(), result);
+        return false;
+    }
+
+    result = RegSetValueExW_Original(key, L"IsPromoted", 0, REG_DWORD,
+                                     (const BYTE*)&isPromoted, sizeof(isPromoted));
+    if (result != ERROR_SUCCESS) {
+        Wh_Log(L"Failed to write to %s: %d", subKey.c_str(), result);
+    }
+
+    RegCloseKey(key);
+    return result == ERROR_SUCCESS;
+}
+
+using RegGetValueW_t = decltype(&RegGetValueW);
+RegGetValueW_t RegGetValueW_Original;
+LONG WINAPI RegGetValueW_Hook(HKEY hkey,
+                              LPCWSTR lpSubKey,
+                              LPCWSTR lpValue,
+                              DWORD dwFlags,
+                              LPDWORD pdwType,
+                              PVOID pvData,
+                              LPDWORD pcbData) {
+    if (!lpSubKey && lpValue && (dwFlags & RRF_RT_REG_DWORD) && pvData &&
+        pcbData && *pcbData >= sizeof(DWORD) &&
+        _wcsicmp(lpValue, L"IsPromoted") == 0) {
+        auto entry = GetNotifyIconSettingsNameFromRegKey(hkey);
+        if (!entry.empty()) {
+            Wh_Log(L"Checking IsPromoted for %s", entry.c_str());
+
+            if (g_settings.mode != Mode::hideAll) {
+                LONG result = RegGetValueW_Original(
+                    hkey, lpSubKey, lpValue, dwFlags, pdwType, pvData, pcbData);
+                if (result != ERROR_FILE_NOT_FOUND) {
+                    return result;
+                }
+
+                Wh_Log(L"No existing IsPromoted value found for %s, setting default 0", entry.c_str());
+                SetIsPromoted(entry.c_str(), 0);
+            }
+
+            if (pdwType) {
+                *pdwType = REG_DWORD;
+            }
+
+            // 0 = Not promoted, keeps icon inside the overflow chevron arrow
+            *(DWORD*)pvData = 0;
+            *pcbData = sizeof(DWORD);
+            return ERROR_SUCCESS;
+        }
+    }
+
+    return RegGetValueW_Original(hkey, lpSubKey, lpValue, dwFlags, pdwType,
+                                 pvData, pcbData);
+}
+
+// Explorer has a registry watcher for each notify icon item. Trigger the
+// watcher by writing and then removing a temporary value.
+void TouchAllNotifyIconSettings() {
+    constexpr WCHAR kBaseKeyPath[] = L"Control Panel\\NotifyIconSettings";
+    constexpr WCHAR kTempValueName[] =
+        L"_temp_windhawk_taskbar-tray-icons-in-overflow";
+
+    HKEY hKey;
+    LONG result = RegOpenKeyEx(HKEY_CURRENT_USER, kBaseKeyPath, 0,
+                               KEY_READ | KEY_WRITE, &hKey);
+    if (result != ERROR_SUCCESS) {
+        Wh_Log(L"Failed to open base key: %d", result);
+        return;
+    }
+
+    DWORD index = 0;
+    WCHAR subKeyName[MAX_PATH];
+    DWORD subKeyNameSize = MAX_PATH;
+
+    while (RegEnumKeyEx(hKey, index, subKeyName, &subKeyNameSize, nullptr,
+                        nullptr, nullptr, nullptr) == ERROR_SUCCESS) {
+        HKEY hSubKey;
+        result = RegOpenKeyEx(hKey, subKeyName, 0, KEY_WRITE, &hSubKey);
+        if (result == ERROR_SUCCESS) {
+            if (RegSetValueEx(hSubKey, kTempValueName, 0, REG_SZ,
+                              (const BYTE*)L"",
+                              sizeof(WCHAR)) != ERROR_SUCCESS) {
+                Wh_Log(L"Failed to create temp value: %s", subKeyName);
+            } else if (RegDeleteValue(hSubKey, kTempValueName) !=
+                       ERROR_SUCCESS) {
+                Wh_Log(L"Failed to remove temp value: %s", subKeyName);
+            }
+
+            RegCloseKey(hSubKey);
+        } else {
+            Wh_Log(L"Failed to open subkey: %d", result);
+        }
+
+        subKeyNameSize = MAX_PATH;
+        index++;
+    }
+
+    RegCloseKey(hKey);
+}
+
+void LoadSettings() {
+    PCWSTR mode = Wh_GetStringSetting(L"mode");
+    g_settings.mode = Mode::hideAll;
+    if (mode && wcscmp(mode, L"hideNew") == 0) {
+        g_settings.mode = Mode::hideNew;
+    }
+    Wh_FreeStringSetting(mode);
+}
+
+BOOL Wh_ModInit() {
+    Wh_Log(L"> Init");
+
+    LoadSettings();
+
+    HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
+    if (!kernelBaseModule) {
+        Wh_Log(L"kernelBaseModule not found");
+        return FALSE;
+    }
+
+    FARPROC pRegGetValueW = GetProcAddress(kernelBaseModule, "RegGetValueW");
+    if (!pRegGetValueW) {
+        Wh_Log(L"RegGetValueW not found");
+        return FALSE;
+    }
+
+    FARPROC pRegSetValueExW =
+        GetProcAddress(kernelBaseModule, "RegSetValueExW");
+    if (!pRegSetValueExW) {
+        Wh_Log(L"RegSetValueExW not found");
+        return FALSE;
+    }
+
+    Wh_SetFunctionHook((void*)pRegSetValueExW, (void*)RegSetValueExW_Hook,
+                       (void**)&RegSetValueExW_Original);
+
+    Wh_SetFunctionHook((void*)pRegGetValueW, (void*)RegGetValueW_Hook,
+                       (void**)&RegGetValueW_Original);
+
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    Wh_Log(L"> AfterInit");
+    TouchAllNotifyIconSettings();
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L"> Uninit");
+    TouchAllNotifyIconSettings();
+}
+
+void Wh_ModSettingsChanged() {
+    Wh_Log(L"> SettingsChanged");
+    LoadSettings();
+    TouchAllNotifyIconSettings();
+}

--- a/mods/taskbar-tray-icons-in-overflow.wh.cpp
+++ b/mods/taskbar-tray-icons-in-overflow.wh.cpp
@@ -7,39 +7,38 @@
 // @github          https://github.com/hlsitechio
 // @include         explorer.exe
 // @architecture    x86-64
-// @license         MIT
+// @license         GPL-3.0
 // ==/WindhawkMod==
+
+// Source code is published under The GNU General Public License v3.0.
+//
+// Based on taskbar-notification-icons-show-all by m417z:
+// https://github.com/ramensoftware/windhawk-mods/blob/main/mods/taskbar-notification-icons-show-all.wh.cpp
+//
+// Registry path helper from valinet:
+// https://github.com/valinet/wh-mods/blob/61319815c7e018e392a08077dc364559548ade02/mods/valinet-unserver.wh.cpp#L95
 
 // ==WindhawkModReadme==
 /*
 # Always hide all taskbar tray icons in overflow
 
 Keep your Windows 11 taskbar minimal, clean, and distraction-free by automatically collapsing
-all notification area (system tray) icons into the overflow arrow (the `^` chevron flyout).
+all notification area (system tray) icons inside the overflow arrow (the `^` / `<` chevron flyout).
 
 ![Demonstration](https://raw.githubusercontent.com/hlsitechio/windhawk-tray-icons-in-overflow/main/assets/tray-icons-after.png)
 
 ### Features
 - **All icons inside the arrow**: Ensures every third-party notification tray icon stays inside the overflow flyout rather than cluttering the main taskbar.
-- **Configurable modes**:
-  - `hideAll` (Default): All notification icons are forced into the overflow flyout.
-  - `hideNew`: New notification icons are sent to the overflow flyout by default, leaving existing configurations intact.
-- **Zero background overhead**: Hooks the Windows registry queries (`NotifyIconSettings\IsPromoted`) directly inside Explorer without running persistent polling loops.
+- **Pure memory hook**: Hooks the Windows registry query (`NotifyIconSettings\IsPromoted`) directly in `explorer.exe` on read and write, leaving the underlying registry untouched. Disabling the mod immediately restores your original icon layout.
+
+### Notes
+- Dragging an icon out of the overflow flyout onto the taskbar will silently snap back inside the overflow while the mod is active.
+- The toggles in *Settings > Personalization > Taskbar > Other system tray icons* are handled by `SystemSettings.exe`, but the taskbar itself will enforce the collapsed state.
 
 ### Supported Windows Versions
 - Windows 11 only (including 22H2, 23H2, and 24H2).
 */
 // ==/WindhawkModReadme==
-
-// ==WindhawkModSettings==
-/*
-- mode: hideAll
-  $name: Mode
-  $options:
-  - hideAll: All icons are hidden inside the overflow arrow
-  - hideNew: New icons are hidden inside the overflow arrow, existing icons are unaffected
-*/
-// ==/WindhawkModSettings==
 
 #include <ntstatus.h>
 
@@ -47,15 +46,8 @@ all notification area (system tray) icons into the overflow arrow (the `^` chevr
 #include <string_view>
 #include <vector>
 
-enum class Mode {
-    hideAll,
-    hideNew,
-};
-
-struct {
-    Mode mode;
-} g_settings;
-
+// https://github.com/valinet/wh-mods/blob/61319815c7e018e392a08077dc364559548ade02/mods/valinet-unserver.wh.cpp#L95
+// https://stackoverflow.com/questions/937044/determine-path-to-registry-key-from-hkey-handle-in-c
 std::wstring GetPathFromHKEY(HKEY key) {
     std::wstring keyPath;
     if (key) {
@@ -88,6 +80,7 @@ std::wstring GetPathFromHKEY(HKEY key) {
     return keyPath;
 }
 
+// https://stackoverflow.com/a/46931770
 std::vector<std::wstring> SplitStringView(std::wstring_view s,
                                           WCHAR delimiter) {
     size_t pos_start = 0, pos_end;
@@ -129,41 +122,16 @@ LONG WINAPI RegSetValueExW_Hook(HKEY hKey,
                                 DWORD dwType,
                                 CONST BYTE* lpData,
                                 DWORD cbData) {
-    if (g_settings.mode == Mode::hideAll && lpValueName &&
-        _wcsicmp(lpValueName, L"IsPromoted") == 0) {
+    if (lpValueName && _wcsicmp(lpValueName, L"IsPromoted") == 0) {
         auto entry = GetNotifyIconSettingsNameFromRegKey(hKey);
         if (!entry.empty()) {
-            Wh_Log(L"Suppressing promotion for %s, keeping inside overflow", entry.c_str());
+            Wh_Log(L"Suppressing promotion for %s", entry.c_str());
             return ERROR_SUCCESS;
         }
     }
 
     return RegSetValueExW_Original(hKey, lpValueName, Reserved, dwType, lpData,
                                    cbData);
-}
-
-bool SetIsPromoted(PCWSTR entry, DWORD isPromoted) {
-    Wh_Log(L"Writing IsPromoted=%u for %s", isPromoted, entry);
-
-    std::wstring subKey = L"Control Panel\\NotifyIconSettings\\";
-    subKey += entry;
-
-    HKEY key;
-    LONG result =
-        RegOpenKeyEx(HKEY_CURRENT_USER, subKey.c_str(), 0, KEY_SET_VALUE, &key);
-    if (result != ERROR_SUCCESS) {
-        Wh_Log(L"Failed to open %s: %d", subKey.c_str(), result);
-        return false;
-    }
-
-    result = RegSetValueExW_Original(key, L"IsPromoted", 0, REG_DWORD,
-                                     (const BYTE*)&isPromoted, sizeof(isPromoted));
-    if (result != ERROR_SUCCESS) {
-        Wh_Log(L"Failed to write to %s: %d", subKey.c_str(), result);
-    }
-
-    RegCloseKey(key);
-    return result == ERROR_SUCCESS;
 }
 
 using RegGetValueW_t = decltype(&RegGetValueW);
@@ -180,24 +148,13 @@ LONG WINAPI RegGetValueW_Hook(HKEY hkey,
         _wcsicmp(lpValue, L"IsPromoted") == 0) {
         auto entry = GetNotifyIconSettingsNameFromRegKey(hkey);
         if (!entry.empty()) {
-            Wh_Log(L"Checking IsPromoted for %s", entry.c_str());
-
-            if (g_settings.mode != Mode::hideAll) {
-                LONG result = RegGetValueW_Original(
-                    hkey, lpSubKey, lpValue, dwFlags, pdwType, pvData, pcbData);
-                if (result != ERROR_FILE_NOT_FOUND) {
-                    return result;
-                }
-
-                Wh_Log(L"No existing IsPromoted value found for %s, setting default 0", entry.c_str());
-                SetIsPromoted(entry.c_str(), 0);
-            }
+            Wh_Log(L"Forcing IsPromoted=0 for %s", entry.c_str());
 
             if (pdwType) {
                 *pdwType = REG_DWORD;
             }
 
-            // 0 = Not promoted, keeps icon inside the overflow chevron arrow
+            // 0 = Not promoted -> keeps icon inside the overflow chevron arrow
             *(DWORD*)pvData = 0;
             *pcbData = sizeof(DWORD);
             return ERROR_SUCCESS;
@@ -253,19 +210,8 @@ void TouchAllNotifyIconSettings() {
     RegCloseKey(hKey);
 }
 
-void LoadSettings() {
-    PCWSTR mode = Wh_GetStringSetting(L"mode");
-    g_settings.mode = Mode::hideAll;
-    if (mode && wcscmp(mode, L"hideNew") == 0) {
-        g_settings.mode = Mode::hideNew;
-    }
-    Wh_FreeStringSetting(mode);
-}
-
 BOOL Wh_ModInit() {
-    Wh_Log(L"> Init");
-
-    LoadSettings();
+    Wh_Log(L">");
 
     HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
     if (!kernelBaseModule) {
@@ -296,17 +242,11 @@ BOOL Wh_ModInit() {
 }
 
 void Wh_ModAfterInit() {
-    Wh_Log(L"> AfterInit");
+    Wh_Log(L">");
     TouchAllNotifyIconSettings();
 }
 
 void Wh_ModUninit() {
-    Wh_Log(L"> Uninit");
-    TouchAllNotifyIconSettings();
-}
-
-void Wh_ModSettingsChanged() {
-    Wh_Log(L"> SettingsChanged");
-    LoadSettings();
+    Wh_Log(L">");
     TouchAllNotifyIconSettings();
 }


### PR DESCRIPTION
### Summary

This pull request adds a new mod: **Always hide all taskbar tray icons in overflow** (	askbar-tray-icons-in-overflow).

### Demonstration

**Before (Cluttered taskbar with all tray icons visible):**
![Before](https://raw.githubusercontent.com/hlsitechio/windhawk-tray-icons-in-overflow/main/assets/tray-icons-before.png)

**After (Clean taskbar with icons collapsed inside the arrow):**
![After](https://raw.githubusercontent.com/hlsitechio/windhawk-tray-icons-in-overflow/main/assets/tray-icons-after.png)

### Description
- **Mod ID**: 	askbar-tray-icons-in-overflow
- **Author**: Hubert (@hlsitechio)
- **Target OS**: Windows 11 (22H2, 23H2, 24H2)
- **Target Process**: xplorer.exe

### Purpose
Keeps the Windows 11 taskbar minimal and distraction-free by automatically collapsing all third-party notification area (system tray) icons inside the overflow chevron flyout (^ / <), rather than allowing them to spread across the taskbar.

### Implementation Details
- Hooks RegGetValueW and RegSetValueExW inside xplorer.exe targeting NotifyIconSettings\IsPromoted to enforce non-promoted state for notification tray icons.
- Includes hideAll (default) and hideNew modes.
- Tested and verified on Windows 11.

---

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Initial release of taskbar-tray-icons-in-overflow

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- [ ] The submitter, without AI assistance
- [x] The submitter, with AI assistance
- [ ] Claude
- [ ] ChatGPT
- [ ] Gemini
- [ ] Another AI (please specify): 
- [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.