### PR TITLE
[faster-virtual-desktop-switching] Update GitHub username

### DIFF
--- a/mods/faster-virtual-desktop-switching.wh.cpp
+++ b/mods/faster-virtual-desktop-switching.wh.cpp
@@ -2,9 +2,9 @@
 // @id              faster-virtual-desktop-switching
 // @name            Faster Virtual Desktop Switching
 // @description     Removes the long pre-animation lag caused by oversized wallpaper thumbnail requests on Windows 11.
-// @version         1.0
+// @version         1.0.1
 // @author          meteoni
-// @github          https://github.com/Meteony
+// @github          https://github.com/Meteoni
 // @include         explorer.exe
 // @architecture    x86-64
 // @compilerOptions -luser32
@@ -16,7 +16,7 @@
 
 Removes the long-standing pre-animation lag caused by oversized wallpaper thumbnail requests on Windows 11.
 
-![GIF](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/faster-virtual-desktop-switching/faster-virtual-desktop-switching.gif)
+![GIF](https://raw.githubusercontent.com/Meteoni/meteoni-assets/main/faster-virtual-desktop-switching/faster-virtual-desktop-switching.gif)
 
 _Note: This can make the wallpaper look softer during the switch. The mod is a no-op on Windows 10._
 


### PR DESCRIPTION
This is an account-rename metadata update for `faster-virtual-desktop-switching`. The original `Meteony` username has been reused by a different GitHub organization, so the old profile and raw asset URLs no longer identify or belong to the mod author.

The `@github` change is intentional and requires maintainer verification as an account rename.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Updated the author's GitHub profile URL after the username changed from `Meteony` to `Meteoni`.
* Updated screenshot and GIF URLs to use the renamed `Meteoni/meteoni-assets` repository.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.