### PR TITLE
[widget-board-size-position] Update GitHub username

### DIFF
--- a/mods/widget-board-size-position.wh.cpp
+++ b/mods/widget-board-size-position.wh.cpp
@@ -2,9 +2,9 @@
 // @id              widget-board-size-position
 // @name            Widget Board Size and Position
 // @description     Set a custom size and position for the new Widget Board on Windows 11.
-// @version         0.1
+// @version         0.1.1
 // @author          meteoni
-// @github          https://github.com/Meteony
+// @github          https://github.com/Meteoni
 // @include         WidgetBoard.exe
 // @architecture    x86-64
 // @compilerOptions -lcomctl32 -lshcore
@@ -18,7 +18,7 @@ Set a custom size and position for the new Widget Board on Windows 11.
 
 Allows you to override the default position and dimensions of the new WinUI 3 Widget Board (`WidgetBoard.exe`).
 
-![Screenshot](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/widget-board-size-position/wboard-size.png)
+![Screenshot](https://raw.githubusercontent.com/Meteoni/meteoni-assets/main/widget-board-size-position/wboard-size.png)
 _Example for making the Widget Board smaller_
 
 Width, height, and offsets are specified in DIPs (96-DPI logical pixels), so a


### PR DESCRIPTION
This is an account-rename metadata update for `widget-board-size-position`. The original `Meteony` username has been reused by a different GitHub organization, so the old profile and raw asset URLs no longer identify or belong to the mod author.

The `@github` change is intentional and requires maintainer verification as an account rename.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Updated the author's GitHub profile URL after the username changed from `Meteony` to `Meteoni`.
* Updated screenshot and GIF URLs to use the renamed `Meteoni/meteoni-assets` repository.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.