### PR TITLE
On-Screen Indicator Position 1.2.7

### DIFF
--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Put the volume, brightness and camera on-screen indicators anywhere on the screen, each in its own spot if you like, instead of the three positions Windows offers
-// @version         1.2.6
+// @version         1.2.7
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -446,11 +446,16 @@ char WINAPI ShowCameraAccessEnabledAsync_Hook(void* pThis, bool value) {
     return ShowCameraAccessEnabledAsync_Original(pThis, value);
 }
 
-using ShowMicrophoneMutedAsync_t = char(WINAPI*)(void* pThis, int value);
+// This one takes a message alongside the state on current builds and took only
+// the state on older ones. Declared with the extra parameter for both, since the
+// build that doesn't take it never reads the register it arrives in.
+using ShowMicrophoneMutedAsync_t = char(WINAPI*)(void* pThis,
+                                                 int value,
+                                                 void* text);
 ShowMicrophoneMutedAsync_t ShowMicrophoneMutedAsync_Original;
-char WINAPI ShowMicrophoneMutedAsync_Hook(void* pThis, int value) {
+char WINAPI ShowMicrophoneMutedAsync_Hook(void* pThis, int value, void* text) {
     g_currentIndicator.store(Indicator::microphone);
-    return ShowMicrophoneMutedAsync_Original(pThis, value);
+    return ShowMicrophoneMutedAsync_Original(pThis, value, text);
 }
 
 using ShowTextAsync_t = char(WINAPI*)(void* pThis, void* text, bool value);
@@ -660,7 +665,9 @@ BOOL Wh_ModInit() {
             true,  // optional
         },
         {
-            {LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowMicrophoneMutedAsync(enum winrt::Windows::Internal::HardwareConfirmator::MicrophoneMuteState))",
+            {LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowMicrophoneMutedAsync(enum winrt::Windows::Internal::HardwareConfirmator::MicrophoneMuteState,struct winrt::hstring))",
+             LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowMicrophoneMutedAsync(enum winrt::HWConfirmatorUI::MicrophoneMuteState,struct winrt::hstring))",
+             LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowMicrophoneMutedAsync(enum winrt::Windows::Internal::HardwareConfirmator::MicrophoneMuteState))",
              LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowMicrophoneMutedAsync(enum winrt::HWConfirmatorUI::MicrophoneMuteState))"},
             &ShowMicrophoneMutedAsync_Original,
             ShowMicrophoneMutedAsync_Hook,

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -96,8 +96,8 @@ both target the same function and work out the origin handling.
 - position: topRight
   $name: Position
   $description: >-
-    Where on the screen the indicator appears. Anything left on Same as the main
-    position below follows this one.
+    Where on the screen the indicator appears. Anything left on "Same as the main
+    position" below follows this one.
   $options:
   - windowsDefault: Windows default (only apply the offsets)
   - topLeft: Top left
