### PR TITLE
[multiwm] Update GitHub username

### DIFF
--- a/mods/multiwm.wh.cpp
+++ b/mods/multiwm.wh.cpp
@@ -2,9 +2,9 @@
 // @id              multiwm
 // @name            MultiWM
 // @description     Lightweight, low-cortisol window manager with true per-virtual-desktop layouts. 
-// @version         1.13.19
+// @version         1.13.20
 // @author          meteoni
-// @github          https://github.com/Meteony
+// @github          https://github.com/Meteoni
 // @license         MIT
 // @include         explorer.exe
 // @architecture    x86-64
@@ -20,7 +20,7 @@ MultiWM is a continuation of the original [Tiling Helper](https://windhawk.net/m
 A lightweight, low-cortisol window manager for Windows 11 with true per-virtual-desktop layouts - 
 including floating - and simple, predictable controls. 
 
-![GIF](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/MultiWM/MultiWM.gif)
+![GIF](https://raw.githubusercontent.com/Meteoni/meteoni-assets/main/MultiWM/MultiWM.gif)
 
 ## Notes
 - *Windhawk 2.0 (or higher) users can change the target process (`explorer.exe` -> `windhawk.exe`) for better stability and workspace preservation across Explorer restarts.*


### PR DESCRIPTION
This is an account-rename metadata update for `multiwm`. The original `Meteony` username has been reused by a different GitHub organization, so the old profile and raw asset URLs no longer identify or belong to the mod author.

The `@github` change is intentional and requires maintainer verification as an account rename.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Updated the author's GitHub profile URL after the username changed from `Meteony` to `Meteoni`.
* Updated screenshot and GIF URLs to use the renamed `Meteoni/meteoni-assets` repository.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.