### PR TITLE
Add a mod to highlight recently used icons and previews on the toolbar

### DIFF
--- a/mods/taskbar-recent-focus-highlight.wh.cpp
+++ b/mods/taskbar-recent-focus-highlight.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-recent-focus-highlight
 // @name            Taskbar Recent Focus Highlight
 // @description     Visually highlight the most recently focused running apps on the taskbar
-// @version         0.9.1
+// @version         0.9.2
 // @author          Jakub Vlášek
 // @github          https://github.com/jvlasek
 // @include         explorer.exe
@@ -64,9 +64,9 @@ clear highlights without unloading the mod.
 
 - Works with Windows 11 Taskbar Styler: the side bar stays visible on hover,
   and preview plate tints are restored when the highlight is cleared.
-- Icon matching prefers the process path from the taskband. Name matching is
-  a fallback and is based on English taskbar labels (`N running`, `pinned`),
-  so it can be weaker on a non-English Windows.
+- Icon matching uses the process path / AppUserModelID from the taskband
+  (not the localized button label). If that resolve is unavailable, the icon
+  is left unhighlighted rather than guessed from its name.
 - Multi-monitor: the same rank is applied on every taskbar that shows that
   app.
 */
@@ -300,7 +300,9 @@ clear highlights without unloading the mod.
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -512,9 +514,6 @@ GUID g_currentDesktopId{};
 bool g_haveCurrentDesktop = false;
 PendingFocus g_pendingFocus;
 
-// process key (UPPER path) -> last seen AutomationProperties.Name of its button
-std::unordered_map<std::wstring, std::wstring> g_keyToAutomationName;
-
 std::atomic<ULONGLONG> g_windowConfirmSeq{0};
 
 // Public IVirtualDesktopManager (fallback when registry current-desktop fails).
@@ -561,7 +560,6 @@ std::vector<winrt::weak_ref<FrameworkElement>> g_trackedThumbViews;
 
 std::atomic<bool> g_unloading{false};
 std::atomic<bool> g_taskbarViewDllLoaded{false};
-std::atomic<bool> g_taskbarDllHooked{false};
 // After decay / empty ranks, force-clear overlays on next button touch if
 // RequestApplyVisuals couldn't run (sleep/wake, no dispatcher yet).
 std::atomic<bool> g_pendingOverlaySweep{false};
@@ -570,6 +568,13 @@ std::mutex g_winEventHookThreadMutex;
 std::atomic<HANDLE> g_winEventHookThread{nullptr};
 std::atomic<HWND> g_hookThreadHwnd{nullptr};
 std::atomic<DWORD> g_hookThreadId{0};
+HANDLE g_hookThreadReadyEvent = nullptr;
+
+void SignalHookThreadReady() {
+    if (g_hookThreadReadyEvent) {
+        SetEvent(g_hookThreadReadyEvent);
+    }
+}
 
 HWND HookThreadWindow() {
     return g_hookThreadHwnd.load(std::memory_order_acquire);
@@ -593,11 +598,14 @@ winrt::weak_ref<FrameworkElement> g_dispatcherAnchor;
 // Agile CoreDispatcher list — captured on the UI thread when we first see a
 // button/thumb/panel. CollectUiDispatchers must not weak.get() XAML objects
 // off the UI thread (last-ref ~FrameworkElement would run on the wrong thread).
+// no_destroy: process teardown must not ~CoreDispatcher after XAML is gone.
 std::mutex g_dispatchersMutex;
-std::vector<winrt::Windows::UI::Core::CoreDispatcher> g_uiDispatchers;
+[[clang::no_destroy]] std::optional<
+    std::vector<winrt::Windows::UI::Core::CoreDispatcher>>
+    g_uiDispatchers{std::in_place};
 
 void RememberUiDispatcher(FrameworkElement el) {
-    if (!el) {
+    if (!el || g_unloading.load()) {
         return;
     }
     try {
@@ -606,31 +614,29 @@ void RememberUiDispatcher(FrameworkElement el) {
             return;
         }
         std::lock_guard<std::mutex> lock(g_dispatchersMutex);
-        for (const auto& existing : g_uiDispatchers) {
+        if (!g_uiDispatchers) {
+            return;
+        }
+        for (const auto& existing : *g_uiDispatchers) {
             if (existing == dispatcher) {
                 return;
             }
         }
-        g_uiDispatchers.push_back(dispatcher);
+        g_uiDispatchers->push_back(dispatcher);
     } catch (...) {
     }
 }
 
 constexpr UINT WM_APP_FOREGROUND_CHANGED = WM_APP + 1;
-constexpr UINT WM_APP_REQUEST_APPLY = WM_APP + 2;
-constexpr UINT WM_APP_REQUEST_PREVIEW_APPLY = WM_APP + 3;
-constexpr UINT WM_APP_DESKTOP_SWITCHED = WM_APP + 4;
-constexpr UINT WM_APP_SHUTDOWN = WM_APP + 5;
-constexpr UINT WM_APP_REQUEST_APPLY_DEBOUNCED = WM_APP + 6;
+constexpr UINT WM_APP_DESKTOP_SWITCHED = WM_APP + 2;
+constexpr UINT WM_APP_SHUTDOWN = WM_APP + 3;
+constexpr UINT WM_APP_REQUEST_APPLY_DEBOUNCED = WM_APP + 4;
 
-// Identity scores. Only exact identity (and name-cache) may bind the same
-// rank to many buttons (secondary taskbar / Never Combine). Score 900 is
-// same filename, different folder — 1:1 so two python.exe installs stay
-// distinct.
+// Identity scores. Only exact identity may bind the same rank to many buttons
+// (secondary taskbar / Never Combine). Score 900 is same filename, different
+// folder — 1:1 so two python.exe installs stay distinct.
 constexpr int kScoreExactIdentity = 1000;
 constexpr int kScoreSameFileDifferentPath = 900;
-constexpr int kScoreNameCache = 96;
-constexpr int kScoreMinBind = 70;
 constexpr UINT_PTR kMinFocusTimerId = 1;
 constexpr UINT_PTR kDecayTimerId = 2;
 constexpr UINT_PTR kPreviewMinFocusTimerId = 3;
@@ -834,6 +840,9 @@ bool DropPendingIfWrongDesktopLocked() {
 }
 
 void OnVirtualDesktopSwitched() {
+    if (g_unloading.load()) {
+        return;
+    }
     ClearButtonRunningGrace();
     RefreshCurrentDesktopId();
     bool droppedPending = false;
@@ -921,7 +930,7 @@ std::wstring ToUpper(std::wstring s) {
     return s;
 }
 
-// Keep A–Z / 0–9 only, uppercased — for fuzzy exe ↔ automation-name match.
+// Keep A–Z / 0–9 only, uppercased — preview unique-title compare.
 std::wstring AlnumUpper(std::wstring_view s) {
     std::wstring out;
     out.reserve(s.size());
@@ -994,14 +1003,6 @@ std::wstring FileNameFromPath(const std::wstring& path) {
         return path;
     }
     return path.substr(pos + 1);
-}
-
-std::wstring StripExtension(std::wstring name) {
-    size_t pos = name.find_last_of(L'.');
-    if (pos != std::wstring::npos && pos > 0) {
-        name.resize(pos);
-    }
-    return name;
 }
 
 bool IsOwnExplorerProcess(DWORD processId) {
@@ -1325,7 +1326,7 @@ bool ResolveAppIdentity(HWND hWnd,
     std::wstring displayName = fileName;
     if (IsUwpHostFileName(fileNameUpper)) {
         // Prefer "Settings" over WINDOWS.IMMERSIVECONTROLPANEL for logs /
-        // exclude / fuzzy. Key remains APPID:… .
+        // exclude. Key remains APPID:… .
         if (!title.empty() && title.size() <= 80 &&
             title.find(L'\\') == std::wstring::npos &&
             title.find(L'/') == std::wstring::npos) {
@@ -1435,38 +1436,6 @@ bool PathAppearsOnTaskbar(const std::wstring& keyOrPath,
     return false;
 }
 
-// Same process path, two taskbar icons (TOTALCMD64 → Total Commander + Lister).
-bool PathHasSplitTaskbarButtons(const std::wstring& pathUpper) {
-    if (pathUpper.empty()) {
-        return false;
-    }
-    const std::wstring fileUpper = ToUpper(FileNameFromPath(pathUpper));
-    std::wstring firstClass;
-    bool sawLister = false;
-    bool sawOther = false;
-    std::lock_guard<std::mutex> lock(g_buttonPathMutex);
-    for (const auto& e : g_buttonPathCache) {
-        if (e.pathUpper.empty()) {
-            continue;
-        }
-        if (e.pathUpper != pathUpper &&
-            ToUpper(FileNameFromPath(e.pathUpper)) != fileUpper) {
-            continue;
-        }
-        if (e.classUpper.find(L"LISTER") != std::wstring::npos) {
-            sawLister = true;
-        } else if (!e.classUpper.empty()) {
-            sawOther = true;
-        }
-        if (firstClass.empty()) {
-            firstClass = e.classUpper;
-        } else if (!e.classUpper.empty() && e.classUpper != firstClass) {
-            return true;
-        }
-    }
-    return sawLister && sawOther;
-}
-
 void RecomputeRanksForDesktopLocked(DesktopRecencyState& desk) {
     desk.rankedApps.clear();
 
@@ -1489,18 +1458,7 @@ void RecomputeRanksForDesktopLocked(DesktopRecencyState& desk) {
         }
         if (IsTickDecayed(info.lastConfirmedFocusTick, decayMs, now)) {
             Wh_Log(L"Decayed: %s", info.displayName.c_str());
-            const std::wstring decayedKey = it->first;
             it = desk.appFocusMap.erase(it);
-            bool stillUsed = false;
-            for (const auto& [oid, other] : g_desktopMaps) {
-                if (other.appFocusMap.contains(decayedKey)) {
-                    stillUsed = true;
-                    break;
-                }
-            }
-            if (!stillUsed) {
-                g_keyToAutomationName.erase(decayedKey);
-            }
             continue;
         }
         // Tray-only / no taskbar button: keep optional history but never rank.
@@ -1799,7 +1757,6 @@ int RankSizeBoost(int rankZeroBased) {
 
 // Defined with option-C resolve stack (button → process path).
 std::wstring EnsureButtonPathCached(FrameworkElement button, bool force);
-std::wstring GetCachedButtonPath(FrameworkElement button);
 struct ButtonIdentity {
     std::wstring pathUpper;
     std::wstring appIdUpper;
@@ -1879,47 +1836,6 @@ std::wstring GetButtonAutomationAppId(FrameworkElement button) {
     } catch (...) {
         return {};
     }
-}
-
-bool IsVisualStateActive(FrameworkElement root) {
-    if (!root) {
-        return false;
-    }
-
-    try {
-        auto groups = VisualStateManager::GetVisualStateGroups(root);
-        for (auto group : groups) {
-            auto current = group.CurrentState();
-            if (!current) {
-                continue;
-            }
-            std::wstring name(current.Name().c_str());
-            // "InactivePointerOver".find("Active") is a hit — that made every
-            // hovered running button look focused (TC stole Lister's glow).
-            if (name.rfind(L"Inactive", 0) == 0) {
-                continue;
-            }
-            if (name.rfind(L"Active", 0) == 0) {
-                return true;
-            }
-        }
-    } catch (...) {
-    }
-
-    // Also check children that host state groups (IconPanel).
-    try {
-        int n = Media::VisualTreeHelper::GetChildrenCount(root);
-        for (int i = 0; i < n; i++) {
-            auto child = Media::VisualTreeHelper::GetChild(root, i)
-                             .try_as<FrameworkElement>();
-            if (child && IsVisualStateActive(child)) {
-                return true;
-            }
-        }
-    } catch (...) {
-    }
-
-    return false;
 }
 
 // Taskbar names look like "App - 2 running windows pinned" — strip that noise.
@@ -2020,143 +1936,7 @@ std::wstring ExtractBracketedPath(const std::wstring& s) {
     return inner;
 }
 
-// Strip marketing suffixes so WINDOWSTERMINAL ≈ TERMINALPREVIEW → TERMINAL.
-std::wstring StripProductNoise(std::wstring alnumUpper) {
-    static const wchar_t* kNoise[] = {L"PREVIEW", L"BETA",   L"PORTABLE",
-                                      L"CANARY",  L"INSIDER", L"NIGHTLY"};
-    for (auto noise : kNoise) {
-        for (;;) {
-            auto pos = alnumUpper.find(noise);
-            if (pos == std::wstring::npos) {
-                break;
-            }
-            alnumUpper.erase(pos, wcslen(noise));
-        }
-    }
-    return alnumUpper;
-}
-
-// True if every char of `needle` appears in order inside `haystack`
-// (not necessarily contiguous). TOTALCMD64 ⊂ TOTALCOMMANDER64BIT.
-bool IsSubsequence(const std::wstring& needle, const std::wstring& haystack) {
-    if (needle.empty()) {
-        return false;
-    }
-    size_t j = 0;
-    for (size_t i = 0; i < haystack.size() && j < needle.size(); ++i) {
-        if (haystack[i] == needle[j]) {
-            ++j;
-        }
-    }
-    return j == needle.size();
-}
-
-// Initials of title words: "Total Commander 64 bit" → TC64B
-std::wstring InitialsAlnum(const std::wstring& automationName) {
-    std::wstring title = NormalizeAutomationName(automationName);
-    std::wstring out;
-    bool atWord = true;
-    for (wchar_t ch : title) {
-        if (ch == L' ' || ch == L'-' || ch == L'_' || ch == L'.') {
-            atWord = true;
-            continue;
-        }
-        if (atWord) {
-            if ((ch >= L'a' && ch <= L'z') || (ch >= L'A' && ch <= L'Z') ||
-                (ch >= L'0' && ch <= L'9')) {
-                if (ch >= L'a' && ch <= L'z') {
-                    ch = static_cast<wchar_t>(ch - L'a' + L'A');
-                }
-                out.push_back(ch);
-            }
-            atWord = false;
-        }
-    }
-    return out;
-}
-
-// Higher = better. 0 = no match.
-// Important: VSCodium must NOT match "Visual Studio Code" (initials VSC alone
-// used to fire). Prefer longer/more specific matches; callers assign 1:1.
-int ScoreExeToAutomationName(const std::wstring& displayName,
-                             const std::wstring& automationName) {
-    if (displayName.empty() || automationName.empty()) {
-        return 0;
-    }
-
-    std::wstring exeAlnum = AlnumUpper(StripExtension(displayName));
-    std::wstring autoAlnum = AlnumUpper(NormalizeAutomationName(automationName));
-    if (exeAlnum.empty() || autoAlnum.empty()) {
-        return 0;
-    }
-
-    if (exeAlnum == autoAlnum) {
-        return 100;
-    }
-
-    // Contiguous containment (CODE ⊂ VISUALSTUDIOCODE, STEAM ⊂ STEAM…).
-    if (exeAlnum.size() >= 4 &&
-        autoAlnum.find(exeAlnum) != std::wstring::npos) {
-        return 92;
-    }
-    if (autoAlnum.size() >= 4 &&
-        exeAlnum.find(autoAlnum) != std::wstring::npos) {
-        // Prefer when title is a large part of the exe (STEAM vs STEAMWEBHELPER).
-        int cover = static_cast<int>(autoAlnum.size() * 100 / exeAlnum.size());
-        return 80 + (std::min)(12, cover / 10);
-    }
-
-    std::wstring exeN = StripProductNoise(exeAlnum);
-    std::wstring autoN = StripProductNoise(autoAlnum);
-    if (!exeN.empty() && exeN == autoN) {
-        return 90;
-    }
-    if (exeN.size() >= 5 && autoN.find(exeN) != std::wstring::npos) {
-        return 88;
-    }
-    if (autoN.size() >= 5 && exeN.find(autoN) != std::wstring::npos) {
-        return 84;
-    }
-
-    // Subsequence: TOTALCMD64 ⊂ TOTALCOMMANDER64BIT (not short initials).
-    std::wstring exeLetters;
-    for (wchar_t c : exeN) {
-        if (c < L'0' || c > L'9') {
-            exeLetters.push_back(c);
-        }
-    }
-    if (exeN.size() >= 5 && IsSubsequence(exeN, autoN)) {
-        return 72;
-    }
-    if (exeLetters.size() >= 5 && IsSubsequence(exeLetters, autoN)) {
-        return 70;
-    }
-
-    // Initials only when they are a *substantial* prefix of the exe.
-    // VSC vs VSCODIUM (3/8) → reject; avoids VS Code button stealing VSCodium.
-    // TC64 vs TOTALCMD64 — initials may be TC64B; require prefix of exe length
-    // and initials covering ≥ half the exe stem.
-    std::wstring initials = InitialsAlnum(automationName);
-    if (initials.size() >= 3) {
-        if (exeN.rfind(initials, 0) == 0 &&
-            initials.size() * 2 >= exeN.size()) {
-            return 55;
-        }
-        // Exe is essentially the initials (rare).
-        if (exeN == initials) {
-            return 95;
-        }
-    }
-
-    return 0;
-}
-
-bool ExeMatchesAutomationName(const std::wstring& displayName,
-                              const std::wstring& automationName) {
-    return ScoreExeToAutomationName(displayName, automationName) > 0;
-}
-
-// Window title ↔ taskbar button title (both normalized).
+// Window title ↔ thumbnail card title (preview unique-title fallback only).
 int ScoreTitleToAutomationName(const std::wstring& windowTitle,
                                const std::wstring& automationName) {
     if (windowTitle.empty() || automationName.empty()) {
@@ -2202,65 +1982,9 @@ int ScoreTitleToAutomationName(const std::wstring& windowTitle,
     return 0;
 }
 
-// True if this button's automation name is a legitimate label for the rank.
-// Class-qualified ranks (TLISTER) must not bind to "Total Commander".
-bool AutomationNameFitsRank(const AppFocusInfo& info,
-                            const std::wstring& autoName) {
-    if (autoName.empty()) {
-        return false;
-    }
-    const std::wstring cls = !info.classUpper.empty()
-                                 ? info.classUpper
-                                 : ClassFromAppKey(info.key);
-    if (!cls.empty() && cls.find(L"LISTER") != std::wstring::npos) {
-        return AlnumUpper(NormalizeAutomationName(autoName)).find(L"LISTER") !=
-               std::wstring::npos;
-    }
-    return ExeMatchesAutomationName(info.displayName, autoName);
-}
-
-void StoreAutomationNameIfFits(const AppFocusInfo& info,
-                               const std::wstring& autoName) {
-    if (!AutomationNameFitsRank(info, autoName)) {
-        return;
-    }
-    std::lock_guard<std::mutex> lock(g_stateMutex);
-    g_keyToAutomationName[info.key] = autoName;
-}
-
-void StoreAutomationName(const AppFocusInfo& info,
-                         const std::wstring& autoName) {
-    if (info.key.empty() || autoName.empty()) {
-        return;
-    }
-    std::lock_guard<std::mutex> lock(g_stateMutex);
-    g_keyToAutomationName[info.key] = autoName;
-}
-
-// Trusted writes only: path/exe binds, or Active-button associate (Windhawk
-// button for VSCodium.exe). Name-equals is then enough, except we refuse
-// a non-fitting name when this exe has two icons (TC vs Lister).
-bool CacheEntryValid(const AppFocusInfo& info,
-                     const std::wstring& cachedAutoName,
-                     const std::wstring& buttonAutoName) {
-    if (cachedAutoName.empty() || buttonAutoName.empty()) {
-        return false;
-    }
-    const bool nameEquals =
-        _wcsicmp(cachedAutoName.c_str(), buttonAutoName.c_str()) == 0 ||
-        _wcsicmp(NormalizeAutomationName(cachedAutoName).c_str(),
-                 NormalizeAutomationName(buttonAutoName).c_str()) == 0;
-    if (!nameEquals) {
-        return false;
-    }
-    if (AutomationNameFitsRank(info, buttonAutoName)) {
-        return true;
-    }
-    const std::wstring path = PathFromAppKey(info.key);
-    return !PathHasSplitTaskbarButtons(path);
-}
-
-// Score this button against one ranked app. Higher is better; 0 = no match.
+// Score this button against one ranked app. Path / AUMID / HWND only — no
+// automation-name fuzzy. 0 = no match. 1000 may bind the same rank to many
+// buttons (secondary taskbar). 900 is 1:1 (same file, different folder).
 int ScoreButtonForRank(FrameworkElement button,
                        const AppFocusInfo& info,
                        bool requireRunning) {
@@ -2276,9 +2000,6 @@ int ScoreButtonForRank(FrameworkElement button,
     const std::wstring rankCls = !info.classUpper.empty()
                                      ? info.classUpper
                                      : ClassFromAppKey(info.key);
-    const std::wstring rankAppId = !info.appIdUpper.empty()
-                                       ? info.appIdUpper
-                                       : AppIdFromAppKey(info.key);
 
     auto hwndOnButton = [&](HWND h) -> bool {
         if (!h) {
@@ -2293,7 +2014,6 @@ int ScoreButtonForRank(FrameworkElement button,
             }
         }
         if (ident.sampleHwnd && SamePidAndClass(h, ident.sampleHwnd)) {
-            // ApplicationFrameHost hosts many apps; PID+class is not identity.
             if (!IsAppIdKey(info.key) && !IsUwpHostPath(ident.pathUpper)) {
                 return true;
             }
@@ -2313,8 +2033,6 @@ int ScoreButtonForRank(FrameworkElement button,
         if (!want.empty() && got == want) {
             return kScoreExactIdentity;
         }
-        // Hosted UWP ranks are AUMID-only. Do not fuzzy "WINDOWS.IMMERSIVE…"
-        // onto Windows Security, or reuse a name-cache replica.
         return 0;
     }
 
@@ -2323,87 +2041,28 @@ int ScoreButtonForRank(FrameworkElement button,
     const bool exactPath =
         !ident.pathUpper.empty() &&
         (ident.pathUpper == info.key || ident.pathUpper == pathKey);
+    if (exactPath) {
+        if (!rankCls.empty() && !ident.classUpper.empty() &&
+            ident.classUpper != rankCls) {
+            // Same exe, different window class (e.g. two icons from one
+            // process). Not a replica.
+            return 0;
+        }
+        return kScoreExactIdentity;
+    }
+
     const bool sameFileName =
         !ident.pathUpper.empty() && !info.displayName.empty() &&
         ToUpper(FileNameFromPath(ident.pathUpper)) ==
             ToUpper(info.displayName);
-    // Both sides resolved, folders differ: not a replica (portable python).
-    const bool pathConflict =
-        sameFileName && !exactPath && !pathKey.empty() &&
-        ident.pathUpper != pathKey && ident.pathUpper != info.key;
-    const bool pathOk = exactPath || (sameFileName && !pathConflict);
-    const bool split = PathHasSplitTaskbarButtons(
-        !pathKey.empty() ? pathKey : ident.pathUpper);
-
-    // Path cache hit: skip fuzzy names (VS Code vs VSCodium stay distinct
-    // via full path). Fuzzy runs only when path is missing or this exe has
-    // two taskbar icons (TOTALCMD64 → Commander + Lister).
-    if (pathOk) {
-        if (!split) {
-            return exactPath ? kScoreExactIdentity
-                             : kScoreSameFileDifferentPath;
-        }
-        if (!rankCls.empty() && ident.classUpper == rankCls) {
-            return kScoreExactIdentity;
-        }
-        if (!rankCls.empty() && !ident.classUpper.empty() &&
-            ident.classUpper != rankCls) {
-            // other half of a split pair
-        } else if (rankCls.empty() || ident.classUpper.empty()) {
-            return kScoreSameFileDifferentPath;
-        }
+    if (sameFileName && !pathKey.empty() && ident.pathUpper != pathKey &&
+        ident.pathUpper != info.key) {
+        return kScoreSameFileDifferentPath;
     }
-
-    const bool identityConflict =
-        pathConflict ||
-        (split && !rankCls.empty() && !ident.classUpper.empty() &&
-         ident.classUpper != rankCls);
-
-    std::wstring autoName = GetButtonAutomationName(button);
-    if (autoName.empty()) {
-        return 0;
-    }
-
-    // Name fallback when path cache missed: "Lister" button vs TLister focus.
-    if (!rankCls.empty() &&
-        rankCls.find(L"LISTER") != std::wstring::npos) {
-        std::wstring n = AlnumUpper(NormalizeAutomationName(autoName));
-        if (n.find(L"LISTER") != std::wstring::npos) {
-            return kScoreExactIdentity;
-        }
-    }
-
-    int score = 0;
-    if (!identityConflict) {
-        score = ScoreExeToAutomationName(info.displayName, autoName);
-    }
-
-    // Do not score last window/tab title against taskbar buttons.
-    // Terminal tabs (and VSCodium editing a Windhawk mod) rename the HWND
-    // to the document — that is preview identity, not which icon to glow.
-
-    {
-        std::lock_guard<std::mutex> lock(g_stateMutex);
-        auto it = g_keyToAutomationName.find(info.key);
-        if (!identityConflict && it != g_keyToAutomationName.end() &&
-            !it->second.empty()) {
-            if (CacheEntryValid(info, it->second, autoName)) {
-                score = (std::max)(score, kScoreNameCache);
-            } else if (_wcsicmp(it->second.c_str(), autoName.c_str()) == 0 ||
-                       _wcsicmp(NormalizeAutomationName(it->second).c_str(),
-                                NormalizeAutomationName(autoName).c_str()) ==
-                           0) {
-                Wh_Log(L"Dropping bad cache: %s was \"%s\" (exe/class mismatch)",
-                       info.displayName.c_str(), it->second.c_str());
-                g_keyToAutomationName.erase(it);
-            }
-        }
-    }
-    return score;
+    return 0;
 }
 
-// Best rank for a single button (1-based), or 0. Prefer highest score.
-// requireRunning uses ButtonCountsAsRunning (short Alt-Tab grace).
+// Best rank for a single button (1-based), or 0.
 int FindRankForButton(FrameworkElement button,
                       const std::vector<AppFocusInfo>& ranks,
                       bool requireRunning = true) {
@@ -2420,136 +2079,10 @@ int FindRankForButton(FrameworkElement button,
             bestRank = static_cast<int>(i) + 1;
         }
     }
-    // Minimum confidence: reject weak initials-only if ever reintroduced.
-    if (bestScore < kScoreMinBind) {
+    if (bestScore < kScoreSameFileDifferentPath) {
         return 0;
     }
-
-    if (bestRank > 0) {
-        StoreAutomationNameIfFits(
-            ranks[static_cast<size_t>(bestRank - 1)],
-            GetButtonAutomationName(button));
-    }
     return bestRank;
-}
-
-void AssociateActiveButtonWithKey(const std::wstring& key) {
-    if (key.empty()) {
-        return;
-    }
-
-    std::wstring displayName;
-    std::wstring windowTitle;
-    {
-        std::lock_guard<std::mutex> lock(g_stateMutex);
-        auto& map = CurrentDeskLocked().appFocusMap;
-        auto it = map.find(key);
-        if (it != map.end()) {
-            displayName = it->second.displayName;
-            windowTitle = it->second.lastWindowTitle;
-        }
-    }
-    if (displayName.empty()) {
-        displayName = FileNameFromPath(key);
-    }
-
-    std::vector<winrt::weak_ref<FrameworkElement>> buttons;
-    {
-        std::lock_guard<std::mutex> lock(g_buttonsMutex);
-        buttons = g_trackedButtons;
-    }
-
-    // Prefer active button; fall back to best-scoring running button for this
-    // app (Windhawk / TC sometimes fail IsVisualStateActive timing).
-    int bestScore = 0;
-    std::wstring bestName;
-
-    for (auto& weak : buttons) {
-        FrameworkElement button = nullptr;
-        try {
-            button = weak.get();
-        } catch (...) {
-            continue;
-        }
-        if (!button || !TaskListButton_IsRunning(button)) {
-            continue;
-        }
-
-        std::wstring autoName = GetButtonAutomationName(button);
-        if (autoName.empty()) {
-            continue;
-        }
-
-        int score = ScoreExeToAutomationName(displayName, autoName);
-        // Identity from path cache (Terminal, VSCodium) beats a window
-        // title that happens to mention another app ("Discord icon…").
-        const ButtonIdentity ident = GetCachedButtonIdentity(button);
-        const std::wstring rankPath = PathFromAppKey(key);
-        if (IsAppIdKey(key)) {
-            const std::wstring want = AppIdFromAppKey(key);
-            std::wstring got = ident.appIdUpper.empty() ? ident.autoIdUpper
-                                                        : ident.appIdUpper;
-            if (!want.empty() && CanonicalAppId(got) == want) {
-                score = (std::max)(score, 1000);
-            } else if (!want.empty()) {
-                continue;
-            }
-        } else if (!ident.pathUpper.empty() && !rankPath.empty() &&
-                   ident.pathUpper == rankPath) {
-            score = (std::max)(score, 1000);
-        } else if (!ident.pathUpper.empty() &&
-                   ToUpper(FileNameFromPath(ident.pathUpper)) ==
-                       ToUpper(displayName)) {
-            score = (std::max)(score, 900);
-        }
-        const bool active = IsVisualStateActive(button);
-        if (active) {
-            score += 5;
-            // Real Active* only (Inactive* is not Active). Windhawk's button
-            // is named "Windhawk" while the process is VSCodium.exe.
-            if (score < 70) {
-                score = 70;
-            }
-        }
-
-        if (score > bestScore) {
-            bestScore = score;
-            bestName = autoName;
-        }
-
-        if (active && score < 70) {
-            Wh_Log(L"Skip associate: active \"%s\" weak match for %s (score=%d)",
-                   autoName.c_str(), displayName.c_str(), score);
-        }
-    }
-
-    AppFocusInfo assocInfo;
-    {
-        std::lock_guard<std::mutex> lock(g_stateMutex);
-        auto& map = CurrentDeskLocked().appFocusMap;
-        auto it = map.find(key);
-        if (it != map.end()) {
-            assocInfo = it->second;
-        }
-    }
-    if (assocInfo.key.empty()) {
-        assocInfo.key = key;
-        assocInfo.displayName = displayName;
-    }
-
-    if (bestScore >= kScoreMinBind && !bestName.empty()) {
-        // Always remember the Active button, even when the label is the host
-        // ("Windhawk") and the process is VSCodium.exe. Scoring trusts this
-        // cache; other write sites still use StoreAutomationNameIfFits.
-        StoreAutomationName(assocInfo, bestName);
-        Wh_Log(L"Associated %s -> \"%s\" (score=%d, fits=%d, title=\"%s\")",
-               displayName.c_str(), bestName.c_str(), bestScore,
-               AutomationNameFitsRank(assocInfo, bestName) ? 1 : 0,
-               windowTitle.c_str());
-    } else {
-        Wh_Log(L"Associate failed for %s (bestScore=%d, title=\"%s\")",
-               displayName.c_str(), bestScore, windowTitle.c_str());
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -3562,38 +3095,19 @@ void EnsureIconPanelLayoutWatch(FrameworkElement button) {
     }
     RememberUiDispatcher(iconPanel);
 
-    const TaskbarEdge edge = DetectTaskbarEdge(iconPanel);
-    bool alreadyWatched = false;
-    bool edgeChanged = false;
-    TaskbarEdge previousEdge = TaskbarEdge::Bottom;
     {
         std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
         for (auto& w : g_layoutWatches) {
             try {
-                if (w.panel.get() != iconPanel) {
-                    continue;
+                if (w.panel.get() == iconPanel) {
+                    return;
                 }
-                alreadyWatched = true;
-                if (w.haveEdge && w.lastEdge != edge) {
-                    edgeChanged = true;
-                    previousEdge = w.lastEdge;
-                }
-                w.lastEdge = edge;
-                w.haveEdge = true;
-                break;
             } catch (...) {
             }
         }
     }
-    if (alreadyWatched) {
-        if (edgeChanged) {
-            Wh_Log(L"Taskbar edge %s -> %s (%.0fx%.0f)",
-                   TaskbarEdgeName(previousEdge), TaskbarEdgeName(edge),
-                   iconPanel.ActualWidth(), iconPanel.ActualHeight());
-            HealRunningIndicatorAfterRelayout(iconPanel);
-        }
-        return;
-    }
+
+    const TaskbarEdge edge = DetectTaskbarEdge(iconPanel);
 
     IconPanelLayoutWatch watch;
     watch.panel = winrt::make_weak(iconPanel);
@@ -4199,12 +3713,9 @@ std::wstring EnsureButtonPathCached(FrameworkElement button, bool force) {
             if (b != button) {
                 continue;
             }
-            const ULONGLONG debounceMs = e.pathUpper.empty() ? 250 : 2000;
-            if (!force && e.resolveAttempted &&
-                (now - e.lastResolveTick) < debounceMs) {
+            if (!force && e.resolveAttempted) {
                 return e.pathUpper;
             }
-            // fall through to re-resolve below using this entry
             break;
         }
     }
@@ -4342,11 +3853,6 @@ std::wstring EnsureButtonPathCached(FrameworkElement button, bool force) {
                GetButtonAutomationName(button).c_str());
     }
     return pathUpper;
-}
-
-// Lookup only (no resolve).
-std::wstring GetCachedButtonPath(FrameworkElement button) {
-    return GetCachedButtonIdentity(button).pathUpper;
 }
 
 ButtonIdentity GetCachedButtonIdentity(FrameworkElement button) {
@@ -4556,8 +4062,7 @@ void ApplyAllHighlights_UIThread() {
         }
     }
 
-    // Prefer process-path cache (option C), then fuzzy name scores.
-    // 1:1 assignment, highest score wins.
+    // Path / AUMID / HWND only. 1:1 except exact identity replicas.
     struct Cand {
         int score;
         size_t rankIdx;
@@ -4566,11 +4071,10 @@ void ApplyAllHighlights_UIThread() {
     std::vector<Cand> cands;
     std::vector<std::wstring> buttonPaths(live.size());
     for (size_t bi = 0; bi < live.size(); ++bi) {
-        // Resolve once if missing (cheap if cached).
         buttonPaths[bi] = EnsureButtonPathCached(live[bi], /*force=*/false);
         for (size_t ri = 0; ri < ranks.size(); ++ri) {
             int s = ScoreButtonForRank(live[bi], ranks[ri], true);
-            if (s >= kScoreMinBind) {
+            if (s >= kScoreSameFileDifferentPath) {
                 cands.push_back({s, ri, bi});
             }
         }
@@ -4582,9 +4086,6 @@ void ApplyAllHighlights_UIThread() {
     std::vector<bool> rankTaken(ranks.size(), false);
     std::vector<bool> buttonTaken(live.size(), false);
 
-    // Replicas of one identity may share a rank (secondary taskbar / Never
-    // Combine). Only exact identity (1000: path / HWND / AUMID). Name-cache
-    // 96 is 1:1 — it used to copy Settings' rank onto Windows Security.
     for (const auto& c : cands) {
         if (buttonTaken[c.buttonIdx]) {
             continue;
@@ -4602,13 +4103,6 @@ void ApplyAllHighlights_UIThread() {
             continue;
         }
 
-        std::wstring autoName = GetButtonAutomationName(live[c.buttonIdx]);
-        if (c.score >= kScoreExactIdentity) {
-            StoreAutomationName(ranks[c.rankIdx], autoName);
-        } else {
-            StoreAutomationNameIfFits(ranks[c.rankIdx], autoName);
-        }
-        // Successful bind ⇒ this process has a taskbar presence.
         {
             std::lock_guard<std::mutex> lock(g_stateMutex);
             auto it = CurrentDeskLocked().appFocusMap.find(ranks[c.rankIdx].key);
@@ -4619,7 +4113,7 @@ void ApplyAllHighlights_UIThread() {
         if (SettingsSnap()->glowDebugLog) {
             Wh_Log(L"  bind rank %zu %s -> \"%s\" (score=%d path=%s)",
                    c.rankIdx + 1, ranks[c.rankIdx].displayName.c_str(),
-                   autoName.c_str(), c.score,
+                   GetButtonAutomationName(live[c.buttonIdx]).c_str(), c.score,
                    buttonPaths[c.buttonIdx].empty()
                        ? L"?"
                        : buttonPaths[c.buttonIdx].c_str());
@@ -4642,75 +4136,27 @@ void ApplyAllHighlights_UIThread() {
                live.size());
     }
 
-    // Second pass: unmatched ranks — pick best free button with lower bar
-    // (uses window title). Helps Windhawk and odd product names.
     std::vector<std::wstring> demoteKeys;
     for (size_t ri = 0; ri < ranks.size(); ++ri) {
         if (rankTaken[ri]) {
             continue;
         }
-        int bestScore = 0;
-        size_t bestBi = SIZE_MAX;
-        for (size_t bi = 0; bi < live.size(); ++bi) {
-            if (buttonTaken[bi]) {
-                continue;
-            }
-            int s = ScoreButtonForRank(live[bi], ranks[ri], true);
-            if (s > bestScore) {
-                bestScore = s;
-                bestBi = bi;
+        if (SettingsSnap()->glowDebugLog) {
+            Wh_Log(L"  UNMATCHED rank %zu: %s (title=\"%s\")", ri + 1,
+                   ranks[ri].displayName.c_str(),
+                   ranks[ri].lastWindowTitle.c_str());
+        }
+        size_t resolvedButtons = 0;
+        {
+            std::lock_guard<std::mutex> lock(g_buttonPathMutex);
+            for (const auto& e : g_buttonPathCache) {
+                if (!e.pathUpper.empty()) {
+                    ++resolvedButtons;
+                }
             }
         }
-        std::wstring autoName = (bestBi != SIZE_MAX)
-                                    ? GetButtonAutomationName(live[bestBi])
-                                    : std::wstring{};
-        if (bestBi != SIZE_MAX && bestScore >= kScoreMinBind &&
-            AutomationNameFitsRank(ranks[ri], autoName)) {
-            rankTaken[ri] = true;
-            buttonTaken[bestBi] = true;
-            buttonRank[bestBi] = static_cast<int>(ri) + 1;
-            StoreAutomationNameIfFits(ranks[ri], autoName);
-            {
-                std::lock_guard<std::mutex> lock(g_stateMutex);
-                auto& map = CurrentDeskLocked().appFocusMap;
-                auto it = map.find(ranks[ri].key);
-                if (it != map.end()) {
-                    it->second.seenOnTaskbar = true;
-                }
-            }
-            if (SettingsSnap()->glowDebugLog) {
-                Wh_Log(L"  bind rank %zu %s -> \"%s\" (score=%d, fallback)",
-                       ri + 1, ranks[ri].displayName.c_str(), autoName.c_str(),
-                       bestScore);
-            }
-            SetCachedPaintRank(live[bestBi], buttonRank[bestBi]);
-            ApplyButtonHighlight(live[bestBi], buttonRank[bestBi]);
-        } else {
-            if (SettingsSnap()->glowDebugLog) {
-                Wh_Log(L"  UNMATCHED rank %zu: %s (bestScore=%d title=\"%s\")",
-                       ri + 1, ranks[ri].displayName.c_str(), bestScore,
-                       ranks[ri].lastWindowTitle.c_str());
-                if (bestBi != SIZE_MAX) {
-                    Wh_Log(L"    closest button was \"%s\"",
-                           GetButtonAutomationName(live[bestBi]).c_str());
-                }
-            }
-            // Tray-only / no button: drop from ranks so it stops occupying a
-            // slot (e.g. HA Desktop Widget). Only demote once we already know
-            // several real taskbar paths (avoid false demote at explorer start).
-            size_t resolvedButtons = 0;
-            {
-                std::lock_guard<std::mutex> lock(g_buttonPathMutex);
-                for (const auto& e : g_buttonPathCache) {
-                    if (!e.pathUpper.empty()) {
-                        ++resolvedButtons;
-                    }
-                }
-            }
-            if (SettingsSnap()->requireTaskbarButton && bestScore == 0 &&
-                resolvedButtons >= 2) {
-                demoteKeys.push_back(ranks[ri].key);
-            }
+        if (SettingsSnap()->requireTaskbarButton && resolvedButtons >= 2) {
+            demoteKeys.push_back(ranks[ri].key);
         }
     }
     // Demote after the loop so rank list stays stable while matching.
@@ -6226,7 +5672,10 @@ std::atomic<bool> g_loggedNoDispatcherAnchor{false};
 
 std::vector<winrt::Windows::UI::Core::CoreDispatcher> CollectUiDispatchers() {
     std::lock_guard<std::mutex> lock(g_dispatchersMutex);
-    return g_uiDispatchers;
+    if (!g_uiDispatchers) {
+        return {};
+    }
+    return *g_uiDispatchers;
 }
 
 // Uninit: run handler at High, then wait for a Low sentinel so earlier
@@ -6285,6 +5734,9 @@ bool RunOnEachUiDispatcherAndWait(
 }
 
 bool RunOnUiThread(const winrt::Windows::UI::Core::DispatchedHandler& handler) {
+    if (g_unloading.load()) {
+        return false;
+    }
     auto dispatchers = CollectUiDispatchers();
 
     if (dispatchers.empty()) {
@@ -6318,7 +5770,9 @@ bool RunOnUiThread(const winrt::Windows::UI::Core::DispatchedHandler& handler) {
 }
 
 void RequestApplyVisuals() {
-    // Prefer UI-thread apply; also keep logging from caller context.
+    if (g_unloading.load()) {
+        return;
+    }
     if (!RunOnUiThread([]() { ApplyAllHighlights_UIThread(); })) {
         // Buttons not tracked yet — will apply on next UpdateVisualStates.
         // Avoid rank dump spam at startup (preview + app both request apply).
@@ -6332,11 +5786,6 @@ void RequestApplyVisuals() {
             }
         }
     }
-}
-
-void ApplyVisualHighlights() {
-    // Legacy entry used by timers / focus path.
-    RequestApplyVisuals();
 }
 
 // ---------------------------------------------------------------------------
@@ -6378,9 +5827,6 @@ void RefreshButtonHighlight(FrameworkElement button) {
             SetCachedPaintRank(button, 0);
             ClearButtonHighlight(button);
             return;
-        }
-        if (TaskListButton_IsRunning(button) && IsVisualStateActive(button)) {
-            StoreAutomationNameIfFits(ranks[0], GetButtonAutomationName(button));
         }
         rank = FindRankForButton(button, ranks, /*requireRunning=*/true);
         SetCachedPaintRank(button, rank);
@@ -6740,8 +6186,11 @@ void WINAPI HoverFlyoutModel_TargetItemKey_Hook(void* pThis, void* param1) {
 }
 
 bool HookTaskbarDllSymbols() {
-    HMODULE module =
-        LoadLibraryEx(L"taskbar.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    HMODULE module = GetModuleHandle(L"taskbar.dll");
+    if (!module) {
+        module = LoadLibraryEx(L"taskbar.dll", nullptr,
+                               LOAD_LIBRARY_SEARCH_SYSTEM32);
+    }
     if (!module) {
         Wh_Log(L"Could not load taskbar.dll — path cache unavailable");
         return false;
@@ -6832,7 +6281,6 @@ bool HookTaskbarDllSymbols() {
         return false;
     }
 
-    g_taskbarDllHooked = true;
     g_taskbandResolveReady = true;
     g_previewHooksReady =
         TaskItemThumbnail_TaskItemThumbnail_Original != nullptr ||
@@ -7123,33 +6571,16 @@ void OnMinFocusTimerElapsed(MinFocusConfirmMode mode) {
         RequestApplyPreviewVisuals();
     }
 
-    // Learn button mapping on UI thread, then apply. Drop tray-only apps that
-    // never show a TaskListButton (HA widget, etc.).
+    // Resolve button paths on the UI thread, then apply. Drop tray-only apps
+    // that never show a TaskListButton.
     RunOnUiThread([key = pending.key, displayName = pending.displayName,
                    desktopId = pending.desktopId]() {
-        AssociateActiveButtonWithKey(key);
-
         auto live = CollectLiveButtonsOnThisDispatcher();
         for (auto& b : live) {
             EnsureButtonPathCached(b, /*force=*/false);
         }
 
-        bool hasNameCache = false;
-        {
-            std::lock_guard<std::mutex> lock(g_stateMutex);
-            hasNameCache = g_keyToAutomationName.contains(key);
-        }
-        bool exeNameOnAButton = false;
-        for (auto& b : live) {
-            if (ScoreExeToAutomationName(displayName,
-                                         GetButtonAutomationName(b)) >=
-                kScoreMinBind) {
-                exeNameOnAButton = true;
-                break;
-            }
-        }
-        const bool appears = PathAppearsOnTaskbar(key, displayName) ||
-                             hasNameCache || exeNameOnAButton;
+        const bool appears = PathAppearsOnTaskbar(key, displayName);
 
         size_t resolvedButtons = 0;
         {
@@ -7178,7 +6609,7 @@ void OnMinFocusTimerElapsed(MinFocusConfirmMode mode) {
                     it->second.lastConfirmedFocusTick = 0;
                     it->second.seenOnTaskbar = false;
                 } else {
-                    // Path cache not ready — keep the rank, name-match later.
+                    // Path cache not ready — keep the rank until buttons exist.
                     it->second.seenOnTaskbar = true;
                 }
             }
@@ -7384,6 +6815,9 @@ void HandleForegroundChanged(HWND hWnd) {
 }
 
 void OnDecayTimer() {
+    if (g_unloading.load()) {
+        return;
+    }
     size_t before = 0;
     size_t after = 0;
     size_t windowsBefore = 0;
@@ -7460,12 +6894,6 @@ LRESULT CALLBACK HookThreadWndProc(HWND hWnd,
         case WM_APP_DESKTOP_SWITCHED:
             OnVirtualDesktopSwitched();
             return 0;
-        case WM_APP_REQUEST_APPLY:
-            RequestApplyVisuals();
-            return 0;
-        case WM_APP_REQUEST_PREVIEW_APPLY:
-            RequestApplyPreviewVisuals();
-            return 0;
         case WM_APP_SHUTDOWN:
             PostQuitMessage(0);
             return 0;
@@ -7509,6 +6937,7 @@ DWORD WINAPI WinEventHookThread(LPVOID /*param*/) {
         Wh_Log(L"GetModuleHandleExW failed for message-window class: %u",
                GetLastError());
         g_hookThreadId.store(0, std::memory_order_release);
+        SignalHookThreadReady();
         return 1;
     }
 
@@ -7520,12 +6949,10 @@ DWORD WINAPI WinEventHookThread(LPVOID /*param*/) {
     };
     ATOM atom = RegisterClassExW(&wc);
     if (!atom) {
-        const DWORD err = GetLastError();
-        if (err != ERROR_CLASS_ALREADY_EXISTS) {
-            Wh_Log(L"RegisterClassExW failed: %u", err);
-            g_hookThreadId.store(0, std::memory_order_release);
-            return 1;
-        }
+        Wh_Log(L"RegisterClassExW failed: %u", GetLastError());
+        g_hookThreadId.store(0, std::memory_order_release);
+        SignalHookThreadReady();
+        return 1;
     }
 
     HWND hwnd =
@@ -7535,9 +6962,11 @@ DWORD WINAPI WinEventHookThread(LPVOID /*param*/) {
         Wh_Log(L"Failed to create message window: %u", GetLastError());
         UnregisterClassW(wc.lpszClassName, wc.hInstance);
         g_hookThreadId.store(0, std::memory_order_release);
+        SignalHookThreadReady();
         return 1;
     }
     g_hookThreadHwnd.store(hwnd, std::memory_order_release);
+    SignalHookThreadReady();
 
     HRESULT coHr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
     if (FAILED(coHr) && coHr != RPC_E_CHANGED_MODE) {
@@ -7610,10 +7039,22 @@ void StartWinEventHookThread() {
     if (g_winEventHookThread) {
         return;
     }
+    if (!g_hookThreadReadyEvent) {
+        g_hookThreadReadyEvent =
+            CreateEventW(nullptr, TRUE, FALSE, nullptr);
+        if (!g_hookThreadReadyEvent) {
+            Wh_Log(L"CreateEventW failed for hook-thread ready: %u",
+                   GetLastError());
+            return;
+        }
+    } else {
+        ResetEvent(g_hookThreadReadyEvent);
+    }
     HANDLE hThread =
         CreateThread(nullptr, 0, WinEventHookThread, nullptr, 0, nullptr);
     if (hThread) {
         g_winEventHookThread = hThread;
+        WaitForSingleObject(g_hookThreadReadyEvent, INFINITE);
         Wh_Log(L"WinEvent hook thread started");
     } else {
         Wh_Log(L"CreateThread failed: %u", GetLastError());
@@ -7640,6 +7081,10 @@ void StopWinEventHookThread() {
     }
     const DWORD w = WaitForSingleObject(hThread, INFINITE);
     CloseHandle(hThread);
+    if (g_hookThreadReadyEvent) {
+        CloseHandle(g_hookThreadReadyEvent);
+        g_hookThreadReadyEvent = nullptr;
+    }
     if (w != WAIT_OBJECT_0) {
         Wh_Log(L"ERROR: focus thread wait failed (%u)", w);
     } else {
@@ -7881,14 +7326,14 @@ void LoadSettings() {
 // ---------------------------------------------------------------------------
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"> Taskbar Recent Focus Highlight init v0.9.1");
+    Wh_Log(L"> Taskbar Recent Focus Highlight init v0.9.2");
 
     g_unloading = false;
     LoadSettings();
 
-    // Identity resolve (taskband) — optional; fuzzy names remain as fallback.
+    // Identity resolve (taskband) — optional; no path cache means no icon glow.
     if (!HookTaskbarDllSymbols()) {
-        Wh_Log(L"Warning: taskbar.dll identity hooks failed — fuzzy match only");
+        Wh_Log(L"Warning: taskbar.dll identity hooks failed — no icon path cache");
     }
 
     if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
@@ -7945,8 +7390,9 @@ void Wh_ModUninit() {
     g_taskbandResolveReady = false;
     g_previewHooksReady = false;
 
-    // Clear visuals and revoke SizeChanged on each dispatcher, then drain
-    // already-queued Normal work (those lambdas no-op on g_unloading).
+    // Stop the worker first so it cannot TryRunAsync after the UI drain.
+    StopWinEventHookThread();
+
     if (!RunOnEachUiDispatcherAndWait([]() {
             ClearAllHighlights_UIThread();
             ClearAllThumbnailHighlights_UIThread();
@@ -7962,15 +7408,12 @@ void Wh_ModUninit() {
         }
     }
 
-    StopWinEventHookThread();
-
     {
         std::lock_guard<std::mutex> lock(g_stateMutex);
         g_desktopMaps.clear();
         g_currentDesktopId = {};
         g_haveCurrentDesktop = false;
         g_pendingFocus = {};
-        g_keyToAutomationName.clear();
     }
     ReleaseVdm();
     {
@@ -7992,7 +7435,7 @@ void Wh_ModUninit() {
     }
     {
         std::lock_guard<std::mutex> lock(g_dispatchersMutex);
-        g_uiDispatchers.clear();
+        g_uiDispatchers.reset();
     }
 }
 
@@ -8008,7 +7451,6 @@ void Wh_ModSettingsChanged() {
                  it != desk.appFocusMap.end();) {
                 std::wstring displayUpper = ToUpper(it->second.displayName);
                 if (IsExcludedKey(it->first, displayUpper)) {
-                    g_keyToAutomationName.erase(it->first);
                     it = desk.appFocusMap.erase(it);
                 } else {
                     ++it;

--- a/mods/taskbar-recent-focus-highlight.wh.cpp
+++ b/mods/taskbar-recent-focus-highlight.wh.cpp
@@ -1,0 +1,8147 @@
+// ==WindhawkMod==
+// @id              taskbar-recent-focus-highlight
+// @name            Taskbar Recent Focus Highlight
+// @description     Visually highlight the most recently focused running apps on the taskbar
+// @version         0.9.0
+// @author          Jakub Vlášek
+// @github          https://github.com/jvlasek
+// @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -lcomctl32 -lole32 -loleaut32 -lruntimeobject -lpropsys -luuid -lshell32 -ladvapi32
+// ==/WindhawkMod==
+
+// Source code is published under The GNU General Public License v3.0.
+
+// ==WindhawkModReadme==
+/*
+# Taskbar Recent Focus Highlight
+
+Visually highlights the most recently used running applications on the taskbar
+for faster context switching. Optionally ranks **windows** inside multi-window
+thumbnail previews (e.g. several VS Code or Terminal instances) with the same
+kind of intensity ladder used on the icons.
+
+## How it works
+
+The mod tracks window focus (`EVENT_SYSTEM_FOREGROUND`) and keeps a ranked list
+of the apps you actually stayed on (after a configurable minimum focus time),
+**per virtual desktop**. The top N **running** taskbar buttons on the current
+desktop receive a highlight (frame, full plate, side bar, or edge bar — bars
+rotate with the taskbar’s screen edge) and optional icon scale. App↔button
+binding uses a process-path cache resolved from the taskband (same approach
+as taskbar-volume-control-per-app),
+with name matching as fallback. Pinned icons that are not running on this
+desktop are never highlighted.
+
+Separately, it tracks **per-window** recency (own min-focus / decay). When you
+hover a combined taskbar icon and the flyout shows 2+ thumbnails, that flyout
+gets its **own** recency list: the top N windows in it are marked with rank
+intensities (title bar, soft title tint, whole plate, hybrid plate+title, or
+ring — configurable). Single-window flyouts are left alone.
+
+## Tips for testing
+
+1. Compile and enable the mod in Windhawk (injects into `explorer.exe`).
+2. Optionally enable **Debug logging**.
+3. Focus apps for at least the minimum focus time (default 8s).
+4. Ranked apps should show a highlight on their taskbar buttons (default: side
+   bar — left on a bottom taskbar, under the icon on a left/right taskbar);
+   rank 1 is strongest. Moving the taskbar to another edge should keep running
+   dots on unranked icons and rotate the bar.
+5. Brief Alt+Tab under the minimum focus time should not change ranks.
+6. Open 3+ windows of one app, focus them in turn, hover the icon — previews
+   show ranks 1 > 2 > 3 (strongest on the last focused window of that app).
+7. Disable the mod or toggle Enabled off to clear highlights.
+8. Multi-monitor: the same rank should appear on every taskbar that shows
+   that app. Combined-icon flyouts should mark the recent window even when
+   titles differ (Total Commander Lister, etc.). Lister has its own taskbar
+   icon — focusing it should highlight Lister, not Total Commander.
+9. Virtual desktops: each desktop has its own recency list. A pinned icon
+   that is not running on this desktop must not glow. Switching back restores
+   that desktop’s ranks.
+10. UWP: Calculator and Settings get separate ranks. Windows Security must
+    not copy Settings’ glow. Packaged apps with their own exe (Terminal) are
+    still path-keyed.
+11. Windows 11 Taskbar Styler: hover must not hide the side bar; preview
+    plate should restore the Styler tint when cleared.
+
+See the repo README.md for full settings and architecture notes.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+# Windhawk shows settings in this list order (no section headers — $group is
+# not allowed by the settings schema). Names use [General] / [Icons] /
+# [Previews] / [Advanced] prefixes so groups stay obvious in a flat list.
+
+# --- General ---
+- enabled: true
+  $name: "[General] Enabled"
+  $description: Master toggle for all highlighting (icons and previews)
+- highlightCount: 3
+  $name: "[General] Number of highlighted apps"
+  $description: How many recent apps to boost on the taskbar (1–6 recommended)
+- minFocusSeconds: 8
+  $name: "[General] Minimum focus time (seconds)"
+  $description: >-
+    Only count an app as recent if it stays focused at least this long.
+    Filters Alt+Tab noise. (Preview windows use a separate timer under Previews.)
+    See “When to skip min-focus” for re-focus of apps already in the list.
+- promoteMode: immediateTracked
+  $name: "[General] When to skip min-focus"
+  $description: >-
+    Controls instant promotion when you re-focus an app (confirmed apps still
+    become rank 1 once promoted — this only skips the wait timer).
+
+    Immediate if in recency map (default): any app still in the map (even if
+    not currently highlighted) promotes immediately.
+
+    Immediate only if highlighted: instant only when the app is already in the
+    top-N glow set; rank 4+ and new apps wait the full min-focus time.
+
+    Always wait: every app focus (including re-focus) waits min-focus seconds.
+  $options:
+  - immediateTracked: Immediate if still in recency map (default)
+  - immediateTopN: Immediate only if already highlighted (top N)
+  - alwaysWait: Always wait min-focus time
+- decayMinutes: 30
+  $name: "[General] Decay time (minutes)"
+  $description: >-
+    Time after last focus before an app drops out of the taskbar highlight
+    list. (Preview windows use a separate decay under Previews.)
+- requireTaskbarButton: true
+  $name: "[General] Only apps on the taskbar"
+  $description: >-
+    Ignore tray-only / tool windows that take focus but have no taskbar button
+    (e.g. desktop widgets that open a popup then hide to the tray).
+- excludedPrograms: [""]
+  $name: "[General] Exclude list"
+  $description: >-
+    Apps that should never be highlighted (icons or previews). Entries can be
+    process names, paths or application IDs, for example:
+
+    mspaint.exe
+
+    C:\Windows\System32\notepad.exe
+
+    Microsoft.WindowsCalculator_8wekyb3d8bbwe!App
+
+# --- Taskbar icons ---
+- glowStyle: leftBar
+  $name: "[Icons] Highlight style"
+  $description: >-
+    How ranked apps look on the taskbar. Bars rotate with the taskbar edge
+    (bottom / left / top / right). Side bar = beside the icon (left on a
+    bottom or top taskbar, under the icon on a left or right taskbar). Edge
+    bar = same side as the native running indicator (screen edge). Frame/Full
+    = rounded rectangle. Edge bar paints our own pill and does not restyle
+    the native running indicator permanently.
+  $options:
+  - leftBar: Side bar (left on bottom/top, under icon on left/right)
+  - frame: Frame (hollow rounded rectangle)
+  - full: Full (filled rounded rectangle)
+  - bottomBar: Edge bar (follows the screen edge)
+- glowColor: accent
+  $name: "[Icons] Glow color"
+  $description: Base color for icon highlights (and previews)
+  $options:
+  - accent: System accent color
+  - green: Green
+  - blue: Blue
+  - orange: Orange
+  - white: White
+  - custom: Custom (see custom glow color)
+- customGlowColor: "#00C853"
+  $name: "[Icons] Custom glow color"
+  $description: Used when glow color is Custom (hex, e.g. #00C853)
+- glowIntensityRank1: 100
+  $name: "[Icons] Intensity rank 1"
+  $description: Strength for the most recent app (0–100)
+- glowIntensityRank2: 70
+  $name: "[Icons] Intensity rank 2"
+  $description: Strength for the 2nd most recent app (0–100)
+- glowIntensityRank3: 45
+  $name: "[Icons] Intensity rank 3"
+  $description: Strength for the 3rd most recent app (0–100); also used for ranks 4+
+- glowThickness: 3
+  $name: "[Icons] Thickness (px)"
+  $description: >-
+    Frame/Full border width, or bar thickness (1–16). For side/edge bars this
+    is the bar’s short dimension.
+- glowRoundness: 28
+  $name: "[Icons] Roundness (%)"
+  $description: >-
+    Corner radius for Frame/Full (0 = square, ~25–35 = Win11, 50 ≈ pill).
+    Side bar uses this for pill rounding; edge bar ignores it.
+- glowSize: 92
+  $name: "[Icons] Size (%)"
+  $description: >-
+    Frame/Full: box size vs icon panel (≤100). Side bar: bar length along the
+    icon. Edge bar: pill length % of the icon’s long side (try 70–100).
+- glowLayers: 2
+  $name: "[Icons] Layers"
+  $description: >-
+    Frame/Full: nested frames (1–3). Side bar: soft outer glow layers. Edge
+    bar: ignored.
+- glowFillOpacity: 40
+  $name: "[Icons] Fill opacity"
+  $description: >-
+    0–100. Plate fill for Full; solid bar opacity for Side/Edge. Frame uses
+    stroke only. (Thumbnail tints use [Previews] Tint opacity.)
+- sizeBoostRank1: 10
+  $name: "[Icons] Size boost rank 1 (%)"
+  $description: Subtle icon scale for rank 1 (0 = disabled)
+- sizeBoostRank2: 6
+  $name: "[Icons] Size boost rank 2 (%)"
+  $description: Subtle icon scale for rank 2 (0 = disabled)
+- sizeBoostRank3: 3
+  $name: "[Icons] Size boost rank 3 (%)"
+  $description: Subtle icon scale for rank 3 (0 = disabled)
+
+# --- Thumbnail previews ---
+- previewHighlightEnabled: true
+  $name: "[Previews] Highlight recent windows"
+  $description: >-
+    When hovering a multi-window taskbar icon, rank that flyout’s thumbnails
+    by window recency and mark the top N. Single-window flyouts are never
+    highlighted.
+- previewHighlightCount: 3
+  $name: "[Previews] Number of highlighted windows"
+  $description: >-
+    How many recent windows to mark in a multi-window flyout (1–6 recommended).
+    Ranking is local to that flyout: the last focused window of this app is
+    rank 1 even if other apps were used more recently. Set to 1 to mark only
+    the latest window.
+- previewStyle: titleBar
+  $name: "[Previews] Highlight style"
+  $description: >-
+    How to mark ranked windows. Title bar = thin line under the title.
+    Title background = soft wash behind the title. Plate = tint the whole card.
+    Hybrid = whole plate for rank 1, title wash for ranks 2+.
+    Ring = hollow border around the card.
+  $options:
+  - titleBar: Bar under window title
+  - titleBg: Title background tint
+  - plate: Whole preview plate
+  - plateTitle: Hybrid (plate rank 1, title tint 2+)
+  - ring: Ring / frame
+- previewIntensityRank1: 100
+  $name: "[Previews] Intensity rank 1"
+  $description: Strength for the most recent window in the flyout (0–100)
+- previewIntensityRank2: 70
+  $name: "[Previews] Intensity rank 2"
+  $description: Strength for the 2nd most recent window in the flyout (0–100)
+- previewIntensityRank3: 45
+  $name: "[Previews] Intensity rank 3"
+  $description: >-
+    Strength for the 3rd most recent window in the flyout (0–100); also used
+    for ranks 4+
+- previewFillOpacity: 40
+  $name: "[Previews] Tint opacity"
+  $description: >-
+    0–100. Strength of title-background wash and whole-preview plate. Title bar
+    line uses full accent and ignores this. Independent of [Icons] Fill opacity.
+    Per-rank intensity still scales the result.
+- previewMinFocusSeconds: 1
+  $name: "[Previews] Minimum focus (seconds)"
+  $description: >-
+    How long a window must stay focused before it enters that flyout’s
+    recency list. Separate from app ranking min focus (0 = immediate).
+- previewDecayMinutes: 15
+  $name: "[Previews] Decay (minutes)"
+  $description: >-
+    Drop a window from preview recency after this idle time (0 = never).
+    Separate from app ranking decay.
+
+# --- Advanced ---
+- glowDebugLog: false
+  $name: "[Advanced] Debug log (verbose)"
+  $description: >-
+    Logs glow metrics, path binds, and preview resolve details. Leave off for
+    normal use; turn on when diagnosing matches.
+*/
+// ==/WindhawkModSettings==
+
+#include <windhawk_utils.h>
+
+#include <commctrl.h>
+#include <initguid.h>
+#include <propkey.h>
+#include <propsys.h>
+#include <psapi.h>
+#include <objbase.h>
+#include <shellapi.h>
+#include <shobjidl.h>
+
+#undef GetCurrentTime
+
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.UI.h>
+#include <winrt/Windows.UI.Core.h>
+#include <winrt/Windows.UI.ViewManagement.h>
+#include <winrt/Windows.UI.Xaml.h>
+#include <winrt/Windows.UI.Xaml.Automation.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Input.h>
+#include <winrt/Windows.UI.Xaml.Markup.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
+#include <winrt/Windows.UI.Xaml.Shapes.h>
+#include <winrt/base.h>
+
+#include <algorithm>
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+using namespace winrt::Windows::UI::Xaml;
+
+// Public IVirtualDesktopManager (Win10+). Defined here so we do not depend on
+// a particular SDK header / uuid.lib export of the CLSID.
+#ifndef __IVirtualDesktopManager_INTERFACE_DEFINED__
+#define __IVirtualDesktopManager_INTERFACE_DEFINED__
+MIDL_INTERFACE("a5cd92ff-29be-454c-8d04-d82879fb3f1b")
+IVirtualDesktopManager : public IUnknown {
+    virtual HRESULT STDMETHODCALLTYPE IsWindowOnCurrentVirtualDesktop(
+        HWND topLevelWindow,
+        BOOL* onCurrentDesktop) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetWindowDesktopId(HWND topLevelWindow,
+                                                         GUID* desktopId) = 0;
+    virtual HRESULT STDMETHODCALLTYPE MoveWindowToDesktop(HWND topLevelWindow,
+                                                          REFGUID desktopId) = 0;
+};
+#endif
+
+// AA509086-5CA9-4C25-8F95-589D3C07B48A
+static const CLSID kClsidVirtualDesktopManager = {
+    0xaa509086,
+    0x5ca9,
+    0x4c25,
+    {0x8f, 0x95, 0x58, 0x9d, 0x3c, 0x07, 0xb4, 0x8a}};
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+enum class GlowColorMode {
+    Accent,
+    Green,
+    Blue,
+    Orange,
+    White,
+    Custom,
+};
+
+enum class GlowStyle {
+    Frame,      // hollow rounded rectangle
+    Full,       // filled rounded rectangle
+    LeftBar,    // side bar: left on horizontal taskbar, bottom on vertical
+    BottomBar,  // edge bar: same side as the native RunningIndicator
+};
+
+// Physical screen edge the taskbar is on (Win11 24H2/25H2 can use all four).
+enum class TaskbarEdge {
+    Bottom,
+    Left,
+    Top,
+    Right,
+};
+
+// Where a bar highlight is painted on the icon button.
+enum class BarSide {
+    Left,
+    Top,
+    Right,
+    Bottom,
+};
+
+// When re-focus may skip the app min-focus timer (see HandleForegroundChanged).
+enum class PromoteMode {
+    ImmediateTracked,  // any app still in this desktop's recency map
+    ImmediateTopN,     // only if currently highlighted on this desktop
+    AlwaysWait,        // always use minFocusSeconds
+};
+
+// Thumbnail flyout highlight (independent of icon GlowStyle).
+enum class PreviewStyle {
+    Ring,       // hollow frame around the whole preview (placeholder)
+    TitleBg,    // tint behind the window title text
+    Plate,      // tint whole preview card (hover-like plate)
+    TitleBar,   // thin bar under the title, above the thumbnail image
+    PlateTitle, // rank 1 = plate; ranks 2+ = title background tint
+};
+
+struct Settings {
+    bool enabled = true;
+    int highlightCount = 3;
+    int minFocusSeconds = 8;
+    PromoteMode promoteMode = PromoteMode::ImmediateTracked;
+    GlowColorMode glowColor = GlowColorMode::Accent;
+    std::wstring customGlowColor = L"#00C853";
+    int glowIntensity[3] = {100, 70, 45};
+    int sizeBoostPercent[3] = {10, 6, 3};
+    GlowStyle glowStyle = GlowStyle::LeftBar;
+    int glowThickness = 3;      // px
+    int glowRoundness = 28;     // % of glow box
+    int glowSize = 92;          // % of icon panel (clamped to fit)
+    int glowLayers = 2;         // 1–3
+    int glowFillOpacity = 40;   // % for Full / left / bottom icon styles
+    int previewFillOpacity = 40;  // % for thumbnail plate / titleBg only
+    bool glowDebugLog = false;
+    int decayMinutes = 30;
+    bool requireTaskbarButton = true;  // skip tray-only focus targets
+    bool previewHighlightEnabled = true;
+    int previewHighlightCount = 3;
+    int previewIntensity[3] = {100, 70, 45};
+    int previewMinFocusSeconds = 1;
+    int previewDecayMinutes = 15;
+    PreviewStyle previewStyle = PreviewStyle::TitleBar;
+    std::unordered_set<std::wstring> excludedPrograms;
+};
+
+// Published as a whole. LoadSettings builds a local Settings, then stores it
+// here so the focus thread and UI dispatchers never iterate a set mid-rehash.
+// Windhawk's libc++ has no std::atomic<shared_ptr> specialization (T must be
+// trivially copyable), so the pointer is swapped under a mutex.
+std::mutex g_settingsMutex;
+std::shared_ptr<const Settings> g_settingsPtr =
+    std::make_shared<const Settings>();
+
+std::shared_ptr<const Settings> SettingsSnap() {
+    std::lock_guard<std::mutex> lock(g_settingsMutex);
+    return g_settingsPtr ? g_settingsPtr : std::make_shared<const Settings>();
+}
+
+void PublishSettings(Settings s) {
+    auto next = std::make_shared<const Settings>(std::move(s));
+    std::lock_guard<std::mutex> lock(g_settingsMutex);
+    g_settingsPtr = std::move(next);
+}
+
+// WM_TIMER may be a leftover from a previous candidate (KillTimer does not
+// flush a message already queued). Immediate confirm skips the deadline.
+enum class MinFocusConfirmMode {
+    FromTimer,
+    Immediate,
+};
+
+// ---------------------------------------------------------------------------
+// Focus / recency state
+// ---------------------------------------------------------------------------
+
+struct AppFocusInfo {
+    std::wstring key;          // APPID:… or PATH|CLS:class or bare path
+    std::wstring displayName;  // e.g. WindowsTerminal.exe
+    std::wstring lastWindowTitle;  // from focused HWND (helps button match)
+    std::wstring classUpper;   // focused window class (TLister vs TTOTAL_CMD)
+    std::wstring appIdUpper;   // window AppUserModelID when present
+    HWND lastHwnd = nullptr;
+    ULONGLONG lastConfirmedFocusTick = 0;
+    // True once we saw a TaskListButton for this path (path cache / bind).
+    bool seenOnTaskbar = false;
+};
+
+struct PendingFocus {
+    HWND hwnd = nullptr;
+    DWORD processId = 0;
+    std::wstring key;
+    std::wstring displayName;
+    std::wstring windowTitle;
+    ULONGLONG focusStartTick = 0;
+    ULONGLONG previewStartTick = 0;  // HWND-level; resets when instance changes
+    GUID desktopId{};
+    bool valid = false;
+};
+
+// Per-window recency for multi-instance thumbnail previews (separate timers).
+struct WindowFocusInfo {
+    HWND hwnd = nullptr;
+    DWORD pid = 0;              // reject recycled HWND with a new process
+    std::wstring processKey;    // UPPER path
+    std::wstring windowTitle;   // fallback match
+    ULONGLONG lastConfirmedTick = 0;
+    ULONGLONG confirmSeq = 0;  // unique per confirm (breaks GetTickCount ties)
+};
+
+struct HwndHash {
+    size_t operator()(HWND h) const noexcept {
+        return std::hash<uintptr_t>{}(reinterpret_cast<uintptr_t>(h));
+    }
+};
+
+struct GuidHash {
+    size_t operator()(const GUID& g) const noexcept {
+        size_t h = 0;
+        const unsigned char* p = reinterpret_cast<const unsigned char*>(&g);
+        for (int i = 0; i < 16; ++i) {
+            h = h * 131u + p[i];
+        }
+        return h;
+    }
+};
+
+struct GuidEqual {
+    bool operator()(const GUID& a, const GUID& b) const noexcept {
+        return InlineIsEqualGUID(a, b) != 0;
+    }
+};
+
+// App + window recency for one virtual desktop (session-wide, not per-monitor).
+struct DesktopRecencyState {
+    std::unordered_map<std::wstring, AppFocusInfo> appFocusMap;
+    std::vector<AppFocusInfo> rankedApps;
+    std::unordered_map<HWND, WindowFocusInfo, HwndHash> windowFocusMap;
+};
+
+std::mutex g_stateMutex;
+std::unordered_map<GUID, DesktopRecencyState, GuidHash, GuidEqual> g_desktopMaps;
+GUID g_currentDesktopId{};
+bool g_haveCurrentDesktop = false;
+PendingFocus g_pendingFocus;
+
+// process key (UPPER path) -> last seen AutomationProperties.Name of its button
+std::unordered_map<std::wstring, std::wstring> g_keyToAutomationName;
+
+std::atomic<ULONGLONG> g_windowConfirmSeq{0};
+
+// Public IVirtualDesktopManager (fallback when registry current-desktop fails).
+IVirtualDesktopManager* g_vdm = nullptr;
+std::mutex g_vdmMutex;
+
+// Option C: long-lived button → process path cache (resolve rarely, paint often).
+struct ButtonPathCacheEntry {
+    winrt::weak_ref<FrameworkElement> button;
+    std::wstring pathUpper;  // empty if resolve failed / not yet tried
+    std::wstring appIdUpper;
+    std::wstring classUpper;
+    std::wstring autoIdUpper;  // AutomationId, often "APPID: …"
+    DWORD pid = 0;
+    HWND sampleHwnd = nullptr;  // sample from resolve; preview uses window map
+    std::vector<HWND> groupHwnds;
+    bool resolveAttempted = false;
+    ULONGLONG lastResolveTick = 0;
+    ULONGLONG lastRunningTick = 0;  // IsRunning grace (Alt-Tab flicker)
+    // Last ApplyAllHighlights assignment: -1 unknown, 0 none, >0 1-based rank.
+    int lastPaintRank = -1;
+};
+std::mutex g_buttonPathMutex;
+std::vector<ButtonPathCacheEntry> g_buttonPathCache;
+std::atomic<bool> g_taskbandResolveReady{false};
+
+// XAML TaskItemThumbnail (model) → native task item (optional hooks).
+struct ThumbnailTaskItemMapping {
+    winrt::weak_ref<winrt::Windows::Foundation::IInspectable> thumbnail;
+    void* taskGroup = nullptr;
+    void* taskItem = nullptr;
+    HWND hwnd = nullptr;  // resolved at map time (stable for same-title windows)
+};
+std::mutex g_thumbnailMapMutex;
+std::vector<ThumbnailTaskItemMapping> g_thumbnailTaskItemMapping;
+std::atomic<bool> g_previewHooksReady{false};
+
+// Live thumbnail views for unload / re-apply while flyout is open.
+std::mutex g_thumbViewsMutex;
+std::vector<winrt::weak_ref<FrameworkElement>> g_trackedThumbViews;
+
+std::atomic<bool> g_unloading{false};
+std::atomic<bool> g_taskbarViewDllLoaded{false};
+std::atomic<bool> g_taskbarDllHooked{false};
+// After decay / empty ranks, force-clear overlays on next button touch if
+// RequestApplyVisuals couldn't run (sleep/wake, no dispatcher yet).
+std::atomic<bool> g_pendingOverlaySweep{false};
+
+std::mutex g_winEventHookThreadMutex;
+std::atomic<HANDLE> g_winEventHookThread{nullptr};
+HWND g_hookThreadHwnd = nullptr;
+
+// UI-thread tracking of task list buttons (weak refs).
+std::mutex g_buttonsMutex;
+std::vector<winrt::weak_ref<FrameworkElement>> g_trackedButtons;
+winrt::weak_ref<FrameworkElement> g_dispatcherAnchor;
+
+constexpr UINT WM_APP_FOREGROUND_CHANGED = WM_APP + 1;
+constexpr UINT WM_APP_REQUEST_APPLY = WM_APP + 2;
+constexpr UINT WM_APP_REQUEST_PREVIEW_APPLY = WM_APP + 3;
+constexpr UINT WM_APP_DESKTOP_SWITCHED = WM_APP + 4;
+constexpr UINT WM_APP_SHUTDOWN = WM_APP + 5;
+
+// Identity scores. Only exact identity (and name-cache) may bind the same
+// rank to many buttons (secondary taskbar / Never Combine). Score 900 is
+// same filename, different folder — 1:1 so two python.exe installs stay
+// distinct.
+constexpr int kScoreExactIdentity = 1000;
+constexpr int kScoreSameFileDifferentPath = 900;
+constexpr int kScoreNameCache = 96;
+constexpr int kScoreMinBind = 70;
+constexpr UINT_PTR kMinFocusTimerId = 1;
+constexpr UINT_PTR kDecayTimerId = 2;
+constexpr UINT_PTR kPreviewMinFocusTimerId = 3;
+constexpr UINT_PTR kFullRebindTimerId = 4;
+constexpr UINT kDecayCheckIntervalMs = 30 * 1000;
+constexpr ULONGLONG kIsRunningGraceMs = 400;
+// Full identity rebind (all buttons). UVS only re-paints the cached rank;
+// siblings whose visuals Windows cleared without another UVS wait for this.
+constexpr ULONGLONG kFullRebindDebounceMs = 300;
+
+// All glow layers live on our overlay (never BackgroundElement — hover/active
+// storyboards own that and constantly wipe our styles).
+constexpr PCWSTR kGlowElementName = L"WhRecentFocusGlow";
+constexpr PCWSTR kGlowLayerNames[] = {
+    L"WhRecentFocusGlowL0",
+    L"WhRecentFocusGlowL1",
+    L"WhRecentFocusGlowL2",
+};
+constexpr int kGlowMaxLayers = 3;
+constexpr PCWSTR kBackgroundElementName = L"BackgroundElement";
+// Present while edge-bar (bottomBar) style is applied — we hid RunningIndicator.
+constexpr PCWSTR kBottomBarMarkerName = L"WhRecentFocusBottomBar";
+// Thumbnail preview glow (own named overlays on TaskItemThumbnailView).
+constexpr PCWSTR kThumbGlowElementName = L"WhRecentFocusThumbGlow";
+constexpr PCWSTR kThumbGlowLayerNames[] = {
+    L"WhRecentFocusThumbGlowL0",
+    L"WhRecentFocusThumbGlowL1",
+};
+// Title-area overlays (separate so plate/ring host can sit full-card).
+constexpr PCWSTR kThumbTitleBgName = L"WhRecentFocusThumbTitleBg";
+constexpr PCWSTR kThumbTitleBarName = L"WhRecentFocusThumbTitleBar";
+// Marker: we tinted native BackgroundBorder. Tag holds the previous Brush
+// (or is empty if the local value was unset) so Taskbar Styler survives clear.
+constexpr PCWSTR kThumbNativeStyleMarker = L"WhRecentFocusThumbNative";
+
+// ---------------------------------------------------------------------------
+// Virtual desktops (public COM + explorer registry — no internal shell GUIDs)
+// ---------------------------------------------------------------------------
+
+void CancelMinFocusTimer();
+void CancelPreviewMinFocusTimer();
+void OnMinFocusTimerElapsed(MinFocusConfirmMode mode = MinFocusConfirmMode::FromTimer);
+void OnPreviewMinFocusTimerElapsed(
+    MinFocusConfirmMode mode = MinFocusConfirmMode::FromTimer);
+void RequestApplyVisuals();
+void RequestApplyPreviewVisuals();
+void RefreshButtonHighlight(FrameworkElement button);
+void ScheduleRefreshAllHighlights(FrameworkElement dispatcherAnchor);
+void RecomputeRanksForDesktopLocked(DesktopRecencyState& desk);
+
+struct IconPanelLayoutWatch {
+    winrt::weak_ref<FrameworkElement> panel;
+    winrt::event_token sizeChanged{};
+    TaskbarEdge lastEdge = TaskbarEdge::Bottom;
+    bool haveEdge = false;
+};
+std::mutex g_layoutWatchMutex;
+std::vector<IconPanelLayoutWatch> g_layoutWatches;
+thread_local int g_iconPanelRelayoutDepth = 0;
+thread_local ULONGLONG g_lastFullRefreshTick = 0;
+
+std::wstring GuidToLogString(const GUID& id) {
+    wchar_t buf[64]{};
+    if (StringFromGUID2(id, buf, ARRAYSIZE(buf)) > 0) {
+        return buf;
+    }
+    return L"{?}";
+}
+
+IVirtualDesktopManager* EnsureVdm() {
+    std::lock_guard<std::mutex> lock(g_vdmMutex);
+    if (g_vdm) {
+        return g_vdm;
+    }
+    IVirtualDesktopManager* vdm = nullptr;
+    HRESULT hr = CoCreateInstance(kClsidVirtualDesktopManager, nullptr,
+                                  CLSCTX_ALL, IID_PPV_ARGS(&vdm));
+    if (FAILED(hr) || !vdm) {
+        Wh_Log(L"IVirtualDesktopManager create failed %08X", hr);
+        return nullptr;
+    }
+    g_vdm = vdm;
+    return g_vdm;
+}
+
+void ReleaseVdm() {
+    std::lock_guard<std::mutex> lock(g_vdmMutex);
+    if (g_vdm) {
+        g_vdm->Release();
+        g_vdm = nullptr;
+    }
+}
+
+bool TryGetWindowDesktopId(HWND hwnd, GUID* outId) {
+    if (!hwnd || !outId) {
+        return false;
+    }
+    IVirtualDesktopManager* vdm = EnsureVdm();
+    if (!vdm) {
+        return false;
+    }
+    GUID id{};
+    HRESULT hr = vdm->GetWindowDesktopId(hwnd, &id);
+    if (FAILED(hr) || InlineIsEqualGUID(id, GUID_NULL)) {
+        return false;
+    }
+    *outId = id;
+    return true;
+}
+
+bool ReadCurrentDesktopFromRegistry(GUID* outId) {
+    if (!outId) {
+        return false;
+    }
+    HKEY key = nullptr;
+    if (RegOpenKeyExW(HKEY_CURRENT_USER,
+                      L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\"
+                      L"VirtualDesktops",
+                      0, KEY_READ, &key) != ERROR_SUCCESS) {
+        return false;
+    }
+    GUID id{};
+    DWORD size = sizeof(id);
+    DWORD type = 0;
+    LONG rc = RegQueryValueExW(key, L"CurrentVirtualDesktop", nullptr, &type,
+                               reinterpret_cast<LPBYTE>(&id), &size);
+    RegCloseKey(key);
+    if (rc != ERROR_SUCCESS || type != REG_BINARY || size != sizeof(GUID) ||
+        InlineIsEqualGUID(id, GUID_NULL)) {
+        return false;
+    }
+    *outId = id;
+    return true;
+}
+
+GUID ResolveCurrentDesktopId() {
+    GUID fromReg{};
+    const bool haveReg = ReadCurrentDesktopFromRegistry(&fromReg);
+    GUID fromWnd{};
+    const bool haveWnd =
+        TryGetWindowDesktopId(GetForegroundWindow(), &fromWnd);
+    if (haveReg && haveWnd && !InlineIsEqualGUID(fromReg, fromWnd) &&
+        SettingsSnap()->glowDebugLog) {
+        Wh_Log(L"Desktop id mismatch registry=%s fgWindow=%s — using registry",
+               GuidToLogString(fromReg).c_str(),
+               GuidToLogString(fromWnd).c_str());
+    }
+    if (haveReg) {
+        return fromReg;
+    }
+    if (haveWnd) {
+        return fromWnd;
+    }
+    std::lock_guard<std::mutex> lock(g_stateMutex);
+    return g_currentDesktopId;
+}
+
+// Returns true when the current-desktop id changed after the first successful
+// read (i.e. a real switch, not startup). Safe to call without g_stateMutex.
+bool RefreshCurrentDesktopId() {
+    const GUID id = ResolveCurrentDesktopId();
+    std::lock_guard<std::mutex> lock(g_stateMutex);
+    const bool first = !g_haveCurrentDesktop;
+    const bool changed = !InlineIsEqualGUID(id, g_currentDesktopId);
+    g_currentDesktopId = id;
+    g_haveCurrentDesktop = true;
+    g_desktopMaps[id];
+    if (changed) {
+        Wh_Log(L"Current virtual desktop: %s (%zu tracked)",
+               GuidToLogString(id).c_str(), g_desktopMaps.size());
+    }
+    return !first && changed;
+}
+
+// Requires g_stateMutex.
+DesktopRecencyState& DeskStateLocked(const GUID& id) {
+    return g_desktopMaps[id];
+}
+
+DesktopRecencyState& CurrentDeskLocked() {
+    return g_desktopMaps[g_currentDesktopId];
+}
+
+void ClearButtonRunningGrace() {
+    std::lock_guard<std::mutex> lock(g_buttonPathMutex);
+    for (auto& e : g_buttonPathCache) {
+        e.lastRunningTick = 0;
+    }
+}
+
+// Requires g_stateMutex. True if pending was dropped.
+bool DropPendingIfWrongDesktopLocked() {
+    if (g_pendingFocus.valid &&
+        !InlineIsEqualGUID(g_pendingFocus.desktopId, g_currentDesktopId)) {
+        g_pendingFocus = {};
+        return true;
+    }
+    return false;
+}
+
+void OnVirtualDesktopSwitched() {
+    ClearButtonRunningGrace();
+    RefreshCurrentDesktopId();
+    bool droppedPending = false;
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        droppedPending = DropPendingIfWrongDesktopLocked();
+        RecomputeRanksForDesktopLocked(CurrentDeskLocked());
+        Wh_Log(L"Virtual desktop switch: %s ranks=%zu droppedPending=%d",
+               GuidToLogString(g_currentDesktopId).c_str(),
+               CurrentDeskLocked().rankedApps.size(),
+               droppedPending ? 1 : 0);
+    }
+    if (droppedPending) {
+        CancelMinFocusTimer();
+        CancelPreviewMinFocusTimer();
+    }
+    g_pendingOverlaySweep = true;
+    RequestApplyVisuals();
+    RequestApplyPreviewVisuals();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+ULONGLONG DecayMsFromMinutes(int minutes) {
+    if (minutes <= 0) {
+        return 0;
+    }
+    return static_cast<ULONGLONG>(minutes) * 60ULL * 1000ULL;
+}
+
+bool IsTickDecayed(ULONGLONG tick, ULONGLONG decayMs, ULONGLONG now) {
+    return decayMs > 0 && tick != 0 && now - tick > decayMs;
+}
+
+// KillTimer does not dequeue a WM_TIMER already posted. Re-check this
+// candidate's start tick and arm the remainder instead of confirming early.
+ULONGLONG RemainingDeadlineMs(ULONGLONG startTick, int seconds, ULONGLONG now) {
+    if (seconds <= 0) {
+        return 0;
+    }
+    const ULONGLONG need = static_cast<ULONGLONG>(seconds) * 1000ULL;
+    if (now < startTick) {
+        return need;
+    }
+    const ULONGLONG elapsed = now - startTick;
+    if (elapsed >= need) {
+        return 0;
+    }
+    return need - elapsed;
+}
+
+UINT ClampWinTimerMs(ULONGLONG ms) {
+    constexpr ULONGLONG kMax = 0x7FFFFFFFULL;
+    if (ms == 0) {
+        return 1;
+    }
+    if (ms > kMax) {
+        return static_cast<UINT>(kMax);
+    }
+    return static_cast<UINT>(ms);
+}
+
+std::wstring ToUpper(std::wstring s) {
+    if (!s.empty()) {
+        LCMapStringEx(LOCALE_NAME_USER_DEFAULT, LCMAP_UPPERCASE, s.data(),
+                      static_cast<int>(s.length()), s.data(),
+                      static_cast<int>(s.length()), nullptr, nullptr, 0);
+    }
+    return s;
+}
+
+// Keep A–Z / 0–9 only, uppercased — for fuzzy exe ↔ automation-name match.
+std::wstring AlnumUpper(std::wstring_view s) {
+    std::wstring out;
+    out.reserve(s.size());
+    for (wchar_t ch : s) {
+        if (ch >= L'a' && ch <= L'z') {
+            out.push_back(static_cast<wchar_t>(ch - L'a' + L'A'));
+        } else if ((ch >= L'A' && ch <= L'Z') || (ch >= L'0' && ch <= L'9')) {
+            out.push_back(ch);
+        }
+    }
+    return out;
+}
+
+std::wstring GetProcessImagePath(DWORD processId) {
+    std::wstring path;
+    HANDLE hProcess =
+        OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, processId);
+    if (!hProcess) {
+        return path;
+    }
+
+    DWORD size = MAX_PATH;
+    for (int attempt = 0; attempt < 5; ++attempt) {
+        path.assign(size, L'\0');
+        DWORD n = size;
+        if (QueryFullProcessImageName(hProcess, 0, path.data(), &n)) {
+            path.resize(n);
+            CloseHandle(hProcess);
+            return path;
+        }
+        const DWORD err = GetLastError();
+        if (err != ERROR_INSUFFICIENT_BUFFER || n <= size) {
+            path.clear();
+            break;
+        }
+        size = n;
+        if (size > 32768) {
+            path.clear();
+            break;
+        }
+    }
+    CloseHandle(hProcess);
+    return path;
+}
+
+DWORD PidFromHwnd(HWND hwnd) {
+    DWORD pid = 0;
+    if (hwnd) {
+        GetWindowThreadProcessId(hwnd, &pid);
+    }
+    return pid;
+}
+
+// False when the handle was recycled into a different process.
+bool HwndMatchesStoredPid(HWND hwnd, DWORD storedPid) {
+    if (!hwnd || !IsWindow(hwnd)) {
+        return false;
+    }
+    if (!storedPid) {
+        return true;
+    }
+    const DWORD pid = PidFromHwnd(hwnd);
+    return pid == 0 || pid == storedPid;
+}
+
+std::wstring FileNameFromPath(const std::wstring& path) {
+    size_t pos = path.find_last_of(L"\\/");
+    if (pos == std::wstring::npos) {
+        return path;
+    }
+    return path.substr(pos + 1);
+}
+
+std::wstring StripExtension(std::wstring name) {
+    size_t pos = name.find_last_of(L'.');
+    if (pos != std::wstring::npos && pos > 0) {
+        name.resize(pos);
+    }
+    return name;
+}
+
+bool IsOwnExplorerProcess(DWORD processId) {
+    return processId == GetCurrentProcessId();
+}
+
+std::wstring PathFromAppKey(const std::wstring& key);
+std::wstring AppIdFromAppKey(const std::wstring& key);
+std::wstring ClassFromAppKey(const std::wstring& key);
+
+bool IsExcludedKey(const std::wstring& keyUpper,
+                   const std::wstring& displayNameUpper) {
+    auto settings = SettingsSnap();
+    const auto& excluded = settings->excludedPrograms;
+    if (excluded.empty()) {
+        return false;
+    }
+    if (excluded.contains(keyUpper)) {
+        return true;
+    }
+    if (!displayNameUpper.empty() && excluded.contains(displayNameUpper)) {
+        return true;
+    }
+    const std::wstring path = PathFromAppKey(keyUpper);
+    if (!path.empty() && excluded.contains(path)) {
+        return true;
+    }
+    if (!path.empty()) {
+        std::wstring fileUpper = ToUpper(FileNameFromPath(path));
+        if (!fileUpper.empty() && excluded.contains(fileUpper)) {
+            return true;
+        }
+    }
+    const std::wstring appId = AppIdFromAppKey(keyUpper);
+    if (!appId.empty() && excluded.contains(appId)) {
+        return true;
+    }
+    return false;
+}
+
+HWND NormalizeFocusHwnd(HWND hWnd) {
+    if (!hWnd || !IsWindow(hWnd)) {
+        return nullptr;
+    }
+    if (GetWindowLong(hWnd, GWL_STYLE) & WS_CHILD) {
+        HWND root = GetAncestor(hWnd, GA_ROOT);
+        if (root && IsWindow(root)) {
+            return root;
+        }
+    }
+    return hWnd;
+}
+
+std::wstring GetWindowClassName(HWND hWnd) {
+    WCHAR buf[256]{};
+    if (!hWnd || !GetClassNameW(hWnd, buf, ARRAYSIZE(buf))) {
+        return {};
+    }
+    return buf;
+}
+
+std::wstring GetWindowAppUserModelId(HWND hWnd) {
+    if (!hWnd || !IsWindow(hWnd)) {
+        return {};
+    }
+    IPropertyStore* store = nullptr;
+    HRESULT hr = SHGetPropertyStoreForWindow(hWnd, IID_IPropertyStore,
+                                             reinterpret_cast<void**>(&store));
+    if (FAILED(hr) || !store) {
+        return {};
+    }
+    PROPVARIANT pv;
+    PropVariantInit(&pv);
+    hr = store->GetValue(PKEY_AppUserModel_ID, &pv);
+    std::wstring id;
+    if (SUCCEEDED(hr) && pv.vt == VT_LPWSTR && pv.pwszVal && pv.pwszVal[0]) {
+        id = pv.pwszVal;
+    }
+    PropVariantClear(&pv);
+    store->Release();
+    return id;
+}
+
+std::wstring StripAppIdPrefix(std::wstring id) {
+    // AutomationId looks like "Appid: com.squirrel.Discord.Discord"
+    constexpr wchar_t kPref[] = L"Appid:";
+    if (id.size() > 6 && _wcsnicmp(id.c_str(), kPref, 6) == 0) {
+        id.erase(0, 6);
+        while (!id.empty() && (id.front() == L' ' || id.front() == L'\t')) {
+            id.erase(id.begin());
+        }
+    }
+    return id;
+}
+
+std::wstring CanonicalAppId(std::wstring id) {
+    return ToUpper(StripAppIdPrefix(std::move(id)));
+}
+
+bool IsAppIdKey(const std::wstring& key) {
+    return key.rfind(L"APPID:", 0) == 0;
+}
+
+bool IsUwpHostFileName(const std::wstring& fileNameUpper) {
+    return fileNameUpper == L"APPLICATIONFRAMEHOST.EXE" ||
+           fileNameUpper == L"WWAHOST.EXE";
+}
+
+bool IsUwpHostPath(const std::wstring& pathUpper) {
+    if (pathUpper.empty()) {
+        return false;
+    }
+    return IsUwpHostFileName(ToUpper(FileNameFromPath(pathUpper)));
+}
+
+// Microsoft.WindowsCalculator_8wekyb3d8bbwe!App → Microsoft.WindowsCalculator
+std::wstring DisplayNameFromAppId(const std::wstring& appIdUpper) {
+    std::wstring s = CanonicalAppId(appIdUpper);
+    auto bang = s.find(L'!');
+    if (bang != std::wstring::npos) {
+        s.resize(bang);
+    }
+    auto us = s.rfind(L'_');
+    if (us != std::wstring::npos && us > 0) {
+        s.resize(us);
+    }
+    return s.empty() ? appIdUpper : s;
+}
+
+std::wstring MakeAppKey(const std::wstring& pathUpper,
+                        const std::wstring& appIdUpper,
+                        const std::wstring& /*classUpper*/) {
+    // Win32: path only. Windhawk's editor is VSCodium.exe with AppId
+    // RAMENSOFTWARE.WINDHAWK — that is still one taskbar button.
+    // UWP hosts (ApplicationFrameHost / WWAHost) share one exe for many
+    // apps; key those by AppUserModelID so Calculator ≠ Settings.
+    if (IsUwpHostPath(pathUpper) && !appIdUpper.empty()) {
+        return std::wstring(L"APPID:") + CanonicalAppId(appIdUpper);
+    }
+    return pathUpper;
+}
+
+std::wstring PathFromAppKey(const std::wstring& key) {
+    if (key.rfind(L"APPID:", 0) == 0) {
+        return {};
+    }
+    auto pos = key.find(L"|CLS:");
+    if (pos != std::wstring::npos) {
+        return key.substr(0, pos);
+    }
+    return key;
+}
+
+std::wstring ClassFromAppKey(const std::wstring& key) {
+    auto pos = key.find(L"|CLS:");
+    if (pos == std::wstring::npos) {
+        return {};
+    }
+    return key.substr(pos + 5);
+}
+
+std::wstring AppIdFromAppKey(const std::wstring& key) {
+    if (key.rfind(L"APPID:", 0) != 0) {
+        return {};
+    }
+    std::wstring rest = key.substr(6);
+    auto pos = rest.find(L"|CLS:");
+    if (pos != std::wstring::npos) {
+        rest.resize(pos);
+    }
+    return rest;
+}
+
+bool SamePidAndClass(HWND a, HWND b) {
+    if (!a || !b || !IsWindow(a) || !IsWindow(b)) {
+        return false;
+    }
+    DWORD pa = 0, pb = 0;
+    GetWindowThreadProcessId(a, &pa);
+    GetWindowThreadProcessId(b, &pb);
+    if (!pa || pa != pb) {
+        return false;
+    }
+    return ToUpper(GetWindowClassName(a)) == ToUpper(GetWindowClassName(b));
+}
+
+bool ShouldIgnoreHwnd(HWND hWnd) {
+    if (!hWnd || !IsWindow(hWnd)) {
+        return true;
+    }
+    if (GetWindowLong(hWnd, GWL_STYLE) & WS_CHILD) {
+        return true;
+    }
+    if (!IsWindowVisible(hWnd)) {
+        return true;
+    }
+
+    WCHAR className[256]{};
+    if (!GetClassName(hWnd, className, ARRAYSIZE(className))) {
+        return true;
+    }
+
+    static const PCWSTR kIgnoredClasses[] = {
+        L"Shell_TrayWnd",
+        L"Shell_SecondaryTrayWnd",
+        L"Shell_TrayWndDummy",
+        L"Progman",
+        L"WorkerW",
+        L"XamlExplorerHostIslandWindow",
+        L"ForegroundStaging",
+        L"MultitaskingViewFrame",
+        L"TaskListThumbnailWnd",
+        L"Windows.Internal.Shell.TabProxyWindow",
+        L"NotifyIconOverflowWindow",
+        L"tooltips_class32",
+    };
+
+    for (auto ignored : kIgnoredClasses) {
+        if (_wcsicmp(className, ignored) == 0) {
+            return true;
+        }
+    }
+
+    LONG exStyle = GetWindowLong(hWnd, GWL_EXSTYLE);
+    if (exStyle & WS_EX_TOOLWINDOW) {
+        // Ignore typical tool popups, but keep sizable titled windows.
+        // Total Commander Lister (and similar viewers) can be tool-styled
+        // yet still appear as grouped taskbar thumbnails.
+        if (GetWindowTextLengthW(hWnd) <= 0) {
+            return true;
+        }
+        RECT rc{};
+        if (!GetWindowRect(hWnd, &rc) || (rc.right - rc.left) < 200 ||
+            (rc.bottom - rc.top) < 150) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool IsShellHostFileName(const std::wstring& fileNameUpper) {
+    return fileNameUpper == L"EXPLORER.EXE" ||
+           fileNameUpper == L"SEARCHHOST.EXE" ||
+           fileNameUpper == L"STARTMENUXPERIENCEHOST.EXE" ||
+           fileNameUpper == L"SHELLHOST.EXE" ||
+           fileNameUpper == L"TEXTINPUTHOST.EXE";
+}
+
+// Alt-Tab UI, taskbar, desktop, IME: not a real app switch. Must not cancel
+// an in-flight min-focus candidate — the landed app often sends no second
+// FOREGROUND after these.
+bool IsTransientForeground(HWND hWnd) {
+    hWnd = NormalizeFocusHwnd(hWnd);
+    if (ShouldIgnoreHwnd(hWnd)) {
+        return true;
+    }
+    DWORD processId = 0;
+    GetWindowThreadProcessId(hWnd, &processId);
+    if (!processId || IsOwnExplorerProcess(processId)) {
+        return true;
+    }
+    return IsShellHostFileName(
+        ToUpper(FileNameFromPath(GetProcessImagePath(processId))));
+}
+
+std::wstring GetWindowTitle(HWND hWnd) {
+    wchar_t buf[512];
+    int n = GetWindowTextW(hWnd, buf, ARRAYSIZE(buf));
+    if (n <= 0) {
+        return {};
+    }
+    return std::wstring(buf, static_cast<size_t>(n));
+}
+
+bool ResolveAppIdentity(HWND hWnd,
+                        std::wstring& outKey,
+                        std::wstring& outDisplayName,
+                        DWORD& outProcessId,
+                        std::wstring* outWindowTitle = nullptr) {
+    outKey.clear();
+    outDisplayName.clear();
+    outProcessId = 0;
+    if (outWindowTitle) {
+        outWindowTitle->clear();
+    }
+
+    hWnd = NormalizeFocusHwnd(hWnd);
+    if (ShouldIgnoreHwnd(hWnd)) {
+        return false;
+    }
+
+    DWORD processId = 0;
+    GetWindowThreadProcessId(hWnd, &processId);
+    if (!processId || IsOwnExplorerProcess(processId)) {
+        return false;
+    }
+
+    std::wstring path = GetProcessImagePath(processId);
+    if (path.empty()) {
+        return false;
+    }
+
+    std::wstring pathUpper = ToUpper(path);
+    std::wstring fileName = FileNameFromPath(path);
+    std::wstring fileNameUpper = ToUpper(fileName);
+
+    if (IsShellHostFileName(fileNameUpper)) {
+        return false;
+    }
+
+    std::wstring appIdUpper = ToUpper(GetWindowAppUserModelId(hWnd));
+    std::wstring classUpper = ToUpper(GetWindowClassName(hWnd));
+
+    if (IsUwpHostFileName(fileNameUpper) && appIdUpper.empty()) {
+        return false;
+    }
+
+    const std::wstring key = MakeAppKey(pathUpper, appIdUpper, classUpper);
+    const std::wstring title = GetWindowTitle(hWnd);
+    std::wstring displayName = fileName;
+    if (IsUwpHostFileName(fileNameUpper)) {
+        // Prefer "Settings" over WINDOWS.IMMERSIVECONTROLPANEL for logs /
+        // exclude / fuzzy. Key remains APPID:… .
+        if (!title.empty() && title.size() <= 80 &&
+            title.find(L'\\') == std::wstring::npos &&
+            title.find(L'/') == std::wstring::npos) {
+            displayName = title;
+        } else {
+            displayName = DisplayNameFromAppId(appIdUpper);
+        }
+    }
+
+    if (IsExcludedKey(key, ToUpper(displayName)) ||
+        (!appIdUpper.empty() &&
+         SettingsSnap()->excludedPrograms.contains(appIdUpper))) {
+        Wh_Log(L"Excluded: %s", displayName.c_str());
+        return false;
+    }
+
+    outKey = key;
+    outDisplayName = displayName;
+    outProcessId = processId;
+    if (outWindowTitle) {
+        *outWindowTitle = title;
+    }
+    return true;
+}
+
+FrameworkElement FindChildByName(FrameworkElement element, PCWSTR name) {
+    if (!element) {
+        return nullptr;
+    }
+
+    int childrenCount = Media::VisualTreeHelper::GetChildrenCount(element);
+    for (int i = 0; i < childrenCount; i++) {
+        auto child = Media::VisualTreeHelper::GetChild(element, i)
+                         .try_as<FrameworkElement>();
+        if (!child) {
+            continue;
+        }
+        if (child.Name() == name) {
+            return child;
+        }
+    }
+    return nullptr;
+}
+
+FrameworkElement FindDescendantByName(FrameworkElement element, PCWSTR name) {
+    if (!element) {
+        return nullptr;
+    }
+    if (element.Name() == name) {
+        return element;
+    }
+
+    int childrenCount = Media::VisualTreeHelper::GetChildrenCount(element);
+    for (int i = 0; i < childrenCount; i++) {
+        auto child = Media::VisualTreeHelper::GetChild(element, i)
+                         .try_as<FrameworkElement>();
+        if (!child) {
+            continue;
+        }
+        if (auto found = FindDescendantByName(child, name)) {
+            return found;
+        }
+    }
+    return nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// Ranking
+// ---------------------------------------------------------------------------
+
+// True if any cached TaskListButton resolved to this process path (or same
+// file name). Call from UI thread after EnsureButtonPathCached, or any thread
+// if only reading the path cache.
+bool PathAppearsOnTaskbar(const std::wstring& keyOrPath,
+                          const std::wstring& displayName) {
+    const std::wstring pathUpper = PathFromAppKey(keyOrPath);
+    const std::wstring wantAppId = CanonicalAppId(AppIdFromAppKey(keyOrPath));
+    std::wstring fileUpper = ToUpper(displayName);
+    if (fileUpper.empty() && !pathUpper.empty()) {
+        fileUpper = ToUpper(FileNameFromPath(pathUpper));
+    }
+    if (pathUpper.empty() && fileUpper.empty() && wantAppId.empty()) {
+        return false;
+    }
+
+    std::lock_guard<std::mutex> lock(g_buttonPathMutex);
+    for (const auto& e : g_buttonPathCache) {
+        if (!wantAppId.empty()) {
+            std::wstring id = e.appIdUpper.empty() ? e.autoIdUpper : e.appIdUpper;
+            if (CanonicalAppId(id) == wantAppId) {
+                return true;
+            }
+        }
+        if (e.pathUpper.empty()) {
+            continue;
+        }
+        // Class is for *which* button to highlight, not whether the app
+        // exists on the taskbar (TC + Lister share a path, different class).
+        if (!pathUpper.empty() && e.pathUpper == pathUpper) {
+            return true;
+        }
+        if (!fileUpper.empty() &&
+            ToUpper(FileNameFromPath(e.pathUpper)) == fileUpper) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Same process path, two taskbar icons (TOTALCMD64 → Total Commander + Lister).
+bool PathHasSplitTaskbarButtons(const std::wstring& pathUpper) {
+    if (pathUpper.empty()) {
+        return false;
+    }
+    const std::wstring fileUpper = ToUpper(FileNameFromPath(pathUpper));
+    std::wstring firstClass;
+    bool sawLister = false;
+    bool sawOther = false;
+    std::lock_guard<std::mutex> lock(g_buttonPathMutex);
+    for (const auto& e : g_buttonPathCache) {
+        if (e.pathUpper.empty()) {
+            continue;
+        }
+        if (e.pathUpper != pathUpper &&
+            ToUpper(FileNameFromPath(e.pathUpper)) != fileUpper) {
+            continue;
+        }
+        if (e.classUpper.find(L"LISTER") != std::wstring::npos) {
+            sawLister = true;
+        } else if (!e.classUpper.empty()) {
+            sawOther = true;
+        }
+        if (firstClass.empty()) {
+            firstClass = e.classUpper;
+        } else if (!e.classUpper.empty() && e.classUpper != firstClass) {
+            return true;
+        }
+    }
+    return sawLister && sawOther;
+}
+
+void RecomputeRanksForDesktopLocked(DesktopRecencyState& desk) {
+    desk.rankedApps.clear();
+
+    auto settings = SettingsSnap();
+    if (!settings->enabled || g_unloading.load()) {
+        return;
+    }
+
+    const ULONGLONG now = GetTickCount64();
+    const ULONGLONG decayMs = DecayMsFromMinutes(settings->decayMinutes);
+
+    std::vector<AppFocusInfo> candidates;
+    candidates.reserve(desk.appFocusMap.size());
+
+    for (auto it = desk.appFocusMap.begin(); it != desk.appFocusMap.end();) {
+        auto& info = it->second;
+        if (info.lastConfirmedFocusTick == 0) {
+            ++it;
+            continue;
+        }
+        if (IsTickDecayed(info.lastConfirmedFocusTick, decayMs, now)) {
+            Wh_Log(L"Decayed: %s", info.displayName.c_str());
+            const std::wstring decayedKey = it->first;
+            it = desk.appFocusMap.erase(it);
+            bool stillUsed = false;
+            for (const auto& [oid, other] : g_desktopMaps) {
+                if (other.appFocusMap.contains(decayedKey)) {
+                    stillUsed = true;
+                    break;
+                }
+            }
+            if (!stillUsed) {
+                g_keyToAutomationName.erase(decayedKey);
+            }
+            continue;
+        }
+        // Tray-only / no taskbar button: keep optional history but never rank.
+        if (settings->requireTaskbarButton && !info.seenOnTaskbar) {
+            // Refresh from path cache if buttons resolved since last time.
+            if (PathAppearsOnTaskbar(info.key, info.displayName)) {
+                info.seenOnTaskbar = true;
+            } else {
+                ++it;
+                continue;
+            }
+        }
+        candidates.push_back(info);
+        ++it;
+    }
+
+    std::sort(candidates.begin(), candidates.end(),
+              [](const AppFocusInfo& a, const AppFocusInfo& b) {
+                  return a.lastConfirmedFocusTick > b.lastConfirmedFocusTick;
+              });
+
+    const int limit = (std::max)(0, settings->highlightCount);
+    if (static_cast<int>(candidates.size()) > limit) {
+        candidates.resize(static_cast<size_t>(limit));
+    }
+
+    desk.rankedApps = std::move(candidates);
+}
+
+void RecomputeRanksLocked() {
+    RecomputeRanksForDesktopLocked(CurrentDeskLocked());
+}
+
+// ---------------------------------------------------------------------------
+// Window-level recency (thumbnail previews)
+// ---------------------------------------------------------------------------
+
+void PruneWindowFocusMapLocked(DesktopRecencyState& desk);
+void StampWindowRecencyLocked(DesktopRecencyState& desk,
+                              HWND hwnd,
+                              const std::wstring& processKey,
+                              const std::wstring& windowTitle,
+                              ULONGLONG now);
+
+void ConfirmPreviewFocusNow(HWND hwnd) {
+    if (!hwnd || g_unloading.load() || !SettingsSnap()->enabled ||
+        !SettingsSnap()->previewHighlightEnabled) {
+        return;
+    }
+    hwnd = NormalizeFocusHwnd(hwnd);
+    if (ShouldIgnoreHwnd(hwnd)) {
+        return;
+    }
+
+    std::wstring key;
+    std::wstring displayName;
+    std::wstring windowTitle;
+    DWORD processId = 0;
+    if (!ResolveAppIdentity(hwnd, key, displayName, processId, &windowTitle)) {
+        return;
+    }
+    if (IsExcludedKey(key, ToUpper(displayName))) {
+        return;
+    }
+
+    const ULONGLONG now = GetTickCount64();
+    RefreshCurrentDesktopId();
+    std::wstring processKey = PathFromAppKey(key);
+    if (processKey.empty()) {
+        processKey = ToUpper(GetProcessImagePath(processId));
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        auto& desk = CurrentDeskLocked();
+        StampWindowRecencyLocked(desk, hwnd, processKey, windowTitle, now);
+        Wh_Log(L"Preview click confirmed: hwnd=%p %s title=\"%s\" (map=%zu "
+               L"desktop=%s)",
+               hwnd, displayName.c_str(), windowTitle.c_str(),
+               desk.windowFocusMap.size(),
+               GuidToLogString(g_currentDesktopId).c_str());
+    }
+    RequestApplyPreviewVisuals();
+}
+
+void PruneWindowFocusMapLocked(DesktopRecencyState& desk) {
+    const ULONGLONG now = GetTickCount64();
+    const ULONGLONG decayMs =
+        DecayMsFromMinutes(SettingsSnap()->previewDecayMinutes);
+
+    for (auto it = desk.windowFocusMap.begin();
+         it != desk.windowFocusMap.end();) {
+        if (!it->first || !IsWindow(it->first) ||
+            !HwndMatchesStoredPid(it->first, it->second.pid)) {
+            it = desk.windowFocusMap.erase(it);
+            continue;
+        }
+        if (IsTickDecayed(it->second.lastConfirmedTick, decayMs, now)) {
+            it = desk.windowFocusMap.erase(it);
+            continue;
+        }
+        ++it;
+    }
+}
+
+// Requires g_stateMutex.
+void StampWindowRecencyLocked(DesktopRecencyState& desk,
+                              HWND hwnd,
+                              const std::wstring& processKey,
+                              const std::wstring& windowTitle,
+                              ULONGLONG now) {
+    if (!hwnd) {
+        return;
+    }
+    const DWORD pid = PidFromHwnd(hwnd);
+    auto it = desk.windowFocusMap.find(hwnd);
+    if (it != desk.windowFocusMap.end() && it->second.pid != 0 && pid != 0 &&
+        it->second.pid != pid) {
+        Wh_Log(L"HWND recycled, dropping stale preview recency: hwnd=%p "
+               L"oldPid=%u newPid=%u",
+               hwnd, it->second.pid, pid);
+        desk.windowFocusMap.erase(it);
+    }
+    WindowFocusInfo& winfo = desk.windowFocusMap[hwnd];
+    winfo.hwnd = hwnd;
+    winfo.pid = pid;
+    if (!processKey.empty()) {
+        winfo.processKey = processKey;
+    }
+    if (!windowTitle.empty()) {
+        winfo.windowTitle = windowTitle;
+    }
+    winfo.lastConfirmedTick = now;
+    winfo.confirmSeq = g_windowConfirmSeq.fetch_add(1) + 1;
+    PruneWindowFocusMapLocked(desk);
+}
+
+// True if hwnd is still a non-decayed confirmed recent window on this desktop.
+bool IsWindowRecentForPreviewLocked(DesktopRecencyState& desk,
+                                    HWND hwnd,
+                                    ULONGLONG* outTick = nullptr) {
+    if (!hwnd) {
+        return false;
+    }
+    auto it = desk.windowFocusMap.find(hwnd);
+    if (it == desk.windowFocusMap.end() || it->second.lastConfirmedTick == 0) {
+        return false;
+    }
+    if (!IsWindow(hwnd) || !HwndMatchesStoredPid(hwnd, it->second.pid)) {
+        return false;
+    }
+    const ULONGLONG now = GetTickCount64();
+    const ULONGLONG decayMs =
+        DecayMsFromMinutes(SettingsSnap()->previewDecayMinutes);
+    if (IsTickDecayed(it->second.lastConfirmedTick, decayMs, now)) {
+        return false;
+    }
+    if (outTick) {
+        *outTick = it->second.lastConfirmedTick;
+    }
+    return true;
+}
+
+// Snapshot of recent windows for UI matching (copy under lock).
+std::vector<WindowFocusInfo> CopyRecentWindowsForPreview() {
+    RefreshCurrentDesktopId();
+    std::lock_guard<std::mutex> lock(g_stateMutex);
+    auto& desk = CurrentDeskLocked();
+    PruneWindowFocusMapLocked(desk);
+    std::vector<WindowFocusInfo> out;
+    out.reserve(desk.windowFocusMap.size());
+    for (const auto& [hwnd, info] : desk.windowFocusMap) {
+        if (IsWindowRecentForPreviewLocked(desk, hwnd)) {
+            out.push_back(info);
+        }
+    }
+    std::sort(out.begin(), out.end(),
+              [](const WindowFocusInfo& a, const WindowFocusInfo& b) {
+                  return a.lastConfirmedTick > b.lastConfirmedTick;
+              });
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Color / style helpers (UI thread)
+// ---------------------------------------------------------------------------
+
+bool ParseHexColor(const std::wstring& text, winrt::Windows::UI::Color& out) {
+    std::wstring s = text;
+    if (!s.empty() && s[0] == L'#') {
+        s.erase(0, 1);
+    }
+    // Allow 0x prefix
+    if (s.size() >= 2 && s[0] == L'0' && (s[1] == L'x' || s[1] == L'X')) {
+        s.erase(0, 2);
+    }
+
+    auto hexVal = [](wchar_t c) -> int {
+        if (c >= L'0' && c <= L'9') {
+            return c - L'0';
+        }
+        if (c >= L'a' && c <= L'f') {
+            return c - L'a' + 10;
+        }
+        if (c >= L'A' && c <= L'F') {
+            return c - L'A' + 10;
+        }
+        return -1;
+    };
+
+    auto readByte = [&](size_t i) -> int {
+        int hi = hexVal(s[i]);
+        int lo = hexVal(s[i + 1]);
+        if (hi < 0 || lo < 0) {
+            return -1;
+        }
+        return (hi << 4) | lo;
+    };
+
+    out.A = 255;
+    if (s.size() == 8) {
+        int a = readByte(0), r = readByte(2), g = readByte(4), b = readByte(6);
+        if (a < 0 || r < 0 || g < 0 || b < 0) {
+            return false;
+        }
+        out.A = static_cast<uint8_t>(a);
+        out.R = static_cast<uint8_t>(r);
+        out.G = static_cast<uint8_t>(g);
+        out.B = static_cast<uint8_t>(b);
+        return true;
+    }
+    if (s.size() == 6) {
+        int r = readByte(0), g = readByte(2), b = readByte(4);
+        if (r < 0 || g < 0 || b < 0) {
+            return false;
+        }
+        out.R = static_cast<uint8_t>(r);
+        out.G = static_cast<uint8_t>(g);
+        out.B = static_cast<uint8_t>(b);
+        return true;
+    }
+    return false;
+}
+
+winrt::Windows::UI::Color ResolveGlowBaseColor() {
+    winrt::Windows::UI::Color c{255, 0, 200, 83};  // default green-ish
+
+    switch (SettingsSnap()->glowColor) {
+        case GlowColorMode::Accent:
+            try {
+                winrt::Windows::UI::ViewManagement::UISettings uiSettings;
+                c = uiSettings.GetColorValue(
+                    winrt::Windows::UI::ViewManagement::UIColorType::Accent);
+                c.A = 255;
+            } catch (...) {
+                c = {255, 0, 120, 215};
+            }
+            break;
+        case GlowColorMode::Green:
+            c = {255, 0, 200, 83};
+            break;
+        case GlowColorMode::Blue:
+            c = {255, 30, 144, 255};
+            break;
+        case GlowColorMode::Orange:
+            c = {255, 255, 140, 0};
+            break;
+        case GlowColorMode::White:
+            c = {255, 255, 255, 255};
+            break;
+        case GlowColorMode::Custom:
+            if (!ParseHexColor(SettingsSnap()->customGlowColor, c)) {
+                c = {255, 0, 200, 83};
+            }
+            break;
+    }
+    return c;
+}
+
+int RankIntensity(int rankZeroBased) {
+    int idx = rankZeroBased < 3 ? rankZeroBased : 2;
+    return SettingsSnap()->glowIntensity[idx];
+}
+
+int PreviewRankIntensity(int rankZeroBased) {
+    int idx = rankZeroBased < 3 ? rankZeroBased : 2;
+    return SettingsSnap()->previewIntensity[idx];
+}
+
+int RankSizeBoost(int rankZeroBased) {
+    int idx = rankZeroBased < 3 ? rankZeroBased : 2;
+    return SettingsSnap()->sizeBoostPercent[idx];
+}
+
+// Defined with option-C resolve stack (button → process path).
+std::wstring EnsureButtonPathCached(FrameworkElement button, bool force);
+std::wstring GetCachedButtonPath(FrameworkElement button);
+struct ButtonIdentity {
+    std::wstring pathUpper;
+    std::wstring appIdUpper;
+    std::wstring classUpper;
+    std::wstring autoIdUpper;
+    DWORD pid = 0;
+    HWND sampleHwnd = nullptr;
+    std::vector<HWND> groupHwnds;
+};
+ButtonIdentity GetCachedButtonIdentity(FrameworkElement button);
+bool RunOnUiThread(const winrt::Windows::UI::Core::DispatchedHandler& handler);
+void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb);
+
+// ---------------------------------------------------------------------------
+// Button identity matching
+// ---------------------------------------------------------------------------
+
+using TaskListButton_get_IsRunning_t = HRESULT(WINAPI*)(void* pThis,
+                                                        bool* running);
+TaskListButton_get_IsRunning_t TaskListButton_get_IsRunning_Original;
+
+bool TaskListButton_IsRunning(FrameworkElement taskListButtonElement) {
+    if (!TaskListButton_get_IsRunning_Original || !taskListButtonElement) {
+        return false;
+    }
+    bool isRunning = false;
+    HRESULT hr = TaskListButton_get_IsRunning_Original(
+        winrt::get_abi(
+            taskListButtonElement.as<winrt::Windows::Foundation::IUnknown>()),
+        &isRunning);
+    return SUCCEEDED(hr) && isRunning;
+}
+
+// IsRunning, plus a short grace so Alt-Tab flicker does not drop glows.
+// Virtual-desktop switches clear lastRunningTick so pinned-not-running icons
+// on another desktop never keep a highlight.
+bool ButtonCountsAsRunning(FrameworkElement button) {
+    const bool running = TaskListButton_IsRunning(button);
+    const ULONGLONG now = GetTickCount64();
+    std::lock_guard<std::mutex> lock(g_buttonPathMutex);
+    for (auto& e : g_buttonPathCache) {
+        try {
+            if (e.button.get() != button) {
+                continue;
+            }
+            if (running) {
+                e.lastRunningTick = now;
+                return true;
+            }
+            return e.lastRunningTick != 0 &&
+                   now - e.lastRunningTick < kIsRunningGraceMs;
+        } catch (...) {
+        }
+    }
+    return running;
+}
+
+std::wstring GetButtonAutomationName(FrameworkElement button) {
+    try {
+        return std::wstring(
+            Automation::AutomationProperties::GetName(button).c_str());
+    } catch (...) {
+        return {};
+    }
+}
+
+std::wstring GetButtonAutomationAppId(FrameworkElement button) {
+    if (!button) {
+        return {};
+    }
+    try {
+        std::wstring id =
+            Automation::AutomationProperties::GetAutomationId(button).c_str();
+        return ToUpper(StripAppIdPrefix(std::move(id)));
+    } catch (...) {
+        return {};
+    }
+}
+
+bool IsVisualStateActive(FrameworkElement root) {
+    if (!root) {
+        return false;
+    }
+
+    try {
+        auto groups = VisualStateManager::GetVisualStateGroups(root);
+        for (auto group : groups) {
+            auto current = group.CurrentState();
+            if (!current) {
+                continue;
+            }
+            std::wstring name(current.Name().c_str());
+            // "InactivePointerOver".find("Active") is a hit — that made every
+            // hovered running button look focused (TC stole Lister's glow).
+            if (name.rfind(L"Inactive", 0) == 0) {
+                continue;
+            }
+            if (name.rfind(L"Active", 0) == 0) {
+                return true;
+            }
+        }
+    } catch (...) {
+    }
+
+    // Also check children that host state groups (IconPanel).
+    try {
+        int n = Media::VisualTreeHelper::GetChildrenCount(root);
+        for (int i = 0; i < n; i++) {
+            auto child = Media::VisualTreeHelper::GetChild(root, i)
+                             .try_as<FrameworkElement>();
+            if (child && IsVisualStateActive(child)) {
+                return true;
+            }
+        }
+    } catch (...) {
+    }
+
+    return false;
+}
+
+// Taskbar names look like "App - 2 running windows pinned" — strip that noise.
+// Do NOT cut at the first " - ": Lister titles are
+// "Lister - [C:\\path\\file.txt] - 3 running windows and 1 group".
+std::wstring NormalizeAutomationName(std::wstring name) {
+    auto isRunningCountSuffix = [](std::wstring_view tail) -> bool {
+        size_t i = 0;
+        while (i < tail.size() && tail[i] == L' ') {
+            ++i;
+        }
+        if (i >= tail.size() || tail[i] < L'0' || tail[i] > L'9') {
+            return false;
+        }
+        while (i < tail.size() && tail[i] >= L'0' && tail[i] <= L'9') {
+            ++i;
+        }
+        if (i >= tail.size() || tail[i] != L' ') {
+            return false;
+        }
+        ++i;
+        constexpr wchar_t kRun[] = L"running";
+        if (i + 7 > tail.size()) {
+            return false;
+        }
+        for (int k = 0; k < 7; ++k) {
+            wchar_t c = tail[i + static_cast<size_t>(k)];
+            if (c >= L'A' && c <= L'Z') {
+                c = static_cast<wchar_t>(c - L'A' + L'a');
+            }
+            if (c != kRun[k]) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    size_t cut = std::wstring::npos;
+    for (size_t search = 0; search + 3 < name.size();) {
+        const auto pos = name.find(L" - ", search);
+        if (pos == std::wstring::npos) {
+            break;
+        }
+        if (isRunningCountSuffix(std::wstring_view(name).substr(pos + 3))) {
+            cut = pos;
+            break;
+        }
+        search = pos + 3;
+    }
+    if (cut != std::wstring::npos) {
+        name.resize(cut);
+    }
+    // Trailing " pinned"
+    constexpr wchar_t kPinned[] = L" pinned";
+    if (name.size() > 7) {
+        auto off = name.size() - 7;
+        if (_wcsicmp(name.c_str() + off, kPinned) == 0) {
+            name.resize(off);
+        }
+    }
+    // Trim spaces
+    while (!name.empty() && name.back() == L' ') {
+        name.pop_back();
+    }
+    return name;
+}
+
+// True for Lister-style "[c:\temp\file.txt]" / "[book.epub]", not Calibre's
+// format tag "[EPUB]" (same on every book — must not be an identity key).
+bool LooksLikeFilePath(const std::wstring& s) {
+    if (s.empty()) {
+        return false;
+    }
+    if (s.find(L'\\') != std::wstring::npos ||
+        s.find(L'/') != std::wstring::npos) {
+        return true;
+    }
+    if (s.size() >= 2 && ((s[0] >= L'A' && s[0] <= L'Z') ||
+                          (s[0] >= L'a' && s[0] <= L'z')) &&
+        s[1] == L':') {
+        return true;
+    }
+    const auto dot = s.rfind(L'.');
+    return dot != std::wstring::npos && dot > 0 && dot + 1 < s.size();
+}
+
+std::wstring ExtractBracketedPath(const std::wstring& s) {
+    const auto open = s.find(L'[');
+    const auto close = s.rfind(L']');
+    if (open == std::wstring::npos || close == std::wstring::npos ||
+        close <= open + 1) {
+        return {};
+    }
+    std::wstring inner = s.substr(open + 1, close - open - 1);
+    if (!LooksLikeFilePath(inner)) {
+        return {};
+    }
+    return inner;
+}
+
+// Strip marketing suffixes so WINDOWSTERMINAL ≈ TERMINALPREVIEW → TERMINAL.
+std::wstring StripProductNoise(std::wstring alnumUpper) {
+    static const wchar_t* kNoise[] = {L"PREVIEW", L"BETA",   L"PORTABLE",
+                                      L"CANARY",  L"INSIDER", L"NIGHTLY"};
+    for (auto noise : kNoise) {
+        for (;;) {
+            auto pos = alnumUpper.find(noise);
+            if (pos == std::wstring::npos) {
+                break;
+            }
+            alnumUpper.erase(pos, wcslen(noise));
+        }
+    }
+    return alnumUpper;
+}
+
+// True if every char of `needle` appears in order inside `haystack`
+// (not necessarily contiguous). TOTALCMD64 ⊂ TOTALCOMMANDER64BIT.
+bool IsSubsequence(const std::wstring& needle, const std::wstring& haystack) {
+    if (needle.empty()) {
+        return false;
+    }
+    size_t j = 0;
+    for (size_t i = 0; i < haystack.size() && j < needle.size(); ++i) {
+        if (haystack[i] == needle[j]) {
+            ++j;
+        }
+    }
+    return j == needle.size();
+}
+
+// Initials of title words: "Total Commander 64 bit" → TC64B
+std::wstring InitialsAlnum(const std::wstring& automationName) {
+    std::wstring title = NormalizeAutomationName(automationName);
+    std::wstring out;
+    bool atWord = true;
+    for (wchar_t ch : title) {
+        if (ch == L' ' || ch == L'-' || ch == L'_' || ch == L'.') {
+            atWord = true;
+            continue;
+        }
+        if (atWord) {
+            if ((ch >= L'a' && ch <= L'z') || (ch >= L'A' && ch <= L'Z') ||
+                (ch >= L'0' && ch <= L'9')) {
+                if (ch >= L'a' && ch <= L'z') {
+                    ch = static_cast<wchar_t>(ch - L'a' + L'A');
+                }
+                out.push_back(ch);
+            }
+            atWord = false;
+        }
+    }
+    return out;
+}
+
+// Higher = better. 0 = no match.
+// Important: VSCodium must NOT match "Visual Studio Code" (initials VSC alone
+// used to fire). Prefer longer/more specific matches; callers assign 1:1.
+int ScoreExeToAutomationName(const std::wstring& displayName,
+                             const std::wstring& automationName) {
+    if (displayName.empty() || automationName.empty()) {
+        return 0;
+    }
+
+    std::wstring exeAlnum = AlnumUpper(StripExtension(displayName));
+    std::wstring autoAlnum = AlnumUpper(NormalizeAutomationName(automationName));
+    if (exeAlnum.empty() || autoAlnum.empty()) {
+        return 0;
+    }
+
+    if (exeAlnum == autoAlnum) {
+        return 100;
+    }
+
+    // Contiguous containment (CODE ⊂ VISUALSTUDIOCODE, STEAM ⊂ STEAM…).
+    if (exeAlnum.size() >= 4 &&
+        autoAlnum.find(exeAlnum) != std::wstring::npos) {
+        return 92;
+    }
+    if (autoAlnum.size() >= 4 &&
+        exeAlnum.find(autoAlnum) != std::wstring::npos) {
+        // Prefer when title is a large part of the exe (STEAM vs STEAMWEBHELPER).
+        int cover = static_cast<int>(autoAlnum.size() * 100 / exeAlnum.size());
+        return 80 + (std::min)(12, cover / 10);
+    }
+
+    std::wstring exeN = StripProductNoise(exeAlnum);
+    std::wstring autoN = StripProductNoise(autoAlnum);
+    if (!exeN.empty() && exeN == autoN) {
+        return 90;
+    }
+    if (exeN.size() >= 5 && autoN.find(exeN) != std::wstring::npos) {
+        return 88;
+    }
+    if (autoN.size() >= 5 && exeN.find(autoN) != std::wstring::npos) {
+        return 84;
+    }
+
+    // Subsequence: TOTALCMD64 ⊂ TOTALCOMMANDER64BIT (not short initials).
+    std::wstring exeLetters;
+    for (wchar_t c : exeN) {
+        if (c < L'0' || c > L'9') {
+            exeLetters.push_back(c);
+        }
+    }
+    if (exeN.size() >= 5 && IsSubsequence(exeN, autoN)) {
+        return 72;
+    }
+    if (exeLetters.size() >= 5 && IsSubsequence(exeLetters, autoN)) {
+        return 70;
+    }
+
+    // Initials only when they are a *substantial* prefix of the exe.
+    // VSC vs VSCODIUM (3/8) → reject; avoids VS Code button stealing VSCodium.
+    // TC64 vs TOTALCMD64 — initials may be TC64B; require prefix of exe length
+    // and initials covering ≥ half the exe stem.
+    std::wstring initials = InitialsAlnum(automationName);
+    if (initials.size() >= 3) {
+        if (exeN.rfind(initials, 0) == 0 &&
+            initials.size() * 2 >= exeN.size()) {
+            return 55;
+        }
+        // Exe is essentially the initials (rare).
+        if (exeN == initials) {
+            return 95;
+        }
+    }
+
+    return 0;
+}
+
+bool ExeMatchesAutomationName(const std::wstring& displayName,
+                              const std::wstring& automationName) {
+    return ScoreExeToAutomationName(displayName, automationName) > 0;
+}
+
+// Window title ↔ taskbar button title (both normalized).
+int ScoreTitleToAutomationName(const std::wstring& windowTitle,
+                               const std::wstring& automationName) {
+    if (windowTitle.empty() || automationName.empty()) {
+        return 0;
+    }
+    std::wstring t = AlnumUpper(NormalizeAutomationName(windowTitle));
+    std::wstring a = AlnumUpper(NormalizeAutomationName(automationName));
+    if (t.empty() || a.empty()) {
+        return 0;
+    }
+    if (t == a) {
+        return 98;
+    }
+    // Button title contained in window title or vice versa (min length 4).
+    if (t.size() >= 4 && a.find(t) != std::wstring::npos) {
+        return 93;
+    }
+    if (a.size() >= 4 && t.find(a) != std::wstring::npos) {
+        return 91;
+    }
+    // Significant shared prefix (e.g. WINDHAWK…).
+    // Do not use this when both sides have distinct [bracket] paths —
+    // "Lister - [c:\tmp\a.txt]" vs "Lister - [c:\tmp\c.txt]" share LISTERCTMP.
+    const std::wstring tPath =
+        ToUpper(ExtractBracketedPath(NormalizeAutomationName(windowTitle)));
+    const std::wstring aPath =
+        ToUpper(ExtractBracketedPath(NormalizeAutomationName(automationName)));
+    if (!tPath.empty() && !aPath.empty() && tPath != aPath) {
+        return 0;
+    }
+    size_t pref = 0;
+    while (pref < t.size() && pref < a.size() && t[pref] == a[pref]) {
+        ++pref;
+    }
+    if (pref >= 6) {
+        // Shared prefix only: "HarryPotter1" vs "HarryPotter2" (or two
+        // "EbookReader…" books) must not count as a match.
+        if (t.size() > pref && a.size() > pref) {
+            return 0;
+        }
+        return 85;
+    }
+    return 0;
+}
+
+// True if this button's automation name is a legitimate label for the rank.
+// Class-qualified ranks (TLISTER) must not bind to "Total Commander".
+bool AutomationNameFitsRank(const AppFocusInfo& info,
+                            const std::wstring& autoName) {
+    if (autoName.empty()) {
+        return false;
+    }
+    const std::wstring cls = !info.classUpper.empty()
+                                 ? info.classUpper
+                                 : ClassFromAppKey(info.key);
+    if (!cls.empty() && cls.find(L"LISTER") != std::wstring::npos) {
+        return AlnumUpper(NormalizeAutomationName(autoName)).find(L"LISTER") !=
+               std::wstring::npos;
+    }
+    return ExeMatchesAutomationName(info.displayName, autoName);
+}
+
+void StoreAutomationNameIfFits(const AppFocusInfo& info,
+                               const std::wstring& autoName) {
+    if (!AutomationNameFitsRank(info, autoName)) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(g_stateMutex);
+    g_keyToAutomationName[info.key] = autoName;
+}
+
+void StoreAutomationName(const AppFocusInfo& info,
+                         const std::wstring& autoName) {
+    if (info.key.empty() || autoName.empty()) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(g_stateMutex);
+    g_keyToAutomationName[info.key] = autoName;
+}
+
+// Trusted writes only: path/exe binds, or Active-button associate (Windhawk
+// button for VSCodium.exe). Name-equals is then enough, except we refuse
+// a non-fitting name when this exe has two icons (TC vs Lister).
+bool CacheEntryValid(const AppFocusInfo& info,
+                     const std::wstring& cachedAutoName,
+                     const std::wstring& buttonAutoName) {
+    if (cachedAutoName.empty() || buttonAutoName.empty()) {
+        return false;
+    }
+    const bool nameEquals =
+        _wcsicmp(cachedAutoName.c_str(), buttonAutoName.c_str()) == 0 ||
+        _wcsicmp(NormalizeAutomationName(cachedAutoName).c_str(),
+                 NormalizeAutomationName(buttonAutoName).c_str()) == 0;
+    if (!nameEquals) {
+        return false;
+    }
+    if (AutomationNameFitsRank(info, buttonAutoName)) {
+        return true;
+    }
+    const std::wstring path = PathFromAppKey(info.key);
+    return !PathHasSplitTaskbarButtons(path);
+}
+
+// Score this button against one ranked app. Higher is better; 0 = no match.
+int ScoreButtonForRank(FrameworkElement button,
+                       const AppFocusInfo& info,
+                       bool requireRunning) {
+    if (!button) {
+        return 0;
+    }
+    if (requireRunning && !ButtonCountsAsRunning(button)) {
+        return 0;
+    }
+
+    const ButtonIdentity ident = GetCachedButtonIdentity(button);
+    const std::wstring rankPath = PathFromAppKey(info.key);
+    const std::wstring rankCls = !info.classUpper.empty()
+                                     ? info.classUpper
+                                     : ClassFromAppKey(info.key);
+    const std::wstring rankAppId = !info.appIdUpper.empty()
+                                       ? info.appIdUpper
+                                       : AppIdFromAppKey(info.key);
+
+    auto hwndOnButton = [&](HWND h) -> bool {
+        if (!h) {
+            return false;
+        }
+        if (ident.sampleHwnd == h) {
+            return true;
+        }
+        for (HWND g : ident.groupHwnds) {
+            if (g == h) {
+                return true;
+            }
+        }
+        if (ident.sampleHwnd && SamePidAndClass(h, ident.sampleHwnd)) {
+            // ApplicationFrameHost hosts many apps; PID+class is not identity.
+            if (!IsAppIdKey(info.key) && !IsUwpHostPath(ident.pathUpper)) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    if (hwndOnButton(info.lastHwnd)) {
+        return kScoreExactIdentity;
+    }
+
+    if (IsAppIdKey(info.key)) {
+        const std::wstring want = AppIdFromAppKey(info.key);
+        std::wstring got =
+            ident.appIdUpper.empty() ? ident.autoIdUpper : ident.appIdUpper;
+        got = CanonicalAppId(got);
+        if (!want.empty() && got == want) {
+            return kScoreExactIdentity;
+        }
+        // Hosted UWP ranks are AUMID-only. Do not fuzzy "WINDOWS.IMMERSIVE…"
+        // onto Windows Security, or reuse a name-cache replica.
+        return 0;
+    }
+
+    const std::wstring pathKey =
+        !rankPath.empty() ? rankPath : PathFromAppKey(info.key);
+    const bool exactPath =
+        !ident.pathUpper.empty() &&
+        (ident.pathUpper == info.key || ident.pathUpper == pathKey);
+    const bool sameFileName =
+        !ident.pathUpper.empty() && !info.displayName.empty() &&
+        ToUpper(FileNameFromPath(ident.pathUpper)) ==
+            ToUpper(info.displayName);
+    // Both sides resolved, folders differ: not a replica (portable python).
+    const bool pathConflict =
+        sameFileName && !exactPath && !pathKey.empty() &&
+        ident.pathUpper != pathKey && ident.pathUpper != info.key;
+    const bool pathOk = exactPath || (sameFileName && !pathConflict);
+    const bool split = PathHasSplitTaskbarButtons(
+        !pathKey.empty() ? pathKey : ident.pathUpper);
+
+    // Path cache hit: skip fuzzy names (VS Code vs VSCodium stay distinct
+    // via full path). Fuzzy runs only when path is missing or this exe has
+    // two taskbar icons (TOTALCMD64 → Commander + Lister).
+    if (pathOk) {
+        if (!split) {
+            return exactPath ? kScoreExactIdentity
+                             : kScoreSameFileDifferentPath;
+        }
+        if (!rankCls.empty() && ident.classUpper == rankCls) {
+            return kScoreExactIdentity;
+        }
+        if (!rankCls.empty() && !ident.classUpper.empty() &&
+            ident.classUpper != rankCls) {
+            // other half of a split pair
+        } else if (rankCls.empty() || ident.classUpper.empty()) {
+            return kScoreSameFileDifferentPath;
+        }
+    }
+
+    const bool identityConflict =
+        pathConflict ||
+        (split && !rankCls.empty() && !ident.classUpper.empty() &&
+         ident.classUpper != rankCls);
+
+    std::wstring autoName = GetButtonAutomationName(button);
+    if (autoName.empty()) {
+        return 0;
+    }
+
+    // Name fallback when path cache missed: "Lister" button vs TLister focus.
+    if (!rankCls.empty() &&
+        rankCls.find(L"LISTER") != std::wstring::npos) {
+        std::wstring n = AlnumUpper(NormalizeAutomationName(autoName));
+        if (n.find(L"LISTER") != std::wstring::npos) {
+            return kScoreExactIdentity;
+        }
+    }
+
+    int score = 0;
+    if (!identityConflict) {
+        score = ScoreExeToAutomationName(info.displayName, autoName);
+    }
+
+    // Do not score last window/tab title against taskbar buttons.
+    // Terminal tabs (and VSCodium editing a Windhawk mod) rename the HWND
+    // to the document — that is preview identity, not which icon to glow.
+
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        auto it = g_keyToAutomationName.find(info.key);
+        if (!identityConflict && it != g_keyToAutomationName.end() &&
+            !it->second.empty()) {
+            if (CacheEntryValid(info, it->second, autoName)) {
+                score = (std::max)(score, kScoreNameCache);
+            } else if (_wcsicmp(it->second.c_str(), autoName.c_str()) == 0 ||
+                       _wcsicmp(NormalizeAutomationName(it->second).c_str(),
+                                NormalizeAutomationName(autoName).c_str()) ==
+                           0) {
+                Wh_Log(L"Dropping bad cache: %s was \"%s\" (exe/class mismatch)",
+                       info.displayName.c_str(), it->second.c_str());
+                g_keyToAutomationName.erase(it);
+            }
+        }
+    }
+    return score;
+}
+
+// Best rank for a single button (1-based), or 0. Prefer highest score.
+// requireRunning uses ButtonCountsAsRunning (short Alt-Tab grace).
+int FindRankForButton(FrameworkElement button,
+                      const std::vector<AppFocusInfo>& ranks,
+                      bool requireRunning = true) {
+    if (!button || ranks.empty()) {
+        return 0;
+    }
+
+    int bestRank = 0;
+    int bestScore = 0;
+    for (size_t i = 0; i < ranks.size(); i++) {
+        int s = ScoreButtonForRank(button, ranks[i], requireRunning);
+        if (s > bestScore) {
+            bestScore = s;
+            bestRank = static_cast<int>(i) + 1;
+        }
+    }
+    // Minimum confidence: reject weak initials-only if ever reintroduced.
+    if (bestScore < kScoreMinBind) {
+        return 0;
+    }
+
+    if (bestRank > 0) {
+        StoreAutomationNameIfFits(
+            ranks[static_cast<size_t>(bestRank - 1)],
+            GetButtonAutomationName(button));
+    }
+    return bestRank;
+}
+
+void AssociateActiveButtonWithKey(const std::wstring& key) {
+    if (key.empty()) {
+        return;
+    }
+
+    std::wstring displayName;
+    std::wstring windowTitle;
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        auto& map = CurrentDeskLocked().appFocusMap;
+        auto it = map.find(key);
+        if (it != map.end()) {
+            displayName = it->second.displayName;
+            windowTitle = it->second.lastWindowTitle;
+        }
+    }
+    if (displayName.empty()) {
+        displayName = FileNameFromPath(key);
+    }
+
+    std::vector<winrt::weak_ref<FrameworkElement>> buttons;
+    {
+        std::lock_guard<std::mutex> lock(g_buttonsMutex);
+        buttons = g_trackedButtons;
+    }
+
+    // Prefer active button; fall back to best-scoring running button for this
+    // app (Windhawk / TC sometimes fail IsVisualStateActive timing).
+    int bestScore = 0;
+    std::wstring bestName;
+
+    for (auto& weak : buttons) {
+        FrameworkElement button = nullptr;
+        try {
+            button = weak.get();
+        } catch (...) {
+            continue;
+        }
+        if (!button || !TaskListButton_IsRunning(button)) {
+            continue;
+        }
+
+        std::wstring autoName = GetButtonAutomationName(button);
+        if (autoName.empty()) {
+            continue;
+        }
+
+        int score = ScoreExeToAutomationName(displayName, autoName);
+        // Identity from path cache (Terminal, VSCodium) beats a window
+        // title that happens to mention another app ("Discord icon…").
+        const ButtonIdentity ident = GetCachedButtonIdentity(button);
+        const std::wstring rankPath = PathFromAppKey(key);
+        if (IsAppIdKey(key)) {
+            const std::wstring want = AppIdFromAppKey(key);
+            std::wstring got = ident.appIdUpper.empty() ? ident.autoIdUpper
+                                                        : ident.appIdUpper;
+            if (!want.empty() && CanonicalAppId(got) == want) {
+                score = (std::max)(score, 1000);
+            } else if (!want.empty()) {
+                continue;
+            }
+        } else if (!ident.pathUpper.empty() && !rankPath.empty() &&
+                   ident.pathUpper == rankPath) {
+            score = (std::max)(score, 1000);
+        } else if (!ident.pathUpper.empty() &&
+                   ToUpper(FileNameFromPath(ident.pathUpper)) ==
+                       ToUpper(displayName)) {
+            score = (std::max)(score, 900);
+        }
+        const bool active = IsVisualStateActive(button);
+        if (active) {
+            score += 5;
+            // Real Active* only (Inactive* is not Active). Windhawk's button
+            // is named "Windhawk" while the process is VSCodium.exe.
+            if (score < 70) {
+                score = 70;
+            }
+        }
+
+        if (score > bestScore) {
+            bestScore = score;
+            bestName = autoName;
+        }
+
+        if (active && score < 70) {
+            Wh_Log(L"Skip associate: active \"%s\" weak match for %s (score=%d)",
+                   autoName.c_str(), displayName.c_str(), score);
+        }
+    }
+
+    AppFocusInfo assocInfo;
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        auto& map = CurrentDeskLocked().appFocusMap;
+        auto it = map.find(key);
+        if (it != map.end()) {
+            assocInfo = it->second;
+        }
+    }
+    if (assocInfo.key.empty()) {
+        assocInfo.key = key;
+        assocInfo.displayName = displayName;
+    }
+
+    if (bestScore >= kScoreMinBind && !bestName.empty()) {
+        // Always remember the Active button, even when the label is the host
+        // ("Windhawk") and the process is VSCodium.exe. Scoring trusts this
+        // cache; other write sites still use StoreAutomationNameIfFits.
+        StoreAutomationName(assocInfo, bestName);
+        Wh_Log(L"Associated %s -> \"%s\" (score=%d, fits=%d, title=\"%s\")",
+               displayName.c_str(), bestName.c_str(), bestScore,
+               AutomationNameFitsRank(assocInfo, bestName) ? 1 : 0,
+               windowTitle.c_str());
+    } else {
+        Wh_Log(L"Associate failed for %s (bestScore=%d, title=\"%s\")",
+               displayName.c_str(), bestScore, windowTitle.c_str());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Apply / clear visual highlight on one button (UI thread)
+// ---------------------------------------------------------------------------
+
+FrameworkElement GetIconPanel(FrameworkElement button) {
+    auto iconPanel = FindChildByName(button, L"IconPanel");
+    if (!iconPanel) {
+        iconPanel = FindDescendantByName(button, L"IconPanel");
+    }
+    return iconPanel;
+}
+
+void RemoveNamedChild(Controls::Panel panel, PCWSTR name) {
+    if (!panel) {
+        return;
+    }
+    if (auto child = FindChildByName(panel, name)) {
+        uint32_t idx = 0;
+        if (panel.Children().IndexOf(child, idx)) {
+            panel.Children().RemoveAt(idx);
+        }
+    }
+}
+
+void SpanHostOverPanel(FrameworkElement host, Controls::Panel panel) {
+    if (!host || !panel) {
+        return;
+    }
+    try {
+        if (auto grid = panel.try_as<Controls::Grid>()) {
+            auto cols = grid.ColumnDefinitions().Size();
+            auto rows = grid.RowDefinitions().Size();
+            Controls::Grid::SetColumn(host, 0);
+            Controls::Grid::SetRow(host, 0);
+            if (cols > 0) {
+                Controls::Grid::SetColumnSpan(host, cols);
+            }
+            if (rows > 0) {
+                Controls::Grid::SetRowSpan(host, rows);
+            }
+        }
+    } catch (...) {
+    }
+}
+
+// Only clear clip on our own host — walking ancestors with Clip(nullptr) can
+// leave native BackgroundElement / RunningIndicator stuck after long idle.
+void ClearOurHostClip(FrameworkElement host) {
+    if (!host) {
+        return;
+    }
+    try {
+        host.Clip(nullptr);
+    } catch (...) {
+    }
+}
+
+// One glow layer: stroked rounded rect; optional fill for Full style.
+void StyleGlowRectangle(Shapes::Rectangle rect,
+                        const winrt::Windows::UI::Color& stroke,
+                        const winrt::Windows::UI::Color& fill,
+                        double strokeThickness,
+                        double corner,
+                        double inset,
+                        double opacity) {
+    rect.Stroke(Media::SolidColorBrush{stroke});
+    rect.StrokeThickness(strokeThickness);
+    rect.Fill(Media::SolidColorBrush{fill});
+    rect.RadiusX(corner);
+    rect.RadiusY(corner);
+    rect.Opacity(opacity);
+    rect.HorizontalAlignment(HorizontalAlignment::Stretch);
+    rect.VerticalAlignment(VerticalAlignment::Stretch);
+    rect.Margin(Thickness{inset, inset, inset, inset});
+    rect.ClearValue(FrameworkElement::WidthProperty());
+    rect.ClearValue(FrameworkElement::HeightProperty());
+    rect.IsHitTestVisible(false);
+    rect.Visibility(Visibility::Visible);
+}
+
+FrameworkElement FindRunningIndicator(FrameworkElement iconPanel) {
+    if (!iconPanel) {
+        return nullptr;
+    }
+    auto indicator = FindChildByName(iconPanel, L"RunningIndicator");
+    if (!indicator) {
+        indicator = FindDescendantByName(iconPanel, L"RunningIndicator");
+    }
+    return indicator;
+}
+
+// Native pill is a 2–4px strip. Taskbar Styler themes restyle RunningIndicator
+// into a full-cell acrylic hover plate that would cover a side bar sitting
+// under it (UWPSpy: 39×38 acrylic on PointerOver vs #00FFFFFF at rest).
+bool RunningIndicatorLooksLikeHoverPlate(FrameworkElement ri,
+                                         FrameworkElement iconPanel) {
+    if (!ri || !iconPanel) {
+        return false;
+    }
+    try {
+        double rw = ri.ActualWidth();
+        double rh = ri.ActualHeight();
+        double pw = iconPanel.ActualWidth();
+        double ph = iconPanel.ActualHeight();
+        if (!(rw > 1.0) || !(rh > 1.0) || !(pw > 1.0) || !(ph > 1.0)) {
+            return false;
+        }
+        return rw > pw * 0.45 && rh > ph * 0.45;
+    } catch (...) {
+        return false;
+    }
+}
+
+std::wstring CurrentRunningIndicatorStateName(FrameworkElement iconPanel,
+                                              FrameworkElement button) {
+    auto from = [](FrameworkElement root) -> std::wstring {
+        if (!root) {
+            return {};
+        }
+        try {
+            for (auto group : VisualStateManager::GetVisualStateGroups(root)) {
+                if (group.Name() != L"RunningIndicatorStates") {
+                    continue;
+                }
+                auto current = group.CurrentState();
+                if (current) {
+                    return std::wstring(current.Name().c_str());
+                }
+            }
+        } catch (...) {
+        }
+        return {};
+    };
+    std::wstring name = from(iconPanel);
+    if (name.empty()) {
+        name = from(button);
+    }
+    return name;
+}
+
+// Only undo Visibility=Collapsed that *we* set. Visual-state setters store
+// Visible as a local value — ClearValue drops it to the template default
+// (Collapsed), and GoToState(InactiveRunningIndicator) is a no-op if already
+// in that state, so the short inactive pill never comes back.
+void RestoreNativeRunningIndicator(FrameworkElement iconPanel,
+                                   FrameworkElement button) {
+    auto indicator = FindRunningIndicator(iconPanel);
+    if (!indicator) {
+        return;
+    }
+    try {
+        if (indicator.ReadLocalValue(UIElement::VisibilityProperty()) ==
+            DependencyProperty::UnsetValue()) {
+            return;
+        }
+        if (indicator.Visibility() != Visibility::Collapsed) {
+            return;
+        }
+        const std::wstring state =
+            CurrentRunningIndicatorStateName(iconPanel, button);
+        if (state == L"NoRunningIndicator") {
+            return;
+        }
+        indicator.Visibility(Visibility::Visible);
+    } catch (...) {
+    }
+}
+
+bool RunningIndicatorHasLocalCollapsed(FrameworkElement iconPanel) {
+    auto indicator = FindRunningIndicator(iconPanel);
+    if (!indicator) {
+        return false;
+    }
+    try {
+        if (indicator.ReadLocalValue(UIElement::VisibilityProperty()) ==
+            DependencyProperty::UnsetValue()) {
+            return false;
+        }
+        return indicator.Visibility() == Visibility::Collapsed;
+    } catch (...) {
+        return false;
+    }
+}
+
+void EnsureOverlayIconAboveGlyph(FrameworkElement iconPanel);
+
+// Place glow host in the IconPanel child list without thrashing native chrome.
+//
+// Moving RunningIndicator every paint (mouse-over UpdateVisualStates) causes
+// the short/long underline to flicker. Instead, put our host *under* native
+// RunningIndicator / MultiWindowElement / ProgressIndicator so they always
+// paint on top — only reorder when the host is in the wrong place.
+void EnsureGlowHostZOrder(Controls::Panel panel,
+                          UIElement host,
+                          GlowStyle style) {
+    if (!panel || !host) {
+        return;
+    }
+    try {
+        auto children = panel.Children();
+        uint32_t hostIdx = 0;
+        if (!children.IndexOf(host, hostIdx)) {
+            return;
+        }
+
+        if (style == GlowStyle::Full) {
+            // Plate behind icon and indicators.
+            if (hostIdx != 0) {
+                children.RemoveAt(hostIdx);
+                children.InsertAt(0, host);
+            }
+            return;
+        }
+
+        if (style == GlowStyle::BottomBar) {
+            // Cover the native pill without Visibility=Collapsed: host after
+            // RunningIndicator. OverlayIcon stays last (badges).
+            uint32_t riIdx = UINT32_MAX;
+            if (auto ri = FindChildByName(panel.as<FrameworkElement>(),
+                                          L"RunningIndicator")) {
+                uint32_t i = 0;
+                if (children.IndexOf(ri, i)) {
+                    riIdx = i;
+                }
+            }
+            if (!children.IndexOf(host, hostIdx)) {
+                return;
+            }
+            if (riIdx != UINT32_MAX) {
+                if (hostIdx != riIdx + 1) {
+                    children.RemoveAt(hostIdx);
+                    if (hostIdx < riIdx) {
+                        children.InsertAt(riIdx, host);
+                    } else {
+                        children.InsertAt(riIdx + 1, host);
+                    }
+                }
+            } else if (hostIdx + 1 != children.Size()) {
+                children.RemoveAt(hostIdx);
+                children.Append(host);
+            }
+            EnsureOverlayIconAboveGlyph(panel.as<FrameworkElement>());
+            return;
+        }
+
+        // Frame / side bar: stay under OverlayIcon, progress, a native thin
+        // running pill, and (for side bar) the glyph. Do *not* stay under a
+        // Styler hover plate (large RunningIndicator) — that covers the bar.
+        auto panelFe = panel.as<FrameworkElement>();
+        uint32_t insertBefore = children.Size();
+        bool foundTop = false;
+        auto considerUnder = [&](PCWSTR name) {
+            auto el = FindChildByName(panelFe, name);
+            if (!el) {
+                return;
+            }
+            uint32_t idx = 0;
+            if (!children.IndexOf(el, idx)) {
+                return;
+            }
+            if (!foundTop || idx < insertBefore) {
+                insertBefore = idx;
+                foundTop = true;
+            }
+        };
+        considerUnder(L"OverlayIcon");
+        considerUnder(L"MultiWindowElement");
+        considerUnder(L"ProgressIndicator");
+        if (style == GlowStyle::LeftBar) {
+            considerUnder(L"Icon");
+            considerUnder(L"DefaultIcon");
+        }
+        if (auto ri = FindRunningIndicator(panelFe)) {
+            if (!RunningIndicatorLooksLikeHoverPlate(ri, panelFe)) {
+                considerUnder(L"RunningIndicator");
+            }
+        }
+
+        if (!children.IndexOf(host, hostIdx)) {
+            return;
+        }
+
+        if (foundTop) {
+            if (hostIdx < insertBefore) {
+                if (hostIdx + 1 == insertBefore) {
+                    // Already immediately under the first element that must
+                    // stay on top.
+                    EnsureOverlayIconAboveGlyph(panelFe);
+                    return;
+                }
+                // Gap (Styler plate between host and icon) — raise the bar.
+                children.RemoveAt(hostIdx);
+                children.InsertAt(insertBefore - 1, host);
+            } else {
+                children.RemoveAt(hostIdx);
+                children.InsertAt(insertBefore, host);
+            }
+        } else if (hostIdx + 1 != children.Size()) {
+            children.RemoveAt(hostIdx);
+            children.Append(host);
+        }
+
+        // Moving the host can leave OverlayIcon behind Icon when Windows later
+        // re-appends the glyph (Discord/Thunderbird ping). Heal after we settle.
+        EnsureOverlayIconAboveGlyph(panel.as<FrameworkElement>());
+    } catch (...) {
+    }
+}
+
+// TaskListLabeledButtonPanel paints later children on top. Native template
+// order is BackgroundElement (back) → Icon → OverlayIcon → RunningIndicator
+// (front). Inserting/removing our host can leave BackgroundElement in front
+// of the running underscore, or leave OverlayIcon *behind* Icon (Discord /
+// Thunderbird / WhatsApp badge clipped by the glyph after a ping + UVS).
+void EnsureOverlayIconAboveGlyph(FrameworkElement iconPanel) {
+    if (!iconPanel) {
+        return;
+    }
+    auto panel = iconPanel.try_as<Controls::Panel>();
+    if (!panel) {
+        return;
+    }
+    try {
+        auto overlay = FindChildByName(iconPanel, L"OverlayIcon");
+        if (!overlay) {
+            return;
+        }
+        auto children = panel.Children();
+        uint32_t oIdx = 0;
+        if (!children.IndexOf(overlay, oIdx)) {
+            return;
+        }
+
+        uint32_t glyphLast = 0;
+        bool haveGlyph = false;
+        for (PCWSTR name : {L"Icon", L"DefaultIcon"}) {
+            auto el = FindChildByName(iconPanel, name);
+            if (!el) {
+                continue;
+            }
+            uint32_t idx = 0;
+            if (!children.IndexOf(el, idx)) {
+                continue;
+            }
+            if (!haveGlyph || idx > glyphLast) {
+                glyphLast = idx;
+                haveGlyph = true;
+            }
+        }
+        if (!haveGlyph || oIdx > glyphLast) {
+            return;
+        }
+
+        children.RemoveAt(oIdx);
+        uint32_t dest = glyphLast;
+        if (dest > children.Size()) {
+            dest = children.Size();
+        }
+        children.InsertAt(dest, overlay);
+        Wh_Log(L"Raised OverlayIcon above Icon (notification badge was behind "
+               L"the glyph)");
+    } catch (...) {
+    }
+}
+
+void RestoreIconPanelNativeZOrder(FrameworkElement iconPanel) {
+    if (!iconPanel) {
+        return;
+    }
+    auto panel = iconPanel.try_as<Controls::Panel>();
+    if (!panel) {
+        return;
+    }
+    try {
+        auto children = panel.Children();
+        auto indexOfName = [&](PCWSTR name) -> int {
+            auto el = FindChildByName(iconPanel, name);
+            if (!el) {
+                return -1;
+            }
+            uint32_t idx = 0;
+            if (!children.IndexOf(el, idx)) {
+                return -1;
+            }
+            return static_cast<int>(idx);
+        };
+
+        const int bg = indexOfName(kBackgroundElementName);
+        const int run = indexOfName(L"RunningIndicator");
+        if (bg >= 0 && run >= 0 && bg > run) {
+            auto bgEl = FindChildByName(iconPanel, kBackgroundElementName);
+            if (bgEl) {
+                uint32_t bgIdx = 0;
+                if (children.IndexOf(bgEl, bgIdx)) {
+                    children.RemoveAt(bgIdx);
+                    children.InsertAt(0, bgEl);
+                    Wh_Log(
+                        L"Restored IconPanel z-order (BackgroundElement was "
+                        L"in front of RunningIndicator)");
+                }
+            }
+        }
+
+        EnsureOverlayIconAboveGlyph(iconPanel);
+    } catch (...) {
+    }
+}
+
+bool ButtonHasOurChrome(FrameworkElement button) {
+    if (!button) {
+        return false;
+    }
+    auto iconPanel = GetIconPanel(button);
+    if (!iconPanel) {
+        return FindDescendantByName(button, kGlowElementName) != nullptr ||
+               FindDescendantByName(button, kBottomBarMarkerName) != nullptr;
+    }
+    return FindChildByName(iconPanel, kGlowElementName) != nullptr ||
+           FindDescendantByName(iconPanel, kGlowElementName) != nullptr ||
+           FindChildByName(iconPanel, kBottomBarMarkerName) != nullptr ||
+           FindDescendantByName(iconPanel, kBottomBarMarkerName) != nullptr;
+}
+
+void ClearButtonHighlight(FrameworkElement button) {
+    if (!button) {
+        return;
+    }
+
+    auto iconPanelEarly = GetIconPanel(button);
+
+    // Skip no-op clears on every mouse-over (UpdateVisualStates storms).
+    // Still heal z-order: after a timed-out glow, our host is gone but
+    // BackgroundElement can remain in front of RunningIndicator (Discord
+    // ping + decay left a red plate and no underscore).
+    if (!ButtonHasOurChrome(button) && !g_pendingOverlaySweep.load()) {
+        RestoreIconPanelNativeZOrder(iconPanelEarly);
+        return;
+    }
+
+    try {
+        auto iconPanel = iconPanelEarly ? iconPanelEarly : GetIconPanel(button);
+        if (!iconPanel) {
+            // Still try to strip our named overlay from the button root.
+            if (auto panel = button.try_as<Controls::Panel>()) {
+                RemoveNamedChild(panel, kGlowElementName);
+                RemoveNamedChild(panel, kBottomBarMarkerName);
+            }
+            return;
+        }
+
+        // Do NOT ClearValue BackgroundElement — we no longer style it; clearing
+        // local values can leave a stuck pale hover plate after decay.
+
+        if (auto panel = iconPanel.try_as<Controls::Panel>()) {
+            // Remove by name even if multiple generations of hosts exist.
+            for (int guard = 0; guard < 4; ++guard) {
+                if (!FindChildByName(panel, kGlowElementName) &&
+                    !FindDescendantByName(iconPanel, kGlowElementName)) {
+                    break;
+                }
+                RemoveNamedChild(panel, kGlowElementName);
+                // Descendant host (unexpected nesting): walk children once.
+                if (auto orphan =
+                        FindDescendantByName(iconPanel, kGlowElementName)) {
+                    try {
+                        if (auto parent =
+                                Media::VisualTreeHelper::GetParent(orphan)
+                                    .try_as<Controls::Panel>()) {
+                            uint32_t idx = 0;
+                            if (parent.Children().IndexOf(orphan, idx)) {
+                                parent.Children().RemoveAt(idx);
+                            }
+                        }
+                    } catch (...) {
+                    }
+                }
+            }
+            RemoveNamedChild(panel, kBottomBarMarkerName);
+        }
+
+        if (RunningIndicatorHasLocalCollapsed(iconPanel)) {
+            RestoreNativeRunningIndicator(iconPanel, button);
+        }
+        // Do not heal Visibility on every clear — that ClearValue thrashing
+        // also flickers the native underline during hover storms.
+
+        if (auto icon = FindChildByName(iconPanel, L"Icon")) {
+            auto localTf =
+                icon.ReadLocalValue(UIElement::RenderTransformProperty());
+            if (localTf != DependencyProperty::UnsetValue()) {
+                if (icon.RenderTransform().try_as<Media::ScaleTransform>()) {
+                    icon.ClearValue(UIElement::RenderTransformProperty());
+                    icon.ClearValue(UIElement::RenderTransformOriginProperty());
+                }
+            }
+        }
+
+        RestoreIconPanelNativeZOrder(iconPanel);
+    } catch (...) {
+        HRESULT hr = winrt::to_hresult();
+        Wh_Log(L"ClearButtonHighlight error %08X", hr);
+    }
+}
+
+// Ensure glow host grid exists (L0–L2 rectangles). Returns host or nullptr.
+Controls::Grid EnsureGlowHost(Controls::Panel panel,
+                              FrameworkElement iconPanel) {
+    Controls::Grid host = nullptr;
+    if (auto existing = FindChildByName(iconPanel, kGlowElementName)) {
+        host = existing.try_as<Controls::Grid>();
+        if (host && !FindChildByName(host, kGlowLayerNames[0])
+                         .try_as<Shapes::Rectangle>()) {
+            RemoveNamedChild(panel, kGlowElementName);
+            host = nullptr;
+        } else if (!host) {
+            RemoveNamedChild(panel, kGlowElementName);
+        }
+    }
+
+    if (!host) {
+        PCWSTR xaml =
+            LR"(
+            <Grid
+                xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                Name="WhRecentFocusGlow"
+                IsHitTestVisible="False"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch">
+                <Rectangle Name="WhRecentFocusGlowL0"
+                           IsHitTestVisible="False"
+                           Fill="Transparent"/>
+                <Rectangle Name="WhRecentFocusGlowL1"
+                           IsHitTestVisible="False"
+                           Fill="Transparent"/>
+                <Rectangle Name="WhRecentFocusGlowL2"
+                           IsHitTestVisible="False"
+                           Fill="Transparent"/>
+            </Grid>
+        )";
+        host = Markup::XamlReader::Load(xaml).as<Controls::Grid>();
+        panel.Children().Append(host);
+    }
+
+    SpanHostOverPanel(host, panel);
+    host.Visibility(Visibility::Visible);
+    ClearOurHostClip(host);
+    return host;
+}
+
+void HideAllGlowLayers(Controls::Grid host) {
+    if (!host) {
+        return;
+    }
+    for (int i = 0; i < kGlowMaxLayers; ++i) {
+        if (auto r =
+                FindChildByName(host, kGlowLayerNames[i]).try_as<Shapes::Rectangle>()) {
+            r.Visibility(Visibility::Collapsed);
+            r.Stroke(nullptr);
+            r.Fill(Media::SolidColorBrush{
+                winrt::Windows::UI::Color{0, 0, 0, 0}});
+        }
+    }
+}
+
+PCWSTR GlowStyleName(GlowStyle s) {
+    switch (s) {
+        case GlowStyle::Full:
+            return L"full";
+        case GlowStyle::LeftBar:
+            return L"leftBar";
+        case GlowStyle::BottomBar:
+            return L"bottomBar";
+        case GlowStyle::Frame:
+        default:
+            return L"frame";
+    }
+}
+
+PCWSTR PromoteModeName(PromoteMode m) {
+    switch (m) {
+        case PromoteMode::ImmediateTopN:
+            return L"immediateTopN";
+        case PromoteMode::AlwaysWait:
+            return L"alwaysWait";
+        case PromoteMode::ImmediateTracked:
+        default:
+            return L"immediateTracked";
+    }
+}
+
+// True if this focus change may skip the app min-focus timer.
+// Caller must hold g_stateMutex when checking ranked list (or we take it).
+bool ShouldSkipAppMinFocus(const std::wstring& key, bool alreadyTracked) {
+    auto settings = SettingsSnap();
+    if (settings->minFocusSeconds <= 0) {
+        return true;
+    }
+    switch (settings->promoteMode) {
+        case PromoteMode::AlwaysWait:
+            return false;
+        case PromoteMode::ImmediateTopN: {
+            if (!alreadyTracked) {
+                return false;
+            }
+            std::lock_guard<std::mutex> lock(g_stateMutex);
+            for (const auto& r : CurrentDeskLocked().rankedApps) {
+                if (r.key == key) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        case PromoteMode::ImmediateTracked:
+        default:
+            return alreadyTracked;
+    }
+}
+
+PCWSTR PreviewStyleName(PreviewStyle s) {
+    switch (s) {
+        case PreviewStyle::TitleBg:
+            return L"titleBg";
+        case PreviewStyle::Plate:
+            return L"plate";
+        case PreviewStyle::TitleBar:
+            return L"titleBar";
+        case PreviewStyle::PlateTitle:
+            return L"plateTitle";
+        case PreviewStyle::Ring:
+        default:
+            return L"ring";
+    }
+}
+
+PCWSTR TaskbarEdgeName(TaskbarEdge e) {
+    switch (e) {
+        case TaskbarEdge::Left:
+            return L"left";
+        case TaskbarEdge::Top:
+            return L"top";
+        case TaskbarEdge::Right:
+            return L"right";
+        case TaskbarEdge::Bottom:
+        default:
+            return L"bottom";
+    }
+}
+
+PCWSTR BarSideName(BarSide s) {
+    switch (s) {
+        case BarSide::Left:
+            return L"left";
+        case BarSide::Top:
+            return L"top";
+        case BarSide::Right:
+            return L"right";
+        case BarSide::Bottom:
+        default:
+            return L"bottom";
+    }
+}
+
+bool HasVisualState(FrameworkElement root, PCWSTR stateName) {
+    if (!root || !stateName) {
+        return false;
+    }
+    try {
+        auto groups = VisualStateManager::GetVisualStateGroups(root);
+        for (auto group : groups) {
+            auto current = group.CurrentState();
+            if (current && current.Name() == stateName) {
+                return true;
+            }
+        }
+    } catch (...) {
+    }
+    return false;
+}
+
+TaskbarEdge TaskbarEdgeFromAppBar() {
+    APPBARDATA abd{};
+    abd.cbSize = sizeof(APPBARDATA);
+    if (!SHAppBarMessage(ABM_GETTASKBARPOS, &abd)) {
+        return TaskbarEdge::Bottom;
+    }
+    switch (abd.uEdge) {
+        case ABE_LEFT:
+            return TaskbarEdge::Left;
+        case ABE_TOP:
+            return TaskbarEdge::Top;
+        case ABE_RIGHT:
+            return TaskbarEdge::Right;
+        default:
+            return TaskbarEdge::Bottom;
+    }
+}
+
+// Prefer OrientationStates. A leftover RunningIndicator VA=Bottom from the
+// previous edge must not win: we used to treat a left taskbar as Bottom and
+// paint full-cell underlines of rank-dependent length.
+// Do not use "wider than tall ⇒ horizontal": a left-edge button is 48×32.
+TaskbarEdge DetectTaskbarEdge(FrameworkElement iconPanel) {
+    bool verticalState = HasVisualState(iconPanel, L"VerticalOrientation");
+    bool horizontalState = HasVisualState(iconPanel, L"HorizontalOrientation");
+    try {
+        auto parent = Media::VisualTreeHelper::GetParent(iconPanel)
+                          .try_as<FrameworkElement>();
+        if (parent) {
+            verticalState =
+                verticalState ||
+                HasVisualState(parent, L"VerticalOrientation");
+            horizontalState =
+                horizontalState ||
+                HasVisualState(parent, L"HorizontalOrientation");
+        }
+    } catch (...) {
+    }
+
+    HorizontalAlignment ha = HorizontalAlignment::Stretch;
+    VerticalAlignment va = VerticalAlignment::Stretch;
+    double riW = 0;
+    double riH = 0;
+    if (auto ri = FindRunningIndicator(iconPanel)) {
+        try {
+            ha = ri.HorizontalAlignment();
+            va = ri.VerticalAlignment();
+            riW = ri.ActualWidth();
+            riH = ri.ActualHeight();
+        } catch (...) {
+        }
+    }
+
+    double pw = 0;
+    double ph = 0;
+    try {
+        pw = iconPanel.ActualWidth();
+        ph = iconPanel.ActualHeight();
+    } catch (...) {
+    }
+    // Vertical bar: each button is short along the bar (≈32) and as wide as
+    // the bar (≈48). Horizontal bar: roughly square / taller (≈44×48).
+    const bool panelLooksVertical = pw > ph + 4.0;
+    const bool panelLooksHorizontal = ph > pw + 4.0;
+    const bool tallPill = riH > riW + 0.5 && riW > 0.5;
+
+    auto pickVertical = [&]() -> TaskbarEdge {
+        if (ha == HorizontalAlignment::Right) {
+            return TaskbarEdge::Right;
+        }
+        if (ha == HorizontalAlignment::Left) {
+            return TaskbarEdge::Left;
+        }
+        return TaskbarEdgeFromAppBar() == TaskbarEdge::Right
+                   ? TaskbarEdge::Right
+                   : TaskbarEdge::Left;
+    };
+    auto pickHorizontal = [&]() -> TaskbarEdge {
+        if (va == VerticalAlignment::Top) {
+            return TaskbarEdge::Top;
+        }
+        if (va == VerticalAlignment::Bottom) {
+            return TaskbarEdge::Bottom;
+        }
+        return TaskbarEdgeFromAppBar() == TaskbarEdge::Top ? TaskbarEdge::Top
+                                                           : TaskbarEdge::Bottom;
+    };
+
+    if (verticalState || panelLooksVertical || tallPill) {
+        return pickVertical();
+    }
+    if (horizontalState || panelLooksHorizontal) {
+        return pickHorizontal();
+    }
+    if (ha == HorizontalAlignment::Right) {
+        return TaskbarEdge::Right;
+    }
+    if (ha == HorizontalAlignment::Left) {
+        return TaskbarEdge::Left;
+    }
+    if (va == VerticalAlignment::Top) {
+        return TaskbarEdge::Top;
+    }
+    if (va == VerticalAlignment::Bottom) {
+        return TaskbarEdge::Bottom;
+    }
+    return TaskbarEdgeFromAppBar();
+}
+
+BarSide BarSideForGlowStyle(GlowStyle style, TaskbarEdge edge) {
+    if (style == GlowStyle::BottomBar) {
+        switch (edge) {
+            case TaskbarEdge::Left:
+                return BarSide::Left;
+            case TaskbarEdge::Top:
+                return BarSide::Top;
+            case TaskbarEdge::Right:
+                return BarSide::Right;
+            case TaskbarEdge::Bottom:
+            default:
+                return BarSide::Bottom;
+        }
+    }
+    // Side bar: perpendicular to the taskbar so it does not cover the native
+    // running pill (left on bottom/top, under the icon on left/right).
+    switch (edge) {
+        case TaskbarEdge::Left:
+        case TaskbarEdge::Right:
+            return BarSide::Bottom;
+        case TaskbarEdge::Top:
+        case TaskbarEdge::Bottom:
+        default:
+            return BarSide::Left;
+    }
+}
+
+void GlowContentBoxSize(FrameworkElement host,
+                        FrameworkElement iconPanel,
+                        double panelW,
+                        double panelH,
+                        double& boxW,
+                        double& boxH) {
+    boxW = 0;
+    boxH = 0;
+    if (host) {
+        try {
+            boxW = host.ActualWidth();
+            boxH = host.ActualHeight();
+        } catch (...) {
+        }
+    }
+    if (!(boxW > 1.0) || !(boxH > 1.0)) {
+        if (auto bg = FindChildByName(iconPanel, kBackgroundElementName)) {
+            try {
+                boxW = bg.ActualWidth();
+                boxH = bg.ActualHeight();
+            } catch (...) {
+            }
+        }
+    }
+    if (!(boxW > 1.0)) {
+        boxW = panelW;
+    }
+    if (!(boxH > 1.0)) {
+        boxH = panelH;
+    }
+}
+
+// Length follows the glow host (padded cell), same for every rank — rank is
+// opacity. Icon-sized underlines on a left taskbar were too short to scan
+// (Windows uses a very small glyph there). Size % still scales the bar.
+double BarLengthForSide(FrameworkElement iconPanel,
+                        double boxW,
+                        double boxH,
+                        BarSide side,
+                        TaskbarEdge edge,
+                        double sizeFrac,
+                        double rankLenScale) {
+    (void)iconPanel;
+    (void)edge;
+    const bool horizontalBar =
+        side == BarSide::Top || side == BarSide::Bottom;
+    const double cellAlong = horizontalBar ? boxW : boxH;
+    double barLen = cellAlong * sizeFrac * rankLenScale;
+    const double maxLen = (std::max)(4.0, cellAlong - 2.0);
+    if (barLen > maxLen) {
+        barLen = maxLen;
+    }
+    if (barLen < 4.0) {
+        barLen = 4.0;
+    }
+    return barLen;
+}
+
+void StyleGlowBarOnSide(Shapes::Rectangle rect,
+                        const winrt::Windows::UI::Color& fill,
+                        double thickness,
+                        double length,
+                        BarSide side,
+                        int layer,
+                        double opacity) {
+    const double t = thickness + static_cast<double>(layer) * 2.0;
+    const double len = length + static_cast<double>(layer) * 2.0;
+    const double edgePad = (side == BarSide::Bottom || side == BarSide::Top)
+                               ? (2.0 + static_cast<double>(layer))
+                               : (1.0 + static_cast<double>(layer));
+
+    rect.Stroke(nullptr);
+    rect.StrokeThickness(0);
+    rect.Fill(Media::SolidColorBrush{fill});
+    rect.RadiusX(t * 0.5);
+    rect.RadiusY(t * 0.5);
+    rect.Opacity(opacity);
+    rect.IsHitTestVisible(false);
+    rect.Visibility(Visibility::Visible);
+
+    switch (side) {
+        case BarSide::Left:
+            rect.Width(t);
+            rect.Height(len);
+            rect.HorizontalAlignment(HorizontalAlignment::Left);
+            rect.VerticalAlignment(VerticalAlignment::Center);
+            rect.Margin(Thickness{edgePad, 0, 0, 0});
+            break;
+        case BarSide::Right:
+            rect.Width(t);
+            rect.Height(len);
+            rect.HorizontalAlignment(HorizontalAlignment::Right);
+            rect.VerticalAlignment(VerticalAlignment::Center);
+            rect.Margin(Thickness{0, 0, edgePad, 0});
+            break;
+        case BarSide::Top:
+            rect.Width(len);
+            rect.Height(t);
+            rect.HorizontalAlignment(HorizontalAlignment::Center);
+            rect.VerticalAlignment(VerticalAlignment::Top);
+            rect.Margin(Thickness{0, edgePad, 0, 0});
+            break;
+        case BarSide::Bottom:
+        default:
+            rect.Width(len);
+            rect.Height(t);
+            rect.HorizontalAlignment(HorizontalAlignment::Center);
+            rect.VerticalAlignment(VerticalAlignment::Bottom);
+            rect.Margin(Thickness{0, 0, 0, edgePad});
+            break;
+    }
+}
+
+FrameworkElement TaskListButtonFromDescendant(FrameworkElement start) {
+    FrameworkElement cur = start;
+    for (int i = 0; i < 12 && cur; ++i) {
+        try {
+            if (cur.Name() == L"TaskListButton") {
+                return cur;
+            }
+            cur = Media::VisualTreeHelper::GetParent(cur)
+                      .try_as<FrameworkElement>();
+        } catch (...) {
+            return nullptr;
+        }
+    }
+    return nullptr;
+}
+
+// Relayout (taskbar moved to another screen edge): put RunningIndicator back
+// in front of BackgroundElement / our host. Do not ClearValue Width/Height —
+// OrientationStates owns those. Only call on size/edge change, not every UVS.
+void HealRunningIndicatorAfterRelayout(FrameworkElement iconPanel) {
+    if (!iconPanel) {
+        return;
+    }
+    RestoreIconPanelNativeZOrder(iconPanel);
+
+    auto panel = iconPanel.try_as<Controls::Panel>();
+    if (!panel) {
+        return;
+    }
+    try {
+        if (auto host = FindChildByName(iconPanel, kGlowElementName)) {
+            EnsureGlowHostZOrder(panel, host, SettingsSnap()->glowStyle);
+        }
+    } catch (...) {
+    }
+}
+
+// Must run on the panel's dispatcher. Pulls only watches for this thread so
+// a primary-taskbar cleanup cannot revoke a secondary bar's tokens.
+void RevokeIconPanelLayoutWatchesOnThisDispatcher() {
+    std::vector<IconPanelLayoutWatch> mine;
+    {
+        std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
+        for (auto it = g_layoutWatches.begin(); it != g_layoutWatches.end();) {
+            bool take = false;
+            try {
+                auto panel = it->panel.get();
+                if (!panel) {
+                    take = true;
+                } else {
+                    auto dispatcher = panel.Dispatcher();
+                    take = dispatcher && dispatcher.HasThreadAccess();
+                }
+            } catch (...) {
+                take = true;
+            }
+            if (take) {
+                mine.push_back(std::move(*it));
+                it = g_layoutWatches.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+    for (auto& w : mine) {
+        try {
+            if (auto panel = w.panel.get()) {
+                if (w.sizeChanged) {
+                    panel.SizeChanged(w.sizeChanged);
+                    w.sizeChanged = {};
+                }
+            }
+        } catch (...) {
+            Wh_Log(L"ERROR: SizeChanged revoke failed");
+        }
+    }
+}
+
+void EnsureIconPanelLayoutWatch(FrameworkElement button) {
+    if (!button || g_unloading.load()) {
+        return;
+    }
+    auto iconPanel = GetIconPanel(button);
+    if (!iconPanel) {
+        return;
+    }
+
+    const TaskbarEdge edge = DetectTaskbarEdge(iconPanel);
+    bool alreadyWatched = false;
+    bool edgeChanged = false;
+    TaskbarEdge previousEdge = TaskbarEdge::Bottom;
+    {
+        std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
+        for (auto& w : g_layoutWatches) {
+            try {
+                if (w.panel.get() != iconPanel) {
+                    continue;
+                }
+                alreadyWatched = true;
+                if (w.haveEdge && w.lastEdge != edge) {
+                    edgeChanged = true;
+                    previousEdge = w.lastEdge;
+                }
+                w.lastEdge = edge;
+                w.haveEdge = true;
+                break;
+            } catch (...) {
+            }
+        }
+    }
+    if (alreadyWatched) {
+        if (edgeChanged) {
+            Wh_Log(L"Taskbar edge %s -> %s (%.0fx%.0f)",
+                   TaskbarEdgeName(previousEdge), TaskbarEdgeName(edge),
+                   iconPanel.ActualWidth(), iconPanel.ActualHeight());
+            HealRunningIndicatorAfterRelayout(iconPanel);
+        }
+        return;
+    }
+
+    IconPanelLayoutWatch watch;
+    watch.panel = winrt::make_weak(iconPanel);
+    watch.lastEdge = edge;
+    watch.haveEdge = true;
+    winrt::weak_ref<FrameworkElement> weakPanel = watch.panel;
+    try {
+        watch.sizeChanged = iconPanel.SizeChanged(
+            [weakPanel](winrt::Windows::Foundation::IInspectable const&,
+                        SizeChangedEventArgs const& args) {
+                if (g_unloading.load()) {
+                    return;
+                }
+                if (g_iconPanelRelayoutDepth > 0) {
+                    return;
+                }
+                FrameworkElement panel = nullptr;
+                try {
+                    panel = weakPanel.get();
+                } catch (...) {
+                    return;
+                }
+                if (!panel) {
+                    return;
+                }
+                const double nw = args.NewSize().Width;
+                const double nh = args.NewSize().Height;
+                const double ow = args.PreviousSize().Width;
+                const double oh = args.PreviousSize().Height;
+                if (!(nw > 1.0 && nh > 1.0)) {
+                    return;
+                }
+                const bool relayout =
+                    ow > 1.0 && oh > 1.0 &&
+                    ((nw > ow + 1.5 || ow > nw + 1.5) ||
+                     (nh > oh + 1.5 || oh > nh + 1.5));
+                const bool firstMeasure = !(ow > 1.0 && oh > 1.0);
+                if (!relayout && !firstMeasure) {
+                    return;
+                }
+                if (relayout) {
+                    Wh_Log(L"IconPanel relayout: %.0fx%.0f -> %.0fx%.0f", ow,
+                           oh, nw, nh);
+                }
+                ++g_iconPanelRelayoutDepth;
+                try {
+                    HealRunningIndicatorAfterRelayout(panel);
+                    if (auto btn = TaskListButtonFromDescendant(panel)) {
+                        RefreshButtonHighlight(btn);
+                        ScheduleRefreshAllHighlights(btn);
+                    }
+                } catch (...) {
+                }
+                --g_iconPanelRelayoutDepth;
+            });
+    } catch (...) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
+    g_layoutWatches.erase(
+        std::remove_if(g_layoutWatches.begin(), g_layoutWatches.end(),
+                       [](IconPanelLayoutWatch& w) {
+                           try {
+                               return !w.panel.get();
+                           } catch (...) {
+                               return true;
+                           }
+                       }),
+        g_layoutWatches.end());
+    g_layoutWatches.push_back(std::move(watch));
+}
+
+void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
+    if (!button) {
+        return;
+    }
+
+    if (rankOneBased <= 0 || g_unloading.load() || !SettingsSnap()->enabled) {
+        ClearButtonHighlight(button);
+        return;
+    }
+
+    try {
+        auto iconPanel = GetIconPanel(button);
+        if (!iconPanel) {
+            return;
+        }
+
+        auto panel = iconPanel.try_as<Controls::Panel>();
+        if (!panel) {
+            return;
+        }
+
+        const int rankIdx = rankOneBased - 1;
+        const int intensity = RankIntensity(rankIdx);
+        const int sizeBoost = RankSizeBoost(rankIdx);
+        const double t = intensity / 100.0;
+
+        winrt::Windows::UI::Color base = ResolveGlowBaseColor();
+
+        auto withAlpha = [](winrt::Windows::UI::Color c,
+                            int a) -> winrt::Windows::UI::Color {
+            c.A = static_cast<uint8_t>((std::max)(0, (std::min)(255, a)));
+            return c;
+        };
+
+        const int layers =
+            (std::max)(1, (std::min)(kGlowMaxLayers, SettingsSnap()->glowLayers));
+        const double thickness = static_cast<double>(
+            (std::max)(1, (std::min)(16, SettingsSnap()->glowThickness)));
+        const double roundnessFrac =
+            (std::max)(0, (std::min)(50, SettingsSnap()->glowRoundness)) / 100.0;
+        const double sizeFrac =
+            (std::max)(40, (std::min)(100, SettingsSnap()->glowSize)) / 100.0;
+        const GlowStyle style = SettingsSnap()->glowStyle;
+        const int fillOpacitySetting =
+            (std::max)(0, (std::min)(100, SettingsSnap()->glowFillOpacity));
+
+        double panelW = iconPanel.ActualWidth();
+        double panelH = iconPanel.ActualHeight();
+        if (!(panelW > 1.0)) {
+            panelW = 44.0;
+        }
+        if (!(panelH > 1.0)) {
+            panelH = 44.0;
+        }
+
+        Controls::Grid host = EnsureGlowHost(panel, iconPanel);
+        if (!host) {
+            return;
+        }
+
+        double boxW = panelW;
+        double boxH = panelH;
+        GlowContentBoxSize(host, iconPanel, panelW, panelH, boxW, boxH);
+
+        const TaskbarEdge edge = DetectTaskbarEdge(iconPanel);
+        const BarSide barSide = BarSideForGlowStyle(style, edge);
+
+        // Heal native stacking first (Discord overlay / leftover attention
+        // plate), then place our host (under a native pill; above a Styler
+        // hover plate so the side bar is not covered on PointerOver).
+        RestoreIconPanelNativeZOrder(iconPanel);
+
+        // Z-order once when wrong — never yank RunningIndicator every paint
+        // (that caused short/long underline flicker on mouse-over).
+        EnsureGlowHostZOrder(panel, host, style);
+
+        HideAllGlowLayers(host);
+
+        // Strip leftover Edge-bar marker from older builds. Do not touch
+        // RunningIndicator unless we actually left Visibility=Collapsed —
+        // ClearValue(Visible) is what killed the short inactive pills.
+        if (style != GlowStyle::BottomBar) {
+            if (FindChildByName(iconPanel, kBottomBarMarkerName)) {
+                if (auto p = iconPanel.try_as<Controls::Panel>()) {
+                    RemoveNamedChild(p, kBottomBarMarkerName);
+                }
+            }
+        }
+        if (RunningIndicatorHasLocalCollapsed(iconPanel)) {
+            RestoreNativeRunningIndicator(iconPanel, button);
+        }
+
+        if (style == GlowStyle::Frame || style == GlowStyle::Full) {
+            const double baseInset =
+                (std::min)(boxW, boxH) * (1.0 - sizeFrac) * 0.5;
+            const bool isFrame = style == GlowStyle::Frame;
+
+            for (int i = 0; i < kGlowMaxLayers; ++i) {
+                auto rect = FindChildByName(host, kGlowLayerNames[i])
+                                .try_as<Shapes::Rectangle>();
+                if (!rect) {
+                    continue;
+                }
+                if (i >= layers) {
+                    continue;
+                }
+
+                const double step =
+                    (i == 0) ? 0.0 : (3.0 + thickness * 0.55) * i;
+                const double inset = baseInset + step;
+                const double inner =
+                    (std::max)(8.0, (std::min)(boxW, boxH) - 2.0 * inset);
+                const double corner = inner * roundnessFrac;
+                const double layerT = t * (1.0 - 0.15 * i);
+                const double th =
+                    (std::max)(1.0, thickness * (1.0 - 0.1 * i));
+                const int strokeA =
+                    static_cast<int>((100 + 130 * layerT) * (1.0 - 0.12 * i));
+                const double opacity = 0.70 + 0.30 * layerT;
+
+                winrt::Windows::UI::Color fill{0, 0, 0, 0};
+                if (!isFrame && i == 0) {
+                    int fillA = static_cast<int>(fillOpacitySetting * 2.55 *
+                                                 (0.45 + 0.55 * layerT));
+                    fill = withAlpha(base, fillA);
+                }
+
+                StyleGlowRectangle(rect, withAlpha(base, strokeA), fill, th,
+                                   corner, inset, opacity);
+            }
+        } else if (style == GlowStyle::LeftBar) {
+            // Side bar: left of the icon on a bottom/top taskbar, under the
+            // icon on a left/right taskbar — never the native-pill edge.
+            const double barT = thickness + 1.0;
+            const double barLen = BarLengthForSide(
+                iconPanel, boxW, boxH, barSide, edge, sizeFrac, 1.0);
+            const int fillBase =
+                static_cast<int>(fillOpacitySetting * 2.55 * (0.55 + 0.45 * t));
+            const int nLeft = (std::max)(1, (std::min)(layers, 2));
+
+            for (int i = 0; i < nLeft; ++i) {
+                auto rect = FindChildByName(host, kGlowLayerNames[i])
+                                .try_as<Shapes::Rectangle>();
+                if (!rect) {
+                    continue;
+                }
+                const int fillA =
+                    i == 0 ? fillBase : static_cast<int>(fillBase * 0.35);
+                const double opacity = i == 0 ? (0.85 + 0.15 * t) : 0.45;
+                StyleGlowBarOnSide(rect, withAlpha(base, fillA), barT, barLen,
+                                   barSide, i, opacity);
+            }
+        } else if (style == GlowStyle::BottomBar) {
+            // Edge bar on the native RunningIndicator side. Cover the pill
+            // by z-order (host after RI). Never set Visibility/Width/Height
+            // on the native indicator.
+            if (SettingsSnap()->glowDebugLog && !FindRunningIndicator(iconPanel)) {
+                Wh_Log(L"EdgeBar: RunningIndicator not found on \"%s\"",
+                       GetButtonAutomationName(button).c_str());
+            }
+
+            const int fillA =
+                static_cast<int>(fillOpacitySetting * 2.55 * (0.6 + 0.4 * t));
+            const double barT =
+                (std::max)(2.0, (std::min)(6.0, thickness));
+            const double barLen = BarLengthForSide(
+                iconPanel, boxW, boxH, barSide, edge, sizeFrac, 1.0);
+
+            if (auto rect = FindChildByName(host, kGlowLayerNames[0])
+                                .try_as<Shapes::Rectangle>()) {
+                StyleGlowBarOnSide(rect, withAlpha(base, fillA), barT, barLen,
+                                   barSide, 0, 0.9 + 0.1 * t);
+            }
+
+        }
+
+        if (auto icon = FindChildByName(iconPanel, L"Icon")) {
+            if (sizeBoost > 0) {
+                double s = 1.0 + static_cast<double>(sizeBoost) / 100.0;
+                Media::ScaleTransform scale;
+                scale.ScaleX(s);
+                scale.ScaleY(s);
+                icon.RenderTransformOrigin(
+                    winrt::Windows::Foundation::Point{0.5f, 0.5f});
+                icon.RenderTransform(scale);
+            } else {
+                if (icon.RenderTransform().try_as<Media::ScaleTransform>()) {
+                    icon.ClearValue(UIElement::RenderTransformProperty());
+                    icon.ClearValue(UIElement::RenderTransformOriginProperty());
+                }
+            }
+        }
+
+        if (SettingsSnap()->glowDebugLog) {
+            Wh_Log(L"Glow rank %d \"%s\" style=%s edge=%s bar=%s box=%.0fx%.0f "
+                   L"th=%.0f round=%d%% size=%d%% layers=%d intensity=%d",
+                   rankOneBased, GetButtonAutomationName(button).c_str(),
+                   GlowStyleName(style), TaskbarEdgeName(edge),
+                   BarSideName(barSide), boxW, boxH, thickness,
+                   SettingsSnap()->glowRoundness, SettingsSnap()->glowSize, layers,
+                   intensity);
+        }
+    } catch (...) {
+        HRESULT hr = winrt::to_hresult();
+        Wh_Log(L"ApplyButtonHighlight error %08X", hr);
+    }
+}
+
+void PruneTrackedButtons_UIThread() {
+    std::lock_guard<std::mutex> lock(g_buttonsMutex);
+    g_trackedButtons.erase(
+        std::remove_if(g_trackedButtons.begin(), g_trackedButtons.end(),
+                       [](winrt::weak_ref<FrameworkElement>& weak) {
+                           try {
+                               return !weak.get();
+                           } catch (...) {
+                               return true;
+                           }
+                       }),
+        g_trackedButtons.end());
+}
+
+void TrackButton_UIThread(FrameworkElement button) {
+    if (!button) {
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_buttonsMutex);
+        g_dispatcherAnchor = winrt::make_weak(button);
+
+        bool tracked = false;
+        for (auto& weak : g_trackedButtons) {
+            try {
+                if (weak.get() == button) {
+                    tracked = true;
+                    break;
+                }
+            } catch (...) {
+            }
+        }
+        if (!tracked) {
+            g_trackedButtons.push_back(winrt::make_weak(button));
+        }
+    }
+    EnsureButtonPathCached(button, /*force=*/false);
+    EnsureIconPanelLayoutWatch(button);
+}
+
+// ---------------------------------------------------------------------------
+// Button → process path (option C) — adapted from taskbar-volume-control-per-app
+// ---------------------------------------------------------------------------
+
+thread_local bool g_captureTaskGroup = false;
+thread_local void* g_capturedTaskGroup = nullptr;
+
+WCHAR g_clickSentinel[] = L"wh-rfh-click-sentinel";
+thread_local void* g_clickSentinel_TaskGroup = nullptr;
+thread_local void* g_clickSentinel_TaskItem = nullptr;
+
+constexpr int kMaxVtableProbeSlots = 32;
+constexpr size_t kMaxTaskItemsArrayOffset = 64;
+
+void* QueryViaVtable(void* object, void* vtable) {
+    if (!object || !vtable) {
+        return nullptr;
+    }
+    void** ptr = static_cast<void**>(object);
+    for (int i = 0; i < kMaxVtableProbeSlots; ++i) {
+        if (ptr[i] == vtable) {
+            return ptr + i;
+        }
+    }
+    return nullptr;
+}
+
+using CWindowTaskItem_GetWindow_t = HWND(WINAPI*)(void* pThis);
+CWindowTaskItem_GetWindow_t CWindowTaskItem_GetWindow;
+
+using CImmersiveTaskItem_GetAppWindow_t = HWND(WINAPI*)(void* pThis);
+CImmersiveTaskItem_GetAppWindow_t CImmersiveTaskItem_GetAppWindow;
+
+void* CImmersiveTaskItem_vftable = nullptr;
+void* CImmersiveTaskItem_vftable_ITaskItem = nullptr;
+void* CWindowTaskItem_vftable = nullptr;
+void* CWindowTaskItem_vftable_ITaskItem = nullptr;
+
+using TryGetItemFromContainer_TaskListWindowViewModel_t =
+    void*(WINAPI*)(void** output, UIElement* container);
+TryGetItemFromContainer_TaskListWindowViewModel_t
+    TryGetItemFromContainer_TaskListWindowViewModel_Original;
+
+using TaskListWindowViewModel_get_TaskItem_t = int(WINAPI*)(void* pThis,
+                                                            void** taskItem);
+TaskListWindowViewModel_get_TaskItem_t
+    TaskListWindowViewModel_get_TaskItem_Original;
+
+using TryGetItemFromContainer_TaskListGroupViewModel_t =
+    void*(WINAPI*)(void** output, UIElement* container);
+TryGetItemFromContainer_TaskListGroupViewModel_t
+    TryGetItemFromContainer_TaskListGroupViewModel_Original;
+
+using TaskListGroupViewModel_IsMultiWindow_t = bool(WINAPI*)(void* pThis);
+TaskListGroupViewModel_IsMultiWindow_t
+    TaskListGroupViewModel_IsMultiWindow_Original;
+
+using ITaskGroup_IsRunning_t = bool(WINAPI*)(void* pThis);
+ITaskGroup_IsRunning_t ITaskGroup_IsRunning_Original;
+bool WINAPI ITaskGroup_IsRunning_Hook(void* pThis) {
+    if (g_captureTaskGroup) {
+        g_capturedTaskGroup = *(void**)pThis;
+        return false;
+    }
+    return ITaskGroup_IsRunning_Original
+               ? ITaskGroup_IsRunning_Original(pThis)
+               : false;
+}
+
+using CTaskGroup_GetNumItems_t = int(WINAPI*)(void* pThis);
+CTaskGroup_GetNumItems_t CTaskGroup_GetNumItems;
+
+HDPA GetTaskItemsArray(void* taskGroup) {
+    if (!CTaskGroup_GetNumItems || !taskGroup) {
+        return nullptr;
+    }
+    static size_t offset = []() -> size_t {
+        constexpr int kIntArraySize = 256;
+        int arrayOfInts[kIntArraySize];
+        int* arrayOfIntPtrs[kIntArraySize];
+        for (int i = 0; i < kIntArraySize; i++) {
+            arrayOfInts[i] = i;
+            arrayOfIntPtrs[i] = &arrayOfInts[i];
+        }
+        const int raw = CTaskGroup_GetNumItems(arrayOfIntPtrs);
+        if (raw < 0 || raw >= kIntArraySize) {
+            return static_cast<size_t>(-1);
+        }
+        return static_cast<size_t>(raw);
+    }();
+    if (offset >= kMaxTaskItemsArrayOffset) {
+        return nullptr;
+    }
+    return (HDPA)((void**)taskGroup)[offset];
+}
+
+using CTaskListWnd_HandleClick_t = HRESULT(WINAPI*)(void* pThis,
+                                                    void* taskGroup,
+                                                    void* taskItem,
+                                                    void** launcherOptions);
+CTaskListWnd_HandleClick_t CTaskListWnd_HandleClick_Original;
+HWND GetWindowFromTaskItem(void* taskItem);
+
+HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
+                                             void* taskGroup,
+                                             void* taskItem,
+                                             void** launcherOptions) {
+    if (launcherOptions && *launcherOptions == &g_clickSentinel) {
+        g_clickSentinel_TaskGroup = taskGroup;
+        g_clickSentinel_TaskItem = taskItem;
+        return S_OK;
+    }
+    const HRESULT hr = CTaskListWnd_HandleClick_Original
+                           ? CTaskListWnd_HandleClick_Original(
+                                 pThis, taskGroup, taskItem, launcherOptions)
+                           : E_FAIL;
+    // Thumbnail (or grouped-icon) click is an explicit "this window".
+    // Confirm it immediately so decay + click does not paint the sibling.
+    if (SUCCEEDED(hr) && taskItem) {
+        if (HWND clicked = GetWindowFromTaskItem(taskItem)) {
+            ConfirmPreviewFocusNow(clicked);
+        }
+    }
+    return hr;
+}
+
+using TaskItem_ReportClicked_t = int(WINAPI*)(void* pThis, void* param);
+TaskItem_ReportClicked_t TaskItem_ReportClicked_Original;
+
+using TaskGroup_ReportClicked_t = int(WINAPI*)(void* pThis, void* param);
+TaskGroup_ReportClicked_t TaskGroup_ReportClicked_Original;
+
+void* GetNativeTaskItemFromWindowsUdkTaskItem(void* windowsUdkTaskItem) {
+    if (!TaskItem_ReportClicked_Original || !windowsUdkTaskItem) {
+        return nullptr;
+    }
+    void* prev = g_clickSentinel_TaskItem;
+    g_clickSentinel_TaskItem = nullptr;
+    TaskItem_ReportClicked_Original(windowsUdkTaskItem, &g_clickSentinel);
+    void* result = g_clickSentinel_TaskItem;
+    g_clickSentinel_TaskItem = prev;
+    return result;
+}
+
+void* GetNativeTaskGroupFromWindowsUdkTaskGroup(void* windowsUdkTaskGroup) {
+    if (!TaskGroup_ReportClicked_Original || !windowsUdkTaskGroup) {
+        return nullptr;
+    }
+    void* prev = g_clickSentinel_TaskGroup;
+    g_clickSentinel_TaskGroup = nullptr;
+    TaskGroup_ReportClicked_Original(windowsUdkTaskGroup, &g_clickSentinel);
+    void* result = g_clickSentinel_TaskGroup;
+    g_clickSentinel_TaskGroup = prev;
+    return result;
+}
+
+winrt::com_ptr<IUnknown> GetWindowsUdkTaskItemFromTaskListButton(
+    UIElement element) {
+    if (!TryGetItemFromContainer_TaskListWindowViewModel_Original ||
+        !TaskListWindowViewModel_get_TaskItem_Original) {
+        return nullptr;
+    }
+    winrt::com_ptr<IUnknown> windowViewModel;
+    TryGetItemFromContainer_TaskListWindowViewModel_Original(
+        windowViewModel.put_void(), &element);
+    if (!windowViewModel) {
+        return nullptr;
+    }
+    winrt::com_ptr<IUnknown> windowsUdkTaskItem;
+    TaskListWindowViewModel_get_TaskItem_Original(
+        windowViewModel.get(), windowsUdkTaskItem.put_void());
+    return windowsUdkTaskItem;
+}
+
+void* GetWindowsUdkTaskGroupFromTaskListButton(UIElement element) {
+    if (!TryGetItemFromContainer_TaskListGroupViewModel_Original ||
+        !TaskListGroupViewModel_IsMultiWindow_Original) {
+        return nullptr;
+    }
+    winrt::com_ptr<IUnknown> groupViewModel;
+    TryGetItemFromContainer_TaskListGroupViewModel_Original(
+        groupViewModel.put_void(), &element);
+    if (!groupViewModel) {
+        return nullptr;
+    }
+    g_capturedTaskGroup = nullptr;
+    g_captureTaskGroup = true;
+    TaskListGroupViewModel_IsMultiWindow_Original((void**)groupViewModel.get() -
+                                                  1);
+    g_captureTaskGroup = false;
+    return g_capturedTaskGroup;
+}
+
+HWND GetWindowFromTaskItem(void* taskItem) {
+    if (!taskItem) {
+        return nullptr;
+    }
+    if (CImmersiveTaskItem_vftable_ITaskItem &&
+        *(void**)taskItem == CImmersiveTaskItem_vftable_ITaskItem &&
+        CImmersiveTaskItem_GetAppWindow && CImmersiveTaskItem_vftable) {
+        void* immersiveTaskItem =
+            QueryViaVtable(taskItem, CImmersiveTaskItem_vftable);
+        if (!immersiveTaskItem) {
+            return nullptr;
+        }
+        return CImmersiveTaskItem_GetAppWindow(immersiveTaskItem);
+    }
+    if (CWindowTaskItem_GetWindow) {
+        void* windowTaskItem = taskItem;
+        if (CWindowTaskItem_vftable_ITaskItem && CWindowTaskItem_vftable &&
+            *(void**)taskItem == CWindowTaskItem_vftable_ITaskItem) {
+            windowTaskItem = QueryViaVtable(taskItem, CWindowTaskItem_vftable);
+            if (!windowTaskItem) {
+                return nullptr;
+            }
+        }
+        return CWindowTaskItem_GetWindow(windowTaskItem);
+    }
+    return nullptr;
+}
+
+// Button → PID via taskband (volume-mod approach).
+DWORD GetProcessIdFromTaskListButton(UIElement element) {
+    try {
+        auto windowsUdkTaskItem =
+            GetWindowsUdkTaskItemFromTaskListButton(element);
+        if (windowsUdkTaskItem) {
+            void* nativeTaskItem = GetNativeTaskItemFromWindowsUdkTaskItem(
+                windowsUdkTaskItem.get());
+            if (nativeTaskItem) {
+                HWND hWnd = GetWindowFromTaskItem(nativeTaskItem);
+                if (hWnd) {
+                    DWORD processId = 0;
+                    GetWindowThreadProcessId(hWnd, &processId);
+                    return processId;
+                }
+            }
+        }
+
+        void* windowsUdkTaskGroup =
+            GetWindowsUdkTaskGroupFromTaskListButton(element);
+        if (windowsUdkTaskGroup) {
+            void* nativeTaskGroup =
+                GetNativeTaskGroupFromWindowsUdkTaskGroup(windowsUdkTaskGroup);
+            if (nativeTaskGroup) {
+                HDPA taskItemsArray = GetTaskItemsArray(nativeTaskGroup);
+                if (taskItemsArray && DPA_GetPtrCount(taskItemsArray) > 0) {
+                    void* taskItem = DPA_GetPtr(taskItemsArray, 0);
+                    HWND hWnd = GetWindowFromTaskItem(taskItem);
+                    if (hWnd) {
+                        DWORD processId = 0;
+                        GetWindowThreadProcessId(hWnd, &processId);
+                        return processId;
+                    }
+                }
+            }
+        }
+    } catch (...) {
+    }
+    return 0;
+}
+
+// Resolve button → path; force=true on click. Returns path upper or empty.
+std::wstring EnsureButtonPathCached(FrameworkElement button, bool force) {
+    if (!button || !g_taskbandResolveReady.load()) {
+        return {};
+    }
+
+    const ULONGLONG now = GetTickCount64();
+    {
+        std::lock_guard<std::mutex> lock(g_buttonPathMutex);
+        for (auto& e : g_buttonPathCache) {
+            FrameworkElement b = nullptr;
+            try {
+                b = e.button.get();
+            } catch (...) {
+                continue;
+            }
+            if (b != button) {
+                continue;
+            }
+            const ULONGLONG debounceMs = e.pathUpper.empty() ? 250 : 2000;
+            if (!force && e.resolveAttempted &&
+                (now - e.lastResolveTick) < debounceMs) {
+                return e.pathUpper;
+            }
+            // fall through to re-resolve below using this entry
+            break;
+        }
+    }
+
+    DWORD pid = 0;
+    HWND hwnd = nullptr;
+    std::vector<HWND> groupHwnds;
+    try {
+        UIElement el = button.as<UIElement>();
+        // Prefer full resolve (also captures HWND via item path).
+        auto udkItem = GetWindowsUdkTaskItemFromTaskListButton(el);
+        if (udkItem) {
+            void* native =
+                GetNativeTaskItemFromWindowsUdkTaskItem(udkItem.get());
+            hwnd = GetWindowFromTaskItem(native);
+            if (hwnd) {
+                GetWindowThreadProcessId(hwnd, &pid);
+                groupHwnds.push_back(hwnd);
+            }
+        }
+        void* windowsUdkTaskGroup =
+            GetWindowsUdkTaskGroupFromTaskListButton(el);
+        if (windowsUdkTaskGroup) {
+            void* nativeTaskGroup =
+                GetNativeTaskGroupFromWindowsUdkTaskGroup(windowsUdkTaskGroup);
+            if (nativeTaskGroup) {
+                HDPA taskItemsArray = GetTaskItemsArray(nativeTaskGroup);
+                if (taskItemsArray) {
+                    const int n = DPA_GetPtrCount(taskItemsArray);
+                    for (int i = 0; i < n; ++i) {
+                        HWND h = GetWindowFromTaskItem(
+                            DPA_GetPtr(taskItemsArray, i));
+                        if (!h || !IsWindow(h)) {
+                            continue;
+                        }
+                        if (std::find(groupHwnds.begin(), groupHwnds.end(),
+                                      h) == groupHwnds.end()) {
+                            groupHwnds.push_back(h);
+                        }
+                        if (!hwnd) {
+                            hwnd = h;
+                        }
+                        if (!pid) {
+                            GetWindowThreadProcessId(h, &pid);
+                        }
+                    }
+                }
+            }
+        }
+        if (!pid) {
+            pid = GetProcessIdFromTaskListButton(el);
+        }
+    } catch (...) {
+        pid = 0;
+    }
+
+    std::wstring pathUpper;
+    if (pid) {
+        std::wstring path = GetProcessImagePath(pid);
+        if (!path.empty()) {
+            pathUpper = ToUpper(path);
+        }
+    }
+
+    std::wstring classUpper =
+        hwnd ? ToUpper(GetWindowClassName(hwnd)) : std::wstring{};
+    std::wstring appIdUpper =
+        hwnd ? ToUpper(GetWindowAppUserModelId(hwnd)) : std::wstring{};
+    std::wstring autoIdUpper = GetButtonAutomationAppId(button);
+    if (appIdUpper.empty()) {
+        appIdUpper = autoIdUpper;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_buttonPathMutex);
+        bool found = false;
+        for (auto& e : g_buttonPathCache) {
+            FrameworkElement b = nullptr;
+            try {
+                b = e.button.get();
+            } catch (...) {
+                continue;
+            }
+            if (b != button) {
+                continue;
+            }
+            e.pathUpper = pathUpper;
+            e.appIdUpper = appIdUpper;
+            e.classUpper = classUpper;
+            e.autoIdUpper = autoIdUpper;
+            e.pid = pid;
+            e.sampleHwnd = hwnd;
+            e.groupHwnds = groupHwnds;
+            e.resolveAttempted = true;
+            e.lastResolveTick = now;
+            found = true;
+            break;
+        }
+        if (!found) {
+            ButtonPathCacheEntry e;
+            e.button = winrt::make_weak(button);
+            e.pathUpper = pathUpper;
+            e.appIdUpper = appIdUpper;
+            e.classUpper = classUpper;
+            e.autoIdUpper = autoIdUpper;
+            e.pid = pid;
+            e.sampleHwnd = hwnd;
+            e.groupHwnds = std::move(groupHwnds);
+            e.resolveAttempted = true;
+            e.lastResolveTick = now;
+            g_buttonPathCache.push_back(std::move(e));
+        }
+        // Prune dead weaks occasionally.
+        if (g_buttonPathCache.size() > 128) {
+            g_buttonPathCache.erase(
+                std::remove_if(
+                    g_buttonPathCache.begin(), g_buttonPathCache.end(),
+                    [](ButtonPathCacheEntry& e) {
+                        try {
+                            return !e.button.get();
+                        } catch (...) {
+                            return true;
+                        }
+                    }),
+                g_buttonPathCache.end());
+        }
+    }
+
+    if (SettingsSnap()->glowDebugLog) {
+        Wh_Log(L"Button path cache: pid=%u path=%s class=%s appId=%s force=%d "
+               L"name=\"%s\"",
+               pid, pathUpper.empty() ? L"(none)" : pathUpper.c_str(),
+               classUpper.empty() ? L"?" : classUpper.c_str(),
+               appIdUpper.empty() ? L"?" : appIdUpper.c_str(), force ? 1 : 0,
+               GetButtonAutomationName(button).c_str());
+    }
+    return pathUpper;
+}
+
+// Lookup only (no resolve).
+std::wstring GetCachedButtonPath(FrameworkElement button) {
+    return GetCachedButtonIdentity(button).pathUpper;
+}
+
+ButtonIdentity GetCachedButtonIdentity(FrameworkElement button) {
+    ButtonIdentity out;
+    if (!button) {
+        return out;
+    }
+    std::lock_guard<std::mutex> lock(g_buttonPathMutex);
+    for (auto& e : g_buttonPathCache) {
+        try {
+            if (e.button.get() == button) {
+                out.pathUpper = e.pathUpper;
+                out.appIdUpper = e.appIdUpper;
+                out.classUpper = e.classUpper;
+                out.autoIdUpper = e.autoIdUpper;
+                out.pid = e.pid;
+                out.sampleHwnd = e.sampleHwnd;
+                out.groupHwnds = e.groupHwnds;
+                return out;
+            }
+        } catch (...) {
+        }
+    }
+    return out;
+}
+
+int GetCachedPaintRank(FrameworkElement button) {
+    if (!button) {
+        return -1;
+    }
+    std::lock_guard<std::mutex> lock(g_buttonPathMutex);
+    for (auto& e : g_buttonPathCache) {
+        try {
+            if (e.button.get() == button) {
+                return e.lastPaintRank;
+            }
+        } catch (...) {
+        }
+    }
+    return -1;
+}
+
+void SetCachedPaintRank(FrameworkElement button, int rank) {
+    if (!button) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(g_buttonPathMutex);
+    for (auto& e : g_buttonPathCache) {
+        try {
+            if (e.button.get() == button) {
+                e.lastPaintRank = rank;
+                return;
+            }
+        } catch (...) {
+        }
+    }
+    ButtonPathCacheEntry stub;
+    stub.button = winrt::make_weak(button);
+    stub.lastPaintRank = rank;
+    g_buttonPathCache.push_back(std::move(stub));
+}
+
+template <typename Fn>
+void ForEachLiveElementOnThisDispatcher(
+    const std::vector<winrt::weak_ref<FrameworkElement>>& weaks,
+    Fn&& fn) {
+    for (auto& weak : weaks) {
+        FrameworkElement el = nullptr;
+        try {
+            el = weak.get();
+        } catch (...) {
+            continue;
+        }
+        if (!el) {
+            continue;
+        }
+        try {
+            auto dispatcher = el.Dispatcher();
+            if (!dispatcher || !dispatcher.HasThreadAccess()) {
+                continue;
+            }
+        } catch (...) {
+            continue;
+        }
+        fn(el);
+    }
+}
+
+std::vector<FrameworkElement> CollectLiveButtonsOnThisDispatcher() {
+    PruneTrackedButtons_UIThread();
+    std::vector<winrt::weak_ref<FrameworkElement>> buttons;
+    {
+        std::lock_guard<std::mutex> lock(g_buttonsMutex);
+        buttons = g_trackedButtons;
+    }
+    std::vector<FrameworkElement> live;
+    live.reserve(buttons.size());
+    ForEachLiveElementOnThisDispatcher(
+        buttons, [&](FrameworkElement b) { live.push_back(b); });
+    return live;
+}
+
+void ApplyAllHighlights_UIThread() {
+    g_lastFullRefreshTick = GetTickCount64();
+    RefreshCurrentDesktopId();
+
+    std::vector<AppFocusInfo> ranks;
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        ranks = CurrentDeskLocked().rankedApps;
+    }
+
+    std::vector<FrameworkElement> live = CollectLiveButtonsOnThisDispatcher();
+
+    if (SettingsSnap()->glowDebugLog) {
+        for (size_t i = 0; i < ranks.size(); ++i) {
+            Wh_Log(L"  rank list[%zu]: %s", i + 1, ranks[i].displayName.c_str());
+        }
+        Wh_Log(L"ApplyAllHighlights: %zu tracked buttons, %zu ranks, enabled=%d "
+               L"desktop=%s",
+               live.size(), ranks.size(), SettingsSnap()->enabled ? 1 : 0,
+               GuidToLogString(g_currentDesktopId).c_str());
+    }
+
+    if (!SettingsSnap()->enabled || g_unloading.load() || ranks.empty()) {
+        for (auto& button : live) {
+            SetCachedPaintRank(button, 0);
+            ClearButtonHighlight(button);
+        }
+        g_pendingOverlaySweep = false;
+        if (SettingsSnap()->glowDebugLog && ranks.empty()) {
+            Wh_Log(L"ApplyAllHighlights: no ranks — cleared overlays on %zu "
+                   L"tracked buttons",
+                   live.size());
+        }
+        return;
+    }
+
+    if (SettingsSnap()->glowDebugLog) {
+        int dumped = 0;
+        for (auto& button : live) {
+            Wh_Log(L"  button[%d]: running=%d name=\"%s\"", dumped,
+                   TaskListButton_IsRunning(button) ? 1 : 0,
+                   GetButtonAutomationName(button).c_str());
+            if (++dumped >= 24) {
+                break;
+            }
+        }
+    }
+
+    // Prefer process-path cache (option C), then fuzzy name scores.
+    // 1:1 assignment, highest score wins.
+    struct Cand {
+        int score;
+        size_t rankIdx;
+        size_t buttonIdx;
+    };
+    std::vector<Cand> cands;
+    std::vector<std::wstring> buttonPaths(live.size());
+    for (size_t bi = 0; bi < live.size(); ++bi) {
+        // Resolve once if missing (cheap if cached).
+        buttonPaths[bi] = EnsureButtonPathCached(live[bi], /*force=*/false);
+        for (size_t ri = 0; ri < ranks.size(); ++ri) {
+            int s = ScoreButtonForRank(live[bi], ranks[ri], true);
+            if (s >= kScoreMinBind) {
+                cands.push_back({s, ri, bi});
+            }
+        }
+    }
+    std::sort(cands.begin(), cands.end(),
+              [](const Cand& a, const Cand& b) { return a.score > b.score; });
+
+    std::vector<int> buttonRank(live.size(), 0);  // 1-based rank or 0
+    std::vector<bool> rankTaken(ranks.size(), false);
+    std::vector<bool> buttonTaken(live.size(), false);
+
+    // Replicas of one identity may share a rank (secondary taskbar / Never
+    // Combine). Only exact identity (1000: path / HWND / AUMID). Name-cache
+    // 96 is 1:1 — it used to copy Settings' rank onto Windows Security.
+    for (const auto& c : cands) {
+        if (buttonTaken[c.buttonIdx]) {
+            continue;
+        }
+        const bool replica = c.score >= kScoreExactIdentity;
+        if (replica) {
+            buttonTaken[c.buttonIdx] = true;
+            rankTaken[c.rankIdx] = true;
+            buttonRank[c.buttonIdx] = static_cast<int>(c.rankIdx) + 1;
+        } else if (!rankTaken[c.rankIdx]) {
+            rankTaken[c.rankIdx] = true;
+            buttonTaken[c.buttonIdx] = true;
+            buttonRank[c.buttonIdx] = static_cast<int>(c.rankIdx) + 1;
+        } else {
+            continue;
+        }
+
+        std::wstring autoName = GetButtonAutomationName(live[c.buttonIdx]);
+        if (c.score >= kScoreExactIdentity) {
+            StoreAutomationName(ranks[c.rankIdx], autoName);
+        } else {
+            StoreAutomationNameIfFits(ranks[c.rankIdx], autoName);
+        }
+        // Successful bind ⇒ this process has a taskbar presence.
+        {
+            std::lock_guard<std::mutex> lock(g_stateMutex);
+            auto it = CurrentDeskLocked().appFocusMap.find(ranks[c.rankIdx].key);
+            if (it != CurrentDeskLocked().appFocusMap.end()) {
+                it->second.seenOnTaskbar = true;
+            }
+        }
+        if (SettingsSnap()->glowDebugLog) {
+            Wh_Log(L"  bind rank %zu %s -> \"%s\" (score=%d path=%s)",
+                   c.rankIdx + 1, ranks[c.rankIdx].displayName.c_str(),
+                   autoName.c_str(), c.score,
+                   buttonPaths[c.buttonIdx].empty()
+                       ? L"?"
+                       : buttonPaths[c.buttonIdx].c_str());
+        }
+    }
+
+    for (size_t bi = 0; bi < live.size(); ++bi) {
+        SetCachedPaintRank(live[bi], buttonRank[bi]);
+        if (buttonRank[bi] > 0) {
+            ApplyButtonHighlight(live[bi], buttonRank[bi]);
+        } else {
+            ClearButtonHighlight(live[bi]);
+        }
+    }
+
+    // Sweep completed for all currently tracked buttons.
+    if (g_pendingOverlaySweep.load()) {
+        g_pendingOverlaySweep = false;
+        Wh_Log(L"Overlay sweep finished (%zu buttons cleared/updated)",
+               live.size());
+    }
+
+// Second pass: unmatched ranks — pick best free button with lower bar
+    // (uses window title). Helps Windhawk and odd product names.
+    std::vector<std::wstring> demoteKeys;
+    for (size_t ri = 0; ri < ranks.size(); ++ri) {
+        if (rankTaken[ri]) {
+            continue;
+        }
+        int bestScore = 0;
+        size_t bestBi = SIZE_MAX;
+        for (size_t bi = 0; bi < live.size(); ++bi) {
+            if (buttonTaken[bi]) {
+                continue;
+            }
+            int s = ScoreButtonForRank(live[bi], ranks[ri], true);
+            if (s > bestScore) {
+                bestScore = s;
+                bestBi = bi;
+            }
+        }
+        std::wstring autoName = (bestBi != SIZE_MAX)
+                                    ? GetButtonAutomationName(live[bestBi])
+                                    : std::wstring{};
+        if (bestBi != SIZE_MAX && bestScore >= kScoreMinBind &&
+            AutomationNameFitsRank(ranks[ri], autoName)) {
+            rankTaken[ri] = true;
+            buttonTaken[bestBi] = true;
+            buttonRank[bestBi] = static_cast<int>(ri) + 1;
+            StoreAutomationNameIfFits(ranks[ri], autoName);
+            {
+                std::lock_guard<std::mutex> lock(g_stateMutex);
+                auto& map = CurrentDeskLocked().appFocusMap;
+                auto it = map.find(ranks[ri].key);
+                if (it != map.end()) {
+                    it->second.seenOnTaskbar = true;
+                }
+            }
+            if (SettingsSnap()->glowDebugLog) {
+                Wh_Log(L"  bind rank %zu %s -> \"%s\" (score=%d, fallback)",
+                       ri + 1, ranks[ri].displayName.c_str(), autoName.c_str(),
+                       bestScore);
+            }
+            SetCachedPaintRank(live[bestBi], buttonRank[bestBi]);
+            ApplyButtonHighlight(live[bestBi], buttonRank[bestBi]);
+        } else {
+            if (SettingsSnap()->glowDebugLog) {
+                Wh_Log(L"  UNMATCHED rank %zu: %s (bestScore=%d title=\"%s\")",
+                       ri + 1, ranks[ri].displayName.c_str(), bestScore,
+                       ranks[ri].lastWindowTitle.c_str());
+                if (bestBi != SIZE_MAX) {
+                    Wh_Log(L"    closest button was \"%s\"",
+                           GetButtonAutomationName(live[bestBi]).c_str());
+                }
+            }
+            // Tray-only / no button: drop from ranks so it stops occupying a
+            // slot (e.g. HA Desktop Widget). Only demote once we already know
+            // several real taskbar paths (avoid false demote at explorer start).
+            size_t resolvedButtons = 0;
+            {
+                std::lock_guard<std::mutex> lock(g_buttonPathMutex);
+                for (const auto& e : g_buttonPathCache) {
+                    if (!e.pathUpper.empty()) {
+                        ++resolvedButtons;
+                    }
+                }
+            }
+            if (SettingsSnap()->requireTaskbarButton && bestScore == 0 &&
+                resolvedButtons >= 2) {
+                demoteKeys.push_back(ranks[ri].key);
+            }
+        }
+    }
+    // Demote after the loop so rank list stays stable while matching.
+    if (!demoteKeys.empty()) {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        auto& map = CurrentDeskLocked().appFocusMap;
+        for (const auto& key : demoteKeys) {
+            auto it = map.find(key);
+            if (it != map.end() && !it->second.seenOnTaskbar) {
+                Wh_Log(L"  demoting non-taskbar app from ranks: %s",
+                       it->second.displayName.c_str());
+                it->second.lastConfirmedFocusTick = 0;
+                it->second.seenOnTaskbar = false;
+            }
+        }
+        RecomputeRanksLocked();
+    }
+}
+
+void ClearAllHighlights_UIThread() {
+    for (auto& button : CollectLiveButtonsOnThisDispatcher()) {
+        SetCachedPaintRank(button, 0);
+        ClearButtonHighlight(button);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Thumbnail preview glow (multi-window flyouts)
+// ---------------------------------------------------------------------------
+
+void AddThumbnailTaskItemMapping(
+    winrt::Windows::Foundation::IInspectable thumbnail,
+    void* taskGroup,
+    void* taskItem) {
+    if (!thumbnail || !taskItem) {
+        return;
+    }
+    HWND hwnd = GetWindowFromTaskItem(taskItem);
+    std::lock_guard<std::mutex> lock(g_thumbnailMapMutex);
+    std::erase_if(g_thumbnailTaskItemMapping, [&](const ThumbnailTaskItemMapping& item) {
+        try {
+            auto t = item.thumbnail.get();
+            if (!t || t == thumbnail) {
+                return true;
+            }
+        } catch (...) {
+            return true;
+        }
+        return item.taskGroup == taskGroup && item.taskItem == taskItem;
+    });
+    ThumbnailTaskItemMapping entry;
+    entry.thumbnail = winrt::make_weak(thumbnail);
+    entry.taskGroup = taskGroup;
+    entry.taskItem = taskItem;
+    entry.hwnd = hwnd;
+    g_thumbnailTaskItemMapping.push_back(std::move(entry));
+    // Soft cap
+    if (g_thumbnailTaskItemMapping.size() > 128) {
+        std::erase_if(g_thumbnailTaskItemMapping, [](const ThumbnailTaskItemMapping& item) {
+            try {
+                return !item.thumbnail.get();
+            } catch (...) {
+                return true;
+            }
+        });
+    }
+}
+
+HWND HwndFromMappingEntry(const ThumbnailTaskItemMapping& item) {
+    if (item.hwnd && IsWindow(item.hwnd)) {
+        return item.hwnd;
+    }
+    if (item.taskItem) {
+        HWND h = GetWindowFromTaskItem(item.taskItem);
+        if (h && IsWindow(h)) {
+            return h;
+        }
+    }
+    return nullptr;
+}
+
+// Closed flyouts leave dead weaks; their HWNDs/groups must not be reused to
+// resolve a later app's sibling count (TC Lister vs an earlier Chrome hover).
+bool ThumbnailMappingLive(const ThumbnailTaskItemMapping& item) {
+    try {
+        return item.thumbnail.get() != nullptr;
+    } catch (...) {
+        return false;
+    }
+}
+
+// True if two WinRT objects are the same COM identity (different projections
+// of the same TaskItemThumbnail still match).
+bool SameInspectableIdentity(winrt::Windows::Foundation::IInspectable const& a,
+                             winrt::Windows::Foundation::IInspectable const& b) {
+    if (!a || !b) {
+        return false;
+    }
+    try {
+        if (a == b) {
+            return true;
+        }
+        if (winrt::get_abi(a) == winrt::get_abi(b)) {
+            return true;
+        }
+        // Canonical COM identity (QI to IUnknown).
+        auto ua = a.as<::IUnknown>();
+        auto ub = b.as<::IUnknown>();
+        return winrt::get_abi(ua) == winrt::get_abi(ub);
+    } catch (...) {
+        return false;
+    }
+}
+
+// Strong resolve: TaskItemThumbnail model (DataContext) → HWND.
+// Returns also taskGroup when found (for index-order fill of siblings).
+HWND ResolveHwndFromThumbnailModel(
+    winrt::Windows::Foundation::IInspectable thumbnail,
+    void** outTaskGroup = nullptr) {
+    if (outTaskGroup) {
+        *outTaskGroup = nullptr;
+    }
+    if (!thumbnail) {
+        return nullptr;
+    }
+    std::lock_guard<std::mutex> lock(g_thumbnailMapMutex);
+    for (const auto& item : g_thumbnailTaskItemMapping) {
+        try {
+            auto t = item.thumbnail.get();
+            if (!t) {
+                continue;
+            }
+            if (!SameInspectableIdentity(t, thumbnail)) {
+                continue;
+            }
+            if (outTaskGroup) {
+                *outTaskGroup = item.taskGroup;
+            }
+            return HwndFromMappingEntry(item);
+        } catch (...) {
+        }
+    }
+    return nullptr;
+}
+
+// HWNDs for one task group in the *current* flyout's construction order.
+// Closed-flyout maps stay in the vector; first-seen order is the previous
+// hover and is often reversed after a click (Windows rebuilds MRU).
+std::vector<HWND> HwndsForTaskGroupInOrder(void* taskGroup) {
+    std::vector<HWND> newestFirst;
+    if (!taskGroup) {
+        return newestFirst;
+    }
+    std::lock_guard<std::mutex> lock(g_thumbnailMapMutex);
+    for (auto it = g_thumbnailTaskItemMapping.rbegin();
+         it != g_thumbnailTaskItemMapping.rend(); ++it) {
+        if (it->taskGroup != taskGroup || !ThumbnailMappingLive(*it)) {
+            continue;
+        }
+        HWND h = HwndFromMappingEntry(*it);
+        if (!h) {
+            continue;
+        }
+        if (std::find(newestFirst.begin(), newestFirst.end(), h) ==
+            newestFirst.end()) {
+            newestFirst.push_back(h);
+        }
+    }
+    std::reverse(newestFirst.begin(), newestFirst.end());
+    return newestFirst;
+}
+
+// Pick a taskGroup that has exactly `siblingCount` unique HWNDs (current flyout).
+void* FindTaskGroupForSiblingCount(size_t siblingCount) {
+    if (siblingCount == 0) {
+        return nullptr;
+    }
+    std::lock_guard<std::mutex> lock(g_thumbnailMapMutex);
+    // group -> ordered unique hwnds
+    struct GroupAcc {
+        void* group = nullptr;
+        std::vector<HWND> hwnds;
+    };
+    std::vector<GroupAcc> groups;
+    for (const auto& item : g_thumbnailTaskItemMapping) {
+        if (!item.taskGroup || !ThumbnailMappingLive(item)) {
+            continue;
+        }
+        HWND h = HwndFromMappingEntry(item);
+        if (!h) {
+            continue;
+        }
+        GroupAcc* acc = nullptr;
+        for (auto& g : groups) {
+            if (g.group == item.taskGroup) {
+                acc = &g;
+                break;
+            }
+        }
+        if (!acc) {
+            groups.push_back({item.taskGroup, {}});
+            acc = &groups.back();
+        }
+        if (std::find(acc->hwnds.begin(), acc->hwnds.end(), h) ==
+            acc->hwnds.end()) {
+            acc->hwnds.push_back(h);
+        }
+    }
+    // Last exact match wins — maps are append-only, so the newest live
+    // flyout is preferred over an older group with the same window count.
+    void* exact = nullptr;
+    for (const auto& g : groups) {
+        if (g.hwnds.size() == siblingCount) {
+            exact = g.group;
+        }
+    }
+    if (exact) {
+        return exact;
+    }
+    // Prefer largest group that is at least siblingCount (partial flyout).
+    void* best = nullptr;
+    size_t bestN = 0;
+    for (const auto& g : groups) {
+        if (g.hwnds.size() >= siblingCount && g.hwnds.size() > bestN) {
+            bestN = g.hwnds.size();
+            best = g.group;
+        }
+    }
+    return best;
+}
+
+// Last N unique HWNDs from the mapping vector (most recently constructed models
+// — typically the open flyout when maps were just created on hover).
+std::vector<HWND> LastMappedHwnds(size_t n) {
+    std::vector<HWND> out;
+    if (n == 0) {
+        return out;
+    }
+    std::lock_guard<std::mutex> lock(g_thumbnailMapMutex);
+    for (auto it = g_thumbnailTaskItemMapping.rbegin();
+         it != g_thumbnailTaskItemMapping.rend() && out.size() < n; ++it) {
+        if (!ThumbnailMappingLive(*it)) {
+            continue;
+        }
+        HWND h = HwndFromMappingEntry(*it);
+        if (!h) {
+            continue;
+        }
+        if (std::find(out.begin(), out.end(), h) == out.end()) {
+            out.push_back(h);
+        }
+    }
+    // We walked newest→oldest; reverse to construction/display order.
+    std::reverse(out.begin(), out.end());
+    return out;
+}
+
+HWND ResolveHwndForThumbnailView(FrameworkElement thumbView,
+                                 void** outTaskGroup = nullptr) {
+    if (outTaskGroup) {
+        *outTaskGroup = nullptr;
+    }
+    if (!thumbView) {
+        return nullptr;
+    }
+    try {
+        // DataContext is often the TaskItemThumbnail model object.
+        auto dc = thumbView.DataContext();
+        if (dc) {
+            if (HWND h = ResolveHwndFromThumbnailModel(dc, outTaskGroup)) {
+                return h;
+            }
+        }
+    } catch (...) {
+    }
+    // No title fallback here — identical titles (Calibre 2× same file) would
+    // all bind to the same HWND. Callers do unique assignment separately.
+    return nullptr;
+}
+
+// Title → HWND only for unique assignment (each HWND at most once).
+HWND MatchTitleToUnusedRecent(const std::wstring& autoName,
+                              const std::vector<WindowFocusInfo>& recent,
+                              const std::unordered_set<HWND>& used) {
+    if (autoName.empty()) {
+        return nullptr;
+    }
+    const std::wstring cardPath = ToUpper(ExtractBracketedPath(autoName));
+    const std::wstring cardFile =
+        cardPath.empty() ? std::wstring{}
+                         : ToUpper(FileNameFromPath(cardPath));
+
+    int bestScore = 0;
+    HWND bestHwnd = nullptr;
+    ULONGLONG bestTick = 0;
+    for (const auto& info : recent) {
+        if (!info.hwnd || used.count(info.hwnd)) {
+            continue;
+        }
+        int s = ScoreTitleToAutomationName(info.windowTitle, autoName);
+        if (IsWindow(info.hwnd)) {
+            const std::wstring liveTitle = GetWindowTitle(info.hwnd);
+            s = (std::max)(s, ScoreTitleToAutomationName(liveTitle, autoName));
+            if (!cardPath.empty()) {
+                const std::wstring winPath =
+                    ToUpper(ExtractBracketedPath(liveTitle));
+                const std::wstring infoPath =
+                    ToUpper(ExtractBracketedPath(info.windowTitle));
+                if (winPath == cardPath || infoPath == cardPath) {
+                    s = (std::max)(s, 100);
+                } else if (!cardFile.empty()) {
+                    if (ToUpper(FileNameFromPath(winPath)) == cardFile ||
+                        ToUpper(FileNameFromPath(infoPath)) == cardFile ||
+                        ToUpper(FileNameFromPath(liveTitle)) == cardFile ||
+                        ToUpper(FileNameFromPath(info.windowTitle)) ==
+                            cardFile) {
+                        s = (std::max)(s, 96);
+                    }
+                }
+            }
+        }
+        if (s > bestScore ||
+            (s == bestScore && s >= 70 && info.lastConfirmedTick > bestTick)) {
+            bestScore = s;
+            bestHwnd = info.hwnd;
+            bestTick = info.lastConfirmedTick;
+        }
+    }
+    return bestScore >= 70 ? bestHwnd : nullptr;
+}
+
+void CollectThumbnailViewsUnder(FrameworkElement root,
+                                std::vector<FrameworkElement>& out) {
+    if (!root) {
+        return;
+    }
+    try {
+        if (winrt::get_class_name(root) == L"Taskbar.TaskItemThumbnailView") {
+            out.push_back(root);
+        }
+        int n = Media::VisualTreeHelper::GetChildrenCount(root);
+        for (int i = 0; i < n; ++i) {
+            auto child = Media::VisualTreeHelper::GetChild(root, i)
+                             .try_as<FrameworkElement>();
+            if (child) {
+                CollectThumbnailViewsUnder(child, out);
+            }
+        }
+    } catch (...) {
+    }
+}
+
+FrameworkElement FindAncestorByClassName(FrameworkElement element,
+                                         PCWSTR className) {
+    FrameworkElement cur = element;
+    for (int guard = 0; guard < 32 && cur; ++guard) {
+        try {
+            if (winrt::get_class_name(cur) == className) {
+                return cur;
+            }
+            cur = Media::VisualTreeHelper::GetParent(cur)
+                      .try_as<FrameworkElement>();
+        } catch (...) {
+            break;
+        }
+    }
+    return nullptr;
+}
+
+std::vector<FrameworkElement> CollectSiblingThumbnailViews(
+    FrameworkElement thumbView) {
+    std::vector<FrameworkElement> out;
+    if (!thumbView) {
+        return out;
+    }
+
+    // Prefer known list hosts from the XAML thumbnail flyout.
+    static const PCWSTR kHosts[] = {
+        L"Taskbar.TaskItemThumbnailList",
+        L"Taskbar.TaskItemThumbnailScrollableList",
+        L"Taskbar.FlyoutFrame",
+    };
+    FrameworkElement host = nullptr;
+    for (auto name : kHosts) {
+        host = FindAncestorByClassName(thumbView, name);
+        if (host) {
+            break;
+        }
+    }
+    if (!host) {
+        // Walk up a few parents and collect from the highest with 2+ thumbs.
+        FrameworkElement cur = thumbView;
+        for (int i = 0; i < 8 && cur; ++i) {
+            try {
+                cur = Media::VisualTreeHelper::GetParent(cur)
+                          .try_as<FrameworkElement>();
+            } catch (...) {
+                cur = nullptr;
+            }
+            if (cur) {
+                host = cur;
+            }
+        }
+    }
+    if (host) {
+        CollectThumbnailViewsUnder(host, out);
+    }
+    if (out.empty()) {
+        out.push_back(thumbView);
+    }
+    return out;
+}
+
+void TrackThumbView_UIThread(FrameworkElement thumbView) {
+    if (!thumbView) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(g_thumbViewsMutex);
+    for (auto& weak : g_trackedThumbViews) {
+        try {
+            if (weak.get() == thumbView) {
+                return;
+            }
+        } catch (...) {
+        }
+    }
+    g_trackedThumbViews.push_back(winrt::make_weak(thumbView));
+    if (g_trackedThumbViews.size() > 64) {
+        g_trackedThumbViews.erase(
+            std::remove_if(
+                g_trackedThumbViews.begin(), g_trackedThumbViews.end(),
+                [](winrt::weak_ref<FrameworkElement>& weak) {
+                    try {
+                        return !weak.get();
+                    } catch (...) {
+                        return true;
+                    }
+                }),
+            g_trackedThumbViews.end());
+    }
+}
+
+void RemoveNamedDescendant(FrameworkElement root, PCWSTR name) {
+    if (!root || !name) {
+        return;
+    }
+    for (int guard = 0; guard < 4; ++guard) {
+        auto existing = FindDescendantByName(root, name);
+        if (!existing) {
+            return;
+        }
+        try {
+            if (auto parent = Media::VisualTreeHelper::GetParent(existing)
+                                  .try_as<Controls::Panel>()) {
+                uint32_t idx = 0;
+                if (parent.Children().IndexOf(existing, idx)) {
+                    parent.Children().RemoveAt(idx);
+                    continue;
+                }
+            }
+        } catch (...) {
+        }
+        break;
+    }
+}
+
+// Find a Panel to host overlays (root Grid under TaskItemThumbnailView).
+Controls::Panel GetThumbnailHostPanel(FrameworkElement thumbView) {
+    if (!thumbView) {
+        return nullptr;
+    }
+    try {
+        if (auto p = thumbView.try_as<Controls::Panel>()) {
+            return p;
+        }
+        int n = Media::VisualTreeHelper::GetChildrenCount(thumbView);
+        for (int i = 0; i < n; ++i) {
+            auto child = Media::VisualTreeHelper::GetChild(thumbView, i)
+                             .try_as<FrameworkElement>();
+            if (!child) {
+                continue;
+            }
+            if (winrt::get_class_name(child) ==
+                L"Windows.UI.Xaml.Controls.Grid") {
+                if (auto p = child.try_as<Controls::Panel>()) {
+                    return p;
+                }
+            }
+            if (auto p = child.try_as<Controls::Panel>()) {
+                return p;
+            }
+        }
+    } catch (...) {
+    }
+    return nullptr;
+}
+
+FrameworkElement FindThumbnailTitleElement(FrameworkElement thumbView) {
+    if (!thumbView) {
+        return nullptr;
+    }
+    static const PCWSTR kNames[] = {
+        L"DisplayNameTextBlock",
+        L"DisplayName",
+        L"TitleTextBlock",
+        L"Title",
+    };
+    for (auto name : kNames) {
+        if (auto el = FindDescendantByName(thumbView, name)) {
+            if (winrt::get_class_name(el) == L"Windows.UI.Xaml.Controls.TextBlock" ||
+                el.try_as<Controls::TextBlock>()) {
+                return el;
+            }
+            // Name matched a wrapper — prefer a TextBlock inside.
+            if (auto tb = FindDescendantByName(el, L"DisplayNameTextBlock")) {
+                return tb;
+            }
+            return el;
+        }
+    }
+    // First TextBlock in the tree (title is usually the only one besides close).
+    try {
+        std::function<FrameworkElement(FrameworkElement)> walk;
+        walk = [&](FrameworkElement root) -> FrameworkElement {
+            if (!root) {
+                return nullptr;
+            }
+            auto cn = winrt::get_class_name(root);
+            if (cn == L"Windows.UI.Xaml.Controls.TextBlock") {
+                // Skip close-button glyphs (often single-char / Segoe icons).
+                try {
+                    if (auto tb = root.try_as<Controls::TextBlock>()) {
+                        auto text = tb.Text();
+                        if (text.size() >= 2) {
+                            return root;
+                        }
+                    }
+                } catch (...) {
+                    return root;
+                }
+            }
+            int n = Media::VisualTreeHelper::GetChildrenCount(root);
+            for (int i = 0; i < n; ++i) {
+                auto child = Media::VisualTreeHelper::GetChild(root, i)
+                                 .try_as<FrameworkElement>();
+                if (auto found = walk(child)) {
+                    return found;
+                }
+            }
+            return nullptr;
+        };
+        return walk(thumbView);
+    } catch (...) {
+    }
+    return nullptr;
+}
+
+std::wstring GetThumbnailAutomationName(FrameworkElement thumbView) {
+    try {
+        return NormalizeAutomationName(
+            Automation::AutomationProperties::GetName(thumbView).c_str());
+    } catch (...) {
+        return {};
+    }
+}
+
+std::wstring GetThumbnailDisplayText(FrameworkElement thumbView) {
+    try {
+        if (auto titleEl = FindThumbnailTitleElement(thumbView)) {
+            if (auto tb = titleEl.try_as<Controls::TextBlock>()) {
+                return NormalizeAutomationName(tb.Text().c_str());
+            }
+        }
+    } catch (...) {
+    }
+    return {};
+}
+
+std::wstring TitleMatchKey(const std::wstring& raw) {
+    std::wstring n = NormalizeAutomationName(raw);
+    std::wstring path = ToUpper(ExtractBracketedPath(n));
+    if (!path.empty()) {
+        return path;
+    }
+    return AlnumUpper(n);
+}
+
+bool TitleKeysAreDistinct(const std::vector<std::wstring>& titles) {
+    if (titles.size() < 2) {
+        return false;
+    }
+    std::unordered_set<std::wstring> seen;
+    for (const auto& t : titles) {
+        std::wstring key = TitleMatchKey(t);
+        if (key.empty() || !seen.insert(key).second) {
+            return false;
+        }
+    }
+    return true;
+}
+
+std::wstring GetThumbnailMatchTitle(FrameworkElement thumbView) {
+    std::wstring autoName = GetThumbnailAutomationName(thumbView);
+    std::wstring text = GetThumbnailDisplayText(thumbView);
+
+    // Prefer the more specific string (file name vs generic "Lister").
+    if (text.size() > autoName.size()) {
+        return text;
+    }
+    if (autoName.size() > text.size()) {
+        return autoName;
+    }
+    return !text.empty() ? text : autoName;
+}
+
+// Per-flyout: pick the title source that actually distinguishes cards.
+// Ebook readers often put the book name on DisplayNameTextBlock while
+// Automation Name is the shared "App - 2 running windows" (same on every
+// sibling) — preferring the longer string then made titlesDistinct fail
+// and we assigned HWNDs by stale group-order (swap after click).
+std::vector<std::wstring> PickFlyoutCardTitles(
+    const std::vector<FrameworkElement>& siblings) {
+    std::vector<std::wstring> autos;
+    std::vector<std::wstring> texts;
+    std::vector<std::wstring> mixed;
+    autos.reserve(siblings.size());
+    texts.reserve(siblings.size());
+    mixed.reserve(siblings.size());
+    for (const auto& v : siblings) {
+        autos.push_back(GetThumbnailAutomationName(v));
+        texts.push_back(GetThumbnailDisplayText(v));
+        mixed.push_back(GetThumbnailMatchTitle(v));
+    }
+    if (TitleKeysAreDistinct(texts)) {
+        return texts;
+    }
+    if (TitleKeysAreDistinct(autos)) {
+        return autos;
+    }
+    return mixed;
+}
+
+int ThumbnailPositionInSet(FrameworkElement view) {
+    try {
+        return Automation::AutomationProperties::GetPositionInSet(view);
+    } catch (...) {
+        return -1;
+    }
+}
+
+void SortThumbnailViewsVisualOrder(std::vector<FrameworkElement>& views) {
+    bool anyPos = false;
+    for (const auto& v : views) {
+        if (ThumbnailPositionInSet(v) >= 1) {
+            anyPos = true;
+            break;
+        }
+    }
+    if (!anyPos) {
+        return;
+    }
+    std::stable_sort(
+        views.begin(), views.end(),
+        [](const FrameworkElement& a, const FrameworkElement& b) {
+            int pa = ThumbnailPositionInSet(a);
+            int pb = ThumbnailPositionInSet(b);
+            if (pa < 1) {
+                pa = 100000;
+            }
+            if (pb < 1) {
+                pb = 100000;
+            }
+            return pa < pb;
+        });
+}
+
+// Snap-group card in the same flyout as the individual windows
+// ("Group | Lister - [file] and 1 other window"). Must not be treated as a
+// window thumbnail — it steals group-order HWND 0 and the recent glow.
+bool IsSnapGroupThumbnailView(FrameworkElement view) {
+    if (!view) {
+        return false;
+    }
+    auto looksLikeGroup = [](const std::wstring& s) -> bool {
+        if (s.empty()) {
+            return false;
+        }
+        if (s.size() >= 5 && _wcsnicmp(s.c_str(), L"Group", 5) == 0 &&
+            (s.size() == 5 || s[5] == L' ' || s[5] == L'|' || s[5] == L'-')) {
+            return true;
+        }
+        if (s.find(L" other window") != std::wstring::npos) {
+            return true;
+        }
+        return false;
+    };
+
+    try {
+        std::wstring name =
+            Automation::AutomationProperties::GetName(view).c_str();
+        if (looksLikeGroup(name) ||
+            looksLikeGroup(NormalizeAutomationName(name))) {
+            return true;
+        }
+    } catch (...) {
+    }
+
+    try {
+        if (auto title = FindThumbnailTitleElement(view)) {
+            if (auto tb = title.try_as<Controls::TextBlock>()) {
+                std::wstring text = tb.Text().c_str();
+                if (looksLikeGroup(text)) {
+                    return true;
+                }
+            }
+        }
+    } catch (...) {
+    }
+
+    if (auto repeater = FindDescendantByName(view, L"IconsRepeater")) {
+        try {
+            if (Media::VisualTreeHelper::GetChildrenCount(repeater) >= 2) {
+                return true;
+            }
+        } catch (...) {
+        }
+    }
+    return false;
+}
+
+struct EnumSameClassCtx {
+    DWORD pid = 0;
+    std::wstring classUpper;
+    std::vector<HWND>* out = nullptr;
+};
+
+BOOL CALLBACK EnumSameClassWndProc(HWND hWnd, LPARAM lParam) {
+    auto* ctx = reinterpret_cast<EnumSameClassCtx*>(lParam);
+    if (!ctx || !ctx->out) {
+        return FALSE;
+    }
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hWnd, &pid);
+    if (pid != ctx->pid || !IsWindowVisible(hWnd)) {
+        return TRUE;
+    }
+    if (GetWindowLong(hWnd, GWL_STYLE) & WS_CHILD) {
+        return TRUE;
+    }
+    if (ToUpper(GetWindowClassName(hWnd)) != ctx->classUpper) {
+        return TRUE;
+    }
+    if (std::find(ctx->out->begin(), ctx->out->end(), hWnd) ==
+        ctx->out->end()) {
+        ctx->out->push_back(hWnd);
+    }
+    return TRUE;
+}
+
+std::vector<HWND> ExpandSameClassWindows(const std::vector<HWND>& seeds) {
+    std::vector<HWND> out;
+    for (HWND seed : seeds) {
+        if (!seed || !IsWindow(seed)) {
+            continue;
+        }
+        if (std::find(out.begin(), out.end(), seed) == out.end()) {
+            out.push_back(seed);
+        }
+        DWORD pid = 0;
+        GetWindowThreadProcessId(seed, &pid);
+        std::wstring cls = ToUpper(GetWindowClassName(seed));
+        if (!pid || cls.empty()) {
+            continue;
+        }
+        EnumSameClassCtx ctx{pid, std::move(cls), &out};
+        EnumWindows(EnumSameClassWndProc, reinterpret_cast<LPARAM>(&ctx));
+    }
+    return out;
+}
+
+FrameworkElement FindThumbnailBackgroundBorder(FrameworkElement thumbView) {
+    if (!thumbView) {
+        return nullptr;
+    }
+    if (auto b = FindDescendantByName(thumbView, L"BackgroundBorder")) {
+        return b;
+    }
+    // First Border under the root grid (styler targets this).
+    try {
+        auto panel = GetThumbnailHostPanel(thumbView);
+        if (!panel) {
+            return nullptr;
+        }
+        auto fe = panel.as<FrameworkElement>();
+        int n = Media::VisualTreeHelper::GetChildrenCount(fe);
+        for (int i = 0; i < n; ++i) {
+            auto child = Media::VisualTreeHelper::GetChild(fe, i)
+                             .try_as<FrameworkElement>();
+            if (!child) {
+                continue;
+            }
+            auto cn = winrt::get_class_name(child);
+            if (cn == L"Windows.UI.Xaml.Controls.Border") {
+                return child;
+            }
+        }
+    } catch (...) {
+    }
+    return nullptr;
+}
+
+FrameworkElement MakeThumbNativeMarker(
+    winrt::Windows::Foundation::IInspectable const& savedBackground) {
+    PCWSTR markerXaml = LR"(
+        <Border xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                Name="WhRecentFocusThumbNative"
+                Width="0" Height="0" Opacity="0"
+                IsHitTestVisible="False" Visibility="Collapsed"/>
+    )";
+    try {
+        auto marker =
+            Markup::XamlReader::Load(markerXaml).as<FrameworkElement>();
+        if (savedBackground) {
+            marker.Tag(savedBackground);
+        }
+        return marker;
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void ClearThumbnailNativeStyles(FrameworkElement thumbView) {
+    if (!thumbView) {
+        return;
+    }
+    auto markerEl = FindDescendantByName(thumbView, kThumbNativeStyleMarker);
+    if (!markerEl) {
+        return;
+    }
+    winrt::Windows::Foundation::IInspectable saved;
+    try {
+        saved = markerEl.Tag();
+    } catch (...) {
+    }
+    try {
+        // Restore the brush Taskbar Styler (or the template) had, if any.
+        if (auto border = FindThumbnailBackgroundBorder(thumbView)) {
+            if (auto b = border.try_as<Controls::Border>()) {
+                if (auto brush = saved.try_as<Media::Brush>()) {
+                    b.Background(brush);
+                } else {
+                    b.ClearValue(Controls::Border::BackgroundProperty());
+                }
+            }
+        }
+    } catch (...) {
+    }
+    RemoveNamedDescendant(thumbView, kThumbNativeStyleMarker);
+}
+
+void ClearThumbnailHighlight(FrameworkElement thumbView) {
+    if (!thumbView) {
+        return;
+    }
+    try {
+        RemoveNamedDescendant(thumbView, kThumbGlowElementName);
+        RemoveNamedDescendant(thumbView, kThumbTitleBgName);
+        RemoveNamedDescendant(thumbView, kThumbTitleBarName);
+        ClearThumbnailNativeStyles(thumbView);
+        if (auto panel = thumbView.try_as<Controls::Panel>()) {
+            RemoveNamedChild(panel, kThumbGlowElementName);
+            RemoveNamedChild(panel, kThumbTitleBgName);
+            RemoveNamedChild(panel, kThumbTitleBarName);
+            RemoveNamedChild(panel, kThumbNativeStyleMarker);
+        }
+        auto hostPanel = GetThumbnailHostPanel(thumbView);
+        if (hostPanel) {
+            RemoveNamedChild(hostPanel, kThumbGlowElementName);
+            RemoveNamedChild(hostPanel, kThumbTitleBgName);
+            RemoveNamedChild(hostPanel, kThumbTitleBarName);
+            RemoveNamedChild(hostPanel, kThumbNativeStyleMarker);
+        }
+    } catch (...) {
+    }
+}
+
+void BringElementToFront(Controls::Panel panel, UIElement el) {
+    if (!panel || !el) {
+        return;
+    }
+    try {
+        auto children = panel.Children();
+        uint32_t idx = 0;
+        if (children.IndexOf(el, idx) && idx + 1 != children.Size()) {
+            children.RemoveAt(idx);
+            children.Append(el);
+        }
+    } catch (...) {
+    }
+}
+
+// Overlay host that must NOT affect parent layout.
+//
+// Thumbnail cards often use a Grid with rows (title | image). A normal child
+// lands in (0,0) — the title row — and expands that row (bar between icon and
+// text + card grows sideways). Same fix as icon glow: span every row/column
+// and Stretch to the arranged card size. Children are positioned with
+// RenderTransform so their layout slot stays tiny (Width×Height of the bar
+// only, transform ignored by measure).
+Controls::Grid EnsureThumbOverlayHost(Controls::Panel panel) {
+    FrameworkElement hostEl =
+        FindChildByName(panel.as<FrameworkElement>(), kThumbGlowElementName);
+    Controls::Grid host = hostEl ? hostEl.try_as<Controls::Grid>() : nullptr;
+    if (!host) {
+        PCWSTR xaml = LR"(
+            <Grid xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                  Name="WhRecentFocusThumbGlow"
+                  IsHitTestVisible="False"
+                  HorizontalAlignment="Stretch"
+                  VerticalAlignment="Stretch">
+                <Rectangle Name="WhRecentFocusThumbGlowL0"
+                           IsHitTestVisible="False" Visibility="Collapsed"/>
+                <Rectangle Name="WhRecentFocusThumbGlowL1"
+                           IsHitTestVisible="False" Visibility="Collapsed"/>
+                <Border Name="WhRecentFocusThumbTitleBg"
+                        IsHitTestVisible="False" Visibility="Collapsed"/>
+                <Rectangle Name="WhRecentFocusThumbTitleBar"
+                           IsHitTestVisible="False" Visibility="Collapsed"/>
+            </Grid>
+        )";
+        host = Markup::XamlReader::Load(xaml).as<Controls::Grid>();
+        panel.Children().Append(host);
+    }
+
+    // Critical: cover title+image rows, not just row 0 (title).
+    SpanHostOverPanel(host, panel);
+
+    host.ClearValue(FrameworkElement::WidthProperty());
+    host.ClearValue(FrameworkElement::HeightProperty());
+    host.ClearValue(FrameworkElement::MaxWidthProperty());
+    host.ClearValue(FrameworkElement::MaxHeightProperty());
+    host.MinWidth(0);
+    host.MinHeight(0);
+    host.Margin(Thickness{0, 0, 0, 0});
+    host.HorizontalAlignment(HorizontalAlignment::Stretch);
+    host.VerticalAlignment(VerticalAlignment::Stretch);
+    host.IsHitTestVisible(false);
+    ClearOurHostClip(host);
+    BringElementToFront(panel, host);
+    return host;
+}
+
+// Layout slot is width×height at (0,0); visual position is (x,y) via transform
+// so measure does not include the offset (avoids expanding the title row).
+void PlaceOverlayChild(FrameworkElement el,
+                       double x,
+                       double y,
+                       double width,
+                       double height) {
+    if (!el) {
+        return;
+    }
+    try {
+        el.HorizontalAlignment(HorizontalAlignment::Left);
+        el.VerticalAlignment(VerticalAlignment::Top);
+        el.Margin(Thickness{0, 0, 0, 0});
+        if (width > 0) {
+            el.Width(width);
+        } else {
+            el.ClearValue(FrameworkElement::WidthProperty());
+        }
+        if (height > 0) {
+            el.Height(height);
+        } else {
+            el.ClearValue(FrameworkElement::HeightProperty());
+        }
+        Media::TranslateTransform tf;
+        tf.X(x);
+        tf.Y(y);
+        el.RenderTransform(tf);
+        el.Visibility(Visibility::Visible);
+    } catch (...) {
+    }
+}
+
+void HideThumbOverlayChildren(Controls::Grid host) {
+    if (!host) {
+        return;
+    }
+    for (auto name : {kThumbGlowLayerNames[0], kThumbGlowLayerNames[1],
+                      kThumbTitleBgName, kThumbTitleBarName}) {
+        if (auto el = FindChildByName(host, name)) {
+            try {
+                el.Visibility(Visibility::Collapsed);
+                el.ClearValue(UIElement::RenderTransformProperty());
+                if (auto r = el.try_as<Shapes::Rectangle>()) {
+                    r.Stroke(nullptr);
+                    r.Fill(Media::SolidColorBrush{
+                        winrt::Windows::UI::Color{0, 0, 0, 0}});
+                }
+                if (auto b = el.try_as<Controls::Border>()) {
+                    b.Background(nullptr);
+                }
+                el.ClearValue(FrameworkElement::WidthProperty());
+                el.ClearValue(FrameworkElement::HeightProperty());
+                el.ClearValue(FrameworkElement::MarginProperty());
+            } catch (...) {
+            }
+        }
+    }
+}
+
+// Title bottom Y relative to `relativeTo` (prefer overlay host).
+// Returns false if transform looks unusable (layout not ready / wrong ancestor).
+bool GetTitleBottomRelative(FrameworkElement title,
+                            FrameworkElement relativeTo,
+                            double cardH,
+                            double& outTop,
+                            double& outBottom) {
+    outTop = outBottom = 0;
+    if (!title || !relativeTo) {
+        return false;
+    }
+    try {
+        try {
+            title.UpdateLayout();
+        } catch (...) {
+        }
+        double th = title.ActualHeight();
+        if (!(th > 1.0)) {
+            th = title.DesiredSize().Height;
+        }
+        if (!(th > 1.0)) {
+            return false;  // not laid out yet — caller should defer
+        }
+        auto xform = title.TransformToVisual(relativeTo);
+        auto topLeft = xform.TransformPoint(
+            winrt::Windows::Foundation::Point{0.f, 0.f});
+        auto bottomLeft = xform.TransformPoint(
+            winrt::Windows::Foundation::Point{0.f, static_cast<float>(th)});
+        // Reject nonsense (wrong ancestor / mid-layout).
+        if (topLeft.Y < -5.0f || topLeft.Y > cardH * 0.55) {
+            return false;
+        }
+        if (bottomLeft.Y < topLeft.Y + 4.0f || bottomLeft.Y > cardH * 0.60) {
+            return false;
+        }
+        outTop = static_cast<double>(topLeft.Y);
+        outBottom = static_cast<double>(bottomLeft.Y);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+// Deferred re-layout for titleBar/titleBg after the flyout finishes measuring.
+// At most one nested pass (avoids infinite Low-priority loops when title never
+// reports a size).
+std::atomic<bool> g_thumbRelayoutPending{false};
+std::atomic<int> g_thumbRelayoutDepth{0};
+
+void ScheduleThumbnailRelayout(FrameworkElement thumbView) {
+    if (!thumbView || g_thumbRelayoutDepth.load() > 0) {
+        return;  // already inside the deferred pass
+    }
+    if (g_thumbRelayoutPending.exchange(true)) {
+        return;
+    }
+    try {
+        auto dispatcher = thumbView.Dispatcher();
+        if (!dispatcher) {
+            g_thumbRelayoutPending = false;
+            return;
+        }
+        winrt::weak_ref<FrameworkElement> weak =
+            winrt::make_weak(thumbView);
+        // Low priority so it runs after the current layout pass.
+        dispatcher.RunAsync(
+            winrt::Windows::UI::Core::CoreDispatcherPriority::Low,
+            [weak]() {
+                g_thumbRelayoutPending = false;
+                try {
+                    FrameworkElement el = weak.get();
+                    if (!el || g_unloading.load()) {
+                        return;
+                    }
+                    g_thumbRelayoutDepth = 1;
+                    RefreshThumbnailFlyout_UIThread(el);
+                    g_thumbRelayoutDepth = 0;
+                } catch (...) {
+                    g_thumbRelayoutDepth = 0;
+                }
+            });
+    } catch (...) {
+        g_thumbRelayoutPending = false;
+    }
+}
+
+void ApplyThumbnailHighlight(FrameworkElement thumbView, int rankOneBased) {
+    if (!thumbView || rankOneBased <= 0 || g_unloading.load() ||
+        !SettingsSnap()->enabled || !SettingsSnap()->previewHighlightEnabled) {
+        ClearThumbnailHighlight(thumbView);
+        return;
+    }
+
+    try {
+        // Start clean so style switches don't leave mixed chrome.
+        ClearThumbnailHighlight(thumbView);
+
+        auto panel = GetThumbnailHostPanel(thumbView);
+        if (!panel) {
+            return;
+        }
+        auto panelFe = panel.as<FrameworkElement>();
+
+        const int intensity = PreviewRankIntensity(rankOneBased - 1);
+        const double t = intensity / 100.0;
+        winrt::Windows::UI::Color base = ResolveGlowBaseColor();
+        auto withAlpha = [](winrt::Windows::UI::Color c, int a) {
+            c.A = static_cast<uint8_t>((std::max)(0, (std::min)(255, a)));
+            return c;
+        };
+
+        const double thickness = static_cast<double>(
+            (std::max)(2, (std::min)(8, SettingsSnap()->glowThickness)));
+        const double roundnessFrac =
+            (std::max)(0, (std::min)(50, SettingsSnap()->glowRoundness)) / 100.0;
+        // Preview plate / titleBg use dedicated opacity (not taskbar fill).
+        const int fillOpacitySetting =
+            (std::max)(0, (std::min)(100, SettingsSnap()->previewFillOpacity));
+        const PreviewStyle style = SettingsSnap()->previewStyle;
+        // Hybrid: plate is the rank-1 “this one” signal; title wash is enough
+        // for 2+ (whole-plate 50/5 looks like leftover hover, not a ladder).
+        PreviewStyle paintStyle = style;
+        if (style == PreviewStyle::PlateTitle) {
+            paintStyle = (rankOneBased <= 1) ? PreviewStyle::Plate
+                                             : PreviewStyle::TitleBg;
+        }
+
+        // Measure card BEFORE injecting any overlay (critical for layout).
+        double cardW = 0, cardH = 0;
+        try {
+            cardW = panelFe.ActualWidth();
+            cardH = panelFe.ActualHeight();
+            if (!(cardW > 1.0)) {
+                cardW = thumbView.ActualWidth();
+            }
+            if (!(cardH > 1.0)) {
+                cardH = thumbView.ActualHeight();
+            }
+        } catch (...) {
+        }
+        const bool cardSizeFallback = !(cardW > 1.0) || !(cardH > 1.0);
+        if (!(cardW > 1.0)) {
+            cardW = 180.0;
+        }
+        if (!(cardH > 1.0)) {
+            cardH = 120.0;
+        }
+        // 180×120 means layout not ready — bar placement will be wrong until
+        // the deferred remeasure runs.
+        if (cardSizeFallback) {
+            ScheduleThumbnailRelayout(thumbView);
+        }
+
+        auto title = FindThumbnailTitleElement(thumbView);
+
+        // Prefer BackgroundBorder size — more stable mid-layout.
+        if (auto bb = FindThumbnailBackgroundBorder(thumbView)) {
+            try {
+                double bw = bb.ActualWidth();
+                double bh = bb.ActualHeight();
+                if (bw > 1.0) {
+                    cardW = bw;
+                }
+                if (bh > 1.0) {
+                    cardH = bh;
+                }
+            } catch (...) {
+            }
+        }
+
+        // Plate prefers native BackgroundBorder (no layout child).
+        if (paintStyle == PreviewStyle::Plate) {
+            bool usedNative = false;
+            if (auto borderEl = FindThumbnailBackgroundBorder(thumbView)) {
+                try {
+                    if (auto border = borderEl.try_as<Controls::Border>()) {
+                        winrt::Windows::Foundation::IInspectable savedBg;
+                        auto local = border.ReadLocalValue(
+                            Controls::Border::BackgroundProperty());
+                        if (local != DependencyProperty::UnsetValue()) {
+                            savedBg = border.Background();
+                        }
+                        auto marker = MakeThumbNativeMarker(savedBg);
+                        if (marker) {
+                            const int fillA = static_cast<int>(
+                                fillOpacitySetting * 2.55 *
+                                (0.45 + 0.55 * t));
+                            border.Background(Media::SolidColorBrush{
+                                withAlpha(base, fillA)});
+                            panel.Children().Append(marker);
+                            usedNative = true;
+                        }
+                    }
+                } catch (...) {
+                }
+            }
+            if (!usedNative) {
+                Controls::Grid host = EnsureThumbOverlayHost(panel);
+                HideThumbOverlayChildren(host);
+                if (auto plate = FindChildByName(host, kThumbGlowLayerNames[0])
+                                     .try_as<Shapes::Rectangle>()) {
+                    const int fillA = static_cast<int>(
+                        fillOpacitySetting * 2.55 * (0.45 + 0.55 * t));
+                    plate.Fill(Media::SolidColorBrush{withAlpha(base, fillA)});
+                    plate.Stroke(nullptr);
+                    plate.StrokeThickness(0);
+                    plate.RadiusX(cardW * roundnessFrac * 0.12);
+                    plate.RadiusY(cardH * roundnessFrac * 0.12);
+                    plate.Opacity(0.85 + 0.15 * t);
+                    PlaceOverlayChild(plate, 0, 0, cardW, cardH);
+                }
+            }
+
+            if (SettingsSnap()->glowDebugLog) {
+                Wh_Log(L"Preview glow rank %d style=%s paint=%s intensity=%d "
+                       L"on \"%s\"",
+                       rankOneBased, PreviewStyleName(style),
+                       PreviewStyleName(paintStyle), intensity,
+                       Automation::AutomationProperties::GetName(thumbView)
+                           .c_str());
+            }
+            return;
+        }
+
+        Controls::Grid host = EnsureThumbOverlayHost(panel);
+        HideThumbOverlayChildren(host);
+
+        if (paintStyle == PreviewStyle::Ring) {
+            const double inset = 3.0;
+            const double corner =
+                (std::max)(12.0, (std::min)(cardW, cardH) - 2.0 * inset) *
+                roundnessFrac;
+
+            for (int i = 0; i < 2; ++i) {
+                auto rect = FindChildByName(host, kThumbGlowLayerNames[i])
+                                .try_as<Shapes::Rectangle>();
+                if (!rect) {
+                    continue;
+                }
+                const double step = i == 0 ? 0.0 : 3.0;
+                const double layerInset = inset + step;
+                const int strokeA =
+                    static_cast<int>((140 + 100 * t) * (1.0 - 0.2 * i));
+                const double opacity = 0.75 + 0.25 * t;
+                const double th =
+                    (std::max)(1.5, thickness * (1.0 - 0.15 * i));
+                const double size = (std::max)(
+                    8.0, (std::min)(cardW, cardH) - 2.0 * layerInset);
+                rect.Stroke(Media::SolidColorBrush{withAlpha(base, strokeA)});
+                rect.StrokeThickness(th);
+                rect.Fill(Media::SolidColorBrush{
+                    winrt::Windows::UI::Color{0, 0, 0, 0}});
+                rect.RadiusX(corner + step);
+                rect.RadiusY(corner + step);
+                rect.Opacity(opacity);
+                PlaceOverlayChild(rect, layerInset, layerInset, size, size);
+            }
+        } else if (paintStyle == PreviewStyle::TitleBg) {
+            double top = 4.0;
+            double stripH = 28.0;
+            double titleTop = 0, titleBottom = 0;
+            bool laidOut = GetTitleBottomRelative(title, host, cardH, titleTop,
+                                                  titleBottom);
+            if (laidOut) {
+                top = (std::max)(2.0, titleTop - 3.0);
+                stripH = (std::max)(20.0, titleBottom - top + 4.0);
+            } else {
+                // Layout not ready — default strip + one deferred remeasure.
+                ScheduleThumbnailRelayout(thumbView);
+            }
+            const double hPad = 8.0;
+            const double stripW = (std::max)(24.0, cardW - 2.0 * hPad);
+
+            auto chip =
+                FindChildByName(host, kThumbTitleBgName).try_as<Controls::Border>();
+            if (chip) {
+                // Soft wash above title glyphs. Rank-1 alpha follows tint
+                // opacity; lower ranks scale linearly with intensity. The old
+                // (0.55+0.45*t) floor made 100 vs 5 look almost the same.
+                const int maxA = (std::max)(
+                    16, (std::min)(140, static_cast<int>(
+                                            14 + fillOpacitySetting * 1.15)));
+                const int chipA = (std::max)(8, static_cast<int>(maxA * t));
+                chip.Background(Media::SolidColorBrush{withAlpha(base, chipA)});
+                chip.CornerRadius(CornerRadius{stripH * 0.35});
+                chip.Opacity(1.0);
+                PlaceOverlayChild(chip, hPad, top, stripW, stripH);
+            }
+        } else {  // TitleBar — underline just under the title glyphs
+            // Prefer transform relative to host (same coordinate space as
+            // PlaceOverlayChild). Small gap under baseline — enough to avoid
+            // strikethrough, not so much that the bar hugs the thumbnail image.
+            constexpr double kGapBelowTitle = 2.0;
+            double top = 30.0;  // fallback under a ~28px header
+            double titleTop = 0, titleBottom = 0;
+            bool laidOut = GetTitleBottomRelative(title, host, cardH, titleTop,
+                                                  titleBottom);
+            if (laidOut) {
+                top = titleBottom + kGapBelowTitle;
+            } else {
+                ScheduleThumbnailRelayout(thumbView);
+            }
+            top = (std::max)(18.0, (std::min)(top, cardH * 0.38));
+
+            const double barH =
+                (std::max)(2.0, (std::min)(5.0, thickness + 0.5));
+            const double hPad = 10.0;
+            const double barW = (std::max)(24.0, cardW - 2.0 * hPad);
+
+            auto bar = FindChildByName(host, kThumbTitleBarName)
+                           .try_as<Shapes::Rectangle>();
+            if (bar) {
+                // Wider alpha range than the old rank-1-only bar so flyout
+                // ranks read as a ladder; t=1 stays fully opaque accent.
+                const int fillA = static_cast<int>(90 + 165 * t);
+                bar.Fill(Media::SolidColorBrush{withAlpha(base, fillA)});
+                bar.Stroke(nullptr);
+                bar.StrokeThickness(0);
+                bar.RadiusX(barH * 0.5);
+                bar.RadiusY(barH * 0.5);
+                bar.Opacity(0.50 + 0.50 * t);
+                PlaceOverlayChild(bar, hPad, top, barW, barH);
+            }
+        }
+
+        if (SettingsSnap()->glowDebugLog) {
+            Wh_Log(L"Preview glow rank %d style=%s paint=%s intensity=%d "
+                   L"card=%.0fx%.0f on \"%s\"",
+                   rankOneBased, PreviewStyleName(style),
+                   PreviewStyleName(paintStyle), intensity, cardW, cardH,
+                   Automation::AutomationProperties::GetName(thumbView)
+                       .c_str());
+        }
+    } catch (...) {
+        HRESULT hr = winrt::to_hresult();
+        Wh_Log(L"ApplyThumbnailHighlight error %08X", hr);
+    }
+}
+
+void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
+    if (!anyThumb) {
+        return;
+    }
+    TrackThumbView_UIThread(anyThumb);
+
+    auto allViews = CollectSiblingThumbnailViews(anyThumb);
+    if (!SettingsSnap()->enabled || !SettingsSnap()->previewHighlightEnabled ||
+        g_unloading.load()) {
+        for (auto& s : allViews) {
+            ClearThumbnailHighlight(s);
+        }
+        return;
+    }
+
+    // Snap-group cards sit in the same ItemsRepeater as the windows
+    // (UWPSpy: PositionInSet 1/4 = "Group | Lister - [file] and 1 other
+    // window"). Never glow those; they are not a window HWND.
+    std::vector<FrameworkElement> siblings;
+    siblings.reserve(allViews.size());
+    for (auto& v : allViews) {
+        if (IsSnapGroupThumbnailView(v)) {
+            ClearThumbnailHighlight(v);
+        } else {
+            siblings.push_back(v);
+        }
+    }
+
+    // Product rule: only multi-window flyouts (group card does not count).
+    if (siblings.size() <= 1) {
+        for (auto& s : siblings) {
+            ClearThumbnailHighlight(s);
+        }
+        return;
+    }
+
+    SortThumbnailViewsVisualOrder(siblings);
+    const std::vector<std::wstring> cardTitles = PickFlyoutCardTitles(siblings);
+
+    // HWND pipeline (this flyout only — not a global window ladder):
+    //   1. TaskItem — DataContext ↔ ctor map (COM identity).
+    //   2. Group-order — live mappings for this hover, not the previous one.
+    //      Dropped when card titles are distinct (index ≠ visual after a click).
+    //   3. Title unique — DisplayNameTextBlock when texts differ; each HWND once.
+    // Then sort by recency tick / confirmSeq and paint top N.
+    enum class ResolveHow : int { None = 0, TaskItem, GroupOrder, Title };
+    struct Scored {
+        FrameworkElement view{nullptr};
+        HWND hwnd = nullptr;
+        ULONGLONG tick = 0;
+        ResolveHow how = ResolveHow::None;
+        int rank = 0;  // 1-based flyout rank; 0 = not highlighted
+    };
+    std::vector<Scored> scored(siblings.size());
+    std::unordered_set<HWND> usedHwnds;
+    void* sharedGroup = nullptr;
+
+    auto recent = CopyRecentWindowsForPreview();
+
+    auto tickFor = [](HWND hwnd) -> ULONGLONG {
+        ULONGLONG tick = 0;
+        if (!hwnd) {
+            return 0;
+        }
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        IsWindowRecentForPreviewLocked(CurrentDeskLocked(), hwnd, &tick);
+        return tick;
+    };
+    auto seqFor = [](HWND hwnd) -> ULONGLONG {
+        if (!hwnd) {
+            return 0;
+        }
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        auto& map = CurrentDeskLocked().windowFocusMap;
+        auto it = map.find(hwnd);
+        if (it == map.end()) {
+            return 0;
+        }
+        return it->second.confirmSeq;
+    };
+
+    // Pass 1: strong identity (TaskItemThumbnail model → HWND). Never use bare
+    // title here — two Calibre windows with the same file name would both bind
+    // to the same HWND.
+    for (size_t i = 0; i < siblings.size(); ++i) {
+        TrackThumbView_UIThread(siblings[i]);
+        scored[i].view = siblings[i];
+        void* group = nullptr;
+        HWND hwnd = ResolveHwndForThumbnailView(siblings[i], &group);
+        if (group && !sharedGroup) {
+            sharedGroup = group;
+        }
+        if (hwnd && IsWindow(hwnd) && !usedHwnds.count(hwnd)) {
+            scored[i].hwnd = hwnd;
+            scored[i].tick = tickFor(hwnd);
+            scored[i].how = ResolveHow::TaskItem;
+            usedHwnds.insert(hwnd);
+        }
+    }
+
+    // Pass 1b: fill from TaskItem maps by group / construction order.
+    // DataContext often does NOT match our ctor IInspectable (logs showed
+    // "2 taskitem maps" but how=title/none) — so discover the group even
+    // when pass 1 resolved nothing.
+    if (usedHwnds.size() < siblings.size()) {
+        void* group = sharedGroup;
+        if (!group) {
+            std::lock_guard<std::mutex> lock(g_thumbnailMapMutex);
+            for (const auto& item : g_thumbnailTaskItemMapping) {
+                HWND h = HwndFromMappingEntry(item);
+                if (h && usedHwnds.count(h) && item.taskGroup) {
+                    group = item.taskGroup;
+                    break;
+                }
+            }
+        }
+        if (!group) {
+            group = FindTaskGroupForSiblingCount(siblings.size());
+        }
+
+        std::vector<HWND> groupHwnds = HwndsForTaskGroupInOrder(group);
+        // Fallback: last N mapped HWNDs (just-created flyout models).
+        if (groupHwnds.size() != siblings.size()) {
+            auto last = LastMappedHwnds(siblings.size());
+            if (last.size() == siblings.size()) {
+                groupHwnds = std::move(last);
+            }
+        }
+        // Do NOT EnumWindows-expand here and then assign by index.
+        // Z-order (focused window first) is not left-to-right flyout order —
+        // that pinned the recent Lister HWND onto card 0 every time.
+
+        if (groupHwnds.size() == siblings.size()) {
+            // Prefer map order for ALL siblings when counts match — more
+            // reliable than leaving a half-filled title match in place.
+            // Only overwrite title-resolved slots when they have no taskitem id.
+            bool anyTaskItem = false;
+            for (const auto& s : scored) {
+                if (s.how == ResolveHow::TaskItem) {
+                    anyTaskItem = true;
+                    break;
+                }
+            }
+            if (!anyTaskItem) {
+                usedHwnds.clear();
+                for (size_t i = 0; i < siblings.size(); ++i) {
+                    HWND h = groupHwnds[i];
+                    scored[i].hwnd = h;
+                    scored[i].tick = tickFor(h);
+                    scored[i].how = ResolveHow::GroupOrder;
+                    if (h) {
+                        usedHwnds.insert(h);
+                    }
+                }
+            } else {
+                for (size_t i = 0; i < siblings.size(); ++i) {
+                    if (scored[i].hwnd) {
+                        continue;
+                    }
+                    HWND h = groupHwnds[i];
+                    if (!h || usedHwnds.count(h)) {
+                        continue;
+                    }
+                    scored[i].hwnd = h;
+                    scored[i].tick = tickFor(h);
+                    scored[i].how = ResolveHow::GroupOrder;
+                    usedHwnds.insert(h);
+                }
+            }
+        } else if (!groupHwnds.empty()) {
+            size_t gi = 0;
+            for (size_t i = 0; i < siblings.size() && gi < groupHwnds.size();
+                 ++i) {
+                if (scored[i].hwnd) {
+                    continue;
+                }
+                while (gi < groupHwnds.size() &&
+                       usedHwnds.count(groupHwnds[gi])) {
+                    ++gi;
+                }
+                if (gi >= groupHwnds.size()) {
+                    break;
+                }
+                HWND h = groupHwnds[gi++];
+                scored[i].hwnd = h;
+                scored[i].tick = tickFor(h);
+                scored[i].how = ResolveHow::GroupOrder;
+                usedHwnds.insert(h);
+            }
+        }
+    }
+
+    // Title pool: recency map plus live same-class windows (TLister a/b/c).
+    // Enumerated HWNDs are candidates only — never assigned by index.
+    std::vector<HWND> titleSeeds;
+    for (const auto& r : recent) {
+        if (r.hwnd) {
+            titleSeeds.push_back(r.hwnd);
+        }
+    }
+    for (const auto& s : scored) {
+        if (s.hwnd) {
+            titleSeeds.push_back(s.hwnd);
+        }
+    }
+    std::vector<WindowFocusInfo> titlePool = recent;
+    {
+        std::unordered_set<HWND> have;
+        for (const auto& r : titlePool) {
+            if (r.hwnd) {
+                have.insert(r.hwnd);
+            }
+        }
+        for (HWND h : ExpandSameClassWindows(titleSeeds)) {
+            if (!h || have.count(h)) {
+                continue;
+            }
+            WindowFocusInfo extra;
+            extra.hwnd = h;
+            extra.windowTitle = GetWindowTitle(h);
+            extra.lastConfirmedTick = tickFor(h);
+            titlePool.push_back(std::move(extra));
+            have.insert(h);
+        }
+    }
+
+    const bool titlesDistinct = TitleKeysAreDistinct(cardTitles);
+
+    auto hwndTitle = [](HWND hwnd) -> std::wstring {
+        return hwnd && IsWindow(hwnd) ? GetWindowTitle(hwnd) : std::wstring{};
+    };
+
+    // Unique titles beat index assignment. Also drop a TaskItem HWND that
+    // clearly belongs to a *different* card (ebook reader: DataContext /
+    // stale map points at the other book in the same process).
+    if (titlesDistinct) {
+        for (size_t i = 0; i < scored.size(); ++i) {
+            if (!scored[i].hwnd) {
+                continue;
+            }
+            const bool dropGroup = scored[i].how == ResolveHow::GroupOrder;
+            int selfScore = ScoreTitleToAutomationName(hwndTitle(scored[i].hwnd),
+                                                       cardTitles[i]);
+            int bestOther = 0;
+            for (size_t j = 0; j < cardTitles.size(); ++j) {
+                if (j == i) {
+                    continue;
+                }
+                bestOther = (std::max)(
+                    bestOther, ScoreTitleToAutomationName(
+                                   hwndTitle(scored[i].hwnd), cardTitles[j]));
+            }
+            const bool belongsElsewhere =
+                bestOther >= 70 && bestOther > selfScore;
+            if (dropGroup || belongsElsewhere) {
+                usedHwnds.erase(scored[i].hwnd);
+                scored[i].hwnd = nullptr;
+                scored[i].tick = 0;
+                scored[i].how = ResolveHow::None;
+            }
+        }
+    }
+
+    // Pass 2: title fallback with unique HWND assignment only.
+    for (size_t i = 0; i < siblings.size(); ++i) {
+        if (scored[i].hwnd) {
+            continue;
+        }
+        std::wstring autoName = cardTitles[i];
+        HWND h = MatchTitleToUnusedRecent(autoName, titlePool, usedHwnds);
+        if (h) {
+            scored[i].hwnd = h;
+            scored[i].tick = tickFor(h);
+            if (scored[i].tick == 0) {
+                // Live window not yet in recency map — still use its title
+                // tick from the pool entry if we recorded one.
+                for (const auto& info : titlePool) {
+                    if (info.hwnd == h && info.lastConfirmedTick > 0) {
+                        scored[i].tick = info.lastConfirmedTick;
+                        break;
+                    }
+                }
+            }
+            scored[i].how = ResolveHow::Title;
+            usedHwnds.insert(h);
+        }
+    }
+
+    // Pass 3: ITaskItem HWND and EVENT_SYSTEM_FOREGROUND HWND can differ
+    // (owned Lister windows, tab proxies). Copy recency from a same-PID
+    // recent window when the card's HWND itself has tick 0.
+    for (size_t i = 0; i < scored.size(); ++i) {
+        if (!scored[i].hwnd || scored[i].tick > 0) {
+            continue;
+        }
+        DWORD cardPid = 0;
+        GetWindowThreadProcessId(scored[i].hwnd, &cardPid);
+        if (!cardPid) {
+            continue;
+        }
+
+        std::wstring autoName = cardTitles[i];
+
+        int bestScore = 0;
+        ULONGLONG bestTick = 0;
+        for (const auto& info : recent) {
+            if (!info.hwnd) {
+                continue;
+            }
+            DWORD rpid = 0;
+            GetWindowThreadProcessId(info.hwnd, &rpid);
+            if (rpid != cardPid) {
+                continue;
+            }
+            int s = 0;
+            if (!autoName.empty()) {
+                s = ScoreTitleToAutomationName(info.windowTitle, autoName);
+                if (s < 70) {
+                    s = (std::max)(
+                        s, ScoreTitleToAutomationName(GetWindowTitle(info.hwnd),
+                                                      autoName));
+                }
+            }
+            if (s > bestScore) {
+                bestScore = s;
+                bestTick = info.lastConfirmedTick;
+            }
+        }
+        // Require a unique title/path (96+). Score 85 prefix would copy the
+        // latest Lister tick onto a.txt AND c.txt, then card 0 always wins.
+        if (bestScore >= 96) {
+            scored[i].tick = bestTick;
+        }
+    }
+
+    // Rank this flyout only (not a global window ladder). Sort siblings that
+    // have a recency tick; ties: confirmSeq, then the live foreground HWND.
+    HWND foreground = GetForegroundWindow();
+    std::vector<size_t> order;
+    order.reserve(scored.size());
+    for (size_t i = 0; i < scored.size(); ++i) {
+        if (scored[i].hwnd && scored[i].tick > 0) {
+            order.push_back(i);
+        }
+    }
+    std::sort(order.begin(), order.end(), [&](size_t a, size_t b) {
+        if (scored[a].tick != scored[b].tick) {
+            return scored[a].tick > scored[b].tick;
+        }
+        const ULONGLONG sa = seqFor(scored[a].hwnd);
+        const ULONGLONG sb = seqFor(scored[b].hwnd);
+        if (sa != sb) {
+            return sa > sb;
+        }
+        const bool aFg = scored[a].hwnd == foreground;
+        const bool bFg = scored[b].hwnd == foreground;
+        if (aFg != bFg) {
+            return aFg;
+        }
+        return a < b;
+    });
+
+    const int limit = (std::max)(0, SettingsSnap()->previewHighlightCount);
+    for (size_t r = 0; r < order.size() && static_cast<int>(r) < limit; ++r) {
+        scored[order[r]].rank = static_cast<int>(r) + 1;
+    }
+
+    if (SettingsSnap()->glowDebugLog) {
+        size_t mapCount = 0;
+        {
+            std::lock_guard<std::mutex> lock(g_thumbnailMapMutex);
+            mapCount = g_thumbnailTaskItemMapping.size();
+        }
+        const size_t painted =
+            (std::min)(order.size(), static_cast<size_t>(limit));
+        Wh_Log(L"Preview resolve: %zu siblings, %zu taskitem maps, "
+               L"highlightCount=%d candidates=%zu painted=%zu",
+               siblings.size(), mapCount, limit, order.size(), painted);
+        for (size_t i = 0; i < scored.size(); ++i) {
+            PCWSTR how = L"none";
+            switch (scored[i].how) {
+                case ResolveHow::TaskItem:
+                    how = L"taskitem";
+                    break;
+                case ResolveHow::GroupOrder:
+                    how = L"group-order";
+                    break;
+                case ResolveHow::Title:
+                    how = L"title";
+                    break;
+                default:
+                    break;
+            }
+            std::wstring name;
+            try {
+                name = Automation::AutomationProperties::GetName(scored[i].view)
+                           .c_str();
+            } catch (...) {
+            }
+            Wh_Log(L"  sibling[%zu]: hwnd=%p tick=%llu how=%s rank=%d%s "
+                   L"name=\"%s\" card=\"%s\"",
+                   i, scored[i].hwnd,
+                   static_cast<unsigned long long>(scored[i].tick), how,
+                   scored[i].rank,
+                   scored[i].rank > 0 ? L" [GLOW]" : L"", name.c_str(),
+                   (i < cardTitles.size()) ? cardTitles[i].c_str() : L"");
+        }
+    }
+
+    for (size_t i = 0; i < scored.size(); ++i) {
+        if (scored[i].rank > 0) {
+            ApplyThumbnailHighlight(scored[i].view, scored[i].rank);
+        } else {
+            ClearThumbnailHighlight(scored[i].view);
+        }
+    }
+}
+
+void ClearAllThumbnailHighlights_UIThread() {
+    std::vector<winrt::weak_ref<FrameworkElement>> thumbs;
+    {
+        std::lock_guard<std::mutex> lock(g_thumbViewsMutex);
+        thumbs = g_trackedThumbViews;
+    }
+    ForEachLiveElementOnThisDispatcher(
+        thumbs, [](FrameworkElement el) { ClearThumbnailHighlight(el); });
+}
+
+void RequestApplyPreviewVisuals() {
+    if (g_unloading.load()) {
+        return;
+    }
+    // Same as RequestApplyVisuals: if no dispatcher yet, wait for the first
+    // TaskListButton / thumbnail OnApplyTemplate. Do not PostMessage to this
+    // focus thread — the WM_APP_REQUEST_PREVIEW_APPLY handler used to call
+    // this again, which spun at 100% CPU and starved WM_TIMER.
+    RunOnUiThread([]() {
+        std::vector<winrt::weak_ref<FrameworkElement>> thumbs;
+        {
+            std::lock_guard<std::mutex> lock(g_thumbViewsMutex);
+            thumbs = g_trackedThumbViews;
+        }
+        ForEachLiveElementOnThisDispatcher(thumbs, [](FrameworkElement el) {
+            RefreshThumbnailFlyout_UIThread(el);
+        });
+    });
+}
+
+// Expected at startup before any TaskListButton is seen — log once, not per call.
+std::atomic<bool> g_loggedNoDispatcherAnchor{false};
+
+std::vector<winrt::Windows::UI::Core::CoreDispatcher> CollectUiDispatchers() {
+    std::vector<winrt::Windows::UI::Core::CoreDispatcher> dispatchers;
+    auto addDispatcher = [&](FrameworkElement el) {
+        if (!el) {
+            return;
+        }
+        try {
+            auto dispatcher = el.Dispatcher();
+            if (!dispatcher) {
+                return;
+            }
+            for (const auto& existing : dispatchers) {
+                if (existing == dispatcher) {
+                    return;
+                }
+            }
+            dispatchers.push_back(dispatcher);
+        } catch (...) {
+        }
+    };
+
+    {
+        std::lock_guard<std::mutex> lock(g_buttonsMutex);
+        try {
+            addDispatcher(g_dispatcherAnchor.get());
+        } catch (...) {
+        }
+        for (auto& weak : g_trackedButtons) {
+            try {
+                addDispatcher(weak.get());
+            } catch (...) {
+            }
+        }
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_thumbViewsMutex);
+        for (auto& weak : g_trackedThumbViews) {
+            try {
+                addDispatcher(weak.get());
+            } catch (...) {
+            }
+        }
+    }
+    std::vector<winrt::weak_ref<FrameworkElement>> layoutPanels;
+    {
+        std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
+        for (auto& w : g_layoutWatches) {
+            layoutPanels.push_back(w.panel);
+        }
+    }
+    for (auto& weak : layoutPanels) {
+        try {
+            addDispatcher(weak.get());
+        } catch (...) {
+        }
+    }
+    return dispatchers;
+}
+
+// Uninit: run handler at High, then wait for a Low sentinel so earlier
+// Normal TryRunAsync work (which no-ops on g_unloading) has drained.
+bool RunOnEachUiDispatcherAndWait(
+    const winrt::Windows::UI::Core::DispatchedHandler& handler,
+    DWORD timeoutMs) {
+    auto dispatchers = CollectUiDispatchers();
+    if (dispatchers.empty()) {
+        Wh_Log(L"UI cleanup: no dispatcher");
+        return true;
+    }
+    bool allOk = true;
+    for (auto& dispatcher : dispatchers) {
+        try {
+            if (dispatcher.HasThreadAccess()) {
+                handler();
+                continue;
+            }
+            HANDLE done = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+            if (!done) {
+                allOk = false;
+                continue;
+            }
+            bool posted = false;
+            bool drainPosted = false;
+            try {
+                posted = static_cast<bool>(dispatcher.TryRunAsync(
+                    winrt::Windows::UI::Core::CoreDispatcherPriority::High,
+                    handler));
+                drainPosted = static_cast<bool>(dispatcher.TryRunAsync(
+                    winrt::Windows::UI::Core::CoreDispatcherPriority::Low,
+                    [done]() { SetEvent(done); }));
+            } catch (...) {
+            }
+            if (!posted) {
+                allOk = false;
+            }
+            if (!drainPosted) {
+                SetEvent(done);
+                allOk = false;
+            }
+            const DWORD w = WaitForSingleObject(done, timeoutMs);
+            if (w == WAIT_OBJECT_0) {
+                CloseHandle(done);
+            } else {
+                // Low sentinel may still run — do not CloseHandle.
+                Wh_Log(L"ERROR: UI dispatcher cleanup timed out (%ums)",
+                       timeoutMs);
+                allOk = false;
+            }
+        } catch (...) {
+            allOk = false;
+            Wh_Log(L"ERROR: UI dispatcher cleanup failed");
+        }
+    }
+    return allOk;
+}
+
+bool RunOnUiThread(const winrt::Windows::UI::Core::DispatchedHandler& handler) {
+    auto dispatchers = CollectUiDispatchers();
+
+    if (dispatchers.empty()) {
+        // App + preview apply both hit this before the first button hook.
+        if (!g_loggedNoDispatcherAnchor.exchange(true)) {
+            Wh_Log(L"RunOnUiThread: no dispatcher anchor yet (no buttons seen) "
+                   L"— will apply on first TaskListButton");
+        }
+        return false;
+    }
+
+    bool any = false;
+    for (auto& dispatcher : dispatchers) {
+        try {
+            if (dispatcher.HasThreadAccess()) {
+                handler();
+                any = true;
+                continue;
+            }
+            if (dispatcher.TryRunAsync(
+                    winrt::Windows::UI::Core::CoreDispatcherPriority::Normal,
+                    handler)) {
+                any = true;
+            }
+        } catch (...) {
+            HRESULT hr = winrt::to_hresult();
+            Wh_Log(L"RunOnUiThread error %08X", hr);
+        }
+    }
+    return any;
+}
+
+void RequestApplyVisuals() {
+    // Prefer UI-thread apply; also keep logging from caller context.
+    if (!RunOnUiThread([]() { ApplyAllHighlights_UIThread(); })) {
+        // Buttons not tracked yet — will apply on next UpdateVisualStates.
+        // Avoid rank dump spam at startup (preview + app both request apply).
+        if (SettingsSnap()->glowDebugLog) {
+            std::lock_guard<std::mutex> lock(g_stateMutex);
+            const auto& ranks = CurrentDeskLocked().rankedApps;
+            Wh_Log(L"Ranks ready (%zu) — waiting for TaskListButton hooks",
+                   ranks.size());
+            for (size_t i = 0; i < ranks.size(); i++) {
+                Wh_Log(L"  Rank %zu: %s", i + 1, ranks[i].displayName.c_str());
+            }
+        }
+    }
+}
+
+void ApplyVisualHighlights() {
+    // Legacy entry used by timers / focus path.
+    RequestApplyVisuals();
+}
+
+// ---------------------------------------------------------------------------
+// Taskbar.View.dll hooks
+// ---------------------------------------------------------------------------
+
+using TaskListButton_UpdateVisualStates_t = void(WINAPI*)(void* pThis);
+TaskListButton_UpdateVisualStates_t TaskListButton_UpdateVisualStates_Original;
+
+FrameworkElement TaskListButtonElementFromThis(void* pThis) {
+    FrameworkElement element = nullptr;
+    // implementation* layout: IUnknown at pThis+3 (same as other taskbar mods).
+    ((IUnknown*)pThis + 3)
+        ->QueryInterface(winrt::guid_of<FrameworkElement>(),
+                         winrt::put_abi(element));
+    return element;
+}
+
+// Re-paint one button from the last full bind. Does not re-score identity —
+// hover UpdateVisualStates would otherwise O(buttons×ranks) every mouse-over.
+void RefreshButtonHighlight(FrameworkElement button) {
+    if (!button || g_unloading.load()) {
+        return;
+    }
+
+    if (g_pendingOverlaySweep.load() || !SettingsSnap()->enabled) {
+        ClearButtonHighlight(button);
+        return;
+    }
+
+    int rank = GetCachedPaintRank(button);
+    if (rank < 0) {
+        std::vector<AppFocusInfo> ranks;
+        {
+            std::lock_guard<std::mutex> lock(g_stateMutex);
+            ranks = CurrentDeskLocked().rankedApps;
+        }
+        if (ranks.empty()) {
+            SetCachedPaintRank(button, 0);
+            ClearButtonHighlight(button);
+            return;
+        }
+        if (TaskListButton_IsRunning(button) && IsVisualStateActive(button)) {
+            StoreAutomationNameIfFits(ranks[0], GetButtonAutomationName(button));
+        }
+        rank = FindRankForButton(button, ranks, /*requireRunning=*/true);
+        SetCachedPaintRank(button, rank);
+    }
+
+    if (rank > 0) {
+        ApplyButtonHighlight(button, rank);
+    } else {
+        ClearButtonHighlight(button);
+    }
+}
+
+// Full identity rebind. Hover UVS paints the cached rank immediately; this
+// pass restores siblings whose visuals Windows reset without another UVS.
+// Per dispatcher so primary and secondary taskbars do not throttle each other.
+void ScheduleRefreshAllHighlights(FrameworkElement dispatcherAnchor) {
+    if (!dispatcherAnchor) {
+        return;
+    }
+    try {
+        winrt::weak_ref<FrameworkElement> weak =
+            winrt::make_weak(dispatcherAnchor);
+        dispatcherAnchor.Dispatcher().TryRunAsync(
+            winrt::Windows::UI::Core::CoreDispatcherPriority::Low,
+            [weak]() {
+                try {
+                    const ULONGLONG now = GetTickCount64();
+                    if (now - g_lastFullRefreshTick < kFullRebindDebounceMs &&
+                        g_lastFullRefreshTick != 0) {
+                        // Coalesce a trailing full bind after the hover storm
+                        // so siblings Windows reset without UVS get restored.
+                        if (g_hookThreadHwnd) {
+                            SetTimer(g_hookThreadHwnd, kFullRebindTimerId,
+                                     static_cast<UINT>(kFullRebindDebounceMs),
+                                     nullptr);
+                        }
+                        return;
+                    }
+                    g_lastFullRefreshTick = now;
+                    if (!weak.get()) {
+                        return;
+                    }
+                    ApplyAllHighlights_UIThread();
+                } catch (...) {
+                }
+            });
+    } catch (...) {
+    }
+}
+
+void WINAPI TaskListButton_UpdateVisualStates_Hook(void* pThis) {
+    TaskListButton_UpdateVisualStates_Original(pThis);
+
+    if (g_unloading.load()) {
+        return;
+    }
+
+    FrameworkElement button = TaskListButtonElementFromThis(pThis);
+    if (!button) {
+        return;
+    }
+
+    try {
+        if (button.Name() != L"TaskListButton") {
+            return;
+        }
+    } catch (...) {
+        return;
+    }
+
+    TrackButton_UIThread(button);
+    RefreshButtonHighlight(button);
+    ScheduleRefreshAllHighlights(button);
+}
+
+// XAML thumbnail view template — apply preview glow when flyout builds items.
+using TaskItemThumbnailView_OnApplyTemplate_t = void(WINAPI*)(void* pThis);
+TaskItemThumbnailView_OnApplyTemplate_t
+    TaskItemThumbnailView_OnApplyTemplate_Original;
+void WINAPI TaskItemThumbnailView_OnApplyTemplate_Hook(void* pThis) {
+    if (TaskItemThumbnailView_OnApplyTemplate_Original) {
+        TaskItemThumbnailView_OnApplyTemplate_Original(pThis);
+    }
+    if (g_unloading.load() || !SettingsSnap()->enabled ||
+        !SettingsSnap()->previewHighlightEnabled) {
+        return;
+    }
+    try {
+        IUnknown* unknownPtr = *((IUnknown**)pThis + 1);
+        if (!unknownPtr) {
+            return;
+        }
+        FrameworkElement element = nullptr;
+        unknownPtr->QueryInterface(winrt::guid_of<FrameworkElement>(),
+                                   winrt::put_abi(element));
+        if (element) {
+            RefreshThumbnailFlyout_UIThread(element);
+        }
+    } catch (...) {
+        HRESULT hr = winrt::to_hresult();
+        Wh_Log(L"TaskItemThumbnailView_OnApplyTemplate error %08X", hr);
+    }
+}
+
+// Option C: re-resolve button → path on click.
+using TaskListButton_OnPointerPressed_t = int(WINAPI*)(void* pThis, void* pArgs);
+TaskListButton_OnPointerPressed_t TaskListButton_OnPointerPressed_Original;
+int WINAPI TaskListButton_OnPointerPressed_Hook(void* pThis, void* pArgs) {
+    int ret = TaskListButton_OnPointerPressed_Original
+                  ? TaskListButton_OnPointerPressed_Original(pThis, pArgs)
+                  : 0;
+    if (g_unloading.load() || !g_taskbandResolveReady.load()) {
+        return ret;
+    }
+    try {
+        UIElement element = nullptr;
+        ((IUnknown*)pThis)
+            ->QueryInterface(winrt::guid_of<UIElement>(),
+                             winrt::put_abi(element));
+        if (!element) {
+            return ret;
+        }
+        if (winrt::get_class_name(element) != L"Taskbar.TaskListButton") {
+            return ret;
+        }
+        auto button = element.try_as<FrameworkElement>();
+        if (button) {
+            EnsureButtonPathCached(button, /*force=*/true);
+        }
+    } catch (...) {
+    }
+    return ret;
+}
+
+bool HookTaskbarViewDllSymbols(HMODULE module) {
+    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListButton,struct winrt::Taskbar::ITaskListButton>::get_IsRunning(bool *))"},
+            &TaskListButton_get_IsRunning_Original,
+        },
+        {
+            {LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateVisualStates(void))"},
+            &TaskListButton_UpdateVisualStates_Original,
+            TaskListButton_UpdateVisualStates_Hook,
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListButton,struct winrt::Windows::UI::Xaml::Controls::IControlOverrides>::OnPointerPressed(void *))"},
+            &TaskListButton_OnPointerPressed_Original,
+            TaskListButton_OnPointerPressed_Hook,
+        },
+        {
+            {LR"(struct winrt::Taskbar::TaskListWindowViewModel __cdecl TryGetItemFromContainer<struct winrt::Taskbar::TaskListWindowViewModel>(struct winrt::Windows::UI::Xaml::UIElement const &))"},
+            &TryGetItemFromContainer_TaskListWindowViewModel_Original,
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListWindowViewModel,struct winrt::Taskbar::ITaskListWindowViewModel>::get_TaskItem(void * *))"},
+            &TaskListWindowViewModel_get_TaskItem_Original,
+        },
+        {
+            {LR"(struct winrt::Taskbar::TaskListGroupViewModel __cdecl TryGetItemFromContainer<struct winrt::Taskbar::TaskListGroupViewModel>(struct winrt::Windows::UI::Xaml::UIElement const &))"},
+            &TryGetItemFromContainer_TaskListGroupViewModel_Original,
+        },
+        {
+            {LR"(public: bool __cdecl winrt::Taskbar::implementation::TaskListGroupViewModel::IsMultiWindow(void)const )"},
+            &TaskListGroupViewModel_IsMultiWindow_Original,
+        },
+        {
+            {LR"(public: __cdecl winrt::impl::consume_WindowsUdk_UI_Shell_ITaskGroup<struct winrt::WindowsUdk::UI::Shell::ITaskGroup>::IsRunning(void)const )"},
+            &ITaskGroup_IsRunning_Original,
+            ITaskGroup_IsRunning_Hook,
+        },
+        {
+            // Optional: XAML thumbnail flyout (Win11). Fail soft if missing.
+            {LR"(public: void __cdecl winrt::Taskbar::implementation::TaskItemThumbnailView::OnApplyTemplate(void))"},
+            &TaskItemThumbnailView_OnApplyTemplate_Original,
+            TaskItemThumbnailView_OnApplyTemplate_Hook,
+            true,
+        },
+    };
+
+    if (!HookSymbols(module, symbolHooks, ARRAYSIZE(symbolHooks))) {
+        Wh_Log(L"HookSymbols failed for Taskbar.View.dll");
+        return false;
+    }
+
+    if (TaskItemThumbnailView_OnApplyTemplate_Original) {
+        Wh_Log(L"Hooked Taskbar.View.dll symbols (identity + paint + thumbnails)");
+    } else {
+        Wh_Log(L"Hooked Taskbar.View.dll symbols (identity + paint; "
+               L"thumbnail OnApplyTemplate unavailable)");
+    }
+    return true;
+}
+
+// Capture TaskItemThumbnail model → ITaskItem for HWND resolve (optional).
+using TaskItemThumbnail_TaskItemThumbnail_t = void*(WINAPI*)(void* param1,
+                                                             void* param2,
+                                                             void* taskGroup,
+                                                             void* taskItem,
+                                                             void* taskListUi,
+                                                             void* param6,
+                                                             void* param7,
+                                                             bool param8);
+TaskItemThumbnail_TaskItemThumbnail_t
+    TaskItemThumbnail_TaskItemThumbnail_Original;
+void* WINAPI TaskItemThumbnail_TaskItemThumbnail_Hook(void* param1,
+                                                      void* param2,
+                                                      void* taskGroup,
+                                                      void* taskItem,
+                                                      void* taskListUi,
+                                                      void* param6,
+                                                      void* param7,
+                                                      bool param8) {
+    void* result = TaskItemThumbnail_TaskItemThumbnail_Original(
+        param1, param2, taskGroup, taskItem, taskListUi, param6, param7,
+        param8);
+    if (result) {
+        try {
+            winrt::Windows::Foundation::IInspectable obj = nullptr;
+            ((IUnknown*)result + 2)
+                ->QueryInterface(
+                    winrt::guid_of<winrt::Windows::Foundation::IInspectable>(),
+                    winrt::put_abi(obj));
+            AddThumbnailTaskItemMapping(obj, taskGroup, taskItem);
+        } catch (...) {
+        }
+    }
+    return result;
+}
+
+using TaskItemThumbnail_TaskItemThumbnail_2_t =
+    void*(WINAPI*)(void* param1,
+                   void* param2,
+                   void* taskGroup,
+                   void* taskItem,
+                   void* taskListUi,
+                   void* param6,
+                   bool param7);
+TaskItemThumbnail_TaskItemThumbnail_2_t
+    TaskItemThumbnail_TaskItemThumbnail_2_Original;
+void* WINAPI TaskItemThumbnail_TaskItemThumbnail_2_Hook(void* param1,
+                                                        void* param2,
+                                                        void* taskGroup,
+                                                        void* taskItem,
+                                                        void* taskListUi,
+                                                        void* param6,
+                                                        bool param7) {
+    void* result = TaskItemThumbnail_TaskItemThumbnail_2_Original(
+        param1, param2, taskGroup, taskItem, taskListUi, param6, param7);
+    if (result) {
+        try {
+            winrt::Windows::Foundation::IInspectable obj = nullptr;
+            ((IUnknown*)result + 2)
+                ->QueryInterface(
+                    winrt::guid_of<winrt::Windows::Foundation::IInspectable>(),
+                    winrt::put_abi(obj));
+            AddThumbnailTaskItemMapping(obj, taskGroup, taskItem);
+        } catch (...) {
+        }
+    }
+    return result;
+}
+
+bool HookTaskbarDllSymbols() {
+    HMODULE module =
+        LoadLibraryEx(L"taskbar.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!module) {
+        Wh_Log(L"Could not load taskbar.dll — path cache unavailable");
+        return false;
+    }
+
+    WindhawkUtils::SYMBOL_HOOK taskbarDllHooks[] = {
+        {
+            {LR"(public: virtual int __cdecl CTaskGroup::GetNumItems(void))"},
+            &CTaskGroup_GetNumItems,
+        },
+        {
+            {LR"(public: virtual struct HWND__ * __cdecl CWindowTaskItem::GetWindow(void))"},
+            &CWindowTaskItem_GetWindow,
+        },
+        {
+            {LR"(public: virtual struct HWND__ * __cdecl CImmersiveTaskItem::GetAppWindow(void))"},
+            &CImmersiveTaskItem_GetAppWindow,
+        },
+        {
+            {LR"(const CImmersiveTaskItem::`vftable')"},
+            &CImmersiveTaskItem_vftable,
+        },
+        {
+            {LR"(const CImmersiveTaskItem::`vftable'{for `ITaskItem'})"},
+            &CImmersiveTaskItem_vftable_ITaskItem,
+        },
+        {
+            {LR"(const CWindowTaskItem::`vftable')"},
+            &CWindowTaskItem_vftable,
+            nullptr,
+            true,
+        },
+        {
+            {LR"(const CWindowTaskItem::`vftable'{for `ITaskItem'})"},
+            &CWindowTaskItem_vftable_ITaskItem,
+            nullptr,
+            true,
+        },
+        {
+            {LR"(public: virtual long __cdecl CTaskListWnd::HandleClick(struct ITaskGroup *,struct ITaskItem *,struct winrt::Windows::System::LauncherOptions const &))"},
+            &CTaskListWnd_HandleClick_Original,
+            CTaskListWnd_HandleClick_Hook,
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::WindowsUdk::UI::Shell::implementation::TaskItem,struct winrt::WindowsUdk::UI::Shell::ITaskItem>::ReportClicked(void *))"},
+            &TaskItem_ReportClicked_Original,
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::WindowsUdk::UI::Shell::implementation::TaskGroup,struct winrt::WindowsUdk::UI::Shell::ITaskGroup>::ReportClicked(void *))"},
+            &TaskGroup_ReportClicked_Original,
+        },
+        {
+            // Optional: older XAML thumbnail model ctor.
+            {LR"(public: __cdecl winrt::WindowsUdk::UI::Shell::implementation::TaskItemThumbnail::TaskItemThumbnail(struct winrt::WindowsUdk::UI::Shell::TaskItem const &,struct ITaskGroup *,struct ITaskItem *,struct ITaskListUI *,struct IWICImagingFactory *,struct ITaskListAcc *,bool))"},
+            &TaskItemThumbnail_TaskItemThumbnail_Original,
+            TaskItemThumbnail_TaskItemThumbnail_Hook,
+            true,
+        },
+        {
+            // Optional: newer ctor (e.g. 10.0.26100.8328+).
+            {LR"(public: __cdecl winrt::WindowsUdk::UI::Shell::implementation::TaskItemThumbnail::TaskItemThumbnail(struct winrt::WindowsUdk::UI::Shell::TaskItem const &,struct ITaskGroup *,struct ITaskItem *,struct ITaskListUI *,struct IWICImagingFactory *,bool))"},
+            &TaskItemThumbnail_TaskItemThumbnail_2_Original,
+            TaskItemThumbnail_TaskItemThumbnail_2_Hook,
+            true,
+        },
+    };
+
+    if (!HookSymbols(module, taskbarDllHooks, ARRAYSIZE(taskbarDllHooks))) {
+        Wh_Log(L"HookSymbols failed for taskbar.dll");
+        return false;
+    }
+
+    g_taskbarDllHooked = true;
+    g_taskbandResolveReady = true;
+    g_previewHooksReady =
+        TaskItemThumbnail_TaskItemThumbnail_Original != nullptr ||
+        TaskItemThumbnail_TaskItemThumbnail_2_Original != nullptr;
+    if (g_previewHooksReady) {
+        Wh_Log(L"Hooked taskbar.dll identity + thumbnail model symbols");
+    } else {
+        Wh_Log(L"Hooked taskbar.dll identity symbols (preview HWND mapping "
+               L"unavailable — title fallback only)");
+    }
+    return true;
+}
+
+HMODULE GetTaskbarViewModuleHandle() {
+    HMODULE module = GetModuleHandle(L"Taskbar.View.dll");
+    if (!module) {
+        module = GetModuleHandle(L"ExplorerExtensions.dll");
+    }
+    return module;
+}
+
+void HandleLoadedModuleIfTaskbarView(HMODULE module, LPCWSTR lpLibFileName) {
+    if (!g_taskbarViewDllLoaded && GetTaskbarViewModuleHandle() == module &&
+        !g_taskbarViewDllLoaded.exchange(true)) {
+        Wh_Log(L"Loaded %s", lpLibFileName);
+        if (HookTaskbarViewDllSymbols(module)) {
+            Wh_ApplyHookOperations();
+        }
+    }
+}
+
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+LoadLibraryExW_t LoadLibraryExW_Original;
+HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
+                                   HANDLE hFile,
+                                   DWORD dwFlags) {
+    HMODULE module = LoadLibraryExW_Original(lpLibFileName, hFile, dwFlags);
+    if (module) {
+        HandleLoadedModuleIfTaskbarView(module, lpLibFileName);
+    }
+    return module;
+}
+
+// ---------------------------------------------------------------------------
+// Focus promotion (min focus time)
+// ---------------------------------------------------------------------------
+
+void CancelMinFocusTimer() {
+    if (g_hookThreadHwnd) {
+        KillTimer(g_hookThreadHwnd, kMinFocusTimerId);
+    }
+}
+
+void CancelPreviewMinFocusTimer() {
+    if (g_hookThreadHwnd) {
+        KillTimer(g_hookThreadHwnd, kPreviewMinFocusTimerId);
+    }
+}
+
+// True if pending is still the focused app. May retarget to a new top-level
+// window of the same PID. False if focus left the process.
+bool StillPendingForeground(const PendingFocus& pending,
+                            HWND* outHwnd,
+                            std::wstring* outTitle) {
+    HWND foreground = GetForegroundWindow();
+    HWND confirmHwnd = pending.hwnd;
+    std::wstring title = pending.windowTitle;
+    if (!foreground || foreground != pending.hwnd) {
+        DWORD fgPid = 0;
+        if (foreground) {
+            GetWindowThreadProcessId(foreground, &fgPid);
+        }
+        if (!foreground || fgPid != pending.processId) {
+            return false;
+        }
+        // ApplicationFrameHost: same PID is not the same app.
+        if (IsAppIdKey(pending.key)) {
+            std::wstring fgId =
+                CanonicalAppId(ToUpper(GetWindowAppUserModelId(foreground)));
+            if (fgId != AppIdFromAppKey(pending.key)) {
+                return false;
+            }
+        }
+        confirmHwnd = foreground;
+        std::wstring t = GetWindowTitle(foreground);
+        if (!t.empty()) {
+            title = std::move(t);
+        }
+    }
+    if (!confirmHwnd || !IsWindow(confirmHwnd)) {
+        return false;
+    }
+    if (outHwnd) {
+        *outHwnd = confirmHwnd;
+    }
+    if (outTitle) {
+        *outTitle = std::move(title);
+    }
+    return true;
+}
+
+void OnPreviewMinFocusTimerElapsed(MinFocusConfirmMode mode) {
+    auto settings = SettingsSnap();
+    if (!settings->enabled || !settings->previewHighlightEnabled ||
+        g_unloading.load()) {
+        return;
+    }
+
+    PendingFocus pending;
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        if (!g_pendingFocus.valid) {
+            return;
+        }
+        pending = g_pendingFocus;
+    }
+
+    if (mode == MinFocusConfirmMode::FromTimer) {
+        const ULONGLONG now = GetTickCount64();
+        const ULONGLONG start = pending.previewStartTick
+                                    ? pending.previewStartTick
+                                    : pending.focusStartTick;
+        const ULONGLONG remaining = RemainingDeadlineMs(
+            start, settings->previewMinFocusSeconds, now);
+        if (remaining > 0) {
+            if (g_hookThreadHwnd) {
+                SetTimer(g_hookThreadHwnd, kPreviewMinFocusTimerId,
+                         ClampWinTimerMs(remaining), nullptr);
+            }
+            return;
+        }
+    }
+
+    HWND confirmHwnd = nullptr;
+    std::wstring title;
+    if (!StillPendingForeground(pending, &confirmHwnd, &title)) {
+        if (mode == MinFocusConfirmMode::FromTimer &&
+            IsTransientForeground(GetForegroundWindow())) {
+            const ULONGLONG start = pending.previewStartTick
+                                        ? pending.previewStartTick
+                                        : pending.focusStartTick;
+            ULONGLONG remaining = RemainingDeadlineMs(
+                start, settings->previewMinFocusSeconds, GetTickCount64());
+            if (remaining == 0) {
+                remaining = 200;
+            }
+            if (g_hookThreadHwnd) {
+                SetTimer(g_hookThreadHwnd, kPreviewMinFocusTimerId,
+                         ClampWinTimerMs(remaining), nullptr);
+            }
+        }
+        // Focus left the app — drop only preview; app timer may still be pending.
+        return;
+    }
+
+    std::wstring processKey = PathFromAppKey(pending.key);
+    if (processKey.empty()) {
+        processKey = ToUpper(GetProcessImagePath(pending.processId));
+    }
+    const ULONGLONG now = GetTickCount64();
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        auto& desk =
+            InlineIsEqualGUID(pending.desktopId, GUID_NULL)
+                ? CurrentDeskLocked()
+                : DeskStateLocked(pending.desktopId);
+        StampWindowRecencyLocked(desk, confirmHwnd, processKey, title, now);
+        Wh_Log(L"Preview focus confirmed: hwnd=%p %s title=\"%s\" (map=%zu "
+               L"desktop=%s)",
+               confirmHwnd, pending.displayName.c_str(), title.c_str(),
+               desk.windowFocusMap.size(),
+               GuidToLogString(pending.desktopId).c_str());
+    }
+
+    RequestApplyPreviewVisuals();
+}
+
+void OnMinFocusTimerElapsed(MinFocusConfirmMode mode) {
+    auto settings = SettingsSnap();
+    PendingFocus pending;
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        if (!g_pendingFocus.valid) {
+            return;
+        }
+        pending = g_pendingFocus;
+    }
+
+    if (mode == MinFocusConfirmMode::FromTimer) {
+        const ULONGLONG now = GetTickCount64();
+        const ULONGLONG remaining = RemainingDeadlineMs(
+            pending.focusStartTick, settings->minFocusSeconds, now);
+        if (remaining > 0) {
+            if (g_hookThreadHwnd) {
+                SetTimer(g_hookThreadHwnd, kMinFocusTimerId,
+                         ClampWinTimerMs(remaining), nullptr);
+            }
+            return;
+        }
+    }
+
+    HWND confirmHwnd = nullptr;
+    std::wstring title;
+    if (!StillPendingForeground(pending, &confirmHwnd, &title)) {
+        if (mode == MinFocusConfirmMode::FromTimer &&
+            IsTransientForeground(GetForegroundWindow())) {
+            // Alt-Tab / taskbar stole FG briefly. WndProc already KillTimer'd;
+            // keep the candidate and wait out the rest of min-focus.
+            ULONGLONG remaining = RemainingDeadlineMs(
+                pending.focusStartTick, settings->minFocusSeconds,
+                GetTickCount64());
+            if (remaining == 0) {
+                remaining = 200;
+            }
+            if (g_hookThreadHwnd) {
+                SetTimer(g_hookThreadHwnd, kMinFocusTimerId,
+                         ClampWinTimerMs(remaining), nullptr);
+            }
+            if (settings->glowDebugLog) {
+                Wh_Log(L"Min-focus timer: transient FG, still waiting on %s "
+                       L"(%llums left)",
+                       pending.displayName.c_str(),
+                       static_cast<unsigned long long>(remaining));
+            }
+            return;
+        }
+        Wh_Log(L"Min-focus timer: focus left %s before confirmation",
+               pending.displayName.c_str());
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        if (g_pendingFocus.hwnd == pending.hwnd) {
+            g_pendingFocus = {};
+        }
+        return;
+    }
+    pending.hwnd = confirmHwnd;
+    if (!title.empty()) {
+        pending.windowTitle = std::move(title);
+    }
+
+    const ULONGLONG now = GetTickCount64();
+    bool alsoConfirmPreviewWindow = false;
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        auto& desk =
+            InlineIsEqualGUID(pending.desktopId, GUID_NULL)
+                ? CurrentDeskLocked()
+                : DeskStateLocked(pending.desktopId);
+        AppFocusInfo& info = desk.appFocusMap[pending.key];
+        info.key = pending.key;
+        info.displayName = pending.displayName;
+        if (!pending.windowTitle.empty()) {
+            info.lastWindowTitle = pending.windowTitle;
+        }
+        info.lastHwnd = pending.hwnd;
+        info.classUpper = ToUpper(GetWindowClassName(pending.hwnd));
+        info.appIdUpper = ToUpper(GetWindowAppUserModelId(pending.hwnd));
+        info.lastConfirmedFocusTick = now;
+
+        // If preview min-focus is not longer than app min-focus, promote the
+        // window here too (covers minFocus=0 / already-tracked immediate path
+        // without waiting for a separate preview timer). When preview min is
+        // longer, leave pending so the preview timer can still fire.
+        alsoConfirmPreviewWindow =
+            settings->previewHighlightEnabled &&
+            settings->previewMinFocusSeconds <=
+                (std::max)(0, settings->minFocusSeconds);
+
+        if (alsoConfirmPreviewWindow && pending.hwnd &&
+            IsWindow(pending.hwnd)) {
+            std::wstring processKey = PathFromAppKey(pending.key);
+            if (processKey.empty()) {
+                processKey = ToUpper(GetProcessImagePath(pending.processId));
+            }
+            StampWindowRecencyLocked(desk, pending.hwnd, processKey,
+                                     pending.windowTitle, now);
+        }
+
+        // Keep pending alive while a longer preview timer may still need it.
+        const bool previewTimerMayRemain =
+            settings->previewHighlightEnabled &&
+            settings->previewMinFocusSeconds >
+                (std::max)(0, settings->minFocusSeconds);
+        if (!previewTimerMayRemain &&
+            (g_pendingFocus.hwnd == pending.hwnd ||
+             g_pendingFocus.processId == pending.processId)) {
+            g_pendingFocus = {};
+        }
+
+        RecomputeRanksForDesktopLocked(desk);
+        Wh_Log(L"Confirmed focus: %s key=%s (map size=%zu, ranks=%zu, "
+               L"title=\"%s\" desktop=%s)",
+               pending.displayName.c_str(), pending.key.c_str(),
+               desk.appFocusMap.size(), desk.rankedApps.size(),
+               pending.windowTitle.c_str(),
+               GuidToLogString(pending.desktopId).c_str());
+    }
+
+    if (alsoConfirmPreviewWindow) {
+        RequestApplyPreviewVisuals();
+    }
+
+    // Learn button mapping on UI thread, then apply. Drop tray-only apps that
+    // never show a TaskListButton (HA widget, etc.).
+    RunOnUiThread([key = pending.key, displayName = pending.displayName,
+                   desktopId = pending.desktopId]() {
+        AssociateActiveButtonWithKey(key);
+
+        auto live = CollectLiveButtonsOnThisDispatcher();
+        for (auto& b : live) {
+            EnsureButtonPathCached(b, /*force=*/false);
+        }
+
+        bool hasNameCache = false;
+        {
+            std::lock_guard<std::mutex> lock(g_stateMutex);
+            hasNameCache = g_keyToAutomationName.contains(key);
+        }
+        bool exeNameOnAButton = false;
+        for (auto& b : live) {
+            if (ScoreExeToAutomationName(displayName,
+                                         GetButtonAutomationName(b)) >=
+                kScoreMinBind) {
+                exeNameOnAButton = true;
+                break;
+            }
+        }
+        const bool appears = PathAppearsOnTaskbar(key, displayName) ||
+                             hasNameCache || exeNameOnAButton;
+
+        size_t resolvedButtons = 0;
+        {
+            std::lock_guard<std::mutex> lock(g_buttonPathMutex);
+            for (const auto& e : g_buttonPathCache) {
+                if (!e.pathUpper.empty()) {
+                    ++resolvedButtons;
+                }
+            }
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(g_stateMutex);
+            auto& desk = InlineIsEqualGUID(desktopId, GUID_NULL)
+                             ? CurrentDeskLocked()
+                             : DeskStateLocked(desktopId);
+            auto it = desk.appFocusMap.find(key);
+            if (it != desk.appFocusMap.end()) {
+                if (appears) {
+                    it->second.seenOnTaskbar = true;
+                } else if (SettingsSnap()->requireTaskbarButton &&
+                           resolvedButtons >= 2) {
+                    Wh_Log(L"Ignoring non-taskbar app: %s (title=\"%s\")",
+                           displayName.c_str(),
+                           it->second.lastWindowTitle.c_str());
+                    it->second.lastConfirmedFocusTick = 0;
+                    it->second.seenOnTaskbar = false;
+                } else {
+                    // Path cache not ready — keep the rank, name-match later.
+                    it->second.seenOnTaskbar = true;
+                }
+            }
+            RecomputeRanksForDesktopLocked(desk);
+        }
+
+        ApplyAllHighlights_UIThread();
+    });
+}
+
+// Keep the app min-focus one-shot alive. A stale WM_TIMER KillTimer's the
+// live timer; same-app FOREGROUND used to assume it was still running.
+void EnsurePendingAppTimer() {
+    auto settings = SettingsSnap();
+    if (settings->minFocusSeconds <= 0) {
+        return;
+    }
+    PendingFocus pending;
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        if (!g_pendingFocus.valid) {
+            return;
+        }
+        pending = g_pendingFocus;
+    }
+    const ULONGLONG remaining = RemainingDeadlineMs(
+        pending.focusStartTick, settings->minFocusSeconds, GetTickCount64());
+    if (remaining == 0) {
+        OnMinFocusTimerElapsed(MinFocusConfirmMode::Immediate);
+        return;
+    }
+    if (g_hookThreadHwnd) {
+        SetTimer(g_hookThreadHwnd, kMinFocusTimerId,
+                 ClampWinTimerMs(remaining), nullptr);
+    }
+}
+
+void SchedulePreviewConfirm(bool windowAlreadyTracked) {
+    if (!SettingsSnap()->previewHighlightEnabled || !SettingsSnap()->enabled) {
+        return;
+    }
+    CancelPreviewMinFocusTimer();
+    const int previewMin = (std::max)(0, SettingsSnap()->previewMinFocusSeconds);
+    if (previewMin <= 0 || windowAlreadyTracked) {
+        OnPreviewMinFocusTimerElapsed(MinFocusConfirmMode::Immediate);
+        return;
+    }
+    if (g_hookThreadHwnd) {
+        SetTimer(g_hookThreadHwnd, kPreviewMinFocusTimerId,
+                 static_cast<UINT>(previewMin) * 1000U, nullptr);
+    }
+}
+
+void HandleForegroundChanged(HWND hWnd) {
+    if (g_unloading.load() || !SettingsSnap()->enabled) {
+        return;
+    }
+
+    hWnd = NormalizeFocusHwnd(hWnd);
+
+    if (IsTransientForeground(hWnd)) {
+        // Alt-Tab frame, taskbar, desktop, IME. Do not cancel min-focus.
+        bool ranksNonEmpty = false;
+        {
+            std::lock_guard<std::mutex> lock(g_stateMutex);
+            ranksNonEmpty = !CurrentDeskLocked().rankedApps.empty();
+        }
+        if (ranksNonEmpty) {
+            RequestApplyVisuals();
+        }
+        return;
+    }
+
+    const bool desktopChanged = RefreshCurrentDesktopId();
+    if (desktopChanged) {
+        ClearButtonRunningGrace();
+        bool droppedPending = false;
+        {
+            std::lock_guard<std::mutex> lock(g_stateMutex);
+            droppedPending = DropPendingIfWrongDesktopLocked();
+            RecomputeRanksForDesktopLocked(CurrentDeskLocked());
+        }
+        if (droppedPending) {
+            CancelMinFocusTimer();
+            CancelPreviewMinFocusTimer();
+        }
+        g_pendingOverlaySweep = true;
+        RequestApplyVisuals();
+        RequestApplyPreviewVisuals();
+    }
+
+    std::wstring key;
+    std::wstring displayName;
+    std::wstring windowTitle;
+    DWORD processId = 0;
+    if (!ResolveAppIdentity(hWnd, key, displayName, processId, &windowTitle)) {
+        CancelMinFocusTimer();
+        CancelPreviewMinFocusTimer();
+        bool ranksNonEmpty = false;
+        {
+            std::lock_guard<std::mutex> lock(g_stateMutex);
+            g_pendingFocus = {};
+            ranksNonEmpty = !CurrentDeskLocked().rankedApps.empty();
+        }
+        // Still repaint ranks — taskbar active states changed.
+        if (ranksNonEmpty) {
+            RequestApplyVisuals();
+        }
+        return;
+    }
+
+    const ULONGLONG now = GetTickCount64();
+    const int minSeconds = (std::max)(0, SettingsSnap()->minFocusSeconds);
+
+    bool alreadyTracked = false;
+    bool windowAlreadyTracked = false;
+    bool ranksNonEmpty = false;
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        auto& desk = CurrentDeskLocked();
+        ranksNonEmpty = !desk.rankedApps.empty();
+        auto it = desk.appFocusMap.find(key);
+        alreadyTracked =
+            it != desk.appFocusMap.end() && it->second.lastConfirmedFocusTick > 0;
+        // Keep title fresh for matching even before min-focus confirms.
+        if (it != desk.appFocusMap.end() && !windowTitle.empty()) {
+            it->second.lastWindowTitle = windowTitle;
+        }
+        auto wit = desk.windowFocusMap.find(hWnd);
+        windowAlreadyTracked =
+            wit != desk.windowFocusMap.end() &&
+            wit->second.lastConfirmedTick > 0;
+        if (wit != desk.windowFocusMap.end() && !windowTitle.empty()) {
+            wit->second.windowTitle = windowTitle;
+        }
+    }
+
+    // Always repaint existing ranks on any focus change (Alt-Tab must not
+    // leave other ranked icons unstyled until the min-focus timer fires).
+    if (ranksNonEmpty || alreadyTracked) {
+        RequestApplyVisuals();
+    }
+
+    bool sameAppPending = false;
+    bool hwndChanged = false;
+    GUID deskForLog{};
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+
+        if (g_pendingFocus.valid && g_pendingFocus.key == key &&
+            InlineIsEqualGUID(g_pendingFocus.desktopId, g_currentDesktopId)) {
+            hwndChanged = g_pendingFocus.hwnd != hWnd;
+            g_pendingFocus.hwnd = hWnd;
+            g_pendingFocus.processId = processId;
+            if (!windowTitle.empty()) {
+                g_pendingFocus.windowTitle = windowTitle;
+            }
+            if (hwndChanged) {
+                g_pendingFocus.previewStartTick = now;
+            }
+            sameAppPending = true;
+        } else {
+            g_pendingFocus.hwnd = hWnd;
+            g_pendingFocus.processId = processId;
+            g_pendingFocus.key = key;
+            g_pendingFocus.displayName = displayName;
+            g_pendingFocus.windowTitle = windowTitle;
+            g_pendingFocus.focusStartTick = now;
+            g_pendingFocus.previewStartTick = now;
+            g_pendingFocus.desktopId = g_currentDesktopId;
+            g_pendingFocus.valid = true;
+        }
+        deskForLog = g_pendingFocus.desktopId;
+    }
+
+    if (sameAppPending) {
+        // Same app: keep app min-focus timer; re-schedule preview if HWND moved
+        // between instances (multi-window VS Code / Terminal).
+        if (hwndChanged || !windowAlreadyTracked) {
+            SchedulePreviewConfirm(windowAlreadyTracked);
+        }
+        EnsurePendingAppTimer();
+        return;
+    }
+
+    CancelMinFocusTimer();
+    CancelPreviewMinFocusTimer();
+
+    const bool skipMinFocus = ShouldSkipAppMinFocus(key, alreadyTracked);
+
+    Wh_Log(L"Focus candidate: %s key=%s (minFocus=%ds, tracked=%d, skipMin=%d, "
+           L"promote=%s, previewTracked=%d desktop=%s)",
+           displayName.c_str(), key.c_str(), minSeconds,
+           alreadyTracked ? 1 : 0, skipMinFocus ? 1 : 0,
+           PromoteModeName(SettingsSnap()->promoteMode),
+           windowAlreadyTracked ? 1 : 0, GuidToLogString(deskForLog).c_str());
+
+    SchedulePreviewConfirm(windowAlreadyTracked);
+
+    if (skipMinFocus) {
+        // minFocus=0, or promoteMode allows instant re-focus (tracked map
+        // and/or currently highlighted top-N).
+        OnMinFocusTimerElapsed(MinFocusConfirmMode::Immediate);
+        return;
+    }
+
+    if (g_hookThreadHwnd) {
+        SetTimer(g_hookThreadHwnd, kMinFocusTimerId,
+                 static_cast<UINT>(minSeconds) * 1000U, nullptr);
+    }
+}
+
+void OnDecayTimer() {
+    size_t before = 0;
+    size_t after = 0;
+    size_t windowsBefore = 0;
+    size_t windowsAfter = 0;
+    RefreshCurrentDesktopId();
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        before = CurrentDeskLocked().rankedApps.size();
+        windowsBefore = CurrentDeskLocked().windowFocusMap.size();
+        for (auto it = g_desktopMaps.begin(); it != g_desktopMaps.end();) {
+            RecomputeRanksForDesktopLocked(it->second);
+            PruneWindowFocusMapLocked(it->second);
+            if (it->second.appFocusMap.empty() &&
+                it->second.windowFocusMap.empty() &&
+                !InlineIsEqualGUID(it->first, g_currentDesktopId)) {
+                it = g_desktopMaps.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        after = CurrentDeskLocked().rankedApps.size();
+        windowsAfter = CurrentDeskLocked().windowFocusMap.size();
+    }
+    if (after != before || after == 0) {
+        Wh_Log(L"Decay recompute: ranks %zu -> %zu", before, after);
+        // Ensure overlays are stripped even if some weak refs are stale after
+        // sleep — every live button will clear on next UpdateVisualStates too.
+        g_pendingOverlaySweep = true;
+        RequestApplyVisuals();
+    }
+    if (windowsAfter != windowsBefore) {
+        Wh_Log(L"Preview decay: windows %zu -> %zu", windowsBefore,
+               windowsAfter);
+        RequestApplyPreviewVisuals();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WinEvent hook thread
+// ---------------------------------------------------------------------------
+
+void CALLBACK WinEventProc(HWINEVENTHOOK /*hWinEventHook*/,
+                           DWORD event,
+                           HWND hWnd,
+                           LONG idObject,
+                           LONG /*idChild*/,
+                           DWORD /*dwEventThread*/,
+                           DWORD /*dwmsEventTime*/) {
+    if (g_unloading.load()) {
+        return;
+    }
+    if (event == EVENT_SYSTEM_DESKTOPSWITCH) {
+        if (g_hookThreadHwnd) {
+            PostMessage(g_hookThreadHwnd, WM_APP_DESKTOP_SWITCHED, 0, 0);
+        }
+        return;
+    }
+    if (event != EVENT_SYSTEM_FOREGROUND) {
+        return;
+    }
+    if (idObject != OBJID_WINDOW || !hWnd) {
+        return;
+    }
+
+    if (g_hookThreadHwnd) {
+        PostMessage(g_hookThreadHwnd, WM_APP_FOREGROUND_CHANGED,
+                    reinterpret_cast<WPARAM>(hWnd), 0);
+    }
+}
+
+LRESULT CALLBACK HookThreadWndProc(HWND hWnd,
+                                   UINT msg,
+                                   WPARAM wParam,
+                                   LPARAM lParam) {
+    switch (msg) {
+        case WM_APP_FOREGROUND_CHANGED:
+            HandleForegroundChanged(reinterpret_cast<HWND>(wParam));
+            return 0;
+        case WM_APP_DESKTOP_SWITCHED:
+            OnVirtualDesktopSwitched();
+            return 0;
+        case WM_APP_REQUEST_APPLY:
+            RequestApplyVisuals();
+            return 0;
+        case WM_APP_REQUEST_PREVIEW_APPLY:
+            RequestApplyPreviewVisuals();
+            return 0;
+        case WM_APP_SHUTDOWN:
+            PostQuitMessage(0);
+            return 0;
+        case WM_TIMER:
+            if (wParam == kMinFocusTimerId) {
+                KillTimer(hWnd, kMinFocusTimerId);
+                OnMinFocusTimerElapsed();
+            } else if (wParam == kPreviewMinFocusTimerId) {
+                KillTimer(hWnd, kPreviewMinFocusTimerId);
+                OnPreviewMinFocusTimerElapsed();
+            } else if (wParam == kDecayTimerId) {
+                OnDecayTimer();
+            } else if (wParam == kFullRebindTimerId) {
+                KillTimer(hWnd, kFullRebindTimerId);
+                RequestApplyVisuals();
+            }
+            return 0;
+        case WM_DESTROY:
+            KillTimer(hWnd, kMinFocusTimerId);
+            KillTimer(hWnd, kPreviewMinFocusTimerId);
+            KillTimer(hWnd, kDecayTimerId);
+            KillTimer(hWnd, kFullRebindTimerId);
+            return 0;
+    }
+    return DefWindowProc(hWnd, msg, wParam, lParam);
+}
+
+DWORD WINAPI WinEventHookThread(LPVOID /*param*/) {
+    WNDCLASSEXW wc{
+        .cbSize = sizeof(WNDCLASSEXW),
+        .lpfnWndProc = HookThreadWndProc,
+        .hInstance = GetModuleHandle(nullptr),
+        .lpszClassName = L"Windhawk_TaskbarRecentFocusHighlight_MsgWnd",
+    };
+    RegisterClassExW(&wc);
+
+    g_hookThreadHwnd =
+        CreateWindowExW(0, wc.lpszClassName, L"", 0, 0, 0, 0, 0, HWND_MESSAGE,
+                        nullptr, wc.hInstance, nullptr);
+    if (!g_hookThreadHwnd) {
+        Wh_Log(L"Failed to create message window: %u", GetLastError());
+        return 1;
+    }
+
+    HRESULT coHr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+    if (FAILED(coHr) && coHr != RPC_E_CHANGED_MODE) {
+        Wh_Log(L"Focus thread CoInitializeEx failed %08X", coHr);
+    }
+
+    HWINEVENTHOOK hook =
+        SetWinEventHook(EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND,
+                        nullptr, WinEventProc, 0, 0, WINEVENT_OUTOFCONTEXT);
+    if (!hook) {
+        Wh_Log(L"SetWinEventHook failed: %u", GetLastError());
+    } else {
+        Wh_Log(L"EVENT_SYSTEM_FOREGROUND hook installed");
+    }
+
+    HWINEVENTHOOK deskHook =
+        SetWinEventHook(EVENT_SYSTEM_DESKTOPSWITCH, EVENT_SYSTEM_DESKTOPSWITCH,
+                        nullptr, WinEventProc, 0, 0, WINEVENT_OUTOFCONTEXT);
+    if (!deskHook) {
+        Wh_Log(L"EVENT_SYSTEM_DESKTOPSWITCH hook failed: %u", GetLastError());
+    } else {
+        Wh_Log(L"EVENT_SYSTEM_DESKTOPSWITCH hook installed");
+    }
+
+    SetTimer(g_hookThreadHwnd, kDecayTimerId, kDecayCheckIntervalMs, nullptr);
+    RefreshCurrentDesktopId();
+
+    if (HWND fg = GetForegroundWindow()) {
+        PostMessage(g_hookThreadHwnd, WM_APP_FOREGROUND_CHANGED,
+                    reinterpret_cast<WPARAM>(fg), 0);
+    }
+
+    MSG msg;
+    BOOL bRet;
+    while ((bRet = GetMessage(&msg, nullptr, 0, 0)) != 0) {
+        if (bRet == -1) {
+            break;
+        }
+        if (msg.message == WM_APP && msg.hwnd == nullptr) {
+            break;
+        }
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+    }
+
+    if (hook) {
+        UnhookWinEvent(hook);
+    }
+    if (deskHook) {
+        UnhookWinEvent(deskHook);
+    }
+
+    ReleaseVdm();
+
+    if (g_hookThreadHwnd) {
+        DestroyWindow(g_hookThreadHwnd);
+        g_hookThreadHwnd = nullptr;
+    }
+    UnregisterClassW(wc.lpszClassName, wc.hInstance);
+
+    if (SUCCEEDED(coHr)) {
+        CoUninitialize();
+    }
+
+    Wh_Log(L"WinEvent hook thread exiting");
+    return 0;
+}
+
+void StartWinEventHookThread() {
+    std::lock_guard<std::mutex> lock(g_winEventHookThreadMutex);
+    if (g_winEventHookThread) {
+        return;
+    }
+    HANDLE hThread =
+        CreateThread(nullptr, 0, WinEventHookThread, nullptr, 0, nullptr);
+    if (hThread) {
+        g_winEventHookThread = hThread;
+        Wh_Log(L"WinEvent hook thread started");
+    } else {
+        Wh_Log(L"CreateThread failed: %u", GetLastError());
+    }
+}
+
+void StopWinEventHookThread() {
+    HANDLE hThread = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(g_winEventHookThreadMutex);
+        hThread = g_winEventHookThread.exchange(nullptr);
+    }
+    if (!hThread) {
+        return;
+    }
+
+    HWND hwnd = g_hookThreadHwnd;
+    if (hwnd) {
+        PostMessage(hwnd, WM_APP_SHUTDOWN, 0, 0);
+    }
+    DWORD threadId = GetThreadId(hThread);
+    if (threadId) {
+        PostThreadMessage(threadId, WM_APP, 0, 0);
+    }
+    const DWORD w = WaitForSingleObject(hThread, 8000);
+    CloseHandle(hThread);
+    if (w != WAIT_OBJECT_0) {
+        Wh_Log(L"ERROR: focus thread still running after 8s (wait=%u) — "
+               L"unload may crash explorer",
+               w);
+    } else {
+        Wh_Log(L"WinEvent hook thread stopped");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Settings load
+// ---------------------------------------------------------------------------
+
+void LoadSettings() {
+    Settings s;
+
+    s.enabled = Wh_GetIntSetting(L"enabled") != 0;
+    s.highlightCount = Wh_GetIntSetting(L"highlightCount");
+    if (s.highlightCount < 0) {
+        s.highlightCount = 0;
+    }
+    if (s.highlightCount > 16) {
+        s.highlightCount = 16;
+    }
+
+    s.minFocusSeconds = Wh_GetIntSetting(L"minFocusSeconds");
+    if (s.minFocusSeconds < 0) {
+        s.minFocusSeconds = 0;
+    }
+
+    PCWSTR promoteMode = Wh_GetStringSetting(L"promoteMode");
+    s.promoteMode = PromoteMode::ImmediateTracked;
+    if (promoteMode) {
+        if (wcscmp(promoteMode, L"immediateTopN") == 0) {
+            s.promoteMode = PromoteMode::ImmediateTopN;
+        } else if (wcscmp(promoteMode, L"alwaysWait") == 0) {
+            s.promoteMode = PromoteMode::AlwaysWait;
+        } else if (wcscmp(promoteMode, L"immediateTracked") == 0) {
+            s.promoteMode = PromoteMode::ImmediateTracked;
+        }
+    }
+    Wh_FreeStringSetting(promoteMode);
+
+    PCWSTR glowColor = Wh_GetStringSetting(L"glowColor");
+    s.glowColor = GlowColorMode::Accent;
+    if (glowColor && *glowColor) {
+        if (wcscmp(glowColor, L"green") == 0) {
+            s.glowColor = GlowColorMode::Green;
+        } else if (wcscmp(glowColor, L"blue") == 0) {
+            s.glowColor = GlowColorMode::Blue;
+        } else if (wcscmp(glowColor, L"orange") == 0) {
+            s.glowColor = GlowColorMode::Orange;
+        } else if (wcscmp(glowColor, L"white") == 0) {
+            s.glowColor = GlowColorMode::White;
+        } else if (wcscmp(glowColor, L"custom") == 0) {
+            s.glowColor = GlowColorMode::Custom;
+        }
+    }
+    Wh_FreeStringSetting(glowColor);
+
+    PCWSTR customColor = Wh_GetStringSetting(L"customGlowColor");
+    s.customGlowColor = customColor ? customColor : L"#00C853";
+    Wh_FreeStringSetting(customColor);
+
+    s.glowIntensity[0] = Wh_GetIntSetting(L"glowIntensityRank1");
+    s.glowIntensity[1] = Wh_GetIntSetting(L"glowIntensityRank2");
+    s.glowIntensity[2] = Wh_GetIntSetting(L"glowIntensityRank3");
+    for (int& v : s.glowIntensity) {
+        if (v < 0) {
+            v = 0;
+        }
+        if (v > 100) {
+            v = 100;
+        }
+    }
+
+    s.sizeBoostPercent[0] = Wh_GetIntSetting(L"sizeBoostRank1");
+    s.sizeBoostPercent[1] = Wh_GetIntSetting(L"sizeBoostRank2");
+    s.sizeBoostPercent[2] = Wh_GetIntSetting(L"sizeBoostRank3");
+    for (int& v : s.sizeBoostPercent) {
+        if (v < 0) {
+            v = 0;
+        }
+        if (v > 50) {
+            v = 50;
+        }
+    }
+
+    PCWSTR glowStyle = Wh_GetStringSetting(L"glowStyle");
+    s.glowStyle = GlowStyle::LeftBar;
+    if (glowStyle) {
+        if (wcscmp(glowStyle, L"full") == 0) {
+            s.glowStyle = GlowStyle::Full;
+        } else if (wcscmp(glowStyle, L"frame") == 0) {
+            s.glowStyle = GlowStyle::Frame;
+        } else if (wcscmp(glowStyle, L"leftBar") == 0) {
+            s.glowStyle = GlowStyle::LeftBar;
+        } else if (wcscmp(glowStyle, L"bottomBar") == 0) {
+            s.glowStyle = GlowStyle::BottomBar;
+        }
+    }
+    Wh_FreeStringSetting(glowStyle);
+
+    s.glowThickness = Wh_GetIntSetting(L"glowThickness");
+    if (s.glowThickness < 1) {
+        s.glowThickness = 1;
+    }
+    if (s.glowThickness > 16) {
+        s.glowThickness = 16;
+    }
+
+    s.glowRoundness = Wh_GetIntSetting(L"glowRoundness");
+    if (s.glowRoundness < 0) {
+        s.glowRoundness = 0;
+    }
+    if (s.glowRoundness > 50) {
+        s.glowRoundness = 50;
+    }
+
+    s.glowSize = Wh_GetIntSetting(L"glowSize");
+    if (s.glowSize < 40) {
+        s.glowSize = 40;
+    }
+    if (s.glowSize > 100) {
+        s.glowSize = 100;
+    }
+
+    s.glowLayers = Wh_GetIntSetting(L"glowLayers");
+    if (s.glowLayers < 1) {
+        s.glowLayers = 1;
+    }
+    if (s.glowLayers > 3) {
+        s.glowLayers = 3;
+    }
+
+    s.glowFillOpacity = Wh_GetIntSetting(L"glowFillOpacity");
+    if (s.glowFillOpacity < 0) {
+        s.glowFillOpacity = 0;
+    }
+    if (s.glowFillOpacity > 100) {
+        s.glowFillOpacity = 100;
+    }
+
+    s.previewFillOpacity = Wh_GetIntSetting(L"previewFillOpacity");
+    if (s.previewFillOpacity < 0) {
+        s.previewFillOpacity = 0;
+    }
+    if (s.previewFillOpacity > 100) {
+        s.previewFillOpacity = 100;
+    }
+
+    s.glowDebugLog = Wh_GetIntSetting(L"glowDebugLog") != 0;
+
+    s.decayMinutes = Wh_GetIntSetting(L"decayMinutes");
+    if (s.decayMinutes < 0) {
+        s.decayMinutes = 0;
+    }
+
+    s.requireTaskbarButton = Wh_GetIntSetting(L"requireTaskbarButton") != 0;
+
+    s.previewHighlightEnabled =
+        Wh_GetIntSetting(L"previewHighlightEnabled") != 0;
+
+    s.previewHighlightCount = Wh_GetIntSetting(L"previewHighlightCount");
+    if (s.previewHighlightCount < 0) {
+        s.previewHighlightCount = 0;
+    }
+    if (s.previewHighlightCount > 16) {
+        s.previewHighlightCount = 16;
+    }
+
+    s.previewIntensity[0] = Wh_GetIntSetting(L"previewIntensityRank1");
+    s.previewIntensity[1] = Wh_GetIntSetting(L"previewIntensityRank2");
+    s.previewIntensity[2] = Wh_GetIntSetting(L"previewIntensityRank3");
+    for (int& v : s.previewIntensity) {
+        if (v < 0) {
+            v = 0;
+        }
+        if (v > 100) {
+            v = 100;
+        }
+    }
+
+    // New keys are blank after an in-place recompile. Wh_GetIntSetting
+    // returns 0 for a missing value, which would paint nothing. Treat the
+    // all-zero cluster as unset and apply the YAML defaults (3 / 100/70/45).
+    // An explicit count of 0 with any intensity set is still honored.
+    const bool previewRanksUnset = s.previewIntensity[0] == 0 &&
+                                   s.previewIntensity[1] == 0 &&
+                                   s.previewIntensity[2] == 0;
+    if (previewRanksUnset) {
+        s.previewIntensity[0] = 100;
+        s.previewIntensity[1] = 70;
+        s.previewIntensity[2] = 45;
+        if (s.previewHighlightCount == 0) {
+            s.previewHighlightCount = 3;
+        }
+    }
+
+    s.previewMinFocusSeconds = Wh_GetIntSetting(L"previewMinFocusSeconds");
+    if (s.previewMinFocusSeconds < 0) {
+        s.previewMinFocusSeconds = 0;
+    }
+    s.previewDecayMinutes = Wh_GetIntSetting(L"previewDecayMinutes");
+    if (s.previewDecayMinutes < 0) {
+        s.previewDecayMinutes = 0;
+    }
+
+    PCWSTR previewStyle = Wh_GetStringSetting(L"previewStyle");
+    s.previewStyle = PreviewStyle::TitleBar;
+    if (previewStyle) {
+        if (wcscmp(previewStyle, L"ring") == 0) {
+            s.previewStyle = PreviewStyle::Ring;
+        } else if (wcscmp(previewStyle, L"titleBg") == 0) {
+            s.previewStyle = PreviewStyle::TitleBg;
+        } else if (wcscmp(previewStyle, L"plate") == 0) {
+            s.previewStyle = PreviewStyle::Plate;
+        } else if (wcscmp(previewStyle, L"plateTitle") == 0) {
+            s.previewStyle = PreviewStyle::PlateTitle;
+        } else if (wcscmp(previewStyle, L"titleBar") == 0) {
+            s.previewStyle = PreviewStyle::TitleBar;
+        }
+    }
+    Wh_FreeStringSetting(previewStyle);
+
+    s.excludedPrograms.clear();
+    for (int i = 0;; i++) {
+        PCWSTR program = Wh_GetStringSetting(L"excludedPrograms[%d]", i);
+        bool hasProgram = program && *program;
+        if (hasProgram) {
+            s.excludedPrograms.insert(ToUpper(program));
+        }
+        Wh_FreeStringSetting(program);
+        if (!hasProgram) {
+            break;
+        }
+    }
+
+    Wh_Log(L"Settings: enabled=%d style=%s th=%d round=%d%% size=%d%% "
+           L"layers=%d fillOp=%d previewFillOp=%d debug=%d decay=%dmin "
+           L"minFocus=%ds promote=%s preview=%d previewCount=%d "
+           L"previewI=%d/%d/%d previewStyle=%s previewMin=%ds previewDecay=%dmin",
+           s.enabled ? 1 : 0, GlowStyleName(s.glowStyle), s.glowThickness,
+           s.glowRoundness, s.glowSize, s.glowLayers, s.glowFillOpacity,
+           s.previewFillOpacity, s.glowDebugLog ? 1 : 0, s.decayMinutes,
+           s.minFocusSeconds, PromoteModeName(s.promoteMode),
+           s.previewHighlightEnabled ? 1 : 0, s.previewHighlightCount,
+           s.previewIntensity[0], s.previewIntensity[1], s.previewIntensity[2],
+           PreviewStyleName(s.previewStyle), s.previewMinFocusSeconds,
+           s.previewDecayMinutes);
+
+    PublishSettings(std::move(s));
+}
+
+// ---------------------------------------------------------------------------
+// Windhawk entry points
+// ---------------------------------------------------------------------------
+
+BOOL Wh_ModInit() {
+    Wh_Log(L"> Taskbar Recent Focus Highlight init v0.9.0");
+
+    g_unloading = false;
+    LoadSettings();
+
+    // Identity resolve (taskband) — optional; fuzzy names remain as fallback.
+    if (!HookTaskbarDllSymbols()) {
+        Wh_Log(L"Warning: taskbar.dll identity hooks failed — fuzzy match only");
+    }
+
+    if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
+        g_taskbarViewDllLoaded = true;
+        if (!HookTaskbarViewDllSymbols(taskbarViewModule)) {
+            Wh_Log(L"Warning: Taskbar.View hooks failed — visuals unavailable");
+        }
+    } else {
+        Wh_Log(L"Taskbar view module not loaded yet");
+    }
+
+    HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
+    auto pKernelBaseLoadLibraryExW = (decltype(&LoadLibraryExW))GetProcAddress(
+        kernelBaseModule, "LoadLibraryExW");
+    WindhawkUtils::SetFunctionHook(pKernelBaseLoadLibraryExW,
+                                   LoadLibraryExW_Hook,
+                                   &LoadLibraryExW_Original);
+
+    StartWinEventHookThread();
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    Wh_Log(L">");
+
+    if (!g_taskbarViewDllLoaded) {
+        if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
+            if (!g_taskbarViewDllLoaded.exchange(true)) {
+                Wh_Log(L"Got Taskbar.View.dll");
+                if (HookTaskbarViewDllSymbols(taskbarViewModule)) {
+                    Wh_ApplyHookOperations();
+                }
+            }
+        }
+    }
+
+    if (g_hookThreadHwnd) {
+        if (HWND fg = GetForegroundWindow()) {
+            PostMessage(g_hookThreadHwnd, WM_APP_FOREGROUND_CHANGED,
+                        reinterpret_cast<WPARAM>(fg), 0);
+        }
+    }
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L">");
+    g_unloading = true;
+    g_taskbandResolveReady = false;
+    g_previewHooksReady = false;
+
+    // Clear visuals and revoke SizeChanged on each dispatcher, then drain
+    // already-queued Normal work (those lambdas no-op on g_unloading).
+    if (!RunOnEachUiDispatcherAndWait(
+            []() {
+                ClearAllHighlights_UIThread();
+                ClearAllThumbnailHighlights_UIThread();
+                RevokeIconPanelLayoutWatchesOnThisDispatcher();
+            },
+            2000)) {
+        Wh_Log(L"ERROR: UI cleanup did not finish on every dispatcher");
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
+        if (!g_layoutWatches.empty()) {
+            Wh_Log(L"ERROR: %zu IconPanel SizeChanged watches not revoked",
+                   g_layoutWatches.size());
+        }
+    }
+
+    StopWinEventHookThread();
+
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        g_desktopMaps.clear();
+        g_currentDesktopId = {};
+        g_haveCurrentDesktop = false;
+        g_pendingFocus = {};
+        g_keyToAutomationName.clear();
+    }
+    ReleaseVdm();
+    {
+        std::lock_guard<std::mutex> lock(g_buttonsMutex);
+        g_trackedButtons.clear();
+        g_dispatcherAnchor = {};
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_buttonPathMutex);
+        g_buttonPathCache.clear();
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_thumbnailMapMutex);
+        g_thumbnailTaskItemMapping.clear();
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_thumbViewsMutex);
+        g_trackedThumbViews.clear();
+    }
+}
+
+BOOL Wh_ModSettingsChanged(BOOL* bReload) {
+    Wh_Log(L">");
+    if (bReload) {
+        *bReload = FALSE;
+    }
+
+    LoadSettings();
+
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        for (auto& [id, desk] : g_desktopMaps) {
+            for (auto it = desk.appFocusMap.begin();
+                 it != desk.appFocusMap.end();) {
+                std::wstring displayUpper = ToUpper(it->second.displayName);
+                if (IsExcludedKey(it->first, displayUpper)) {
+                    g_keyToAutomationName.erase(it->first);
+                    it = desk.appFocusMap.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+            for (auto it = desk.windowFocusMap.begin();
+                 it != desk.windowFocusMap.end();) {
+                std::wstring fileUpper =
+                    ToUpper(FileNameFromPath(it->second.processKey));
+                if (IsExcludedKey(it->second.processKey, fileUpper)) {
+                    it = desk.windowFocusMap.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+            PruneWindowFocusMapLocked(desk);
+            RecomputeRanksForDesktopLocked(desk);
+        }
+    }
+
+    RequestApplyVisuals();
+    RequestApplyPreviewVisuals();
+    return TRUE;
+}

--- a/mods/taskbar-recent-focus-highlight.wh.cpp
+++ b/mods/taskbar-recent-focus-highlight.wh.cpp
@@ -6732,6 +6732,7 @@ int WINAPI TaskListButton_OnPointerPressed_Hook(void* pThis, void* pArgs) {
 }
 
 bool HookTaskbarViewDllSymbols(HMODULE module) {
+    // Taskbar.View.dll, ExplorerExtensions.dll
     WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
             {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListButton,struct winrt::Taskbar::ITaskListButton>::get_IsRunning(bool *))"},

--- a/mods/taskbar-recent-focus-highlight.wh.cpp
+++ b/mods/taskbar-recent-focus-highlight.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-recent-focus-highlight
 // @name            Taskbar Recent Focus Highlight
 // @description     Visually highlight the most recently focused running apps on the taskbar
-// @version         0.9.0
+// @version         0.9.1
 // @author          Jakub Vlášek
 // @github          https://github.com/jvlasek
 // @include         explorer.exe
@@ -16,56 +16,59 @@
 /*
 # Taskbar Recent Focus Highlight
 
-Visually highlights the most recently used running applications on the taskbar
-for faster context switching. Optionally ranks **windows** inside multi-window
-thumbnail previews (e.g. several VS Code or Terminal instances) with the same
-kind of intensity ladder used on the icons.
+Highlights the taskbar icons of the apps you actually stayed on, and (optionally)
+the recently focused windows inside a multi-window thumbnail flyout.
 
-## How it works
+![Taskbar side-bar highlight](https://raw.githubusercontent.com/jvlasek/taskbar-recent-focus-highlight/main/screenshots/taskbar-highlight-edge.png)
 
-The mod tracks window focus (`EVENT_SYSTEM_FOREGROUND`) and keeps a ranked list
-of the apps you actually stayed on (after a configurable minimum focus time),
-**per virtual desktop**. The top N **running** taskbar buttons on the current
-desktop receive a highlight (frame, full plate, side bar, or edge bar — bars
-rotate with the taskbar’s screen edge) and optional icon scale. App↔button
-binding uses a process-path cache resolved from the taskband (same approach
-as taskbar-volume-control-per-app),
-with name matching as fallback. Pinned icons that are not running on this
-desktop are never highlighted.
+![Thumbnail flyout ranks](https://raw.githubusercontent.com/jvlasek/taskbar-recent-focus-highlight/main/screenshots/flyout-preview-highlight.png)
 
-Separately, it tracks **per-window** recency (own min-focus / decay). When you
-hover a combined taskbar icon and the flyout shows 2+ thumbnails, that flyout
-gets its **own** recency list: the top N windows in it are marked with rank
-intensities (title bar, soft title tint, whole plate, hybrid plate+title, or
-ring — configurable). Single-window flyouts are left alone.
+## What you see
 
-## Tips for testing
+After an app stays focused for the **minimum focus time** (default 8 seconds),
+it joins a per-virtual-desktop recency list. The top N **running** taskbar
+buttons on the current desktop get a highlight:
 
-1. Compile and enable the mod in Windhawk (injects into `explorer.exe`).
-2. Optionally enable **Debug logging**.
-3. Focus apps for at least the minimum focus time (default 8s).
-4. Ranked apps should show a highlight on their taskbar buttons (default: side
-   bar — left on a bottom taskbar, under the icon on a left/right taskbar);
-   rank 1 is strongest. Moving the taskbar to another edge should keep running
-   dots on unranked icons and rotate the bar.
-5. Brief Alt+Tab under the minimum focus time should not change ranks.
-6. Open 3+ windows of one app, focus them in turn, hover the icon — previews
-   show ranks 1 > 2 > 3 (strongest on the last focused window of that app).
-7. Disable the mod or toggle Enabled off to clear highlights.
-8. Multi-monitor: the same rank should appear on every taskbar that shows
-   that app. Combined-icon flyouts should mark the recent window even when
-   titles differ (Total Commander Lister, etc.). Lister has its own taskbar
-   icon — focusing it should highlight Lister, not Total Commander.
-9. Virtual desktops: each desktop has its own recency list. A pinned icon
-   that is not running on this desktop must not glow. Switching back restores
-   that desktop’s ranks.
-10. UWP: Calculator and Settings get separate ranks. Windows Security must
-    not copy Settings’ glow. Packaged apps with their own exe (Terminal) are
-    still path-keyed.
-11. Windows 11 Taskbar Styler: hover must not hide the side bar; preview
-    plate should restore the Styler tint when cleared.
+- **Side bar** (default) — a bar beside the icon (left on a bottom/top
+  taskbar, under the icon on a left/right taskbar)
+- **Edge bar** — a pill on the same side as the native running indicator
+- **Frame** / **Full** — a rounded rectangle around or behind the icon
 
-See the repo README.md for full settings and architecture notes.
+Rank 1 is strongest; ranks 2 and 3 (and 4+) use the intensities you set.
+Pinned icons that are not running on this desktop are never highlighted.
+A short Alt+Tab that does not meet the minimum focus time does not change
+ranks. Each virtual desktop keeps its own list.
+
+When you hover a combined icon and the flyout shows **two or more** windows,
+that flyout gets its own recency ladder (independent of icon ranks). The
+last focused window of that app is rank 1 in the flyout even if you used
+other apps more recently. Single-window flyouts are left alone.
+
+Preview styles: a thin bar under the title, a soft title tint, a whole-card
+plate, hybrid (plate for rank 1, title tint for the rest), or a ring.
+
+## Settings (short)
+
+- **General** — how many apps, min-focus wait, when to skip the wait on
+  re-focus, decay, exclude list, tray-only filter
+- **Icons** — style, color (including system accent), per-rank intensity,
+  thickness / size / fill, optional icon scale
+- **Previews** — on/off, how many windows, style, intensities, separate
+  min-focus and decay
+- **Advanced** — verbose debug log
+
+All of those are in the Windhawk settings panel. Turn **Enabled** off to
+clear highlights without unloading the mod.
+
+## Notes
+
+- Works with Windows 11 Taskbar Styler: the side bar stays visible on hover,
+  and preview plate tints are restored when the highlight is cleared.
+- Icon matching prefers the process path from the taskband. Name matching is
+  a fallback and is based on English taskbar labels (`N running`, `pinned`),
+  so it can be weaker on a non-English Windows.
+- Multi-monitor: the same rank is applied on every taskbar that shows that
+  app.
 */
 // ==/WindhawkModReadme==
 
@@ -269,7 +272,6 @@ See the repo README.md for full settings and architecture notes.
 #include <initguid.h>
 #include <propkey.h>
 #include <propsys.h>
-#include <psapi.h>
 #include <objbase.h>
 #include <shellapi.h>
 #include <shobjidl.h>
@@ -284,6 +286,9 @@ See the repo README.md for full settings and architecture notes.
 #include <winrt/Windows.UI.Xaml.h>
 #include <winrt/Windows.UI.Xaml.Automation.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
+// WinUI 2 ItemsRepeater (thumbnail flyout). Same as taskbar-thumbnail-reorder.
+#define WH_WINRT_WINUI2
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Input.h>
 #include <winrt/Windows.UI.Xaml.Markup.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
@@ -403,6 +408,8 @@ struct Settings {
     int previewDecayMinutes = 15;
     PreviewStyle previewStyle = PreviewStyle::TitleBar;
     std::unordered_set<std::wstring> excludedPrograms;
+    // Resolved once in LoadSettings (Accent mode). Not queried on every paint.
+    winrt::Windows::UI::Color cachedAccent{255, 0, 120, 215};
 };
 
 // Published as a whole. LoadSettings builds a local Settings, then stores it
@@ -529,6 +536,9 @@ struct ButtonPathCacheEntry {
     ULONGLONG lastRunningTick = 0;  // IsRunning grace (Alt-Tab flicker)
     // Last ApplyAllHighlights assignment: -1 unknown, 0 none, >0 1-based rank.
     int lastPaintRank = -1;
+    // ScaleTransform we applied for size boost. Clear only this instance so
+    // other mods (taskbar-dock-animation) keep their hover scale.
+    winrt::weak_ref<Media::ScaleTransform> ourIconScale;
 };
 std::mutex g_buttonPathMutex;
 std::vector<ButtonPathCacheEntry> g_buttonPathCache;
@@ -558,18 +568,60 @@ std::atomic<bool> g_pendingOverlaySweep{false};
 
 std::mutex g_winEventHookThreadMutex;
 std::atomic<HANDLE> g_winEventHookThread{nullptr};
-HWND g_hookThreadHwnd = nullptr;
+std::atomic<HWND> g_hookThreadHwnd{nullptr};
+std::atomic<DWORD> g_hookThreadId{0};
+
+HWND HookThreadWindow() {
+    return g_hookThreadHwnd.load(std::memory_order_acquire);
+}
+
+bool PostToHookThread(UINT msg, WPARAM wParam = 0, LPARAM lParam = 0) {
+    HWND hwnd = HookThreadWindow();
+    return hwnd && PostMessage(hwnd, msg, wParam, lParam);
+}
+
+bool OnHookThread() {
+    DWORD id = g_hookThreadId.load(std::memory_order_acquire);
+    return id != 0 && GetCurrentThreadId() == id;
+}
 
 // UI-thread tracking of task list buttons (weak refs).
 std::mutex g_buttonsMutex;
 std::vector<winrt::weak_ref<FrameworkElement>> g_trackedButtons;
 winrt::weak_ref<FrameworkElement> g_dispatcherAnchor;
 
+// Agile CoreDispatcher list — captured on the UI thread when we first see a
+// button/thumb/panel. CollectUiDispatchers must not weak.get() XAML objects
+// off the UI thread (last-ref ~FrameworkElement would run on the wrong thread).
+std::mutex g_dispatchersMutex;
+std::vector<winrt::Windows::UI::Core::CoreDispatcher> g_uiDispatchers;
+
+void RememberUiDispatcher(FrameworkElement el) {
+    if (!el) {
+        return;
+    }
+    try {
+        auto dispatcher = el.Dispatcher();
+        if (!dispatcher) {
+            return;
+        }
+        std::lock_guard<std::mutex> lock(g_dispatchersMutex);
+        for (const auto& existing : g_uiDispatchers) {
+            if (existing == dispatcher) {
+                return;
+            }
+        }
+        g_uiDispatchers.push_back(dispatcher);
+    } catch (...) {
+    }
+}
+
 constexpr UINT WM_APP_FOREGROUND_CHANGED = WM_APP + 1;
 constexpr UINT WM_APP_REQUEST_APPLY = WM_APP + 2;
 constexpr UINT WM_APP_REQUEST_PREVIEW_APPLY = WM_APP + 3;
 constexpr UINT WM_APP_DESKTOP_SWITCHED = WM_APP + 4;
 constexpr UINT WM_APP_SHUTDOWN = WM_APP + 5;
+constexpr UINT WM_APP_REQUEST_APPLY_DEBOUNCED = WM_APP + 6;
 
 // Identity scores. Only exact identity (and name-cache) may bind the same
 // rank to many buttons (secondary taskbar / Never Combine). Score 900 is
@@ -649,6 +701,12 @@ std::wstring GuidToLogString(const GUID& id) {
 }
 
 IVirtualDesktopManager* EnsureVdm() {
+    // CoCreate on the STA that will use it. UI threads must not create or
+    // call this pointer — they read the cached desktop GUID instead.
+    if (!OnHookThread()) {
+        std::lock_guard<std::mutex> lock(g_vdmMutex);
+        return g_vdm;
+    }
     std::lock_guard<std::mutex> lock(g_vdmMutex);
     if (g_vdm) {
         return g_vdm;
@@ -665,6 +723,9 @@ IVirtualDesktopManager* EnsureVdm() {
 }
 
 void ReleaseVdm() {
+    if (!OnHookThread() && g_hookThreadId.load() != 0) {
+        return;
+    }
     std::lock_guard<std::mutex> lock(g_vdmMutex);
     if (g_vdm) {
         g_vdm->Release();
@@ -716,20 +777,13 @@ bool ReadCurrentDesktopFromRegistry(GUID* outId) {
 
 GUID ResolveCurrentDesktopId() {
     GUID fromReg{};
-    const bool haveReg = ReadCurrentDesktopFromRegistry(&fromReg);
-    GUID fromWnd{};
-    const bool haveWnd =
-        TryGetWindowDesktopId(GetForegroundWindow(), &fromWnd);
-    if (haveReg && haveWnd && !InlineIsEqualGUID(fromReg, fromWnd) &&
-        SettingsSnap()->glowDebugLog) {
-        Wh_Log(L"Desktop id mismatch registry=%s fgWindow=%s — using registry",
-               GuidToLogString(fromReg).c_str(),
-               GuidToLogString(fromWnd).c_str());
-    }
-    if (haveReg) {
+    if (ReadCurrentDesktopFromRegistry(&fromReg)) {
         return fromReg;
     }
-    if (haveWnd) {
+    // Registry missing (rare). VDM is worker-thread only.
+    GUID fromWnd{};
+    if (OnHookThread() &&
+        TryGetWindowDesktopId(GetForegroundWindow(), &fromWnd)) {
         return fromWnd;
     }
     std::lock_guard<std::mutex> lock(g_stateMutex);
@@ -844,6 +898,20 @@ UINT ClampWinTimerMs(ULONGLONG ms) {
     return static_cast<UINT>(ms);
 }
 
+void ArmHookTimer(UINT_PTR id, ULONGLONG ms) {
+    HWND hwnd = HookThreadWindow();
+    if (hwnd) {
+        SetTimer(hwnd, id, ClampWinTimerMs(ms), nullptr);
+    }
+}
+
+void DisarmHookTimer(UINT_PTR id) {
+    HWND hwnd = HookThreadWindow();
+    if (hwnd) {
+        KillTimer(hwnd, id);
+    }
+}
+
 std::wstring ToUpper(std::wstring s) {
     if (!s.empty()) {
         LCMapStringEx(LOCALE_NAME_USER_DEFAULT, LCMAP_UPPERCASE, s.data(),
@@ -916,7 +984,8 @@ bool HwndMatchesStoredPid(HWND hwnd, DWORD storedPid) {
         return true;
     }
     const DWORD pid = PidFromHwnd(hwnd);
-    return pid == 0 || pid == storedPid;
+    // pid 0: window is gone / inaccessible — not a match (handle recycle).
+    return pid != 0 && pid == storedPid;
 }
 
 std::wstring FileNameFromPath(const std::wstring& path) {
@@ -1498,7 +1567,6 @@ void ConfirmPreviewFocusNow(HWND hwnd) {
     }
 
     const ULONGLONG now = GetTickCount64();
-    RefreshCurrentDesktopId();
     std::wstring processKey = PathFromAppKey(key);
     if (processKey.empty()) {
         processKey = ToUpper(GetProcessImagePath(processId));
@@ -1596,7 +1664,6 @@ bool IsWindowRecentForPreviewLocked(DesktopRecencyState& desk,
 
 // Snapshot of recent windows for UI matching (copy under lock).
 std::vector<WindowFocusInfo> CopyRecentWindowsForPreview() {
-    RefreshCurrentDesktopId();
     std::lock_guard<std::mutex> lock(g_stateMutex);
     auto& desk = CurrentDeskLocked();
     PruneWindowFocusMapLocked(desk);
@@ -1675,19 +1742,24 @@ bool ParseHexColor(const std::wstring& text, winrt::Windows::UI::Color& out) {
     return false;
 }
 
-winrt::Windows::UI::Color ResolveGlowBaseColor() {
+winrt::Windows::UI::Color QuerySystemAccentColor() {
+    try {
+        winrt::Windows::UI::ViewManagement::UISettings uiSettings;
+        auto c = uiSettings.GetColorValue(
+            winrt::Windows::UI::ViewManagement::UIColorType::Accent);
+        c.A = 255;
+        return c;
+    } catch (...) {
+        return {255, 0, 120, 215};
+    }
+}
+
+winrt::Windows::UI::Color ResolveGlowBaseColor(const Settings& settings) {
     winrt::Windows::UI::Color c{255, 0, 200, 83};  // default green-ish
 
-    switch (SettingsSnap()->glowColor) {
+    switch (settings.glowColor) {
         case GlowColorMode::Accent:
-            try {
-                winrt::Windows::UI::ViewManagement::UISettings uiSettings;
-                c = uiSettings.GetColorValue(
-                    winrt::Windows::UI::ViewManagement::UIColorType::Accent);
-                c.A = 255;
-            } catch (...) {
-                c = {255, 0, 120, 215};
-            }
+            c = settings.cachedAccent;
             break;
         case GlowColorMode::Green:
             c = {255, 0, 200, 83};
@@ -1702,7 +1774,7 @@ winrt::Windows::UI::Color ResolveGlowBaseColor() {
             c = {255, 255, 255, 255};
             break;
         case GlowColorMode::Custom:
-            if (!ParseHexColor(SettingsSnap()->customGlowColor, c)) {
+            if (!ParseHexColor(settings.customGlowColor, c)) {
                 c = {255, 0, 200, 83};
             }
             break;
@@ -1738,6 +1810,8 @@ struct ButtonIdentity {
     std::vector<HWND> groupHwnds;
 };
 ButtonIdentity GetCachedButtonIdentity(FrameworkElement button);
+void RememberOurIconScale(FrameworkElement button, Media::ScaleTransform scale);
+void ClearIconScaleIfOurs(FrameworkElement icon, FrameworkElement button);
 bool RunOnUiThread(const winrt::Windows::UI::Core::DispatchedHandler& handler);
 void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb);
 
@@ -2965,14 +3039,7 @@ void ClearButtonHighlight(FrameworkElement button) {
         // also flickers the native underline during hover storms.
 
         if (auto icon = FindChildByName(iconPanel, L"Icon")) {
-            auto localTf =
-                icon.ReadLocalValue(UIElement::RenderTransformProperty());
-            if (localTf != DependencyProperty::UnsetValue()) {
-                if (icon.RenderTransform().try_as<Media::ScaleTransform>()) {
-                    icon.ClearValue(UIElement::RenderTransformProperty());
-                    icon.ClearValue(UIElement::RenderTransformOriginProperty());
-                }
-            }
+            ClearIconScaleIfOurs(icon, button);
         }
 
         RestoreIconPanelNativeZOrder(iconPanel);
@@ -3493,6 +3560,7 @@ void EnsureIconPanelLayoutWatch(FrameworkElement button) {
     if (!iconPanel) {
         return;
     }
+    RememberUiDispatcher(iconPanel);
 
     const TaskbarEdge edge = DetectTaskbarEdge(iconPanel);
     bool alreadyWatched = false;
@@ -3604,7 +3672,8 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
         return;
     }
 
-    if (rankOneBased <= 0 || g_unloading.load() || !SettingsSnap()->enabled) {
+    auto settings = SettingsSnap();
+    if (rankOneBased <= 0 || g_unloading.load() || !settings->enabled) {
         ClearButtonHighlight(button);
         return;
     }
@@ -3621,11 +3690,13 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
         }
 
         const int rankIdx = rankOneBased - 1;
-        const int intensity = RankIntensity(rankIdx);
-        const int sizeBoost = RankSizeBoost(rankIdx);
+        const int intensity =
+            settings->glowIntensity[rankIdx < 3 ? rankIdx : 2];
+        const int sizeBoost =
+            settings->sizeBoostPercent[rankIdx < 3 ? rankIdx : 2];
         const double t = intensity / 100.0;
 
-        winrt::Windows::UI::Color base = ResolveGlowBaseColor();
+        winrt::Windows::UI::Color base = ResolveGlowBaseColor(*settings);
 
         auto withAlpha = [](winrt::Windows::UI::Color c,
                             int a) -> winrt::Windows::UI::Color {
@@ -3634,16 +3705,16 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
         };
 
         const int layers =
-            (std::max)(1, (std::min)(kGlowMaxLayers, SettingsSnap()->glowLayers));
+            (std::max)(1, (std::min)(kGlowMaxLayers, settings->glowLayers));
         const double thickness = static_cast<double>(
-            (std::max)(1, (std::min)(16, SettingsSnap()->glowThickness)));
+            (std::max)(1, (std::min)(16, settings->glowThickness)));
         const double roundnessFrac =
-            (std::max)(0, (std::min)(50, SettingsSnap()->glowRoundness)) / 100.0;
+            (std::max)(0, (std::min)(50, settings->glowRoundness)) / 100.0;
         const double sizeFrac =
-            (std::max)(40, (std::min)(100, SettingsSnap()->glowSize)) / 100.0;
-        const GlowStyle style = SettingsSnap()->glowStyle;
+            (std::max)(40, (std::min)(100, settings->glowSize)) / 100.0;
+        const GlowStyle style = settings->glowStyle;
         const int fillOpacitySetting =
-            (std::max)(0, (std::min)(100, SettingsSnap()->glowFillOpacity));
+            (std::max)(0, (std::min)(100, settings->glowFillOpacity));
 
         double panelW = iconPanel.ActualWidth();
         double panelH = iconPanel.ActualHeight();
@@ -3755,7 +3826,7 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
             // Edge bar on the native RunningIndicator side. Cover the pill
             // by z-order (host after RI). Never set Visibility/Width/Height
             // on the native indicator.
-            if (SettingsSnap()->glowDebugLog && !FindRunningIndicator(iconPanel)) {
+            if (settings->glowDebugLog && !FindRunningIndicator(iconPanel)) {
                 Wh_Log(L"EdgeBar: RunningIndicator not found on \"%s\"",
                        GetButtonAutomationName(button).c_str());
             }
@@ -3784,21 +3855,19 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
                 icon.RenderTransformOrigin(
                     winrt::Windows::Foundation::Point{0.5f, 0.5f});
                 icon.RenderTransform(scale);
+                RememberOurIconScale(button, scale);
             } else {
-                if (icon.RenderTransform().try_as<Media::ScaleTransform>()) {
-                    icon.ClearValue(UIElement::RenderTransformProperty());
-                    icon.ClearValue(UIElement::RenderTransformOriginProperty());
-                }
+                ClearIconScaleIfOurs(icon, button);
             }
         }
 
-        if (SettingsSnap()->glowDebugLog) {
+        if (settings->glowDebugLog) {
             Wh_Log(L"Glow rank %d \"%s\" style=%s edge=%s bar=%s box=%.0fx%.0f "
                    L"th=%.0f round=%d%% size=%d%% layers=%d intensity=%d",
                    rankOneBased, GetButtonAutomationName(button).c_str(),
                    GlowStyleName(style), TaskbarEdgeName(edge),
                    BarSideName(barSide), boxW, boxH, thickness,
-                   SettingsSnap()->glowRoundness, SettingsSnap()->glowSize, layers,
+                   settings->glowRoundness, settings->glowSize, layers,
                    intensity);
         }
     } catch (...) {
@@ -3826,6 +3895,7 @@ void TrackButton_UIThread(FrameworkElement button) {
         return;
     }
 
+    RememberUiDispatcher(button);
     {
         std::lock_guard<std::mutex> lock(g_buttonsMutex);
         g_dispatcherAnchor = winrt::make_weak(button);
@@ -4339,6 +4409,66 @@ void SetCachedPaintRank(FrameworkElement button, int rank) {
     g_buttonPathCache.push_back(std::move(stub));
 }
 
+void RememberOurIconScale(FrameworkElement button, Media::ScaleTransform scale) {
+    if (!button) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(g_buttonPathMutex);
+    for (auto& e : g_buttonPathCache) {
+        try {
+            if (e.button.get() == button) {
+                e.ourIconScale = scale ? winrt::make_weak(scale)
+                                       : winrt::weak_ref<Media::ScaleTransform>{};
+                return;
+            }
+        } catch (...) {
+        }
+    }
+    ButtonPathCacheEntry stub;
+    stub.button = winrt::make_weak(button);
+    if (scale) {
+        stub.ourIconScale = winrt::make_weak(scale);
+    }
+    g_buttonPathCache.push_back(std::move(stub));
+}
+
+void ClearIconScaleIfOurs(FrameworkElement icon, FrameworkElement button) {
+    if (!icon) {
+        return;
+    }
+    try {
+        auto localTf = icon.ReadLocalValue(UIElement::RenderTransformProperty());
+        if (localTf == DependencyProperty::UnsetValue()) {
+            return;
+        }
+        auto current = icon.RenderTransform().try_as<Media::ScaleTransform>();
+        if (!current) {
+            return;
+        }
+        Media::ScaleTransform ours = nullptr;
+        {
+            std::lock_guard<std::mutex> lock(g_buttonPathMutex);
+            for (auto& e : g_buttonPathCache) {
+                try {
+                    if (e.button.get() == button) {
+                        ours = e.ourIconScale.get();
+                        if (ours && current == ours) {
+                            e.ourIconScale = {};
+                        }
+                        break;
+                    }
+                } catch (...) {
+                }
+            }
+        }
+        if (ours && current == ours) {
+            icon.ClearValue(UIElement::RenderTransformProperty());
+            icon.ClearValue(UIElement::RenderTransformOriginProperty());
+        }
+    } catch (...) {
+    }
+}
+
 template <typename Fn>
 void ForEachLiveElementOnThisDispatcher(
     const std::vector<winrt::weak_ref<FrameworkElement>>& weaks,
@@ -4381,7 +4511,6 @@ std::vector<FrameworkElement> CollectLiveButtonsOnThisDispatcher() {
 
 void ApplyAllHighlights_UIThread() {
     g_lastFullRefreshTick = GetTickCount64();
-    RefreshCurrentDesktopId();
 
     std::vector<AppFocusInfo> ranks;
     {
@@ -4513,7 +4642,7 @@ void ApplyAllHighlights_UIThread() {
                live.size());
     }
 
-// Second pass: unmatched ranks — pick best free button with lower bar
+    // Second pass: unmatched ranks — pick best free button with lower bar
     // (uses window title). Helps Windhawk and odd product names.
     std::vector<std::wstring> demoteKeys;
     for (size_t ri = 0; ri < ranks.size(); ++ri) {
@@ -4663,16 +4792,6 @@ HWND HwndFromMappingEntry(const ThumbnailTaskItemMapping& item) {
     return nullptr;
 }
 
-// Closed flyouts leave dead weaks; their HWNDs/groups must not be reused to
-// resolve a later app's sibling count (TC Lister vs an earlier Chrome hover).
-bool ThumbnailMappingLive(const ThumbnailTaskItemMapping& item) {
-    try {
-        return item.thumbnail.get() != nullptr;
-    } catch (...) {
-        return false;
-    }
-}
-
 // True if two WinRT objects are the same COM identity (different projections
 // of the same TaskItemThumbnail still match).
 bool SameInspectableIdentity(winrt::Windows::Foundation::IInspectable const& a,
@@ -4725,118 +4844,6 @@ HWND ResolveHwndFromThumbnailModel(
         }
     }
     return nullptr;
-}
-
-// HWNDs for one task group in the *current* flyout's construction order.
-// Closed-flyout maps stay in the vector; first-seen order is the previous
-// hover and is often reversed after a click (Windows rebuilds MRU).
-std::vector<HWND> HwndsForTaskGroupInOrder(void* taskGroup) {
-    std::vector<HWND> newestFirst;
-    if (!taskGroup) {
-        return newestFirst;
-    }
-    std::lock_guard<std::mutex> lock(g_thumbnailMapMutex);
-    for (auto it = g_thumbnailTaskItemMapping.rbegin();
-         it != g_thumbnailTaskItemMapping.rend(); ++it) {
-        if (it->taskGroup != taskGroup || !ThumbnailMappingLive(*it)) {
-            continue;
-        }
-        HWND h = HwndFromMappingEntry(*it);
-        if (!h) {
-            continue;
-        }
-        if (std::find(newestFirst.begin(), newestFirst.end(), h) ==
-            newestFirst.end()) {
-            newestFirst.push_back(h);
-        }
-    }
-    std::reverse(newestFirst.begin(), newestFirst.end());
-    return newestFirst;
-}
-
-// Pick a taskGroup that has exactly `siblingCount` unique HWNDs (current flyout).
-void* FindTaskGroupForSiblingCount(size_t siblingCount) {
-    if (siblingCount == 0) {
-        return nullptr;
-    }
-    std::lock_guard<std::mutex> lock(g_thumbnailMapMutex);
-    // group -> ordered unique hwnds
-    struct GroupAcc {
-        void* group = nullptr;
-        std::vector<HWND> hwnds;
-    };
-    std::vector<GroupAcc> groups;
-    for (const auto& item : g_thumbnailTaskItemMapping) {
-        if (!item.taskGroup || !ThumbnailMappingLive(item)) {
-            continue;
-        }
-        HWND h = HwndFromMappingEntry(item);
-        if (!h) {
-            continue;
-        }
-        GroupAcc* acc = nullptr;
-        for (auto& g : groups) {
-            if (g.group == item.taskGroup) {
-                acc = &g;
-                break;
-            }
-        }
-        if (!acc) {
-            groups.push_back({item.taskGroup, {}});
-            acc = &groups.back();
-        }
-        if (std::find(acc->hwnds.begin(), acc->hwnds.end(), h) ==
-            acc->hwnds.end()) {
-            acc->hwnds.push_back(h);
-        }
-    }
-    // Last exact match wins — maps are append-only, so the newest live
-    // flyout is preferred over an older group with the same window count.
-    void* exact = nullptr;
-    for (const auto& g : groups) {
-        if (g.hwnds.size() == siblingCount) {
-            exact = g.group;
-        }
-    }
-    if (exact) {
-        return exact;
-    }
-    // Prefer largest group that is at least siblingCount (partial flyout).
-    void* best = nullptr;
-    size_t bestN = 0;
-    for (const auto& g : groups) {
-        if (g.hwnds.size() >= siblingCount && g.hwnds.size() > bestN) {
-            bestN = g.hwnds.size();
-            best = g.group;
-        }
-    }
-    return best;
-}
-
-// Last N unique HWNDs from the mapping vector (most recently constructed models
-// — typically the open flyout when maps were just created on hover).
-std::vector<HWND> LastMappedHwnds(size_t n) {
-    std::vector<HWND> out;
-    if (n == 0) {
-        return out;
-    }
-    std::lock_guard<std::mutex> lock(g_thumbnailMapMutex);
-    for (auto it = g_thumbnailTaskItemMapping.rbegin();
-         it != g_thumbnailTaskItemMapping.rend() && out.size() < n; ++it) {
-        if (!ThumbnailMappingLive(*it)) {
-            continue;
-        }
-        HWND h = HwndFromMappingEntry(*it);
-        if (!h) {
-            continue;
-        }
-        if (std::find(out.begin(), out.end(), h) == out.end()) {
-            out.push_back(h);
-        }
-    }
-    // We walked newest→oldest; reverse to construction/display order.
-    std::reverse(out.begin(), out.end());
-    return out;
 }
 
 HWND ResolveHwndForThumbnailView(FrameworkElement thumbView,
@@ -4995,10 +5002,66 @@ std::vector<FrameworkElement> CollectSiblingThumbnailViews(
     return out;
 }
 
+FrameworkElement FindAncestorItemsRepeater(FrameworkElement el) {
+    FrameworkElement cur = el;
+    for (int guard = 0; guard < 32 && cur; ++guard) {
+        try {
+            if (winrt::get_class_name(cur) ==
+                L"Microsoft.UI.Xaml.Controls.ItemsRepeater") {
+                return cur;
+            }
+            cur = Media::VisualTreeHelper::GetParent(cur)
+                      .try_as<FrameworkElement>();
+        } catch (...) {
+            break;
+        }
+    }
+    return nullptr;
+}
+
+// Repeater index is the flyout visual order (unlike PositionInSet, which the
+// automation peer may not refresh after a thumbnail reorder).
+std::vector<FrameworkElement> CollectRepeaterThumbnailViews(
+    FrameworkElement thumbView) {
+    std::vector<FrameworkElement> out;
+    auto repeaterEl = FindAncestorItemsRepeater(thumbView);
+    if (!repeaterEl) {
+        return out;
+    }
+    auto repeater =
+        repeaterEl.try_as<winrt::Microsoft::UI::Xaml::Controls::ItemsRepeater>();
+    if (!repeater) {
+        return out;
+    }
+    try {
+        auto itemsSourceView = repeater.ItemsSourceView();
+        const int count = itemsSourceView ? itemsSourceView.Count() : 0;
+        for (int i = 0; i < count; ++i) {
+            auto element = repeater.TryGetElement(i);
+            if (!element) {
+                continue;
+            }
+            auto child = element.try_as<FrameworkElement>();
+            if (!child) {
+                continue;
+            }
+            if (winrt::get_class_name(child) ==
+                L"Taskbar.TaskItemThumbnailView") {
+                out.push_back(child);
+            }
+        }
+    } catch (...) {
+    }
+    return out;
+}
+
+HWND HwndFromThumbnailsGetAt(int index);
+
 void TrackThumbView_UIThread(FrameworkElement thumbView) {
     if (!thumbView) {
         return;
     }
+    RememberUiDispatcher(thumbView);
     std::lock_guard<std::mutex> lock(g_thumbViewsMutex);
     for (auto& weak : g_trackedThumbViews) {
         try {
@@ -5258,49 +5321,13 @@ void SortThumbnailViewsVisualOrder(std::vector<FrameworkElement>& views) {
         });
 }
 
-// Snap-group card in the same flyout as the individual windows
-// ("Group | Lister - [file] and 1 other window"). Must not be treated as a
-// window thumbnail — it steals group-order HWND 0 and the recent glow.
+// Snap-group card in the same flyout as the individual windows. Must not be
+// treated as a window thumbnail. Language-independent: the group card hosts
+// an IconsRepeater with 2+ icon children.
 bool IsSnapGroupThumbnailView(FrameworkElement view) {
     if (!view) {
         return false;
     }
-    auto looksLikeGroup = [](const std::wstring& s) -> bool {
-        if (s.empty()) {
-            return false;
-        }
-        if (s.size() >= 5 && _wcsnicmp(s.c_str(), L"Group", 5) == 0 &&
-            (s.size() == 5 || s[5] == L' ' || s[5] == L'|' || s[5] == L'-')) {
-            return true;
-        }
-        if (s.find(L" other window") != std::wstring::npos) {
-            return true;
-        }
-        return false;
-    };
-
-    try {
-        std::wstring name =
-            Automation::AutomationProperties::GetName(view).c_str();
-        if (looksLikeGroup(name) ||
-            looksLikeGroup(NormalizeAutomationName(name))) {
-            return true;
-        }
-    } catch (...) {
-    }
-
-    try {
-        if (auto title = FindThumbnailTitleElement(view)) {
-            if (auto tb = title.try_as<Controls::TextBlock>()) {
-                std::wstring text = tb.Text().c_str();
-                if (looksLikeGroup(text)) {
-                    return true;
-                }
-            }
-        }
-    } catch (...) {
-    }
-
     if (auto repeater = FindDescendantByName(view, L"IconsRepeater")) {
         try {
             if (Media::VisualTreeHelper::GetChildrenCount(repeater) >= 2) {
@@ -5310,56 +5337,6 @@ bool IsSnapGroupThumbnailView(FrameworkElement view) {
         }
     }
     return false;
-}
-
-struct EnumSameClassCtx {
-    DWORD pid = 0;
-    std::wstring classUpper;
-    std::vector<HWND>* out = nullptr;
-};
-
-BOOL CALLBACK EnumSameClassWndProc(HWND hWnd, LPARAM lParam) {
-    auto* ctx = reinterpret_cast<EnumSameClassCtx*>(lParam);
-    if (!ctx || !ctx->out) {
-        return FALSE;
-    }
-    DWORD pid = 0;
-    GetWindowThreadProcessId(hWnd, &pid);
-    if (pid != ctx->pid || !IsWindowVisible(hWnd)) {
-        return TRUE;
-    }
-    if (GetWindowLong(hWnd, GWL_STYLE) & WS_CHILD) {
-        return TRUE;
-    }
-    if (ToUpper(GetWindowClassName(hWnd)) != ctx->classUpper) {
-        return TRUE;
-    }
-    if (std::find(ctx->out->begin(), ctx->out->end(), hWnd) ==
-        ctx->out->end()) {
-        ctx->out->push_back(hWnd);
-    }
-    return TRUE;
-}
-
-std::vector<HWND> ExpandSameClassWindows(const std::vector<HWND>& seeds) {
-    std::vector<HWND> out;
-    for (HWND seed : seeds) {
-        if (!seed || !IsWindow(seed)) {
-            continue;
-        }
-        if (std::find(out.begin(), out.end(), seed) == out.end()) {
-            out.push_back(seed);
-        }
-        DWORD pid = 0;
-        GetWindowThreadProcessId(seed, &pid);
-        std::wstring cls = ToUpper(GetWindowClassName(seed));
-        if (!pid || cls.empty()) {
-            continue;
-        }
-        EnumSameClassCtx ctx{pid, std::move(cls), &out};
-        EnumWindows(EnumSameClassWndProc, reinterpret_cast<LPARAM>(&ctx));
-    }
-    return out;
 }
 
 FrameworkElement FindThumbnailBackgroundBorder(FrameworkElement thumbView) {
@@ -5681,8 +5658,9 @@ void ScheduleThumbnailRelayout(FrameworkElement thumbView) {
 }
 
 void ApplyThumbnailHighlight(FrameworkElement thumbView, int rankOneBased) {
+    auto settings = SettingsSnap();
     if (!thumbView || rankOneBased <= 0 || g_unloading.load() ||
-        !SettingsSnap()->enabled || !SettingsSnap()->previewHighlightEnabled) {
+        !settings->enabled || !settings->previewHighlightEnabled) {
         ClearThumbnailHighlight(thumbView);
         return;
     }
@@ -5697,22 +5675,24 @@ void ApplyThumbnailHighlight(FrameworkElement thumbView, int rankOneBased) {
         }
         auto panelFe = panel.as<FrameworkElement>();
 
-        const int intensity = PreviewRankIntensity(rankOneBased - 1);
+        const int rankIdx = rankOneBased - 1;
+        const int intensity =
+            settings->previewIntensity[rankIdx < 3 ? rankIdx : 2];
         const double t = intensity / 100.0;
-        winrt::Windows::UI::Color base = ResolveGlowBaseColor();
+        winrt::Windows::UI::Color base = ResolveGlowBaseColor(*settings);
         auto withAlpha = [](winrt::Windows::UI::Color c, int a) {
             c.A = static_cast<uint8_t>((std::max)(0, (std::min)(255, a)));
             return c;
         };
 
         const double thickness = static_cast<double>(
-            (std::max)(2, (std::min)(8, SettingsSnap()->glowThickness)));
+            (std::max)(2, (std::min)(8, settings->glowThickness)));
         const double roundnessFrac =
-            (std::max)(0, (std::min)(50, SettingsSnap()->glowRoundness)) / 100.0;
+            (std::max)(0, (std::min)(50, settings->glowRoundness)) / 100.0;
         // Preview plate / titleBg use dedicated opacity (not taskbar fill).
         const int fillOpacitySetting =
-            (std::max)(0, (std::min)(100, SettingsSnap()->previewFillOpacity));
-        const PreviewStyle style = SettingsSnap()->previewStyle;
+            (std::max)(0, (std::min)(100, settings->previewFillOpacity));
+        const PreviewStyle style = settings->previewStyle;
         // Hybrid: plate is the rank-1 “this one” signal; title wash is enough
         // for 2+ (whole-plate 50/5 looks like leftover hover, not a ladder).
         PreviewStyle paintStyle = style;
@@ -5807,7 +5787,7 @@ void ApplyThumbnailHighlight(FrameworkElement thumbView, int rankOneBased) {
                 }
             }
 
-            if (SettingsSnap()->glowDebugLog) {
+            if (settings->glowDebugLog) {
                 Wh_Log(L"Preview glow rank %d style=%s paint=%s intensity=%d "
                        L"on \"%s\"",
                        rankOneBased, PreviewStyleName(style),
@@ -5919,7 +5899,7 @@ void ApplyThumbnailHighlight(FrameworkElement thumbView, int rankOneBased) {
             }
         }
 
-        if (SettingsSnap()->glowDebugLog) {
+        if (settings->glowDebugLog) {
             Wh_Log(L"Preview glow rank %d style=%s paint=%s intensity=%d "
                    L"card=%.0fx%.0f on \"%s\"",
                    rankOneBased, PreviewStyleName(style),
@@ -5939,7 +5919,11 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
     }
     TrackThumbView_UIThread(anyThumb);
 
-    auto allViews = CollectSiblingThumbnailViews(anyThumb);
+    auto repeaterViews = CollectRepeaterThumbnailViews(anyThumb);
+    const bool usedRepeater = !repeaterViews.empty();
+    auto allViews =
+        usedRepeater ? std::move(repeaterViews)
+                     : CollectSiblingThumbnailViews(anyThumb);
     if (!SettingsSnap()->enabled || !SettingsSnap()->previewHighlightEnabled ||
         g_unloading.load()) {
         for (auto& s : allViews) {
@@ -5948,9 +5932,8 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
         return;
     }
 
-    // Snap-group cards sit in the same ItemsRepeater as the windows
-    // (UWPSpy: PositionInSet 1/4 = "Group | Lister - [file] and 1 other
-    // window"). Never glow those; they are not a window HWND.
+    // Snap-group cards sit in the same ItemsRepeater as the windows.
+    // Never glow those; they are not a window HWND.
     std::vector<FrameworkElement> siblings;
     siblings.reserve(allViews.size());
     for (auto& v : allViews) {
@@ -5969,16 +5952,16 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
         return;
     }
 
-    SortThumbnailViewsVisualOrder(siblings);
+    if (!usedRepeater) {
+        SortThumbnailViewsVisualOrder(siblings);
+    }
     const std::vector<std::wstring> cardTitles = PickFlyoutCardTitles(siblings);
 
     // HWND pipeline (this flyout only — not a global window ladder):
-    //   1. TaskItem — DataContext ↔ ctor map (COM identity).
-    //   2. Group-order — live mappings for this hover, not the previous one.
-    //      Dropped when card titles are distinct (index ≠ visual after a click).
-    //   3. Title unique — DisplayNameTextBlock when texts differ; each HWND once.
-    // Then sort by recency tick / confirmSeq and paint top N.
-    enum class ResolveHow : int { None = 0, TaskItem, GroupOrder, Title };
+    //   1. Repeater index + Thumbnails.GetAt + ctor map (authoritative).
+    //   2. TaskItem — DataContext ↔ ctor map (COM identity).
+    //   3. Title unique — only for unresolved cards; each HWND once.
+    enum class ResolveHow : int { None = 0, Repeater, TaskItem, Title };
     struct Scored {
         FrameworkElement view{nullptr};
         HWND hwnd = nullptr;
@@ -5988,7 +5971,6 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
     };
     std::vector<Scored> scored(siblings.size());
     std::unordered_set<HWND> usedHwnds;
-    void* sharedGroup = nullptr;
 
     auto recent = CopyRecentWindowsForPreview();
 
@@ -6014,17 +5996,37 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
         return it->second.confirmSeq;
     };
 
-    // Pass 1: strong identity (TaskItemThumbnail model → HWND). Never use bare
-    // title here — two Calibre windows with the same file name would both bind
-    // to the same HWND.
     for (size_t i = 0; i < siblings.size(); ++i) {
         TrackThumbView_UIThread(siblings[i]);
         scored[i].view = siblings[i];
-        void* group = nullptr;
-        HWND hwnd = ResolveHwndForThumbnailView(siblings[i], &group);
-        if (group && !sharedGroup) {
-            sharedGroup = group;
+    }
+
+    // Pass 1: repeater index → GetAt → ctor map HWND.
+    // Index is against allViews (includes snap-group cards), not siblings.
+    if (usedRepeater) {
+        size_t si = 0;
+        for (size_t ri = 0; ri < allViews.size() && si < siblings.size();
+             ++ri) {
+            if (IsSnapGroupThumbnailView(allViews[ri])) {
+                continue;
+            }
+            HWND hwnd = HwndFromThumbnailsGetAt(static_cast<int>(ri));
+            if (hwnd && IsWindow(hwnd) && !usedHwnds.count(hwnd)) {
+                scored[si].hwnd = hwnd;
+                scored[si].tick = tickFor(hwnd);
+                scored[si].how = ResolveHow::Repeater;
+                usedHwnds.insert(hwnd);
+            }
+            ++si;
         }
+    }
+
+    // Pass 2: DataContext ↔ ctor map. Never overwrite a repeater bind.
+    for (size_t i = 0; i < siblings.size(); ++i) {
+        if (scored[i].hwnd) {
+            continue;
+        }
+        HWND hwnd = ResolveHwndForThumbnailView(siblings[i]);
         if (hwnd && IsWindow(hwnd) && !usedHwnds.count(hwnd)) {
             scored[i].hwnd = hwnd;
             scored[i].tick = tickFor(hwnd);
@@ -6033,191 +6035,29 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
         }
     }
 
-    // Pass 1b: fill from TaskItem maps by group / construction order.
-    // DataContext often does NOT match our ctor IInspectable (logs showed
-    // "2 taskitem maps" but how=title/none) — so discover the group even
-    // when pass 1 resolved nothing.
-    if (usedHwnds.size() < siblings.size()) {
-        void* group = sharedGroup;
-        if (!group) {
-            std::lock_guard<std::mutex> lock(g_thumbnailMapMutex);
-            for (const auto& item : g_thumbnailTaskItemMapping) {
-                HWND h = HwndFromMappingEntry(item);
-                if (h && usedHwnds.count(h) && item.taskGroup) {
-                    group = item.taskGroup;
-                    break;
-                }
+    // Pass 3: unique-title fallback for cards still unresolved. Identical
+    // titles stay unmatched (do not steal another card's HWND).
+    const bool titlesDistinct = TitleKeysAreDistinct(cardTitles);
+    if (titlesDistinct) {
+        for (size_t i = 0; i < siblings.size(); ++i) {
+            if (scored[i].hwnd) {
+                continue;
             }
-        }
-        if (!group) {
-            group = FindTaskGroupForSiblingCount(siblings.size());
-        }
-
-        std::vector<HWND> groupHwnds = HwndsForTaskGroupInOrder(group);
-        // Fallback: last N mapped HWNDs (just-created flyout models).
-        if (groupHwnds.size() != siblings.size()) {
-            auto last = LastMappedHwnds(siblings.size());
-            if (last.size() == siblings.size()) {
-                groupHwnds = std::move(last);
-            }
-        }
-        // Do NOT EnumWindows-expand here and then assign by index.
-        // Z-order (focused window first) is not left-to-right flyout order —
-        // that pinned the recent Lister HWND onto card 0 every time.
-
-        if (groupHwnds.size() == siblings.size()) {
-            // Prefer map order for ALL siblings when counts match — more
-            // reliable than leaving a half-filled title match in place.
-            // Only overwrite title-resolved slots when they have no taskitem id.
-            bool anyTaskItem = false;
-            for (const auto& s : scored) {
-                if (s.how == ResolveHow::TaskItem) {
-                    anyTaskItem = true;
-                    break;
-                }
-            }
-            if (!anyTaskItem) {
-                usedHwnds.clear();
-                for (size_t i = 0; i < siblings.size(); ++i) {
-                    HWND h = groupHwnds[i];
-                    scored[i].hwnd = h;
-                    scored[i].tick = tickFor(h);
-                    scored[i].how = ResolveHow::GroupOrder;
-                    if (h) {
-                        usedHwnds.insert(h);
-                    }
-                }
-            } else {
-                for (size_t i = 0; i < siblings.size(); ++i) {
-                    if (scored[i].hwnd) {
-                        continue;
-                    }
-                    HWND h = groupHwnds[i];
-                    if (!h || usedHwnds.count(h)) {
-                        continue;
-                    }
-                    scored[i].hwnd = h;
-                    scored[i].tick = tickFor(h);
-                    scored[i].how = ResolveHow::GroupOrder;
-                    usedHwnds.insert(h);
-                }
-            }
-        } else if (!groupHwnds.empty()) {
-            size_t gi = 0;
-            for (size_t i = 0; i < siblings.size() && gi < groupHwnds.size();
-                 ++i) {
-                if (scored[i].hwnd) {
-                    continue;
-                }
-                while (gi < groupHwnds.size() &&
-                       usedHwnds.count(groupHwnds[gi])) {
-                    ++gi;
-                }
-                if (gi >= groupHwnds.size()) {
-                    break;
-                }
-                HWND h = groupHwnds[gi++];
+            HWND h = MatchTitleToUnusedRecent(cardTitles[i], recent, usedHwnds);
+            if (h) {
                 scored[i].hwnd = h;
                 scored[i].tick = tickFor(h);
-                scored[i].how = ResolveHow::GroupOrder;
-                usedHwnds.insert(h);
-            }
-        }
-    }
-
-    // Title pool: recency map plus live same-class windows (TLister a/b/c).
-    // Enumerated HWNDs are candidates only — never assigned by index.
-    std::vector<HWND> titleSeeds;
-    for (const auto& r : recent) {
-        if (r.hwnd) {
-            titleSeeds.push_back(r.hwnd);
-        }
-    }
-    for (const auto& s : scored) {
-        if (s.hwnd) {
-            titleSeeds.push_back(s.hwnd);
-        }
-    }
-    std::vector<WindowFocusInfo> titlePool = recent;
-    {
-        std::unordered_set<HWND> have;
-        for (const auto& r : titlePool) {
-            if (r.hwnd) {
-                have.insert(r.hwnd);
-            }
-        }
-        for (HWND h : ExpandSameClassWindows(titleSeeds)) {
-            if (!h || have.count(h)) {
-                continue;
-            }
-            WindowFocusInfo extra;
-            extra.hwnd = h;
-            extra.windowTitle = GetWindowTitle(h);
-            extra.lastConfirmedTick = tickFor(h);
-            titlePool.push_back(std::move(extra));
-            have.insert(h);
-        }
-    }
-
-    const bool titlesDistinct = TitleKeysAreDistinct(cardTitles);
-
-    auto hwndTitle = [](HWND hwnd) -> std::wstring {
-        return hwnd && IsWindow(hwnd) ? GetWindowTitle(hwnd) : std::wstring{};
-    };
-
-    // Unique titles beat index assignment. Also drop a TaskItem HWND that
-    // clearly belongs to a *different* card (ebook reader: DataContext /
-    // stale map points at the other book in the same process).
-    if (titlesDistinct) {
-        for (size_t i = 0; i < scored.size(); ++i) {
-            if (!scored[i].hwnd) {
-                continue;
-            }
-            const bool dropGroup = scored[i].how == ResolveHow::GroupOrder;
-            int selfScore = ScoreTitleToAutomationName(hwndTitle(scored[i].hwnd),
-                                                       cardTitles[i]);
-            int bestOther = 0;
-            for (size_t j = 0; j < cardTitles.size(); ++j) {
-                if (j == i) {
-                    continue;
-                }
-                bestOther = (std::max)(
-                    bestOther, ScoreTitleToAutomationName(
-                                   hwndTitle(scored[i].hwnd), cardTitles[j]));
-            }
-            const bool belongsElsewhere =
-                bestOther >= 70 && bestOther > selfScore;
-            if (dropGroup || belongsElsewhere) {
-                usedHwnds.erase(scored[i].hwnd);
-                scored[i].hwnd = nullptr;
-                scored[i].tick = 0;
-                scored[i].how = ResolveHow::None;
-            }
-        }
-    }
-
-    // Pass 2: title fallback with unique HWND assignment only.
-    for (size_t i = 0; i < siblings.size(); ++i) {
-        if (scored[i].hwnd) {
-            continue;
-        }
-        std::wstring autoName = cardTitles[i];
-        HWND h = MatchTitleToUnusedRecent(autoName, titlePool, usedHwnds);
-        if (h) {
-            scored[i].hwnd = h;
-            scored[i].tick = tickFor(h);
-            if (scored[i].tick == 0) {
-                // Live window not yet in recency map — still use its title
-                // tick from the pool entry if we recorded one.
-                for (const auto& info : titlePool) {
-                    if (info.hwnd == h && info.lastConfirmedTick > 0) {
-                        scored[i].tick = info.lastConfirmedTick;
-                        break;
+                if (scored[i].tick == 0) {
+                    for (const auto& info : recent) {
+                        if (info.hwnd == h && info.lastConfirmedTick > 0) {
+                            scored[i].tick = info.lastConfirmedTick;
+                            break;
+                        }
                     }
                 }
+                scored[i].how = ResolveHow::Title;
+                usedHwnds.insert(h);
             }
-            scored[i].how = ResolveHow::Title;
-            usedHwnds.insert(h);
         }
     }
 
@@ -6314,11 +6154,11 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
         for (size_t i = 0; i < scored.size(); ++i) {
             PCWSTR how = L"none";
             switch (scored[i].how) {
+                case ResolveHow::Repeater:
+                    how = L"repeater";
+                    break;
                 case ResolveHow::TaskItem:
                     how = L"taskitem";
-                    break;
-                case ResolveHow::GroupOrder:
-                    how = L"group-order";
                     break;
                 case ResolveHow::Title:
                     how = L"title";
@@ -6385,69 +6225,16 @@ void RequestApplyPreviewVisuals() {
 std::atomic<bool> g_loggedNoDispatcherAnchor{false};
 
 std::vector<winrt::Windows::UI::Core::CoreDispatcher> CollectUiDispatchers() {
-    std::vector<winrt::Windows::UI::Core::CoreDispatcher> dispatchers;
-    auto addDispatcher = [&](FrameworkElement el) {
-        if (!el) {
-            return;
-        }
-        try {
-            auto dispatcher = el.Dispatcher();
-            if (!dispatcher) {
-                return;
-            }
-            for (const auto& existing : dispatchers) {
-                if (existing == dispatcher) {
-                    return;
-                }
-            }
-            dispatchers.push_back(dispatcher);
-        } catch (...) {
-        }
-    };
-
-    {
-        std::lock_guard<std::mutex> lock(g_buttonsMutex);
-        try {
-            addDispatcher(g_dispatcherAnchor.get());
-        } catch (...) {
-        }
-        for (auto& weak : g_trackedButtons) {
-            try {
-                addDispatcher(weak.get());
-            } catch (...) {
-            }
-        }
-    }
-    {
-        std::lock_guard<std::mutex> lock(g_thumbViewsMutex);
-        for (auto& weak : g_trackedThumbViews) {
-            try {
-                addDispatcher(weak.get());
-            } catch (...) {
-            }
-        }
-    }
-    std::vector<winrt::weak_ref<FrameworkElement>> layoutPanels;
-    {
-        std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
-        for (auto& w : g_layoutWatches) {
-            layoutPanels.push_back(w.panel);
-        }
-    }
-    for (auto& weak : layoutPanels) {
-        try {
-            addDispatcher(weak.get());
-        } catch (...) {
-        }
-    }
-    return dispatchers;
+    std::lock_guard<std::mutex> lock(g_dispatchersMutex);
+    return g_uiDispatchers;
 }
 
 // Uninit: run handler at High, then wait for a Low sentinel so earlier
 // Normal TryRunAsync work (which no-ops on g_unloading) has drained.
+// Must not return until every dispatcher has run — SizeChanged tokens live
+// in this image.
 bool RunOnEachUiDispatcherAndWait(
-    const winrt::Windows::UI::Core::DispatchedHandler& handler,
-    DWORD timeoutMs) {
+    const winrt::Windows::UI::Core::DispatchedHandler& handler) {
     auto dispatchers = CollectUiDispatchers();
     if (dispatchers.empty()) {
         Wh_Log(L"UI cleanup: no dispatcher");
@@ -6483,13 +6270,10 @@ bool RunOnEachUiDispatcherAndWait(
                 SetEvent(done);
                 allOk = false;
             }
-            const DWORD w = WaitForSingleObject(done, timeoutMs);
-            if (w == WAIT_OBJECT_0) {
-                CloseHandle(done);
-            } else {
-                // Low sentinel may still run — do not CloseHandle.
-                Wh_Log(L"ERROR: UI dispatcher cleanup timed out (%ums)",
-                       timeoutMs);
+            const DWORD w = WaitForSingleObject(done, INFINITE);
+            CloseHandle(done);
+            if (w != WAIT_OBJECT_0) {
+                Wh_Log(L"ERROR: UI dispatcher cleanup wait failed (%u)", w);
                 allOk = false;
             }
         } catch (...) {
@@ -6628,11 +6412,8 @@ void ScheduleRefreshAllHighlights(FrameworkElement dispatcherAnchor) {
                         g_lastFullRefreshTick != 0) {
                         // Coalesce a trailing full bind after the hover storm
                         // so siblings Windows reset without UVS get restored.
-                        if (g_hookThreadHwnd) {
-                            SetTimer(g_hookThreadHwnd, kFullRebindTimerId,
-                                     static_cast<UINT>(kFullRebindDebounceMs),
-                                     nullptr);
-                        }
+                        // SetTimer must run on the hook thread (window owner).
+                        PostToHookThread(WM_APP_REQUEST_APPLY_DEBOUNCED);
                         return;
                     }
                     g_lastFullRefreshTick = now;
@@ -6731,6 +6512,11 @@ int WINAPI TaskListButton_OnPointerPressed_Hook(void* pThis, void* pArgs) {
     return ret;
 }
 
+using HoverFlyoutModel_TargetItemKey_t = void(WINAPI*)(void* pThis,
+                                                       void* param1);
+extern HoverFlyoutModel_TargetItemKey_t HoverFlyoutModel_TargetItemKey_Original;
+void WINAPI HoverFlyoutModel_TargetItemKey_Hook(void* pThis, void* param1);
+
 bool HookTaskbarViewDllSymbols(HMODULE module) {
     // Taskbar.View.dll, ExplorerExtensions.dll
     WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
@@ -6774,6 +6560,14 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
             {LR"(public: void __cdecl winrt::Taskbar::implementation::TaskItemThumbnailView::OnApplyTemplate(void))"},
             &TaskItemThumbnailView_OnApplyTemplate_Original,
             TaskItemThumbnailView_OnApplyTemplate_Hook,
+            true,
+        },
+        {
+            // Optional: capture the live Thumbnails collection (same as
+            // taskbar-thumbnail-reorder).
+            {LR"(private: void __cdecl winrt::Taskbar::implementation::HoverFlyoutModel::TargetItemKey(struct winrt::hstring const &))"},
+            &HoverFlyoutModel_TargetItemKey_Original,
+            HoverFlyoutModel_TargetItemKey_Hook,
             true,
         },
     };
@@ -6861,6 +6655,90 @@ void* WINAPI TaskItemThumbnail_TaskItemThumbnail_2_Hook(void* param1,
     return result;
 }
 
+thread_local bool g_inHoverFlyoutModel_TargetItemKey = false;
+winrt::weak_ref<winrt::Windows::Foundation::IInspectable>
+    g_TaskGroup_Thumbnails;
+
+using TaskGroup_Thumbnails_t = void*(WINAPI*)(void* pThis, void* param1);
+TaskGroup_Thumbnails_t TaskGroup_Thumbnails_Original;
+void* WINAPI TaskGroup_Thumbnails_Hook(void* pThis, void* param1) {
+    void* result = TaskGroup_Thumbnails_Original(pThis, param1);
+    if (!g_inHoverFlyoutModel_TargetItemKey || !result) {
+        return result;
+    }
+    try {
+        winrt::Windows::Foundation::IInspectable obj = nullptr;
+        (*reinterpret_cast<IUnknown**>(result))
+            ->QueryInterface(
+                winrt::guid_of<winrt::Windows::Foundation::IInspectable>(),
+                winrt::put_abi(obj));
+        if (obj) {
+            g_TaskGroup_Thumbnails = obj;
+        }
+    } catch (...) {
+    }
+    return result;
+}
+
+using TaskItemThumbnail_Size_t = int(WINAPI*)(void* pThis);
+TaskItemThumbnail_Size_t TaskItemThumbnail_Size_Original;
+
+using TaskItemThumbnail_GetAt_t = void*(WINAPI*)(void* pThis,
+                                                 void** result,
+                                                 int index);
+TaskItemThumbnail_GetAt_t TaskItemThumbnail_GetAt_Original;
+
+HWND HwndFromThumbnailsGetAt(int index) {
+    if (!TaskItemThumbnail_GetAt_Original || !TaskItemThumbnail_Size_Original ||
+        index < 0) {
+        return nullptr;
+    }
+    winrt::Windows::Foundation::IInspectable thumbnails = nullptr;
+    try {
+        thumbnails = g_TaskGroup_Thumbnails.get();
+    } catch (...) {
+        return nullptr;
+    }
+    if (!thumbnails) {
+        return nullptr;
+    }
+    try {
+        auto* thumbnailsPtr = winrt::get_abi(thumbnails);
+        const int size = TaskItemThumbnail_Size_Original(&thumbnailsPtr);
+        if (index >= size) {
+            return nullptr;
+        }
+        winrt::com_ptr<IUnknown> item;
+        TaskItemThumbnail_GetAt_Original(&thumbnailsPtr, item.put_void(),
+                                         index);
+        if (!item) {
+            return nullptr;
+        }
+        std::lock_guard<std::mutex> lock(g_thumbnailMapMutex);
+        for (const auto& iter : g_thumbnailTaskItemMapping) {
+            try {
+                auto t = iter.thumbnail.get();
+                if (!t) {
+                    continue;
+                }
+                if (winrt::get_abi(t) == item.get()) {
+                    return HwndFromMappingEntry(iter);
+                }
+            } catch (...) {
+            }
+        }
+    } catch (...) {
+    }
+    return nullptr;
+}
+
+HoverFlyoutModel_TargetItemKey_t HoverFlyoutModel_TargetItemKey_Original;
+void WINAPI HoverFlyoutModel_TargetItemKey_Hook(void* pThis, void* param1) {
+    g_inHoverFlyoutModel_TargetItemKey = true;
+    HoverFlyoutModel_TargetItemKey_Original(pThis, param1);
+    g_inHoverFlyoutModel_TargetItemKey = false;
+}
+
 bool HookTaskbarDllSymbols() {
     HMODULE module =
         LoadLibraryEx(L"taskbar.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
@@ -6929,6 +6807,24 @@ bool HookTaskbarDllSymbols() {
             TaskItemThumbnail_TaskItemThumbnail_2_Hook,
             true,
         },
+        {
+            {LR"(public: struct winrt::Windows::Foundation::Collections::IObservableVector<struct winrt::WindowsUdk::UI::Shell::TaskItemThumbnail> __cdecl winrt::WindowsUdk::UI::Shell::implementation::TaskGroup::Thumbnails(void))"},
+            &TaskGroup_Thumbnails_Original,
+            TaskGroup_Thumbnails_Hook,
+            true,
+        },
+        {
+            {LR"(public: __cdecl winrt::impl::consume_Windows_Foundation_Collections_IVector<struct winrt::Windows::Foundation::Collections::IObservableVector<struct winrt::WindowsUdk::UI::Shell::TaskItemThumbnail>,struct winrt::WindowsUdk::UI::Shell::TaskItemThumbnail>::Size(void)const )"},
+            &TaskItemThumbnail_Size_Original,
+            nullptr,
+            true,
+        },
+        {
+            {LR"(public: __cdecl winrt::impl::consume_Windows_Foundation_Collections_IVector<struct winrt::Windows::Foundation::Collections::IObservableVector<struct winrt::WindowsUdk::UI::Shell::TaskItemThumbnail>,struct winrt::WindowsUdk::UI::Shell::TaskItemThumbnail>::GetAt(unsigned int)const )"},
+            &TaskItemThumbnail_GetAt_Original,
+            nullptr,
+            true,
+        },
     };
 
     if (!HookSymbols(module, taskbarDllHooks, ARRAYSIZE(taskbarDllHooks))) {
@@ -6985,15 +6881,11 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
 // ---------------------------------------------------------------------------
 
 void CancelMinFocusTimer() {
-    if (g_hookThreadHwnd) {
-        KillTimer(g_hookThreadHwnd, kMinFocusTimerId);
-    }
+    DisarmHookTimer(kMinFocusTimerId);
 }
 
 void CancelPreviewMinFocusTimer() {
-    if (g_hookThreadHwnd) {
-        KillTimer(g_hookThreadHwnd, kPreviewMinFocusTimerId);
-    }
+    DisarmHookTimer(kPreviewMinFocusTimerId);
 }
 
 // True if pending is still the focused app. May retarget to a new top-level
@@ -7062,10 +6954,7 @@ void OnPreviewMinFocusTimerElapsed(MinFocusConfirmMode mode) {
         const ULONGLONG remaining = RemainingDeadlineMs(
             start, settings->previewMinFocusSeconds, now);
         if (remaining > 0) {
-            if (g_hookThreadHwnd) {
-                SetTimer(g_hookThreadHwnd, kPreviewMinFocusTimerId,
-                         ClampWinTimerMs(remaining), nullptr);
-            }
+            ArmHookTimer(kPreviewMinFocusTimerId, remaining);
             return;
         }
     }
@@ -7083,10 +6972,7 @@ void OnPreviewMinFocusTimerElapsed(MinFocusConfirmMode mode) {
             if (remaining == 0) {
                 remaining = 200;
             }
-            if (g_hookThreadHwnd) {
-                SetTimer(g_hookThreadHwnd, kPreviewMinFocusTimerId,
-                         ClampWinTimerMs(remaining), nullptr);
-            }
+            ArmHookTimer(kPreviewMinFocusTimerId, remaining);
         }
         // Focus left the app — drop only preview; app timer may still be pending.
         return;
@@ -7130,10 +7016,7 @@ void OnMinFocusTimerElapsed(MinFocusConfirmMode mode) {
         const ULONGLONG remaining = RemainingDeadlineMs(
             pending.focusStartTick, settings->minFocusSeconds, now);
         if (remaining > 0) {
-            if (g_hookThreadHwnd) {
-                SetTimer(g_hookThreadHwnd, kMinFocusTimerId,
-                         ClampWinTimerMs(remaining), nullptr);
-            }
+            ArmHookTimer(kMinFocusTimerId, remaining);
             return;
         }
     }
@@ -7151,10 +7034,7 @@ void OnMinFocusTimerElapsed(MinFocusConfirmMode mode) {
             if (remaining == 0) {
                 remaining = 200;
             }
-            if (g_hookThreadHwnd) {
-                SetTimer(g_hookThreadHwnd, kMinFocusTimerId,
-                         ClampWinTimerMs(remaining), nullptr);
-            }
+            ArmHookTimer(kMinFocusTimerId, remaining);
             if (settings->glowDebugLog) {
                 Wh_Log(L"Min-focus timer: transient FG, still waiting on %s "
                        L"(%llums left)",
@@ -7176,8 +7056,22 @@ void OnMinFocusTimerElapsed(MinFocusConfirmMode mode) {
         pending.windowTitle = std::move(title);
     }
 
+    const std::wstring classUpper = ToUpper(GetWindowClassName(pending.hwnd));
+    const std::wstring appIdUpper =
+        ToUpper(GetWindowAppUserModelId(pending.hwnd));
+    const bool alsoConfirmPreviewWindow =
+        settings->previewHighlightEnabled &&
+        settings->previewMinFocusSeconds <=
+            (std::max)(0, settings->minFocusSeconds);
+    std::wstring processKey;
+    if (alsoConfirmPreviewWindow && pending.hwnd && IsWindow(pending.hwnd)) {
+        processKey = PathFromAppKey(pending.key);
+        if (processKey.empty()) {
+            processKey = ToUpper(GetProcessImagePath(pending.processId));
+        }
+    }
+
     const ULONGLONG now = GetTickCount64();
-    bool alsoConfirmPreviewWindow = false;
     {
         std::lock_guard<std::mutex> lock(g_stateMutex);
         auto& desk =
@@ -7191,25 +7085,16 @@ void OnMinFocusTimerElapsed(MinFocusConfirmMode mode) {
             info.lastWindowTitle = pending.windowTitle;
         }
         info.lastHwnd = pending.hwnd;
-        info.classUpper = ToUpper(GetWindowClassName(pending.hwnd));
-        info.appIdUpper = ToUpper(GetWindowAppUserModelId(pending.hwnd));
+        info.classUpper = classUpper;
+        info.appIdUpper = appIdUpper;
         info.lastConfirmedFocusTick = now;
 
         // If preview min-focus is not longer than app min-focus, promote the
         // window here too (covers minFocus=0 / already-tracked immediate path
         // without waiting for a separate preview timer). When preview min is
         // longer, leave pending so the preview timer can still fire.
-        alsoConfirmPreviewWindow =
-            settings->previewHighlightEnabled &&
-            settings->previewMinFocusSeconds <=
-                (std::max)(0, settings->minFocusSeconds);
-
         if (alsoConfirmPreviewWindow && pending.hwnd &&
             IsWindow(pending.hwnd)) {
-            std::wstring processKey = PathFromAppKey(pending.key);
-            if (processKey.empty()) {
-                processKey = ToUpper(GetProcessImagePath(pending.processId));
-            }
             StampWindowRecencyLocked(desk, pending.hwnd, processKey,
                                      pending.windowTitle, now);
         }
@@ -7325,10 +7210,7 @@ void EnsurePendingAppTimer() {
         OnMinFocusTimerElapsed(MinFocusConfirmMode::Immediate);
         return;
     }
-    if (g_hookThreadHwnd) {
-        SetTimer(g_hookThreadHwnd, kMinFocusTimerId,
-                 ClampWinTimerMs(remaining), nullptr);
-    }
+    ArmHookTimer(kMinFocusTimerId, remaining);
 }
 
 void SchedulePreviewConfirm(bool windowAlreadyTracked) {
@@ -7341,10 +7223,8 @@ void SchedulePreviewConfirm(bool windowAlreadyTracked) {
         OnPreviewMinFocusTimerElapsed(MinFocusConfirmMode::Immediate);
         return;
     }
-    if (g_hookThreadHwnd) {
-        SetTimer(g_hookThreadHwnd, kPreviewMinFocusTimerId,
-                 static_cast<UINT>(previewMin) * 1000U, nullptr);
-    }
+    ArmHookTimer(kPreviewMinFocusTimerId,
+                 static_cast<ULONGLONG>(previewMin) * 1000ULL);
 }
 
 void HandleForegroundChanged(HWND hWnd) {
@@ -7500,10 +7380,7 @@ void HandleForegroundChanged(HWND hWnd) {
         return;
     }
 
-    if (g_hookThreadHwnd) {
-        SetTimer(g_hookThreadHwnd, kMinFocusTimerId,
-                 static_cast<UINT>(minSeconds) * 1000U, nullptr);
-    }
+    ArmHookTimer(kMinFocusTimerId, static_cast<ULONGLONG>(minSeconds) * 1000ULL);
 }
 
 void OnDecayTimer() {
@@ -7559,9 +7436,7 @@ void CALLBACK WinEventProc(HWINEVENTHOOK /*hWinEventHook*/,
         return;
     }
     if (event == EVENT_SYSTEM_DESKTOPSWITCH) {
-        if (g_hookThreadHwnd) {
-            PostMessage(g_hookThreadHwnd, WM_APP_DESKTOP_SWITCHED, 0, 0);
-        }
+        PostToHookThread(WM_APP_DESKTOP_SWITCHED);
         return;
     }
     if (event != EVENT_SYSTEM_FOREGROUND) {
@@ -7571,10 +7446,7 @@ void CALLBACK WinEventProc(HWINEVENTHOOK /*hWinEventHook*/,
         return;
     }
 
-    if (g_hookThreadHwnd) {
-        PostMessage(g_hookThreadHwnd, WM_APP_FOREGROUND_CHANGED,
-                    reinterpret_cast<WPARAM>(hWnd), 0);
-    }
+    PostToHookThread(WM_APP_FOREGROUND_CHANGED, reinterpret_cast<WPARAM>(hWnd));
 }
 
 LRESULT CALLBACK HookThreadWndProc(HWND hWnd,
@@ -7596,6 +7468,10 @@ LRESULT CALLBACK HookThreadWndProc(HWND hWnd,
             return 0;
         case WM_APP_SHUTDOWN:
             PostQuitMessage(0);
+            return 0;
+        case WM_APP_REQUEST_APPLY_DEBOUNCED:
+            SetTimer(hWnd, kFullRebindTimerId,
+                     static_cast<UINT>(kFullRebindDebounceMs), nullptr);
             return 0;
         case WM_TIMER:
             if (wParam == kMinFocusTimerId) {
@@ -7622,21 +7498,46 @@ LRESULT CALLBACK HookThreadWndProc(HWND hWnd,
 }
 
 DWORD WINAPI WinEventHookThread(LPVOID /*param*/) {
+    g_hookThreadId.store(GetCurrentThreadId(), std::memory_order_release);
+
+    HMODULE hMod = nullptr;
+    if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                            reinterpret_cast<LPCWSTR>(&HookThreadWndProc),
+                            &hMod) ||
+        !hMod) {
+        Wh_Log(L"GetModuleHandleExW failed for message-window class: %u",
+               GetLastError());
+        g_hookThreadId.store(0, std::memory_order_release);
+        return 1;
+    }
+
     WNDCLASSEXW wc{
         .cbSize = sizeof(WNDCLASSEXW),
         .lpfnWndProc = HookThreadWndProc,
-        .hInstance = GetModuleHandle(nullptr),
+        .hInstance = hMod,
         .lpszClassName = L"Windhawk_TaskbarRecentFocusHighlight_MsgWnd",
     };
-    RegisterClassExW(&wc);
+    ATOM atom = RegisterClassExW(&wc);
+    if (!atom) {
+        const DWORD err = GetLastError();
+        if (err != ERROR_CLASS_ALREADY_EXISTS) {
+            Wh_Log(L"RegisterClassExW failed: %u", err);
+            g_hookThreadId.store(0, std::memory_order_release);
+            return 1;
+        }
+    }
 
-    g_hookThreadHwnd =
+    HWND hwnd =
         CreateWindowExW(0, wc.lpszClassName, L"", 0, 0, 0, 0, 0, HWND_MESSAGE,
                         nullptr, wc.hInstance, nullptr);
-    if (!g_hookThreadHwnd) {
+    if (!hwnd) {
         Wh_Log(L"Failed to create message window: %u", GetLastError());
+        UnregisterClassW(wc.lpszClassName, wc.hInstance);
+        g_hookThreadId.store(0, std::memory_order_release);
         return 1;
     }
+    g_hookThreadHwnd.store(hwnd, std::memory_order_release);
 
     HRESULT coHr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
     if (FAILED(coHr) && coHr != RPC_E_CHANGED_MODE) {
@@ -7661,11 +7562,11 @@ DWORD WINAPI WinEventHookThread(LPVOID /*param*/) {
         Wh_Log(L"EVENT_SYSTEM_DESKTOPSWITCH hook installed");
     }
 
-    SetTimer(g_hookThreadHwnd, kDecayTimerId, kDecayCheckIntervalMs, nullptr);
+    SetTimer(hwnd, kDecayTimerId, kDecayCheckIntervalMs, nullptr);
     RefreshCurrentDesktopId();
 
     if (HWND fg = GetForegroundWindow()) {
-        PostMessage(g_hookThreadHwnd, WM_APP_FOREGROUND_CHANGED,
+        PostMessage(hwnd, WM_APP_FOREGROUND_CHANGED,
                     reinterpret_cast<WPARAM>(fg), 0);
     }
 
@@ -7691,11 +7592,10 @@ DWORD WINAPI WinEventHookThread(LPVOID /*param*/) {
 
     ReleaseVdm();
 
-    if (g_hookThreadHwnd) {
-        DestroyWindow(g_hookThreadHwnd);
-        g_hookThreadHwnd = nullptr;
-    }
+    g_hookThreadHwnd.store(nullptr, std::memory_order_release);
+    DestroyWindow(hwnd);
     UnregisterClassW(wc.lpszClassName, wc.hInstance);
+    g_hookThreadId.store(0, std::memory_order_release);
 
     if (SUCCEEDED(coHr)) {
         CoUninitialize();
@@ -7730,7 +7630,7 @@ void StopWinEventHookThread() {
         return;
     }
 
-    HWND hwnd = g_hookThreadHwnd;
+    HWND hwnd = HookThreadWindow();
     if (hwnd) {
         PostMessage(hwnd, WM_APP_SHUTDOWN, 0, 0);
     }
@@ -7738,12 +7638,10 @@ void StopWinEventHookThread() {
     if (threadId) {
         PostThreadMessage(threadId, WM_APP, 0, 0);
     }
-    const DWORD w = WaitForSingleObject(hThread, 8000);
+    const DWORD w = WaitForSingleObject(hThread, INFINITE);
     CloseHandle(hThread);
     if (w != WAIT_OBJECT_0) {
-        Wh_Log(L"ERROR: focus thread still running after 8s (wait=%u) — "
-               L"unload may crash explorer",
-               w);
+        Wh_Log(L"ERROR: focus thread wait failed (%u)", w);
     } else {
         Wh_Log(L"WinEvent hook thread stopped");
     }
@@ -7772,20 +7670,18 @@ void LoadSettings() {
 
     PCWSTR promoteMode = Wh_GetStringSetting(L"promoteMode");
     s.promoteMode = PromoteMode::ImmediateTracked;
-    if (promoteMode) {
-        if (wcscmp(promoteMode, L"immediateTopN") == 0) {
-            s.promoteMode = PromoteMode::ImmediateTopN;
-        } else if (wcscmp(promoteMode, L"alwaysWait") == 0) {
-            s.promoteMode = PromoteMode::AlwaysWait;
-        } else if (wcscmp(promoteMode, L"immediateTracked") == 0) {
-            s.promoteMode = PromoteMode::ImmediateTracked;
-        }
+    if (wcscmp(promoteMode, L"immediateTopN") == 0) {
+        s.promoteMode = PromoteMode::ImmediateTopN;
+    } else if (wcscmp(promoteMode, L"alwaysWait") == 0) {
+        s.promoteMode = PromoteMode::AlwaysWait;
+    } else if (wcscmp(promoteMode, L"immediateTracked") == 0) {
+        s.promoteMode = PromoteMode::ImmediateTracked;
     }
     Wh_FreeStringSetting(promoteMode);
 
     PCWSTR glowColor = Wh_GetStringSetting(L"glowColor");
     s.glowColor = GlowColorMode::Accent;
-    if (glowColor && *glowColor) {
+    if (*glowColor) {
         if (wcscmp(glowColor, L"green") == 0) {
             s.glowColor = GlowColorMode::Green;
         } else if (wcscmp(glowColor, L"blue") == 0) {
@@ -7801,7 +7697,7 @@ void LoadSettings() {
     Wh_FreeStringSetting(glowColor);
 
     PCWSTR customColor = Wh_GetStringSetting(L"customGlowColor");
-    s.customGlowColor = customColor ? customColor : L"#00C853";
+    s.customGlowColor = *customColor ? customColor : L"#00C853";
     Wh_FreeStringSetting(customColor);
 
     s.glowIntensity[0] = Wh_GetIntSetting(L"glowIntensityRank1");
@@ -7830,7 +7726,7 @@ void LoadSettings() {
 
     PCWSTR glowStyle = Wh_GetStringSetting(L"glowStyle");
     s.glowStyle = GlowStyle::LeftBar;
-    if (glowStyle) {
+    if (*glowStyle) {
         if (wcscmp(glowStyle, L"full") == 0) {
             s.glowStyle = GlowStyle::Full;
         } else if (wcscmp(glowStyle, L"frame") == 0) {
@@ -7923,22 +7819,6 @@ void LoadSettings() {
         }
     }
 
-    // New keys are blank after an in-place recompile. Wh_GetIntSetting
-    // returns 0 for a missing value, which would paint nothing. Treat the
-    // all-zero cluster as unset and apply the YAML defaults (3 / 100/70/45).
-    // An explicit count of 0 with any intensity set is still honored.
-    const bool previewRanksUnset = s.previewIntensity[0] == 0 &&
-                                   s.previewIntensity[1] == 0 &&
-                                   s.previewIntensity[2] == 0;
-    if (previewRanksUnset) {
-        s.previewIntensity[0] = 100;
-        s.previewIntensity[1] = 70;
-        s.previewIntensity[2] = 45;
-        if (s.previewHighlightCount == 0) {
-            s.previewHighlightCount = 3;
-        }
-    }
-
     s.previewMinFocusSeconds = Wh_GetIntSetting(L"previewMinFocusSeconds");
     if (s.previewMinFocusSeconds < 0) {
         s.previewMinFocusSeconds = 0;
@@ -7950,7 +7830,7 @@ void LoadSettings() {
 
     PCWSTR previewStyle = Wh_GetStringSetting(L"previewStyle");
     s.previewStyle = PreviewStyle::TitleBar;
-    if (previewStyle) {
+    if (*previewStyle) {
         if (wcscmp(previewStyle, L"ring") == 0) {
             s.previewStyle = PreviewStyle::Ring;
         } else if (wcscmp(previewStyle, L"titleBg") == 0) {
@@ -7968,7 +7848,7 @@ void LoadSettings() {
     s.excludedPrograms.clear();
     for (int i = 0;; i++) {
         PCWSTR program = Wh_GetStringSetting(L"excludedPrograms[%d]", i);
-        bool hasProgram = program && *program;
+        bool hasProgram = *program;
         if (hasProgram) {
             s.excludedPrograms.insert(ToUpper(program));
         }
@@ -7991,6 +7871,8 @@ void LoadSettings() {
            PreviewStyleName(s.previewStyle), s.previewMinFocusSeconds,
            s.previewDecayMinutes);
 
+    s.cachedAccent = QuerySystemAccentColor();
+
     PublishSettings(std::move(s));
 }
 
@@ -7999,7 +7881,7 @@ void LoadSettings() {
 // ---------------------------------------------------------------------------
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"> Taskbar Recent Focus Highlight init v0.9.0");
+    Wh_Log(L"> Taskbar Recent Focus Highlight init v0.9.1");
 
     g_unloading = false;
     LoadSettings();
@@ -8019,8 +7901,16 @@ BOOL Wh_ModInit() {
     }
 
     HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
+    if (!kernelBaseModule) {
+        Wh_Log(L"kernelbase.dll not loaded");
+        return FALSE;
+    }
     auto pKernelBaseLoadLibraryExW = (decltype(&LoadLibraryExW))GetProcAddress(
         kernelBaseModule, "LoadLibraryExW");
+    if (!pKernelBaseLoadLibraryExW) {
+        Wh_Log(L"LoadLibraryExW not found in kernelbase.dll");
+        return FALSE;
+    }
     WindhawkUtils::SetFunctionHook(pKernelBaseLoadLibraryExW,
                                    LoadLibraryExW_Hook,
                                    &LoadLibraryExW_Original);
@@ -8043,11 +7933,9 @@ void Wh_ModAfterInit() {
         }
     }
 
-    if (g_hookThreadHwnd) {
-        if (HWND fg = GetForegroundWindow()) {
-            PostMessage(g_hookThreadHwnd, WM_APP_FOREGROUND_CHANGED,
-                        reinterpret_cast<WPARAM>(fg), 0);
-        }
+    if (HWND fg = GetForegroundWindow()) {
+        PostToHookThread(WM_APP_FOREGROUND_CHANGED,
+                         reinterpret_cast<WPARAM>(fg));
     }
 }
 
@@ -8059,13 +7947,11 @@ void Wh_ModUninit() {
 
     // Clear visuals and revoke SizeChanged on each dispatcher, then drain
     // already-queued Normal work (those lambdas no-op on g_unloading).
-    if (!RunOnEachUiDispatcherAndWait(
-            []() {
-                ClearAllHighlights_UIThread();
-                ClearAllThumbnailHighlights_UIThread();
-                RevokeIconPanelLayoutWatchesOnThisDispatcher();
-            },
-            2000)) {
+    if (!RunOnEachUiDispatcherAndWait([]() {
+            ClearAllHighlights_UIThread();
+            ClearAllThumbnailHighlights_UIThread();
+            RevokeIconPanelLayoutWatchesOnThisDispatcher();
+        })) {
         Wh_Log(L"ERROR: UI cleanup did not finish on every dispatcher");
     }
     {
@@ -8104,13 +7990,14 @@ void Wh_ModUninit() {
         std::lock_guard<std::mutex> lock(g_thumbViewsMutex);
         g_trackedThumbViews.clear();
     }
+    {
+        std::lock_guard<std::mutex> lock(g_dispatchersMutex);
+        g_uiDispatchers.clear();
+    }
 }
 
-BOOL Wh_ModSettingsChanged(BOOL* bReload) {
+void Wh_ModSettingsChanged() {
     Wh_Log(L">");
-    if (bReload) {
-        *bReload = FALSE;
-    }
 
     LoadSettings();
 
@@ -8144,5 +8031,4 @@ BOOL Wh_ModSettingsChanged(BOOL* bReload) {
 
     RequestApplyVisuals();
     RequestApplyPreviewVisuals();
-    return TRUE;
 }

--- a/mods/taskbar-recent-focus-highlight.wh.cpp
+++ b/mods/taskbar-recent-focus-highlight.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-recent-focus-highlight
 // @name            Taskbar Recent Focus Highlight
 // @description     Visually highlight the most recently focused running apps on the taskbar
-// @version         0.9.8
+// @version         0.9.10
 // @author          Jakub Vlášek
 // @github          https://github.com/jvlasek
 // @include         explorer.exe
@@ -550,6 +550,8 @@ struct ButtonPathCacheEntry {
     std::vector<HWND> groupHwnds;
     bool resolveAttempted = false;
     bool resolvedWhileRunning = false;  // re-resolve once on pinned → running
+    // Running + dead sample HWND / live image-path mismatch also re-resolves
+    // (Explorer reuses TaskListButton when the exe is replaced).
     int emptyResolveAttempts = 0;  // capped while path and AUMID stay empty
     ULONGLONG lastResolveTick = 0;  // empty-identity retry throttle
     ULONGLONG lastRunningTick = 0;  // IsRunning grace (Alt-Tab flicker)
@@ -751,9 +753,9 @@ struct IconPanelLayoutWatch {
     winrt::event_token sizeChanged{};
     TaskbarEdge lastEdge = TaskbarEdge::Bottom;
     bool haveEdge = false;
-    // Child names in IconPanel before we first moved natives. Restore this
-    // on clear so Taskbar Styler (or a custom template) gets its order back.
-    std::vector<std::wstring> nativeChildNames;
+    // Native IconPanel children in visual order before we first moved them
+    // (including unnamed Styler-injected elements). Restore by identity.
+    std::vector<winrt::weak_ref<UIElement>> nativeChildren;
     bool haveNativeOrder = false;
 };
 std::mutex g_layoutWatchMutex;
@@ -1044,13 +1046,39 @@ std::wstring AlnumUpper(std::wstring_view s) {
     return out;
 }
 
+thread_local DWORD g_imagePathCachePid = 0;
+thread_local std::wstring g_imagePathCache;
+thread_local int g_imagePathCacheScope = 0;
+
+struct ProcessImagePathCacheScope {
+    ProcessImagePathCacheScope() { ++g_imagePathCacheScope; }
+    ~ProcessImagePathCacheScope() {
+        if (--g_imagePathCacheScope <= 0) {
+            g_imagePathCacheScope = 0;
+            g_imagePathCachePid = 0;
+            g_imagePathCache.clear();
+        }
+    }
+};
+
 std::wstring GetProcessImagePath(DWORD processId) {
+    if (g_imagePathCacheScope > 0 && processId != 0 &&
+        processId == g_imagePathCachePid) {
+        return g_imagePathCache;
+    }
     std::wstring path;
     HANDLE hProcess =
         OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, processId);
     if (!hProcess) {
         return path;
     }
+
+    auto remember = [&]() {
+        if (g_imagePathCacheScope > 0 && processId != 0) {
+            g_imagePathCachePid = processId;
+            g_imagePathCache = path;
+        }
+    };
 
     DWORD size = MAX_PATH;
     for (int attempt = 0; attempt < 5; ++attempt) {
@@ -1059,6 +1087,7 @@ std::wstring GetProcessImagePath(DWORD processId) {
         if (QueryFullProcessImageName(hProcess, 0, path.data(), &n)) {
             path.resize(n);
             CloseHandle(hProcess);
+            remember();
             return path;
         }
         const DWORD err = GetLastError();
@@ -1073,6 +1102,7 @@ std::wstring GetProcessImagePath(DWORD processId) {
         }
     }
     CloseHandle(hProcess);
+    remember();
     return path;
 }
 
@@ -1478,18 +1508,15 @@ FrameworkElement FindDescendantByName(FrameworkElement element, PCWSTR name) {
 // Ranking
 // ---------------------------------------------------------------------------
 
-// True if any cached TaskListButton resolved to this process path (or same
-// file name). Call from UI thread after EnsureButtonPathCached, or any thread
-// if only reading the path cache.
-bool PathAppearsOnTaskbar(const std::wstring& keyOrPath,
-                          const std::wstring& displayName) {
+// True if any cached TaskListButton resolved to this exact process path or
+// AppUserModelID. Filename-only is not a match (two folders of python.exe).
+// Call from UI thread after EnsureButtonPathCached, or any thread if only
+// reading the path cache. Do not weak.get() here — RecomputeRanks can run
+// on the focus thread.
+bool PathAppearsOnTaskbar(const std::wstring& keyOrPath) {
     const std::wstring pathUpper = PathFromAppKey(keyOrPath);
     const std::wstring wantAppId = CanonicalAppId(AppIdFromAppKey(keyOrPath));
-    std::wstring fileUpper = ToUpper(displayName);
-    if (fileUpper.empty() && !pathUpper.empty()) {
-        fileUpper = ToUpper(FileNameFromPath(pathUpper));
-    }
-    if (pathUpper.empty() && fileUpper.empty() && wantAppId.empty()) {
+    if (pathUpper.empty() && wantAppId.empty()) {
         return false;
     }
 
@@ -1507,10 +1534,6 @@ bool PathAppearsOnTaskbar(const std::wstring& keyOrPath,
         // Class is for *which* button to highlight, not whether the app
         // exists on the taskbar (TC + Lister share a path, different class).
         if (!pathUpper.empty() && e.pathUpper == pathUpper) {
-            return true;
-        }
-        if (!fileUpper.empty() &&
-            ToUpper(FileNameFromPath(e.pathUpper)) == fileUpper) {
             return true;
         }
     }
@@ -1545,7 +1568,7 @@ void RecomputeRanksForDesktopLocked(DesktopRecencyState& desk) {
         // Tray-only / no taskbar button: keep optional history but never rank.
         if (settings->requireTaskbarButton && !info.seenOnTaskbar) {
             // Refresh from path cache if buttons resolved since last time.
-            if (PathAppearsOnTaskbar(info.key, info.displayName)) {
+            if (PathAppearsOnTaskbar(info.key)) {
                 info.seenOnTaskbar = true;
             } else {
                 ++it;
@@ -2156,18 +2179,6 @@ int ScoreCachedIdentityForRank(const ButtonIdentity& ident,
     return 0;
 }
 
-int ScoreButtonForRank(FrameworkElement button,
-                       const AppFocusInfo& info,
-                       bool requireRunning) {
-    if (!button) {
-        return 0;
-    }
-    if (requireRunning && !ButtonCountsAsRunning(button)) {
-        return 0;
-    }
-    return ScoreCachedIdentityForRank(GetCachedButtonIdentity(button), info);
-}
-
 // Best rank for a single button (1-based), or 0.
 int FindRankForButton(FrameworkElement button,
                       const std::vector<AppFocusInfo>& ranks,
@@ -2501,21 +2512,25 @@ void RememberNativeIconPanelOrder(FrameworkElement iconPanel) {
     if (!id) {
         return;
     }
-    std::vector<std::wstring> names;
+    std::vector<winrt::weak_ref<UIElement>> saved;
     try {
         auto children = panel.Children();
         const uint32_t n = children.Size();
-        names.reserve(n);
+        saved.reserve(n);
         for (uint32_t i = 0; i < n; ++i) {
-            auto fe = children.GetAt(i).try_as<FrameworkElement>();
-            if (!fe) {
+            auto el = children.GetAt(i);
+            if (!el) {
                 continue;
             }
-            std::wstring name = fe.Name().c_str();
-            if (name.empty() || name == kGlowElementName) {
-                continue;
+            try {
+                if (auto fe = el.try_as<FrameworkElement>()) {
+                    if (fe.Name() == kGlowElementName) {
+                        continue;
+                    }
+                }
+            } catch (...) {
             }
-            names.push_back(std::move(name));
+            saved.push_back(winrt::make_weak(el));
         }
     } catch (...) {
         return;
@@ -2527,7 +2542,7 @@ void RememberNativeIconPanelOrder(FrameworkElement iconPanel) {
         it->second.haveNativeOrder) {
         return;
     }
-    it->second.nativeChildNames = std::move(names);
+    it->second.nativeChildren = std::move(saved);
     it->second.haveNativeOrder = true;
 }
 
@@ -2541,7 +2556,7 @@ void RestoreIconPanelNativeZOrder(FrameworkElement iconPanel) {
     }
     try {
         auto children = panel.Children();
-        std::vector<std::wstring> saved;
+        std::vector<winrt::weak_ref<UIElement>> saved;
         {
             void* id = InspectableIdentity(iconPanel);
             std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
@@ -2549,13 +2564,18 @@ void RestoreIconPanelNativeZOrder(FrameworkElement iconPanel) {
             if (it != g_layoutWatches.end() &&
                 WeakIsSameElement(it->second.panel, iconPanel) &&
                 it->second.haveNativeOrder) {
-                saved = it->second.nativeChildNames;
+                saved = it->second.nativeChildren;
             }
         }
         if (!saved.empty()) {
             uint32_t dest = 0;
-            for (const auto& name : saved) {
-                auto el = FindChildByName(iconPanel, name.c_str());
+            for (auto& weak : saved) {
+                UIElement el = nullptr;
+                try {
+                    el = weak.get();
+                } catch (...) {
+                    continue;
+                }
                 if (!el) {
                     continue;
                 }
@@ -2614,10 +2634,9 @@ bool ButtonHasOurChrome(FrameworkElement button) {
     }
     auto iconPanel = GetIconPanel(button);
     if (!iconPanel) {
-        return FindDescendantByName(button, kGlowElementName) != nullptr;
+        return FindChildByName(button, kGlowElementName) != nullptr;
     }
-    return FindChildByName(iconPanel, kGlowElementName) != nullptr ||
-           FindDescendantByName(iconPanel, kGlowElementName) != nullptr;
+    return FindChildByName(iconPanel, kGlowElementName) != nullptr;
 }
 
 void ClearButtonHighlight(FrameworkElement button) {
@@ -3356,8 +3375,12 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
             panelH = 44.0;
         }
         const TaskbarEdge edge = CachedTaskbarEdge(iconPanel);
-        const int boxWi = static_cast<int>(panelW + 0.5);
-        const int boxHi = static_cast<int>(panelH + 0.5);
+        auto existingHost = FindChildByName(iconPanel, kGlowElementName);
+        double keyW = panelW;
+        double keyH = panelH;
+        GlowContentBoxSize(existingHost, iconPanel, panelW, panelH, keyW, keyH);
+        const int boxWi = static_cast<int>(keyW + 0.5);
+        const int boxHi = static_cast<int>(keyH + 0.5);
         {
             auto painted = GetCachedPaintState(button);
             if (painted.rank == rankOneBased &&
@@ -3826,6 +3849,34 @@ DWORD GetProcessIdFromTaskListButton(UIElement element) {
     return 0;
 }
 
+// True when a running button's cached HWND is gone or now belongs to a
+// different image path / AUMID. Do not call while holding g_buttonPathMutex
+// (OpenProcess / SHGetPropertyStoreForWindow). A deleted-but-still-running
+// process can keep the old path — empty GetProcessImagePath is not stale,
+// and a missing file on disk is not a reason to re-resolve.
+bool CachedButtonIdentityStale(HWND sampleHwnd,
+                               const std::wstring& pathUpper,
+                               const std::wstring& appIdUpper) {
+    if (!sampleHwnd || !IsWindow(sampleHwnd)) {
+        return true;
+    }
+    if (!pathUpper.empty() && !IsUwpHostPath(pathUpper)) {
+        const DWORD pid = PidFromHwnd(sampleHwnd);
+        if (!pid) {
+            return true;
+        }
+        const std::wstring live = ToUpper(GetProcessImagePath(pid));
+        return !live.empty() && live != pathUpper;
+    }
+    if (!appIdUpper.empty()) {
+        const std::wstring liveId =
+            CanonicalAppId(ToUpper(GetWindowAppUserModelId(sampleHwnd)));
+        const std::wstring want = CanonicalAppId(appIdUpper);
+        return !liveId.empty() && liveId != want;
+    }
+    return false;
+}
+
 // Resolve button → path; force=true on click. Returns path upper or empty.
 std::wstring EnsureButtonPathCached(FrameworkElement button, bool force) {
     if (!button || !g_taskbandResolveReady.load()) {
@@ -3835,6 +3886,11 @@ std::wstring EnsureButtonPathCached(FrameworkElement button, bool force) {
     const ULONGLONG now = GetTickCount64();
     const bool running = TaskListButton_IsRunning(button);
     void* id = InspectableIdentity(button);
+    std::wstring cachedPath;
+    HWND cachedHwnd = nullptr;
+    std::wstring cachedAppId;
+    bool skipResolve = false;
+    bool checkStale = false;
     {
         std::lock_guard<std::mutex> lock(g_buttonPathMutex);
         auto it = id ? g_buttonPathCache.find(id) : g_buttonPathCache.end();
@@ -3852,10 +3908,30 @@ std::wstring EnsureButtonPathCached(FrameworkElement button, bool force) {
                     now - it->second.lastResolveTick < kUnresolvedRetryMs ||
                     it->second.emptyResolveAttempts >=
                         kMaxEmptyResolveAttempts) {
-                    return it->second.pathUpper;
+                    cachedPath = it->second.pathUpper;
+                    if (!haveIdentity || !running) {
+                        skipResolve = true;
+                    } else {
+                        checkStale = true;
+                        cachedHwnd = it->second.sampleHwnd;
+                        cachedAppId = it->second.appIdUpper;
+                    }
                 }
             }
         }
+    }
+    if (skipResolve) {
+        return cachedPath;
+    }
+    if (checkStale &&
+        !CachedButtonIdentityStale(cachedHwnd, cachedPath, cachedAppId)) {
+        return cachedPath;
+    }
+    if (checkStale) {
+        Wh_Log(L"Button path cache: stale identity, re-resolving name=\"%s\" "
+               L"oldPath=%s",
+               GetButtonAutomationName(button).c_str(),
+               cachedPath.empty() ? L"(none)" : cachedPath.c_str());
     }
 
     DWORD pid = 0;
@@ -3945,21 +4021,50 @@ std::wstring EnsureButtonPathCached(FrameworkElement button, bool force) {
             e = &it->second;
         }
         if (e) {
-            e->pathUpper = pathUpper;
-            e->appIdUpper = appIdUpper;
-            e->classUpper = classUpper;
-            e->sampleHwnd = hwnd;
-            e->groupHwnds = std::move(groupHwnds);
             e->resolveAttempted = true;
-            e->resolvedWhileRunning = running;
             e->lastResolveTick = now;
-            if (e->pathUpper.empty() && e->appIdUpper.empty()) {
-                if (e->emptyResolveAttempts < kMaxEmptyResolveAttempts) {
-                    ++e->emptyResolveAttempts;
-                }
-            } else {
-                e->emptyResolveAttempts = 0;
+            if (running) {
+                e->resolvedWhileRunning = true;
             }
+            if (!pathUpper.empty()) {
+                if (e->pathUpper != pathUpper ||
+                    e->appIdUpper != appIdUpper) {
+                    e->lastPaintRank = -1;
+                }
+                e->pathUpper = pathUpper;
+                e->appIdUpper = appIdUpper;
+                e->classUpper = classUpper;
+                e->sampleHwnd = hwnd;
+                e->groupHwnds = std::move(groupHwnds);
+                e->emptyResolveAttempts = 0;
+            } else if (!appIdUpper.empty() && e->pathUpper.empty()) {
+                // Pinned AutomationId only — do not treat as a Win32 path.
+                e->appIdUpper = appIdUpper;
+                if (hwnd) {
+                    e->sampleHwnd = hwnd;
+                    e->groupHwnds = std::move(groupHwnds);
+                    if (!classUpper.empty()) {
+                        e->classUpper = classUpper;
+                    }
+                }
+                e->emptyResolveAttempts = 0;
+            } else {
+                // Task item flickered (hwnd dead during close / replace).
+                // Do not wipe a known path — the next bind retries.
+                if (e->pathUpper.empty() && e->appIdUpper.empty()) {
+                    if (e->emptyResolveAttempts < kMaxEmptyResolveAttempts) {
+                        ++e->emptyResolveAttempts;
+                    }
+                }
+                if (hwnd) {
+                    e->sampleHwnd = hwnd;
+                    e->groupHwnds = std::move(groupHwnds);
+                    if (!classUpper.empty()) {
+                        e->classUpper = classUpper;
+                    }
+                }
+            }
+            pathUpper = e->pathUpper;
         }
         if (g_buttonPathCache.size() > 128) {
             for (auto it = g_buttonPathCache.begin();
@@ -4231,6 +4336,7 @@ void ApplyAllHighlights_UIThread() {
         size_t rankIdx;
         size_t buttonIdx;
     };
+    ProcessImagePathCacheScope pathCacheScope;
     std::vector<Cand> cands;
     std::vector<std::wstring> buttonPaths(live.size());
     std::vector<ButtonIdentity> idents(live.size());
@@ -4294,6 +4400,16 @@ void ApplyAllHighlights_UIThread() {
                live.size());
     }
 
+    size_t resolvedButtons = 0;
+    {
+        std::lock_guard<std::mutex> lock(g_buttonPathMutex);
+        for (const auto& [id, e] : g_buttonPathCache) {
+            if (!e.pathUpper.empty() || !e.appIdUpper.empty()) {
+                ++resolvedButtons;
+            }
+        }
+    }
+    const bool requireTb = SettingsSnap()->requireTaskbarButton;
     std::vector<std::wstring> demoteKeys;
     for (size_t ri = 0; ri < ranks.size(); ++ri) {
         if (rankTaken[ri]) {
@@ -4302,33 +4418,30 @@ void ApplyAllHighlights_UIThread() {
         Wh_Log(L"  UNMATCHED rank %zu: %s (title=\"%s\")", ri + 1,
                ranks[ri].displayName.c_str(),
                ranks[ri].lastWindowTitle.c_str());
-        size_t resolvedButtons = 0;
-        {
-            std::lock_guard<std::mutex> lock(g_buttonPathMutex);
-            for (const auto& [id, e] : g_buttonPathCache) {
-                if (!e.pathUpper.empty()) {
-                    ++resolvedButtons;
-                }
-            }
-        }
-        if (SettingsSnap()->requireTaskbarButton && resolvedButtons >= 2) {
+        // Drop the old path even if it was bound before — filename-only is
+        // not "still on the taskbar" (deleted exe, same name elsewhere).
+        if (requireTb && resolvedButtons >= 2 &&
+            !PathAppearsOnTaskbar(ranks[ri].key)) {
             demoteKeys.push_back(ranks[ri].key);
         }
     }
     // Demote after the loop so rank list stays stable while matching.
     if (!demoteKeys.empty()) {
-        std::lock_guard<std::mutex> lock(g_stateMutex);
-        auto& map = CurrentDeskLocked().appFocusMap;
-        for (const auto& key : demoteKeys) {
-            auto it = map.find(key);
-            if (it != map.end() && !it->second.seenOnTaskbar) {
-                Wh_Log(L"  demoting non-taskbar app from ranks: %s",
-                       it->second.displayName.c_str());
-                it->second.lastConfirmedFocusTick = 0;
-                it->second.seenOnTaskbar = false;
+        {
+            std::lock_guard<std::mutex> lock(g_stateMutex);
+            auto& map = CurrentDeskLocked().appFocusMap;
+            for (const auto& key : demoteKeys) {
+                auto it = map.find(key);
+                if (it != map.end()) {
+                    Wh_Log(L"  demoting unmatched app from ranks: %s",
+                           it->second.displayName.c_str());
+                    it->second.lastConfirmedFocusTick = 0;
+                    it->second.seenOnTaskbar = false;
+                }
             }
+            RecomputeRanksLocked();
         }
-        RecomputeRanksLocked();
+        RequestApplyVisualsDebounced();
     }
 }
 
@@ -4928,7 +5041,7 @@ void SortThumbnailViewsVisualOrder(std::vector<FrameworkElement>& views) {
 
 // Snap-group card in the same flyout as the individual windows. Must not be
 // treated as a window thumbnail. Language-independent: the group card hosts
-// an IconsRepeater with 2+ icon children.
+// an IconsRepeater with 2+ icon children and has no window HWND.
 bool IsSnapGroupThumbnailView(FrameworkElement view) {
     if (!view) {
         return false;
@@ -4936,6 +5049,11 @@ bool IsSnapGroupThumbnailView(FrameworkElement view) {
     if (auto repeater = FindDescendantByName(view, L"IconsRepeater")) {
         try {
             if (Media::VisualTreeHelper::GetChildrenCount(repeater) >= 2) {
+                // A real window card that gained a second icon still has an
+                // HWND. A snap-group card does not.
+                if (ResolveHwndForThumbnailView(view)) {
+                    return false;
+                }
                 return true;
             }
         } catch (...) {
@@ -5264,8 +5382,9 @@ void SchedulePreviewFlyoutRefresh(FrameworkElement dispatcherAnchor) {
         }
         winrt::weak_ref<FrameworkElement> weak =
             winrt::make_weak(dispatcherAnchor);
-        dispatcher.RunAsync(
-            winrt::Windows::UI::Core::CoreDispatcherPriority::Low, [weak]() {
+        if (!dispatcher.TryRunAsync(
+                winrt::Windows::UI::Core::CoreDispatcherPriority::Low,
+                [weak]() {
                 g_previewFlyoutRefreshPending = false;
                 try {
                     if (g_unloading.load()) {
@@ -5302,7 +5421,9 @@ void SchedulePreviewFlyoutRefresh(FrameworkElement dispatcherAnchor) {
                     g_thumbRelayoutDepth = 0;
                     g_previewFlyoutRefreshFollowUps = 0;
                 }
-            });
+            })) {
+            g_previewFlyoutRefreshPending = false;
+        }
     } catch (...) {
         g_previewFlyoutRefreshPending = false;
     }
@@ -5606,8 +5727,10 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
     const std::vector<std::wstring> cardTitles = PickFlyoutCardTitles(siblings);
 
     // HWND pipeline (this flyout only — not a global window ladder):
-    //   1. Repeater index + Thumbnails.GetAt + ctor map (authoritative).
-    //   2. TaskItem — DataContext ↔ ctor map (COM identity).
+    //   1. TaskItem — DataContext ↔ ctor map (COM identity, per card).
+    //   2. Repeater index + Thumbnails.GetAt — only for holes, and only if
+    //      that collection agrees with a DataContext HWND (it is a global
+    //      captured on TargetItemKey and can be another app's flyout).
     //   3. Title unique — only for unresolved cards; each HWND once.
     enum class ResolveHow : int { None = 0, Repeater, TaskItem, Title };
     struct Scored {
@@ -5656,11 +5779,20 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
         scored[i].view = siblings[i];
     }
 
-    // Pass 1: repeater index → GetAt → ctor map HWND.
-    // repeaterSourceIndex is the ItemsSource slot (round-3 compacted-vs-source
-    // fix). TaskGroup::Thumbnails is a different collection: a snap-group card
-    // can sit in the repeater and not in Thumbnails. Compare sizes before
-    // using source index as GetAt.
+    // Pass 1: DataContext ↔ ctor map. Exact, per card, cannot go stale.
+    for (size_t i = 0; i < siblings.size(); ++i) {
+        HWND hwnd = ResolveHwndForThumbnailView(siblings[i]);
+        if (hwnd && IsWindow(hwnd) && !usedHwnds.count(hwnd)) {
+            stampRecency(i, hwnd);
+            scored[i].how = ResolveHow::TaskItem;
+            usedHwnds.insert(hwnd);
+        }
+    }
+
+    // Pass 2: repeater index → GetAt → ctor map HWND, holes only.
+    // repeaterSourceIndex is the ItemsSource slot. g_TaskGroup_Thumbnails is
+    // a global captured on TargetItemKey — skip it if it disagrees with a
+    // DataContext HWND on the same card.
     if (usedRepeater) {
         const int thumbCount = ThumbnailsCollectionSize();
         int nSnap = 0;
@@ -5676,49 +5808,61 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
             !sizeUnknown && nSnap > 0 && thumbCount == nWindows;
         const bool sizesAgree =
             sizeUnknown || thumbCount == nRepeater || compactSnap;
+        bool indexBindTrusted = sizesAgree;
         if (!sizesAgree) {
             Wh_Log(L"Preview resolve: repeater/Thumbnails size mismatch "
                    L"(repeater=%d thumbs=%d snap=%d) — skip index bind",
                    nRepeater, thumbCount, nSnap);
-        } else {
-            if (compactSnap) {
-                Wh_Log(L"Preview resolve: snap-group extra in repeater "
-                       L"(repeater=%d thumbs=%d) — compact GetAt index",
-                       nRepeater, thumbCount);
-            }
+        } else if (compactSnap) {
+            Wh_Log(L"Preview resolve: snap-group extra in repeater "
+                   L"(repeater=%d thumbs=%d) — compact GetAt index",
+                   nRepeater, thumbCount);
+        }
+        auto getAtIndexForSibling = [&](size_t siWant) -> int {
             size_t si = 0;
-            for (size_t ri = 0; ri < allViews.size() && si < siblings.size();
-                 ++ri) {
+            for (size_t ri = 0; ri < allViews.size(); ++ri) {
                 if (IsSnapGroupThumbnailView(allViews[ri])) {
                     continue;
                 }
-                const int srcIndex =
-                    (ri < repeaterSourceIndex.size())
-                        ? repeaterSourceIndex[ri]
-                        : static_cast<int>(ri);
-                const int getAtIndex =
-                    compactSnap ? static_cast<int>(si) : srcIndex;
-                HWND hwnd = HwndFromThumbnailsGetAt(getAtIndex);
-                if (hwnd && IsWindow(hwnd) && !usedHwnds.count(hwnd)) {
-                    stampRecency(si, hwnd);
-                    scored[si].how = ResolveHow::Repeater;
-                    usedHwnds.insert(hwnd);
+                if (si == siWant) {
+                    const int srcIndex =
+                        (ri < repeaterSourceIndex.size())
+                            ? repeaterSourceIndex[ri]
+                            : static_cast<int>(ri);
+                    return compactSnap ? static_cast<int>(si) : srcIndex;
                 }
                 ++si;
             }
+            return -1;
+        };
+        if (indexBindTrusted) {
+            for (size_t i = 0; i < siblings.size(); ++i) {
+                if (scored[i].how != ResolveHow::TaskItem) {
+                    continue;
+                }
+                const int idx = getAtIndexForSibling(i);
+                HWND fromAt = HwndFromThumbnailsGetAt(idx);
+                if (fromAt && fromAt != scored[i].hwnd) {
+                    Wh_Log(L"Preview resolve: Thumbnails collection does not "
+                           L"match this flyout — skip index bind");
+                    indexBindTrusted = false;
+                    break;
+                }
+            }
         }
-    }
-
-    // Pass 2: DataContext ↔ ctor map. Never overwrite a repeater bind.
-    for (size_t i = 0; i < siblings.size(); ++i) {
-        if (scored[i].hwnd) {
-            continue;
-        }
-        HWND hwnd = ResolveHwndForThumbnailView(siblings[i]);
-        if (hwnd && IsWindow(hwnd) && !usedHwnds.count(hwnd)) {
-            stampRecency(i, hwnd);
-            scored[i].how = ResolveHow::TaskItem;
-            usedHwnds.insert(hwnd);
+        if (indexBindTrusted) {
+            for (size_t i = 0; i < siblings.size(); ++i) {
+                if (scored[i].hwnd) {
+                    continue;
+                }
+                const int getAtIndex = getAtIndexForSibling(i);
+                HWND hwnd = HwndFromThumbnailsGetAt(getAtIndex);
+                if (hwnd && IsWindow(hwnd) && !usedHwnds.count(hwnd)) {
+                    stampRecency(i, hwnd);
+                    scored[i].how = ResolveHow::Repeater;
+                    usedHwnds.insert(hwnd);
+                }
+            }
         }
     }
 
@@ -6049,6 +6193,21 @@ void RefreshButtonHighlight(FrameworkElement button) {
         return;
     }
 
+    // Explorer reuses a TaskListButton when the exe is replaced. The cached
+    // paint rank still belongs to the old path if that HWND is gone. IsWindow
+    // only — do not OpenProcess from UpdateVisualStates.
+    if (TaskListButton_IsRunning(button)) {
+        const ButtonIdentity ident = GetCachedButtonIdentity(button);
+        if (ident.sampleHwnd && !IsWindow(ident.sampleHwnd)) {
+            if (ButtonHasOurChrome(button)) {
+                ClearButtonHighlight(button);
+            }
+            SetCachedPaintState(button, -1, SettingsSnap()->generation);
+            ScheduleRefreshAllHighlights(button);
+            return;
+        }
+    }
+
     // Sweep is ApplyAllHighlights. Clearing here blanks ranked icons until
     // that pass (desktop switch / decay flicker).
     int rank = GetCachedPaintState(button).rank;
@@ -6092,9 +6251,16 @@ void RefreshButtonHighlight(FrameworkElement button) {
 // pass restores siblings whose visuals Windows reset without another UVS.
 // Per dispatcher so primary and secondary taskbars do not throttle each other.
 void ScheduleRefreshAllHighlights(FrameworkElement dispatcherAnchor) {
-    if (!dispatcherAnchor) {
+    if (!dispatcherAnchor || g_unloading.load()) {
         return;
     }
+    const ULONGLONG now = GetTickCount64();
+    if (now - g_lastFullRefreshTick < kFullRebindDebounceMs &&
+        g_lastFullRefreshTick != 0) {
+        PostToHookThread(WM_APP_REQUEST_APPLY_DEBOUNCED);
+        return;
+    }
+    g_lastFullRefreshTick = now;
     try {
         winrt::weak_ref<FrameworkElement> weak =
             winrt::make_weak(dispatcherAnchor);
@@ -6102,17 +6268,7 @@ void ScheduleRefreshAllHighlights(FrameworkElement dispatcherAnchor) {
             winrt::Windows::UI::Core::CoreDispatcherPriority::Low,
             [weak]() {
                 try {
-                    const ULONGLONG now = GetTickCount64();
-                    if (now - g_lastFullRefreshTick < kFullRebindDebounceMs &&
-                        g_lastFullRefreshTick != 0) {
-                        // Coalesce a trailing full bind after the hover storm
-                        // so siblings Windows reset without UVS get restored.
-                        // SetTimer must run on the hook thread (window owner).
-                        PostToHookThread(WM_APP_REQUEST_APPLY_DEBOUNCED);
-                        return;
-                    }
-                    g_lastFullRefreshTick = now;
-                    if (!weak.get()) {
+                    if (g_unloading.load() || !weak.get()) {
                         return;
                     }
                     ApplyAllHighlights_UIThread();
@@ -6869,18 +7025,19 @@ void OnMinFocusTimerElapsed(MinFocusConfirmMode mode) {
     // that never show a TaskListButton.
     RunOnUiThread([key = pending.key, displayName = pending.displayName,
                    desktopId = pending.desktopId]() {
+        ProcessImagePathCacheScope pathCacheScope;
         auto live = CollectLiveButtonsOnThisDispatcher();
         for (auto& b : live) {
             EnsureButtonPathCached(b, /*force=*/false);
         }
 
-        const bool appears = PathAppearsOnTaskbar(key, displayName);
+        const bool appears = PathAppearsOnTaskbar(key);
 
         size_t resolvedButtons = 0;
         {
             std::lock_guard<std::mutex> lock(g_buttonPathMutex);
             for (const auto& [id, e] : g_buttonPathCache) {
-                if (!e.pathUpper.empty()) {
+                if (!e.pathUpper.empty() || !e.appIdUpper.empty()) {
                     ++resolvedButtons;
                 }
             }
@@ -6956,6 +7113,7 @@ void HandleForegroundChanged(HWND hWnd) {
     if (g_unloading.load()) {
         return;
     }
+    ProcessImagePathCacheScope pathCacheScope;
 
     hWnd = NormalizeFocusHwnd(hWnd);
 
@@ -7623,10 +7781,19 @@ void LoadSettings() {
 // ---------------------------------------------------------------------------
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"> Taskbar Recent Focus Highlight init v0.9.8");
+    Wh_Log(L"> Taskbar Recent Focus Highlight init v0.9.10");
 
     g_unloading = false;
     LoadSettings();
+    {
+        auto settings = SettingsSnap();
+        if (settings->highlightCount <= 0 &&
+            !settings->previewHighlightEnabled) {
+            Wh_Log(L"Nothing to paint (highlightCount=0, previews off) — "
+                   L"skipping init");
+            return FALSE;
+        }
+    }
 
     HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
     if (!kernelBaseModule) {
@@ -7724,6 +7891,7 @@ void Wh_ModUninit() {
         std::lock_guard<std::mutex> lock(g_thumbnailMapMutex);
         g_thumbnailTaskItemMapping.clear();
     }
+    g_TaskGroup_Thumbnails = {};
     {
         std::lock_guard<std::mutex> lock(g_thumbViewsMutex);
         g_trackedThumbViews.clear();

--- a/mods/taskbar-recent-focus-highlight.wh.cpp
+++ b/mods/taskbar-recent-focus-highlight.wh.cpp
@@ -2,13 +2,14 @@
 // @id              taskbar-recent-focus-highlight
 // @name            Taskbar Recent Focus Highlight
 // @description     Visually highlight the most recently focused running apps on the taskbar
-// @version         0.9.3
+// @version         0.9.4
 // @author          Jakub Vlášek
 // @github          https://github.com/jvlasek
 // @include         explorer.exe
 // @architecture    x86-64
 // @compilerOptions -lcomctl32 -lole32 -loleaut32 -lruntimeobject -luuid -lshell32 -ladvapi32
 // ==/WindhawkMod==
+// -loleaut32 is required: WinRT hresult_error calls SysFreeString / SysStringLen.
 
 // Source code is published under The GNU General Public License v3.0.
 
@@ -398,9 +399,6 @@ struct Settings {
     int previewDecayMinutes = 15;
     PreviewStyle previewStyle = PreviewStyle::TitleBar;
     std::unordered_set<std::wstring> excludedPrograms;
-    // Resolved on the focus-thread STA (and on DWM/SETTINGCHANGE). Not
-    // queried on every paint.
-    winrt::Windows::UI::Color cachedAccent{255, 0, 120, 215};
     // Bumped in PublishSettings so UVS can skip a no-op repaint.
     uint32_t generation = 0;
 };
@@ -425,6 +423,27 @@ void PublishSettings(Settings s) {
     std::lock_guard<std::mutex> lock(g_settingsMutex);
     g_settingsPtr = std::move(next);
 }
+
+// Accent is not inside Settings: ColorValuesChanged must not republish a
+// stale snapshot over a concurrent LoadSettings. Packed ARGB.
+constexpr uint32_t kDefaultAccentPacked = 0xFF0078D7u;  // #0078D7
+std::atomic<uint32_t> g_cachedAccent{kDefaultAccentPacked};
+
+uint32_t PackColor(winrt::Windows::UI::Color c) {
+    return (static_cast<uint32_t>(c.A) << 24) |
+           (static_cast<uint32_t>(c.R) << 16) |
+           (static_cast<uint32_t>(c.G) << 8) | static_cast<uint32_t>(c.B);
+}
+
+winrt::Windows::UI::Color UnpackColor(uint32_t v) {
+    return {static_cast<uint8_t>(v >> 24), static_cast<uint8_t>(v >> 16),
+            static_cast<uint8_t>(v >> 8), static_cast<uint8_t>(v)};
+}
+
+[[clang::no_destroy]] std::optional<
+    winrt::Windows::UI::ViewManagement::UISettings>
+    g_uiSettings;
+winrt::event_token g_colorValuesChangedToken{};
 
 // WM_TIMER may be a leftover from a previous candidate (KillTimer does not
 // flush a message already queued). Immediate confirm skips the deadline.
@@ -529,6 +548,7 @@ struct ButtonPathCacheEntry {
     // Last ApplyAllHighlights assignment: -1 unknown, 0 none, >0 1-based rank.
     int lastPaintRank = -1;
     uint32_t lastPaintSettingsGen = 0;
+    uint32_t lastPaintAccent = 0;
     // ScaleTransform we applied for size boost. Clear only this instance so
     // other mods (taskbar-dock-animation) keep their hover scale.
     winrt::weak_ref<Media::ScaleTransform> ourIconScale;
@@ -536,6 +556,8 @@ struct ButtonPathCacheEntry {
 std::mutex g_buttonPathMutex;
 std::unordered_map<void*, ButtonPathCacheEntry> g_buttonPathCache;
 std::atomic<bool> g_taskbandResolveReady{false};
+HMODULE g_taskbarDll = nullptr;
+bool g_taskbarDllLoadedByUs = false;
 
 // XAML TaskItemThumbnail (model) → native task item (optional hooks).
 struct ThumbnailTaskItemMapping {
@@ -597,6 +619,19 @@ void* InspectableIdentity(winrt::Windows::Foundation::IInspectable const& obj) {
     }
 }
 
+bool WeakIsSameElement(winrt::weak_ref<FrameworkElement> const& weak,
+                       FrameworkElement expected) {
+    if (!expected) {
+        return false;
+    }
+    try {
+        auto live = weak.get();
+        return live && live == expected;
+    } catch (...) {
+        return false;
+    }
+}
+
 // UI-thread tracking of task list buttons (weak refs, keyed by IUnknown*).
 std::mutex g_buttonsMutex;
 std::unordered_map<void*, winrt::weak_ref<FrameworkElement>> g_trackedButtons;
@@ -642,10 +677,8 @@ constexpr UINT WM_APP_REQUEST_APPLY_DEBOUNCED = WM_APP + 4;
 constexpr UINT WM_APP_REFRESH_ACCENT = WM_APP + 5;
 
 // Identity scores. Only exact identity may bind the same rank to many buttons
-// (secondary taskbar / Never Combine). Score 900 is same filename, different
-// folder — 1:1 so two python.exe installs stay distinct.
+// (secondary taskbar / Never Combine). Filename-only is not a match.
 constexpr int kScoreExactIdentity = 1000;
-constexpr int kScoreSameFileDifferentPath = 900;
 constexpr UINT_PTR kMinFocusTimerId = 1;
 constexpr UINT_PTR kDecayTimerId = 2;
 constexpr UINT_PTR kPreviewMinFocusTimerId = 3;
@@ -1715,22 +1748,45 @@ winrt::Windows::UI::Color QuerySystemAccentColor() {
         c.A = 255;
         return c;
     } catch (...) {
-        return {255, 0, 120, 215};
+        return UnpackColor(kDefaultAccentPacked);
     }
 }
 
 void RefreshCachedAccent() {
     winrt::Windows::UI::Color accent = QuerySystemAccentColor();
-    auto cur = SettingsSnap();
-    if (cur->cachedAccent.A == accent.A && cur->cachedAccent.R == accent.R &&
-        cur->cachedAccent.G == accent.G && cur->cachedAccent.B == accent.B) {
+    const uint32_t packed = PackColor(accent);
+    const uint32_t prev =
+        g_cachedAccent.exchange(packed, std::memory_order_relaxed);
+    if (prev != packed) {
+        Wh_Log(L"System accent updated: #%02X%02X%02X", accent.R, accent.G,
+               accent.B);
+    }
+}
+
+void SubscribeAccentChanges() {
+    if (g_uiSettings) {
         return;
     }
-    Settings next = *cur;
-    next.cachedAccent = accent;
-    PublishSettings(std::move(next));
-    Wh_Log(L"System accent updated: #%02X%02X%02X", accent.R, accent.G,
-           accent.B);
+    try {
+        g_uiSettings.emplace();
+        g_colorValuesChangedToken = g_uiSettings->ColorValuesChanged(
+            [](auto&&, auto&&) { PostToHookThread(WM_APP_REFRESH_ACCENT); });
+    } catch (...) {
+        g_uiSettings.reset();
+        g_colorValuesChangedToken = {};
+        Wh_Log(L"UISettings ColorValuesChanged subscribe failed");
+    }
+}
+
+void UnsubscribeAccentChanges() {
+    try {
+        if (g_uiSettings) {
+            g_uiSettings->ColorValuesChanged(g_colorValuesChangedToken);
+        }
+    } catch (...) {
+    }
+    g_colorValuesChangedToken = {};
+    g_uiSettings.reset();
 }
 
 winrt::Windows::UI::Color ResolveGlowBaseColor(const Settings& settings) {
@@ -1738,7 +1794,7 @@ winrt::Windows::UI::Color ResolveGlowBaseColor(const Settings& settings) {
 
     switch (settings.glowColor) {
         case GlowColorMode::Accent:
-            c = settings.cachedAccent;
+            c = UnpackColor(g_cachedAccent.load(std::memory_order_relaxed));
             break;
         case GlowColorMode::Green:
             c = {255, 0, 200, 83};
@@ -1776,6 +1832,7 @@ ButtonIdentity GetCachedButtonIdentity(FrameworkElement button);
 struct PaintCacheState {
     int rank = -1;
     uint32_t settingsGen = 0;
+    uint32_t accent = 0;
 };
 PaintCacheState GetCachedPaintState(FrameworkElement button);
 void SetCachedPaintState(FrameworkElement button, int rank, uint32_t gen);
@@ -1783,6 +1840,10 @@ TaskbarEdge CachedTaskbarEdge(FrameworkElement iconPanel);
 void RememberOurIconScale(FrameworkElement button, Media::ScaleTransform scale);
 void ClearIconScaleIfOurs(FrameworkElement icon, FrameworkElement button);
 void RefreshCachedAccent();
+void SubscribeAccentChanges();
+void UnsubscribeAccentChanges();
+void ScheduleThumbnailRelayout(FrameworkElement thumbView);
+void ClearAllThumbnailHighlights_UIThread();
 bool RunOnUiThread(const winrt::Windows::UI::Core::DispatchedHandler& handler);
 void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb);
 
@@ -1816,6 +1877,10 @@ bool ButtonCountsAsRunning(FrameworkElement button) {
     std::lock_guard<std::mutex> lock(g_buttonPathMutex);
     auto it = id ? g_buttonPathCache.find(id) : g_buttonPathCache.end();
     if (it == g_buttonPathCache.end()) {
+        return running;
+    }
+    if (!WeakIsSameElement(it->second.button, button)) {
+        g_buttonPathCache.erase(it);
         return running;
     }
     auto& e = it->second;
@@ -2061,15 +2126,6 @@ int ScoreButtonForRank(FrameworkElement button,
         }
         return kScoreExactIdentity;
     }
-
-    const bool sameFileName =
-        !ident.pathUpper.empty() && !info.displayName.empty() &&
-        ToUpper(FileNameFromPath(ident.pathUpper)) ==
-            ToUpper(info.displayName);
-    if (sameFileName && !pathKey.empty() && ident.pathUpper != pathKey &&
-        ident.pathUpper != info.key) {
-        return kScoreSameFileDifferentPath;
-    }
     return 0;
 }
 
@@ -2090,7 +2146,7 @@ int FindRankForButton(FrameworkElement button,
             bestRank = static_cast<int>(i) + 1;
         }
     }
-    if (bestScore < kScoreSameFileDifferentPath) {
+    if (bestScore < kScoreExactIdentity) {
         return 0;
     }
     return bestRank;
@@ -2204,77 +2260,6 @@ bool RunningIndicatorLooksLikeHoverPlate(FrameworkElement ri,
             return false;
         }
         return rw > pw * 0.45 && rh > ph * 0.45;
-    } catch (...) {
-        return false;
-    }
-}
-
-std::wstring CurrentRunningIndicatorStateName(FrameworkElement iconPanel,
-                                              FrameworkElement button) {
-    auto from = [](FrameworkElement root) -> std::wstring {
-        if (!root) {
-            return {};
-        }
-        try {
-            for (auto group : VisualStateManager::GetVisualStateGroups(root)) {
-                if (group.Name() != L"RunningIndicatorStates") {
-                    continue;
-                }
-                auto current = group.CurrentState();
-                if (current) {
-                    return std::wstring(current.Name().c_str());
-                }
-            }
-        } catch (...) {
-        }
-        return {};
-    };
-    std::wstring name = from(iconPanel);
-    if (name.empty()) {
-        name = from(button);
-    }
-    return name;
-}
-
-// Only undo Visibility=Collapsed that *we* set. Visual-state setters store
-// Visible as a local value — ClearValue drops it to the template default
-// (Collapsed), and GoToState(InactiveRunningIndicator) is a no-op if already
-// in that state, so the short inactive pill never comes back.
-void RestoreNativeRunningIndicator(FrameworkElement iconPanel,
-                                   FrameworkElement button) {
-    auto indicator = FindRunningIndicator(iconPanel);
-    if (!indicator) {
-        return;
-    }
-    try {
-        if (indicator.ReadLocalValue(UIElement::VisibilityProperty()) ==
-            DependencyProperty::UnsetValue()) {
-            return;
-        }
-        if (indicator.Visibility() != Visibility::Collapsed) {
-            return;
-        }
-        const std::wstring state =
-            CurrentRunningIndicatorStateName(iconPanel, button);
-        if (state == L"NoRunningIndicator") {
-            return;
-        }
-        indicator.Visibility(Visibility::Visible);
-    } catch (...) {
-    }
-}
-
-bool RunningIndicatorHasLocalCollapsed(FrameworkElement iconPanel) {
-    auto indicator = FindRunningIndicator(iconPanel);
-    if (!indicator) {
-        return false;
-    }
-    try {
-        if (indicator.ReadLocalValue(UIElement::VisibilityProperty()) ==
-            DependencyProperty::UnsetValue()) {
-            return false;
-        }
-        return indicator.Visibility() == Visibility::Collapsed;
     } catch (...) {
         return false;
     }
@@ -2523,10 +2508,10 @@ void ClearButtonHighlight(FrameworkElement button) {
 
     auto iconPanelEarly = GetIconPanel(button);
 
-    // Skip no-op clears on every mouse-over. Do not reorder native children
-    // on buttons we never painted — that fights Taskbar Styler / badges and
-    // is not undone on unload. Z-order heal runs only after we remove our host.
-    if (!ButtonHasOurChrome(button) && !g_pendingOverlaySweep.load()) {
+    // Skip no-op clears on every mouse-over, including overlay sweep.
+    // Sweep only removes leftover WhRecentFocusGlow; do not reorder native
+    // children on buttons we never painted.
+    if (!ButtonHasOurChrome(button)) {
         SetCachedPaintState(button, 0, SettingsSnap()->generation);
         return;
     }
@@ -2570,12 +2555,6 @@ void ClearButtonHighlight(FrameworkElement button) {
                 }
             }
         }
-
-        if (RunningIndicatorHasLocalCollapsed(iconPanel)) {
-            RestoreNativeRunningIndicator(iconPanel, button);
-        }
-        // Do not heal Visibility on every clear — that ClearValue thrashing
-        // also flickers the native underline during hover storms.
 
         if (auto icon = FindChildByName(iconPanel, L"Icon")) {
             ClearIconScaleIfOurs(icon, button);
@@ -2748,7 +2727,7 @@ PCWSTR BarSideName(BarSide s) {
     }
 }
 
-bool HasVisualState(FrameworkElement root, PCWSTR stateName) {
+bool IsInVisualState(FrameworkElement root, PCWSTR stateName) {
     if (!root || !stateName) {
         return false;
     }
@@ -2788,18 +2767,18 @@ TaskbarEdge TaskbarEdgeFromAppBar() {
 // paint full-cell underlines of rank-dependent length.
 // Do not use "wider than tall ⇒ horizontal": a left-edge button is 48×32.
 TaskbarEdge DetectTaskbarEdge(FrameworkElement iconPanel) {
-    bool verticalState = HasVisualState(iconPanel, L"VerticalOrientation");
-    bool horizontalState = HasVisualState(iconPanel, L"HorizontalOrientation");
+    bool verticalState = IsInVisualState(iconPanel, L"VerticalOrientation");
+    bool horizontalState = IsInVisualState(iconPanel, L"HorizontalOrientation");
     try {
         auto parent = Media::VisualTreeHelper::GetParent(iconPanel)
                           .try_as<FrameworkElement>();
         if (parent) {
             verticalState =
                 verticalState ||
-                HasVisualState(parent, L"VerticalOrientation");
+                IsInVisualState(parent, L"VerticalOrientation");
             horizontalState =
                 horizontalState ||
-                HasVisualState(parent, L"HorizontalOrientation");
+                IsInVisualState(parent, L"HorizontalOrientation");
         }
     } catch (...) {
     }
@@ -2936,19 +2915,14 @@ void GlowContentBoxSize(FrameworkElement host,
 // Length follows the glow host (padded cell), same for every rank — rank is
 // opacity. Icon-sized underlines on a left taskbar were too short to scan
 // (Windows uses a very small glyph there). Size % still scales the bar.
-double BarLengthForSide(FrameworkElement iconPanel,
-                        double boxW,
+double BarLengthForSide(double boxW,
                         double boxH,
                         BarSide side,
-                        TaskbarEdge edge,
-                        double sizeFrac,
-                        double rankLenScale) {
-    (void)iconPanel;
-    (void)edge;
+                        double sizeFrac) {
     const bool horizontalBar =
         side == BarSide::Top || side == BarSide::Bottom;
     const double cellAlong = horizontalBar ? boxW : boxH;
-    double barLen = cellAlong * sizeFrac * rankLenScale;
+    double barLen = cellAlong * sizeFrac;
     const double maxLen = (std::max)(4.0, cellAlong - 2.0);
     if (barLen > maxLen) {
         barLen = maxLen;
@@ -3097,15 +3071,20 @@ TaskbarEdge CachedTaskbarEdge(FrameworkElement iconPanel) {
     {
         std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
         auto it = id ? g_layoutWatches.find(id) : g_layoutWatches.end();
-        if (it != g_layoutWatches.end() && it->second.haveEdge) {
-            return it->second.lastEdge;
+        if (it != g_layoutWatches.end()) {
+            if (!WeakIsSameElement(it->second.panel, iconPanel)) {
+                g_layoutWatches.erase(it);
+            } else if (it->second.haveEdge) {
+                return it->second.lastEdge;
+            }
         }
     }
     const TaskbarEdge edge = DetectTaskbarEdge(iconPanel);
     if (id) {
         std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
         auto it = g_layoutWatches.find(id);
-        if (it != g_layoutWatches.end()) {
+        if (it != g_layoutWatches.end() &&
+            WeakIsSameElement(it->second.panel, iconPanel)) {
             it->second.lastEdge = edge;
             it->second.haveEdge = true;
         }
@@ -3133,12 +3112,10 @@ void EnsureIconPanelLayoutWatch(FrameworkElement button) {
         std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
         auto it = g_layoutWatches.find(id);
         if (it != g_layoutWatches.end()) {
-            try {
-                if (it->second.panel.get() == iconPanel) {
-                    return;
-                }
-            } catch (...) {
+            if (WeakIsSameElement(it->second.panel, iconPanel)) {
+                return;
             }
+            g_layoutWatches.erase(it);
         }
     }
 
@@ -3242,6 +3219,8 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
         auto painted = GetCachedPaintState(button);
         if (painted.rank == rankOneBased &&
             painted.settingsGen == settings->generation &&
+            painted.accent ==
+                g_cachedAccent.load(std::memory_order_relaxed) &&
             ButtonHasOurChrome(button)) {
             return;
         }
@@ -3318,10 +3297,6 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
 
         HideAllGlowLayers(host);
 
-        if (RunningIndicatorHasLocalCollapsed(iconPanel)) {
-            RestoreNativeRunningIndicator(iconPanel, button);
-        }
-
         if (style == GlowStyle::Frame || style == GlowStyle::Full) {
             const double baseInset =
                 (std::min)(boxW, boxH) * (1.0 - sizeFrac) * 0.5;
@@ -3364,8 +3339,8 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
             // Side bar: left of the icon on a bottom/top taskbar, under the
             // icon on a left/right taskbar — never the native-pill edge.
             const double barT = thickness + 1.0;
-            const double barLen = BarLengthForSide(
-                iconPanel, boxW, boxH, barSide, edge, sizeFrac, 1.0);
+            const double barLen =
+                BarLengthForSide(boxW, boxH, barSide, sizeFrac);
             const int fillBase =
                 static_cast<int>(fillOpacitySetting * 2.55 * (0.55 + 0.45 * t));
             const int nLeft = (std::max)(1, (std::min)(layers, 2));
@@ -3395,8 +3370,8 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
                 static_cast<int>(fillOpacitySetting * 2.55 * (0.6 + 0.4 * t));
             const double barT =
                 (std::max)(2.0, (std::min)(6.0, thickness));
-            const double barLen = BarLengthForSide(
-                iconPanel, boxW, boxH, barSide, edge, sizeFrac, 1.0);
+            const double barLen =
+                BarLengthForSide(boxW, boxH, barSide, sizeFrac);
 
             if (auto rect = FindChildByName(host, kGlowLayerNames[0])
                                 .try_as<Shapes::Rectangle>()) {
@@ -3460,7 +3435,6 @@ void TrackButton_UIThread(FrameworkElement button) {
         std::lock_guard<std::mutex> lock(g_buttonsMutex);
         g_trackedButtons[id] = winrt::make_weak(button);
     }
-    EnsureButtonPathCached(button, /*force=*/false);
 }
 
 // ---------------------------------------------------------------------------
@@ -3736,9 +3710,12 @@ std::wstring EnsureButtonPathCached(FrameworkElement button, bool force) {
     {
         std::lock_guard<std::mutex> lock(g_buttonPathMutex);
         auto it = id ? g_buttonPathCache.find(id) : g_buttonPathCache.end();
-        if (it != g_buttonPathCache.end() && !force &&
-            it->second.resolveAttempted) {
-            return it->second.pathUpper;
+        if (it != g_buttonPathCache.end()) {
+            if (!WeakIsSameElement(it->second.button, button)) {
+                g_buttonPathCache.erase(it);
+            } else if (!force && it->second.resolveAttempted) {
+                return it->second.pathUpper;
+            }
         }
     }
 
@@ -3816,6 +3793,11 @@ std::wstring EnsureButtonPathCached(FrameworkElement button, bool force) {
         ButtonPathCacheEntry* e = nullptr;
         if (id) {
             auto it = g_buttonPathCache.find(id);
+            if (it != g_buttonPathCache.end() &&
+                !WeakIsSameElement(it->second.button, button)) {
+                g_buttonPathCache.erase(it);
+                it = g_buttonPathCache.end();
+            }
             if (it == g_buttonPathCache.end()) {
                 ButtonPathCacheEntry created;
                 created.button = winrt::make_weak(button);
@@ -3870,6 +3852,10 @@ ButtonIdentity GetCachedButtonIdentity(FrameworkElement button) {
     if (it == g_buttonPathCache.end()) {
         return out;
     }
+    if (!WeakIsSameElement(it->second.button, button)) {
+        g_buttonPathCache.erase(it);
+        return out;
+    }
     const auto& e = it->second;
     out.pathUpper = e.pathUpper;
     out.appIdUpper = e.appIdUpper;
@@ -3892,8 +3878,13 @@ PaintCacheState GetCachedPaintState(FrameworkElement button) {
     if (it == g_buttonPathCache.end()) {
         return out;
     }
+    if (!WeakIsSameElement(it->second.button, button)) {
+        g_buttonPathCache.erase(it);
+        return out;
+    }
     out.rank = it->second.lastPaintRank;
     out.settingsGen = it->second.lastPaintSettingsGen;
+    out.accent = it->second.lastPaintAccent;
     return out;
 }
 
@@ -3905,18 +3896,26 @@ void SetCachedPaintState(FrameworkElement button, int rank, uint32_t gen) {
     if (!id) {
         return;
     }
+    const uint32_t accent = g_cachedAccent.load(std::memory_order_relaxed);
     std::lock_guard<std::mutex> lock(g_buttonPathMutex);
     auto it = g_buttonPathCache.find(id);
+    if (it != g_buttonPathCache.end() &&
+        !WeakIsSameElement(it->second.button, button)) {
+        g_buttonPathCache.erase(it);
+        it = g_buttonPathCache.end();
+    }
     if (it == g_buttonPathCache.end()) {
         ButtonPathCacheEntry stub;
         stub.button = winrt::make_weak(button);
         stub.lastPaintRank = rank;
         stub.lastPaintSettingsGen = gen;
+        stub.lastPaintAccent = accent;
         g_buttonPathCache.emplace(id, std::move(stub));
         return;
     }
     it->second.lastPaintRank = rank;
     it->second.lastPaintSettingsGen = gen;
+    it->second.lastPaintAccent = accent;
 }
 
 void RememberOurIconScale(FrameworkElement button, Media::ScaleTransform scale) {
@@ -3929,6 +3928,11 @@ void RememberOurIconScale(FrameworkElement button, Media::ScaleTransform scale) 
     }
     std::lock_guard<std::mutex> lock(g_buttonPathMutex);
     auto it = g_buttonPathCache.find(id);
+    if (it != g_buttonPathCache.end() &&
+        !WeakIsSameElement(it->second.button, button)) {
+        g_buttonPathCache.erase(it);
+        it = g_buttonPathCache.end();
+    }
     if (it == g_buttonPathCache.end()) {
         ButtonPathCacheEntry stub;
         stub.button = winrt::make_weak(button);
@@ -3961,7 +3965,8 @@ void ClearIconScaleIfOurs(FrameworkElement icon, FrameworkElement button) {
             void* id = InspectableIdentity(button);
             std::lock_guard<std::mutex> lock(g_buttonPathMutex);
             auto it = id ? g_buttonPathCache.find(id) : g_buttonPathCache.end();
-            if (it != g_buttonPathCache.end()) {
+            if (it != g_buttonPathCache.end() &&
+                WeakIsSameElement(it->second.button, button)) {
                 try {
                     ours = it->second.ourIconScale.get();
                     if (ours && current == ours) {
@@ -4075,7 +4080,7 @@ void ApplyAllHighlights_UIThread() {
         buttonPaths[bi] = EnsureButtonPathCached(live[bi], /*force=*/false);
         for (size_t ri = 0; ri < ranks.size(); ++ri) {
             int s = ScoreButtonForRank(live[bi], ranks[ri], true);
-            if (s >= kScoreSameFileDifferentPath) {
+            if (s >= kScoreExactIdentity) {
                 cands.push_back({s, ri, bi});
             }
         }
@@ -5033,10 +5038,6 @@ bool GetTitleBottomRelative(FrameworkElement title,
         return false;
     }
     try {
-        try {
-            title.UpdateLayout();
-        } catch (...) {
-        }
         double th = title.ActualHeight();
         if (!(th > 1.0)) {
             th = title.DesiredSize().Height;
@@ -5067,16 +5068,17 @@ bool GetTitleBottomRelative(FrameworkElement title,
 // Deferred re-layout for titleBar/titleBg after the flyout finishes measuring.
 // At most one nested pass (avoids infinite Low-priority loops when title never
 // reports a size).
-std::atomic<bool> g_thumbRelayoutPending{false};
-std::atomic<int> g_thumbRelayoutDepth{0};
+thread_local bool g_thumbRelayoutPending = false;
+thread_local int g_thumbRelayoutDepth = 0;
 
 void ScheduleThumbnailRelayout(FrameworkElement thumbView) {
-    if (!thumbView || g_thumbRelayoutDepth.load() > 0) {
+    if (!thumbView || g_thumbRelayoutDepth > 0) {
         return;  // already inside the deferred pass
     }
-    if (g_thumbRelayoutPending.exchange(true)) {
+    if (g_thumbRelayoutPending) {
         return;
     }
+    g_thumbRelayoutPending = true;
     try {
         auto dispatcher = thumbView.Dispatcher();
         if (!dispatcher) {
@@ -6193,8 +6195,23 @@ void WINAPI HoverFlyoutModel_TargetItemKey_Hook(void* pThis, void* param1) {
     g_inHoverFlyoutModel_TargetItemKey = true;
     HoverFlyoutModel_TargetItemKey_Original(pThis, param1);
     g_inHoverFlyoutModel_TargetItemKey = false;
-    if (SettingsSnap()->previewHighlightEnabled) {
-        RequestApplyPreviewVisuals();
+    if (g_unloading.load() || !SettingsSnap()->previewHighlightEnabled) {
+        return;
+    }
+    // Repeater may not have swapped realized cards yet. Clear leftover chrome
+    // now and paint at Low after layout so new HWNDs are not bound to the
+    // previous app's views.
+    try {
+        ClearAllThumbnailHighlights_UIThread();
+        std::vector<winrt::weak_ref<FrameworkElement>> thumbs;
+        {
+            std::lock_guard<std::mutex> lock(g_thumbViewsMutex);
+            thumbs = g_trackedThumbViews;
+        }
+        ForEachLiveElementOnThisDispatcher(thumbs, [](FrameworkElement el) {
+            ScheduleThumbnailRelayout(el);
+        });
+    } catch (...) {
     }
 }
 
@@ -6203,7 +6220,11 @@ bool HookTaskbarDllSymbols() {
     if (!module) {
         module = LoadLibraryEx(L"taskbar.dll", nullptr,
                                LOAD_LIBRARY_SEARCH_SYSTEM32);
+        if (module) {
+            g_taskbarDllLoadedByUs = true;
+        }
     }
+    g_taskbarDll = module;
     if (!module) {
         Wh_Log(L"Could not load taskbar.dll — path cache unavailable");
         return false;
@@ -6916,21 +6937,6 @@ LRESULT CALLBACK HookThreadWndProc(HWND hWnd,
             RequestApplyVisuals();
             RequestApplyPreviewVisuals();
             return 0;
-        case WM_DWMCOLORIZATIONCOLORCHANGED:
-            RefreshCachedAccent();
-            RequestApplyVisuals();
-            RequestApplyPreviewVisuals();
-            return 0;
-        case WM_SETTINGCHANGE:
-            if (!lParam ||
-                _wcsicmp(reinterpret_cast<PCWSTR>(lParam),
-                         L"ImmersiveColorSet") == 0) {
-                RefreshCachedAccent();
-                RequestApplyVisuals();
-                RequestApplyPreviewVisuals();
-                return 0;
-            }
-            break;
         case WM_TIMER:
             if (wParam == kMinFocusTimerId) {
                 KillTimer(hWnd, kMinFocusTimerId);
@@ -7002,6 +7008,8 @@ DWORD WINAPI WinEventHookThread(LPVOID /*param*/) {
     if (FAILED(coHr) && coHr != RPC_E_CHANGED_MODE) {
         Wh_Log(L"Focus thread CoInitializeEx failed %08X", coHr);
     }
+    SubscribeAccentChanges();
+    RefreshCachedAccent();
 
     HWINEVENTHOOK hook =
         SetWinEventHook(EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND,
@@ -7023,7 +7031,6 @@ DWORD WINAPI WinEventHookThread(LPVOID /*param*/) {
 
     SetTimer(hwnd, kDecayTimerId, kDecayCheckIntervalMs, nullptr);
     RefreshCurrentDesktopId();
-    RefreshCachedAccent();
 
     if (HWND fg = GetForegroundWindow()) {
         PostMessage(hwnd, WM_APP_FOREGROUND_CHANGED,
@@ -7051,6 +7058,7 @@ DWORD WINAPI WinEventHookThread(LPVOID /*param*/) {
     }
 
     ReleaseVdm();
+    UnsubscribeAccentChanges();
 
     g_hookThreadHwnd.store(nullptr, std::memory_order_release);
     DestroyWindow(hwnd);
@@ -7323,8 +7331,6 @@ void LoadSettings() {
         s.excludedPrograms.insert(ToUpper(program.get()));
     }
 
-    s.cachedAccent = SettingsSnap()->cachedAccent;
-
     Wh_Log(L"Settings: style=%s th=%d round=%d%% size=%d%% "
            L"layers=%d fillOp=%d previewFillOp=%d decay=%dmin "
            L"minFocus=%ds promote=%s preview=%d previewCount=%d "
@@ -7347,7 +7353,7 @@ void LoadSettings() {
 // ---------------------------------------------------------------------------
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"> Taskbar Recent Focus Highlight init v0.9.3");
+    Wh_Log(L"> Taskbar Recent Focus Highlight init v0.9.4");
 
     g_unloading = false;
     LoadSettings();
@@ -7456,6 +7462,11 @@ void Wh_ModUninit() {
         std::lock_guard<std::mutex> lock(g_dispatchersMutex);
         g_uiDispatchers.reset();
     }
+    if (g_taskbarDllLoadedByUs && g_taskbarDll) {
+        FreeLibrary(g_taskbarDll);
+    }
+    g_taskbarDll = nullptr;
+    g_taskbarDllLoadedByUs = false;
 }
 
 void Wh_ModSettingsChanged() {

--- a/mods/taskbar-recent-focus-highlight.wh.cpp
+++ b/mods/taskbar-recent-focus-highlight.wh.cpp
@@ -2,12 +2,12 @@
 // @id              taskbar-recent-focus-highlight
 // @name            Taskbar Recent Focus Highlight
 // @description     Visually highlight the most recently focused running apps on the taskbar
-// @version         0.9.2
+// @version         0.9.3
 // @author          Jakub Vlášek
 // @github          https://github.com/jvlasek
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lcomctl32 -lole32 -loleaut32 -lruntimeobject -lpropsys -luuid -lshell32 -ladvapi32
+// @compilerOptions -lcomctl32 -lole32 -loleaut32 -lruntimeobject -luuid -lshell32 -ladvapi32
 // ==/WindhawkMod==
 
 // Source code is published under The GNU General Public License v3.0.
@@ -55,10 +55,9 @@ plate, hybrid (plate for rank 1, title tint for the rest), or a ring.
   thickness / size / fill, optional icon scale
 - **Previews** — on/off, how many windows, style, intensities, separate
   min-focus and decay
-- **Advanced** — verbose debug log
 
-All of those are in the Windhawk settings panel. Turn **Enabled** off to
-clear highlights without unloading the mod.
+All of those are in the Windhawk settings panel. Disable the mod in Windhawk
+to clear highlights.
 
 ## Notes
 
@@ -67,32 +66,31 @@ clear highlights without unloading the mod.
 - Icon matching uses the process path / AppUserModelID from the taskband
   (not the localized button label). If that resolve is unavailable, the icon
   is left unhighlighted rather than guessed from its name.
+- Preview cards prefer the flyout’s thumbnail index. If that is unavailable,
+  a unique window title is used as a last resort. Title cleanup understands
+  English “N running windows” / “pinned” suffixes; on other languages that
+  strip is a no-op, so two cards with the same stem may stay unmatched
+  instead of guessing.
 - Multi-monitor: the same rank is applied on every taskbar that shows that
   app.
+- Verbose bind / preview-resolve lines go to Windhawk’s **Mod logs** (Advanced
+  tab). There is no extra in-mod debug toggle.
 */
 // ==/WindhawkModReadme==
 
 // ==WindhawkModSettings==
 /*
-# Windhawk shows settings in this list order (no section headers — $group is
-# not allowed by the settings schema). Names use [General] / [Icons] /
-# [Previews] / [Advanced] prefixes so groups stay obvious in a flat list.
-
-# --- General ---
-- enabled: true
-  $name: "[General] Enabled"
-  $description: Master toggle for all highlighting (icons and previews)
 - highlightCount: 3
-  $name: "[General] Number of highlighted apps"
+  $name: Number of highlighted apps
   $description: How many recent apps to boost on the taskbar (1–6 recommended)
 - minFocusSeconds: 8
-  $name: "[General] Minimum focus time (seconds)"
+  $name: Minimum focus time (seconds)
   $description: >-
     Only count an app as recent if it stays focused at least this long.
     Filters Alt+Tab noise. (Preview windows use a separate timer under Previews.)
     See “When to skip min-focus” for re-focus of apps already in the list.
 - promoteMode: immediateTracked
-  $name: "[General] When to skip min-focus"
+  $name: When to skip min-focus
   $description: >-
     Controls instant promotion when you re-focus an app (confirmed apps still
     become rank 1 once promoted — this only skips the wait timer).
@@ -109,17 +107,17 @@ clear highlights without unloading the mod.
   - immediateTopN: Immediate only if already highlighted (top N)
   - alwaysWait: Always wait min-focus time
 - decayMinutes: 30
-  $name: "[General] Decay time (minutes)"
+  $name: Decay time (minutes)
   $description: >-
     Time after last focus before an app drops out of the taskbar highlight
     list. (Preview windows use a separate decay under Previews.)
 - requireTaskbarButton: true
-  $name: "[General] Only apps on the taskbar"
+  $name: Only apps on the taskbar
   $description: >-
     Ignore tray-only / tool windows that take focus but have no taskbar button
     (e.g. desktop widgets that open a popup then hide to the tray).
 - excludedPrograms: [""]
-  $name: "[General] Exclude list"
+  $name: Exclude list
   $description: >-
     Apps that should never be highlighted (icons or previews). Entries can be
     process names, paths or application IDs, for example:
@@ -129,140 +127,133 @@ clear highlights without unloading the mod.
     C:\Windows\System32\notepad.exe
 
     Microsoft.WindowsCalculator_8wekyb3d8bbwe!App
-
-# --- Taskbar icons ---
-- glowStyle: leftBar
-  $name: "[Icons] Highlight style"
-  $description: >-
-    How ranked apps look on the taskbar. Bars rotate with the taskbar edge
-    (bottom / left / top / right). Side bar = beside the icon (left on a
-    bottom or top taskbar, under the icon on a left or right taskbar). Edge
-    bar = same side as the native running indicator (screen edge). Frame/Full
-    = rounded rectangle. Edge bar paints our own pill and does not restyle
-    the native running indicator permanently.
-  $options:
-  - leftBar: Side bar (left on bottom/top, under icon on left/right)
-  - frame: Frame (hollow rounded rectangle)
-  - full: Full (filled rounded rectangle)
-  - bottomBar: Edge bar (follows the screen edge)
-- glowColor: accent
-  $name: "[Icons] Glow color"
-  $description: Base color for icon highlights (and previews)
-  $options:
-  - accent: System accent color
-  - green: Green
-  - blue: Blue
-  - orange: Orange
-  - white: White
-  - custom: Custom (see custom glow color)
-- customGlowColor: "#00C853"
-  $name: "[Icons] Custom glow color"
-  $description: Used when glow color is Custom (hex, e.g. #00C853)
-- glowIntensityRank1: 100
-  $name: "[Icons] Intensity rank 1"
-  $description: Strength for the most recent app (0–100)
-- glowIntensityRank2: 70
-  $name: "[Icons] Intensity rank 2"
-  $description: Strength for the 2nd most recent app (0–100)
-- glowIntensityRank3: 45
-  $name: "[Icons] Intensity rank 3"
-  $description: Strength for the 3rd most recent app (0–100); also used for ranks 4+
-- glowThickness: 3
-  $name: "[Icons] Thickness (px)"
-  $description: >-
-    Frame/Full border width, or bar thickness (1–16). For side/edge bars this
-    is the bar’s short dimension.
-- glowRoundness: 28
-  $name: "[Icons] Roundness (%)"
-  $description: >-
-    Corner radius for Frame/Full (0 = square, ~25–35 = Win11, 50 ≈ pill).
-    Side bar uses this for pill rounding; edge bar ignores it.
-- glowSize: 92
-  $name: "[Icons] Size (%)"
-  $description: >-
-    Frame/Full: box size vs icon panel (≤100). Side bar: bar length along the
-    icon. Edge bar: pill length % of the icon’s long side (try 70–100).
-- glowLayers: 2
-  $name: "[Icons] Layers"
-  $description: >-
-    Frame/Full: nested frames (1–3). Side bar: soft outer glow layers. Edge
-    bar: ignored.
-- glowFillOpacity: 40
-  $name: "[Icons] Fill opacity"
-  $description: >-
-    0–100. Plate fill for Full; solid bar opacity for Side/Edge. Frame uses
-    stroke only. (Thumbnail tints use [Previews] Tint opacity.)
-- sizeBoostRank1: 10
-  $name: "[Icons] Size boost rank 1 (%)"
-  $description: Subtle icon scale for rank 1 (0 = disabled)
-- sizeBoostRank2: 6
-  $name: "[Icons] Size boost rank 2 (%)"
-  $description: Subtle icon scale for rank 2 (0 = disabled)
-- sizeBoostRank3: 3
-  $name: "[Icons] Size boost rank 3 (%)"
-  $description: Subtle icon scale for rank 3 (0 = disabled)
-
-# --- Thumbnail previews ---
-- previewHighlightEnabled: true
-  $name: "[Previews] Highlight recent windows"
-  $description: >-
-    When hovering a multi-window taskbar icon, rank that flyout’s thumbnails
-    by window recency and mark the top N. Single-window flyouts are never
-    highlighted.
-- previewHighlightCount: 3
-  $name: "[Previews] Number of highlighted windows"
-  $description: >-
-    How many recent windows to mark in a multi-window flyout (1–6 recommended).
-    Ranking is local to that flyout: the last focused window of this app is
-    rank 1 even if other apps were used more recently. Set to 1 to mark only
-    the latest window.
-- previewStyle: titleBar
-  $name: "[Previews] Highlight style"
-  $description: >-
-    How to mark ranked windows. Title bar = thin line under the title.
-    Title background = soft wash behind the title. Plate = tint the whole card.
-    Hybrid = whole plate for rank 1, title wash for ranks 2+.
-    Ring = hollow border around the card.
-  $options:
-  - titleBar: Bar under window title
-  - titleBg: Title background tint
-  - plate: Whole preview plate
-  - plateTitle: Hybrid (plate rank 1, title tint 2+)
-  - ring: Ring / frame
-- previewIntensityRank1: 100
-  $name: "[Previews] Intensity rank 1"
-  $description: Strength for the most recent window in the flyout (0–100)
-- previewIntensityRank2: 70
-  $name: "[Previews] Intensity rank 2"
-  $description: Strength for the 2nd most recent window in the flyout (0–100)
-- previewIntensityRank3: 45
-  $name: "[Previews] Intensity rank 3"
-  $description: >-
-    Strength for the 3rd most recent window in the flyout (0–100); also used
-    for ranks 4+
-- previewFillOpacity: 40
-  $name: "[Previews] Tint opacity"
-  $description: >-
-    0–100. Strength of title-background wash and whole-preview plate. Title bar
-    line uses full accent and ignores this. Independent of [Icons] Fill opacity.
-    Per-rank intensity still scales the result.
-- previewMinFocusSeconds: 1
-  $name: "[Previews] Minimum focus (seconds)"
-  $description: >-
-    How long a window must stay focused before it enters that flyout’s
-    recency list. Separate from app ranking min focus (0 = immediate).
-- previewDecayMinutes: 15
-  $name: "[Previews] Decay (minutes)"
-  $description: >-
-    Drop a window from preview recency after this idle time (0 = never).
-    Separate from app ranking decay.
-
-# --- Advanced ---
-- glowDebugLog: false
-  $name: "[Advanced] Debug log (verbose)"
-  $description: >-
-    Logs glow metrics, path binds, and preview resolve details. Leave off for
-    normal use; turn on when diagnosing matches.
+- icons:
+    - glowStyle: leftBar
+      $name: Highlight style
+      $description: >-
+        How ranked apps look on the taskbar. Bars rotate with the taskbar edge
+        (bottom / left / top / right). Side bar = beside the icon (left on a
+        bottom or top taskbar, under the icon on a left or right taskbar). Edge
+        bar = same side as the native running indicator (screen edge). Frame/Full
+        = rounded rectangle. Edge bar paints our own pill and does not restyle
+        the native running indicator permanently.
+      $options:
+      - leftBar: Side bar (left on bottom/top, under icon on left/right)
+      - frame: Frame (hollow rounded rectangle)
+      - full: Full (filled rounded rectangle)
+      - bottomBar: Edge bar (follows the screen edge)
+    - glowColor: accent
+      $name: Glow color
+      $description: Base color for icon highlights (and previews)
+      $options:
+      - accent: System accent color
+      - green: Green
+      - blue: Blue
+      - orange: Orange
+      - white: White
+      - custom: Custom (see custom glow color)
+    - customGlowColor: "#00C853"
+      $name: Custom glow color
+      $description: Used when glow color is Custom (hex, e.g. #00C853)
+    - glowIntensityRank1: 100
+      $name: Intensity rank 1
+      $description: Strength for the most recent app (0–100)
+    - glowIntensityRank2: 70
+      $name: Intensity rank 2
+      $description: Strength for the 2nd most recent app (0–100)
+    - glowIntensityRank3: 45
+      $name: Intensity rank 3
+      $description: Strength for the 3rd most recent app (0–100); also used for ranks 4+
+    - glowThickness: 3
+      $name: Thickness (px)
+      $description: >-
+        Frame/Full border width, or bar thickness (1–16). For side/edge bars this
+        is the bar’s short dimension.
+    - glowRoundness: 28
+      $name: Roundness (%)
+      $description: >-
+        Corner radius for Frame/Full (0 = square, ~25–35 = Win11, 50 ≈ pill).
+        Side bar uses this for pill rounding; edge bar ignores it.
+    - glowSize: 92
+      $name: Size (%)
+      $description: >-
+        Frame/Full: box size vs icon panel (≤100). Side bar: bar length along the
+        icon. Edge bar: pill length % of the icon’s long side (try 70–100).
+    - glowLayers: 2
+      $name: Layers
+      $description: >-
+        Frame/Full: nested frames (1–3). Side bar: soft outer glow layers. Edge
+        bar: ignored.
+    - glowFillOpacity: 40
+      $name: Fill opacity
+      $description: >-
+        0–100. Plate fill for Full; solid bar opacity for Side/Edge. Frame uses
+        stroke only. (Thumbnail tints use Previews → Tint opacity.)
+    - sizeBoostRank1: 10
+      $name: Size boost rank 1 (%)
+      $description: Subtle icon scale for rank 1 (0 = disabled)
+    - sizeBoostRank2: 6
+      $name: Size boost rank 2 (%)
+      $description: Subtle icon scale for rank 2 (0 = disabled)
+    - sizeBoostRank3: 3
+      $name: Size boost rank 3 (%)
+      $description: Subtle icon scale for rank 3 (0 = disabled)
+  $name: Taskbar icons
+- previews:
+    - highlightEnabled: true
+      $name: Highlight recent windows
+      $description: >-
+        When hovering a multi-window taskbar icon, rank that flyout’s thumbnails
+        by window recency and mark the top N. Single-window flyouts are never
+        highlighted.
+    - highlightCount: 3
+      $name: Number of highlighted windows
+      $description: >-
+        How many recent windows to mark in a multi-window flyout (1–6 recommended).
+        Ranking is local to that flyout: the last focused window of this app is
+        rank 1 even if other apps were used more recently. Set to 1 to mark only
+        the latest window.
+    - style: titleBar
+      $name: Highlight style
+      $description: >-
+        How to mark ranked windows. Title bar = thin line under the title.
+        Title background = soft wash behind the title. Plate = tint the whole card.
+        Hybrid = whole plate for rank 1, title wash for ranks 2+.
+        Ring = hollow border around the card.
+      $options:
+      - titleBar: Bar under window title
+      - titleBg: Title background tint
+      - plate: Whole preview plate
+      - plateTitle: Hybrid (plate rank 1, title tint 2+)
+      - ring: Ring / frame
+    - intensityRank1: 100
+      $name: Intensity rank 1
+      $description: Strength for the most recent window in the flyout (0–100)
+    - intensityRank2: 70
+      $name: Intensity rank 2
+      $description: Strength for the 2nd most recent window in the flyout (0–100)
+    - intensityRank3: 45
+      $name: Intensity rank 3
+      $description: >-
+        Strength for the 3rd most recent window in the flyout (0–100); also used
+        for ranks 4+
+    - fillOpacity: 40
+      $name: Tint opacity
+      $description: >-
+        0–100. Strength of title-background wash and whole-preview plate. Title bar
+        line uses full accent and ignores this. Independent of Icons → Fill opacity.
+        Per-rank intensity still scales the result.
+    - minFocusSeconds: 1
+      $name: Minimum focus (seconds)
+      $description: >-
+        How long a window must stay focused before it enters that flyout’s
+        recency list. Separate from app ranking min focus (0 = immediate).
+    - decayMinutes: 15
+      $name: Decay (minutes)
+      $description: >-
+        Drop a window from preview recency after this idle time (0 = never).
+        Separate from app ranking decay.
+  $name: Thumbnail previews
 */
 // ==/WindhawkModSettings==
 
@@ -271,7 +262,6 @@ clear highlights without unloading the mod.
 #include <commctrl.h>
 #include <initguid.h>
 #include <propkey.h>
-#include <propsys.h>
 #include <objbase.h>
 #include <shellapi.h>
 #include <shobjidl.h>
@@ -289,7 +279,6 @@ clear highlights without unloading the mod.
 // WinUI 2 ItemsRepeater (thumbnail flyout). Same as taskbar-thumbnail-reorder.
 #define WH_WINRT_WINUI2
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Input.h>
 #include <winrt/Windows.UI.Xaml.Markup.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.Shapes.h>
@@ -297,6 +286,7 @@ clear highlights without unloading the mod.
 
 #include <algorithm>
 #include <atomic>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -385,7 +375,6 @@ enum class PreviewStyle {
 };
 
 struct Settings {
-    bool enabled = true;
     int highlightCount = 3;
     int minFocusSeconds = 8;
     PromoteMode promoteMode = PromoteMode::ImmediateTracked;
@@ -400,7 +389,6 @@ struct Settings {
     int glowLayers = 2;         // 1–3
     int glowFillOpacity = 40;   // % for Full / left / bottom icon styles
     int previewFillOpacity = 40;  // % for thumbnail plate / titleBg only
-    bool glowDebugLog = false;
     int decayMinutes = 30;
     bool requireTaskbarButton = true;  // skip tray-only focus targets
     bool previewHighlightEnabled = true;
@@ -410,8 +398,11 @@ struct Settings {
     int previewDecayMinutes = 15;
     PreviewStyle previewStyle = PreviewStyle::TitleBar;
     std::unordered_set<std::wstring> excludedPrograms;
-    // Resolved once in LoadSettings (Accent mode). Not queried on every paint.
+    // Resolved on the focus-thread STA (and on DWM/SETTINGCHANGE). Not
+    // queried on every paint.
     winrt::Windows::UI::Color cachedAccent{255, 0, 120, 215};
+    // Bumped in PublishSettings so UVS can skip a no-op repaint.
+    uint32_t generation = 0;
 };
 
 // Published as a whole. LoadSettings builds a local Settings, then stores it
@@ -428,6 +419,8 @@ std::shared_ptr<const Settings> SettingsSnap() {
 }
 
 void PublishSettings(Settings s) {
+    static std::atomic<uint32_t> seq{0};
+    s.generation = seq.fetch_add(1, std::memory_order_relaxed) + 1;
     auto next = std::make_shared<const Settings>(std::move(s));
     std::lock_guard<std::mutex> lock(g_settingsMutex);
     g_settingsPtr = std::move(next);
@@ -535,12 +528,13 @@ struct ButtonPathCacheEntry {
     ULONGLONG lastRunningTick = 0;  // IsRunning grace (Alt-Tab flicker)
     // Last ApplyAllHighlights assignment: -1 unknown, 0 none, >0 1-based rank.
     int lastPaintRank = -1;
+    uint32_t lastPaintSettingsGen = 0;
     // ScaleTransform we applied for size boost. Clear only this instance so
     // other mods (taskbar-dock-animation) keep their hover scale.
     winrt::weak_ref<Media::ScaleTransform> ourIconScale;
 };
 std::mutex g_buttonPathMutex;
-std::vector<ButtonPathCacheEntry> g_buttonPathCache;
+std::unordered_map<void*, ButtonPathCacheEntry> g_buttonPathCache;
 std::atomic<bool> g_taskbandResolveReady{false};
 
 // XAML TaskItemThumbnail (model) → native task item (optional hooks).
@@ -552,7 +546,6 @@ struct ThumbnailTaskItemMapping {
 };
 std::mutex g_thumbnailMapMutex;
 std::vector<ThumbnailTaskItemMapping> g_thumbnailTaskItemMapping;
-std::atomic<bool> g_previewHooksReady{false};
 
 // Live thumbnail views for unload / re-apply while flyout is open.
 std::mutex g_thumbViewsMutex;
@@ -590,10 +583,23 @@ bool OnHookThread() {
     return id != 0 && GetCurrentThreadId() == id;
 }
 
-// UI-thread tracking of task list buttons (weak refs).
+// Canonical COM identity for hash maps. The weak_ref in the value is the
+// liveness token; recycled pointers are dropped when the weak_ref dies.
+void* InspectableIdentity(winrt::Windows::Foundation::IInspectable const& obj) {
+    if (!obj) {
+        return nullptr;
+    }
+    try {
+        auto unk = obj.as<::IUnknown>();
+        return winrt::get_abi(unk);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+// UI-thread tracking of task list buttons (weak refs, keyed by IUnknown*).
 std::mutex g_buttonsMutex;
-std::vector<winrt::weak_ref<FrameworkElement>> g_trackedButtons;
-winrt::weak_ref<FrameworkElement> g_dispatcherAnchor;
+std::unordered_map<void*, winrt::weak_ref<FrameworkElement>> g_trackedButtons;
 
 // Agile CoreDispatcher list — captured on the UI thread when we first see a
 // button/thumb/panel. CollectUiDispatchers must not weak.get() XAML objects
@@ -604,26 +610,28 @@ std::mutex g_dispatchersMutex;
     std::vector<winrt::Windows::UI::Core::CoreDispatcher>>
     g_uiDispatchers{std::in_place};
 
-void RememberUiDispatcher(FrameworkElement el) {
+bool RememberUiDispatcher(FrameworkElement el) {
     if (!el || g_unloading.load()) {
-        return;
+        return false;
     }
     try {
         auto dispatcher = el.Dispatcher();
         if (!dispatcher) {
-            return;
+            return false;
         }
         std::lock_guard<std::mutex> lock(g_dispatchersMutex);
         if (!g_uiDispatchers) {
-            return;
+            return false;
         }
         for (const auto& existing : *g_uiDispatchers) {
             if (existing == dispatcher) {
-                return;
+                return true;
             }
         }
         g_uiDispatchers->push_back(dispatcher);
+        return true;
     } catch (...) {
+        return false;
     }
 }
 
@@ -631,6 +639,7 @@ constexpr UINT WM_APP_FOREGROUND_CHANGED = WM_APP + 1;
 constexpr UINT WM_APP_DESKTOP_SWITCHED = WM_APP + 2;
 constexpr UINT WM_APP_SHUTDOWN = WM_APP + 3;
 constexpr UINT WM_APP_REQUEST_APPLY_DEBOUNCED = WM_APP + 4;
+constexpr UINT WM_APP_REFRESH_ACCENT = WM_APP + 5;
 
 // Identity scores. Only exact identity may bind the same rank to many buttons
 // (secondary taskbar / Never Combine). Score 900 is same filename, different
@@ -657,8 +666,6 @@ constexpr PCWSTR kGlowLayerNames[] = {
 };
 constexpr int kGlowMaxLayers = 3;
 constexpr PCWSTR kBackgroundElementName = L"BackgroundElement";
-// Present while edge-bar (bottomBar) style is applied — we hid RunningIndicator.
-constexpr PCWSTR kBottomBarMarkerName = L"WhRecentFocusBottomBar";
 // Thumbnail preview glow (own named overlays on TaskItemThumbnailView).
 constexpr PCWSTR kThumbGlowElementName = L"WhRecentFocusThumbGlow";
 constexpr PCWSTR kThumbGlowLayerNames[] = {
@@ -694,7 +701,7 @@ struct IconPanelLayoutWatch {
     bool haveEdge = false;
 };
 std::mutex g_layoutWatchMutex;
-std::vector<IconPanelLayoutWatch> g_layoutWatches;
+std::unordered_map<void*, IconPanelLayoutWatch> g_layoutWatches;
 thread_local int g_iconPanelRelayoutDepth = 0;
 thread_local ULONGLONG g_lastFullRefreshTick = 0;
 
@@ -824,7 +831,7 @@ DesktopRecencyState& CurrentDeskLocked() {
 
 void ClearButtonRunningGrace() {
     std::lock_guard<std::mutex> lock(g_buttonPathMutex);
-    for (auto& e : g_buttonPathCache) {
+    for (auto& [id, e] : g_buttonPathCache) {
         e.lastRunningTick = 0;
     }
 }
@@ -1413,7 +1420,7 @@ bool PathAppearsOnTaskbar(const std::wstring& keyOrPath,
     }
 
     std::lock_guard<std::mutex> lock(g_buttonPathMutex);
-    for (const auto& e : g_buttonPathCache) {
+    for (const auto& [id, e] : g_buttonPathCache) {
         if (!wantAppId.empty()) {
             std::wstring id = e.appIdUpper.empty() ? e.autoIdUpper : e.appIdUpper;
             if (CanonicalAppId(id) == wantAppId) {
@@ -1440,7 +1447,7 @@ void RecomputeRanksForDesktopLocked(DesktopRecencyState& desk) {
     desk.rankedApps.clear();
 
     auto settings = SettingsSnap();
-    if (!settings->enabled || g_unloading.load()) {
+    if (g_unloading.load()) {
         return;
     }
 
@@ -1504,7 +1511,7 @@ void StampWindowRecencyLocked(DesktopRecencyState& desk,
                               ULONGLONG now);
 
 void ConfirmPreviewFocusNow(HWND hwnd) {
-    if (!hwnd || g_unloading.load() || !SettingsSnap()->enabled ||
+    if (!hwnd || g_unloading.load() ||
         !SettingsSnap()->previewHighlightEnabled) {
         return;
     }
@@ -1712,6 +1719,20 @@ winrt::Windows::UI::Color QuerySystemAccentColor() {
     }
 }
 
+void RefreshCachedAccent() {
+    winrt::Windows::UI::Color accent = QuerySystemAccentColor();
+    auto cur = SettingsSnap();
+    if (cur->cachedAccent.A == accent.A && cur->cachedAccent.R == accent.R &&
+        cur->cachedAccent.G == accent.G && cur->cachedAccent.B == accent.B) {
+        return;
+    }
+    Settings next = *cur;
+    next.cachedAccent = accent;
+    PublishSettings(std::move(next));
+    Wh_Log(L"System accent updated: #%02X%02X%02X", accent.R, accent.G,
+           accent.B);
+}
+
 winrt::Windows::UI::Color ResolveGlowBaseColor(const Settings& settings) {
     winrt::Windows::UI::Color c{255, 0, 200, 83};  // default green-ish
 
@@ -1740,21 +1761,6 @@ winrt::Windows::UI::Color ResolveGlowBaseColor(const Settings& settings) {
     return c;
 }
 
-int RankIntensity(int rankZeroBased) {
-    int idx = rankZeroBased < 3 ? rankZeroBased : 2;
-    return SettingsSnap()->glowIntensity[idx];
-}
-
-int PreviewRankIntensity(int rankZeroBased) {
-    int idx = rankZeroBased < 3 ? rankZeroBased : 2;
-    return SettingsSnap()->previewIntensity[idx];
-}
-
-int RankSizeBoost(int rankZeroBased) {
-    int idx = rankZeroBased < 3 ? rankZeroBased : 2;
-    return SettingsSnap()->sizeBoostPercent[idx];
-}
-
 // Defined with option-C resolve stack (button → process path).
 std::wstring EnsureButtonPathCached(FrameworkElement button, bool force);
 struct ButtonIdentity {
@@ -1767,8 +1773,16 @@ struct ButtonIdentity {
     std::vector<HWND> groupHwnds;
 };
 ButtonIdentity GetCachedButtonIdentity(FrameworkElement button);
+struct PaintCacheState {
+    int rank = -1;
+    uint32_t settingsGen = 0;
+};
+PaintCacheState GetCachedPaintState(FrameworkElement button);
+void SetCachedPaintState(FrameworkElement button, int rank, uint32_t gen);
+TaskbarEdge CachedTaskbarEdge(FrameworkElement iconPanel);
 void RememberOurIconScale(FrameworkElement button, Media::ScaleTransform scale);
 void ClearIconScaleIfOurs(FrameworkElement icon, FrameworkElement button);
+void RefreshCachedAccent();
 bool RunOnUiThread(const winrt::Windows::UI::Core::DispatchedHandler& handler);
 void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb);
 
@@ -1798,22 +1812,19 @@ bool TaskListButton_IsRunning(FrameworkElement taskListButtonElement) {
 bool ButtonCountsAsRunning(FrameworkElement button) {
     const bool running = TaskListButton_IsRunning(button);
     const ULONGLONG now = GetTickCount64();
+    void* id = InspectableIdentity(button);
     std::lock_guard<std::mutex> lock(g_buttonPathMutex);
-    for (auto& e : g_buttonPathCache) {
-        try {
-            if (e.button.get() != button) {
-                continue;
-            }
-            if (running) {
-                e.lastRunningTick = now;
-                return true;
-            }
-            return e.lastRunningTick != 0 &&
-                   now - e.lastRunningTick < kIsRunningGraceMs;
-        } catch (...) {
-        }
+    auto it = id ? g_buttonPathCache.find(id) : g_buttonPathCache.end();
+    if (it == g_buttonPathCache.end()) {
+        return running;
     }
-    return running;
+    auto& e = it->second;
+    if (running) {
+        e.lastRunningTick = now;
+        return true;
+    }
+    return e.lastRunningTick != 0 &&
+           now - e.lastRunningTick < kIsRunningGraceMs;
 }
 
 std::wstring GetButtonAutomationName(FrameworkElement button) {
@@ -2499,13 +2510,10 @@ bool ButtonHasOurChrome(FrameworkElement button) {
     }
     auto iconPanel = GetIconPanel(button);
     if (!iconPanel) {
-        return FindDescendantByName(button, kGlowElementName) != nullptr ||
-               FindDescendantByName(button, kBottomBarMarkerName) != nullptr;
+        return FindDescendantByName(button, kGlowElementName) != nullptr;
     }
     return FindChildByName(iconPanel, kGlowElementName) != nullptr ||
-           FindDescendantByName(iconPanel, kGlowElementName) != nullptr ||
-           FindChildByName(iconPanel, kBottomBarMarkerName) != nullptr ||
-           FindDescendantByName(iconPanel, kBottomBarMarkerName) != nullptr;
+           FindDescendantByName(iconPanel, kGlowElementName) != nullptr;
 }
 
 void ClearButtonHighlight(FrameworkElement button) {
@@ -2515,12 +2523,11 @@ void ClearButtonHighlight(FrameworkElement button) {
 
     auto iconPanelEarly = GetIconPanel(button);
 
-    // Skip no-op clears on every mouse-over (UpdateVisualStates storms).
-    // Still heal z-order: after a timed-out glow, our host is gone but
-    // BackgroundElement can remain in front of RunningIndicator (Discord
-    // ping + decay left a red plate and no underscore).
+    // Skip no-op clears on every mouse-over. Do not reorder native children
+    // on buttons we never painted — that fights Taskbar Styler / badges and
+    // is not undone on unload. Z-order heal runs only after we remove our host.
     if (!ButtonHasOurChrome(button) && !g_pendingOverlaySweep.load()) {
-        RestoreIconPanelNativeZOrder(iconPanelEarly);
+        SetCachedPaintState(button, 0, SettingsSnap()->generation);
         return;
     }
 
@@ -2530,8 +2537,8 @@ void ClearButtonHighlight(FrameworkElement button) {
             // Still try to strip our named overlay from the button root.
             if (auto panel = button.try_as<Controls::Panel>()) {
                 RemoveNamedChild(panel, kGlowElementName);
-                RemoveNamedChild(panel, kBottomBarMarkerName);
             }
+            SetCachedPaintState(button, 0, SettingsSnap()->generation);
             return;
         }
 
@@ -2562,7 +2569,6 @@ void ClearButtonHighlight(FrameworkElement button) {
                     }
                 }
             }
-            RemoveNamedChild(panel, kBottomBarMarkerName);
         }
 
         if (RunningIndicatorHasLocalCollapsed(iconPanel)) {
@@ -2576,6 +2582,7 @@ void ClearButtonHighlight(FrameworkElement button) {
         }
 
         RestoreIconPanelNativeZOrder(iconPanel);
+        SetCachedPaintState(button, 0, SettingsSnap()->generation);
     } catch (...) {
         HRESULT hr = winrt::to_hresult();
         Wh_Log(L"ClearButtonHighlight error %08X", hr);
@@ -3053,7 +3060,7 @@ void RevokeIconPanelLayoutWatchesOnThisDispatcher() {
         for (auto it = g_layoutWatches.begin(); it != g_layoutWatches.end();) {
             bool take = false;
             try {
-                auto panel = it->panel.get();
+                auto panel = it->second.panel.get();
                 if (!panel) {
                     take = true;
                 } else {
@@ -3064,7 +3071,7 @@ void RevokeIconPanelLayoutWatchesOnThisDispatcher() {
                 take = true;
             }
             if (take) {
-                mine.push_back(std::move(*it));
+                mine.push_back(std::move(it->second));
                 it = g_layoutWatches.erase(it);
             } else {
                 ++it;
@@ -3085,6 +3092,27 @@ void RevokeIconPanelLayoutWatchesOnThisDispatcher() {
     }
 }
 
+TaskbarEdge CachedTaskbarEdge(FrameworkElement iconPanel) {
+    void* id = InspectableIdentity(iconPanel);
+    {
+        std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
+        auto it = id ? g_layoutWatches.find(id) : g_layoutWatches.end();
+        if (it != g_layoutWatches.end() && it->second.haveEdge) {
+            return it->second.lastEdge;
+        }
+    }
+    const TaskbarEdge edge = DetectTaskbarEdge(iconPanel);
+    if (id) {
+        std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
+        auto it = g_layoutWatches.find(id);
+        if (it != g_layoutWatches.end()) {
+            it->second.lastEdge = edge;
+            it->second.haveEdge = true;
+        }
+    }
+    return edge;
+}
+
 void EnsureIconPanelLayoutWatch(FrameworkElement button) {
     if (!button || g_unloading.load()) {
         return;
@@ -3093,13 +3121,20 @@ void EnsureIconPanelLayoutWatch(FrameworkElement button) {
     if (!iconPanel) {
         return;
     }
-    RememberUiDispatcher(iconPanel);
+    if (!RememberUiDispatcher(iconPanel)) {
+        return;
+    }
 
+    void* id = InspectableIdentity(iconPanel);
+    if (!id) {
+        return;
+    }
     {
         std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
-        for (auto& w : g_layoutWatches) {
+        auto it = g_layoutWatches.find(id);
+        if (it != g_layoutWatches.end()) {
             try {
-                if (w.panel.get() == iconPanel) {
+                if (it->second.panel.get() == iconPanel) {
                     return;
                 }
             } catch (...) {
@@ -3152,6 +3187,15 @@ void EnsureIconPanelLayoutWatch(FrameworkElement button) {
                     Wh_Log(L"IconPanel relayout: %.0fx%.0f -> %.0fx%.0f", ow,
                            oh, nw, nh);
                 }
+                const TaskbarEdge edgeNow = DetectTaskbarEdge(panel);
+                if (void* pid = InspectableIdentity(panel)) {
+                    std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
+                    auto it = g_layoutWatches.find(pid);
+                    if (it != g_layoutWatches.end()) {
+                        it->second.lastEdge = edgeNow;
+                        it->second.haveEdge = true;
+                    }
+                }
                 ++g_iconPanelRelayoutDepth;
                 try {
                     HealRunningIndicatorAfterRelayout(panel);
@@ -3168,17 +3212,19 @@ void EnsureIconPanelLayoutWatch(FrameworkElement button) {
     }
 
     std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
-    g_layoutWatches.erase(
-        std::remove_if(g_layoutWatches.begin(), g_layoutWatches.end(),
-                       [](IconPanelLayoutWatch& w) {
-                           try {
-                               return !w.panel.get();
-                           } catch (...) {
-                               return true;
-                           }
-                       }),
-        g_layoutWatches.end());
-    g_layoutWatches.push_back(std::move(watch));
+    for (auto it = g_layoutWatches.begin(); it != g_layoutWatches.end();) {
+        try {
+            if (!it->second.panel.get()) {
+                it = g_layoutWatches.erase(it);
+                continue;
+            }
+        } catch (...) {
+            it = g_layoutWatches.erase(it);
+            continue;
+        }
+        ++it;
+    }
+    g_layoutWatches[id] = std::move(watch);
 }
 
 void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
@@ -3187,9 +3233,18 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
     }
 
     auto settings = SettingsSnap();
-    if (rankOneBased <= 0 || g_unloading.load() || !settings->enabled) {
+    if (rankOneBased <= 0 || g_unloading.load()) {
         ClearButtonHighlight(button);
         return;
+    }
+
+    {
+        auto painted = GetCachedPaintState(button);
+        if (painted.rank == rankOneBased &&
+            painted.settingsGen == settings->generation &&
+            ButtonHasOurChrome(button)) {
+            return;
+        }
     }
 
     try {
@@ -3197,6 +3252,7 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
         if (!iconPanel) {
             return;
         }
+        EnsureIconPanelLayoutWatch(button);
 
         auto panel = iconPanel.try_as<Controls::Panel>();
         if (!panel) {
@@ -3248,7 +3304,7 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
         double boxH = panelH;
         GlowContentBoxSize(host, iconPanel, panelW, panelH, boxW, boxH);
 
-        const TaskbarEdge edge = DetectTaskbarEdge(iconPanel);
+        const TaskbarEdge edge = CachedTaskbarEdge(iconPanel);
         const BarSide barSide = BarSideForGlowStyle(style, edge);
 
         // Heal native stacking first (Discord overlay / leftover attention
@@ -3262,16 +3318,6 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
 
         HideAllGlowLayers(host);
 
-        // Strip leftover Edge-bar marker from older builds. Do not touch
-        // RunningIndicator unless we actually left Visibility=Collapsed —
-        // ClearValue(Visible) is what killed the short inactive pills.
-        if (style != GlowStyle::BottomBar) {
-            if (FindChildByName(iconPanel, kBottomBarMarkerName)) {
-                if (auto p = iconPanel.try_as<Controls::Panel>()) {
-                    RemoveNamedChild(p, kBottomBarMarkerName);
-                }
-            }
-        }
         if (RunningIndicatorHasLocalCollapsed(iconPanel)) {
             RestoreNativeRunningIndicator(iconPanel, button);
         }
@@ -3340,7 +3386,7 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
             // Edge bar on the native RunningIndicator side. Cover the pill
             // by z-order (host after RI). Never set Visibility/Width/Height
             // on the native indicator.
-            if (settings->glowDebugLog && !FindRunningIndicator(iconPanel)) {
+            if (!FindRunningIndicator(iconPanel)) {
                 Wh_Log(L"EdgeBar: RunningIndicator not found on \"%s\"",
                        GetButtonAutomationName(button).c_str());
             }
@@ -3375,15 +3421,14 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
             }
         }
 
-        if (settings->glowDebugLog) {
-            Wh_Log(L"Glow rank %d \"%s\" style=%s edge=%s bar=%s box=%.0fx%.0f "
-                   L"th=%.0f round=%d%% size=%d%% layers=%d intensity=%d",
-                   rankOneBased, GetButtonAutomationName(button).c_str(),
-                   GlowStyleName(style), TaskbarEdgeName(edge),
-                   BarSideName(barSide), boxW, boxH, thickness,
-                   settings->glowRoundness, settings->glowSize, layers,
-                   intensity);
-        }
+        Wh_Log(L"Glow rank %d \"%s\" style=%s edge=%s bar=%s box=%.0fx%.0f "
+               L"th=%.0f round=%d%% size=%d%% layers=%d intensity=%d",
+               rankOneBased, GetButtonAutomationName(button).c_str(),
+               GlowStyleName(style), TaskbarEdgeName(edge),
+               BarSideName(barSide), boxW, boxH, thickness,
+               settings->glowRoundness, settings->glowSize, layers,
+               intensity);
+        SetCachedPaintState(button, rankOneBased, settings->generation);
     } catch (...) {
         HRESULT hr = winrt::to_hresult();
         Wh_Log(L"ApplyButtonHighlight error %08X", hr);
@@ -3392,16 +3437,17 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
 
 void PruneTrackedButtons_UIThread() {
     std::lock_guard<std::mutex> lock(g_buttonsMutex);
-    g_trackedButtons.erase(
-        std::remove_if(g_trackedButtons.begin(), g_trackedButtons.end(),
-                       [](winrt::weak_ref<FrameworkElement>& weak) {
-                           try {
-                               return !weak.get();
-                           } catch (...) {
-                               return true;
-                           }
-                       }),
-        g_trackedButtons.end());
+    for (auto it = g_trackedButtons.begin(); it != g_trackedButtons.end();) {
+        try {
+            if (!it->second.get()) {
+                it = g_trackedButtons.erase(it);
+            } else {
+                ++it;
+            }
+        } catch (...) {
+            it = g_trackedButtons.erase(it);
+        }
+    }
 }
 
 void TrackButton_UIThread(FrameworkElement button) {
@@ -3410,26 +3456,11 @@ void TrackButton_UIThread(FrameworkElement button) {
     }
 
     RememberUiDispatcher(button);
-    {
+    if (void* id = InspectableIdentity(button)) {
         std::lock_guard<std::mutex> lock(g_buttonsMutex);
-        g_dispatcherAnchor = winrt::make_weak(button);
-
-        bool tracked = false;
-        for (auto& weak : g_trackedButtons) {
-            try {
-                if (weak.get() == button) {
-                    tracked = true;
-                    break;
-                }
-            } catch (...) {
-            }
-        }
-        if (!tracked) {
-            g_trackedButtons.push_back(winrt::make_weak(button));
-        }
+        g_trackedButtons[id] = winrt::make_weak(button);
     }
     EnsureButtonPathCached(button, /*force=*/false);
-    EnsureIconPanelLayoutWatch(button);
 }
 
 // ---------------------------------------------------------------------------
@@ -3701,22 +3732,13 @@ std::wstring EnsureButtonPathCached(FrameworkElement button, bool force) {
     }
 
     const ULONGLONG now = GetTickCount64();
+    void* id = InspectableIdentity(button);
     {
         std::lock_guard<std::mutex> lock(g_buttonPathMutex);
-        for (auto& e : g_buttonPathCache) {
-            FrameworkElement b = nullptr;
-            try {
-                b = e.button.get();
-            } catch (...) {
-                continue;
-            }
-            if (b != button) {
-                continue;
-            }
-            if (!force && e.resolveAttempted) {
-                return e.pathUpper;
-            }
-            break;
+        auto it = id ? g_buttonPathCache.find(id) : g_buttonPathCache.end();
+        if (it != g_buttonPathCache.end() && !force &&
+            it->second.resolveAttempted) {
+            return it->second.pathUpper;
         }
     }
 
@@ -3791,67 +3813,49 @@ std::wstring EnsureButtonPathCached(FrameworkElement button, bool force) {
 
     {
         std::lock_guard<std::mutex> lock(g_buttonPathMutex);
-        bool found = false;
-        for (auto& e : g_buttonPathCache) {
-            FrameworkElement b = nullptr;
-            try {
-                b = e.button.get();
-            } catch (...) {
-                continue;
+        ButtonPathCacheEntry* e = nullptr;
+        if (id) {
+            auto it = g_buttonPathCache.find(id);
+            if (it == g_buttonPathCache.end()) {
+                ButtonPathCacheEntry created;
+                created.button = winrt::make_weak(button);
+                it = g_buttonPathCache.emplace(id, std::move(created)).first;
             }
-            if (b != button) {
-                continue;
-            }
-            e.pathUpper = pathUpper;
-            e.appIdUpper = appIdUpper;
-            e.classUpper = classUpper;
-            e.autoIdUpper = autoIdUpper;
-            e.pid = pid;
-            e.sampleHwnd = hwnd;
-            e.groupHwnds = groupHwnds;
-            e.resolveAttempted = true;
-            e.lastResolveTick = now;
-            found = true;
-            break;
+            e = &it->second;
         }
-        if (!found) {
-            ButtonPathCacheEntry e;
-            e.button = winrt::make_weak(button);
-            e.pathUpper = pathUpper;
-            e.appIdUpper = appIdUpper;
-            e.classUpper = classUpper;
-            e.autoIdUpper = autoIdUpper;
-            e.pid = pid;
-            e.sampleHwnd = hwnd;
-            e.groupHwnds = std::move(groupHwnds);
-            e.resolveAttempted = true;
-            e.lastResolveTick = now;
-            g_buttonPathCache.push_back(std::move(e));
+        if (e) {
+            e->pathUpper = pathUpper;
+            e->appIdUpper = appIdUpper;
+            e->classUpper = classUpper;
+            e->autoIdUpper = autoIdUpper;
+            e->pid = pid;
+            e->sampleHwnd = hwnd;
+            e->groupHwnds = std::move(groupHwnds);
+            e->resolveAttempted = true;
+            e->lastResolveTick = now;
         }
-        // Prune dead weaks occasionally.
         if (g_buttonPathCache.size() > 128) {
-            g_buttonPathCache.erase(
-                std::remove_if(
-                    g_buttonPathCache.begin(), g_buttonPathCache.end(),
-                    [](ButtonPathCacheEntry& e) {
-                        try {
-                            return !e.button.get();
-                        } catch (...) {
-                            return true;
-                        }
-                    }),
-                g_buttonPathCache.end());
+            for (auto it = g_buttonPathCache.begin();
+                 it != g_buttonPathCache.end();) {
+                try {
+                    if (!it->second.button.get()) {
+                        it = g_buttonPathCache.erase(it);
+                    } else {
+                        ++it;
+                    }
+                } catch (...) {
+                    it = g_buttonPathCache.erase(it);
+                }
+            }
         }
     }
 
-    if (SettingsSnap()->glowDebugLog) {
-        Wh_Log(L"Button path cache: pid=%u path=%s class=%s appId=%s force=%d "
-               L"name=\"%s\"",
-               pid, pathUpper.empty() ? L"(none)" : pathUpper.c_str(),
-               classUpper.empty() ? L"?" : classUpper.c_str(),
-               appIdUpper.empty() ? L"?" : appIdUpper.c_str(), force ? 1 : 0,
-               GetButtonAutomationName(button).c_str());
-    }
+    Wh_Log(L"Button path cache: pid=%u path=%s class=%s appId=%s force=%d "
+           L"name=\"%s\"",
+           pid, pathUpper.empty() ? L"(none)" : pathUpper.c_str(),
+           classUpper.empty() ? L"?" : classUpper.c_str(),
+           appIdUpper.empty() ? L"?" : appIdUpper.c_str(), force ? 1 : 0,
+           GetButtonAutomationName(button).c_str());
     return pathUpper;
 }
 
@@ -3860,82 +3864,83 @@ ButtonIdentity GetCachedButtonIdentity(FrameworkElement button) {
     if (!button) {
         return out;
     }
+    void* id = InspectableIdentity(button);
     std::lock_guard<std::mutex> lock(g_buttonPathMutex);
-    for (auto& e : g_buttonPathCache) {
-        try {
-            if (e.button.get() == button) {
-                out.pathUpper = e.pathUpper;
-                out.appIdUpper = e.appIdUpper;
-                out.classUpper = e.classUpper;
-                out.autoIdUpper = e.autoIdUpper;
-                out.pid = e.pid;
-                out.sampleHwnd = e.sampleHwnd;
-                out.groupHwnds = e.groupHwnds;
-                return out;
-            }
-        } catch (...) {
-        }
+    auto it = id ? g_buttonPathCache.find(id) : g_buttonPathCache.end();
+    if (it == g_buttonPathCache.end()) {
+        return out;
     }
+    const auto& e = it->second;
+    out.pathUpper = e.pathUpper;
+    out.appIdUpper = e.appIdUpper;
+    out.classUpper = e.classUpper;
+    out.autoIdUpper = e.autoIdUpper;
+    out.pid = e.pid;
+    out.sampleHwnd = e.sampleHwnd;
+    out.groupHwnds = e.groupHwnds;
     return out;
 }
 
-int GetCachedPaintRank(FrameworkElement button) {
+PaintCacheState GetCachedPaintState(FrameworkElement button) {
+    PaintCacheState out;
     if (!button) {
-        return -1;
+        return out;
     }
+    void* id = InspectableIdentity(button);
     std::lock_guard<std::mutex> lock(g_buttonPathMutex);
-    for (auto& e : g_buttonPathCache) {
-        try {
-            if (e.button.get() == button) {
-                return e.lastPaintRank;
-            }
-        } catch (...) {
-        }
+    auto it = id ? g_buttonPathCache.find(id) : g_buttonPathCache.end();
+    if (it == g_buttonPathCache.end()) {
+        return out;
     }
-    return -1;
+    out.rank = it->second.lastPaintRank;
+    out.settingsGen = it->second.lastPaintSettingsGen;
+    return out;
 }
 
-void SetCachedPaintRank(FrameworkElement button, int rank) {
+void SetCachedPaintState(FrameworkElement button, int rank, uint32_t gen) {
     if (!button) {
         return;
     }
-    std::lock_guard<std::mutex> lock(g_buttonPathMutex);
-    for (auto& e : g_buttonPathCache) {
-        try {
-            if (e.button.get() == button) {
-                e.lastPaintRank = rank;
-                return;
-            }
-        } catch (...) {
-        }
+    void* id = InspectableIdentity(button);
+    if (!id) {
+        return;
     }
-    ButtonPathCacheEntry stub;
-    stub.button = winrt::make_weak(button);
-    stub.lastPaintRank = rank;
-    g_buttonPathCache.push_back(std::move(stub));
+    std::lock_guard<std::mutex> lock(g_buttonPathMutex);
+    auto it = g_buttonPathCache.find(id);
+    if (it == g_buttonPathCache.end()) {
+        ButtonPathCacheEntry stub;
+        stub.button = winrt::make_weak(button);
+        stub.lastPaintRank = rank;
+        stub.lastPaintSettingsGen = gen;
+        g_buttonPathCache.emplace(id, std::move(stub));
+        return;
+    }
+    it->second.lastPaintRank = rank;
+    it->second.lastPaintSettingsGen = gen;
 }
 
 void RememberOurIconScale(FrameworkElement button, Media::ScaleTransform scale) {
     if (!button) {
         return;
     }
+    void* id = InspectableIdentity(button);
+    if (!id) {
+        return;
+    }
     std::lock_guard<std::mutex> lock(g_buttonPathMutex);
-    for (auto& e : g_buttonPathCache) {
-        try {
-            if (e.button.get() == button) {
-                e.ourIconScale = scale ? winrt::make_weak(scale)
-                                       : winrt::weak_ref<Media::ScaleTransform>{};
-                return;
-            }
-        } catch (...) {
+    auto it = g_buttonPathCache.find(id);
+    if (it == g_buttonPathCache.end()) {
+        ButtonPathCacheEntry stub;
+        stub.button = winrt::make_weak(button);
+        if (scale) {
+            stub.ourIconScale = winrt::make_weak(scale);
         }
+        g_buttonPathCache.emplace(id, std::move(stub));
+        return;
     }
-    ButtonPathCacheEntry stub;
-    stub.button = winrt::make_weak(button);
-    if (scale) {
-        stub.ourIconScale = winrt::make_weak(scale);
-    }
-    g_buttonPathCache.push_back(std::move(stub));
+    it->second.ourIconScale =
+        scale ? winrt::make_weak(scale)
+              : winrt::weak_ref<Media::ScaleTransform>{};
 }
 
 void ClearIconScaleIfOurs(FrameworkElement icon, FrameworkElement button) {
@@ -3953,15 +3958,14 @@ void ClearIconScaleIfOurs(FrameworkElement icon, FrameworkElement button) {
         }
         Media::ScaleTransform ours = nullptr;
         {
+            void* id = InspectableIdentity(button);
             std::lock_guard<std::mutex> lock(g_buttonPathMutex);
-            for (auto& e : g_buttonPathCache) {
+            auto it = id ? g_buttonPathCache.find(id) : g_buttonPathCache.end();
+            if (it != g_buttonPathCache.end()) {
                 try {
-                    if (e.button.get() == button) {
-                        ours = e.ourIconScale.get();
-                        if (ours && current == ours) {
-                            e.ourIconScale = {};
-                        }
-                        break;
+                    ours = it->second.ourIconScale.get();
+                    if (ours && current == ours) {
+                        it->second.ourIconScale = {};
                     }
                 } catch (...) {
                 }
@@ -4006,7 +4010,10 @@ std::vector<FrameworkElement> CollectLiveButtonsOnThisDispatcher() {
     std::vector<winrt::weak_ref<FrameworkElement>> buttons;
     {
         std::lock_guard<std::mutex> lock(g_buttonsMutex);
-        buttons = g_trackedButtons;
+        buttons.reserve(g_trackedButtons.size());
+        for (auto& [id, weak] : g_trackedButtons) {
+            buttons.push_back(weak);
+        }
     }
     std::vector<FrameworkElement> live;
     live.reserve(buttons.size());
@@ -4026,23 +4033,19 @@ void ApplyAllHighlights_UIThread() {
 
     std::vector<FrameworkElement> live = CollectLiveButtonsOnThisDispatcher();
 
-    if (SettingsSnap()->glowDebugLog) {
-        for (size_t i = 0; i < ranks.size(); ++i) {
-            Wh_Log(L"  rank list[%zu]: %s", i + 1, ranks[i].displayName.c_str());
-        }
-        Wh_Log(L"ApplyAllHighlights: %zu tracked buttons, %zu ranks, enabled=%d "
-               L"desktop=%s",
-               live.size(), ranks.size(), SettingsSnap()->enabled ? 1 : 0,
-               GuidToLogString(g_currentDesktopId).c_str());
+    for (size_t i = 0; i < ranks.size(); ++i) {
+        Wh_Log(L"  rank list[%zu]: %s", i + 1, ranks[i].displayName.c_str());
     }
+    Wh_Log(L"ApplyAllHighlights: %zu tracked buttons, %zu ranks desktop=%s",
+           live.size(), ranks.size(),
+           GuidToLogString(g_currentDesktopId).c_str());
 
-    if (!SettingsSnap()->enabled || g_unloading.load() || ranks.empty()) {
+    if (g_unloading.load() || ranks.empty()) {
         for (auto& button : live) {
-            SetCachedPaintRank(button, 0);
             ClearButtonHighlight(button);
         }
         g_pendingOverlaySweep = false;
-        if (SettingsSnap()->glowDebugLog && ranks.empty()) {
+        if (ranks.empty()) {
             Wh_Log(L"ApplyAllHighlights: no ranks — cleared overlays on %zu "
                    L"tracked buttons",
                    live.size());
@@ -4050,15 +4053,13 @@ void ApplyAllHighlights_UIThread() {
         return;
     }
 
-    if (SettingsSnap()->glowDebugLog) {
-        int dumped = 0;
-        for (auto& button : live) {
-            Wh_Log(L"  button[%d]: running=%d name=\"%s\"", dumped,
-                   TaskListButton_IsRunning(button) ? 1 : 0,
-                   GetButtonAutomationName(button).c_str());
-            if (++dumped >= 24) {
-                break;
-            }
+    int dumped = 0;
+    for (auto& button : live) {
+        Wh_Log(L"  button[%d]: running=%d name=\"%s\"", dumped,
+               TaskListButton_IsRunning(button) ? 1 : 0,
+               GetButtonAutomationName(button).c_str());
+        if (++dumped >= 24) {
+            break;
         }
     }
 
@@ -4110,18 +4111,15 @@ void ApplyAllHighlights_UIThread() {
                 it->second.seenOnTaskbar = true;
             }
         }
-        if (SettingsSnap()->glowDebugLog) {
-            Wh_Log(L"  bind rank %zu %s -> \"%s\" (score=%d path=%s)",
-                   c.rankIdx + 1, ranks[c.rankIdx].displayName.c_str(),
-                   GetButtonAutomationName(live[c.buttonIdx]).c_str(), c.score,
-                   buttonPaths[c.buttonIdx].empty()
-                       ? L"?"
-                       : buttonPaths[c.buttonIdx].c_str());
-        }
+        Wh_Log(L"  bind rank %zu %s -> \"%s\" (score=%d path=%s)",
+               c.rankIdx + 1, ranks[c.rankIdx].displayName.c_str(),
+               GetButtonAutomationName(live[c.buttonIdx]).c_str(), c.score,
+               buttonPaths[c.buttonIdx].empty()
+                   ? L"?"
+                   : buttonPaths[c.buttonIdx].c_str());
     }
 
     for (size_t bi = 0; bi < live.size(); ++bi) {
-        SetCachedPaintRank(live[bi], buttonRank[bi]);
         if (buttonRank[bi] > 0) {
             ApplyButtonHighlight(live[bi], buttonRank[bi]);
         } else {
@@ -4141,15 +4139,13 @@ void ApplyAllHighlights_UIThread() {
         if (rankTaken[ri]) {
             continue;
         }
-        if (SettingsSnap()->glowDebugLog) {
-            Wh_Log(L"  UNMATCHED rank %zu: %s (title=\"%s\")", ri + 1,
-                   ranks[ri].displayName.c_str(),
-                   ranks[ri].lastWindowTitle.c_str());
-        }
+        Wh_Log(L"  UNMATCHED rank %zu: %s (title=\"%s\")", ri + 1,
+               ranks[ri].displayName.c_str(),
+               ranks[ri].lastWindowTitle.c_str());
         size_t resolvedButtons = 0;
         {
             std::lock_guard<std::mutex> lock(g_buttonPathMutex);
-            for (const auto& e : g_buttonPathCache) {
+            for (const auto& [id, e] : g_buttonPathCache) {
                 if (!e.pathUpper.empty()) {
                     ++resolvedButtons;
                 }
@@ -4178,7 +4174,6 @@ void ApplyAllHighlights_UIThread() {
 
 void ClearAllHighlights_UIThread() {
     for (auto& button : CollectLiveButtonsOnThisDispatcher()) {
-        SetCachedPaintRank(button, 0);
         ClearButtonHighlight(button);
     }
 }
@@ -4467,9 +4462,15 @@ FrameworkElement FindAncestorItemsRepeater(FrameworkElement el) {
 
 // Repeater index is the flyout visual order (unlike PositionInSet, which the
 // automation peer may not refresh after a thumbnail reorder).
+// outSourceIndex is parallel to the returned views and holds the ItemsSource
+// index (skips of unrealized elements must not shift GetAt).
 std::vector<FrameworkElement> CollectRepeaterThumbnailViews(
-    FrameworkElement thumbView) {
+    FrameworkElement thumbView,
+    std::vector<int>* outSourceIndex) {
     std::vector<FrameworkElement> out;
+    if (outSourceIndex) {
+        outSourceIndex->clear();
+    }
     auto repeaterEl = FindAncestorItemsRepeater(thumbView);
     if (!repeaterEl) {
         return out;
@@ -4494,6 +4495,9 @@ std::vector<FrameworkElement> CollectRepeaterThumbnailViews(
             if (winrt::get_class_name(child) ==
                 L"Taskbar.TaskItemThumbnailView") {
                 out.push_back(child);
+                if (outSourceIndex) {
+                    outSourceIndex->push_back(i);
+                }
             }
         }
     } catch (...) {
@@ -5106,7 +5110,7 @@ void ScheduleThumbnailRelayout(FrameworkElement thumbView) {
 void ApplyThumbnailHighlight(FrameworkElement thumbView, int rankOneBased) {
     auto settings = SettingsSnap();
     if (!thumbView || rankOneBased <= 0 || g_unloading.load() ||
-        !settings->enabled || !settings->previewHighlightEnabled) {
+        !settings->previewHighlightEnabled) {
         ClearThumbnailHighlight(thumbView);
         return;
     }
@@ -5233,14 +5237,12 @@ void ApplyThumbnailHighlight(FrameworkElement thumbView, int rankOneBased) {
                 }
             }
 
-            if (settings->glowDebugLog) {
-                Wh_Log(L"Preview glow rank %d style=%s paint=%s intensity=%d "
-                       L"on \"%s\"",
-                       rankOneBased, PreviewStyleName(style),
-                       PreviewStyleName(paintStyle), intensity,
-                       Automation::AutomationProperties::GetName(thumbView)
-                           .c_str());
-            }
+            Wh_Log(L"Preview glow rank %d style=%s paint=%s intensity=%d "
+                   L"on \"%s\"",
+                   rankOneBased, PreviewStyleName(style),
+                   PreviewStyleName(paintStyle), intensity,
+                   Automation::AutomationProperties::GetName(thumbView)
+                       .c_str());
             return;
         }
 
@@ -5345,14 +5347,12 @@ void ApplyThumbnailHighlight(FrameworkElement thumbView, int rankOneBased) {
             }
         }
 
-        if (settings->glowDebugLog) {
-            Wh_Log(L"Preview glow rank %d style=%s paint=%s intensity=%d "
-                   L"card=%.0fx%.0f on \"%s\"",
-                   rankOneBased, PreviewStyleName(style),
-                   PreviewStyleName(paintStyle), intensity, cardW, cardH,
-                   Automation::AutomationProperties::GetName(thumbView)
-                       .c_str());
-        }
+        Wh_Log(L"Preview glow rank %d style=%s paint=%s intensity=%d "
+               L"card=%.0fx%.0f on \"%s\"",
+               rankOneBased, PreviewStyleName(style),
+               PreviewStyleName(paintStyle), intensity, cardW, cardH,
+               Automation::AutomationProperties::GetName(thumbView)
+                   .c_str());
     } catch (...) {
         HRESULT hr = winrt::to_hresult();
         Wh_Log(L"ApplyThumbnailHighlight error %08X", hr);
@@ -5365,13 +5365,14 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
     }
     TrackThumbView_UIThread(anyThumb);
 
-    auto repeaterViews = CollectRepeaterThumbnailViews(anyThumb);
+    std::vector<int> repeaterSourceIndex;
+    auto repeaterViews =
+        CollectRepeaterThumbnailViews(anyThumb, &repeaterSourceIndex);
     const bool usedRepeater = !repeaterViews.empty();
     auto allViews =
         usedRepeater ? std::move(repeaterViews)
                      : CollectSiblingThumbnailViews(anyThumb);
-    if (!SettingsSnap()->enabled || !SettingsSnap()->previewHighlightEnabled ||
-        g_unloading.load()) {
+    if (!SettingsSnap()->previewHighlightEnabled || g_unloading.load()) {
         for (auto& s : allViews) {
             ClearThumbnailHighlight(s);
         }
@@ -5412,6 +5413,7 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
         FrameworkElement view{nullptr};
         HWND hwnd = nullptr;
         ULONGLONG tick = 0;
+        ULONGLONG confirmSeq = 0;
         ResolveHow how = ResolveHow::None;
         int rank = 0;  // 1-based flyout rank; 0 = not highlighted
     };
@@ -5442,6 +5444,12 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
         return it->second.confirmSeq;
     };
 
+    auto stampRecency = [&](size_t i, HWND hwnd) {
+        scored[i].hwnd = hwnd;
+        scored[i].tick = tickFor(hwnd);
+        scored[i].confirmSeq = seqFor(hwnd);
+    };
+
     for (size_t i = 0; i < siblings.size(); ++i) {
         TrackThumbView_UIThread(siblings[i]);
         scored[i].view = siblings[i];
@@ -5456,10 +5464,13 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
             if (IsSnapGroupThumbnailView(allViews[ri])) {
                 continue;
             }
-            HWND hwnd = HwndFromThumbnailsGetAt(static_cast<int>(ri));
+            const int srcIndex =
+                (ri < repeaterSourceIndex.size())
+                    ? repeaterSourceIndex[ri]
+                    : static_cast<int>(ri);
+            HWND hwnd = HwndFromThumbnailsGetAt(srcIndex);
             if (hwnd && IsWindow(hwnd) && !usedHwnds.count(hwnd)) {
-                scored[si].hwnd = hwnd;
-                scored[si].tick = tickFor(hwnd);
+                stampRecency(si, hwnd);
                 scored[si].how = ResolveHow::Repeater;
                 usedHwnds.insert(hwnd);
             }
@@ -5474,8 +5485,7 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
         }
         HWND hwnd = ResolveHwndForThumbnailView(siblings[i]);
         if (hwnd && IsWindow(hwnd) && !usedHwnds.count(hwnd)) {
-            scored[i].hwnd = hwnd;
-            scored[i].tick = tickFor(hwnd);
+            stampRecency(i, hwnd);
             scored[i].how = ResolveHow::TaskItem;
             usedHwnds.insert(hwnd);
         }
@@ -5491,8 +5501,7 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
             }
             HWND h = MatchTitleToUnusedRecent(cardTitles[i], recent, usedHwnds);
             if (h) {
-                scored[i].hwnd = h;
-                scored[i].tick = tickFor(h);
+                stampRecency(i, h);
                 if (scored[i].tick == 0) {
                     for (const auto& info : recent) {
                         if (info.hwnd == h && info.lastConfirmedTick > 0) {
@@ -5507,7 +5516,7 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
         }
     }
 
-    // Pass 3: ITaskItem HWND and EVENT_SYSTEM_FOREGROUND HWND can differ
+    // Pass 4: ITaskItem HWND and EVENT_SYSTEM_FOREGROUND HWND can differ
     // (owned Lister windows, tab proxies). Copy recency from a same-PID
     // recent window when the card's HWND itself has tick 0.
     for (size_t i = 0; i < scored.size(); ++i) {
@@ -5568,10 +5577,8 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
         if (scored[a].tick != scored[b].tick) {
             return scored[a].tick > scored[b].tick;
         }
-        const ULONGLONG sa = seqFor(scored[a].hwnd);
-        const ULONGLONG sb = seqFor(scored[b].hwnd);
-        if (sa != sb) {
-            return sa > sb;
+        if (scored[a].confirmSeq != scored[b].confirmSeq) {
+            return scored[a].confirmSeq > scored[b].confirmSeq;
         }
         const bool aFg = scored[a].hwnd == foreground;
         const bool bFg = scored[b].hwnd == foreground;
@@ -5586,7 +5593,7 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
         scored[order[r]].rank = static_cast<int>(r) + 1;
     }
 
-    if (SettingsSnap()->glowDebugLog) {
+    {
         size_t mapCount = 0;
         {
             std::lock_guard<std::mutex> lock(g_thumbnailMapMutex);
@@ -5775,15 +5782,12 @@ void RequestApplyVisuals() {
     }
     if (!RunOnUiThread([]() { ApplyAllHighlights_UIThread(); })) {
         // Buttons not tracked yet — will apply on next UpdateVisualStates.
-        // Avoid rank dump spam at startup (preview + app both request apply).
-        if (SettingsSnap()->glowDebugLog) {
-            std::lock_guard<std::mutex> lock(g_stateMutex);
-            const auto& ranks = CurrentDeskLocked().rankedApps;
-            Wh_Log(L"Ranks ready (%zu) — waiting for TaskListButton hooks",
-                   ranks.size());
-            for (size_t i = 0; i < ranks.size(); i++) {
-                Wh_Log(L"  Rank %zu: %s", i + 1, ranks[i].displayName.c_str());
-            }
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        const auto& ranks = CurrentDeskLocked().rankedApps;
+        Wh_Log(L"Ranks ready (%zu) — waiting for TaskListButton hooks",
+               ranks.size());
+        for (size_t i = 0; i < ranks.size(); i++) {
+            Wh_Log(L"  Rank %zu: %s", i + 1, ranks[i].displayName.c_str());
         }
     }
 }
@@ -5811,12 +5815,12 @@ void RefreshButtonHighlight(FrameworkElement button) {
         return;
     }
 
-    if (g_pendingOverlaySweep.load() || !SettingsSnap()->enabled) {
+    if (g_pendingOverlaySweep.load()) {
         ClearButtonHighlight(button);
         return;
     }
 
-    int rank = GetCachedPaintRank(button);
+    int rank = GetCachedPaintState(button).rank;
     if (rank < 0) {
         std::vector<AppFocusInfo> ranks;
         {
@@ -5824,18 +5828,22 @@ void RefreshButtonHighlight(FrameworkElement button) {
             ranks = CurrentDeskLocked().rankedApps;
         }
         if (ranks.empty()) {
-            SetCachedPaintRank(button, 0);
-            ClearButtonHighlight(button);
+            if (ButtonHasOurChrome(button)) {
+                ClearButtonHighlight(button);
+            } else {
+                SetCachedPaintState(button, 0, SettingsSnap()->generation);
+            }
             return;
         }
         rank = FindRankForButton(button, ranks, /*requireRunning=*/true);
-        SetCachedPaintRank(button, rank);
     }
 
     if (rank > 0) {
         ApplyButtonHighlight(button, rank);
-    } else {
+    } else if (ButtonHasOurChrome(button)) {
         ClearButtonHighlight(button);
+    } else {
+        SetCachedPaintState(button, 0, SettingsSnap()->generation);
     }
 }
 
@@ -5896,7 +5904,10 @@ void WINAPI TaskListButton_UpdateVisualStates_Hook(void* pThis) {
 
     TrackButton_UIThread(button);
     RefreshButtonHighlight(button);
-    ScheduleRefreshAllHighlights(button);
+    const int rank = GetCachedPaintState(button).rank;
+    if (rank > 0 || g_pendingOverlaySweep.load()) {
+        ScheduleRefreshAllHighlights(button);
+    }
 }
 
 // XAML thumbnail view template — apply preview glow when flyout builds items.
@@ -5907,8 +5918,7 @@ void WINAPI TaskItemThumbnailView_OnApplyTemplate_Hook(void* pThis) {
     if (TaskItemThumbnailView_OnApplyTemplate_Original) {
         TaskItemThumbnailView_OnApplyTemplate_Original(pThis);
     }
-    if (g_unloading.load() || !SettingsSnap()->enabled ||
-        !SettingsSnap()->previewHighlightEnabled) {
+    if (g_unloading.load() || !SettingsSnap()->previewHighlightEnabled) {
         return;
     }
     try {
@@ -6183,6 +6193,9 @@ void WINAPI HoverFlyoutModel_TargetItemKey_Hook(void* pThis, void* param1) {
     g_inHoverFlyoutModel_TargetItemKey = true;
     HoverFlyoutModel_TargetItemKey_Original(pThis, param1);
     g_inHoverFlyoutModel_TargetItemKey = false;
+    if (SettingsSnap()->previewHighlightEnabled) {
+        RequestApplyPreviewVisuals();
+    }
 }
 
 bool HookTaskbarDllSymbols() {
@@ -6282,10 +6295,10 @@ bool HookTaskbarDllSymbols() {
     }
 
     g_taskbandResolveReady = true;
-    g_previewHooksReady =
+    const bool previewHooksReady =
         TaskItemThumbnail_TaskItemThumbnail_Original != nullptr ||
         TaskItemThumbnail_TaskItemThumbnail_2_Original != nullptr;
-    if (g_previewHooksReady) {
+    if (previewHooksReady) {
         Wh_Log(L"Hooked taskbar.dll identity + thumbnail model symbols");
     } else {
         Wh_Log(L"Hooked taskbar.dll identity symbols (preview HWND mapping "
@@ -6380,8 +6393,7 @@ bool StillPendingForeground(const PendingFocus& pending,
 
 void OnPreviewMinFocusTimerElapsed(MinFocusConfirmMode mode) {
     auto settings = SettingsSnap();
-    if (!settings->enabled || !settings->previewHighlightEnabled ||
-        g_unloading.load()) {
+    if (!settings->previewHighlightEnabled || g_unloading.load()) {
         return;
     }
 
@@ -6483,12 +6495,10 @@ void OnMinFocusTimerElapsed(MinFocusConfirmMode mode) {
                 remaining = 200;
             }
             ArmHookTimer(kMinFocusTimerId, remaining);
-            if (settings->glowDebugLog) {
-                Wh_Log(L"Min-focus timer: transient FG, still waiting on %s "
-                       L"(%llums left)",
-                       pending.displayName.c_str(),
-                       static_cast<unsigned long long>(remaining));
-            }
+            Wh_Log(L"Min-focus timer: transient FG, still waiting on %s "
+                   L"(%llums left)",
+                   pending.displayName.c_str(),
+                   static_cast<unsigned long long>(remaining));
             return;
         }
         Wh_Log(L"Min-focus timer: focus left %s before confirmation",
@@ -6585,7 +6595,7 @@ void OnMinFocusTimerElapsed(MinFocusConfirmMode mode) {
         size_t resolvedButtons = 0;
         {
             std::lock_guard<std::mutex> lock(g_buttonPathMutex);
-            for (const auto& e : g_buttonPathCache) {
+            for (const auto& [id, e] : g_buttonPathCache) {
                 if (!e.pathUpper.empty()) {
                     ++resolvedButtons;
                 }
@@ -6645,7 +6655,7 @@ void EnsurePendingAppTimer() {
 }
 
 void SchedulePreviewConfirm(bool windowAlreadyTracked) {
-    if (!SettingsSnap()->previewHighlightEnabled || !SettingsSnap()->enabled) {
+    if (!SettingsSnap()->previewHighlightEnabled) {
         return;
     }
     CancelPreviewMinFocusTimer();
@@ -6659,7 +6669,7 @@ void SchedulePreviewConfirm(bool windowAlreadyTracked) {
 }
 
 void HandleForegroundChanged(HWND hWnd) {
-    if (g_unloading.load() || !SettingsSnap()->enabled) {
+    if (g_unloading.load()) {
         return;
     }
 
@@ -6901,6 +6911,26 @@ LRESULT CALLBACK HookThreadWndProc(HWND hWnd,
             SetTimer(hWnd, kFullRebindTimerId,
                      static_cast<UINT>(kFullRebindDebounceMs), nullptr);
             return 0;
+        case WM_APP_REFRESH_ACCENT:
+            RefreshCachedAccent();
+            RequestApplyVisuals();
+            RequestApplyPreviewVisuals();
+            return 0;
+        case WM_DWMCOLORIZATIONCOLORCHANGED:
+            RefreshCachedAccent();
+            RequestApplyVisuals();
+            RequestApplyPreviewVisuals();
+            return 0;
+        case WM_SETTINGCHANGE:
+            if (!lParam ||
+                _wcsicmp(reinterpret_cast<PCWSTR>(lParam),
+                         L"ImmersiveColorSet") == 0) {
+                RefreshCachedAccent();
+                RequestApplyVisuals();
+                RequestApplyPreviewVisuals();
+                return 0;
+            }
+            break;
         case WM_TIMER:
             if (wParam == kMinFocusTimerId) {
                 KillTimer(hWnd, kMinFocusTimerId);
@@ -6993,6 +7023,7 @@ DWORD WINAPI WinEventHookThread(LPVOID /*param*/) {
 
     SetTimer(hwnd, kDecayTimerId, kDecayCheckIntervalMs, nullptr);
     RefreshCurrentDesktopId();
+    RefreshCachedAccent();
 
     if (HWND fg = GetForegroundWindow()) {
         PostMessage(hwnd, WM_APP_FOREGROUND_CHANGED,
@@ -7058,6 +7089,10 @@ void StartWinEventHookThread() {
         Wh_Log(L"WinEvent hook thread started");
     } else {
         Wh_Log(L"CreateThread failed: %u", GetLastError());
+        if (g_hookThreadReadyEvent) {
+            CloseHandle(g_hookThreadReadyEvent);
+            g_hookThreadReadyEvent = nullptr;
+        }
     }
 }
 
@@ -7099,7 +7134,6 @@ void StopWinEventHookThread() {
 void LoadSettings() {
     Settings s;
 
-    s.enabled = Wh_GetIntSetting(L"enabled") != 0;
     s.highlightCount = Wh_GetIntSetting(L"highlightCount");
     if (s.highlightCount < 0) {
         s.highlightCount = 0;
@@ -7113,41 +7147,38 @@ void LoadSettings() {
         s.minFocusSeconds = 0;
     }
 
-    PCWSTR promoteMode = Wh_GetStringSetting(L"promoteMode");
+    auto promoteMode = WindhawkUtils::StringSetting::make(L"promoteMode");
     s.promoteMode = PromoteMode::ImmediateTracked;
-    if (wcscmp(promoteMode, L"immediateTopN") == 0) {
+    if (wcscmp(promoteMode.get(), L"immediateTopN") == 0) {
         s.promoteMode = PromoteMode::ImmediateTopN;
-    } else if (wcscmp(promoteMode, L"alwaysWait") == 0) {
+    } else if (wcscmp(promoteMode.get(), L"alwaysWait") == 0) {
         s.promoteMode = PromoteMode::AlwaysWait;
-    } else if (wcscmp(promoteMode, L"immediateTracked") == 0) {
+    } else if (wcscmp(promoteMode.get(), L"immediateTracked") == 0) {
         s.promoteMode = PromoteMode::ImmediateTracked;
     }
-    Wh_FreeStringSetting(promoteMode);
 
-    PCWSTR glowColor = Wh_GetStringSetting(L"glowColor");
+    auto glowColor = WindhawkUtils::StringSetting::make(L"icons.glowColor");
     s.glowColor = GlowColorMode::Accent;
-    if (*glowColor) {
-        if (wcscmp(glowColor, L"green") == 0) {
-            s.glowColor = GlowColorMode::Green;
-        } else if (wcscmp(glowColor, L"blue") == 0) {
-            s.glowColor = GlowColorMode::Blue;
-        } else if (wcscmp(glowColor, L"orange") == 0) {
-            s.glowColor = GlowColorMode::Orange;
-        } else if (wcscmp(glowColor, L"white") == 0) {
-            s.glowColor = GlowColorMode::White;
-        } else if (wcscmp(glowColor, L"custom") == 0) {
-            s.glowColor = GlowColorMode::Custom;
-        }
+    if (wcscmp(glowColor.get(), L"green") == 0) {
+        s.glowColor = GlowColorMode::Green;
+    } else if (wcscmp(glowColor.get(), L"blue") == 0) {
+        s.glowColor = GlowColorMode::Blue;
+    } else if (wcscmp(glowColor.get(), L"orange") == 0) {
+        s.glowColor = GlowColorMode::Orange;
+    } else if (wcscmp(glowColor.get(), L"white") == 0) {
+        s.glowColor = GlowColorMode::White;
+    } else if (wcscmp(glowColor.get(), L"custom") == 0) {
+        s.glowColor = GlowColorMode::Custom;
     }
-    Wh_FreeStringSetting(glowColor);
 
-    PCWSTR customColor = Wh_GetStringSetting(L"customGlowColor");
-    s.customGlowColor = *customColor ? customColor : L"#00C853";
-    Wh_FreeStringSetting(customColor);
+    auto customColor =
+        WindhawkUtils::StringSetting::make(L"icons.customGlowColor");
+    s.customGlowColor =
+        customColor.get() && *customColor.get() ? customColor.get() : L"#00C853";
 
-    s.glowIntensity[0] = Wh_GetIntSetting(L"glowIntensityRank1");
-    s.glowIntensity[1] = Wh_GetIntSetting(L"glowIntensityRank2");
-    s.glowIntensity[2] = Wh_GetIntSetting(L"glowIntensityRank3");
+    s.glowIntensity[0] = Wh_GetIntSetting(L"icons.glowIntensityRank1");
+    s.glowIntensity[1] = Wh_GetIntSetting(L"icons.glowIntensityRank2");
+    s.glowIntensity[2] = Wh_GetIntSetting(L"icons.glowIntensityRank3");
     for (int& v : s.glowIntensity) {
         if (v < 0) {
             v = 0;
@@ -7157,9 +7188,9 @@ void LoadSettings() {
         }
     }
 
-    s.sizeBoostPercent[0] = Wh_GetIntSetting(L"sizeBoostRank1");
-    s.sizeBoostPercent[1] = Wh_GetIntSetting(L"sizeBoostRank2");
-    s.sizeBoostPercent[2] = Wh_GetIntSetting(L"sizeBoostRank3");
+    s.sizeBoostPercent[0] = Wh_GetIntSetting(L"icons.sizeBoostRank1");
+    s.sizeBoostPercent[1] = Wh_GetIntSetting(L"icons.sizeBoostRank2");
+    s.sizeBoostPercent[2] = Wh_GetIntSetting(L"icons.sizeBoostRank3");
     for (int& v : s.sizeBoostPercent) {
         if (v < 0) {
             v = 0;
@@ -7169,22 +7200,19 @@ void LoadSettings() {
         }
     }
 
-    PCWSTR glowStyle = Wh_GetStringSetting(L"glowStyle");
+    auto glowStyle = WindhawkUtils::StringSetting::make(L"icons.glowStyle");
     s.glowStyle = GlowStyle::LeftBar;
-    if (*glowStyle) {
-        if (wcscmp(glowStyle, L"full") == 0) {
-            s.glowStyle = GlowStyle::Full;
-        } else if (wcscmp(glowStyle, L"frame") == 0) {
-            s.glowStyle = GlowStyle::Frame;
-        } else if (wcscmp(glowStyle, L"leftBar") == 0) {
-            s.glowStyle = GlowStyle::LeftBar;
-        } else if (wcscmp(glowStyle, L"bottomBar") == 0) {
-            s.glowStyle = GlowStyle::BottomBar;
-        }
+    if (wcscmp(glowStyle.get(), L"full") == 0) {
+        s.glowStyle = GlowStyle::Full;
+    } else if (wcscmp(glowStyle.get(), L"frame") == 0) {
+        s.glowStyle = GlowStyle::Frame;
+    } else if (wcscmp(glowStyle.get(), L"leftBar") == 0) {
+        s.glowStyle = GlowStyle::LeftBar;
+    } else if (wcscmp(glowStyle.get(), L"bottomBar") == 0) {
+        s.glowStyle = GlowStyle::BottomBar;
     }
-    Wh_FreeStringSetting(glowStyle);
 
-    s.glowThickness = Wh_GetIntSetting(L"glowThickness");
+    s.glowThickness = Wh_GetIntSetting(L"icons.glowThickness");
     if (s.glowThickness < 1) {
         s.glowThickness = 1;
     }
@@ -7192,7 +7220,7 @@ void LoadSettings() {
         s.glowThickness = 16;
     }
 
-    s.glowRoundness = Wh_GetIntSetting(L"glowRoundness");
+    s.glowRoundness = Wh_GetIntSetting(L"icons.glowRoundness");
     if (s.glowRoundness < 0) {
         s.glowRoundness = 0;
     }
@@ -7200,7 +7228,7 @@ void LoadSettings() {
         s.glowRoundness = 50;
     }
 
-    s.glowSize = Wh_GetIntSetting(L"glowSize");
+    s.glowSize = Wh_GetIntSetting(L"icons.glowSize");
     if (s.glowSize < 40) {
         s.glowSize = 40;
     }
@@ -7208,7 +7236,7 @@ void LoadSettings() {
         s.glowSize = 100;
     }
 
-    s.glowLayers = Wh_GetIntSetting(L"glowLayers");
+    s.glowLayers = Wh_GetIntSetting(L"icons.glowLayers");
     if (s.glowLayers < 1) {
         s.glowLayers = 1;
     }
@@ -7216,7 +7244,7 @@ void LoadSettings() {
         s.glowLayers = 3;
     }
 
-    s.glowFillOpacity = Wh_GetIntSetting(L"glowFillOpacity");
+    s.glowFillOpacity = Wh_GetIntSetting(L"icons.glowFillOpacity");
     if (s.glowFillOpacity < 0) {
         s.glowFillOpacity = 0;
     }
@@ -7224,15 +7252,13 @@ void LoadSettings() {
         s.glowFillOpacity = 100;
     }
 
-    s.previewFillOpacity = Wh_GetIntSetting(L"previewFillOpacity");
+    s.previewFillOpacity = Wh_GetIntSetting(L"previews.fillOpacity");
     if (s.previewFillOpacity < 0) {
         s.previewFillOpacity = 0;
     }
     if (s.previewFillOpacity > 100) {
         s.previewFillOpacity = 100;
     }
-
-    s.glowDebugLog = Wh_GetIntSetting(L"glowDebugLog") != 0;
 
     s.decayMinutes = Wh_GetIntSetting(L"decayMinutes");
     if (s.decayMinutes < 0) {
@@ -7242,9 +7268,9 @@ void LoadSettings() {
     s.requireTaskbarButton = Wh_GetIntSetting(L"requireTaskbarButton") != 0;
 
     s.previewHighlightEnabled =
-        Wh_GetIntSetting(L"previewHighlightEnabled") != 0;
+        Wh_GetIntSetting(L"previews.highlightEnabled") != 0;
 
-    s.previewHighlightCount = Wh_GetIntSetting(L"previewHighlightCount");
+    s.previewHighlightCount = Wh_GetIntSetting(L"previews.highlightCount");
     if (s.previewHighlightCount < 0) {
         s.previewHighlightCount = 0;
     }
@@ -7252,9 +7278,9 @@ void LoadSettings() {
         s.previewHighlightCount = 16;
     }
 
-    s.previewIntensity[0] = Wh_GetIntSetting(L"previewIntensityRank1");
-    s.previewIntensity[1] = Wh_GetIntSetting(L"previewIntensityRank2");
-    s.previewIntensity[2] = Wh_GetIntSetting(L"previewIntensityRank3");
+    s.previewIntensity[0] = Wh_GetIntSetting(L"previews.intensityRank1");
+    s.previewIntensity[1] = Wh_GetIntSetting(L"previews.intensityRank2");
+    s.previewIntensity[2] = Wh_GetIntSetting(L"previews.intensityRank3");
     for (int& v : s.previewIntensity) {
         if (v < 0) {
             v = 0;
@@ -7264,61 +7290,56 @@ void LoadSettings() {
         }
     }
 
-    s.previewMinFocusSeconds = Wh_GetIntSetting(L"previewMinFocusSeconds");
+    s.previewMinFocusSeconds = Wh_GetIntSetting(L"previews.minFocusSeconds");
     if (s.previewMinFocusSeconds < 0) {
         s.previewMinFocusSeconds = 0;
     }
-    s.previewDecayMinutes = Wh_GetIntSetting(L"previewDecayMinutes");
+    s.previewDecayMinutes = Wh_GetIntSetting(L"previews.decayMinutes");
     if (s.previewDecayMinutes < 0) {
         s.previewDecayMinutes = 0;
     }
 
-    PCWSTR previewStyle = Wh_GetStringSetting(L"previewStyle");
+    auto previewStyle = WindhawkUtils::StringSetting::make(L"previews.style");
     s.previewStyle = PreviewStyle::TitleBar;
-    if (*previewStyle) {
-        if (wcscmp(previewStyle, L"ring") == 0) {
-            s.previewStyle = PreviewStyle::Ring;
-        } else if (wcscmp(previewStyle, L"titleBg") == 0) {
-            s.previewStyle = PreviewStyle::TitleBg;
-        } else if (wcscmp(previewStyle, L"plate") == 0) {
-            s.previewStyle = PreviewStyle::Plate;
-        } else if (wcscmp(previewStyle, L"plateTitle") == 0) {
-            s.previewStyle = PreviewStyle::PlateTitle;
-        } else if (wcscmp(previewStyle, L"titleBar") == 0) {
-            s.previewStyle = PreviewStyle::TitleBar;
-        }
+    if (wcscmp(previewStyle.get(), L"ring") == 0) {
+        s.previewStyle = PreviewStyle::Ring;
+    } else if (wcscmp(previewStyle.get(), L"titleBg") == 0) {
+        s.previewStyle = PreviewStyle::TitleBg;
+    } else if (wcscmp(previewStyle.get(), L"plate") == 0) {
+        s.previewStyle = PreviewStyle::Plate;
+    } else if (wcscmp(previewStyle.get(), L"plateTitle") == 0) {
+        s.previewStyle = PreviewStyle::PlateTitle;
+    } else if (wcscmp(previewStyle.get(), L"titleBar") == 0) {
+        s.previewStyle = PreviewStyle::TitleBar;
     }
-    Wh_FreeStringSetting(previewStyle);
 
     s.excludedPrograms.clear();
     for (int i = 0;; i++) {
-        PCWSTR program = Wh_GetStringSetting(L"excludedPrograms[%d]", i);
-        bool hasProgram = *program;
-        if (hasProgram) {
-            s.excludedPrograms.insert(ToUpper(program));
-        }
-        Wh_FreeStringSetting(program);
-        if (!hasProgram) {
+        auto program =
+            WindhawkUtils::StringSetting::make(L"excludedPrograms[%d]", i);
+        if (!program.get() || !*program.get()) {
             break;
         }
+        s.excludedPrograms.insert(ToUpper(program.get()));
     }
 
-    Wh_Log(L"Settings: enabled=%d style=%s th=%d round=%d%% size=%d%% "
-           L"layers=%d fillOp=%d previewFillOp=%d debug=%d decay=%dmin "
+    s.cachedAccent = SettingsSnap()->cachedAccent;
+
+    Wh_Log(L"Settings: style=%s th=%d round=%d%% size=%d%% "
+           L"layers=%d fillOp=%d previewFillOp=%d decay=%dmin "
            L"minFocus=%ds promote=%s preview=%d previewCount=%d "
            L"previewI=%d/%d/%d previewStyle=%s previewMin=%ds previewDecay=%dmin",
-           s.enabled ? 1 : 0, GlowStyleName(s.glowStyle), s.glowThickness,
+           GlowStyleName(s.glowStyle), s.glowThickness,
            s.glowRoundness, s.glowSize, s.glowLayers, s.glowFillOpacity,
-           s.previewFillOpacity, s.glowDebugLog ? 1 : 0, s.decayMinutes,
+           s.previewFillOpacity, s.decayMinutes,
            s.minFocusSeconds, PromoteModeName(s.promoteMode),
            s.previewHighlightEnabled ? 1 : 0, s.previewHighlightCount,
            s.previewIntensity[0], s.previewIntensity[1], s.previewIntensity[2],
            PreviewStyleName(s.previewStyle), s.previewMinFocusSeconds,
            s.previewDecayMinutes);
 
-    s.cachedAccent = QuerySystemAccentColor();
-
     PublishSettings(std::move(s));
+    PostToHookThread(WM_APP_REFRESH_ACCENT);
 }
 
 // ---------------------------------------------------------------------------
@@ -7326,7 +7347,7 @@ void LoadSettings() {
 // ---------------------------------------------------------------------------
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"> Taskbar Recent Focus Highlight init v0.9.2");
+    Wh_Log(L"> Taskbar Recent Focus Highlight init v0.9.3");
 
     g_unloading = false;
     LoadSettings();
@@ -7388,7 +7409,6 @@ void Wh_ModUninit() {
     Wh_Log(L">");
     g_unloading = true;
     g_taskbandResolveReady = false;
-    g_previewHooksReady = false;
 
     // Stop the worker first so it cannot TryRunAsync after the UI drain.
     StopWinEventHookThread();
@@ -7419,7 +7439,6 @@ void Wh_ModUninit() {
     {
         std::lock_guard<std::mutex> lock(g_buttonsMutex);
         g_trackedButtons.clear();
-        g_dispatcherAnchor = {};
     }
     {
         std::lock_guard<std::mutex> lock(g_buttonPathMutex);

--- a/mods/taskbar-recent-focus-highlight.wh.cpp
+++ b/mods/taskbar-recent-focus-highlight.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-recent-focus-highlight
 // @name            Taskbar Recent Focus Highlight
 // @description     Visually highlight the most recently focused running apps on the taskbar
-// @version         0.9.4
+// @version         0.9.6
 // @author          Jakub Vlášek
 // @github          https://github.com/jvlasek
 // @include         explorer.exe
@@ -457,12 +457,13 @@ enum class MinFocusConfirmMode {
 // ---------------------------------------------------------------------------
 
 struct AppFocusInfo {
-    std::wstring key;          // APPID:… or PATH|CLS:class or bare path
+    std::wstring key;          // APPID:… or uppercase image path
     std::wstring displayName;  // e.g. WindowsTerminal.exe
-    std::wstring lastWindowTitle;  // from focused HWND (helps button match)
+    std::wstring lastWindowTitle;  // unmatched-rank logs only
     std::wstring classUpper;   // focused window class (TLister vs TTOTAL_CMD)
     std::wstring appIdUpper;   // window AppUserModelID when present
     HWND lastHwnd = nullptr;
+    DWORD lastPid = 0;  // reject recycled lastHwnd (preview already does this)
     ULONGLONG lastConfirmedFocusTick = 0;
     // True once we saw a TaskListButton for this path (path cache / bind).
     bool seenOnTaskbar = false;
@@ -543,7 +544,7 @@ struct ButtonPathCacheEntry {
     HWND sampleHwnd = nullptr;  // sample from resolve; preview uses window map
     std::vector<HWND> groupHwnds;
     bool resolveAttempted = false;
-    ULONGLONG lastResolveTick = 0;
+    ULONGLONG lastResolveTick = 0;  // empty-identity retry throttle
     ULONGLONG lastRunningTick = 0;  // IsRunning grace (Alt-Tab flicker)
     // Last ApplyAllHighlights assignment: -1 unknown, 0 none, >0 1-based rank.
     int lastPaintRank = -1;
@@ -578,6 +579,7 @@ std::atomic<bool> g_taskbarViewDllLoaded{false};
 // After decay / empty ranks, force-clear overlays on next button touch if
 // RequestApplyVisuals couldn't run (sleep/wake, no dispatcher yet).
 std::atomic<bool> g_pendingOverlaySweep{false};
+std::atomic<bool> g_decayTimerArmed{false};
 
 std::mutex g_winEventHookThreadMutex;
 std::atomic<HANDLE> g_winEventHookThread{nullptr};
@@ -675,6 +677,7 @@ constexpr UINT WM_APP_DESKTOP_SWITCHED = WM_APP + 2;
 constexpr UINT WM_APP_SHUTDOWN = WM_APP + 3;
 constexpr UINT WM_APP_REQUEST_APPLY_DEBOUNCED = WM_APP + 4;
 constexpr UINT WM_APP_REFRESH_ACCENT = WM_APP + 5;
+constexpr UINT WM_APP_PREVIEW_CLICK = WM_APP + 6;
 
 // Identity scores. Only exact identity may bind the same rank to many buttons
 // (secondary taskbar / Never Combine). Filename-only is not a match.
@@ -688,6 +691,8 @@ constexpr ULONGLONG kIsRunningGraceMs = 400;
 // Full identity rebind (all buttons). UVS only re-paints the cached rank;
 // siblings whose visuals Windows cleared without another UVS wait for this.
 constexpr ULONGLONG kFullRebindDebounceMs = 300;
+// Empty identity (pinned, no task item) is retried; successful path/AUMID is not.
+constexpr ULONGLONG kUnresolvedRetryMs = 2000;
 
 // All glow layers live on our overlay (never BackgroundElement — hover/active
 // storyboards own that and constantly wipe our styles).
@@ -961,6 +966,43 @@ void DisarmHookTimer(UINT_PTR id) {
     }
 }
 
+// Requires g_stateMutex.
+bool RecencyMapsEmptyLocked() {
+    for (const auto& [id, desk] : g_desktopMaps) {
+        (void)id;
+        if (!desk.appFocusMap.empty() || !desk.windowFocusMap.empty()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void EnsureDecayTimerArmed() {
+    if (!OnHookThread()) {
+        return;
+    }
+    if (g_decayTimerArmed.exchange(true)) {
+        return;
+    }
+    ArmHookTimer(kDecayTimerId, kDecayCheckIntervalMs);
+    Wh_Log(L"Decay timer armed");
+}
+
+void StopDecayTimerIfIdle() {
+    if (!OnHookThread()) {
+        return;
+    }
+    bool idle = false;
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        idle = RecencyMapsEmptyLocked() && !g_pendingFocus.valid;
+    }
+    if (idle && g_decayTimerArmed.exchange(false)) {
+        DisarmHookTimer(kDecayTimerId);
+        Wh_Log(L"Decay timer stopped (no tracked apps/windows)");
+    }
+}
+
 std::wstring ToUpper(std::wstring s) {
     if (!s.empty()) {
         LCMapStringEx(LOCALE_NAME_USER_DEFAULT, LCMAP_UPPERCASE, s.data(),
@@ -1051,7 +1093,6 @@ bool IsOwnExplorerProcess(DWORD processId) {
 
 std::wstring PathFromAppKey(const std::wstring& key);
 std::wstring AppIdFromAppKey(const std::wstring& key);
-std::wstring ClassFromAppKey(const std::wstring& key);
 
 bool IsExcludedKey(const std::wstring& keyUpper,
                    const std::wstring& displayNameUpper) {
@@ -1173,8 +1214,7 @@ std::wstring DisplayNameFromAppId(const std::wstring& appIdUpper) {
 }
 
 std::wstring MakeAppKey(const std::wstring& pathUpper,
-                        const std::wstring& appIdUpper,
-                        const std::wstring& /*classUpper*/) {
+                        const std::wstring& appIdUpper) {
     // Win32: path only. Windhawk's editor is VSCodium.exe with AppId
     // RAMENSOFTWARE.WINDHAWK — that is still one taskbar button.
     // UWP hosts (ApplicationFrameHost / WWAHost) share one exe for many
@@ -1189,31 +1229,14 @@ std::wstring PathFromAppKey(const std::wstring& key) {
     if (key.rfind(L"APPID:", 0) == 0) {
         return {};
     }
-    auto pos = key.find(L"|CLS:");
-    if (pos != std::wstring::npos) {
-        return key.substr(0, pos);
-    }
     return key;
-}
-
-std::wstring ClassFromAppKey(const std::wstring& key) {
-    auto pos = key.find(L"|CLS:");
-    if (pos == std::wstring::npos) {
-        return {};
-    }
-    return key.substr(pos + 5);
 }
 
 std::wstring AppIdFromAppKey(const std::wstring& key) {
     if (key.rfind(L"APPID:", 0) != 0) {
         return {};
     }
-    std::wstring rest = key.substr(6);
-    auto pos = rest.find(L"|CLS:");
-    if (pos != std::wstring::npos) {
-        rest.resize(pos);
-    }
-    return rest;
+    return key.substr(6);
 }
 
 bool SamePidAndClass(HWND a, HWND b) {
@@ -1361,7 +1384,7 @@ bool ResolveAppIdentity(HWND hWnd,
         return false;
     }
 
-    const std::wstring key = MakeAppKey(pathUpper, appIdUpper, classUpper);
+    const std::wstring key = MakeAppKey(pathUpper, appIdUpper);
     const std::wstring title = GetWindowTitle(hWnd);
     std::wstring displayName = fileName;
     if (IsUwpHostFileName(fileNameUpper)) {
@@ -1453,10 +1476,12 @@ bool PathAppearsOnTaskbar(const std::wstring& keyOrPath,
     }
 
     std::lock_guard<std::mutex> lock(g_buttonPathMutex);
-    for (const auto& [id, e] : g_buttonPathCache) {
+    for (const auto& [cacheKey, e] : g_buttonPathCache) {
+        (void)cacheKey;
         if (!wantAppId.empty()) {
-            std::wstring id = e.appIdUpper.empty() ? e.autoIdUpper : e.appIdUpper;
-            if (CanonicalAppId(id) == wantAppId) {
+            std::wstring gotId =
+                e.appIdUpper.empty() ? e.autoIdUpper : e.appIdUpper;
+            if (CanonicalAppId(gotId) == wantAppId) {
                 return true;
             }
         }
@@ -1543,9 +1568,12 @@ void StampWindowRecencyLocked(DesktopRecencyState& desk,
                               const std::wstring& windowTitle,
                               ULONGLONG now);
 
-void ConfirmPreviewFocusNow(HWND hwnd) {
+void ConfirmPreviewFocusNow(HWND hwnd, DWORD expectedPid = 0) {
     if (!hwnd || g_unloading.load() ||
         !SettingsSnap()->previewHighlightEnabled) {
+        return;
+    }
+    if (expectedPid && !HwndMatchesStoredPid(hwnd, expectedPid)) {
         return;
     }
     hwnd = NormalizeFocusHwnd(hwnd);
@@ -1579,6 +1607,7 @@ void ConfirmPreviewFocusNow(HWND hwnd) {
                desk.windowFocusMap.size(),
                GuidToLogString(g_currentDesktopId).c_str());
     }
+    EnsureDecayTimerArmed();
     RequestApplyPreviewVisuals();
 }
 
@@ -1817,8 +1846,6 @@ winrt::Windows::UI::Color ResolveGlowBaseColor(const Settings& settings) {
     return c;
 }
 
-// Defined with option-C resolve stack (button → process path).
-std::wstring EnsureButtonPathCached(FrameworkElement button, bool force);
 struct ButtonIdentity {
     std::wstring pathUpper;
     std::wstring appIdUpper;
@@ -1836,14 +1863,8 @@ struct PaintCacheState {
 };
 PaintCacheState GetCachedPaintState(FrameworkElement button);
 void SetCachedPaintState(FrameworkElement button, int rank, uint32_t gen);
-TaskbarEdge CachedTaskbarEdge(FrameworkElement iconPanel);
 void RememberOurIconScale(FrameworkElement button, Media::ScaleTransform scale);
 void ClearIconScaleIfOurs(FrameworkElement icon, FrameworkElement button);
-void RefreshCachedAccent();
-void SubscribeAccentChanges();
-void UnsubscribeAccentChanges();
-void ScheduleThumbnailRelayout(FrameworkElement thumbView);
-void ClearAllThumbnailHighlights_UIThread();
 bool RunOnUiThread(const winrt::Windows::UI::Core::DispatchedHandler& handler);
 void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb);
 
@@ -2060,7 +2081,7 @@ int ScoreTitleToAutomationName(const std::wstring& windowTitle,
 
 // Score this button against one ranked app. Path / AUMID / HWND only — no
 // automation-name fuzzy. 0 = no match. 1000 may bind the same rank to many
-// buttons (secondary taskbar). 900 is 1:1 (same file, different folder).
+// buttons (secondary taskbar).
 int ScoreButtonForRank(FrameworkElement button,
                        const AppFocusInfo& info,
                        bool requireRunning) {
@@ -2072,10 +2093,7 @@ int ScoreButtonForRank(FrameworkElement button,
     }
 
     const ButtonIdentity ident = GetCachedButtonIdentity(button);
-    const std::wstring rankPath = PathFromAppKey(info.key);
-    const std::wstring rankCls = !info.classUpper.empty()
-                                     ? info.classUpper
-                                     : ClassFromAppKey(info.key);
+    const std::wstring& rankCls = info.classUpper;
 
     auto hwndOnButton = [&](HWND h) -> bool {
         if (!h) {
@@ -2097,7 +2115,9 @@ int ScoreButtonForRank(FrameworkElement button,
         return false;
     };
 
-    if (hwndOnButton(info.lastHwnd)) {
+    if (info.lastHwnd && info.lastPid &&
+        HwndMatchesStoredPid(info.lastHwnd, info.lastPid) &&
+        hwndOnButton(info.lastHwnd)) {
         return kScoreExactIdentity;
     }
 
@@ -2112,16 +2132,13 @@ int ScoreButtonForRank(FrameworkElement button,
         return 0;
     }
 
-    const std::wstring pathKey =
-        !rankPath.empty() ? rankPath : PathFromAppKey(info.key);
     const bool exactPath =
-        !ident.pathUpper.empty() &&
-        (ident.pathUpper == info.key || ident.pathUpper == pathKey);
+        !ident.pathUpper.empty() && ident.pathUpper == info.key;
     if (exactPath) {
         if (!rankCls.empty() && !ident.classUpper.empty() &&
             ident.classUpper != rankCls) {
             // Same exe, different window class (e.g. two icons from one
-            // process). Not a replica.
+            // process).
             return 0;
         }
         return kScoreExactIdentity;
@@ -3554,10 +3571,14 @@ HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
                                  pThis, taskGroup, taskItem, launcherOptions)
                            : E_FAIL;
     // Thumbnail (or grouped-icon) click is an explicit "this window".
-    // Confirm it immediately so decay + click does not paint the sibling.
+    // Confirm on the focus thread — ResolveAppIdentity + preview apply must
+    // not run inline on the taskbar UI thread inside HandleClick.
     if (SUCCEEDED(hr) && taskItem) {
         if (HWND clicked = GetWindowFromTaskItem(taskItem)) {
-            ConfirmPreviewFocusNow(clicked);
+            const DWORD pid = PidFromHwnd(clicked);
+            PostToHookThread(WM_APP_PREVIEW_CLICK,
+                             reinterpret_cast<WPARAM>(clicked),
+                             static_cast<LPARAM>(pid));
         }
     }
     return hr;
@@ -3707,6 +3728,7 @@ std::wstring EnsureButtonPathCached(FrameworkElement button, bool force) {
 
     const ULONGLONG now = GetTickCount64();
     void* id = InspectableIdentity(button);
+    bool unresolvedRecent = false;
     {
         std::lock_guard<std::mutex> lock(g_buttonPathMutex);
         auto it = id ? g_buttonPathCache.find(id) : g_buttonPathCache.end();
@@ -3714,9 +3736,19 @@ std::wstring EnsureButtonPathCached(FrameworkElement button, bool force) {
             if (!WeakIsSameElement(it->second.button, button)) {
                 g_buttonPathCache.erase(it);
             } else if (!force && it->second.resolveAttempted) {
-                return it->second.pathUpper;
+                const bool haveIdentity = !it->second.pathUpper.empty() ||
+                                          !it->second.appIdUpper.empty();
+                if (haveIdentity) {
+                    return it->second.pathUpper;
+                }
+                if (now - it->second.lastResolveTick < kUnresolvedRetryMs) {
+                    unresolvedRecent = true;
+                }
             }
         }
+    }
+    if (unresolvedRecent && !TaskListButton_IsRunning(button)) {
+        return {};
     }
 
     DWORD pid = 0;
@@ -4068,9 +4100,9 @@ void ApplyAllHighlights_UIThread() {
         }
     }
 
-    // Path / AUMID / HWND only. 1:1 except exact identity replicas.
+    // Path / AUMID / HWND only. Exact identity may bind the same rank to many
+    // buttons (secondary taskbar / Never Combine).
     struct Cand {
-        int score;
         size_t rankIdx;
         size_t buttonIdx;
     };
@@ -4081,12 +4113,10 @@ void ApplyAllHighlights_UIThread() {
         for (size_t ri = 0; ri < ranks.size(); ++ri) {
             int s = ScoreButtonForRank(live[bi], ranks[ri], true);
             if (s >= kScoreExactIdentity) {
-                cands.push_back({s, ri, bi});
+                cands.push_back({ri, bi});
             }
         }
     }
-    std::sort(cands.begin(), cands.end(),
-              [](const Cand& a, const Cand& b) { return a.score > b.score; });
 
     std::vector<int> buttonRank(live.size(), 0);  // 1-based rank or 0
     std::vector<bool> rankTaken(ranks.size(), false);
@@ -4096,18 +4126,9 @@ void ApplyAllHighlights_UIThread() {
         if (buttonTaken[c.buttonIdx]) {
             continue;
         }
-        const bool replica = c.score >= kScoreExactIdentity;
-        if (replica) {
-            buttonTaken[c.buttonIdx] = true;
-            rankTaken[c.rankIdx] = true;
-            buttonRank[c.buttonIdx] = static_cast<int>(c.rankIdx) + 1;
-        } else if (!rankTaken[c.rankIdx]) {
-            rankTaken[c.rankIdx] = true;
-            buttonTaken[c.buttonIdx] = true;
-            buttonRank[c.buttonIdx] = static_cast<int>(c.rankIdx) + 1;
-        } else {
-            continue;
-        }
+        buttonTaken[c.buttonIdx] = true;
+        rankTaken[c.rankIdx] = true;
+        buttonRank[c.buttonIdx] = static_cast<int>(c.rankIdx) + 1;
 
         {
             std::lock_guard<std::mutex> lock(g_stateMutex);
@@ -4116,9 +4137,9 @@ void ApplyAllHighlights_UIThread() {
                 it->second.seenOnTaskbar = true;
             }
         }
-        Wh_Log(L"  bind rank %zu %s -> \"%s\" (score=%d path=%s)",
+        Wh_Log(L"  bind rank %zu %s -> \"%s\" (path=%s)",
                c.rankIdx + 1, ranks[c.rankIdx].displayName.c_str(),
-               GetButtonAutomationName(live[c.buttonIdx]).c_str(), c.score,
+               GetButtonAutomationName(live[c.buttonIdx]).c_str(),
                buttonPaths[c.buttonIdx].empty()
                    ? L"?"
                    : buttonPaths[c.buttonIdx].c_str());
@@ -4511,6 +4532,7 @@ std::vector<FrameworkElement> CollectRepeaterThumbnailViews(
 }
 
 HWND HwndFromThumbnailsGetAt(int index);
+int ThumbnailsCollectionSize();
 
 void TrackThumbView_UIThread(FrameworkElement thumbView) {
     if (!thumbView) {
@@ -5065,47 +5087,84 @@ bool GetTitleBottomRelative(FrameworkElement title,
     }
 }
 
-// Deferred re-layout for titleBar/titleBg after the flyout finishes measuring.
-// At most one nested pass (avoids infinite Low-priority loops when title never
-// reports a size).
-thread_local bool g_thumbRelayoutPending = false;
+// One Low-priority flyout refresh per UI thread. Title remeasure, hover-switch
+// (TargetItemKey), and OnApplyTemplate all coalesce here. The callback picks a
+// card that still has an ItemsRepeater ancestor — do not reuse the weak_ref
+// captured at schedule time (often the oldest tracked card, already recycled).
+// At most one follow-up when the first pass still sees unmeasured cards.
+thread_local bool g_previewFlyoutRefreshPending = false;
+thread_local bool g_previewFlyoutRefreshNeeded = false;
 thread_local int g_thumbRelayoutDepth = 0;
+thread_local int g_previewFlyoutRefreshFollowUps = 0;
 
-void ScheduleThumbnailRelayout(FrameworkElement thumbView) {
-    if (!thumbView || g_thumbRelayoutDepth > 0) {
-        return;  // already inside the deferred pass
+FrameworkElement PickLiveFlyoutThumbOnThisDispatcher() {
+    FrameworkElement withRepeater = nullptr;
+    FrameworkElement any = nullptr;
+    std::vector<winrt::weak_ref<FrameworkElement>> thumbs;
+    {
+        std::lock_guard<std::mutex> lock(g_thumbViewsMutex);
+        thumbs = g_trackedThumbViews;
     }
-    if (g_thumbRelayoutPending) {
+    ForEachLiveElementOnThisDispatcher(thumbs, [&](FrameworkElement el) {
+        if (!any) {
+            any = el;
+        }
+        if (!withRepeater && FindAncestorItemsRepeater(el)) {
+            withRepeater = el;
+        }
+    });
+    return withRepeater ? withRepeater : any;
+}
+
+void SchedulePreviewFlyoutRefresh(FrameworkElement dispatcherAnchor) {
+    if (!dispatcherAnchor || g_unloading.load()) {
         return;
     }
-    g_thumbRelayoutPending = true;
+    if (g_thumbRelayoutDepth > 0) {
+        g_previewFlyoutRefreshNeeded = true;
+        return;
+    }
+    if (g_previewFlyoutRefreshPending) {
+        return;
+    }
+    g_previewFlyoutRefreshPending = true;
     try {
-        auto dispatcher = thumbView.Dispatcher();
+        auto dispatcher = dispatcherAnchor.Dispatcher();
         if (!dispatcher) {
-            g_thumbRelayoutPending = false;
+            g_previewFlyoutRefreshPending = false;
             return;
         }
-        winrt::weak_ref<FrameworkElement> weak =
-            winrt::make_weak(thumbView);
-        // Low priority so it runs after the current layout pass.
         dispatcher.RunAsync(
-            winrt::Windows::UI::Core::CoreDispatcherPriority::Low,
-            [weak]() {
-                g_thumbRelayoutPending = false;
+            winrt::Windows::UI::Core::CoreDispatcherPriority::Low, []() {
+                g_previewFlyoutRefreshPending = false;
                 try {
-                    FrameworkElement el = weak.get();
-                    if (!el || g_unloading.load()) {
+                    if (g_unloading.load()) {
+                        return;
+                    }
+                    FrameworkElement el = PickLiveFlyoutThumbOnThisDispatcher();
+                    if (!el) {
                         return;
                     }
                     g_thumbRelayoutDepth = 1;
+                    g_previewFlyoutRefreshNeeded = false;
                     RefreshThumbnailFlyout_UIThread(el);
                     g_thumbRelayoutDepth = 0;
+                    const bool again = g_previewFlyoutRefreshNeeded &&
+                                       g_previewFlyoutRefreshFollowUps < 1;
+                    g_previewFlyoutRefreshNeeded = false;
+                    if (again) {
+                        ++g_previewFlyoutRefreshFollowUps;
+                        SchedulePreviewFlyoutRefresh(el);
+                    } else {
+                        g_previewFlyoutRefreshFollowUps = 0;
+                    }
                 } catch (...) {
                     g_thumbRelayoutDepth = 0;
+                    g_previewFlyoutRefreshFollowUps = 0;
                 }
             });
     } catch (...) {
-        g_thumbRelayoutPending = false;
+        g_previewFlyoutRefreshPending = false;
     }
 }
 
@@ -5176,7 +5235,7 @@ void ApplyThumbnailHighlight(FrameworkElement thumbView, int rankOneBased) {
         // 180×120 means layout not ready — bar placement will be wrong until
         // the deferred remeasure runs.
         if (cardSizeFallback) {
-            ScheduleThumbnailRelayout(thumbView);
+            SchedulePreviewFlyoutRefresh(thumbView);
         }
 
         auto title = FindThumbnailTitleElement(thumbView);
@@ -5292,7 +5351,7 @@ void ApplyThumbnailHighlight(FrameworkElement thumbView, int rankOneBased) {
                 stripH = (std::max)(20.0, titleBottom - top + 4.0);
             } else {
                 // Layout not ready — default strip + one deferred remeasure.
-                ScheduleThumbnailRelayout(thumbView);
+                SchedulePreviewFlyoutRefresh(thumbView);
             }
             const double hPad = 8.0;
             const double stripW = (std::max)(24.0, cardW - 2.0 * hPad);
@@ -5324,7 +5383,7 @@ void ApplyThumbnailHighlight(FrameworkElement thumbView, int rankOneBased) {
             if (laidOut) {
                 top = titleBottom + kGapBelowTitle;
             } else {
-                ScheduleThumbnailRelayout(thumbView);
+                SchedulePreviewFlyoutRefresh(thumbView);
             }
             top = (std::max)(18.0, (std::min)(top, cardH * 0.38));
 
@@ -5458,25 +5517,56 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
     }
 
     // Pass 1: repeater index → GetAt → ctor map HWND.
-    // Index is against allViews (includes snap-group cards), not siblings.
+    // repeaterSourceIndex is the ItemsSource slot (round-3 compacted-vs-source
+    // fix). TaskGroup::Thumbnails is a different collection: a snap-group card
+    // can sit in the repeater and not in Thumbnails. Compare sizes before
+    // using source index as GetAt.
     if (usedRepeater) {
-        size_t si = 0;
-        for (size_t ri = 0; ri < allViews.size() && si < siblings.size();
-             ++ri) {
-            if (IsSnapGroupThumbnailView(allViews[ri])) {
-                continue;
+        const int thumbCount = ThumbnailsCollectionSize();
+        int nSnap = 0;
+        for (const auto& v : allViews) {
+            if (IsSnapGroupThumbnailView(v)) {
+                ++nSnap;
             }
-            const int srcIndex =
-                (ri < repeaterSourceIndex.size())
-                    ? repeaterSourceIndex[ri]
-                    : static_cast<int>(ri);
-            HWND hwnd = HwndFromThumbnailsGetAt(srcIndex);
-            if (hwnd && IsWindow(hwnd) && !usedHwnds.count(hwnd)) {
-                stampRecency(si, hwnd);
-                scored[si].how = ResolveHow::Repeater;
-                usedHwnds.insert(hwnd);
+        }
+        const int nRepeater = static_cast<int>(allViews.size());
+        const int nWindows = nRepeater - nSnap;
+        const bool sizeUnknown = thumbCount < 0;
+        const bool compactSnap =
+            !sizeUnknown && nSnap > 0 && thumbCount == nWindows;
+        const bool sizesAgree =
+            sizeUnknown || thumbCount == nRepeater || compactSnap;
+        if (!sizesAgree) {
+            Wh_Log(L"Preview resolve: repeater/Thumbnails size mismatch "
+                   L"(repeater=%d thumbs=%d snap=%d) — skip index bind",
+                   nRepeater, thumbCount, nSnap);
+        } else {
+            if (compactSnap) {
+                Wh_Log(L"Preview resolve: snap-group extra in repeater "
+                       L"(repeater=%d thumbs=%d) — compact GetAt index",
+                       nRepeater, thumbCount);
             }
-            ++si;
+            size_t si = 0;
+            int windowOrdinal = 0;
+            for (size_t ri = 0; ri < allViews.size() && si < siblings.size();
+                 ++ri) {
+                if (IsSnapGroupThumbnailView(allViews[ri])) {
+                    continue;
+                }
+                const int srcIndex =
+                    (ri < repeaterSourceIndex.size())
+                        ? repeaterSourceIndex[ri]
+                        : static_cast<int>(ri);
+                const int getAtIndex = compactSnap ? windowOrdinal : srcIndex;
+                HWND hwnd = HwndFromThumbnailsGetAt(getAtIndex);
+                if (hwnd && IsWindow(hwnd) && !usedHwnds.count(hwnd)) {
+                    stampRecency(si, hwnd);
+                    scored[si].how = ResolveHow::Repeater;
+                    usedHwnds.insert(hwnd);
+                }
+                ++si;
+                ++windowOrdinal;
+            }
         }
     }
 
@@ -5665,14 +5755,10 @@ void RequestApplyPreviewVisuals() {
     // focus thread — the WM_APP_REQUEST_PREVIEW_APPLY handler used to call
     // this again, which spun at 100% CPU and starved WM_TIMER.
     RunOnUiThread([]() {
-        std::vector<winrt::weak_ref<FrameworkElement>> thumbs;
-        {
-            std::lock_guard<std::mutex> lock(g_thumbViewsMutex);
-            thumbs = g_trackedThumbViews;
+        FrameworkElement el = PickLiveFlyoutThumbOnThisDispatcher();
+        if (el) {
+            SchedulePreviewFlyoutRefresh(el);
         }
-        ForEachLiveElementOnThisDispatcher(thumbs, [](FrameworkElement el) {
-            RefreshThumbnailFlyout_UIThread(el);
-        });
     });
 }
 
@@ -5833,7 +5919,12 @@ void RefreshButtonHighlight(FrameworkElement button) {
             if (ButtonHasOurChrome(button)) {
                 ClearButtonHighlight(button);
             } else {
-                SetCachedPaintState(button, 0, SettingsSnap()->generation);
+                auto ident = GetCachedButtonIdentity(button);
+                if (ident.pathUpper.empty() && ident.appIdUpper.empty()) {
+                    ScheduleRefreshAllHighlights(button);
+                } else {
+                    SetCachedPaintState(button, 0, SettingsSnap()->generation);
+                }
             }
             return;
         }
@@ -5845,7 +5936,12 @@ void RefreshButtonHighlight(FrameworkElement button) {
     } else if (ButtonHasOurChrome(button)) {
         ClearButtonHighlight(button);
     } else {
-        SetCachedPaintState(button, 0, SettingsSnap()->generation);
+        auto ident = GetCachedButtonIdentity(button);
+        if (ident.pathUpper.empty() && ident.appIdUpper.empty()) {
+            ScheduleRefreshAllHighlights(button);
+        } else {
+            SetCachedPaintState(button, 0, SettingsSnap()->generation);
+        }
     }
 }
 
@@ -5907,7 +6003,8 @@ void WINAPI TaskListButton_UpdateVisualStates_Hook(void* pThis) {
     TrackButton_UIThread(button);
     RefreshButtonHighlight(button);
     const int rank = GetCachedPaintState(button).rank;
-    if (rank > 0 || g_pendingOverlaySweep.load()) {
+    // rank -1 = identity not resolved yet; do not treat as "unranked".
+    if (rank != 0 || g_pendingOverlaySweep.load()) {
         ScheduleRefreshAllHighlights(button);
     }
 }
@@ -5932,7 +6029,8 @@ void WINAPI TaskItemThumbnailView_OnApplyTemplate_Hook(void* pThis) {
         unknownPtr->QueryInterface(winrt::guid_of<FrameworkElement>(),
                                    winrt::put_abi(element));
         if (element) {
-            RefreshThumbnailFlyout_UIThread(element);
+            TrackThumbView_UIThread(element);
+            SchedulePreviewFlyoutRefresh(element);
         }
     } catch (...) {
         HRESULT hr = winrt::to_hresult();
@@ -6146,6 +6244,27 @@ using TaskItemThumbnail_GetAt_t = void*(WINAPI*)(void* pThis,
                                                  int index);
 TaskItemThumbnail_GetAt_t TaskItemThumbnail_GetAt_Original;
 
+int ThumbnailsCollectionSize() {
+    if (!TaskItemThumbnail_Size_Original) {
+        return -1;
+    }
+    winrt::Windows::Foundation::IInspectable thumbnails = nullptr;
+    try {
+        thumbnails = g_TaskGroup_Thumbnails.get();
+    } catch (...) {
+        return -1;
+    }
+    if (!thumbnails) {
+        return -1;
+    }
+    try {
+        auto* thumbnailsPtr = winrt::get_abi(thumbnails);
+        return TaskItemThumbnail_Size_Original(&thumbnailsPtr);
+    } catch (...) {
+        return -1;
+    }
+}
+
 HWND HwndFromThumbnailsGetAt(int index) {
     if (!TaskItemThumbnail_GetAt_Original || !TaskItemThumbnail_Size_Original ||
         index < 0) {
@@ -6203,14 +6322,10 @@ void WINAPI HoverFlyoutModel_TargetItemKey_Hook(void* pThis, void* param1) {
     // previous app's views.
     try {
         ClearAllThumbnailHighlights_UIThread();
-        std::vector<winrt::weak_ref<FrameworkElement>> thumbs;
-        {
-            std::lock_guard<std::mutex> lock(g_thumbViewsMutex);
-            thumbs = g_trackedThumbViews;
+        FrameworkElement el = PickLiveFlyoutThumbOnThisDispatcher();
+        if (el) {
+            SchedulePreviewFlyoutRefresh(el);
         }
-        ForEachLiveElementOnThisDispatcher(thumbs, [](FrameworkElement el) {
-            ScheduleThumbnailRelayout(el);
-        });
     } catch (...) {
     }
 }
@@ -6478,6 +6593,7 @@ void OnPreviewMinFocusTimerElapsed(MinFocusConfirmMode mode) {
                GuidToLogString(pending.desktopId).c_str());
     }
 
+    EnsureDecayTimerArmed();
     RequestApplyPreviewVisuals();
 }
 
@@ -6564,6 +6680,8 @@ void OnMinFocusTimerElapsed(MinFocusConfirmMode mode) {
             info.lastWindowTitle = pending.windowTitle;
         }
         info.lastHwnd = pending.hwnd;
+        info.lastPid = pending.processId ? pending.processId
+                                         : PidFromHwnd(pending.hwnd);
         info.classUpper = classUpper;
         info.appIdUpper = appIdUpper;
         info.lastConfirmedFocusTick = now;
@@ -6597,6 +6715,8 @@ void OnMinFocusTimerElapsed(MinFocusConfirmMode mode) {
                pending.windowTitle.c_str(),
                GuidToLogString(pending.desktopId).c_str());
     }
+
+    EnsureDecayTimerArmed();
 
     if (alsoConfirmPreviewWindow) {
         RequestApplyPreviewVisuals();
@@ -6884,6 +7004,7 @@ void OnDecayTimer() {
                windowsAfter);
         RequestApplyPreviewVisuals();
     }
+    StopDecayTimerIfIdle();
 }
 
 // ---------------------------------------------------------------------------
@@ -6937,6 +7058,10 @@ LRESULT CALLBACK HookThreadWndProc(HWND hWnd,
             RequestApplyVisuals();
             RequestApplyPreviewVisuals();
             return 0;
+        case WM_APP_PREVIEW_CLICK:
+            ConfirmPreviewFocusNow(reinterpret_cast<HWND>(wParam),
+                                   static_cast<DWORD>(lParam));
+            return 0;
         case WM_TIMER:
             if (wParam == kMinFocusTimerId) {
                 KillTimer(hWnd, kMinFocusTimerId);
@@ -6963,6 +7088,7 @@ LRESULT CALLBACK HookThreadWndProc(HWND hWnd,
 
 DWORD WINAPI WinEventHookThread(LPVOID /*param*/) {
     g_hookThreadId.store(GetCurrentThreadId(), std::memory_order_release);
+    g_decayTimerArmed.store(false);
 
     HMODULE hMod = nullptr;
     if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
@@ -7029,7 +7155,6 @@ DWORD WINAPI WinEventHookThread(LPVOID /*param*/) {
         Wh_Log(L"EVENT_SYSTEM_DESKTOPSWITCH hook installed");
     }
 
-    SetTimer(hwnd, kDecayTimerId, kDecayCheckIntervalMs, nullptr);
     RefreshCurrentDesktopId();
 
     if (HWND fg = GetForegroundWindow()) {
@@ -7060,6 +7185,7 @@ DWORD WINAPI WinEventHookThread(LPVOID /*param*/) {
     ReleaseVdm();
     UnsubscribeAccentChanges();
 
+    g_decayTimerArmed.store(false);
     g_hookThreadHwnd.store(nullptr, std::memory_order_release);
     DestroyWindow(hwnd);
     UnregisterClassW(wc.lpszClassName, wc.hInstance);
@@ -7353,7 +7479,7 @@ void LoadSettings() {
 // ---------------------------------------------------------------------------
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"> Taskbar Recent Focus Highlight init v0.9.4");
+    Wh_Log(L"> Taskbar Recent Focus Highlight init v0.9.6");
 
     g_unloading = false;
     LoadSettings();

--- a/mods/taskbar-recent-focus-highlight.wh.cpp
+++ b/mods/taskbar-recent-focus-highlight.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-recent-focus-highlight
 // @name            Taskbar Recent Focus Highlight
 // @description     Visually highlight the most recently focused running apps on the taskbar
-// @version         0.9.7
+// @version         0.9.8
 // @author          Jakub Vlášek
 // @github          https://github.com/jvlasek
 // @include         explorer.exe
@@ -254,6 +254,8 @@ to clear highlights.
       $description: >-
         How long a window must stay focused before it enters that flyout’s
         recency list. Separate from app ranking min focus (0 = immediate).
+        A click on a thumbnail or grouped-icon flyout confirms that window
+        immediately (does not wait this timer).
     - decayMinutes: 15
       $name: Decay (minutes)
       $description: >-
@@ -418,7 +420,7 @@ std::shared_ptr<const Settings> g_settingsPtr =
 
 std::shared_ptr<const Settings> SettingsSnap() {
     std::lock_guard<std::mutex> lock(g_settingsMutex);
-    return g_settingsPtr ? g_settingsPtr : std::make_shared<const Settings>();
+    return g_settingsPtr;
 }
 
 void PublishSettings(Settings s) {
@@ -548,12 +550,16 @@ struct ButtonPathCacheEntry {
     std::vector<HWND> groupHwnds;
     bool resolveAttempted = false;
     bool resolvedWhileRunning = false;  // re-resolve once on pinned → running
+    int emptyResolveAttempts = 0;  // capped while path and AUMID stay empty
     ULONGLONG lastResolveTick = 0;  // empty-identity retry throttle
     ULONGLONG lastRunningTick = 0;  // IsRunning grace (Alt-Tab flicker)
     // Last ApplyAllHighlights assignment: -1 unknown, 0 none, >0 1-based rank.
     int lastPaintRank = -1;
     uint32_t lastPaintSettingsGen = 0;
     uint32_t lastPaintAccent = 0;
+    TaskbarEdge lastPaintEdge = TaskbarEdge::Bottom;
+    int lastPaintBoxW = 0;
+    int lastPaintBoxH = 0;
     // ScaleTransform we applied for size boost. Clear only this instance so
     // other mods (taskbar-dock-animation) keep their hover scale.
     winrt::weak_ref<Media::ScaleTransform> ourIconScale;
@@ -697,6 +703,9 @@ constexpr ULONGLONG kIsRunningGraceMs = 400;
 constexpr ULONGLONG kFullRebindDebounceMs = 300;
 // Empty identity (pinned, no task item) is retried; successful path/AUMID is not.
 constexpr ULONGLONG kUnresolvedRetryMs = 2000;
+// Widgets / Copilot / never-resolving buttons: stop probing after this many
+// empty path+AUMID misses. Pinned→running still forces one more try.
+constexpr int kMaxEmptyResolveAttempts = 8;
 
 // All glow layers live on our overlay (never BackgroundElement — hover/active
 // storyboards own that and constantly wipe our styles).
@@ -742,6 +751,10 @@ struct IconPanelLayoutWatch {
     winrt::event_token sizeChanged{};
     TaskbarEdge lastEdge = TaskbarEdge::Bottom;
     bool haveEdge = false;
+    // Child names in IconPanel before we first moved natives. Restore this
+    // on clear so Taskbar Styler (or a custom template) gets its order back.
+    std::vector<std::wstring> nativeChildNames;
+    bool haveNativeOrder = false;
 };
 std::mutex g_layoutWatchMutex;
 std::unordered_map<void*, IconPanelLayoutWatch> g_layoutWatches;
@@ -1861,9 +1874,17 @@ struct PaintCacheState {
     int rank = -1;
     uint32_t settingsGen = 0;
     uint32_t accent = 0;
+    TaskbarEdge edge = TaskbarEdge::Bottom;
+    int boxW = 0;
+    int boxH = 0;
 };
 PaintCacheState GetCachedPaintState(FrameworkElement button);
-void SetCachedPaintState(FrameworkElement button, int rank, uint32_t gen);
+void SetCachedPaintState(FrameworkElement button,
+                         int rank,
+                         uint32_t gen,
+                         TaskbarEdge edge = TaskbarEdge::Bottom,
+                         int boxW = 0,
+                         int boxH = 0);
 void RememberOurIconScale(FrameworkElement button, Media::ScaleTransform scale);
 void ClearIconScaleIfOurs(FrameworkElement icon, FrameworkElement button);
 bool RunOnUiThread(const winrt::Windows::UI::Core::DispatchedHandler& handler);
@@ -2080,20 +2101,10 @@ int ScoreTitleToAutomationName(const std::wstring& windowTitle,
     return 0;
 }
 
-// Score this button against one ranked app. Path / AUMID / HWND only — no
-// automation-name fuzzy. 0 = no match. 1000 may bind the same rank to many
-// buttons (secondary taskbar).
-int ScoreButtonForRank(FrameworkElement button,
-                       const AppFocusInfo& info,
-                       bool requireRunning) {
-    if (!button) {
-        return 0;
-    }
-    if (requireRunning && !ButtonCountsAsRunning(button)) {
-        return 0;
-    }
-
-    const ButtonIdentity ident = GetCachedButtonIdentity(button);
+// Score a cached identity against one ranked app. Path / AUMID / HWND only.
+// 0 = no match. 1000 may bind the same rank to many buttons (secondary).
+int ScoreCachedIdentityForRank(const ButtonIdentity& ident,
+                               const AppFocusInfo& info) {
     const std::wstring& rankCls = info.classUpper;
 
     auto hwndOnButton = [&](HWND h) -> bool {
@@ -2145,6 +2156,18 @@ int ScoreButtonForRank(FrameworkElement button,
     return 0;
 }
 
+int ScoreButtonForRank(FrameworkElement button,
+                       const AppFocusInfo& info,
+                       bool requireRunning) {
+    if (!button) {
+        return 0;
+    }
+    if (requireRunning && !ButtonCountsAsRunning(button)) {
+        return 0;
+    }
+    return ScoreCachedIdentityForRank(GetCachedButtonIdentity(button), info);
+}
+
 // Best rank for a single button (1-based), or 0.
 int FindRankForButton(FrameworkElement button,
                       const std::vector<AppFocusInfo>& ranks,
@@ -2152,11 +2175,15 @@ int FindRankForButton(FrameworkElement button,
     if (!button || ranks.empty()) {
         return 0;
     }
+    if (requireRunning && !ButtonCountsAsRunning(button)) {
+        return 0;
+    }
 
+    const ButtonIdentity ident = GetCachedButtonIdentity(button);
     int bestRank = 0;
     int bestScore = 0;
     for (size_t i = 0; i < ranks.size(); i++) {
-        int s = ScoreButtonForRank(button, ranks[i], requireRunning);
+        int s = ScoreCachedIdentityForRank(ident, ranks[i]);
         if (s > bestScore) {
             bestScore = s;
             bestRank = static_cast<int>(i) + 1;
@@ -2462,6 +2489,48 @@ void EnsureOverlayIconAboveGlyph(FrameworkElement iconPanel) {
     }
 }
 
+void RememberNativeIconPanelOrder(FrameworkElement iconPanel) {
+    if (!iconPanel) {
+        return;
+    }
+    auto panel = iconPanel.try_as<Controls::Panel>();
+    if (!panel) {
+        return;
+    }
+    void* id = InspectableIdentity(iconPanel);
+    if (!id) {
+        return;
+    }
+    std::vector<std::wstring> names;
+    try {
+        auto children = panel.Children();
+        const uint32_t n = children.Size();
+        names.reserve(n);
+        for (uint32_t i = 0; i < n; ++i) {
+            auto fe = children.GetAt(i).try_as<FrameworkElement>();
+            if (!fe) {
+                continue;
+            }
+            std::wstring name = fe.Name().c_str();
+            if (name.empty() || name == kGlowElementName) {
+                continue;
+            }
+            names.push_back(std::move(name));
+        }
+    } catch (...) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
+    auto it = g_layoutWatches.find(id);
+    if (it == g_layoutWatches.end() ||
+        !WeakIsSameElement(it->second.panel, iconPanel) ||
+        it->second.haveNativeOrder) {
+        return;
+    }
+    it->second.nativeChildNames = std::move(names);
+    it->second.haveNativeOrder = true;
+}
+
 void RestoreIconPanelNativeZOrder(FrameworkElement iconPanel) {
     if (!iconPanel) {
         return;
@@ -2472,6 +2541,40 @@ void RestoreIconPanelNativeZOrder(FrameworkElement iconPanel) {
     }
     try {
         auto children = panel.Children();
+        std::vector<std::wstring> saved;
+        {
+            void* id = InspectableIdentity(iconPanel);
+            std::lock_guard<std::mutex> lock(g_layoutWatchMutex);
+            auto it = id ? g_layoutWatches.find(id) : g_layoutWatches.end();
+            if (it != g_layoutWatches.end() &&
+                WeakIsSameElement(it->second.panel, iconPanel) &&
+                it->second.haveNativeOrder) {
+                saved = it->second.nativeChildNames;
+            }
+        }
+        if (!saved.empty()) {
+            uint32_t dest = 0;
+            for (const auto& name : saved) {
+                auto el = FindChildByName(iconPanel, name.c_str());
+                if (!el) {
+                    continue;
+                }
+                uint32_t idx = 0;
+                if (!children.IndexOf(el, idx)) {
+                    continue;
+                }
+                if (idx != dest) {
+                    children.RemoveAt(idx);
+                    if (idx < dest) {
+                        --dest;
+                    }
+                    children.InsertAt(dest, el);
+                }
+                ++dest;
+            }
+            return;
+        }
+
         auto indexOfName = [&](PCWSTR name) -> int {
             auto el = FindChildByName(iconPanel, name);
             if (!el) {
@@ -2600,6 +2703,7 @@ Controls::Grid EnsureGlowHost(Controls::Panel panel,
     }
 
     if (!host) {
+        RememberNativeIconPanelOrder(iconPanel);
         PCWSTR xaml =
             LR"(
             <Grid
@@ -3231,17 +3335,6 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
         return;
     }
 
-    {
-        auto painted = GetCachedPaintState(button);
-        if (painted.rank == rankOneBased &&
-            painted.settingsGen == settings->generation &&
-            painted.accent ==
-                g_cachedAccent.load(std::memory_order_relaxed) &&
-            ButtonHasOurChrome(button)) {
-            return;
-        }
-    }
-
     try {
         auto iconPanel = GetIconPanel(button);
         if (!iconPanel) {
@@ -3252,6 +3345,29 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
         auto panel = iconPanel.try_as<Controls::Panel>();
         if (!panel) {
             return;
+        }
+
+        double panelW = iconPanel.ActualWidth();
+        double panelH = iconPanel.ActualHeight();
+        if (!(panelW > 1.0)) {
+            panelW = 44.0;
+        }
+        if (!(panelH > 1.0)) {
+            panelH = 44.0;
+        }
+        const TaskbarEdge edge = CachedTaskbarEdge(iconPanel);
+        const int boxWi = static_cast<int>(panelW + 0.5);
+        const int boxHi = static_cast<int>(panelH + 0.5);
+        {
+            auto painted = GetCachedPaintState(button);
+            if (painted.rank == rankOneBased &&
+                painted.settingsGen == settings->generation &&
+                painted.accent ==
+                    g_cachedAccent.load(std::memory_order_relaxed) &&
+                painted.edge == edge && painted.boxW == boxWi &&
+                painted.boxH == boxHi && ButtonHasOurChrome(button)) {
+                return;
+            }
         }
 
         const int rankIdx = rankOneBased - 1;
@@ -3281,15 +3397,6 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
         const int fillOpacitySetting =
             (std::max)(0, (std::min)(100, settings->glowFillOpacity));
 
-        double panelW = iconPanel.ActualWidth();
-        double panelH = iconPanel.ActualHeight();
-        if (!(panelW > 1.0)) {
-            panelW = 44.0;
-        }
-        if (!(panelH > 1.0)) {
-            panelH = 44.0;
-        }
-
         Controls::Grid host = EnsureGlowHost(panel, iconPanel);
         if (!host) {
             return;
@@ -3299,7 +3406,6 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
         double boxH = panelH;
         GlowContentBoxSize(host, iconPanel, panelW, panelH, boxW, boxH);
 
-        const TaskbarEdge edge = CachedTaskbarEdge(iconPanel);
         const BarSide barSide = BarSideForGlowStyle(style, edge);
 
         // Heal native stacking first (Discord overlay / leftover attention
@@ -3419,7 +3525,8 @@ void ApplyButtonHighlight(FrameworkElement button, int rankOneBased) {
                BarSideName(barSide), boxW, boxH, thickness,
                settings->glowRoundness, settings->glowSize, layers,
                intensity);
-        SetCachedPaintState(button, rankOneBased, settings->generation);
+        SetCachedPaintState(button, rankOneBased, settings->generation, edge,
+                            boxWi, boxHi);
     } catch (...) {
         HRESULT hr = winrt::to_hresult();
         Wh_Log(L"ApplyButtonHighlight error %08X", hr);
@@ -3742,7 +3849,9 @@ std::wstring EnsureButtonPathCached(FrameworkElement button, bool force) {
                 const bool haveIdentity = !it->second.pathUpper.empty() ||
                                           !it->second.appIdUpper.empty();
                 if (haveIdentity ||
-                    now - it->second.lastResolveTick < kUnresolvedRetryMs) {
+                    now - it->second.lastResolveTick < kUnresolvedRetryMs ||
+                    it->second.emptyResolveAttempts >=
+                        kMaxEmptyResolveAttempts) {
                     return it->second.pathUpper;
                 }
             }
@@ -3844,6 +3953,13 @@ std::wstring EnsureButtonPathCached(FrameworkElement button, bool force) {
             e->resolveAttempted = true;
             e->resolvedWhileRunning = running;
             e->lastResolveTick = now;
+            if (e->pathUpper.empty() && e->appIdUpper.empty()) {
+                if (e->emptyResolveAttempts < kMaxEmptyResolveAttempts) {
+                    ++e->emptyResolveAttempts;
+                }
+            } else {
+                e->emptyResolveAttempts = 0;
+            }
         }
         if (g_buttonPathCache.size() > 128) {
             for (auto it = g_buttonPathCache.begin();
@@ -3912,10 +4028,18 @@ PaintCacheState GetCachedPaintState(FrameworkElement button) {
     out.rank = it->second.lastPaintRank;
     out.settingsGen = it->second.lastPaintSettingsGen;
     out.accent = it->second.lastPaintAccent;
+    out.edge = it->second.lastPaintEdge;
+    out.boxW = it->second.lastPaintBoxW;
+    out.boxH = it->second.lastPaintBoxH;
     return out;
 }
 
-void SetCachedPaintState(FrameworkElement button, int rank, uint32_t gen) {
+void SetCachedPaintState(FrameworkElement button,
+                         int rank,
+                         uint32_t gen,
+                         TaskbarEdge edge,
+                         int boxW,
+                         int boxH) {
     if (!button) {
         return;
     }
@@ -3937,12 +4061,18 @@ void SetCachedPaintState(FrameworkElement button, int rank, uint32_t gen) {
         stub.lastPaintRank = rank;
         stub.lastPaintSettingsGen = gen;
         stub.lastPaintAccent = accent;
+        stub.lastPaintEdge = edge;
+        stub.lastPaintBoxW = boxW;
+        stub.lastPaintBoxH = boxH;
         g_buttonPathCache.emplace(id, std::move(stub));
         return;
     }
     it->second.lastPaintRank = rank;
     it->second.lastPaintSettingsGen = gen;
     it->second.lastPaintAccent = accent;
+    it->second.lastPaintEdge = edge;
+    it->second.lastPaintBoxW = boxW;
+    it->second.lastPaintBoxH = boxH;
 }
 
 void RememberOurIconScale(FrameworkElement button, Media::ScaleTransform scale) {
@@ -4103,10 +4233,19 @@ void ApplyAllHighlights_UIThread() {
     };
     std::vector<Cand> cands;
     std::vector<std::wstring> buttonPaths(live.size());
+    std::vector<ButtonIdentity> idents(live.size());
+    std::vector<char> running(live.size(), 0);
     for (size_t bi = 0; bi < live.size(); ++bi) {
         buttonPaths[bi] = EnsureButtonPathCached(live[bi], /*force=*/false);
+        running[bi] = ButtonCountsAsRunning(live[bi]) ? 1 : 0;
+        if (running[bi]) {
+            idents[bi] = GetCachedButtonIdentity(live[bi]);
+        }
         for (size_t ri = 0; ri < ranks.size(); ++ri) {
-            int s = ScoreButtonForRank(live[bi], ranks[ri], true);
+            if (!running[bi]) {
+                continue;
+            }
+            int s = ScoreCachedIdentityForRank(idents[bi], ranks[ri]);
             if (s >= kScoreExactIdentity) {
                 cands.push_back({ri, bi});
             }
@@ -7313,7 +7452,7 @@ void LoadSettings() {
     auto customColor =
         WindhawkUtils::StringSetting::make(L"icons.customGlowColor");
     s.customGlowColor =
-        customColor.get() && *customColor.get() ? customColor.get() : L"#00C853";
+        *customColor.get() ? customColor.get() : L"#00C853";
 
     s.glowIntensity[0] = Wh_GetIntSetting(L"icons.glowIntensityRank1");
     s.glowIntensity[1] = Wh_GetIntSetting(L"icons.glowIntensityRank2");
@@ -7456,7 +7595,7 @@ void LoadSettings() {
     for (int i = 0;; i++) {
         auto program =
             WindhawkUtils::StringSetting::make(L"excludedPrograms[%d]", i);
-        if (!program.get() || !*program.get()) {
+        if (!*program.get()) {
             break;
         }
         s.excludedPrograms.insert(ToUpper(program.get()));
@@ -7484,24 +7623,10 @@ void LoadSettings() {
 // ---------------------------------------------------------------------------
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"> Taskbar Recent Focus Highlight init v0.9.7");
+    Wh_Log(L"> Taskbar Recent Focus Highlight init v0.9.8");
 
     g_unloading = false;
     LoadSettings();
-
-    // Identity resolve (taskband) — optional; no path cache means no icon glow.
-    if (!HookTaskbarDllSymbols()) {
-        Wh_Log(L"Warning: taskbar.dll identity hooks failed — no icon path cache");
-    }
-
-    if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
-        g_taskbarViewDllLoaded = true;
-        if (!HookTaskbarViewDllSymbols(taskbarViewModule)) {
-            Wh_Log(L"Warning: Taskbar.View hooks failed — visuals unavailable");
-        }
-    } else {
-        Wh_Log(L"Taskbar view module not loaded yet");
-    }
 
     HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
     if (!kernelBaseModule) {
@@ -7517,6 +7642,20 @@ BOOL Wh_ModInit() {
     WindhawkUtils::SetFunctionHook(pKernelBaseLoadLibraryExW,
                                    LoadLibraryExW_Hook,
                                    &LoadLibraryExW_Original);
+
+    // Identity resolve (taskband) — optional; no path cache means no icon glow.
+    if (!HookTaskbarDllSymbols()) {
+        Wh_Log(L"Warning: taskbar.dll identity hooks failed — no icon path cache");
+    }
+
+    if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
+        g_taskbarViewDllLoaded = true;
+        if (!HookTaskbarViewDllSymbols(taskbarViewModule)) {
+            Wh_Log(L"Warning: Taskbar.View hooks failed — visuals unavailable");
+        }
+    } else {
+        Wh_Log(L"Taskbar view module not loaded yet");
+    }
 
     StartWinEventHookThread();
     return TRUE;

--- a/mods/taskbar-recent-focus-highlight.wh.cpp
+++ b/mods/taskbar-recent-focus-highlight.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-recent-focus-highlight
 // @name            Taskbar Recent Focus Highlight
 // @description     Visually highlight the most recently focused running apps on the taskbar
-// @version         0.9.6
+// @version         0.9.7
 // @author          Jakub Vlášek
 // @github          https://github.com/jvlasek
 // @include         explorer.exe
@@ -45,8 +45,9 @@ that flyout gets its own recency ladder (independent of icon ranks). The
 last focused window of that app is rank 1 in the flyout even if you used
 other apps more recently. Single-window flyouts are left alone.
 
-Preview styles: a thin bar under the title, a soft title tint, a whole-card
-plate, hybrid (plate for rank 1, title tint for the rest), or a ring.
+Preview styles (default **hybrid**): whole-card plate for rank 1 and a title
+tint for ranks 2+; or a thin bar under the title, a soft title tint, a
+whole-card plate, or a ring.
 
 ## Settings (short)
 
@@ -76,6 +77,10 @@ to clear highlights.
   app.
 - Verbose bind / preview-resolve lines go to Windhawk’s **Mod logs** (Advanced
   tab). There is no extra in-mod debug toggle.
+- Taskband identity resolve is adapted from
+  [taskbar-volume-control-per-app](https://github.com/ramensoftware/windhawk-mods/blob/main/mods/taskbar-volume-control-per-app.wh.cpp);
+  thumbnail HWND mapping from
+  [taskbar-thumbnail-reorder](https://github.com/ramensoftware/windhawk-mods/blob/main/mods/taskbar-thumbnail-reorder.wh.cpp).
 */
 // ==/WindhawkModReadme==
 
@@ -214,12 +219,12 @@ to clear highlights.
         Ranking is local to that flyout: the last focused window of this app is
         rank 1 even if other apps were used more recently. Set to 1 to mark only
         the latest window.
-    - style: titleBar
+    - style: plateTitle
       $name: Highlight style
       $description: >-
-        How to mark ranked windows. Title bar = thin line under the title.
+        How to mark ranked windows. Hybrid (default) = whole plate for rank 1,
+        title wash for ranks 2+. Title bar = thin line under the title.
         Title background = soft wash behind the title. Plate = tint the whole card.
-        Hybrid = whole plate for rank 1, title wash for ranks 2+.
         Ring = hollow border around the card.
       $options:
       - titleBar: Bar under window title
@@ -397,7 +402,7 @@ struct Settings {
     int previewIntensity[3] = {100, 70, 45};
     int previewMinFocusSeconds = 1;
     int previewDecayMinutes = 15;
-    PreviewStyle previewStyle = PreviewStyle::TitleBar;
+    PreviewStyle previewStyle = PreviewStyle::PlateTitle;
     std::unordered_set<std::wstring> excludedPrograms;
     // Bumped in PublishSettings so UVS can skip a no-op repaint.
     uint32_t generation = 0;
@@ -539,11 +544,10 @@ struct ButtonPathCacheEntry {
     std::wstring pathUpper;  // empty if resolve failed / not yet tried
     std::wstring appIdUpper;
     std::wstring classUpper;
-    std::wstring autoIdUpper;  // AutomationId, often "APPID: …"
-    DWORD pid = 0;
     HWND sampleHwnd = nullptr;  // sample from resolve; preview uses window map
     std::vector<HWND> groupHwnds;
     bool resolveAttempted = false;
+    bool resolvedWhileRunning = false;  // re-resolve once on pinned → running
     ULONGLONG lastResolveTick = 0;  // empty-identity retry throttle
     ULONGLONG lastRunningTick = 0;  // IsRunning grace (Alt-Tab flicker)
     // Last ApplyAllHighlights assignment: -1 unknown, 0 none, >0 1-based rank.
@@ -576,8 +580,8 @@ std::vector<winrt::weak_ref<FrameworkElement>> g_trackedThumbViews;
 
 std::atomic<bool> g_unloading{false};
 std::atomic<bool> g_taskbarViewDllLoaded{false};
-// After decay / empty ranks, force-clear overlays on next button touch if
-// RequestApplyVisuals couldn't run (sleep/wake, no dispatcher yet).
+// After decay / empty ranks / desktop switch: ApplyAllHighlights must visit
+// every button. UVS must not clear chrome just because this is set (flicker).
 std::atomic<bool> g_pendingOverlaySweep{false};
 std::atomic<bool> g_decayTimerArmed{false};
 
@@ -727,6 +731,7 @@ void OnMinFocusTimerElapsed(MinFocusConfirmMode mode = MinFocusConfirmMode::From
 void OnPreviewMinFocusTimerElapsed(
     MinFocusConfirmMode mode = MinFocusConfirmMode::FromTimer);
 void RequestApplyVisuals();
+void RequestApplyVisualsDebounced();
 void RequestApplyPreviewVisuals();
 void RefreshButtonHighlight(FrameworkElement button);
 void ScheduleRefreshAllHighlights(FrameworkElement dispatcherAnchor);
@@ -1479,9 +1484,7 @@ bool PathAppearsOnTaskbar(const std::wstring& keyOrPath,
     for (const auto& [cacheKey, e] : g_buttonPathCache) {
         (void)cacheKey;
         if (!wantAppId.empty()) {
-            std::wstring gotId =
-                e.appIdUpper.empty() ? e.autoIdUpper : e.appIdUpper;
-            if (CanonicalAppId(gotId) == wantAppId) {
+            if (CanonicalAppId(e.appIdUpper) == wantAppId) {
                 return true;
             }
         }
@@ -1850,8 +1853,6 @@ struct ButtonIdentity {
     std::wstring pathUpper;
     std::wstring appIdUpper;
     std::wstring classUpper;
-    std::wstring autoIdUpper;
-    DWORD pid = 0;
     HWND sampleHwnd = nullptr;
     std::vector<HWND> groupHwnds;
 };
@@ -2123,9 +2124,7 @@ int ScoreButtonForRank(FrameworkElement button,
 
     if (IsAppIdKey(info.key)) {
         const std::wstring want = AppIdFromAppKey(info.key);
-        std::wstring got =
-            ident.appIdUpper.empty() ? ident.autoIdUpper : ident.appIdUpper;
-        got = CanonicalAppId(got);
+        const std::wstring got = CanonicalAppId(ident.appIdUpper);
         if (!want.empty() && got == want) {
             return kScoreExactIdentity;
         }
@@ -3727,28 +3726,27 @@ std::wstring EnsureButtonPathCached(FrameworkElement button, bool force) {
     }
 
     const ULONGLONG now = GetTickCount64();
+    const bool running = TaskListButton_IsRunning(button);
     void* id = InspectableIdentity(button);
-    bool unresolvedRecent = false;
     {
         std::lock_guard<std::mutex> lock(g_buttonPathMutex);
         auto it = id ? g_buttonPathCache.find(id) : g_buttonPathCache.end();
         if (it != g_buttonPathCache.end()) {
             if (!WeakIsSameElement(it->second.button, button)) {
                 g_buttonPathCache.erase(it);
-            } else if (!force && it->second.resolveAttempted) {
+            } else if (!force && it->second.resolveAttempted &&
+                       !(running && !it->second.resolvedWhileRunning)) {
+                // AutomationId on a pinned button is not a finished Win32
+                // resolve (rank key is the image path). Re-resolve once when
+                // the same TaskListButton flips to running.
                 const bool haveIdentity = !it->second.pathUpper.empty() ||
                                           !it->second.appIdUpper.empty();
-                if (haveIdentity) {
+                if (haveIdentity ||
+                    now - it->second.lastResolveTick < kUnresolvedRetryMs) {
                     return it->second.pathUpper;
-                }
-                if (now - it->second.lastResolveTick < kUnresolvedRetryMs) {
-                    unresolvedRecent = true;
                 }
             }
         }
-    }
-    if (unresolvedRecent && !TaskListButton_IsRunning(button)) {
-        return {};
     }
 
     DWORD pid = 0;
@@ -3841,11 +3839,10 @@ std::wstring EnsureButtonPathCached(FrameworkElement button, bool force) {
             e->pathUpper = pathUpper;
             e->appIdUpper = appIdUpper;
             e->classUpper = classUpper;
-            e->autoIdUpper = autoIdUpper;
-            e->pid = pid;
             e->sampleHwnd = hwnd;
             e->groupHwnds = std::move(groupHwnds);
             e->resolveAttempted = true;
+            e->resolvedWhileRunning = running;
             e->lastResolveTick = now;
         }
         if (g_buttonPathCache.size() > 128) {
@@ -3892,8 +3889,6 @@ ButtonIdentity GetCachedButtonIdentity(FrameworkElement button) {
     out.pathUpper = e.pathUpper;
     out.appIdUpper = e.appIdUpper;
     out.classUpper = e.classUpper;
-    out.autoIdUpper = e.autoIdUpper;
-    out.pid = e.pid;
     out.sampleHwnd = e.sampleHwnd;
     out.groupHwnds = e.groupHwnds;
     return out;
@@ -4247,16 +4242,10 @@ void AddThumbnailTaskItemMapping(
 }
 
 HWND HwndFromMappingEntry(const ThumbnailTaskItemMapping& item) {
-    if (item.hwnd && IsWindow(item.hwnd)) {
-        return item.hwnd;
-    }
-    if (item.taskItem) {
-        HWND h = GetWindowFromTaskItem(item.taskItem);
-        if (h && IsWindow(h)) {
-            return h;
-        }
-    }
-    return nullptr;
+    // HWND was read in the ctor hook while taskItem was live. Do not
+    // dereference the raw ITaskItem* later — thumbnail-reorder only compares
+    // that pointer, and the native object is gone when IsWindow fails.
+    return (item.hwnd && IsWindow(item.hwnd)) ? item.hwnd : nullptr;
 }
 
 // True if two WinRT objects are the same COM identity (different projections
@@ -5134,14 +5123,26 @@ void SchedulePreviewFlyoutRefresh(FrameworkElement dispatcherAnchor) {
             g_previewFlyoutRefreshPending = false;
             return;
         }
+        winrt::weak_ref<FrameworkElement> weak =
+            winrt::make_weak(dispatcherAnchor);
         dispatcher.RunAsync(
-            winrt::Windows::UI::Core::CoreDispatcherPriority::Low, []() {
+            winrt::Windows::UI::Core::CoreDispatcherPriority::Low, [weak]() {
                 g_previewFlyoutRefreshPending = false;
                 try {
                     if (g_unloading.load()) {
                         return;
                     }
-                    FrameworkElement el = PickLiveFlyoutThumbOnThisDispatcher();
+                    FrameworkElement el = nullptr;
+                    try {
+                        el = weak.get();
+                    } catch (...) {
+                    }
+                    if (el && !FindAncestorItemsRepeater(el)) {
+                        el = nullptr;
+                    }
+                    if (!el) {
+                        el = PickLiveFlyoutThumbOnThisDispatcher();
+                    }
                     if (!el) {
                         return;
                     }
@@ -5547,7 +5548,6 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
                        nRepeater, thumbCount);
             }
             size_t si = 0;
-            int windowOrdinal = 0;
             for (size_t ri = 0; ri < allViews.size() && si < siblings.size();
                  ++ri) {
                 if (IsSnapGroupThumbnailView(allViews[ri])) {
@@ -5557,7 +5557,8 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
                     (ri < repeaterSourceIndex.size())
                         ? repeaterSourceIndex[ri]
                         : static_cast<int>(ri);
-                const int getAtIndex = compactSnap ? windowOrdinal : srcIndex;
+                const int getAtIndex =
+                    compactSnap ? static_cast<int>(si) : srcIndex;
                 HWND hwnd = HwndFromThumbnailsGetAt(getAtIndex);
                 if (hwnd && IsWindow(hwnd) && !usedHwnds.count(hwnd)) {
                     stampRecency(si, hwnd);
@@ -5565,7 +5566,6 @@ void RefreshThumbnailFlyout_UIThread(FrameworkElement anyThumb) {
                     usedHwnds.insert(hwnd);
                 }
                 ++si;
-                ++windowOrdinal;
             }
         }
     }
@@ -5880,6 +5880,13 @@ void RequestApplyVisuals() {
     }
 }
 
+void RequestApplyVisualsDebounced() {
+    if (g_unloading.load()) {
+        return;
+    }
+    PostToHookThread(WM_APP_REQUEST_APPLY_DEBOUNCED);
+}
+
 // ---------------------------------------------------------------------------
 // Taskbar.View.dll hooks
 // ---------------------------------------------------------------------------
@@ -5903,11 +5910,8 @@ void RefreshButtonHighlight(FrameworkElement button) {
         return;
     }
 
-    if (g_pendingOverlaySweep.load()) {
-        ClearButtonHighlight(button);
-        return;
-    }
-
+    // Sweep is ApplyAllHighlights. Clearing here blanks ranked icons until
+    // that pass (desktop switch / decay flicker).
     int rank = GetCachedPaintState(button).rank;
     if (rank < 0) {
         std::vector<AppFocusInfo> ranks;
@@ -6824,7 +6828,7 @@ void HandleForegroundChanged(HWND hWnd) {
             ranksNonEmpty = !CurrentDeskLocked().rankedApps.empty();
         }
         if (ranksNonEmpty) {
-            RequestApplyVisuals();
+            RequestApplyVisualsDebounced();
         }
         return;
     }
@@ -6862,7 +6866,7 @@ void HandleForegroundChanged(HWND hWnd) {
         }
         // Still repaint ranks — taskbar active states changed.
         if (ranksNonEmpty) {
-            RequestApplyVisuals();
+            RequestApplyVisualsDebounced();
         }
         return;
     }
@@ -6895,8 +6899,9 @@ void HandleForegroundChanged(HWND hWnd) {
 
     // Always repaint existing ranks on any focus change (Alt-Tab must not
     // leave other ranked icons unstyled until the min-focus timer fires).
+    // Debounce: transient FG + landed app would otherwise full-rebind twice.
     if (ranksNonEmpty || alreadyTracked) {
-        RequestApplyVisuals();
+        RequestApplyVisualsDebounced();
     }
 
     bool sameAppPending = false;
@@ -7434,17 +7439,17 @@ void LoadSettings() {
     }
 
     auto previewStyle = WindhawkUtils::StringSetting::make(L"previews.style");
-    s.previewStyle = PreviewStyle::TitleBar;
+    s.previewStyle = PreviewStyle::PlateTitle;
     if (wcscmp(previewStyle.get(), L"ring") == 0) {
         s.previewStyle = PreviewStyle::Ring;
     } else if (wcscmp(previewStyle.get(), L"titleBg") == 0) {
         s.previewStyle = PreviewStyle::TitleBg;
     } else if (wcscmp(previewStyle.get(), L"plate") == 0) {
         s.previewStyle = PreviewStyle::Plate;
-    } else if (wcscmp(previewStyle.get(), L"plateTitle") == 0) {
-        s.previewStyle = PreviewStyle::PlateTitle;
     } else if (wcscmp(previewStyle.get(), L"titleBar") == 0) {
         s.previewStyle = PreviewStyle::TitleBar;
+    } else if (wcscmp(previewStyle.get(), L"plateTitle") == 0) {
+        s.previewStyle = PreviewStyle::PlateTitle;
     }
 
     s.excludedPrograms.clear();
@@ -7479,7 +7484,7 @@ void LoadSettings() {
 // ---------------------------------------------------------------------------
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"> Taskbar Recent Focus Highlight init v0.9.6");
+    Wh_Log(L"> Taskbar Recent Focus Highlight init v0.9.7");
 
     g_unloading = false;
     LoadSettings();


### PR DESCRIPTION
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->
taskbar-recent-focus-highlight.wh.cpp
## taskbar-recent-focus-highlight
This mod highlights taskbar icons of recently focused apps and also highlights the recently focused windows inside the preview flyout. 

## Screenshots
Configured with left bar highlighting last 3 apps:
<img width="629" height="37" alt="image" src="https://github.com/user-attachments/assets/01b5a9f3-0086-453b-ba70-64f1c666c28b" />

Preview pane highlighting the last focused (right) and the one before (left) window inside the preview flyout:  
<img width="274" height="167" alt="image" src="https://github.com/user-attachments/assets/0cf57edb-ce0a-418f-98b9-dc99c40229f4" />

## Mod authorship

This mod was created by:
- - [X] Another AI (please specify):  Grok Build
