### PR TITLE
[taskbar-z-order-override] Update GitHub username

### DIFF
--- a/mods/taskbar-z-order-override.wh.cpp
+++ b/mods/taskbar-z-order-override.wh.cpp
@@ -2,9 +2,9 @@
 // @id              taskbar-z-order-override
 // @name            Taskbar Z-Order Override
 // @description     Control whether the taskbar stays always on top, always at the bottom, or behaves like a normal window
-// @version         0.8
+// @version         0.8.1
 // @author          meteoni
-// @github          https://github.com/Meteony
+// @github          https://github.com/Meteoni
 // @include         explorer.exe
 // @architecture    x86-64
 // @compilerOptions -lcomctl32
@@ -21,7 +21,7 @@ Control whether the Windows taskbar stays always on top, always at the bottom, o
 
 Makes the taskbar behave like a regular window - like how it was possible pre-Vista. 
 
-![Behaves like a normal window](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/taskbar-z-order-override/interactive.gif)
+![Behaves like a normal window](https://raw.githubusercontent.com/Meteoni/meteoni-assets/main/taskbar-z-order-override/interactive.gif)
 
 ### Always on top
 
@@ -30,7 +30,7 @@ Great for games or browser fullscreen.
 
 This is mainly useful for people who use **auto-hide** and want the taskbar to stay accessible consistently.
 
-![Always on top](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/taskbar-z-order-override/always_on_top_low.gif)
+![Always on top](https://raw.githubusercontent.com/Meteoni/meteoni-assets/main/taskbar-z-order-override/always_on_top_low.gif)
 
 ### Always at bottom
 
@@ -38,7 +38,7 @@ Keeps the taskbar at the bottom of the Z-order.
 
 If you are more of a window enjoyer than a taskbar enjoyer, this is for you. 
 
-![Always at bottom](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/taskbar-z-order-override/always_bottom_low.gif)
+![Always at bottom](https://raw.githubusercontent.com/Meteoni/meteoni-assets/main/taskbar-z-order-override/always_bottom_low.gif)
 
 ## Notes
 


### PR DESCRIPTION
This is an account-rename metadata update for `taskbar-z-order-override`. The original `Meteony` username has been reused by a different GitHub organization, so the old profile and raw asset URLs no longer identify or belong to the mod author.

The `@github` change is intentional and requires maintainer verification as an account rename.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Updated the author's GitHub profile URL after the username changed from `Meteony` to `Meteoni`.
* Updated screenshot and GIF URLs to use the renamed `Meteoni/meteoni-assets` repository.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.