@@ -453,7 +453,10 @@ char WINAPI ShowCameraAccessEnabledAsync_Hook(void* pThis, bool value) {
 
 // This one takes a message alongside the state on current builds and took only
 // the state on older ones. Declared with the extra parameter for both, since the
-// build that doesn't take it never reads the register it arrives in.
+// build that doesn't take it never reads the register it arrives in. That holds
+// because the mod is x86-64 only and the caller does the cleaning up. On a
+// 32-bit stdcall build the callee pops its own arguments and the same mismatch
+// would walk the stack.
 using ShowMicrophoneMutedAsync_t = char(WINAPI*)(void* pThis,
                                                  int value,
                                                  void* text);
@@ -478,7 +481,7 @@ WinrtRect* WINAPI
 HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
                                              WinrtRect* retval,
                                              const WinrtRect* rect) {
-    Wh_Log(L">");
+    Wh_Log(L"> indicator=%d", (int)g_currentIndicator.load());
 
     // Read the offsets once so the placement below uses one consistent pair.
     int offsetSettingX = g_settings.offsetX.load();
@@ -712,11 +715,15 @@ BOOL Wh_ModInit() {
 
     for (const void* recorder : kindRecorders) {
         if (!recorder) {
-            Wh_Log(
-                L"An indicator entry point didn't resolve, so the position "
-                L"per indicator settings are ignored and everything uses "
-                L"the main position");
             g_kindUnreliable = true;
+            // Only worth saying to someone who has an override set. With the
+            // shipped defaults there is nothing being ignored to complain about.
+            if (anyPerIndicator) {
+                Wh_Log(
+                    L"An indicator entry point didn't resolve, so the position "
+                    L"per indicator settings are ignored and everything uses "
+                    L"the main position");
+            }
             break;
         }
     }

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -454,9 +454,9 @@ char WINAPI ShowCameraAccessEnabledAsync_Hook(void* pThis, bool value) {
 // This one takes a message alongside the state on current builds and took only
 // the state on older ones. Declared with the extra parameter for both, since the
 // build that doesn't take it never reads the register it arrives in. That holds
-// because the mod is x86-64 only and the caller does the cleaning up. On a
-// 32-bit stdcall build the callee pops its own arguments and the same mismatch
-// would walk the stack.
+// because the mod is 64-bit only, x64 and arm64 both, where arguments go in
+// registers and the caller does the cleaning up. On a 32-bit stdcall build the
+// callee pops its own arguments and the same mismatch would walk the stack.
 using ShowMicrophoneMutedAsync_t = char(WINAPI*)(void* pThis,
                                                  int value,
                                                  void* text);
@@ -749,4 +749,13 @@ void Wh_ModSettingsChanged() {
     // Every hook is installed either way now, so nothing here needs a reload and
     // a change takes effect on the next indicator.
     LoadSettings();
+
+    // Turning on the first override no longer re-runs Wh_ModInit, so this is the
+    // only place the person it concerns can still be told.
+    if (g_kindUnreliable && AnyPerIndicator()) {
+        Wh_Log(
+            L"An indicator entry point didn't resolve, so the position "
+            L"per indicator settings are ignored and everything uses "
+            L"the main position");
+    }
 }

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -76,6 +76,9 @@ a monitor by number or by interface name. The two work together.
 * Offsets are given at 100% scaling and scaled to whichever monitor the
   indicator appears on, so the same value moves the same distance on a display
   running at 150%.
+* With two indicators set to different spots you can catch the previous one
+  flashing at the new spot for a frame before the new one draws. That's the
+  confirmator reusing its frame, the placement hook can't do anything about it.
 * Tested on Windows 11 build 26200 (25H2) x64, on a 100% and a 150% display.
 
 ## Credits
@@ -92,7 +95,9 @@ both target the same function and work out the origin handling.
 /*
 - position: topRight
   $name: Position
-  $description: Where on the screen the indicator appears
+  $description: >-
+    Where on the screen the indicator appears. Anything left on Same as the main
+    position below follows this one.
   $options:
   - windowsDefault: Windows default (only apply the offsets)
   - topLeft: Top left
@@ -285,7 +290,6 @@ struct {
     std::atomic<Position> perIndicator[(size_t)Indicator::count];
 } g_settings;
 
-// The position to place the indicator that is being shown right now.
 bool AnyPerIndicator() {
     for (size_t i = 0; i < (size_t)Indicator::count; i++) {
         if (g_settings.perIndicator[i].load() != Position::windowsDefault) {
@@ -296,6 +300,7 @@ bool AnyPerIndicator() {
     return false;
 }
 
+// The position to place the indicator that is being shown right now.
 Position CurrentPosition() {
     if (g_kindUnreliable.load()) {
         return g_settings.position.load();
@@ -675,15 +680,18 @@ BOOL Wh_ModInit() {
         },
     };
 
-    // The placement hook is the first entry and is always needed. The eight that
-    // record which kind is being shown only matter when a kind has a spot of its
-    // own, and with the shipped defaults none does, so they aren't installed at
-    // all rather than patching eight entry points to write a value that would be
-    // thrown away.
-    size_t hookCount = anyPerIndicator ? ARRAYSIZE(symbolHooks) : 1;
-
-    if (!HookSymbols(g_hardwareConfirmatorModule, symbolHooks, hookCount)) {
+    // All nine go in every time. The eight that record which kind is being shown
+    // are coroutine ramps that store a value and tail-call the original, so
+    // patching them when no kind has a spot of its own costs nothing worth
+    // measuring, and installing the same set every time keeps the symbol cache
+    // from being resolved again the first time someone turns an override on.
+    if (!HookSymbols(g_hardwareConfirmatorModule, symbolHooks,
+                     ARRAYSIZE(symbolHooks))) {
         Wh_Log(L"HookSymbols failed");
+        // Wh_ModUninit doesn't run when Wh_ModInit returns FALSE, so the
+        // reference taken above has to go back here.
+        FreeLibrary(g_hardwareConfirmatorModule);
+        g_hardwareConfirmatorModule = nullptr;
         return FALSE;
     }
 
@@ -691,27 +699,25 @@ BOOL Wh_ModInit() {
     // a null here means that kind would never be recorded and every kind after
     // it would be placed using a stale one. Rather than misplace an indicator,
     // drop to the main position for everything and say so in the log.
-    if (anyPerIndicator) {
-        const void* kindRecorders[] = {
-            (void*)ShowVolumeAsync_Original,
-            (void*)ShowBrightnessAsync_Original,
-            (void*)ShowKeyboardBrightnessAsync_Original,
-            (void*)ShowAirplaneModeOnAsync_Original,
-            (void*)ShowCameraOnAsync_Original,
-            (void*)ShowCameraAccessEnabledAsync_Original,
-            (void*)ShowMicrophoneMutedAsync_Original,
-            (void*)ShowTextAsync_Original,
-        };
+    const void* kindRecorders[] = {
+        (void*)ShowVolumeAsync_Original,
+        (void*)ShowBrightnessAsync_Original,
+        (void*)ShowKeyboardBrightnessAsync_Original,
+        (void*)ShowAirplaneModeOnAsync_Original,
+        (void*)ShowCameraOnAsync_Original,
+        (void*)ShowCameraAccessEnabledAsync_Original,
+        (void*)ShowMicrophoneMutedAsync_Original,
+        (void*)ShowTextAsync_Original,
+    };
 
-        for (const void* recorder : kindRecorders) {
-            if (!recorder) {
-                Wh_Log(
-                    L"An indicator entry point didn't resolve, so the position "
-                    L"per indicator settings are ignored and everything uses "
-                    L"the main position");
-                g_kindUnreliable = true;
-                break;
-            }
+    for (const void* recorder : kindRecorders) {
+        if (!recorder) {
+            Wh_Log(
+                L"An indicator entry point didn't resolve, so the position "
+                L"per indicator settings are ignored and everything uses "
+                L"the main position");
+            g_kindUnreliable = true;
+            break;
         }
     }
 
@@ -730,15 +736,10 @@ void Wh_ModUninit() {
     }
 }
 
-BOOL Wh_ModSettingsChanged(BOOL* bReload) {
+void Wh_ModSettingsChanged() {
     Wh_Log(L">");
 
-    // Whether the kind recorders are installed is decided in Wh_ModInit, so
-    // turning the first override on, or the last one off, needs a reload to
-    // match. Everything else takes effect on the next indicator.
-    bool hadPerIndicator = AnyPerIndicator();
+    // Every hook is installed either way now, so nothing here needs a reload and
+    // a change takes effect on the next indicator.
     LoadSettings();
-    *bReload = AnyPerIndicator() != hadPerIndicator;
-
-    return TRUE;
 }


### PR DESCRIPTION
the mic hook name is wrong, there's an hstring after the state and there has been since 22H2, so it was never resolving. checked a few pdbs going back to 22621 and they're all the same shape, so this isn't just my build, per indicator has been broken for everyone since 1.2.6.

since it's one of the kind recorders, not resolving means the whole per indicator thing shuts off for the session. mine was on windows default for the main position so nothing got placed at all and it looked like the mod had died.

left the old names in behind the new ones. never found a build with them but they're free.

one thing i can't vouch for, the mic key on this laptop is oem handled so it never reaches windows. volume and brightness are what tell me the recorders resolve now.

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Fixes the per indicator positions, which have not worked at all since 1.2.6. Everything was falling back to the main position instead.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
