### PR TITLE
Taskbar Labels for Windows 11 v1.4.4

### DIFF
--- a/mods/taskbar-labels.wh.cpp
+++ b/mods/taskbar-labels.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-labels
 // @name            Taskbar Labels for Windows 11
 // @description     Customize text labels and combining for running programs on the taskbar (Windows 11 only)
-// @version         1.4.3
+// @version         1.4.4
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -180,12 +180,19 @@ Labels can also be shown or hidden per-program in the settings.
 #undef GetCurrentTime
 
 #include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Foundation.Numerics.h>
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Interop.h>
 #include <winrt/Windows.UI.Xaml.Markup.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/base.h>
+
+// The taskbar items live in a WinUI 2 (MUX) ItemsRepeater built on top of
+// system XAML. Pull in its projection to enumerate the realized items
+// (ItemsSourceView / TryGetElement).
+#define WH_WINRT_WINUI2
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
 
 #include <algorithm>
 #include <atomic>
@@ -415,49 +422,6 @@ bool TaskListButton_IsRunning(FrameworkElement taskListButtonElement) {
     return isRunning;
 }
 
-// {0BD894F2-EDFC-5DDF-A166-2DB14BBFDF35}
-constexpr winrt::guid IItemsRepeater{
-    0x0BD894F2,
-    0xEDFC,
-    0x5DDF,
-    {0xA1, 0x66, 0x2D, 0xB1, 0x4B, 0xBF, 0xDF, 0x35}};
-
-int ItemsRepeater_GetElementIndex(FrameworkElement taskbarFrameRepeaterElement,
-                                  UIElement element) {
-    winrt::Windows::Foundation::IUnknown pThis = nullptr;
-    taskbarFrameRepeaterElement.as(IItemsRepeater, winrt::put_abi(pThis));
-
-    using GetElementIndex_t =
-        HRESULT(WINAPI*)(void* pThis, void* element, void* index);
-
-    void** vtable = *(void***)winrt::get_abi(pThis);
-    auto GetElementIndex = (GetElementIndex_t)vtable[19];
-
-    int index = -1;
-    GetElementIndex(winrt::get_abi(pThis), winrt::get_abi(element), &index);
-
-    return index;
-}
-
-FrameworkElement ItemsRepeater_TryGetElement(
-    FrameworkElement taskbarFrameRepeaterElement,
-    int index) {
-    winrt::Windows::Foundation::IUnknown pThis = nullptr;
-    taskbarFrameRepeaterElement.as(IItemsRepeater, winrt::put_abi(pThis));
-
-    using TryGetElement_t =
-        HRESULT(WINAPI*)(void* pThis, int index, void** uiElement);
-
-    void** vtable = *(void***)winrt::get_abi(pThis);
-    auto TryGetElement = (TryGetElement_t)vtable[20];
-
-    void* uiElement = nullptr;
-    TryGetElement(winrt::get_abi(pThis), index, &uiElement);
-
-    return UIElement{uiElement, winrt::take_ownership_from_abi}
-        .try_as<FrameworkElement>();
-}
-
 double CalculateTaskbarItemWidth(FrameworkElement taskbarFrameRepeaterElement,
                                  double minWidth,
                                  double maxWidth) {
@@ -513,20 +477,34 @@ double CalculateTaskbarItemWidth(FrameworkElement taskbarFrameRepeaterElement,
             MulDiv(rcTrayNotify.left, 96, GetDpiForWindow(hTrayNotifyWnd));
     }
 
+    auto repeater =
+        taskbarFrameRepeaterElement
+            .try_as<winrt::Microsoft::UI::Xaml::Controls::ItemsRepeater>();
+    if (!repeater) {
+        Wh_Log(L"Not an ItemsRepeater");
+        return minWidth;
+    }
+
     bool hasOverflowButton = false;
     int taskListRunningButtonsCount = 0;
     double otherElementsWidth = 0;
 
-    for (auto panelChild :
-         taskbarFrameRepeaterElement.as<Controls::Panel>().Children()) {
-        int index = ItemsRepeater_GetElementIndex(taskbarFrameRepeaterElement,
-                                                  panelChild);
-        if (index < 0) {
+    auto itemsSourceView = repeater.ItemsSourceView();
+    if (!itemsSourceView) {
+        Wh_Log(L"No ItemsSourceView");
+        return minWidth;
+    }
+
+    int count = itemsSourceView.Count();
+
+    for (int index = 0; index < count; index++) {
+        auto element = repeater.TryGetElement(index);
+        if (!element) {
+            // Not realized (virtualized away).
             continue;
         }
 
-        auto child =
-            ItemsRepeater_TryGetElement(taskbarFrameRepeaterElement, index);
+        auto child = element.try_as<FrameworkElement>();
         if (!child) {
             continue;
         }
@@ -920,14 +898,34 @@ void UpdateTaskListButtonWidth(FrameworkElement taskListButtonElement,
     }
 }
 
-void UpdateTaskListButtonWithLabelStyle(
-    FrameworkElement taskListButtonElement) {
-    auto iconPanelElement =
-        FindChildByName(taskListButtonElement, L"IconPanel");
-    if (!iconPanelElement) {
-        return;
+FrameworkElement GetOrCreateLabelSpacer(Controls::Grid iconPanelElement) {
+    auto spacerElement =
+        FindChildByName(iconPanelElement, L"WindhawkLabelSpacer");
+    if (!spacerElement) {
+        Controls::Border spacer;
+        spacer.Name(L"WindhawkLabelSpacer");
+        spacer.Height(0);
+        Controls::Grid::SetColumn(spacer, 1);
+        iconPanelElement.Children().Append(spacer);
+        spacerElement = spacer;
     }
 
+    return spacerElement;
+}
+
+// Don't remove the spacer, for some reason it causes a bug - the running
+// indicator ends up being behind the semi-transparent rectangle of the active
+// button. Hide it instead.
+void HideLabelSpacer(Controls::Grid iconPanelElement) {
+    auto spacerElement =
+        FindChildByName(iconPanelElement, L"WindhawkLabelSpacer");
+    if (spacerElement) {
+        spacerElement.Width(0);
+    }
+}
+
+void UpdateTaskListButtonWithLabelStyle(FrameworkElement taskListButtonElement,
+                                        Controls::Grid iconPanelElement) {
     auto iconElement = FindChildByName(iconPanelElement, L"Icon");
     if (!iconElement) {
         return;
@@ -936,8 +934,7 @@ void UpdateTaskListButtonWithLabelStyle(
     double taskListButtonWidth = taskListButtonElement.ActualWidth();
     double iconWidth = iconElement.ActualWidth();
 
-    auto columnDefinitions =
-        iconPanelElement.as<Controls::Grid>().ColumnDefinitions();
+    auto columnDefinitions = iconPanelElement.ColumnDefinitions();
 
     auto firstColumnWidth = columnDefinitions.GetAt(0).Width();
     auto firstColumnWidthPixels =
@@ -945,10 +942,14 @@ void UpdateTaskListButtonWithLabelStyle(
             ? firstColumnWidth.Value
             : 0.0;
 
+    auto iconPanelPadding = iconPanelElement.Padding();
+
     double secondColumnWidthPixels =
         g_unloading ? 0 : g_settings.taskbarItemWidth;
     if (secondColumnWidthPixels > 0) {
-        secondColumnWidthPixels -= firstColumnWidthPixels;
+        secondColumnWidthPixels -= firstColumnWidthPixels +
+                                   iconPanelPadding.Left +
+                                   iconPanelPadding.Right;
         if (secondColumnWidthPixels < 1) {
             secondColumnWidthPixels = 1;
         }
@@ -964,21 +965,6 @@ void UpdateTaskListButtonWithLabelStyle(
         secondColumnWidthPixels = 0;
         labelControlElement.Visibility(Visibility::Collapsed);
         labelControlElement = nullptr;
-
-        columnDefinitions.GetAt(1).Width(GridLength({
-            .Value = 0,
-            .GridUnitType = GridUnitType::Pixel,
-        }));
-    } else if (secondColumnWidthPixels > 0 && labelControlElement) {
-        columnDefinitions.GetAt(1).Width(GridLength({
-            .Value = secondColumnWidthPixels,
-            .GridUnitType = GridUnitType::Pixel,
-        }));
-    } else {
-        columnDefinitions.GetAt(1).Width(GridLength({
-            .Value = 1,
-            .GridUnitType = GridUnitType::Auto,
-        }));
     }
 
     if (labelControlElement) {
@@ -990,18 +976,6 @@ void UpdateTaskListButtonWithLabelStyle(
             labelControlElement.HorizontalAlignment(horizontalAlignment);
         }
 
-        if (g_unloading) {
-            labelControlElement.MaxWidth(
-                std::fmax(0.0, 176 - firstColumnWidthPixels));
-        } else if (g_settings.taskbarItemWidth == 0) {
-            labelControlElement.MaxWidth(std::fmax(
-                0.0,
-                g_settings.maximumTaskbarItemWidth - firstColumnWidthPixels));
-        } else {
-            labelControlElement.MaxWidth(
-                std::numeric_limits<double>::infinity());
-        }
-
         auto labelControlMargin = labelControlElement.Margin();
         labelControlMargin.Left =
             g_unloading ? 0
@@ -1010,6 +984,26 @@ void UpdateTaskListButtonWithLabelStyle(
         labelControlMargin.Right =
             g_unloading ? 0 : (g_settings.leftAndRightPaddingSize - 10);
         labelControlElement.Margin(labelControlMargin);
+
+        double columnWidth;
+        if (g_unloading || g_settings.taskbarItemWidth == 0) {
+            columnWidth = std::fmax(
+                0.0, (g_unloading ? 176 : g_settings.maximumTaskbarItemWidth) -
+                         firstColumnWidthPixels);
+            HideLabelSpacer(iconPanelElement);
+        } else {
+            columnWidth = secondColumnWidthPixels;
+            GetOrCreateLabelSpacer(iconPanelElement).Width(columnWidth);
+        }
+
+        // The column is auto-sized, and the label's desired width includes its
+        // margins, so exclude them to keep the column within columnWidth.
+        double maxWidth = std::fmax(0.0, columnWidth - labelControlMargin.Left -
+                                             labelControlMargin.Right);
+        if (labelControlElement.MaxWidth() != maxWidth) {
+            labelControlElement.MaxWidth(maxWidth);
+            taskListButtonElement.InvalidateMeasure();
+        }
 
         double fontSize = g_unloading ? 12 : g_settings.fontSize;
         if (labelControlElement.FontSize() != fontSize) {
@@ -1041,6 +1035,8 @@ void UpdateTaskListButtonWithLabelStyle(
         if (labelControlElement.TextTrimming() != textTrimming) {
             labelControlElement.TextTrimming(textTrimming);
         }
+    } else {
+        HideLabelSpacer(iconPanelElement);
     }
 
     iconElement.HorizontalAlignment((g_unloading || !labelControlElement)
@@ -1168,11 +1164,15 @@ void UpdateTaskListButtonWithLabelStyle(
                          : std::max(g_settings.runningIndicatorHeight, 0);
         indicatorElement.Height(height);
 
-        int verticalOffset =
-            g_unloading ? 0 : g_settings.runningIndicatorVerticalOffset;
-        Media::TranslateTransform verticalOffsetTransform;
-        verticalOffsetTransform.Y(verticalOffset);
-        indicatorElement.RenderTransform(verticalOffsetTransform);
+        float verticalOffset =
+            g_unloading
+                ? 0.0f
+                : static_cast<float>(g_settings.runningIndicatorVerticalOffset);
+        auto translation = indicatorElement.Translation();
+        if (translation.y != verticalOffset) {
+            translation.y = verticalOffset;
+            indicatorElement.Translation(translation);
+        }
 
         if (isProgressIndicator) {
             auto element = indicatorElement;
@@ -1226,10 +1226,10 @@ void UpdateTaskListButtonCustomizations(
     }
 
     // Only true with the native labels implementation of Windows.
-    auto columnDefinitions =
-        iconPanelElement.as<Controls::Grid>().ColumnDefinitions();
-    if (columnDefinitions.Size() == 2) {
-        UpdateTaskListButtonWithLabelStyle(taskListButtonElement);
+    auto iconPanelGrid = iconPanelElement.as<Controls::Grid>();
+    if (iconPanelGrid.ColumnDefinitions().Size() == 2) {
+        UpdateTaskListButtonWithLabelStyle(taskListButtonElement,
+                                           iconPanelGrid);
         return;
     }
 
@@ -1430,11 +1430,32 @@ void WINAPI TaskbarFrame_OnTaskbarLayoutChildBoundsChanged_Hook(void* pThis) {
         return;
     }
 
-    for (int i = 0;; i++) {
-        auto child =
-            ItemsRepeater_TryGetElement(taskbarFrameRepeaterElement, i);
+    auto repeater =
+        taskbarFrameRepeaterElement
+            .try_as<winrt::Microsoft::UI::Xaml::Controls::ItemsRepeater>();
+    if (!repeater) {
+        Wh_Log(L"Not an ItemsRepeater");
+        return;
+    }
+
+    auto itemsSourceView = repeater.ItemsSourceView();
+    if (!itemsSourceView) {
+        Wh_Log(L"No ItemsSourceView");
+        return;
+    }
+
+    int count = itemsSourceView.Count();
+
+    for (int index = 0; index < count; index++) {
+        auto element = repeater.TryGetElement(index);
+        if (!element) {
+            // Not realized (virtualized away).
+            continue;
+        }
+
+        auto child = element.try_as<FrameworkElement>();
         if (!child) {
-            break;
+            continue;
         }
 
         if (child.Name() == L"TaskListButton") {


### PR DESCRIPTION
* Fixed compatibility with the latest Windows 11 update. You might need to restart explorer after updating the old version of the mod.
* Fixed a crash in some cases when a progress indicator is shown.