### PR TITLE
[prevent-virtual-desktop-stealing] Update GitHub username

### DIFF
--- a/mods/prevent-virtual-desktop-stealing.wh.cpp
+++ b/mods/prevent-virtual-desktop-stealing.wh.cpp
@@ -2,9 +2,9 @@
 // @id              prevent-virtual-desktop-stealing
 // @name            Don't Pull Me to Another Desktop
 // @description     Summon existing windows to the current virtual desktop instead of pulling you away.
-// @version         0.4.0
+// @version         0.4.1
 // @author          meteoni
-// @github          https://github.com/Meteony
+// @github          https://github.com/Meteoni
 // @include         explorer.exe
 // @architecture    x86-64
 // @compilerOptions -lole32
@@ -22,7 +22,7 @@ something that reuses an existing window.
 This mod keeps you on the virtual desktop you're using and brings that activated
 window to you instead.
 
-![Screenshot](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/prevent-virtual-desktop-stealing/prevent-virtual-desktop-stealing.gif)
+![Screenshot](https://raw.githubusercontent.com/Meteoni/meteoni-assets/main/prevent-virtual-desktop-stealing/prevent-virtual-desktop-stealing.gif)
 
 If you haven't seen the problem before, try this:
 


### PR DESCRIPTION
This is an account-rename metadata update for `prevent-virtual-desktop-stealing`. The original `Meteony` username has been reused by a different GitHub organization, so the old profile and raw asset URLs no longer identify or belong to the mod author.

The `@github` change is intentional and requires maintainer verification as an account rename.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Updated the author's GitHub profile URL after the username changed from `Meteony` to `Meteoni`.
* Updated screenshot and GIF URLs to use the renamed `Meteoni/meteoni-assets` repository.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.