### PR TITLE
On-Screen Indicator Position 1.4.0

### DIFF
--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -331,6 +331,16 @@ void LogKindUnreliable() {
         L"the main position");
 }
 
+// Set when either half of the hide pair didn't resolve, which leaves the skip
+// setting with nothing to do.
+std::atomic<bool> g_hideAnimationUnavailable{false};
+
+void LogHideAnimationUnavailable() {
+    Wh_Log(
+        L"The hide entry points didn't resolve, so the slide out animation "
+        L"is left alone");
+}
+
 // The position to place the indicator that is being shown right now.
 Position CurrentPosition() {
     if (g_kindUnreliable.load()) {
@@ -502,7 +512,12 @@ char WINAPI ShowMicrophoneMutedAsync_Hook(void* pThis, int value, void* text) {
 // animation and nothing outside this control is touched.
 using ConfirmatorHostControl_Hide_t = void(WINAPI*)(void* pThis);
 ConfirmatorHostControl_Hide_t ConfirmatorHostControl_Hide_Original;
-ConfirmatorHostControl_Hide_t ConfirmatorHostControl_HideWithoutAnimation_Original;
+
+// Same shape as the one above today, declared separately so a drift in one doesn't
+// quietly redefine the other.
+using ConfirmatorHostControl_HideWithoutAnimation_t = void(WINAPI*)(void* pThis);
+ConfirmatorHostControl_HideWithoutAnimation_t
+    ConfirmatorHostControl_HideWithoutAnimation_Original;
 void WINAPI ConfirmatorHostControl_Hide_Hook(void* pThis) {
     if (g_settings.skipHideAnimation.load() &&
         ConfirmatorHostControl_HideWithoutAnimation_Original) {
@@ -566,10 +581,20 @@ HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
     WinrtRect* result = HardwareConfirmatorHost_GetPositionRect_Original(
         pThis, retval, &shiftedRect);
 
-    if (result) {
-        PlaceInArea(shiftedRect, CurrentPosition(), offsetSettingX,
-                    offsetSettingY, result);
+    // Someone who only wants the animation setting gets here with nothing to
+    // place, and the edge clamp inside PlaceInArea would still be free to move the
+    // indicator off the spot Windows picked. The shift above stays either way,
+    // since the original needs it.
+    Position position = CurrentPosition();
+    bool anyPlacement = position != Position::windowsDefault || offsetSettingX ||
+                        offsetSettingY;
 
+    if (result && anyPlacement) {
+        PlaceInArea(shiftedRect, position, offsetSettingX, offsetSettingY,
+                    result);
+    }
+
+    if (result) {
         // Shift the result back.
         result->X += offsetX;
         result->Y += offsetY;
@@ -774,6 +799,14 @@ BOOL Wh_ModInit() {
         (void*)ShowTextAsync_Original,
     };
 
+    if (!ConfirmatorHostControl_Hide_Original ||
+        !ConfirmatorHostControl_HideWithoutAnimation_Original) {
+        g_hideAnimationUnavailable = true;
+        if (g_settings.skipHideAnimation) {
+            LogHideAnimationUnavailable();
+        }
+    }
+
     for (const void* recorder : kindRecorders) {
         if (!recorder) {
             g_kindUnreliable = true;
@@ -812,5 +845,9 @@ void Wh_ModSettingsChanged() {
     // only place the person it concerns can still be told.
     if (g_kindUnreliable && AnyPerIndicator()) {
         LogKindUnreliable();
+    }
+
+    if (g_hideAnimationUnavailable && g_settings.skipHideAnimation) {
+        LogHideAnimationUnavailable();
     }
 }

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -1,7 +1,7 @@
 // ==WindhawkMod==
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
-// @description     Put the volume, brightness and camera on-screen indicators anywhere on the screen, each in its own spot if you like, instead of the three positions Windows offers
+// @description     Put the volume, brightness and camera on-screen indicators anywhere on the screen, each in its own spot if you like, instead of the three positions Windows offers, and skip the slide out animation
 // @version         1.3.0
 // @author          mario0318
 // @github          https://github.com/mario0318

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -87,6 +87,9 @@ a monitor by number or by interface name. The two work together.
 * With two indicators set to different spots you can catch the previous one
   flashing at the new spot for a frame before the new one draws. That's the
   confirmator reusing its frame, the placement hook can't do anything about it.
+  Skipping the slide out makes it easier to catch rather than harder, since what
+  lands at the new spot is the tail end of the previous indicator instead of an
+  empty frame.
 * Tested on Windows 11 build 26200 (25H2) x64, on a 100% and a 150% display.
 
 ## Credits

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -7,7 +7,7 @@
 // @github          https://github.com/mario0318
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lshcore
+// @compilerOptions -lshcore -lole32 -loleaut32 -lruntimeobject
 // ==/WindhawkMod==
 
 // Source code is published under The GNU General Public License v3.0.
@@ -60,6 +60,17 @@ ever on screen at a time, so this is the same desktop photographed twice:
 
 ![Volume top left, brightness center](https://raw.githubusercontent.com/mario0318/windhawk-mods/628f80317652209d3feed54eadf9c329e77b04a7/on-screen-indicator-position/per-indicator.jpg)
 
+## How long it stays, and the sliding
+
+**Seconds on screen** changes how long the indicator waits before hiding itself.
+Leave it at 0 and Windows decides, same as before.
+
+**Skip the slide in animation** and **Skip the slide out animation** do what they
+say. The indicator appears and disappears in place instead of sliding. They are
+separate settings since you might want one and not the other. Neither one touches
+anything outside the indicator, so other mods and the rest of the shell animate
+exactly as they did.
+
 ## Choosing a monitor
 
 This mod only changes where the indicator sits on a screen, not which screen it
@@ -72,7 +83,8 @@ a monitor by number or by interface name. The two work together.
 * The slide-in animation direction is chosen by Windows from the built-in
   setting, not by this mod. If the animation looks wrong for your new position,
   change the built-in setting to whichever of the three has the animation you
-  like, then let this mod do the actual placement.
+  like, then let this mod do the actual placement, or skip the animation
+  altogether with the setting above.
 * Offsets are given at 100% scaling and scaled to whichever monitor the
   indicator appears on, so the same value moves the same distance on a display
   running at 150%.
@@ -130,6 +142,11 @@ both target the same function and work out the origin handling.
   $description: >-
     How long the indicator stays before it hides itself. 0 keeps whatever Windows
     uses. Anything from 1 to 60 is accepted.
+- skipShowAnimation: false
+  $name: Skip the slide in animation
+  $description: >-
+    The indicator appears where it is going to sit instead of sliding in. The
+    slide out is a separate setting below.
 - skipHideAnimation: false
   $name: Skip the slide out animation
   $description: >-
@@ -239,6 +256,11 @@ both target the same function and work out the origin handling.
 
 #include <shellscalingapi.h>
 
+// winbase.h defines GetCurrentTime, which collides with the WinRT headers.
+#undef GetCurrentTime
+#include <winrt/base.h>
+#include <winrt/Windows.Foundation.h>
+
 #include <atomic>
 
 enum class Position {
@@ -295,6 +317,7 @@ struct {
     std::atomic<int> offsetX;
     std::atomic<int> offsetY;
     std::atomic<int> durationSeconds;
+    std::atomic<bool> skipShowAnimation;
     std::atomic<bool> skipHideAnimation;
     // Position::windowsDefault means "no override", so the main position is used.
     // It is never offered as a per-indicator choice, which leaves it free to be
@@ -552,6 +575,36 @@ BOOL WINAPI SetThreadpoolTimerEx_Hook(PTP_TIMER timer,
     return SetThreadpoolTimerEx_Original(timer, dueTime, period, windowLength);
 }
 
+// The two values AnimateConfirmator is called with. 0 arrives as the indicator is
+// shown and 1 as it is hidden, which is what the log said on 26200 and is all the
+// stripped pdb will support, since it carries no enumerator names.
+constexpr int kAnimationShow = 0;
+
+// Handed back in place of the animation the caller was going to await. It is
+// already complete, so the await returns at once and nothing is animated.
+winrt::Windows::Foundation::IAsyncAction CompletedAction() {
+    co_return;
+}
+
+// IAsyncAction is returned by value and isn't trivially copyable, so it comes back
+// through a hidden pointer, the same shape GetPositionRect's Rect uses. The
+// interface is one COM pointer, so detaching the completed action into that slot
+// hands the caller an object it owns and will release.
+using AnimateConfirmator_t = void*(WINAPI*)(void* pThis,
+                                            void* retval,
+                                            int animation);
+AnimateConfirmator_t AnimateConfirmator_Original;
+void* WINAPI AnimateConfirmator_Hook(void* pThis,
+                                     void* retval,
+                                     int animation) {
+    if (animation == kAnimationShow && g_settings.skipShowAnimation.load()) {
+        *(void**)retval = winrt::detach_abi(CompletedAction());
+        return retval;
+    }
+
+    return AnimateConfirmator_Original(pThis, retval, animation);
+}
+
 // The control hides itself two ways and Windows picks the animated one. Handing the
 // call to the other is the whole feature, so nothing has to be torn out of the
 // animation and nothing outside this control is touched.
@@ -684,6 +737,7 @@ void LoadSettings() {
     int seconds = Wh_GetIntSetting(L"durationSeconds");
     g_settings.durationSeconds = (seconds >= 1 && seconds <= 60) ? seconds : 0;
 
+    g_settings.skipShowAnimation = Wh_GetIntSetting(L"skipShowAnimation");
     g_settings.skipHideAnimation = Wh_GetIntSetting(L"skipHideAnimation");
 
     static const PCWSTR kIndicatorSettings[] = {
@@ -719,7 +773,8 @@ BOOL Wh_ModInit() {
 
     if (g_settings.position == Position::windowsDefault && !anyPerIndicator &&
         !g_settings.offsetX && !g_settings.offsetY &&
-        !g_settings.durationSeconds && !g_settings.skipHideAnimation) {
+        !g_settings.durationSeconds && !g_settings.skipShowAnimation &&
+        !g_settings.skipHideAnimation) {
         Wh_Log(L"Nothing to do");
         return FALSE;
     }
@@ -788,6 +843,12 @@ BOOL Wh_ModInit() {
              LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowMicrophoneMutedAsync(enum winrt::HWConfirmatorUI::MicrophoneMuteState))"},
             &ShowMicrophoneMutedAsync_Original,
             ShowMicrophoneMutedAsync_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(private: struct winrt::Windows::Foundation::IAsyncAction __cdecl winrt::HWConfirmatorUI::implementation::ConfirmatorHostControl::AnimateConfirmator(enum winrt::HWConfirmatorUI::ConfirmatorAnimation))"},
+            &AnimateConfirmator_Original,
+            AnimateConfirmator_Hook,
             true,  // optional
         },
         {

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -1,7 +1,7 @@
 // ==WindhawkMod==
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
-// @description     Put the volume, brightness and camera on-screen indicators anywhere on the screen, each in its own spot if you like, instead of the three positions Windows offers, and skip the slide out animation
+// @description     Put the volume, brightness and camera on-screen indicators anywhere on the screen, each in its own spot if you like, instead of the three positions Windows offers
 // @version         1.3.0
 // @author          mario0318
 // @github          https://github.com/mario0318
@@ -60,14 +60,6 @@ ever on screen at a time, so this is the same desktop photographed twice:
 
 ![Volume top left, brightness center](https://raw.githubusercontent.com/mario0318/windhawk-mods/628f80317652209d3feed54eadf9c329e77b04a7/on-screen-indicator-position/per-indicator.jpg)
 
-## The slide out
-
-**Skip the slide out animation** makes the indicator disappear instead of sliding
-away, which is the half of it you tend to notice, since that is what keeps it
-hanging around. Windows has its own no animation path for hiding and the mod asks
-for that one, so nothing outside the indicator is affected and the sliding in is
-left alone.
-
 ## Choosing a monitor
 
 This mod only changes where the indicator sits on a screen, not which screen it
@@ -77,6 +69,9 @@ a monitor by number or by interface name. The two work together.
 
 ## Notes
 
+* **Skip the slide out animation** has the indicator disappear rather than slide
+  away. Windows has its own no animation path for hiding and the mod asks for that
+  one, so the sliding in and everything outside the indicator are left alone.
 * The slide-in animation direction is chosen by Windows from the built-in
   setting, not by this mod. If the animation looks wrong for your new position,
   change the built-in setting to whichever of the three has the animation you
@@ -134,8 +129,7 @@ both target the same function and work out the origin handling.
     the same number moves it the same distance on any display.
 - skipHideAnimation: false
   $name: Skip the slide out animation
-  $description: >-
-    The indicator disappears instead of sliding away.
+  $description: The indicator disappears instead of sliding away.
 - perIndicator:
   - volume: same
     $name: Volume
@@ -510,6 +504,13 @@ char WINAPI ShowMicrophoneMutedAsync_Hook(void* pThis, int value, void* text) {
     return ShowMicrophoneMutedAsync_Original(pThis, value, text);
 }
 
+using ShowTextAsync_t = char(WINAPI*)(void* pThis, void* text, bool value);
+ShowTextAsync_t ShowTextAsync_Original;
+char WINAPI ShowTextAsync_Hook(void* pThis, void* text, bool value) {
+    g_currentIndicator.store(Indicator::text);
+    return ShowTextAsync_Original(pThis, text, value);
+}
+
 // The control hides itself two ways and Windows picks the animated one. Handing the
 // call to the other is the whole feature, so nothing has to be torn out of the
 // animation and nothing outside this control is touched.
@@ -528,13 +529,6 @@ void WINAPI ConfirmatorHostControl_Hide_Hook(void* pThis) {
     }
 
     return ConfirmatorHostControl_Hide_Original(pThis);
-}
-
-using ShowTextAsync_t = char(WINAPI*)(void* pThis, void* text, bool value);
-ShowTextAsync_t ShowTextAsync_Original;
-char WINAPI ShowTextAsync_Hook(void* pThis, void* text, bool value) {
-    g_currentIndicator.store(Indicator::text);
-    return ShowTextAsync_Original(pThis, text, value);
 }
 
 using HardwareConfirmatorHost_GetPositionRect_t =
@@ -584,10 +578,11 @@ HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
     WinrtRect* result = HardwareConfirmatorHost_GetPositionRect_Original(
         pThis, retval, &shiftedRect);
 
-    // Someone who only wants the animation setting gets here with nothing to
-    // place, and the edge clamp inside PlaceInArea would still be free to move the
-    // indicator off the spot Windows picked. The shift above stays either way,
-    // since the original needs it.
+    // Nothing to place happens for a kind left on the main position while that is
+    // on Windows default, and for someone who only wanted the animation setting.
+    // The edge clamp inside PlaceInArea would still be free to move the indicator
+    // off the spot Windows picked, so it is skipped rather than run with nothing to
+    // do. The shift above stays either way, since the original needs it.
     Position position = CurrentPosition();
     bool anyPlacement = position != Position::windowsDefault || offsetSettingX ||
                         offsetSettingY;
@@ -772,11 +767,12 @@ BOOL Wh_ModInit() {
         },
     };
 
-    // All nine go in every time. The eight that record which kind is being shown
-    // are coroutine ramps that store a value and tail-call the original, so
+    // The whole set goes in every time. The eight that record which kind is being
+    // shown are coroutine ramps that store a value and tail-call the original, so
     // patching them when no kind has a spot of its own costs nothing worth
     // measuring, and installing the same set every time keeps the symbol cache
-    // from being resolved again the first time someone turns an override on.
+    // from being resolved again the first time someone turns an override on. The
+    // same goes for the hide pair and the animation setting.
     if (!HookSymbols(g_hardwareConfirmatorModule, symbolHooks,
                      ARRAYSIZE(symbolHooks))) {
         Wh_Log(L"HookSymbols failed");

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Put the volume, brightness and camera on-screen indicators anywhere on the screen, each in its own spot if you like, instead of the three positions Windows offers
-// @version         1.2.6
+// @version         1.2.7
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -446,11 +446,16 @@ char WINAPI ShowCameraAccessEnabledAsync_Hook(void* pThis, bool value) {
     return ShowCameraAccessEnabledAsync_Original(pThis, value);
 }
 
-using ShowMicrophoneMutedAsync_t = char(WINAPI*)(void* pThis, int value);
+// This one takes a message alongside the state on current builds and took only
+// the state on older ones. Declared with the extra parameter for both, since the
+// build that doesn't take it never reads the register it arrives in.
+using ShowMicrophoneMutedAsync_t = char(WINAPI*)(void* pThis,
+                                                 int value,
+                                                 void* text);
 ShowMicrophoneMutedAsync_t ShowMicrophoneMutedAsync_Original;
-char WINAPI ShowMicrophoneMutedAsync_Hook(void* pThis, int value) {
+char WINAPI ShowMicrophoneMutedAsync_Hook(void* pThis, int value, void* text) {
     g_currentIndicator.store(Indicator::microphone);
-    return ShowMicrophoneMutedAsync_Original(pThis, value);
+    return ShowMicrophoneMutedAsync_Original(pThis, value, text);
 }
 
 using ShowTextAsync_t = char(WINAPI*)(void* pThis, void* text, bool value);
@@ -660,7 +665,9 @@ BOOL Wh_ModInit() {
             true,  // optional
         },
         {
-            {LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowMicrophoneMutedAsync(enum winrt::Windows::Internal::HardwareConfirmator::MicrophoneMuteState))",
+            {LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowMicrophoneMutedAsync(enum winrt::Windows::Internal::HardwareConfirmator::MicrophoneMuteState,struct winrt::hstring))",
+             LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowMicrophoneMutedAsync(enum winrt::HWConfirmatorUI::MicrophoneMuteState,struct winrt::hstring))",
+             LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowMicrophoneMutedAsync(enum winrt::Windows::Internal::HardwareConfirmator::MicrophoneMuteState))",
              LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowMicrophoneMutedAsync(enum winrt::HWConfirmatorUI::MicrophoneMuteState))"},
             &ShowMicrophoneMutedAsync_Original,
             ShowMicrophoneMutedAsync_Hook,

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -60,10 +60,7 @@ ever on screen at a time, so this is the same desktop photographed twice:
 
 ![Volume top left, brightness center](https://raw.githubusercontent.com/mario0318/windhawk-mods/628f80317652209d3feed54eadf9c329e77b04a7/on-screen-indicator-position/per-indicator.jpg)
 
-## How long it stays, and the sliding
-
-**Seconds on screen** changes how long the indicator waits before hiding itself.
-Leave it at 0 and Windows decides, same as before.
+## The slide out
 
 **Skip the slide out animation** makes the indicator disappear instead of sliding
 away, which is the half of it you tend to notice, since that is what keeps it
@@ -132,11 +129,6 @@ both target the same function and work out the origin handling.
     Nudge the indicator up or down. A positive number moves it down, a negative one
     moves it up. It stops at the edge of the screen rather than going off it, and
     the same number moves it the same distance on any display.
-- durationSeconds: 0
-  $name: Seconds on screen
-  $description: >-
-    How long the indicator stays on screen. Leave it at 0 to keep the timing
-    Windows uses. Anything from 1 to 60 seconds works.
 - skipHideAnimation: false
   $name: Skip the slide out animation
   $description: >-
@@ -300,7 +292,6 @@ struct {
     std::atomic<Position> position;
     std::atomic<int> offsetX;
     std::atomic<int> offsetY;
-    std::atomic<int> durationSeconds;
     std::atomic<bool> skipHideAnimation;
     // Position::windowsDefault means "no override", so the main position is used.
     // It is never offered as a per-indicator choice, which leaves it free to be
@@ -485,79 +476,6 @@ char WINAPI ShowMicrophoneMutedAsync_Hook(void* pThis, int value, void* text) {
     return ShowMicrophoneMutedAsync_Original(pThis, value, text);
 }
 
-// The indicator hides itself off a threadpool timer, so rewriting the due time of
-// the one the confirmator sets is what changes how long it stays. SetThreadpoolTimer
-// is used all over explorer, so the setting is checked first and the caller second,
-// and a call from anywhere else is left alone.
-bool IsCallerTheConfirmator(void* returnAddress) {
-    HMODULE module;
-    return GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
-                                 GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                             (PCWSTR)returnAddress, &module) &&
-           module == g_hardwareConfirmatorModule;
-}
-
-// Only a relative due time within a plausible range is touched. A relative time is
-// negative, and the confirmator's own countdown sits comfortably inside these
-// bounds, which keeps any other timer the DLL might set out of it.
-bool AdjustDueTime(void* returnAddress, PFILETIME due, FILETIME* adjusted) {
-    int seconds = g_settings.durationSeconds.load();
-    if (!seconds || !due) {
-        return false;
-    }
-
-    LARGE_INTEGER original;
-    original.LowPart = due->dwLowDateTime;
-    original.HighPart = (LONG)due->dwHighDateTime;
-    if (original.QuadPart >= 0) {
-        return false;  // An absolute time, not a countdown.
-    }
-
-    LONGLONG ms = -original.QuadPart / 10000;
-    if (ms < 250 || ms > 60000) {
-        return false;
-    }
-
-    if (!IsCallerTheConfirmator(returnAddress)) {
-        return false;
-    }
-
-    LARGE_INTEGER replacement;
-    replacement.QuadPart = -((LONGLONG)seconds * 10000000);
-    adjusted->dwLowDateTime = replacement.LowPart;
-    adjusted->dwHighDateTime = (DWORD)replacement.HighPart;
-    Wh_Log(L"Indicator timeout %lldms -> %dms", ms, seconds * 1000);
-    return true;
-}
-
-using SetThreadpoolTimer_t = decltype(&SetThreadpoolTimer);
-SetThreadpoolTimer_t SetThreadpoolTimer_Original;
-void WINAPI SetThreadpoolTimer_Hook(PTP_TIMER timer,
-                                    PFILETIME dueTime,
-                                    DWORD period,
-                                    DWORD windowLength) {
-    FILETIME adjusted;
-    if (AdjustDueTime(__builtin_return_address(0), dueTime, &adjusted)) {
-        dueTime = &adjusted;
-    }
-
-    return SetThreadpoolTimer_Original(timer, dueTime, period, windowLength);
-}
-
-using SetThreadpoolTimerEx_t = decltype(&SetThreadpoolTimerEx);
-SetThreadpoolTimerEx_t SetThreadpoolTimerEx_Original;
-BOOL WINAPI SetThreadpoolTimerEx_Hook(PTP_TIMER timer,
-                                      PFILETIME dueTime,
-                                      DWORD period,
-                                      DWORD windowLength) {
-    FILETIME adjusted;
-    if (AdjustDueTime(__builtin_return_address(0), dueTime, &adjusted)) {
-        dueTime = &adjusted;
-    }
-
-    return SetThreadpoolTimerEx_Original(timer, dueTime, period, windowLength);
-}
-
 // The control hides itself two ways and Windows picks the animated one. Handing the
 // call to the other is the whole feature, so nothing has to be torn out of the
 // animation and nothing outside this control is touched.
@@ -685,11 +603,6 @@ void LoadSettings() {
     g_settings.offsetX = Wh_GetIntSetting(L"offsetX");
     g_settings.offsetY = Wh_GetIntSetting(L"offsetY");
 
-    // Out of range is treated as off rather than clamped, since a number nobody
-    // meant is more likely a typo than a request for a minute of indicator.
-    int seconds = Wh_GetIntSetting(L"durationSeconds");
-    g_settings.durationSeconds = (seconds >= 1 && seconds <= 60) ? seconds : 0;
-
     g_settings.skipHideAnimation = Wh_GetIntSetting(L"skipHideAnimation");
 
     static const PCWSTR kIndicatorSettings[] = {
@@ -725,7 +638,7 @@ BOOL Wh_ModInit() {
 
     if (g_settings.position == Position::windowsDefault && !anyPerIndicator &&
         !g_settings.offsetX && !g_settings.offsetY &&
-        !g_settings.durationSeconds && !g_settings.skipHideAnimation) {
+        !g_settings.skipHideAnimation) {
         Wh_Log(L"Nothing to do");
         return FALSE;
     }
@@ -854,15 +767,6 @@ BOOL Wh_ModInit() {
             break;
         }
     }
-
-    // Installed whichever way the setting is set, since the hook reads it per call
-    // and returns immediately when there is nothing to change. Making the install
-    // conditional would only bring back a reload on the settings change.
-    WindhawkUtils::SetFunctionHook(SetThreadpoolTimer, SetThreadpoolTimer_Hook,
-                                   &SetThreadpoolTimer_Original);
-    WindhawkUtils::SetFunctionHook(SetThreadpoolTimerEx,
-                                   SetThreadpoolTimerEx_Hook,
-                                   &SetThreadpoolTimerEx_Original);
 
     return TRUE;
 }

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -96,8 +96,8 @@ both target the same function and work out the origin handling.
 - position: topRight
   $name: Position
   $description: >-
-    Where on the screen the indicator appears. Anything left on Same as the main
-    position below follows this one.
+    Where on the screen the indicator appears. Anything left on "Same as the main
+    position" below follows this one.
   $options:
   - windowsDefault: Windows default (only apply the offsets)
   - topLeft: Top left
@@ -453,7 +453,10 @@ char WINAPI ShowCameraAccessEnabledAsync_Hook(void* pThis, bool value) {
 
 // This one takes a message alongside the state on current builds and took only
 // the state on older ones. Declared with the extra parameter for both, since the
-// build that doesn't take it never reads the register it arrives in.
+// build that doesn't take it never reads the register it arrives in. That holds
+// because the mod is x86-64 only and the caller does the cleaning up. On a
+// 32-bit stdcall build the callee pops its own arguments and the same mismatch
+// would walk the stack.
 using ShowMicrophoneMutedAsync_t = char(WINAPI*)(void* pThis,
                                                  int value,
                                                  void* text);
@@ -478,7 +481,7 @@ WinrtRect* WINAPI
 HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
                                              WinrtRect* retval,
                                              const WinrtRect* rect) {
-    Wh_Log(L">");
+    Wh_Log(L"> indicator=%d", (int)g_currentIndicator.load());
 
     // Read the offsets once so the placement below uses one consistent pair.
     int offsetSettingX = g_settings.offsetX.load();
@@ -712,11 +715,15 @@ BOOL Wh_ModInit() {
 
     for (const void* recorder : kindRecorders) {
         if (!recorder) {
-            Wh_Log(
-                L"An indicator entry point didn't resolve, so the position "
-                L"per indicator settings are ignored and everything uses "
-                L"the main position");
             g_kindUnreliable = true;
+            // Only worth saying to someone who has an override set. With the
+            // shipped defaults there is nothing being ignored to complain about.
+            if (anyPerIndicator) {
+                Wh_Log(
+                    L"An indicator entry point didn't resolve, so the position "
+                    L"per indicator settings are ignored and everything uses "
+                    L"the main position");
+            }
             break;
         }
     }

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -454,9 +454,9 @@ char WINAPI ShowCameraAccessEnabledAsync_Hook(void* pThis, bool value) {
 // This one takes a message alongside the state on current builds and took only
 // the state on older ones. Declared with the extra parameter for both, since the
 // build that doesn't take it never reads the register it arrives in. That holds
-// because the mod is x86-64 only and the caller does the cleaning up. On a
-// 32-bit stdcall build the callee pops its own arguments and the same mismatch
-// would walk the stack.
+// because the mod is 64-bit only, x64 and arm64 both, where arguments go in
+// registers and the caller does the cleaning up. On a 32-bit stdcall build the
+// callee pops its own arguments and the same mismatch would walk the stack.
 using ShowMicrophoneMutedAsync_t = char(WINAPI*)(void* pThis,
                                                  int value,
                                                  void* text);
@@ -749,4 +749,13 @@ void Wh_ModSettingsChanged() {
     // Every hook is installed either way now, so nothing here needs a reload and
     // a change takes effect on the next indicator.
     LoadSettings();
+
+    // Turning on the first override no longer re-runs Wh_ModInit, so this is the
+    // only place the person it concerns can still be told.
+    if (g_kindUnreliable && AnyPerIndicator()) {
+        Wh_Log(
+            L"An indicator entry point didn't resolve, so the position "
+            L"per indicator settings are ignored and everything uses "
+            L"the main position");
+    }
 }

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -7,7 +7,7 @@
 // @github          https://github.com/mario0318
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lshcore -lole32 -loleaut32 -lruntimeobject
+// @compilerOptions -lshcore
 // ==/WindhawkMod==
 
 // Source code is published under The GNU General Public License v3.0.
@@ -65,11 +65,11 @@ ever on screen at a time, so this is the same desktop photographed twice:
 **Seconds on screen** changes how long the indicator waits before hiding itself.
 Leave it at 0 and Windows decides, same as before.
 
-**Skip the slide in animation** and **Skip the slide out animation** do what they
-say. The indicator appears and disappears in place instead of sliding. They are
-separate settings since you might want one and not the other. Neither one touches
-anything outside the indicator, so other mods and the rest of the shell animate
-exactly as they did.
+**Skip the slide out animation** makes the indicator disappear instead of sliding
+away, which is the half of it you tend to notice, since that is what keeps it
+hanging around. Windows has its own no animation path for hiding and the mod asks
+for that one, so nothing outside the indicator is affected and the sliding in is
+left alone.
 
 ## Choosing a monitor
 
@@ -83,8 +83,7 @@ a monitor by number or by interface name. The two work together.
 * The slide-in animation direction is chosen by Windows from the built-in
   setting, not by this mod. If the animation looks wrong for your new position,
   change the built-in setting to whichever of the three has the animation you
-  like, then let this mod do the actual placement, or skip the animation
-  altogether with the setting above.
+  like, then let this mod do the actual placement.
 * Offsets are given at 100% scaling and scaled to whichever monitor the
   indicator appears on, so the same value moves the same distance on a display
   running at 150%.
@@ -138,10 +137,6 @@ both target the same function and work out the origin handling.
   $description: >-
     How long the indicator stays on screen. Leave it at 0 to keep the timing
     Windows uses. Anything from 1 to 60 seconds works.
-- skipShowAnimation: false
-  $name: Skip the slide in animation
-  $description: >-
-    The indicator appears in place instead of sliding in.
 - skipHideAnimation: false
   $name: Skip the slide out animation
   $description: >-
@@ -250,11 +245,6 @@ both target the same function and work out the origin handling.
 
 #include <shellscalingapi.h>
 
-// winbase.h defines GetCurrentTime, which collides with the WinRT headers.
-#undef GetCurrentTime
-#include <winrt/base.h>
-#include <winrt/Windows.Foundation.h>
-
 #include <atomic>
 
 enum class Position {
@@ -311,7 +301,6 @@ struct {
     std::atomic<int> offsetX;
     std::atomic<int> offsetY;
     std::atomic<int> durationSeconds;
-    std::atomic<bool> skipShowAnimation;
     std::atomic<bool> skipHideAnimation;
     // Position::windowsDefault means "no override", so the main position is used.
     // It is never offered as a per-indicator choice, which leaves it free to be
@@ -569,36 +558,6 @@ BOOL WINAPI SetThreadpoolTimerEx_Hook(PTP_TIMER timer,
     return SetThreadpoolTimerEx_Original(timer, dueTime, period, windowLength);
 }
 
-// The two values AnimateConfirmator is called with. 0 arrives as the indicator is
-// shown and 1 as it is hidden, which is what the log said on 26200 and is all the
-// stripped pdb will support, since it carries no enumerator names.
-constexpr int kAnimationShow = 0;
-
-// Handed back in place of the animation the caller was going to await. It is
-// already complete, so the await returns at once and nothing is animated.
-winrt::Windows::Foundation::IAsyncAction CompletedAction() {
-    co_return;
-}
-
-// IAsyncAction is returned by value and isn't trivially copyable, so it comes back
-// through a hidden pointer, the same shape GetPositionRect's Rect uses. The
-// interface is one COM pointer, so detaching the completed action into that slot
-// hands the caller an object it owns and will release.
-using AnimateConfirmator_t = void*(WINAPI*)(void* pThis,
-                                            void* retval,
-                                            int animation);
-AnimateConfirmator_t AnimateConfirmator_Original;
-void* WINAPI AnimateConfirmator_Hook(void* pThis,
-                                     void* retval,
-                                     int animation) {
-    if (animation == kAnimationShow && g_settings.skipShowAnimation.load()) {
-        *(void**)retval = winrt::detach_abi(CompletedAction());
-        return retval;
-    }
-
-    return AnimateConfirmator_Original(pThis, retval, animation);
-}
-
 // The control hides itself two ways and Windows picks the animated one. Handing the
 // call to the other is the whole feature, so nothing has to be torn out of the
 // animation and nothing outside this control is touched.
@@ -731,7 +690,6 @@ void LoadSettings() {
     int seconds = Wh_GetIntSetting(L"durationSeconds");
     g_settings.durationSeconds = (seconds >= 1 && seconds <= 60) ? seconds : 0;
 
-    g_settings.skipShowAnimation = Wh_GetIntSetting(L"skipShowAnimation");
     g_settings.skipHideAnimation = Wh_GetIntSetting(L"skipHideAnimation");
 
     static const PCWSTR kIndicatorSettings[] = {
@@ -767,8 +725,7 @@ BOOL Wh_ModInit() {
 
     if (g_settings.position == Position::windowsDefault && !anyPerIndicator &&
         !g_settings.offsetX && !g_settings.offsetY &&
-        !g_settings.durationSeconds && !g_settings.skipShowAnimation &&
-        !g_settings.skipHideAnimation) {
+        !g_settings.durationSeconds && !g_settings.skipHideAnimation) {
         Wh_Log(L"Nothing to do");
         return FALSE;
     }
@@ -837,12 +794,6 @@ BOOL Wh_ModInit() {
              LR"(private: struct winrt::fire_and_forget __cdecl winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost::ShowMicrophoneMutedAsync(enum winrt::HWConfirmatorUI::MicrophoneMuteState))"},
             &ShowMicrophoneMutedAsync_Original,
             ShowMicrophoneMutedAsync_Hook,
-            true,  // optional
-        },
-        {
-            {LR"(private: struct winrt::Windows::Foundation::IAsyncAction __cdecl winrt::HWConfirmatorUI::implementation::ConfirmatorHostControl::AnimateConfirmator(enum winrt::HWConfirmatorUI::ConfirmatorAnimation))"},
-            &AnimateConfirmator_Original,
-            AnimateConfirmator_Hook,
             true,  // optional
         },
         {

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -124,35 +124,28 @@ both target the same function and work out the origin handling.
 - offsetX: 0
   $name: Horizontal offset
   $description: >-
-    Pixels to nudge the indicator by, at 100% scaling. Positive moves right,
-    negative moves left. The value is scaled to match the monitor, so the same
-    setting moves the same distance on a scaled display. The indicator is kept
-    inside the area Windows lays it out in, so an offset that would push it past
-    an edge stops at the edge instead.
+    Nudge the indicator sideways. A positive number moves it right, a negative one
+    moves it left. It stops at the edge of the screen rather than going off it, and
+    the same number moves it the same distance on any display.
 - offsetY: 0
   $name: Vertical offset
   $description: >-
-    Pixels to nudge the indicator by, at 100% scaling. Positive moves down,
-    negative moves up. The value is scaled to match the monitor, so the same
-    setting moves the same distance on a scaled display. The indicator is kept
-    inside the area Windows lays it out in, so an offset that would push it past
-    an edge stops at the edge instead.
+    Nudge the indicator up or down. A positive number moves it down, a negative one
+    moves it up. It stops at the edge of the screen rather than going off it, and
+    the same number moves it the same distance on any display.
 - durationSeconds: 0
   $name: Seconds on screen
   $description: >-
-    How long the indicator stays before it hides itself. 0 keeps whatever Windows
-    uses. Anything from 1 to 60 is accepted.
+    How long the indicator stays on screen. Leave it at 0 to keep the timing
+    Windows uses. Anything from 1 to 60 seconds works.
 - skipShowAnimation: false
   $name: Skip the slide in animation
   $description: >-
-    The indicator appears where it is going to sit instead of sliding in. The
-    slide out is a separate setting below.
+    The indicator appears in place instead of sliding in.
 - skipHideAnimation: false
   $name: Skip the slide out animation
   $description: >-
-    The indicator disappears at once instead of sliding away. Windows has its own
-    no animation path for this and the mod just asks for that one, so nothing
-    outside the indicator is affected.
+    The indicator disappears instead of sliding away.
 - perIndicator:
   - volume: same
     $name: Volume
@@ -247,8 +240,9 @@ both target the same function and work out the origin handling.
     - bottomRight: Bottom right
   $name: Position per indicator
   $description: >-
-    Give an individual indicator its own spot. Anything left on Same as the main
-    position follows the Position setting above. The offsets apply to all of them.
+    Give one kind of indicator a spot of its own. Anything left on "Same as the
+    main position" follows the Position setting above. The offsets apply to all
+    of them either way.
 */
 // ==/WindhawkModSettings==
 

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Put the volume, brightness and camera on-screen indicators anywhere on the screen, each in its own spot if you like, instead of the three positions Windows offers
-// @version         1.2.7
+// @version         1.3.0
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -125,6 +125,17 @@ both target the same function and work out the origin handling.
     setting moves the same distance on a scaled display. The indicator is kept
     inside the area Windows lays it out in, so an offset that would push it past
     an edge stops at the edge instead.
+- durationSeconds: 0
+  $name: Seconds on screen
+  $description: >-
+    How long the indicator stays before it hides itself. 0 keeps whatever Windows
+    uses. Anything from 1 to 60 is accepted.
+- skipHideAnimation: false
+  $name: Skip the slide out animation
+  $description: >-
+    The indicator disappears at once instead of sliding away. Windows has its own
+    no animation path for this and the mod just asks for that one, so nothing
+    outside the indicator is affected.
 - perIndicator:
   - volume: same
     $name: Volume
@@ -283,6 +294,8 @@ struct {
     std::atomic<Position> position;
     std::atomic<int> offsetX;
     std::atomic<int> offsetY;
+    std::atomic<int> durationSeconds;
+    std::atomic<bool> skipHideAnimation;
     // Position::windowsDefault means "no override", so the main position is used.
     // It is never offered as a per-indicator choice, which leaves it free to be
     // the sentinel. The main position keeps its own meaning of leaving Windows'
@@ -466,6 +479,94 @@ char WINAPI ShowMicrophoneMutedAsync_Hook(void* pThis, int value, void* text) {
     return ShowMicrophoneMutedAsync_Original(pThis, value, text);
 }
 
+// The indicator hides itself off a threadpool timer, so rewriting the due time of
+// the one the confirmator sets is what changes how long it stays. SetThreadpoolTimer
+// is used all over explorer, so the setting is checked first and the caller second,
+// and a call from anywhere else is left alone.
+bool IsCallerTheConfirmator(void* returnAddress) {
+    HMODULE module;
+    return GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                                 GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                             (PCWSTR)returnAddress, &module) &&
+           module == g_hardwareConfirmatorModule;
+}
+
+// Only a relative due time within a plausible range is touched. A relative time is
+// negative, and the confirmator's own countdown sits comfortably inside these
+// bounds, which keeps any other timer the DLL might set out of it.
+bool AdjustDueTime(void* returnAddress, PFILETIME due, FILETIME* adjusted) {
+    int seconds = g_settings.durationSeconds.load();
+    if (!seconds || !due) {
+        return false;
+    }
+
+    LARGE_INTEGER original;
+    original.LowPart = due->dwLowDateTime;
+    original.HighPart = (LONG)due->dwHighDateTime;
+    if (original.QuadPart >= 0) {
+        return false;  // An absolute time, not a countdown.
+    }
+
+    LONGLONG ms = -original.QuadPart / 10000;
+    if (ms < 250 || ms > 60000) {
+        return false;
+    }
+
+    if (!IsCallerTheConfirmator(returnAddress)) {
+        return false;
+    }
+
+    LARGE_INTEGER replacement;
+    replacement.QuadPart = -((LONGLONG)seconds * 10000000);
+    adjusted->dwLowDateTime = replacement.LowPart;
+    adjusted->dwHighDateTime = (DWORD)replacement.HighPart;
+    Wh_Log(L"Indicator timeout %lldms -> %dms", ms, seconds * 1000);
+    return true;
+}
+
+using SetThreadpoolTimer_t = decltype(&SetThreadpoolTimer);
+SetThreadpoolTimer_t SetThreadpoolTimer_Original;
+void WINAPI SetThreadpoolTimer_Hook(PTP_TIMER timer,
+                                    PFILETIME dueTime,
+                                    DWORD period,
+                                    DWORD windowLength) {
+    FILETIME adjusted;
+    if (AdjustDueTime(__builtin_return_address(0), dueTime, &adjusted)) {
+        dueTime = &adjusted;
+    }
+
+    return SetThreadpoolTimer_Original(timer, dueTime, period, windowLength);
+}
+
+using SetThreadpoolTimerEx_t = decltype(&SetThreadpoolTimerEx);
+SetThreadpoolTimerEx_t SetThreadpoolTimerEx_Original;
+BOOL WINAPI SetThreadpoolTimerEx_Hook(PTP_TIMER timer,
+                                      PFILETIME dueTime,
+                                      DWORD period,
+                                      DWORD windowLength) {
+    FILETIME adjusted;
+    if (AdjustDueTime(__builtin_return_address(0), dueTime, &adjusted)) {
+        dueTime = &adjusted;
+    }
+
+    return SetThreadpoolTimerEx_Original(timer, dueTime, period, windowLength);
+}
+
+// The control hides itself two ways and Windows picks the animated one. Handing the
+// call to the other is the whole feature, so nothing has to be torn out of the
+// animation and nothing outside this control is touched.
+using ConfirmatorHostControl_Hide_t = void(WINAPI*)(void* pThis);
+ConfirmatorHostControl_Hide_t ConfirmatorHostControl_Hide_Original;
+ConfirmatorHostControl_Hide_t ConfirmatorHostControl_HideWithoutAnimation_Original;
+void WINAPI ConfirmatorHostControl_Hide_Hook(void* pThis) {
+    if (g_settings.skipHideAnimation.load() &&
+        ConfirmatorHostControl_HideWithoutAnimation_Original) {
+        return ConfirmatorHostControl_HideWithoutAnimation_Original(pThis);
+    }
+
+    return ConfirmatorHostControl_Hide_Original(pThis);
+}
+
 using ShowTextAsync_t = char(WINAPI*)(void* pThis, void* text, bool value);
 ShowTextAsync_t ShowTextAsync_Original;
 char WINAPI ShowTextAsync_Hook(void* pThis, void* text, bool value) {
@@ -578,6 +679,13 @@ void LoadSettings() {
     g_settings.offsetX = Wh_GetIntSetting(L"offsetX");
     g_settings.offsetY = Wh_GetIntSetting(L"offsetY");
 
+    // Out of range is treated as off rather than clamped, since a number nobody
+    // meant is more likely a typo than a request for a minute of indicator.
+    int seconds = Wh_GetIntSetting(L"durationSeconds");
+    g_settings.durationSeconds = (seconds >= 1 && seconds <= 60) ? seconds : 0;
+
+    g_settings.skipHideAnimation = Wh_GetIntSetting(L"skipHideAnimation");
+
     static const PCWSTR kIndicatorSettings[] = {
         L"perIndicator.volume",
         L"perIndicator.brightness",
@@ -610,7 +718,8 @@ BOOL Wh_ModInit() {
     bool anyPerIndicator = AnyPerIndicator();
 
     if (g_settings.position == Position::windowsDefault && !anyPerIndicator &&
-        !g_settings.offsetX && !g_settings.offsetY) {
+        !g_settings.offsetX && !g_settings.offsetY &&
+        !g_settings.durationSeconds && !g_settings.skipHideAnimation) {
         Wh_Log(L"Nothing to do");
         return FALSE;
     }
@@ -681,6 +790,18 @@ BOOL Wh_ModInit() {
             ShowMicrophoneMutedAsync_Hook,
             true,  // optional
         },
+        {
+            {LR"(public: void __cdecl winrt::HWConfirmatorUI::implementation::ConfirmatorHostControl::Hide(void))"},
+            &ConfirmatorHostControl_Hide_Original,
+            ConfirmatorHostControl_Hide_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(public: void __cdecl winrt::HWConfirmatorUI::implementation::ConfirmatorHostControl::HideWithoutAnimation(void))"},
+            &ConfirmatorHostControl_HideWithoutAnimation_Original,
+            nullptr,  // wanted for its address, not hooked
+            true,     // optional
+        },
     };
 
     // All nine go in every time. The eight that record which kind is being shown
@@ -727,6 +848,15 @@ BOOL Wh_ModInit() {
             break;
         }
     }
+
+    // Installed whichever way the setting is set, since the hook reads it per call
+    // and returns immediately when there is nothing to change. Making the install
+    // conditional would only bring back a reload on the settings change.
+    WindhawkUtils::SetFunctionHook(SetThreadpoolTimer, SetThreadpoolTimer_Hook,
+                                   &SetThreadpoolTimer_Original);
+    WindhawkUtils::SetFunctionHook(SetThreadpoolTimerEx,
+                                   SetThreadpoolTimerEx_Hook,
+                                   &SetThreadpoolTimerEx_Original);
 
     return TRUE;
 }

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -76,6 +76,9 @@ a monitor by number or by interface name. The two work together.
 * Offsets are given at 100% scaling and scaled to whichever monitor the
   indicator appears on, so the same value moves the same distance on a display
   running at 150%.
+* With two indicators set to different spots you can catch the previous one
+  flashing at the new spot for a frame before the new one draws. That's the
+  confirmator reusing its frame, the placement hook can't do anything about it.
 * Tested on Windows 11 build 26200 (25H2) x64, on a 100% and a 150% display.
 
 ## Credits
@@ -92,7 +95,9 @@ both target the same function and work out the origin handling.
 /*
 - position: topRight
   $name: Position
-  $description: Where on the screen the indicator appears
+  $description: >-
+    Where on the screen the indicator appears. Anything left on Same as the main
+    position below follows this one.
   $options:
   - windowsDefault: Windows default (only apply the offsets)
   - topLeft: Top left
@@ -285,7 +290,6 @@ struct {
     std::atomic<Position> perIndicator[(size_t)Indicator::count];
 } g_settings;
 
-// The position to place the indicator that is being shown right now.
 bool AnyPerIndicator() {
     for (size_t i = 0; i < (size_t)Indicator::count; i++) {
         if (g_settings.perIndicator[i].load() != Position::windowsDefault) {
@@ -296,6 +300,7 @@ bool AnyPerIndicator() {
     return false;
 }
 
+// The position to place the indicator that is being shown right now.
 Position CurrentPosition() {
     if (g_kindUnreliable.load()) {
         return g_settings.position.load();
@@ -675,15 +680,18 @@ BOOL Wh_ModInit() {
         },
     };
 
-    // The placement hook is the first entry and is always needed. The eight that
-    // record which kind is being shown only matter when a kind has a spot of its
-    // own, and with the shipped defaults none does, so they aren't installed at
-    // all rather than patching eight entry points to write a value that would be
-    // thrown away.
-    size_t hookCount = anyPerIndicator ? ARRAYSIZE(symbolHooks) : 1;
-
-    if (!HookSymbols(g_hardwareConfirmatorModule, symbolHooks, hookCount)) {
+    // All nine go in every time. The eight that record which kind is being shown
+    // are coroutine ramps that store a value and tail-call the original, so
+    // patching them when no kind has a spot of its own costs nothing worth
+    // measuring, and installing the same set every time keeps the symbol cache
+    // from being resolved again the first time someone turns an override on.
+    if (!HookSymbols(g_hardwareConfirmatorModule, symbolHooks,
+                     ARRAYSIZE(symbolHooks))) {
         Wh_Log(L"HookSymbols failed");
+        // Wh_ModUninit doesn't run when Wh_ModInit returns FALSE, so the
+        // reference taken above has to go back here.
+        FreeLibrary(g_hardwareConfirmatorModule);
+        g_hardwareConfirmatorModule = nullptr;
         return FALSE;
     }
 
@@ -691,27 +699,25 @@ BOOL Wh_ModInit() {
     // a null here means that kind would never be recorded and every kind after
     // it would be placed using a stale one. Rather than misplace an indicator,
     // drop to the main position for everything and say so in the log.
-    if (anyPerIndicator) {
-        const void* kindRecorders[] = {
-            (void*)ShowVolumeAsync_Original,
-            (void*)ShowBrightnessAsync_Original,
-            (void*)ShowKeyboardBrightnessAsync_Original,
-            (void*)ShowAirplaneModeOnAsync_Original,
-            (void*)ShowCameraOnAsync_Original,
-            (void*)ShowCameraAccessEnabledAsync_Original,
-            (void*)ShowMicrophoneMutedAsync_Original,
-            (void*)ShowTextAsync_Original,
-        };
+    const void* kindRecorders[] = {
+        (void*)ShowVolumeAsync_Original,
+        (void*)ShowBrightnessAsync_Original,
+        (void*)ShowKeyboardBrightnessAsync_Original,
+        (void*)ShowAirplaneModeOnAsync_Original,
+        (void*)ShowCameraOnAsync_Original,
+        (void*)ShowCameraAccessEnabledAsync_Original,
+        (void*)ShowMicrophoneMutedAsync_Original,
+        (void*)ShowTextAsync_Original,
+    };
 
-        for (const void* recorder : kindRecorders) {
-            if (!recorder) {
-                Wh_Log(
-                    L"An indicator entry point didn't resolve, so the position "
-                    L"per indicator settings are ignored and everything uses "
-                    L"the main position");
-                g_kindUnreliable = true;
-                break;
-            }
+    for (const void* recorder : kindRecorders) {
+        if (!recorder) {
+            Wh_Log(
+                L"An indicator entry point didn't resolve, so the position "
+                L"per indicator settings are ignored and everything uses "
+                L"the main position");
+            g_kindUnreliable = true;
+            break;
         }
     }
 
@@ -730,15 +736,10 @@ void Wh_ModUninit() {
     }
 }
 
-BOOL Wh_ModSettingsChanged(BOOL* bReload) {
+void Wh_ModSettingsChanged() {
     Wh_Log(L">");
 
-    // Whether the kind recorders are installed is decided in Wh_ModInit, so
-    // turning the first override on, or the last one off, needs a reload to
-    // match. Everything else takes effect on the next indicator.
-    bool hadPerIndicator = AnyPerIndicator();
+    // Every hook is installed either way now, so nothing here needs a reload and
+    // a change takes effect on the next indicator.
     LoadSettings();
-    *bReload = AnyPerIndicator() != hadPerIndicator;
-
-    return TRUE;
 }

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -310,6 +310,27 @@ bool AnyPerIndicator() {
     return false;
 }
 
+// Only for the log, so a line someone is asked to read back says which kind it was
+// rather than a number to count enum members against.
+PCWSTR IndicatorName(Indicator indicator) {
+    static constexpr PCWSTR kNames[] = {
+        L"volume",     L"brightness", L"keyboardBrightness", L"airplaneMode",
+        L"camera",     L"microphone", L"text",
+    };
+    static_assert(ARRAYSIZE(kNames) == (size_t)Indicator::count);
+
+    size_t i = (size_t)indicator;
+    return i < ARRAYSIZE(kNames) ? kNames[i] : L"unknown";
+}
+
+// Said from two places, so it lives in one.
+void LogKindUnreliable() {
+    Wh_Log(
+        L"An indicator entry point didn't resolve, so the position "
+        L"per indicator settings are ignored and everything uses "
+        L"the main position");
+}
+
 // The position to place the indicator that is being shown right now.
 Position CurrentPosition() {
     if (g_kindUnreliable.load()) {
@@ -506,7 +527,7 @@ WinrtRect* WINAPI
 HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
                                              WinrtRect* retval,
                                              const WinrtRect* rect) {
-    Wh_Log(L"> indicator=%d", (int)g_currentIndicator.load());
+    Wh_Log(L"> indicator=%s", IndicatorName(g_currentIndicator.load()));
 
     // Read the offsets once so the placement below uses one consistent pair.
     int offsetSettingX = g_settings.offsetX.load();
@@ -759,10 +780,7 @@ BOOL Wh_ModInit() {
             // Only worth saying to someone who has an override set. With the
             // shipped defaults there is nothing being ignored to complain about.
             if (anyPerIndicator) {
-                Wh_Log(
-                    L"An indicator entry point didn't resolve, so the position "
-                    L"per indicator settings are ignored and everything uses "
-                    L"the main position");
+                LogKindUnreliable();
             }
             break;
         }
@@ -793,9 +811,6 @@ void Wh_ModSettingsChanged() {
     // Turning on the first override no longer re-runs Wh_ModInit, so this is the
     // only place the person it concerns can still be told.
     if (g_kindUnreliable && AnyPerIndicator()) {
-        Wh_Log(
-            L"An indicator entry point didn't resolve, so the position "
-            L"per indicator settings are ignored and everything uses "
-            L"the main position");
+        LogKindUnreliable();
     }
 }

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Put the volume, brightness and camera on-screen indicators anywhere on the screen, each in its own spot if you like, and optionally skip the slide out animation
-// @version         1.4.0
+// @version         1.4.1
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -55,6 +55,10 @@ position. Anything left on **Same as the main position** follows the setting abo
 so you only have to touch the ones you want somewhere else. Handy if you want the
 volume indicator out of the way at the bottom but still want the camera one where
 you will notice it.
+
+If you used **Plain text indicator** to place the "Desktop N" popup before 1.4.0,
+set **Virtual desktop name** to that spot after updating. It now has its own setting
+and otherwise follows the main position.
 
 Volume kept at the top left while brightness sits in the middle. Only one of them is
 ever on screen at a time, so this is the same desktop photographed twice:
@@ -454,64 +458,32 @@ void PlaceInArea(const WinrtRect& area,
     }
 }
 
-// The same eight kinds arrive here first. These are the com vtable entries the
-// interface is called through, so they run before the host's own entry points
-// and before the position is worked out, and they are still there on builds
-// where the host's private coroutines have been refactored away. Whichever of
-// the two fires first records the kind, and recording it twice for one showing
-// is harmless since both agree. They return an HRESULT rather than the
-// implementation's own return.
+// Both the public COM thunk and the host's private coroutine record the kind.
+// The thunk survives on builds where the private name moves; the coroutine is
+// retained as the fallback for builds where a thunk has moved instead.
+#define DEFINE_RECORDER_HOOK(name, returnType, kind, parameters, arguments) \
+    using name##_t = returnType(WINAPI*) parameters;                         \
+    name##_t name##_Original;                                                 \
+    returnType WINAPI name##_Hook parameters {                                \
+        g_currentIndicator.store(kind);                                       \
+        return name##_Original arguments;                                     \
+    }
 
-using ShowVolumeThunk_t = int(WINAPI*)(void* pThis, int value);
-ShowVolumeThunk_t ShowVolumeThunk_Original;
-int WINAPI ShowVolumeThunk_Hook(void* pThis, int value) {
-    g_currentIndicator.store(Indicator::volume);
-    return ShowVolumeThunk_Original(pThis, value);
-}
-
-using ShowBrightnessThunk_t = int(WINAPI*)(void* pThis, int value);
-ShowBrightnessThunk_t ShowBrightnessThunk_Original;
-int WINAPI ShowBrightnessThunk_Hook(void* pThis, int value) {
-    g_currentIndicator.store(Indicator::brightness);
-    return ShowBrightnessThunk_Original(pThis, value);
-}
-
-using ShowKeyboardBrightnessThunk_t = int(WINAPI*)(void* pThis, int value);
-ShowKeyboardBrightnessThunk_t ShowKeyboardBrightnessThunk_Original;
-int WINAPI ShowKeyboardBrightnessThunk_Hook(void* pThis, int value) {
-    g_currentIndicator.store(Indicator::keyboardBrightness);
-    return ShowKeyboardBrightnessThunk_Original(pThis, value);
-}
-
-using ShowAirplaneModeOnThunk_t = int(WINAPI*)(void* pThis, bool value);
-ShowAirplaneModeOnThunk_t ShowAirplaneModeOnThunk_Original;
-int WINAPI ShowAirplaneModeOnThunk_Hook(void* pThis, bool value) {
-    g_currentIndicator.store(Indicator::airplaneMode);
-    return ShowAirplaneModeOnThunk_Original(pThis, value);
-}
-
-using ShowCameraOnThunk_t = int(WINAPI*)(void* pThis, bool value);
-ShowCameraOnThunk_t ShowCameraOnThunk_Original;
-int WINAPI ShowCameraOnThunk_Hook(void* pThis, bool value) {
-    g_currentIndicator.store(Indicator::camera);
-    return ShowCameraOnThunk_Original(pThis, value);
-}
-
-using ShowCameraAccessEnabledThunk_t = int(WINAPI*)(void* pThis, bool value);
-ShowCameraAccessEnabledThunk_t ShowCameraAccessEnabledThunk_Original;
-int WINAPI ShowCameraAccessEnabledThunk_Hook(void* pThis, bool value) {
-    g_currentIndicator.store(Indicator::camera);
-    return ShowCameraAccessEnabledThunk_Original(pThis, value);
-}
-
-using ShowMicrophoneMutedThunk_t = int(WINAPI*)(void* pThis,
-                                                int state,
-                                                void* text);
-ShowMicrophoneMutedThunk_t ShowMicrophoneMutedThunk_Original;
-int WINAPI ShowMicrophoneMutedThunk_Hook(void* pThis, int state, void* text) {
-    g_currentIndicator.store(Indicator::microphone);
-    return ShowMicrophoneMutedThunk_Original(pThis, state, text);
-}
+DEFINE_RECORDER_HOOK(ShowVolumeThunk, int, Indicator::volume,
+                     (void* pThis, int value), (pThis, value));
+DEFINE_RECORDER_HOOK(ShowBrightnessThunk, int, Indicator::brightness,
+                     (void* pThis, int value), (pThis, value));
+DEFINE_RECORDER_HOOK(ShowKeyboardBrightnessThunk, int,
+                     Indicator::keyboardBrightness, (void* pThis, int value),
+                     (pThis, value));
+DEFINE_RECORDER_HOOK(ShowAirplaneModeOnThunk, int, Indicator::airplaneMode,
+                     (void* pThis, bool value), (pThis, value));
+DEFINE_RECORDER_HOOK(ShowCameraOnThunk, int, Indicator::camera,
+                     (void* pThis, bool value), (pThis, value));
+DEFINE_RECORDER_HOOK(ShowCameraAccessEnabledThunk, int, Indicator::camera,
+                     (void* pThis, bool value), (pThis, value));
+DEFINE_RECORDER_HOOK(ShowMicrophoneMutedThunk, int, Indicator::microphone,
+                     (void* pThis, int state, void* text), (pThis, state, text));
 
 // The virtual desktop name popup goes through the same ShowText entry point as
 // every other text indicator. The only thing that tells them apart at hook time
@@ -541,69 +513,37 @@ bool ReturnAddressIsTwinui(void* returnAddress) {
 // into a later plain text show on the same thread.
 thread_local bool g_textCallFromTwinui = false;
 
+struct ResetOnExit {
+    bool& flag;
+    ~ResetOnExit() { flag = false; }
+};
+
 using ShowTextThunk_t = int(WINAPI*)(void* pThis, void* text, bool value);
 ShowTextThunk_t ShowTextThunk_Original;
 int WINAPI ShowTextThunk_Hook(void* pThis, void* text, bool value) {
     bool fromTwinui = ReturnAddressIsTwinui(__builtin_return_address(0));
     g_textCallFromTwinui = fromTwinui;
+    ResetOnExit reset{g_textCallFromTwinui};
     g_currentIndicator.store(fromTwinui ? Indicator::virtualDesktop
                                         : Indicator::text);
-    int result = ShowTextThunk_Original(pThis, text, value);
-    g_textCallFromTwinui = false;
-    return result;
+    return ShowTextThunk_Original(pThis, text, value);
 }
 
-// Each kind of indicator has its own entry point on the host, so the kind is
-// recorded as one is asked for and read back when the position is worked out.
-// They are private coroutines returning winrt::fire_and_forget, an empty struct,
-// so the return is passed through as the single byte it occupies. Every one is
-// hooked as optional, so a name that stops resolving on some build costs the per
-// indicator feature rather than the whole mod. Wh_ModInit checks afterwards that
-// each kind can still be recognised by one layer or the other, and if any kind
-// has neither it ignores the overrides for the session instead of placing one
-// kind using another kind's spot.
-
-using ShowVolumeAsync_t = char(WINAPI*)(void* pThis, int value);
-ShowVolumeAsync_t ShowVolumeAsync_Original;
-char WINAPI ShowVolumeAsync_Hook(void* pThis, int value) {
-    g_currentIndicator.store(Indicator::volume);
-    return ShowVolumeAsync_Original(pThis, value);
-}
-
-using ShowBrightnessAsync_t = char(WINAPI*)(void* pThis, int value);
-ShowBrightnessAsync_t ShowBrightnessAsync_Original;
-char WINAPI ShowBrightnessAsync_Hook(void* pThis, int value) {
-    g_currentIndicator.store(Indicator::brightness);
-    return ShowBrightnessAsync_Original(pThis, value);
-}
-
-using ShowKeyboardBrightnessAsync_t = char(WINAPI*)(void* pThis, int value);
-ShowKeyboardBrightnessAsync_t ShowKeyboardBrightnessAsync_Original;
-char WINAPI ShowKeyboardBrightnessAsync_Hook(void* pThis, int value) {
-    g_currentIndicator.store(Indicator::keyboardBrightness);
-    return ShowKeyboardBrightnessAsync_Original(pThis, value);
-}
-
-using ShowAirplaneModeOnAsync_t = char(WINAPI*)(void* pThis, bool value);
-ShowAirplaneModeOnAsync_t ShowAirplaneModeOnAsync_Original;
-char WINAPI ShowAirplaneModeOnAsync_Hook(void* pThis, bool value) {
-    g_currentIndicator.store(Indicator::airplaneMode);
-    return ShowAirplaneModeOnAsync_Original(pThis, value);
-}
-
-using ShowCameraOnAsync_t = char(WINAPI*)(void* pThis, bool value);
-ShowCameraOnAsync_t ShowCameraOnAsync_Original;
-char WINAPI ShowCameraOnAsync_Hook(void* pThis, bool value) {
-    g_currentIndicator.store(Indicator::camera);
-    return ShowCameraOnAsync_Original(pThis, value);
-}
-
-using ShowCameraAccessEnabledAsync_t = char(WINAPI*)(void* pThis, bool value);
-ShowCameraAccessEnabledAsync_t ShowCameraAccessEnabledAsync_Original;
-char WINAPI ShowCameraAccessEnabledAsync_Hook(void* pThis, bool value) {
-    g_currentIndicator.store(Indicator::camera);
-    return ShowCameraAccessEnabledAsync_Original(pThis, value);
-}
+// Each name is optional. If neither layer resolves for a kind, Wh_ModInit
+// disables per-indicator placement rather than reuse a previous kind's spot.
+DEFINE_RECORDER_HOOK(ShowVolumeAsync, char, Indicator::volume,
+                     (void* pThis, int value), (pThis, value));
+DEFINE_RECORDER_HOOK(ShowBrightnessAsync, char, Indicator::brightness,
+                     (void* pThis, int value), (pThis, value));
+DEFINE_RECORDER_HOOK(ShowKeyboardBrightnessAsync, char,
+                     Indicator::keyboardBrightness, (void* pThis, int value),
+                     (pThis, value));
+DEFINE_RECORDER_HOOK(ShowAirplaneModeOnAsync, char, Indicator::airplaneMode,
+                     (void* pThis, bool value), (pThis, value));
+DEFINE_RECORDER_HOOK(ShowCameraOnAsync, char, Indicator::camera,
+                     (void* pThis, bool value), (pThis, value));
+DEFINE_RECORDER_HOOK(ShowCameraAccessEnabledAsync, char, Indicator::camera,
+                     (void* pThis, bool value), (pThis, value));
 
 // This one takes a message alongside the state on current builds and took only
 // the state on older ones. Declared with the extra parameter for both, since the
@@ -611,14 +551,8 @@ char WINAPI ShowCameraAccessEnabledAsync_Hook(void* pThis, bool value) {
 // because the mod is 64-bit only, x64 and arm64 both, where arguments go in
 // registers and the caller does the cleaning up. On a 32-bit stdcall build the
 // callee pops its own arguments and the same mismatch would walk the stack.
-using ShowMicrophoneMutedAsync_t = char(WINAPI*)(void* pThis,
-                                                 int value,
-                                                 void* text);
-ShowMicrophoneMutedAsync_t ShowMicrophoneMutedAsync_Original;
-char WINAPI ShowMicrophoneMutedAsync_Hook(void* pThis, int value, void* text) {
-    g_currentIndicator.store(Indicator::microphone);
-    return ShowMicrophoneMutedAsync_Original(pThis, value, text);
-}
+DEFINE_RECORDER_HOOK(ShowMicrophoneMutedAsync, char, Indicator::microphone,
+                     (void* pThis, int value, void* text), (pThis, value, text));
 
 using ShowTextAsync_t = char(WINAPI*)(void* pThis, void* text, bool value);
 ShowTextAsync_t ShowTextAsync_Original;
@@ -653,10 +587,7 @@ void WINAPI ConfirmatorHostControl_Hide_Hook(void* pThis) {
         // Restored however this returns. Hide is an implementation method rather
         // than an abi thunk, so an hresult_error coming out of it would otherwise
         // leave the flag latched and the setting dead for the rest of the session.
-        struct Restore {
-            bool& flag;
-            ~Restore() { flag = false; }
-        } restore{redirecting};
+        ResetOnExit reset{redirecting};
 
         redirecting = true;
         return ConfirmatorHostControl_HideWithoutAnimation_Original(pThis);
@@ -669,9 +600,7 @@ void WINAPI ConfirmatorHostControl_Hide_Hook(void* pThis) {
 // the hidden-pointer form on x64 and the HFA-in-registers form on ARM64.
 // Hand-rolling the hidden pointer worked on x64 but shifted every argument on
 // ARM64, where four floats are a homogeneous aggregate returned in s0-s3.
-// WinrtRect is four floats = 16 bytes. Both x64 and ARM64 return it via
-// hidden pointer, but the pointer slot differs by architecture and, on x64,
-// by compiler:
+// WinrtRect is four floats = 16 bytes:
 //
 //   - MSVC treats this as a non-static member function: RCX carries `this`,
 //     the hidden retval pointer goes in RDX, and the rect argument follows.
@@ -687,21 +616,12 @@ void WINAPI ConfirmatorHostControl_Hide_Hook(void* pThis) {
 // So the signature is declared per architecture: hand-rolled hidden pointer on
 // x64 to match MSVC's placement, compiler-managed return by value on ARM64 so
 // the compiler emits the HFA form.
-#if defined(_M_ARM64) || defined(__aarch64__)
-using HardwareConfirmatorHost_GetPositionRect_t =
-    WinrtRect(WINAPI*)(void* pThis, const WinrtRect& rect);
-HardwareConfirmatorHost_GetPositionRect_t
-    HardwareConfirmatorHost_GetPositionRect_Original;
-WinrtRect WINAPI
-HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
-                                             const WinrtRect& rect) {
+void AdjustPositionRect(const WinrtRect& rect, WinrtRect* result) {
     Wh_Log(L"> indicator=%s", IndicatorName(g_currentIndicator.load()));
 
     int offsetSettingX = g_settings.offsetX.load();
     int offsetSettingY = g_settings.offsetY.load();
 
-    // Scale the offsets to the target monitor's DPI so the same number moves
-    // the same distance everywhere.
     if (offsetSettingX || offsetSettingY) {
         RECT areaRect{
             .left = (LONG)rect.X,
@@ -712,38 +632,45 @@ HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
         HMONITOR monitor = MonitorFromRect(&areaRect, MONITOR_DEFAULTTONEAREST);
         UINT dpiX = 96;
         UINT dpiY = 96;
-        if (SUCCEEDED(GetDpiForMonitor(monitor, MDT_DEFAULT, &dpiX, &dpiY)) &&
+        if (SUCCEEDED(GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY)) &&
             dpiX && dpiY) {
             offsetSettingX = MulDiv(offsetSettingX, dpiX, 96);
             offsetSettingY = MulDiv(offsetSettingY, dpiY, 96);
         }
     }
 
-    // Shift the input rect to 0,0 since the original function assumes that.
     WinrtRect shiftedRect = rect;
     float offsetX = shiftedRect.X;
     float offsetY = shiftedRect.Y;
     shiftedRect.X = 0;
     shiftedRect.Y = 0;
 
-    WinrtRect result = HardwareConfirmatorHost_GetPositionRect_Original(
-        pThis, shiftedRect);
-
     Position position = CurrentPosition();
-    bool anyPlacement = position != Position::windowsDefault || offsetSettingX ||
-                        offsetSettingY;
-
-    if (anyPlacement) {
-        PlaceInArea(shiftedRect, position, offsetSettingX, offsetSettingY,
-                    &result);
+    if (position != Position::windowsDefault || offsetSettingX || offsetSettingY) {
+        PlaceInArea(shiftedRect, position, offsetSettingX, offsetSettingY, result);
     }
 
-    result.X += offsetX;
-    result.Y += offsetY;
+    result->X += offsetX;
+    result->Y += offsetY;
+}
+
+#undef DEFINE_RECORDER_HOOK
+
+#if defined(_M_ARM64) || defined(__aarch64__)
+using HardwareConfirmatorHost_GetPositionRect_t =
+    WinrtRect(WINAPI*)(void* pThis, const WinrtRect& rect);
+HardwareConfirmatorHost_GetPositionRect_t
+    HardwareConfirmatorHost_GetPositionRect_Original;
+WinrtRect WINAPI
+HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
+                                             const WinrtRect& rect) {
+    WinrtRect result = HardwareConfirmatorHost_GetPositionRect_Original(
+        pThis, WinrtRect{0, 0, rect.Width, rect.Height});
+    AdjustPositionRect(rect, &result);
 
     return result;
 }
-#else
+#elif defined(_M_X64) || defined(__x86_64__)
 using HardwareConfirmatorHost_GetPositionRect_t =
     WinrtRect*(WINAPI*)(void* pThis, WinrtRect* retval, const WinrtRect* rect);
 HardwareConfirmatorHost_GetPositionRect_t
@@ -752,56 +679,19 @@ WinrtRect* WINAPI
 HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
                                              WinrtRect* retval,
                                              const WinrtRect* rect) {
-    Wh_Log(L"> indicator=%s", IndicatorName(g_currentIndicator.load()));
-
-    int offsetSettingX = g_settings.offsetX.load();
-    int offsetSettingY = g_settings.offsetY.load();
-
-    // Scale the offsets to the target monitor's DPI so the same number moves
-    // the same distance everywhere.
-    if (offsetSettingX || offsetSettingY) {
-        RECT areaRect{
-            .left = (LONG)rect->X,
-            .top = (LONG)rect->Y,
-            .right = (LONG)(rect->X + rect->Width),
-            .bottom = (LONG)(rect->Y + rect->Height),
-        };
-        HMONITOR monitor = MonitorFromRect(&areaRect, MONITOR_DEFAULTTONEAREST);
-        UINT dpiX = 96;
-        UINT dpiY = 96;
-        if (SUCCEEDED(GetDpiForMonitor(monitor, MDT_DEFAULT, &dpiX, &dpiY)) &&
-            dpiX && dpiY) {
-            offsetSettingX = MulDiv(offsetSettingX, dpiX, 96);
-            offsetSettingY = MulDiv(offsetSettingY, dpiY, 96);
-        }
-    }
-
-    // Shift the input rect to 0,0 since the original function assumes that.
-    WinrtRect shiftedRect = *rect;
-    float offsetX = shiftedRect.X;
-    float offsetY = shiftedRect.Y;
-    shiftedRect.X = 0;
-    shiftedRect.Y = 0;
+    WinrtRect shiftedRect{0, 0, rect->Width, rect->Height};
 
     WinrtRect* result = HardwareConfirmatorHost_GetPositionRect_Original(
         pThis, retval, &shiftedRect);
 
     if (result) {
-        Position position = CurrentPosition();
-        bool anyPlacement = position != Position::windowsDefault ||
-                            offsetSettingX || offsetSettingY;
-
-        if (anyPlacement) {
-            PlaceInArea(shiftedRect, position, offsetSettingX,
-                        offsetSettingY, result);
-        }
-
-        result->X += offsetX;
-        result->Y += offsetY;
+        AdjustPositionRect(*rect, result);
     }
 
     return result;
 }
+#else
+#error "Unsupported architecture"
 #endif
 
 Position PositionFromString(PCWSTR value) {

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Put the volume, brightness and camera on-screen indicators anywhere on the screen, each in its own spot if you like, and optionally skip the slide out animation
-// @version         1.4.1
+// @version         1.4.2
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -96,8 +96,9 @@ a monitor by number or by interface name. The two work together.
   lands at the new spot is the tail end of the previous indicator instead of an
   empty frame.
 * Tested on Windows 11 build 26200 (25H2) x64, on a 100% and a 150% display.
-  ARM64 hasn't been tested; the position lookup follows a different calling
-  convention there, so if you run it on ARM64 please let me know how it goes.
+  The ARM64 hooks were checked against the disassembly of the confirmator DLL
+  but not run on hardware, so if you use it there please let me know how it
+  goes.
 
 ## Credits
 
@@ -529,21 +530,35 @@ int WINAPI ShowTextThunk_Hook(void* pThis, void* text, bool value) {
     return ShowTextThunk_Original(pThis, text, value);
 }
 
-// Each name is optional. If neither layer resolves for a kind, Wh_ModInit
-// disables per-indicator placement rather than reuse a previous kind's spot.
-DEFINE_RECORDER_HOOK(ShowVolumeAsync, char, Indicator::volume,
-                     (void* pThis, int value), (pThis, value));
-DEFINE_RECORDER_HOOK(ShowBrightnessAsync, char, Indicator::brightness,
-                     (void* pThis, int value), (pThis, value));
-DEFINE_RECORDER_HOOK(ShowKeyboardBrightnessAsync, char,
-                     Indicator::keyboardBrightness, (void* pThis, int value),
-                     (pThis, value));
-DEFINE_RECORDER_HOOK(ShowAirplaneModeOnAsync, char, Indicator::airplaneMode,
-                     (void* pThis, bool value), (pThis, value));
-DEFINE_RECORDER_HOOK(ShowCameraOnAsync, char, Indicator::camera,
-                     (void* pThis, bool value), (pThis, value));
-DEFINE_RECORDER_HOOK(ShowCameraAccessEnabledAsync, char, Indicator::camera,
-                     (void* pThis, bool value), (pThis, value));
+// Each of these is winrt::fire_and_forget, an empty struct but not a trivial
+// one, so MSVC still returns it through a hidden pointer rather than in a
+// register: `this` first, the hidden retval pointer next, then the source
+// arguments, with the pointer handed back as the return value. A signature
+// without that slot compiles and links, but every real argument then arrives
+// one register late and the original coroutine gets called with garbage
+// where it expects its own arguments to be — this shipped for a session
+// before a maintainer caught it from the disassembly. Each name is optional;
+// if neither layer resolves for a kind, Wh_ModInit disables per-indicator
+// placement rather than reuse a previous kind's spot.
+DEFINE_RECORDER_HOOK(ShowVolumeAsync, void*, Indicator::volume,
+                     (void* pThis, void* retval, int value),
+                     (pThis, retval, value));
+DEFINE_RECORDER_HOOK(ShowBrightnessAsync, void*, Indicator::brightness,
+                     (void* pThis, void* retval, int value),
+                     (pThis, retval, value));
+DEFINE_RECORDER_HOOK(ShowKeyboardBrightnessAsync, void*,
+                     Indicator::keyboardBrightness,
+                     (void* pThis, void* retval, int value),
+                     (pThis, retval, value));
+DEFINE_RECORDER_HOOK(ShowAirplaneModeOnAsync, void*, Indicator::airplaneMode,
+                     (void* pThis, void* retval, bool value),
+                     (pThis, retval, value));
+DEFINE_RECORDER_HOOK(ShowCameraOnAsync, void*, Indicator::camera,
+                     (void* pThis, void* retval, bool value),
+                     (pThis, retval, value));
+DEFINE_RECORDER_HOOK(ShowCameraAccessEnabledAsync, void*, Indicator::camera,
+                     (void* pThis, void* retval, bool value),
+                     (pThis, retval, value));
 
 // This one takes a message alongside the state on current builds and took only
 // the state on older ones. Declared with the extra parameter for both, since the
@@ -551,15 +566,22 @@ DEFINE_RECORDER_HOOK(ShowCameraAccessEnabledAsync, char, Indicator::camera,
 // because the mod is 64-bit only, x64 and arm64 both, where arguments go in
 // registers and the caller does the cleaning up. On a 32-bit stdcall build the
 // callee pops its own arguments and the same mismatch would walk the stack.
-DEFINE_RECORDER_HOOK(ShowMicrophoneMutedAsync, char, Indicator::microphone,
-                     (void* pThis, int value, void* text), (pThis, value, text));
+DEFINE_RECORDER_HOOK(ShowMicrophoneMutedAsync, void*, Indicator::microphone,
+                     (void* pThis, void* retval, int value, void* text),
+                     (pThis, retval, value, text));
 
-using ShowTextAsync_t = char(WINAPI*)(void* pThis, void* text, bool value);
+using ShowTextAsync_t = void*(WINAPI*)(void* pThis,
+                                       void* retval,
+                                       void* text,
+                                       bool value);
 ShowTextAsync_t ShowTextAsync_Original;
-char WINAPI ShowTextAsync_Hook(void* pThis, void* text, bool value) {
+void* WINAPI ShowTextAsync_Hook(void* pThis,
+                                void* retval,
+                                void* text,
+                                bool value) {
     g_currentIndicator.store(g_textCallFromTwinui ? Indicator::virtualDesktop
                                                   : Indicator::text);
-    return ShowTextAsync_Original(pThis, text, value);
+    return ShowTextAsync_Original(pThis, retval, text, value);
 }
 
 // The control hides itself two ways and Windows picks the animated one. Handing the
@@ -596,26 +618,6 @@ void WINAPI ConfirmatorHostControl_Hide_Hook(void* pThis) {
     return ConfirmatorHostControl_Hide_Original(pThis);
 }
 
-// Declared with the platform's own return convention so the compiler produces
-// the hidden-pointer form on x64 and the HFA-in-registers form on ARM64.
-// Hand-rolling the hidden pointer worked on x64 but shifted every argument on
-// ARM64, where four floats are a homogeneous aggregate returned in s0-s3.
-// WinrtRect is four floats = 16 bytes:
-//
-//   - MSVC treats this as a non-static member function: RCX carries `this`,
-//     the hidden retval pointer goes in RDX, and the rect argument follows.
-//   - Clang targeting x86_64-w64-mingw32 sees the WINAPI-declared type as a
-//     free function and puts the hidden retval pointer in RCX with `this` in
-//     RDX. The MSVC-compiled explorer.exe caller expects the MSVC layout, so
-//     the compiler-managed return-by-value form writes the result to what the
-//     caller was using as `this`. The shell crashes on the first call.
-//   - ARM64 uses AAPCS64: four floats are a Homogeneous Floating-point
-//     Aggregate returned in s0-s3 with no hidden pointer at all, so the
-//     compiler-managed form emits exactly what the target expects.
-//
-// So the signature is declared per architecture: hand-rolled hidden pointer on
-// x64 to match MSVC's placement, compiler-managed return by value on ARM64 so
-// the compiler emits the HFA form.
 void AdjustPositionRect(const WinrtRect& rect, WinrtRect* result) {
     Wh_Log(L"> indicator=%s", IndicatorName(g_currentIndicator.load()));
 
@@ -656,21 +658,15 @@ void AdjustPositionRect(const WinrtRect& rect, WinrtRect* result) {
 
 #undef DEFINE_RECORDER_HOOK
 
-#if defined(_M_ARM64) || defined(__aarch64__)
-using HardwareConfirmatorHost_GetPositionRect_t =
-    WinrtRect(WINAPI*)(void* pThis, const WinrtRect& rect);
-HardwareConfirmatorHost_GetPositionRect_t
-    HardwareConfirmatorHost_GetPositionRect_Original;
-WinrtRect WINAPI
-HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
-                                             const WinrtRect& rect) {
-    WinrtRect result = HardwareConfirmatorHost_GetPositionRect_Original(
-        pThis, WinrtRect{0, 0, rect.Width, rect.Height});
-    AdjustPositionRect(rect, &result);
-
-    return result;
-}
-#elif defined(_M_X64) || defined(__x86_64__)
+// winrt::Windows::Foundation::Rect has a user-provided constructor, so MSVC
+// returns it through a hidden pointer rather than in registers on both
+// architectures it's built for here: `this` first, the hidden retval pointer
+// next, then the rect argument (RCX/RDX/R8 on x64, x0/x1/x2 on ARM64), with
+// the pointer handed back as the return value. Confirmed against the ARM64
+// binary's disassembly, not just inferred from the ABI docs, since the
+// mismatch is exactly the kind of thing that looks plausible and crashes the
+// shell on the first call. One signature covers both, so there's nothing to
+// branch on here.
 using HardwareConfirmatorHost_GetPositionRect_t =
     WinrtRect*(WINAPI*)(void* pThis, WinrtRect* retval, const WinrtRect* rect);
 HardwareConfirmatorHost_GetPositionRect_t
@@ -690,9 +686,6 @@ HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
 
     return result;
 }
-#else
-#error "Unsupported architecture"
-#endif
 
 Position PositionFromString(PCWSTR value) {
     if (wcscmp(value, L"topLeft") == 0) {

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -1,7 +1,7 @@
 // ==WindhawkMod==
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
-// @description     Put the volume, brightness and camera on-screen indicators anywhere on the screen, each in its own spot if you like, instead of the three positions Windows offers
+// @description     Put the volume, brightness and camera on-screen indicators anywhere on the screen, each in its own spot if you like, and optionally skip the slide out animation
 // @version         1.3.1
 // @author          mario0318
 // @github          https://github.com/mario0318
@@ -60,6 +60,14 @@ ever on screen at a time, so this is the same desktop photographed twice:
 
 ![Volume top left, brightness center](https://raw.githubusercontent.com/mario0318/windhawk-mods/628f80317652209d3feed54eadf9c329e77b04a7/on-screen-indicator-position/per-indicator.jpg)
 
+## Skip the slide out animation
+
+The indicator normally slides off screen when it's done. With **Skip the slide out
+animation** on, it just disappears. Windows already has a no-animation hide path
+and the mod asks for that one instead, so the slide in and everything outside the
+indicator are left alone. If the setting ever appears to do nothing, the mod's log
+says so on a build where the entry points have moved.
+
 ## Choosing a monitor
 
 This mod only changes where the indicator sits on a screen, not which screen it
@@ -69,11 +77,6 @@ a monitor by number or by interface name. The two work together.
 
 ## Notes
 
-* **Skip the slide out animation** has the indicator disappear rather than slide
-  away. Windows has its own no animation path for hiding and the mod asks for that
-  one, so the sliding in and everything outside the indicator are left alone. If it
-  ever appears to do nothing, the mod's log says so on a build where those entry
-  points have moved.
 * The slide-in animation direction is chosen by Windows from the built-in
   setting, not by this mod. If the animation looks wrong for your new position,
   change the built-in setting to whichever of the three has the animation you
@@ -283,10 +286,7 @@ std::atomic<bool> g_kindUnreliable{false};
 constexpr Position kDefaultPosition = Position::topRight;
 
 // Written from Wh_ModSettingsChanged on an arbitrary thread and read on the
-// confirmator's UI thread, so the members are atomic. Each field is still read
-// separately, so a settings change landing mid-placement can put one indicator
-// on screen with a mix of old and new values. That was true before the atomics
-// too, and one misplaced indicator is the whole cost.
+// confirmator's UI thread, so the members are atomic.
 struct {
     std::atomic<Position> position;
     std::atomic<int> offsetX;
@@ -328,9 +328,8 @@ constexpr PCWSTR kKindUnreliableMessage =
     L"An indicator entry point didn't resolve, so the position per indicator "
     L"settings are ignored and everything uses the main position";
 
-// Set when either half of the hide pair didn't resolve, which leaves the skip
-// setting with nothing to do.
-std::atomic<bool> g_hideAnimationUnavailable{false};
+// Set once in Wh_ModInit when either half of the hide pair didn't resolve.
+bool g_hideAnimationUnavailable = false;
 
 constexpr PCWSTR kHideAnimationUnavailableMessage =
     L"The hide entry points didn't resolve, so the slide out animation is left "
@@ -613,32 +612,30 @@ void WINAPI ConfirmatorHostControl_Hide_Hook(void* pThis) {
     return ConfirmatorHostControl_Hide_Original(pThis);
 }
 
+// Declared with the platform's own return convention so the compiler produces
+// the hidden-pointer form on x64 and the HFA-in-registers form on ARM64.
+// Hand-rolling the hidden pointer worked on x64 but shifted every argument on
+// ARM64, where four floats are a homogeneous aggregate returned in s0-s3.
 using HardwareConfirmatorHost_GetPositionRect_t =
-    WinrtRect*(WINAPI*)(void* pThis, WinrtRect* retval, const WinrtRect* rect);
+    WinrtRect(WINAPI*)(void* pThis, const WinrtRect& rect);
 HardwareConfirmatorHost_GetPositionRect_t
     HardwareConfirmatorHost_GetPositionRect_Original;
-WinrtRect* WINAPI
+WinrtRect WINAPI
 HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
-                                             WinrtRect* retval,
-                                             const WinrtRect* rect) {
+                                             const WinrtRect& rect) {
     Wh_Log(L"> indicator=%s", IndicatorName(g_currentIndicator.load()));
 
-    // Read the offsets once so the placement below uses one consistent pair.
     int offsetSettingX = g_settings.offsetX.load();
     int offsetSettingY = g_settings.offsetY.load();
 
-    // The rect is in the target monitor's physical pixels, so a raw offset would
-    // cover less ground the more that monitor is scaled up. Scaling by its DPI
-    // keeps the setting meaning the same distance everywhere. Both offsets are
-    // zero by default, and then there is nothing to scale and no reason to look
-    // the monitor up on every showing. Resolve it before the origin is shifted
-    // away.
+    // Scale the offsets to the target monitor's DPI so the same number moves
+    // the same distance everywhere.
     if (offsetSettingX || offsetSettingY) {
         RECT areaRect{
-            .left = (LONG)rect->X,
-            .top = (LONG)rect->Y,
-            .right = (LONG)(rect->X + rect->Width),
-            .bottom = (LONG)(rect->Y + rect->Height),
+            .left = (LONG)rect.X,
+            .top = (LONG)rect.Y,
+            .right = (LONG)(rect.X + rect.Width),
+            .bottom = (LONG)(rect.Y + rect.Height),
         };
         HMONITOR monitor = MonitorFromRect(&areaRect, MONITOR_DEFAULTTONEAREST);
         UINT dpiX = 96;
@@ -651,34 +648,26 @@ HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
     }
 
     // Shift the input rect to 0,0 since the original function assumes that.
-    WinrtRect shiftedRect = *rect;
+    WinrtRect shiftedRect = rect;
     float offsetX = shiftedRect.X;
     float offsetY = shiftedRect.Y;
     shiftedRect.X = 0;
     shiftedRect.Y = 0;
 
-    WinrtRect* result = HardwareConfirmatorHost_GetPositionRect_Original(
-        pThis, retval, &shiftedRect);
+    WinrtRect result = HardwareConfirmatorHost_GetPositionRect_Original(
+        pThis, shiftedRect);
 
-    // Nothing to place happens for a kind left on the main position while that is
-    // on Windows default, and for someone who only wanted the animation setting.
-    // The edge clamp inside PlaceInArea would still be free to move the indicator
-    // off the spot Windows picked, so it is skipped rather than run with nothing to
-    // do. The shift above stays either way, since the original needs it.
     Position position = CurrentPosition();
     bool anyPlacement = position != Position::windowsDefault || offsetSettingX ||
                         offsetSettingY;
 
-    if (result && anyPlacement) {
+    if (anyPlacement) {
         PlaceInArea(shiftedRect, position, offsetSettingX, offsetSettingY,
-                    result);
+                    &result);
     }
 
-    if (result) {
-        // Shift the result back.
-        result->X += offsetX;
-        result->Y += offsetY;
-    }
+    result.X += offsetX;
+    result.Y += offsetY;
 
     return result;
 }
@@ -872,7 +861,8 @@ BOOL Wh_ModInit() {
             true,  // optional
         },
         {
-            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost,struct winrt::Windows::Internal::HardwareConfirmator::IHardwareConfirmatorHost>::ShowMicrophoneMuted(int,void *))"},
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost,struct winrt::Windows::Internal::HardwareConfirmator::IHardwareConfirmatorHost>::ShowMicrophoneMuted(int,void *))",
+             LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost,struct winrt::Windows::Internal::HardwareConfirmator::IHardwareConfirmatorHost>::ShowMicrophoneMuted(int))"},
             &ShowMicrophoneMutedThunk_Original,
             ShowMicrophoneMutedThunk_Hook,
             true,  // optional
@@ -897,12 +887,8 @@ BOOL Wh_ModInit() {
         },
     };
 
-    // The whole set goes in every time. The eight that record which kind is being
-    // shown are coroutine ramps that store a value and tail-call the original, so
-    // patching them when no kind has a spot of its own costs nothing worth
-    // measuring, and installing the same set every time keeps the symbol cache
-    // from being resolved again the first time someone turns an override on. The
-    // same goes for the hide pair and the animation setting.
+    // The whole set goes in every time so the symbol cache doesn't need to be
+    // resolved again when someone turns a setting on later.
     if (!HookSymbols(g_hardwareConfirmatorModule, symbolHooks,
                      ARRAYSIZE(symbolHooks))) {
         Wh_Log(L"HookSymbols failed");
@@ -913,13 +899,8 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
-    // An optional symbol that isn't found leaves its original pointer alone, so
-    // a null here means that kind would never be recorded and every kind after
-    // it would be placed using a stale one. Rather than misplace an indicator,
-    // drop to the main position for everything and say so in the log.
     // Each kind is recognised as long as one of its two entry points resolved.
-    // These are named after the symbols rather than the kinds, since there are
-    // eight of them and only seven kinds, camera having two.
+    // Named after the symbols, not the kinds, since camera has two.
     const struct {
         PCWSTR name;
         const void* ramp;
@@ -959,8 +940,7 @@ BOOL Wh_ModInit() {
         }
     }
 
-    // Every one is reported rather than stopping at the first missing entry point,
-    // since a build that moved several names should show all of them.
+    // Report all of them before deciding, so a build that moved several shows all.
     for (const auto& recorder : kindRecorders) {
         Wh_Log(L"Entry point %s resolved through ramp=%d thunk=%d", recorder.name,
                !!recorder.ramp, !!recorder.thunk);
@@ -982,9 +962,6 @@ BOOL Wh_ModInit() {
 void Wh_ModUninit() {
     Wh_Log(L">");
 
-    // The hooks are already gone by this point, so handing back the reference
-    // taken in Wh_ModInit is safe. Without this every enable and disable cycle
-    // leaves one behind.
     if (g_hardwareConfirmatorModule) {
         FreeLibrary(g_hardwareConfirmatorModule);
         g_hardwareConfirmatorModule = nullptr;
@@ -994,12 +971,7 @@ void Wh_ModUninit() {
 void Wh_ModSettingsChanged() {
     Wh_Log(L">");
 
-    // Every hook is installed either way now, so nothing here needs a reload and
-    // a change takes effect on the next indicator.
     LoadSettings();
-
-    // Turning on the first override no longer re-runs Wh_ModInit, so this is the
-    // only place the person it concerns can still be told.
     if (g_kindUnreliable && AnyPerIndicator()) {
         Wh_Log(L"%s", kKindUnreliableMessage);
     }

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,12 +2,12 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Put the volume, brightness and camera on-screen indicators anywhere on the screen, each in its own spot if you like, and optionally skip the slide out animation
-// @version         1.3.1
+// @version         1.4.0
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lshcore
+// @compilerOptions -lshcore -lpsapi
 // ==/WindhawkMod==
 
 // Source code is published under The GNU General Public License v3.0.
@@ -49,11 +49,12 @@ nudge one of the built-in positions.
 
 ## A different spot per indicator
 
-Volume, brightness, keyboard brightness, airplane mode, camera, microphone and the
-plain text indicator can each be given their own position. Anything left on **Same
-as the main position** follows the setting above, so you only have to touch the ones
-you want somewhere else. Handy if you want the volume indicator out of the way at the
-bottom but still want the camera one where you will notice it.
+Volume, brightness, keyboard brightness, airplane mode, camera, microphone, the
+virtual desktop name popup and the plain text indicator can each be given their own
+position. Anything left on **Same as the main position** follows the setting above,
+so you only have to touch the ones you want somewhere else. Handy if you want the
+volume indicator out of the way at the bottom but still want the camera one where
+you will notice it.
 
 Volume kept at the top left while brightness sits in the middle. Only one of them is
 ever on screen at a time, so this is the same desktop photographed twice:
@@ -227,16 +228,31 @@ both target the same function and work out the origin handling.
     - bottomLeft: Bottom left
     - bottomCenter: Bottom center
     - bottomRight: Bottom right
+  - virtualDesktop: same
+    $name: Virtual desktop name
+    $options:
+    - same: Same as the main position
+    - topLeft: Top left
+    - topCenter: Top center
+    - topRight: Top right
+    - middleLeft: Middle left
+    - center: Center
+    - middleRight: Middle right
+    - bottomLeft: Bottom left
+    - bottomCenter: Bottom center
+    - bottomRight: Bottom right
   $name: Position per indicator
   $description: >-
-    Give one kind of indicator a spot of its own. Anything left on "Same as the
-    main position" follows the Position setting above. The offsets apply to all
-    of them either way.
+    Give one kind of indicator a spot of its own. The virtual desktop name popup
+    is separated from other text indicators so it can be placed independently.
+    Anything left on "Same as the main position" follows the Position setting
+    above. The offsets apply to all of them either way.
 */
 // ==/WindhawkModSettings==
 
 #include <windhawk_utils.h>
 
+#include <psapi.h>
 #include <shellscalingapi.h>
 
 #include <atomic>
@@ -265,6 +281,7 @@ enum class Indicator {
     camera,
     microphone,
     text,
+    virtualDesktop,
     count,
     // Nothing has been shown yet, so there is no kind to look up and the main
     // position is used.
@@ -313,8 +330,9 @@ bool AnyPerIndicator() {
 // rather than a number to count enum members against.
 PCWSTR IndicatorName(Indicator indicator) {
     static constexpr PCWSTR kNames[] = {
-        L"volume",     L"brightness", L"keyboardBrightness", L"airplaneMode",
-        L"camera",     L"microphone", L"text",
+        L"volume",     L"brightness",      L"keyboardBrightness",
+        L"airplaneMode", L"camera",        L"microphone",
+        L"text",       L"virtualDesktop",
     };
     static_assert(ARRAYSIZE(kNames) == (size_t)Indicator::count);
 
@@ -494,11 +512,51 @@ int WINAPI ShowMicrophoneMutedThunk_Hook(void* pThis, int state, void* text) {
     return ShowMicrophoneMutedThunk_Original(pThis, state, text);
 }
 
+// The virtual desktop name popup goes through the same ShowText entry point as
+// every other text indicator. The only thing that tells them apart at hook time
+// is who called it: twinui.dll for the virtual desktop switch, the aeh module
+// for everything else. Hooking twinui.dll directly crashes the shell, so the
+// caller module is looked up from the return address instead. Cheap, no other
+// module touched, no chance of conflicting with another mod that hooks the same
+// twinui function.
+HMODULE g_twinuiModule = nullptr;
+uintptr_t g_twinuiBase = 0;
+uintptr_t g_twinuiEnd = 0;
+
+bool ReturnAddressIsTwinui(void* returnAddress) {
+    if (!g_twinuiBase) {
+        return false;
+    }
+    uintptr_t ra = reinterpret_cast<uintptr_t>(returnAddress);
+    return ra >= g_twinuiBase && ra < g_twinuiEnd;
+}
+
+// A ShowText call from twinui goes through the thunk first, and the thunk then
+// calls into the async ramp internally. That means the ramp's own return
+// address sits inside the thunk, not inside twinui, so a naive return-address
+// check would classify the ramp as a plain text indicator and clobber the
+// virtualDesktop classification the thunk just made. The thunk sets this
+// thread_local before it dispatches, the ramp inherits it, and the thunk
+// clears it after the call returns so it doesn't leak into a later text show
+// on the same thread.
+thread_local bool g_textCallFromTwinui = false;
+
+Indicator ClassifyTextCall(void* returnAddress) {
+    return (g_textCallFromTwinui || ReturnAddressIsTwinui(returnAddress))
+               ? Indicator::virtualDesktop
+               : Indicator::text;
+}
+
 using ShowTextThunk_t = int(WINAPI*)(void* pThis, void* text, bool value);
 ShowTextThunk_t ShowTextThunk_Original;
 int WINAPI ShowTextThunk_Hook(void* pThis, void* text, bool value) {
-    g_currentIndicator.store(Indicator::text);
-    return ShowTextThunk_Original(pThis, text, value);
+    bool fromTwinui = ReturnAddressIsTwinui(__builtin_return_address(0));
+    g_textCallFromTwinui = fromTwinui;
+    g_currentIndicator.store(fromTwinui ? Indicator::virtualDesktop
+                                        : Indicator::text);
+    int result = ShowTextThunk_Original(pThis, text, value);
+    g_textCallFromTwinui = false;
+    return result;
 }
 
 // Each kind of indicator has its own entry point on the host, so the kind is
@@ -571,7 +629,7 @@ char WINAPI ShowMicrophoneMutedAsync_Hook(void* pThis, int value, void* text) {
 using ShowTextAsync_t = char(WINAPI*)(void* pThis, void* text, bool value);
 ShowTextAsync_t ShowTextAsync_Original;
 char WINAPI ShowTextAsync_Hook(void* pThis, void* text, bool value) {
-    g_currentIndicator.store(Indicator::text);
+    g_currentIndicator.store(ClassifyTextCall(__builtin_return_address(0)));
     return ShowTextAsync_Original(pThis, text, value);
 }
 
@@ -616,6 +674,25 @@ void WINAPI ConfirmatorHostControl_Hide_Hook(void* pThis) {
 // the hidden-pointer form on x64 and the HFA-in-registers form on ARM64.
 // Hand-rolling the hidden pointer worked on x64 but shifted every argument on
 // ARM64, where four floats are a homogeneous aggregate returned in s0-s3.
+// WinrtRect is four floats = 16 bytes. The calling convention for a 16-byte
+// aggregate return differs by architecture, and worse, differs by *compiler* on
+// x64:
+//
+//   - MSVC on x64 uses the MS ABI: a hidden first pointer, the callee writes
+//     the result through it and returns the pointer in RAX.
+//   - Clang/mingw targeting x86_64-w64-mingw32 does NOT reliably generate that
+//     hidden-pointer form for a return-by-value 16-byte aggregate; it splits
+//     the return into XMM0/XMM1 registers, which does not match what the
+//     MSVC-compiled explorer.exe caller expects. The mismatch corrupts the
+//     return path and crashes the shell on the first call.
+//   - ARM64 uses AAPCS64: four floats are a Homogeneous Floating-point
+//     Aggregate returned in s0-s3, and a hidden pointer would shift every
+//     other argument by one slot and pass garbage through.
+//
+// So the signature is declared per architecture: hand-rolled hidden pointer on
+// x64 to match MSVC exactly, compiler-managed return by value on ARM64 so the
+// compiler emits the HFA form.
+#if defined(_M_ARM64) || defined(__aarch64__)
 using HardwareConfirmatorHost_GetPositionRect_t =
     WinrtRect(WINAPI*)(void* pThis, const WinrtRect& rect);
 HardwareConfirmatorHost_GetPositionRect_t
@@ -671,6 +748,66 @@ HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
 
     return result;
 }
+#else
+using HardwareConfirmatorHost_GetPositionRect_t =
+    WinrtRect*(WINAPI*)(void* pThis, WinrtRect* retval, const WinrtRect* rect);
+HardwareConfirmatorHost_GetPositionRect_t
+    HardwareConfirmatorHost_GetPositionRect_Original;
+WinrtRect* WINAPI
+HardwareConfirmatorHost_GetPositionRect_Hook(void* pThis,
+                                             WinrtRect* retval,
+                                             const WinrtRect* rect) {
+    Wh_Log(L"> indicator=%s", IndicatorName(g_currentIndicator.load()));
+
+    int offsetSettingX = g_settings.offsetX.load();
+    int offsetSettingY = g_settings.offsetY.load();
+
+    // Scale the offsets to the target monitor's DPI so the same number moves
+    // the same distance everywhere.
+    if (offsetSettingX || offsetSettingY) {
+        RECT areaRect{
+            .left = (LONG)rect->X,
+            .top = (LONG)rect->Y,
+            .right = (LONG)(rect->X + rect->Width),
+            .bottom = (LONG)(rect->Y + rect->Height),
+        };
+        HMONITOR monitor = MonitorFromRect(&areaRect, MONITOR_DEFAULTTONEAREST);
+        UINT dpiX = 96;
+        UINT dpiY = 96;
+        if (SUCCEEDED(GetDpiForMonitor(monitor, MDT_DEFAULT, &dpiX, &dpiY)) &&
+            dpiX && dpiY) {
+            offsetSettingX = MulDiv(offsetSettingX, dpiX, 96);
+            offsetSettingY = MulDiv(offsetSettingY, dpiY, 96);
+        }
+    }
+
+    // Shift the input rect to 0,0 since the original function assumes that.
+    WinrtRect shiftedRect = *rect;
+    float offsetX = shiftedRect.X;
+    float offsetY = shiftedRect.Y;
+    shiftedRect.X = 0;
+    shiftedRect.Y = 0;
+
+    WinrtRect* result = HardwareConfirmatorHost_GetPositionRect_Original(
+        pThis, retval, &shiftedRect);
+
+    if (result) {
+        Position position = CurrentPosition();
+        bool anyPlacement = position != Position::windowsDefault ||
+                            offsetSettingX || offsetSettingY;
+
+        if (anyPlacement) {
+            PlaceInArea(shiftedRect, position, offsetSettingX,
+                        offsetSettingY, result);
+        }
+
+        result->X += offsetX;
+        result->Y += offsetY;
+    }
+
+    return result;
+}
+#endif
 
 Position PositionFromString(PCWSTR value) {
     if (wcscmp(value, L"topLeft") == 0) {
@@ -728,6 +865,7 @@ void LoadSettings() {
         L"perIndicator.camera",
         L"perIndicator.microphone",
         L"perIndicator.text",
+        L"perIndicator.virtualDesktop",
     };
     static_assert(ARRAYSIZE(kIndicatorSettings) == (size_t)Indicator::count);
 
@@ -954,6 +1092,29 @@ BOOL Wh_ModInit() {
     // defaults there is nothing being ignored to complain about.
     if (g_kindUnreliable && anyPerIndicator) {
         Wh_Log(L"%s", kKindUnreliableMessage);
+    }
+
+    // Resolve twinui.dll's loaded range so ShowText can tell a virtual desktop
+    // switch popup apart from other text indicators by checking the return
+    // address. Nothing in twinui is hooked, just its address range is read.
+    // If twinui isn't loaded yet or the query fails, the popup falls back to
+    // the plain text position, same as before.
+    g_twinuiModule = GetModuleHandleW(L"twinui.dll");
+    if (g_twinuiModule) {
+        MODULEINFO mi{};
+        if (GetModuleInformation(GetCurrentProcess(), g_twinuiModule, &mi,
+                                 sizeof(mi))) {
+            g_twinuiBase = reinterpret_cast<uintptr_t>(mi.lpBaseOfDll);
+            g_twinuiEnd = g_twinuiBase + mi.SizeOfImage;
+            Wh_Log(L"twinui.dll range 0x%p - 0x%p", (void*)g_twinuiBase,
+                   (void*)g_twinuiEnd);
+        } else {
+            Wh_Log(L"twinui.dll present but GetModuleInformation failed, "
+                   L"virtual desktop indicator uses text position");
+        }
+    } else {
+        Wh_Log(L"twinui.dll not loaded, virtual desktop indicator uses text "
+               L"position");
     }
 
     return TRUE;

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -7,7 +7,7 @@
 // @github          https://github.com/mario0318
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lshcore -lpsapi
+// @compilerOptions -lshcore
 // ==/WindhawkMod==
 
 // Source code is published under The GNU General Public License v3.0.
@@ -92,6 +92,8 @@ a monitor by number or by interface name. The two work together.
   lands at the new spot is the tail end of the previous indicator instead of an
   empty frame.
 * Tested on Windows 11 build 26200 (25H2) x64, on a 100% and a 150% display.
+  ARM64 hasn't been tested; the position lookup follows a different calling
+  convention there, so if you run it on ARM64 please let me know how it goes.
 
 ## Credits
 
@@ -252,7 +254,6 @@ both target the same function and work out the origin handling.
 
 #include <windhawk_utils.h>
 
-#include <psapi.h>
 #include <shellscalingapi.h>
 
 #include <atomic>
@@ -518,34 +519,27 @@ int WINAPI ShowMicrophoneMutedThunk_Hook(void* pThis, int state, void* text) {
 // for everything else. Hooking twinui.dll directly crashes the shell, so the
 // caller module is looked up from the return address instead. Cheap, no other
 // module touched, no chance of conflicting with another mod that hooks the same
-// twinui function.
-HMODULE g_twinuiModule = nullptr;
-uintptr_t g_twinuiBase = 0;
-uintptr_t g_twinuiEnd = 0;
-
+// twinui function. GetModuleHandleEx is used at call time rather than caching a
+// range at init, since Wh_ModInit runs before the target process begins and
+// twinui isn't loaded yet on a fresh explorer start.
 bool ReturnAddressIsTwinui(void* returnAddress) {
-    if (!g_twinuiBase) {
+    HMODULE fromModule = nullptr;
+    if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                            reinterpret_cast<PCWSTR>(returnAddress),
+                            &fromModule)) {
         return false;
     }
-    uintptr_t ra = reinterpret_cast<uintptr_t>(returnAddress);
-    return ra >= g_twinuiBase && ra < g_twinuiEnd;
+    return fromModule == GetModuleHandleW(L"twinui.dll");
 }
 
 // A ShowText call from twinui goes through the thunk first, and the thunk then
-// calls into the async ramp internally. That means the ramp's own return
-// address sits inside the thunk, not inside twinui, so a naive return-address
-// check would classify the ramp as a plain text indicator and clobber the
-// virtualDesktop classification the thunk just made. The thunk sets this
-// thread_local before it dispatches, the ramp inherits it, and the thunk
-// clears it after the call returns so it doesn't leak into a later text show
-// on the same thread.
+// calls into the async ramp internally. The ramp is a private coroutine only
+// reachable from inside the confirmator DLL, so its own return address can
+// never be in twinui. The thunk records the decision in this thread_local and
+// the ramp reads it back. Cleared when the thunk returns so it doesn't leak
+// into a later plain text show on the same thread.
 thread_local bool g_textCallFromTwinui = false;
-
-Indicator ClassifyTextCall(void* returnAddress) {
-    return (g_textCallFromTwinui || ReturnAddressIsTwinui(returnAddress))
-               ? Indicator::virtualDesktop
-               : Indicator::text;
-}
 
 using ShowTextThunk_t = int(WINAPI*)(void* pThis, void* text, bool value);
 ShowTextThunk_t ShowTextThunk_Original;
@@ -629,7 +623,8 @@ char WINAPI ShowMicrophoneMutedAsync_Hook(void* pThis, int value, void* text) {
 using ShowTextAsync_t = char(WINAPI*)(void* pThis, void* text, bool value);
 ShowTextAsync_t ShowTextAsync_Original;
 char WINAPI ShowTextAsync_Hook(void* pThis, void* text, bool value) {
-    g_currentIndicator.store(ClassifyTextCall(__builtin_return_address(0)));
+    g_currentIndicator.store(g_textCallFromTwinui ? Indicator::virtualDesktop
+                                                  : Indicator::text);
     return ShowTextAsync_Original(pThis, text, value);
 }
 
@@ -674,24 +669,24 @@ void WINAPI ConfirmatorHostControl_Hide_Hook(void* pThis) {
 // the hidden-pointer form on x64 and the HFA-in-registers form on ARM64.
 // Hand-rolling the hidden pointer worked on x64 but shifted every argument on
 // ARM64, where four floats are a homogeneous aggregate returned in s0-s3.
-// WinrtRect is four floats = 16 bytes. The calling convention for a 16-byte
-// aggregate return differs by architecture, and worse, differs by *compiler* on
-// x64:
+// WinrtRect is four floats = 16 bytes. Both x64 and ARM64 return it via
+// hidden pointer, but the pointer slot differs by architecture and, on x64,
+// by compiler:
 //
-//   - MSVC on x64 uses the MS ABI: a hidden first pointer, the callee writes
-//     the result through it and returns the pointer in RAX.
-//   - Clang/mingw targeting x86_64-w64-mingw32 does NOT reliably generate that
-//     hidden-pointer form for a return-by-value 16-byte aggregate; it splits
-//     the return into XMM0/XMM1 registers, which does not match what the
-//     MSVC-compiled explorer.exe caller expects. The mismatch corrupts the
-//     return path and crashes the shell on the first call.
+//   - MSVC treats this as a non-static member function: RCX carries `this`,
+//     the hidden retval pointer goes in RDX, and the rect argument follows.
+//   - Clang targeting x86_64-w64-mingw32 sees the WINAPI-declared type as a
+//     free function and puts the hidden retval pointer in RCX with `this` in
+//     RDX. The MSVC-compiled explorer.exe caller expects the MSVC layout, so
+//     the compiler-managed return-by-value form writes the result to what the
+//     caller was using as `this`. The shell crashes on the first call.
 //   - ARM64 uses AAPCS64: four floats are a Homogeneous Floating-point
-//     Aggregate returned in s0-s3, and a hidden pointer would shift every
-//     other argument by one slot and pass garbage through.
+//     Aggregate returned in s0-s3 with no hidden pointer at all, so the
+//     compiler-managed form emits exactly what the target expects.
 //
 // So the signature is declared per architecture: hand-rolled hidden pointer on
-// x64 to match MSVC exactly, compiler-managed return by value on ARM64 so the
-// compiler emits the HFA form.
+// x64 to match MSVC's placement, compiler-managed return by value on ARM64 so
+// the compiler emits the HFA form.
 #if defined(_M_ARM64) || defined(__aarch64__)
 using HardwareConfirmatorHost_GetPositionRect_t =
     WinrtRect(WINAPI*)(void* pThis, const WinrtRect& rect);
@@ -1094,27 +1089,17 @@ BOOL Wh_ModInit() {
         Wh_Log(L"%s", kKindUnreliableMessage);
     }
 
-    // Resolve twinui.dll's loaded range so ShowText can tell a virtual desktop
-    // switch popup apart from other text indicators by checking the return
-    // address. Nothing in twinui is hooked, just its address range is read.
-    // If twinui isn't loaded yet or the query fails, the popup falls back to
-    // the plain text position, same as before.
-    g_twinuiModule = GetModuleHandleW(L"twinui.dll");
-    if (g_twinuiModule) {
-        MODULEINFO mi{};
-        if (GetModuleInformation(GetCurrentProcess(), g_twinuiModule, &mi,
-                                 sizeof(mi))) {
-            g_twinuiBase = reinterpret_cast<uintptr_t>(mi.lpBaseOfDll);
-            g_twinuiEnd = g_twinuiBase + mi.SizeOfImage;
-            Wh_Log(L"twinui.dll range 0x%p - 0x%p", (void*)g_twinuiBase,
-                   (void*)g_twinuiEnd);
-        } else {
-            Wh_Log(L"twinui.dll present but GetModuleInformation failed, "
-                   L"virtual desktop indicator uses text position");
-        }
-    } else {
-        Wh_Log(L"twinui.dll not loaded, virtual desktop indicator uses text "
-               L"position");
+    // The thread_local flag that tells virtual desktop popups apart from other
+    // text indicators is set from ShowText's thunk, so if the thunk didn't
+    // resolve, virtual desktop popups silently follow the plain text position.
+    // The ramp resolving on its own is enough to keep text detection working,
+    // so it wouldn't trip the recorder check above. Only worth saying if the
+    // user has actually set a per-kind position for the virtual desktop popup.
+    if (!ShowTextThunk_Original && ShowTextAsync_Original &&
+        g_settings.perIndicator[(size_t)Indicator::virtualDesktop].load() !=
+            Position::windowsDefault) {
+        Wh_Log(L"ShowText thunk did not resolve, virtual desktop popup will "
+               L"use the plain text position");
     }
 
     return TRUE;

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -912,25 +912,36 @@ BOOL Wh_ModInit() {
     // it would be placed using a stale one. Rather than misplace an indicator,
     // drop to the main position for everything and say so in the log.
     // Each kind is recognised as long as one of its two entry points resolved.
+    // There are eight entry points but seven kinds, since camera has two, so each
+    // one is named rather than numbered.
     const struct {
+        PCWSTR name;
         const void* ramp;
         const void* thunk;
     } kindRecorders[] = {
-        {(void*)ShowVolumeAsync_Original,
+        {L"volume",
+         (void*)ShowVolumeAsync_Original,
          (void*)ShowVolumeThunk_Original},
-        {(void*)ShowBrightnessAsync_Original,
+        {L"brightness",
+         (void*)ShowBrightnessAsync_Original,
          (void*)ShowBrightnessThunk_Original},
-        {(void*)ShowKeyboardBrightnessAsync_Original,
+        {L"keyboard brightness",
+         (void*)ShowKeyboardBrightnessAsync_Original,
          (void*)ShowKeyboardBrightnessThunk_Original},
-        {(void*)ShowAirplaneModeOnAsync_Original,
+        {L"airplane mode",
+         (void*)ShowAirplaneModeOnAsync_Original,
          (void*)ShowAirplaneModeOnThunk_Original},
-        {(void*)ShowCameraOnAsync_Original,
+        {L"camera on",
+         (void*)ShowCameraOnAsync_Original,
          (void*)ShowCameraOnThunk_Original},
-        {(void*)ShowCameraAccessEnabledAsync_Original,
+        {L"camera access",
+         (void*)ShowCameraAccessEnabledAsync_Original,
          (void*)ShowCameraAccessEnabledThunk_Original},
-        {(void*)ShowMicrophoneMutedAsync_Original,
+        {L"microphone",
+         (void*)ShowMicrophoneMutedAsync_Original,
          (void*)ShowMicrophoneMutedThunk_Original},
-        {(void*)ShowTextAsync_Original,
+        {L"text",
+         (void*)ShowTextAsync_Original,
          (void*)ShowTextThunk_Original},
     };
 
@@ -942,20 +953,21 @@ BOOL Wh_ModInit() {
         }
     }
 
+    // Every one is reported rather than stopping at the first missing entry point,
+    // since a build that moved several names should show all of them.
     for (const auto& recorder : kindRecorders) {
-        Wh_Log(L"Kind %d resolved through ramp=%d thunk=%d",
-               (int)(&recorder - kindRecorders), !!recorder.ramp,
-               !!recorder.thunk);
+        Wh_Log(L"Entry point %s resolved through ramp=%d thunk=%d", recorder.name,
+               !!recorder.ramp, !!recorder.thunk);
 
         if (!recorder.ramp && !recorder.thunk) {
             g_kindUnreliable = true;
-            // Only worth saying to someone who has an override set. With the
-            // shipped defaults there is nothing being ignored to complain about.
-            if (anyPerIndicator) {
-                Wh_Log(L"%s", kKindUnreliableMessage);
-            }
-            break;
         }
+    }
+
+    // Only worth saying to someone who has an override set. With the shipped
+    // defaults there is nothing being ignored to complain about.
+    if (g_kindUnreliable && anyPerIndicator) {
+        Wh_Log(L"%s", kKindUnreliableMessage);
     }
 
     return TRUE;

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -2,7 +2,7 @@
 // @id              on-screen-indicator-position
 // @name            On-Screen Indicator Position
 // @description     Put the volume, brightness and camera on-screen indicators anywhere on the screen, each in its own spot if you like, instead of the three positions Windows offers
-// @version         1.3.0
+// @version         1.3.1
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         explorer.exe
@@ -438,14 +438,81 @@ void PlaceInArea(const WinrtRect& area,
     }
 }
 
+// The same eight kinds arrive here first. These are the com vtable entries the
+// interface is called through, so they run before the host's own entry points
+// and before the position is worked out, and they are still there on builds
+// where the host's private coroutines have been refactored away. Whichever of
+// the two fires first records the kind, and recording it twice for one showing
+// is harmless since both agree. They return an HRESULT rather than the
+// implementation's own return.
+
+using ShowVolumeThunk_t = int(WINAPI*)(void* pThis, int value);
+ShowVolumeThunk_t ShowVolumeThunk_Original;
+int WINAPI ShowVolumeThunk_Hook(void* pThis, int value) {
+    g_currentIndicator.store(Indicator::volume);
+    return ShowVolumeThunk_Original(pThis, value);
+}
+
+using ShowBrightnessThunk_t = int(WINAPI*)(void* pThis, int value);
+ShowBrightnessThunk_t ShowBrightnessThunk_Original;
+int WINAPI ShowBrightnessThunk_Hook(void* pThis, int value) {
+    g_currentIndicator.store(Indicator::brightness);
+    return ShowBrightnessThunk_Original(pThis, value);
+}
+
+using ShowKeyboardBrightnessThunk_t = int(WINAPI*)(void* pThis, int value);
+ShowKeyboardBrightnessThunk_t ShowKeyboardBrightnessThunk_Original;
+int WINAPI ShowKeyboardBrightnessThunk_Hook(void* pThis, int value) {
+    g_currentIndicator.store(Indicator::keyboardBrightness);
+    return ShowKeyboardBrightnessThunk_Original(pThis, value);
+}
+
+using ShowAirplaneModeOnThunk_t = int(WINAPI*)(void* pThis, bool value);
+ShowAirplaneModeOnThunk_t ShowAirplaneModeOnThunk_Original;
+int WINAPI ShowAirplaneModeOnThunk_Hook(void* pThis, bool value) {
+    g_currentIndicator.store(Indicator::airplaneMode);
+    return ShowAirplaneModeOnThunk_Original(pThis, value);
+}
+
+using ShowCameraOnThunk_t = int(WINAPI*)(void* pThis, bool value);
+ShowCameraOnThunk_t ShowCameraOnThunk_Original;
+int WINAPI ShowCameraOnThunk_Hook(void* pThis, bool value) {
+    g_currentIndicator.store(Indicator::camera);
+    return ShowCameraOnThunk_Original(pThis, value);
+}
+
+using ShowCameraAccessEnabledThunk_t = int(WINAPI*)(void* pThis, bool value);
+ShowCameraAccessEnabledThunk_t ShowCameraAccessEnabledThunk_Original;
+int WINAPI ShowCameraAccessEnabledThunk_Hook(void* pThis, bool value) {
+    g_currentIndicator.store(Indicator::camera);
+    return ShowCameraAccessEnabledThunk_Original(pThis, value);
+}
+
+using ShowMicrophoneMutedThunk_t = int(WINAPI*)(void* pThis,
+                                                int state,
+                                                void* text);
+ShowMicrophoneMutedThunk_t ShowMicrophoneMutedThunk_Original;
+int WINAPI ShowMicrophoneMutedThunk_Hook(void* pThis, int state, void* text) {
+    g_currentIndicator.store(Indicator::microphone);
+    return ShowMicrophoneMutedThunk_Original(pThis, state, text);
+}
+
+using ShowTextThunk_t = int(WINAPI*)(void* pThis, void* text, bool value);
+ShowTextThunk_t ShowTextThunk_Original;
+int WINAPI ShowTextThunk_Hook(void* pThis, void* text, bool value) {
+    g_currentIndicator.store(Indicator::text);
+    return ShowTextThunk_Original(pThis, text, value);
+}
+
 // Each kind of indicator has its own entry point on the host, so the kind is
 // recorded as one is asked for and read back when the position is worked out.
 // They are private coroutines returning winrt::fire_and_forget, an empty struct,
 // so the return is passed through as the single byte it occupies. Every one is
 // hooked as optional, so a name that stops resolving on some build costs the per
 // indicator feature rather than the whole mod. Wh_ModInit checks afterwards that
-// all eight resolved, and if any didn't it ignores the overrides for the session
-// instead of placing one kind using another kind's spot.
+// each kind can still be recognised by one layer or the other, and if any kind
+// has neither it ignores the overrides for the session instead of placing one
+// kind using another kind's spot.
 
 using ShowVolumeAsync_t = char(WINAPI*)(void* pThis, int value);
 ShowVolumeAsync_t ShowVolumeAsync_Original;
@@ -754,6 +821,56 @@ BOOL Wh_ModInit() {
             true,  // optional
         },
         {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost,struct winrt::Windows::Internal::HardwareConfirmator::IHardwareConfirmatorHost>::ShowVolume(int))"},
+            &ShowVolumeThunk_Original,
+            ShowVolumeThunk_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost,struct winrt::Windows::Internal::HardwareConfirmator::IHardwareConfirmatorHost>::ShowBrightness(int))"},
+            &ShowBrightnessThunk_Original,
+            ShowBrightnessThunk_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost,struct winrt::Windows::Internal::HardwareConfirmator::IHardwareConfirmatorHost>::ShowKeyboardBrightness(int))"},
+            &ShowKeyboardBrightnessThunk_Original,
+            ShowKeyboardBrightnessThunk_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost,struct winrt::Windows::Internal::HardwareConfirmator::IHardwareConfirmatorHost>::ShowAirplaneModeOn(bool))"},
+            &ShowAirplaneModeOnThunk_Original,
+            ShowAirplaneModeOnThunk_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost,struct winrt::Windows::Internal::HardwareConfirmator::IHardwareConfirmatorHost>::ShowCameraOn(bool))"},
+            &ShowCameraOnThunk_Original,
+            ShowCameraOnThunk_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost,struct winrt::Windows::Internal::HardwareConfirmator::IHardwareConfirmatorHost>::ShowCameraAccessEnabled(bool))"},
+            &ShowCameraAccessEnabledThunk_Original,
+            ShowCameraAccessEnabledThunk_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost,struct winrt::Windows::Internal::HardwareConfirmator::IHardwareConfirmatorHost>::ShowMicrophoneMuted(int,void *))",
+             LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost,struct winrt::Windows::Internal::HardwareConfirmator::IHardwareConfirmatorHost>::ShowMicrophoneMuted(enum winrt::Windows::Internal::HardwareConfirmator::MicrophoneMuteState,void *))",
+             LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost,struct winrt::Windows::Internal::HardwareConfirmator::IHardwareConfirmatorHost>::ShowMicrophoneMuted(enum winrt::HWConfirmatorUI::MicrophoneMuteState,void *))"},
+            &ShowMicrophoneMutedThunk_Original,
+            ShowMicrophoneMutedThunk_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost,struct winrt::Windows::Internal::HardwareConfirmator::IHardwareConfirmatorHost>::ShowText(void *,bool))"},
+            &ShowTextThunk_Original,
+            ShowTextThunk_Hook,
+            true,  // optional
+        },
+        {
             {LR"(public: void __cdecl winrt::HWConfirmatorUI::implementation::ConfirmatorHostControl::Hide(void))"},
             &ConfirmatorHostControl_Hide_Original,
             ConfirmatorHostControl_Hide_Hook,
@@ -787,15 +904,27 @@ BOOL Wh_ModInit() {
     // a null here means that kind would never be recorded and every kind after
     // it would be placed using a stale one. Rather than misplace an indicator,
     // drop to the main position for everything and say so in the log.
-    const void* kindRecorders[] = {
-        (void*)ShowVolumeAsync_Original,
-        (void*)ShowBrightnessAsync_Original,
-        (void*)ShowKeyboardBrightnessAsync_Original,
-        (void*)ShowAirplaneModeOnAsync_Original,
-        (void*)ShowCameraOnAsync_Original,
-        (void*)ShowCameraAccessEnabledAsync_Original,
-        (void*)ShowMicrophoneMutedAsync_Original,
-        (void*)ShowTextAsync_Original,
+    // Each kind is recognised as long as one of its two entry points resolved.
+    const struct {
+        const void* ramp;
+        const void* thunk;
+    } kindRecorders[] = {
+        {(void*)ShowVolumeAsync_Original,
+         (void*)ShowVolumeThunk_Original},
+        {(void*)ShowBrightnessAsync_Original,
+         (void*)ShowBrightnessThunk_Original},
+        {(void*)ShowKeyboardBrightnessAsync_Original,
+         (void*)ShowKeyboardBrightnessThunk_Original},
+        {(void*)ShowAirplaneModeOnAsync_Original,
+         (void*)ShowAirplaneModeOnThunk_Original},
+        {(void*)ShowCameraOnAsync_Original,
+         (void*)ShowCameraOnThunk_Original},
+        {(void*)ShowCameraAccessEnabledAsync_Original,
+         (void*)ShowCameraAccessEnabledThunk_Original},
+        {(void*)ShowMicrophoneMutedAsync_Original,
+         (void*)ShowMicrophoneMutedThunk_Original},
+        {(void*)ShowTextAsync_Original,
+         (void*)ShowTextThunk_Original},
     };
 
     if (!ConfirmatorHostControl_Hide_Original ||
@@ -806,8 +935,8 @@ BOOL Wh_ModInit() {
         }
     }
 
-    for (const void* recorder : kindRecorders) {
-        if (!recorder) {
+    for (const auto& recorder : kindRecorders) {
+        if (!recorder.ramp && !recorder.thunk) {
             g_kindUnreliable = true;
             // Only worth saying to someone who has an override set. With the
             // shipped defaults there is nothing being ignored to complain about.

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -71,7 +71,9 @@ a monitor by number or by interface name. The two work together.
 
 * **Skip the slide out animation** has the indicator disappear rather than slide
   away. Windows has its own no animation path for hiding and the mod asks for that
-  one, so the sliding in and everything outside the indicator are left alone.
+  one, so the sliding in and everything outside the indicator are left alone. If it
+  ever appears to do nothing, the mod's log says so on a build where those entry
+  points have moved.
 * The slide-in animation direction is chosen by Windows from the built-in
   setting, not by this mod. If the animation looks wrong for your new position,
   change the built-in setting to whichever of the three has the animation you
@@ -320,23 +322,19 @@ PCWSTR IndicatorName(Indicator indicator) {
     return i < ARRAYSIZE(kNames) ? kNames[i] : L"unknown";
 }
 
-// Said from two places, so it lives in one.
-void LogKindUnreliable() {
-    Wh_Log(
-        L"An indicator entry point didn't resolve, so the position "
-        L"per indicator settings are ignored and everything uses "
-        L"the main position");
-}
+// Said from two places. The text is shared rather than the call, so the line still
+// reports whichever function actually logged it.
+constexpr PCWSTR kKindUnreliableMessage =
+    L"An indicator entry point didn't resolve, so the position per indicator "
+    L"settings are ignored and everything uses the main position";
 
 // Set when either half of the hide pair didn't resolve, which leaves the skip
 // setting with nothing to do.
 std::atomic<bool> g_hideAnimationUnavailable{false};
 
-void LogHideAnimationUnavailable() {
-    Wh_Log(
-        L"The hide entry points didn't resolve, so the slide out animation "
-        L"is left alone");
-}
+constexpr PCWSTR kHideAnimationUnavailableMessage =
+    L"The hide entry points didn't resolve, so the slide out animation is left "
+    L"alone";
 
 // The position to place the indicator that is being shown right now.
 Position CurrentPosition() {
@@ -590,9 +588,20 @@ using ConfirmatorHostControl_HideWithoutAnimation_t = void(WINAPI*)(void* pThis)
 ConfirmatorHostControl_HideWithoutAnimation_t
     ConfirmatorHostControl_HideWithoutAnimation_Original;
 void WINAPI ConfirmatorHostControl_Hide_Hook(void* pThis) {
-    if (g_settings.skipHideAnimation.load() &&
-        ConfirmatorHostControl_HideWithoutAnimation_Original) {
-        return ConfirmatorHostControl_HideWithoutAnimation_Original(pThis);
+    // Nothing on the builds this was written against calls back the other way,
+    // but a build where HideWithoutAnimation went through Hide would otherwise
+    // turn the redirect into unbounded recursion rather than a dead setting.
+    thread_local bool redirecting = false;
+
+    bool skip = !redirecting && g_settings.skipHideAnimation.load() &&
+                ConfirmatorHostControl_HideWithoutAnimation_Original;
+    Wh_Log(L"> skip=%d", (int)skip);
+
+    if (skip) {
+        redirecting = true;
+        ConfirmatorHostControl_HideWithoutAnimation_Original(pThis);
+        redirecting = false;
+        return;
     }
 
     return ConfirmatorHostControl_Hide_Original(pThis);
@@ -857,9 +866,7 @@ BOOL Wh_ModInit() {
             true,  // optional
         },
         {
-            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost,struct winrt::Windows::Internal::HardwareConfirmator::IHardwareConfirmatorHost>::ShowMicrophoneMuted(int,void *))",
-             LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost,struct winrt::Windows::Internal::HardwareConfirmator::IHardwareConfirmatorHost>::ShowMicrophoneMuted(enum winrt::Windows::Internal::HardwareConfirmator::MicrophoneMuteState,void *))",
-             LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost,struct winrt::Windows::Internal::HardwareConfirmator::IHardwareConfirmatorHost>::ShowMicrophoneMuted(enum winrt::HWConfirmatorUI::MicrophoneMuteState,void *))"},
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Windows::Internal::HardwareConfirmator::implementation::HardwareConfirmatorHost,struct winrt::Windows::Internal::HardwareConfirmator::IHardwareConfirmatorHost>::ShowMicrophoneMuted(int,void *))"},
             &ShowMicrophoneMutedThunk_Original,
             ShowMicrophoneMutedThunk_Hook,
             true,  // optional
@@ -931,17 +938,21 @@ BOOL Wh_ModInit() {
         !ConfirmatorHostControl_HideWithoutAnimation_Original) {
         g_hideAnimationUnavailable = true;
         if (g_settings.skipHideAnimation) {
-            LogHideAnimationUnavailable();
+            Wh_Log(L"%s", kHideAnimationUnavailableMessage);
         }
     }
 
     for (const auto& recorder : kindRecorders) {
+        Wh_Log(L"Kind %d resolved through ramp=%d thunk=%d",
+               (int)(&recorder - kindRecorders), !!recorder.ramp,
+               !!recorder.thunk);
+
         if (!recorder.ramp && !recorder.thunk) {
             g_kindUnreliable = true;
             // Only worth saying to someone who has an override set. With the
             // shipped defaults there is nothing being ignored to complain about.
             if (anyPerIndicator) {
-                LogKindUnreliable();
+                Wh_Log(L"%s", kKindUnreliableMessage);
             }
             break;
         }
@@ -972,10 +983,10 @@ void Wh_ModSettingsChanged() {
     // Turning on the first override no longer re-runs Wh_ModInit, so this is the
     // only place the person it concerns can still be told.
     if (g_kindUnreliable && AnyPerIndicator()) {
-        LogKindUnreliable();
+        Wh_Log(L"%s", kKindUnreliableMessage);
     }
 
     if (g_hideAnimationUnavailable && g_settings.skipHideAnimation) {
-        LogHideAnimationUnavailable();
+        Wh_Log(L"%s", kHideAnimationUnavailableMessage);
     }
 }

--- a/mods/on-screen-indicator-position.wh.cpp
+++ b/mods/on-screen-indicator-position.wh.cpp
@@ -598,10 +598,16 @@ void WINAPI ConfirmatorHostControl_Hide_Hook(void* pThis) {
     Wh_Log(L"> skip=%d", (int)skip);
 
     if (skip) {
+        // Restored however this returns. Hide is an implementation method rather
+        // than an abi thunk, so an hresult_error coming out of it would otherwise
+        // leave the flag latched and the setting dead for the rest of the session.
+        struct Restore {
+            bool& flag;
+            ~Restore() { flag = false; }
+        } restore{redirecting};
+
         redirecting = true;
-        ConfirmatorHostControl_HideWithoutAnimation_Original(pThis);
-        redirecting = false;
-        return;
+        return ConfirmatorHostControl_HideWithoutAnimation_Original(pThis);
     }
 
     return ConfirmatorHostControl_Hide_Original(pThis);
@@ -912,35 +918,35 @@ BOOL Wh_ModInit() {
     // it would be placed using a stale one. Rather than misplace an indicator,
     // drop to the main position for everything and say so in the log.
     // Each kind is recognised as long as one of its two entry points resolved.
-    // There are eight entry points but seven kinds, since camera has two, so each
-    // one is named rather than numbered.
+    // These are named after the symbols rather than the kinds, since there are
+    // eight of them and only seven kinds, camera having two.
     const struct {
         PCWSTR name;
         const void* ramp;
         const void* thunk;
     } kindRecorders[] = {
-        {L"volume",
+        {L"ShowVolume",
          (void*)ShowVolumeAsync_Original,
          (void*)ShowVolumeThunk_Original},
-        {L"brightness",
+        {L"ShowBrightness",
          (void*)ShowBrightnessAsync_Original,
          (void*)ShowBrightnessThunk_Original},
-        {L"keyboard brightness",
+        {L"ShowKeyboardBrightness",
          (void*)ShowKeyboardBrightnessAsync_Original,
          (void*)ShowKeyboardBrightnessThunk_Original},
-        {L"airplane mode",
+        {L"ShowAirplaneModeOn",
          (void*)ShowAirplaneModeOnAsync_Original,
          (void*)ShowAirplaneModeOnThunk_Original},
-        {L"camera on",
+        {L"ShowCameraOn",
          (void*)ShowCameraOnAsync_Original,
          (void*)ShowCameraOnThunk_Original},
-        {L"camera access",
+        {L"ShowCameraAccessEnabled",
          (void*)ShowCameraAccessEnabledAsync_Original,
          (void*)ShowCameraAccessEnabledThunk_Original},
-        {L"microphone",
+        {L"ShowMicrophoneMuted",
          (void*)ShowMicrophoneMutedAsync_Original,
          (void*)ShowMicrophoneMutedThunk_Original},
-        {L"text",
+        {L"ShowText",
          (void*)ShowTextAsync_Original,
          (void*)ShowTextThunk_Original},
     };


### PR DESCRIPTION
the indicator sliding away is the part you notice, since that's what keeps it on screen after you're done with it. this adds a setting to have it just go.

windows already has a hide path that doesn't animate, so the mod asks for that one instead of the animated one. nothing outside the indicator changes.

i tried the same thing for the slide in and took it back out. there's no matching path for showing, and skipping the animation leaves the indicator invisible, so only the slide out is here.

other half of this is future proofing. the per indicator positions hook eight functions that 26H1 has already dropped, found that out poking around in the pdbs, so it reads the kind off the com interface as well now. that path's been around since 22H2.

and 1.4.0 pulls the "Desktop N" popup out of the plain text indicator's slot. they used to share a spot, so text in one place meant the desktop name went to the same place. now it's its own entry in Position per indicator.

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Give the "Desktop N" popup that appears on virtual desktop change its own position, separate from other text indicators.
* New setting to make the indicator disappear straight away instead of sliding off screen.
* Keeps working on future Windows builds where the parts it hooks into get moved around.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
