### PR TITLE
[startup-app-delay-fix] Update GitHub username

### DIFF
--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -2,9 +2,9 @@
 // @id              startup-app-delay-fix
 // @name            Startup App Delay Fix
 // @description     Removes the delay Windows applies to startup applications after sign-in
-// @version         1.4
+// @version         1.4.1
 // @author          meteoni
-// @github          https://github.com/Meteony
+// @github          https://github.com/Meteoni
 // @include         explorer.exe
 // @compilerOptions -ladvapi32 -lntdll
 // ==/WindhawkMod==
@@ -14,7 +14,7 @@ Windows intentionally delays startup applications after sign-in to reduce
 system load, which can cause apps to open minutes after startup.
 
 Common fix (which the mod intends to emulate): 
-![Common Fix](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/startup-app-delay-fix/startup-app-delay-fix.png)
+![Common Fix](https://raw.githubusercontent.com/Meteoni/meteoni-assets/main/startup-app-delay-fix/startup-app-delay-fix.png)
 
 This mod redirects Explorer's startup-serialization key to a dedicated,
 volatile key where both `WaitforIdleState` and `StartupDelayInMSec` are zero.


### PR DESCRIPTION
This is an account-rename metadata update for `startup-app-delay-fix`. The original `Meteony` username has been reused by a different GitHub organization, so the old profile and raw asset URLs no longer identify or belong to the mod author.

The `@github` change is intentional and requires maintainer verification as an account rename.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Updated the author's GitHub profile URL after the username changed from `Meteony` to `Meteoni`.
* Updated screenshot and GIF URLs to use the renamed `Meteoni/meteoni-assets` repository.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.