### PR TITLE
[taskbar-icon-separators] Update GitHub username

### DIFF
--- a/mods/taskbar-icon-separators.wh.cpp
+++ b/mods/taskbar-icon-separators.wh.cpp
@@ -2,9 +2,9 @@
 // @id              taskbar-icon-separators
 // @name            Taskbar Icon Separators
 // @description     Create tracked icon separators with configurable padding on the taskbar.
-// @version         1.0.32
+// @version         1.0.33
 // @author          meteoni
-// @github          https://github.com/Meteony
+// @github          https://github.com/Meteoni
 // @license         GPL-3.0
 // @include         explorer.exe
 // @architecture    x86-64
@@ -17,7 +17,7 @@
 
 Create tracked icon separators with configurable padding on the taskbar.
 
-![Screenshot](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/taskbar-icon-separators/SEP2.png)
+![Screenshot](https://raw.githubusercontent.com/Meteoni/meteoni-assets/main/taskbar-icon-separators/SEP2.png)
 _Example for creating separators on the taskbar_
 
 Another mod offers similar functionality; this implementation takes on a more native-first spin.


### PR DESCRIPTION
This is an account-rename metadata update for `taskbar-icon-separators`. The original `Meteony` username has been reused by a different GitHub organization, so the old profile and raw asset URLs no longer identify or belong to the mod author.

The `@github` change is intentional and requires maintainer verification as an account rename.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Updated the author's GitHub profile URL after the username changed from `Meteony` to `Meteoni`.
* Updated screenshot and GIF URLs to use the renamed `Meteoni/meteoni-assets` repository.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.