### PR TITLE
Add Taskbar Countdown Timer mod

### DIFF
--- a/mods/taskbar-countdown-timer.wh.cpp
+++ b/mods/taskbar-countdown-timer.wh.cpp
@@ -2,13 +2,13 @@
 // @id              taskbar-countdown-timer
 // @name            Taskbar Countdown Timer
 // @description     A simple countdown timer integrated into the Windows taskbar
-// @version         1.1
+// @version         1.2
 // @author          Richi
+// @github          https://github.com/richilp
 // @include         explorer.exe
-// @architecture    x86-64
+// @architecture    amd64
 // @compilerOptions -lole32 -loleaut32 -lruntimeobject -ldwmapi -lgdi32
 // @license         MIT
-// @github          richilp
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -52,7 +52,11 @@ While the timer is running, the remaining time is shown directly on the taskbar.
 #undef GetCurrentTime
 #endif
 
+#include <algorithm>
+#include <atomic>
 #include <chrono>
+#include <cstdint>
+#include <cstdlib>
 #include <functional>
 #include <string>
 #include <dwmapi.h>
@@ -74,20 +78,28 @@ using namespace winrt::Windows::UI::Xaml::Media;
 // Globals
 // -----------------------------------------------------------------------------
 
-static Button g_timerButton{nullptr};
-static TextBlock g_timerText{nullptr};
-static DispatcherTimer g_countdownTimer{nullptr};
+[[clang::no_destroy]] static Button g_timerButton{nullptr};
+[[clang::no_destroy]] static TextBlock g_timerText{nullptr};
+[[clang::no_destroy]] static DispatcherTimer g_countdownTimer{nullptr};
 
 static winrt::event_token g_timerButtonClickToken{};
 static winrt::event_token g_timerTickToken{};
 
-static int g_secondsRemaining = 0;
+static std::atomic<int> g_secondsRemaining{0};
+static std::atomic<ULONGLONG> g_deadlineTick{0};
 static wchar_t g_reminder[256]{};
 
 static HWND g_timerPopup = nullptr;
 static HWND g_finishedPopup = nullptr;
 static DWORD g_timerPopupThreadId = 0;
 static HANDLE g_timerPopupThread = nullptr;
+static HANDLE g_popupThreadReadyEvent = nullptr;
+
+static HINSTANCE g_modInstance = nullptr;
+
+static std::atomic_bool g_unloading{false};
+static HANDLE g_retryStopEvent = nullptr;
+static HANDLE g_retryThread = nullptr;
 
 
 // -----------------------------------------------------------------------------
@@ -97,6 +109,7 @@ static HANDLE g_timerPopupThread = nullptr;
 static HBRUSH g_popupBackgroundBrush = nullptr;
 static HBRUSH g_popupEditBrush = nullptr;
 static HFONT g_popupFont = nullptr;
+static UINT g_popupFontDpi = 0;
 
 static constexpr COLORREF kPopupBackground =
     RGB(32, 32, 32);
@@ -111,7 +124,8 @@ static constexpr COLORREF kPopupMutedText =
     RGB(190, 190, 190);
 
 
-static void EnsurePopupResources()
+static void EnsurePopupResources(
+    UINT dpi = 96)
 {
     if (!g_popupBackgroundBrush) {
         g_popupBackgroundBrush =
@@ -127,10 +141,28 @@ static void EnsurePopupResources()
             );
     }
 
-    if (!g_popupFont) {
+    if (!dpi) {
+        dpi = 96;
+    }
+
+    if (!g_popupFont ||
+        g_popupFontDpi != dpi)
+    {
+        if (g_popupFont) {
+            DeleteObject(
+                g_popupFont
+            );
+
+            g_popupFont = nullptr;
+        }
+
         g_popupFont =
             CreateFontW(
-                -16,
+                -MulDiv(
+                    12,
+                    dpi,
+                    72
+                ),
                 0,
                 0,
                 0,
@@ -146,6 +178,8 @@ static void EnsurePopupResources()
                     FF_DONTCARE,
                 L"Segoe UI"
             );
+
+        g_popupFontDpi = dpi;
     }
 }
 
@@ -153,11 +187,18 @@ static void EnsurePopupResources()
 static void ApplyModernWindowStyle(
     HWND hWnd)
 {
-    EnsurePopupResources();
+    UINT dpi =
+        GetDpiForWindow(hWnd);
 
-    // Rounded Windows 11 corners.
-    constexpr DWORD DWMWA_WINDOW_CORNER_PREFERENCE_LOCAL = 33;
-    constexpr int DWMWCP_ROUND_LOCAL = 2;
+    EnsurePopupResources(
+        dpi ? dpi : 96
+    );
+
+    constexpr DWORD
+        DWMWA_WINDOW_CORNER_PREFERENCE_LOCAL = 33;
+
+    constexpr int
+        DWMWCP_ROUND_LOCAL = 2;
 
     int cornerPreference =
         DWMWCP_ROUND_LOCAL;
@@ -169,8 +210,8 @@ static void ApplyModernWindowStyle(
         sizeof(cornerPreference)
     );
 
-    // Dark title / non-client rendering where supported.
-    constexpr DWORD DWMWA_USE_IMMERSIVE_DARK_MODE_LOCAL = 20;
+    constexpr DWORD
+        DWMWA_USE_IMMERSIVE_DARK_MODE_LOCAL = 20;
 
     BOOL darkMode = TRUE;
 
@@ -181,7 +222,6 @@ static void ApplyModernWindowStyle(
         sizeof(darkMode)
     );
 
-    // Add a subtle system shadow without a classic caption.
     MARGINS margins{
         1,
         1,
@@ -197,11 +237,21 @@ static void ApplyModernWindowStyle(
 
 
 static void ApplyPopupFont(
-    HWND hWnd)
+    HWND hWnd,
+    UINT dpi = 0)
 {
     if (!hWnd) {
         return;
     }
+
+    if (!dpi) {
+        dpi =
+            GetDpiForWindow(hWnd);
+    }
+
+    EnsurePopupResources(
+        dpi ? dpi : 96
+    );
 
     SendMessageW(
         hWnd,
@@ -231,6 +281,7 @@ constexpr int IDC_SNOOZE_MINUTES = 1101;
 constexpr int IDC_SNOOZE         = 1102;
 constexpr int IDC_DISMISS        = 1103;
 constexpr int IDC_CLOSE_FINISHED = 1104;
+constexpr int IDC_FINISHED_TEXT   = 1105;
 
 constexpr UINT WM_APP_TIMER_SHOW =
     WM_APP + 1;
@@ -240,6 +291,331 @@ constexpr UINT WM_APP_TIMER_FINISHED =
 
 constexpr UINT WM_APP_TIMER_SHUTDOWN =
     WM_APP + 3;
+
+
+// -----------------------------------------------------------------------------
+// Popup DPI/layout helpers
+// -----------------------------------------------------------------------------
+
+static int ScaleByDpi(
+    int value,
+    UINT dpi)
+{
+    return MulDiv(
+        value,
+        dpi ? dpi : 96,
+        96
+    );
+}
+
+
+static UINT GetPopupDpi(
+    HWND owner)
+{
+    UINT dpi =
+        owner
+            ? GetDpiForWindow(owner)
+            : 0;
+
+    return dpi ? dpi : 96;
+}
+
+
+static void PositionPopupNearTaskbar(
+    HWND hWnd,
+    HWND taskbar,
+    int baseWidth,
+    int baseHeight,
+    UINT dpi)
+{
+    int width =
+        ScaleByDpi(
+            baseWidth,
+            dpi
+        );
+
+    int height =
+        ScaleByDpi(
+            baseHeight,
+            dpi
+        );
+
+    int margin =
+        ScaleByDpi(
+            10,
+            dpi
+        );
+
+    HMONITOR monitor =
+        MonitorFromWindow(
+            taskbar ? taskbar : hWnd,
+            MONITOR_DEFAULTTONEAREST
+        );
+
+    MONITORINFO monitorInfo{
+        sizeof(monitorInfo)
+    };
+
+    if (!GetMonitorInfoW(
+            monitor,
+            &monitorInfo))
+    {
+        SetWindowPos(
+            hWnd,
+            HWND_TOPMOST,
+            0,
+            0,
+            width,
+            height,
+            SWP_SHOWWINDOW
+        );
+
+        return;
+    }
+
+    RECT work =
+        monitorInfo.rcWork;
+
+    RECT monitorRect =
+        monitorInfo.rcMonitor;
+
+    RECT taskbarRect{};
+
+    bool haveTaskbar =
+        taskbar &&
+        GetWindowRect(
+            taskbar,
+            &taskbarRect
+        );
+
+    int x =
+        work.right -
+        width -
+        margin;
+
+    int y =
+        work.bottom -
+        height -
+        margin;
+
+    if (haveTaskbar) {
+        const int taskbarWidth =
+            taskbarRect.right -
+            taskbarRect.left;
+
+        const int taskbarHeight =
+            taskbarRect.bottom -
+            taskbarRect.top;
+
+        const bool horizontal =
+            taskbarWidth >= taskbarHeight;
+
+        if (horizontal) {
+            // A horizontal taskbar spans the monitor width, so its left/right
+            // edges also touch the monitor. Determine top vs bottom only.
+            const int topDistance =
+                std::abs(
+                    taskbarRect.top -
+                    monitorRect.top
+                );
+
+            const int bottomDistance =
+                std::abs(
+                    monitorRect.bottom -
+                    taskbarRect.bottom
+                );
+
+            if (topDistance < bottomDistance) {
+                y =
+                    work.top +
+                    margin;
+            }
+            else {
+                y =
+                    work.bottom -
+                    height -
+                    margin;
+            }
+
+            // Keep the popup aligned to the right side, matching the timer
+            // button/system tray area.
+            x =
+                work.right -
+                width -
+                margin;
+        }
+        else {
+            // Vertical taskbar: determine left vs right only.
+            const int leftDistance =
+                std::abs(
+                    taskbarRect.left -
+                    monitorRect.left
+                );
+
+            const int rightDistance =
+                std::abs(
+                    monitorRect.right -
+                    taskbarRect.right
+                );
+
+            if (leftDistance < rightDistance) {
+                x =
+                    work.left +
+                    margin;
+            }
+            else {
+                x =
+                    work.right -
+                    width -
+                    margin;
+            }
+
+            y =
+                work.bottom -
+                height -
+                margin;
+        }
+    }
+
+    x =
+        std::max<int>(
+            static_cast<int>(work.left),
+            std::min<int>(
+                x,
+                static_cast<int>(
+                    work.right
+                ) - width
+            )
+        );
+
+    y =
+        std::max<int>(
+            static_cast<int>(work.top),
+            std::min<int>(
+                y,
+                static_cast<int>(
+                    work.bottom
+                ) - height
+            )
+        );
+
+    SetWindowPos(
+        hWnd,
+        HWND_TOPMOST,
+        x,
+        y,
+        width,
+        height,
+        SWP_SHOWWINDOW
+    );
+}
+
+
+static void LayoutTimerPopup(
+    HWND hWnd,
+    UINT dpi)
+{
+    struct Item {
+        int id;
+        int x;
+        int y;
+        int w;
+        int h;
+    };
+
+    constexpr Item items[] = {
+        {IDC_CLOSE_TIMER,      338,   8,  24, 24},
+        {IDC_REMINDER_LABEL,    20,  20, 300, 20},
+        {IDC_REMINDER,          20,  45, 340, 30},
+        {IDC_MINUTES_LABEL,     20,  90, 150, 20},
+        {IDC_MINUTES,           20, 115, 110, 30},
+        {IDC_START,             20, 165, 165, 34},
+        {IDC_CANCEL_TIMER,     195, 165, 165, 34},
+    };
+
+    EnsurePopupResources(dpi);
+
+    for (const auto& item : items) {
+        HWND child =
+            GetDlgItem(
+                hWnd,
+                item.id
+            );
+
+        if (!child) {
+            continue;
+        }
+
+        SetWindowPos(
+            child,
+            nullptr,
+            ScaleByDpi(item.x, dpi),
+            ScaleByDpi(item.y, dpi),
+            ScaleByDpi(item.w, dpi),
+            ScaleByDpi(item.h, dpi),
+            SWP_NOZORDER |
+                SWP_NOACTIVATE
+        );
+
+        ApplyPopupFont(
+            child,
+            dpi
+        );
+    }
+}
+
+
+static void LayoutFinishedPopup(
+    HWND hWnd,
+    UINT dpi)
+{
+    struct Item {
+        int id;
+        int x;
+        int y;
+        int w;
+        int h;
+    };
+
+    constexpr Item items[] = {
+        {IDC_CLOSE_FINISHED,   338,   8,  24, 24},
+        {IDC_FINISHED_TEXT,     20,  20, 340, 45},
+        {IDC_SNOOZE_LABEL,      20,  82, 160, 20},
+        {IDC_SNOOZE_MINUTES,   190,  78,  70, 30},
+        {IDC_SNOOZE,            20, 135, 165, 34},
+        {IDC_DISMISS,          195, 135, 165, 34},
+    };
+
+    EnsurePopupResources(dpi);
+
+    for (const auto& item : items) {
+        HWND child =
+            GetDlgItem(
+                hWnd,
+                item.id
+            );
+
+        if (!child) {
+            continue;
+        }
+
+        SetWindowPos(
+            child,
+            nullptr,
+            ScaleByDpi(item.x, dpi),
+            ScaleByDpi(item.y, dpi),
+            ScaleByDpi(item.w, dpi),
+            ScaleByDpi(item.h, dpi),
+            SWP_NOZORDER |
+                SWP_NOACTIVATE
+        );
+
+        ApplyPopupFont(
+            child,
+            dpi
+        );
+    }
+}
 
 
 // -----------------------------------------------------------------------------
@@ -502,8 +878,9 @@ static XamlRoot GetTaskbarXamlRoot(
         return nullptr;
     }
 
-    size_t offset = 0x10;
+    size_t offset = 0x48;
 
+#if defined(_M_X64)
     const BYTE* code =
         reinterpret_cast<const BYTE*>(
             TaskbarHost_FrameHeight_Original
@@ -521,15 +898,12 @@ static XamlRoot GetTaskbarXamlRoot(
     }
     else {
         Wh_Log(
-            L"ERROR: Unsupported TaskbarHost::FrameHeight"
+            L"Unsupported TaskbarHost::FrameHeight, using default offset"
         );
-
-        std__Ref_count_base__Decref_Original(
-            taskbarHostSharedPtr[1]
-        );
-
-        return nullptr;
     }
+#else
+#error "Unsupported architecture"
+#endif
 
     auto* unknown =
         *reinterpret_cast<IUnknown**>(
@@ -620,12 +994,6 @@ static bool RunFromWindowThread(
                         const CWPSTRUCT*>(
                             lParam
                         );
-
-                const UINT message =
-                    RegisterWindowMessageW(
-                        L"Windhawk_RunFromWindowThread_"
-                        WH_MOD_ID
-                    );
 
                 if (cwp->message == message) {
                     auto* param =
@@ -723,8 +1091,16 @@ static void StartCountdownOnTaskbarThread(
 
     g_countdownTimer.Stop();
 
-    g_secondsRemaining =
-        request->seconds;
+    g_secondsRemaining.store(
+        request->seconds
+    );
+
+    g_deadlineTick.store(
+        GetTickCount64() +
+        static_cast<ULONGLONG>(
+            request->seconds
+        ) * 1000ULL
+    );
 
     wcsncpy_s(
         g_reminder,
@@ -734,7 +1110,7 @@ static void StartCountdownOnTaskbarThread(
 
     g_timerText.Text(
         FormatCountdown(
-            g_secondsRemaining
+            request->seconds
         )
     );
 
@@ -743,7 +1119,7 @@ static void StartCountdownOnTaskbarThread(
     Wh_Log(
         L"Timer started: '%s' - %d seconds",
         g_reminder,
-        g_secondsRemaining
+        request->seconds
     );
 }
 
@@ -755,7 +1131,8 @@ static void CancelCountdownOnTaskbarThread(
         g_countdownTimer.Stop();
     }
 
-    g_secondsRemaining = 0;
+    g_secondsRemaining.store(0);
+    g_deadlineTick.store(0);
 
     if (g_timerText) {
         g_timerText.Text(
@@ -805,8 +1182,11 @@ static void ResetPopupForNewTimer(
             IDC_CANCEL_TIMER
         );
 
+    const int secondsRemaining =
+        g_secondsRemaining.load();
+
     const bool timerRunning =
-        g_secondsRemaining > 0;
+        secondsRemaining > 0;
 
     if (timerRunning) {
         SetWindowTextW(
@@ -819,7 +1199,7 @@ static void ResetPopupForNewTimer(
         // The input accepts whole minutes, so show the remaining time
         // rounded up to the next minute.
         int remainingMinutes =
-            (g_secondsRemaining + 59) / 60;
+            (secondsRemaining + 59) / 60;
 
         wchar_t minutesText[32]{};
 
@@ -874,11 +1254,16 @@ static LRESULT CALLBACK FinishedPopupWndProc(
     WPARAM wParam,
     LPARAM lParam)
 {
+    EnsurePopupResources(
+        96
+    );
+
     switch (msg)
     {
     case WM_ERASEBKGND:
     {
         RECT rect{};
+
         GetClientRect(
             hWnd,
             &rect
@@ -894,6 +1279,7 @@ static LRESULT CALLBACK FinishedPopupWndProc(
     }
 
     case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
     {
         HDC hdc =
             reinterpret_cast<HDC>(wParam);
@@ -933,6 +1319,37 @@ static LRESULT CALLBACK FinishedPopupWndProc(
         );
     }
 
+    case WM_DPICHANGED:
+    {
+        UINT dpi =
+            HIWORD(wParam);
+
+        RECT* suggested =
+            reinterpret_cast<RECT*>(
+                lParam
+            );
+
+        SetWindowPos(
+            hWnd,
+            nullptr,
+            suggested->left,
+            suggested->top,
+            suggested->right -
+                suggested->left,
+            suggested->bottom -
+                suggested->top,
+            SWP_NOZORDER |
+                SWP_NOACTIVATE
+        );
+
+        LayoutFinishedPopup(
+            hWnd,
+            dpi
+        );
+
+        return 0;
+    }
+
     case WM_COMMAND:
         if (LOWORD(wParam) == IDC_SNOOZE &&
             HIWORD(wParam) == BN_CLICKED)
@@ -954,16 +1371,39 @@ static LRESULT CALLBACK FinishedPopupWndProc(
             if (minutes <= 0 ||
                 minutes > 1440)
             {
-                MessageBoxW(
-                    hWnd,
-                    L"Enter a number of minutes between 1 and 1440.",
-                    L"Snooze timer",
-                    MB_OK |
-                        MB_ICONWARNING
+                SetWindowTextW(
+                    GetDlgItem(
+                        hWnd,
+                        IDC_SNOOZE_LABEL
+                    ),
+                    L"Snooze minutes (1-1440):"
+                );
+
+                HWND edit =
+                    GetDlgItem(
+                        hWnd,
+                        IDC_SNOOZE_MINUTES
+                    );
+
+                SetFocus(edit);
+
+                SendMessageW(
+                    edit,
+                    EM_SETSEL,
+                    0,
+                    -1
                 );
 
                 return 0;
             }
+
+            SetWindowTextW(
+                GetDlgItem(
+                    hWnd,
+                    IDC_SNOOZE_LABEL
+                ),
+                L"Snooze minutes:"
+            );
 
             HWND taskbar =
                 FindCurrentProcessTaskbarWnd();
@@ -1009,14 +1449,8 @@ static LRESULT CALLBACK FinishedPopupWndProc(
             return 0;
         }
 
-        if (LOWORD(wParam) == IDC_DISMISS &&
-            HIWORD(wParam) == BN_CLICKED)
-        {
-            DestroyWindow(hWnd);
-            return 0;
-        }
-
-        if (LOWORD(wParam) == IDC_CLOSE_FINISHED &&
+        if ((LOWORD(wParam) == IDC_DISMISS ||
+             LOWORD(wParam) == IDC_CLOSE_FINISHED) &&
             HIWORD(wParam) == BN_CLICKED)
         {
             DestroyWindow(hWnd);
@@ -1025,11 +1459,9 @@ static LRESULT CALLBACK FinishedPopupWndProc(
 
         break;
 
-
     case WM_CLOSE:
         DestroyWindow(hWnd);
         return 0;
-
 
     case WM_DESTROY:
         g_finishedPopup = nullptr;
@@ -1045,11 +1477,124 @@ static LRESULT CALLBACK FinishedPopupWndProc(
 }
 
 
+static LRESULT CALLBACK TimerPopupWndProc(
+    HWND hWnd,
+    UINT msg,
+    WPARAM wParam,
+    LPARAM lParam);
+
+
+static constexpr wchar_t kTimerPopupClass[] =
+    L"TaskbarCountdownTimerPopup_v12";
+
+static constexpr wchar_t kFinishedPopupClass[] =
+    L"TaskbarCountdownTimerFinishedPopup_v12";
+
+
+static bool RegisterOnePopupClass(
+    const wchar_t* className,
+    WNDPROC wndProc)
+{
+    // No window exists yet at class-registration time.
+    EnsurePopupResources(
+        96
+    );
+
+    WNDCLASSEXW wc{
+        sizeof(wc)
+    };
+
+    wc.lpfnWndProc =
+        wndProc;
+
+    wc.hInstance =
+        g_modInstance;
+
+    wc.lpszClassName =
+        className;
+
+    wc.hCursor =
+        LoadCursorW(
+            nullptr,
+            IDC_ARROW
+        );
+
+    wc.hbrBackground =
+        reinterpret_cast<HBRUSH>(
+            COLOR_WINDOW + 1
+        );
+
+    if (RegisterClassExW(&wc)) {
+        return true;
+    }
+
+    if (GetLastError() !=
+        ERROR_CLASS_ALREADY_EXISTS)
+    {
+        return false;
+    }
+
+    if (!UnregisterClassW(
+            className,
+            g_modInstance))
+    {
+        return false;
+    }
+
+    return RegisterClassExW(&wc) != 0;
+}
+
+
+static bool RegisterPopupClasses()
+{
+    if (!RegisterOnePopupClass(
+            kTimerPopupClass,
+            TimerPopupWndProc))
+    {
+        Wh_Log(
+            L"ERROR: Could not register timer popup class"
+        );
+
+        return false;
+    }
+
+    if (!RegisterOnePopupClass(
+            kFinishedPopupClass,
+            FinishedPopupWndProc))
+    {
+        UnregisterClassW(
+            kTimerPopupClass,
+            g_modInstance
+        );
+
+        Wh_Log(
+            L"ERROR: Could not register finished popup class"
+        );
+
+        return false;
+    }
+
+    return true;
+}
+
+
+static void UnregisterPopupClasses()
+{
+    UnregisterClassW(
+        kFinishedPopupClass,
+        g_modInstance
+    );
+
+    UnregisterClassW(
+        kTimerPopupClass,
+        g_modInstance
+    );
+}
+
+
 static void ShowFinishedPopup(
     HWND owner)
 {
-    static bool classRegistered = false;
-
     if (g_finishedPopup) {
         SetForegroundWindow(
             g_finishedPopup
@@ -1058,57 +1603,23 @@ static void ShowFinishedPopup(
         return;
     }
 
-    if (!classRegistered) {
-        WNDCLASSW wc{};
-
-        wc.lpfnWndProc =
-            FinishedPopupWndProc;
-
-        wc.hInstance =
-            GetModuleHandleW(nullptr);
-
-        wc.lpszClassName =
-            L"TaskbarCountdownTimerFinishedPopup";
-
-        wc.hCursor =
-            LoadCursorW(
-                nullptr,
-                IDC_ARROW
-            );
-
-        wc.hbrBackground =
-            reinterpret_cast<HBRUSH>(
-                COLOR_WINDOW + 1
-            );
-
-        if (!RegisterClassW(&wc) &&
-            GetLastError() !=
-                ERROR_CLASS_ALREADY_EXISTS)
-        {
-            Wh_Log(
-                L"ERROR: Could not register finished popup class"
-            );
-
-            return;
-        }
-
-        classRegistered = true;
-    }
+    UINT dpi =
+        GetPopupDpi(owner);
 
     HWND hWnd = CreateWindowExW(
         WS_EX_TOOLWINDOW |
             WS_EX_TOPMOST,
-        L"TaskbarCountdownTimerFinishedPopup",
+        kFinishedPopupClass,
         L"Timer finished",
         WS_POPUP |
             WS_BORDER,
         CW_USEDEFAULT,
         CW_USEDEFAULT,
-        380,
-        220,
-        owner,
+        ScaleByDpi(380, dpi),
+        ScaleByDpi(220, dpi),
         nullptr,
-        GetModuleHandleW(nullptr),
+        nullptr,
+        g_modInstance,
         nullptr
     );
 
@@ -1134,15 +1645,12 @@ static void ShowFinishedPopup(
             WS_VISIBLE |
             WS_TABSTOP |
             BS_FLAT,
-        338,
-        8,
-        24,
-        24,
+        0, 0, 0, 0,
         hWnd,
         reinterpret_cast<HMENU>(
             IDC_CLOSE_FINISHED
         ),
-        GetModuleHandleW(nullptr),
+        g_modInstance,
         nullptr
     );
 
@@ -1155,13 +1663,12 @@ static void ShowFinishedPopup(
         WS_CHILD |
             WS_VISIBLE |
             SS_CENTER,
-        20,
-        20,
-        340,
-        45,
+        0, 0, 0, 0,
         hWnd,
-        nullptr,
-        GetModuleHandleW(nullptr),
+        reinterpret_cast<HMENU>(
+            IDC_FINISHED_TEXT
+        ),
+        g_modInstance,
         nullptr
     );
 
@@ -1171,15 +1678,12 @@ static void ShowFinishedPopup(
         L"Snooze minutes:",
         WS_CHILD |
             WS_VISIBLE,
-        20,
-        82,
-        160,
-        20,
+        0, 0, 0, 0,
         hWnd,
         reinterpret_cast<HMENU>(
             IDC_SNOOZE_LABEL
         ),
-        GetModuleHandleW(nullptr),
+        g_modInstance,
         nullptr
     );
 
@@ -1191,15 +1695,12 @@ static void ShowFinishedPopup(
             WS_VISIBLE |
             WS_TABSTOP |
             ES_NUMBER,
-        190,
-        78,
-        70,
-        30,
+        0, 0, 0, 0,
         hWnd,
         reinterpret_cast<HMENU>(
             IDC_SNOOZE_MINUTES
         ),
-        GetModuleHandleW(nullptr),
+        g_modInstance,
         nullptr
     );
 
@@ -1211,15 +1712,12 @@ static void ShowFinishedPopup(
             WS_VISIBLE |
             WS_TABSTOP |
             BS_PUSHBUTTON,
-        20,
-        135,
-        165,
-        34,
+        0, 0, 0, 0,
         hWnd,
         reinterpret_cast<HMENU>(
             IDC_SNOOZE
         ),
-        GetModuleHandleW(nullptr),
+        g_modInstance,
         nullptr
     );
 
@@ -1231,60 +1729,26 @@ static void ShowFinishedPopup(
             WS_VISIBLE |
             WS_TABSTOP |
             BS_PUSHBUTTON,
-        195,
-        135,
-        165,
-        34,
+        0, 0, 0, 0,
         hWnd,
         reinterpret_cast<HMENU>(
             IDC_DISMISS
         ),
-        GetModuleHandleW(nullptr),
+        g_modInstance,
         nullptr
     );
 
-    for (int id : {
-             IDC_SNOOZE_LABEL,
-             IDC_SNOOZE_MINUTES,
-             IDC_SNOOZE,
-             IDC_DISMISS,
-             IDC_CLOSE_FINISHED})
-    {
-        ApplyPopupFont(
-            GetDlgItem(
-                hWnd,
-                id
-            )
-        );
-    }
-
-    RECT taskbarRect{};
-    GetWindowRect(
-        owner,
-        &taskbarRect
+    LayoutFinishedPopup(
+        hWnd,
+        dpi
     );
 
-    constexpr int width = 380;
-    constexpr int height = 220;
-
-    int x =
-        taskbarRect.right -
-        width -
-        20;
-
-    int y =
-        taskbarRect.top -
-        height -
-        10;
-
-    SetWindowPos(
+    PositionPopupNearTaskbar(
         hWnd,
-        HWND_TOPMOST,
-        x,
-        y,
-        width,
-        height,
-        SWP_SHOWWINDOW
+        owner,
+        380,
+        220,
+        dpi
     );
 
     MessageBeep(
@@ -1320,6 +1784,7 @@ static LRESULT CALLBACK TimerPopupWndProc(
     case WM_ERASEBKGND:
     {
         RECT rect{};
+
         GetClientRect(
             hWnd,
             &rect
@@ -1335,6 +1800,7 @@ static LRESULT CALLBACK TimerPopupWndProc(
     }
 
     case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
     {
         HDC hdc =
             reinterpret_cast<HDC>(wParam);
@@ -1374,6 +1840,37 @@ static LRESULT CALLBACK TimerPopupWndProc(
         );
     }
 
+    case WM_DPICHANGED:
+    {
+        UINT dpi =
+            HIWORD(wParam);
+
+        RECT* suggested =
+            reinterpret_cast<RECT*>(
+                lParam
+            );
+
+        SetWindowPos(
+            hWnd,
+            nullptr,
+            suggested->left,
+            suggested->top,
+            suggested->right -
+                suggested->left,
+            suggested->bottom -
+                suggested->top,
+            SWP_NOZORDER |
+                SWP_NOACTIVATE
+        );
+
+        LayoutTimerPopup(
+            hWnd,
+            dpi
+        );
+
+        return 0;
+    }
+
     case WM_COMMAND:
         if (LOWORD(wParam) == IDC_START &&
             HIWORD(wParam) == BN_CLICKED)
@@ -1405,16 +1902,39 @@ static LRESULT CALLBACK TimerPopupWndProc(
             if (minutes <= 0 ||
                 minutes > 1440)
             {
-                MessageBoxW(
-                    hWnd,
-                    L"Enter a number of minutes between 1 and 1440.",
-                    L"Timer",
-                    MB_OK |
-                        MB_ICONWARNING
+                SetWindowTextW(
+                    GetDlgItem(
+                        hWnd,
+                        IDC_MINUTES_LABEL
+                    ),
+                    L"Minutes (1-1440):"
+                );
+
+                HWND edit =
+                    GetDlgItem(
+                        hWnd,
+                        IDC_MINUTES
+                    );
+
+                SetFocus(edit);
+
+                SendMessageW(
+                    edit,
+                    EM_SETSEL,
+                    0,
+                    -1
                 );
 
                 return 0;
             }
+
+            SetWindowTextW(
+                GetDlgItem(
+                    hWnd,
+                    IDC_MINUTES_LABEL
+                ),
+                L"Minutes:"
+            );
 
             if (!reminder[0]) {
                 wcsncpy_s(
@@ -1512,10 +2032,14 @@ static LRESULT CALLBACK TimerPopupWndProc(
 
         break;
 
-
     case WM_APP_TIMER_SHOW:
         ResetPopupForNewTimer(
             hWnd
+        );
+
+        LayoutTimerPopup(
+            hWnd,
+            GetDpiForWindow(hWnd)
         );
 
         ShowWindow(
@@ -1546,7 +2070,6 @@ static LRESULT CALLBACK TimerPopupWndProc(
 
         return 0;
 
-
     case WM_APP_TIMER_FINISHED:
         ShowWindow(
             hWnd,
@@ -1559,11 +2082,9 @@ static LRESULT CALLBACK TimerPopupWndProc(
 
         return 0;
 
-
     case WM_APP_TIMER_SHUTDOWN:
         DestroyWindow(hWnd);
         return 0;
-
 
     case WM_CLOSE:
         ShowWindow(
@@ -1573,12 +2094,11 @@ static LRESULT CALLBACK TimerPopupWndProc(
 
         return 0;
 
-
     case WM_DESTROY:
         g_timerPopup = nullptr;
-        g_timerPopupThreadId = 0;
 
         PostQuitMessage(0);
+
         return 0;
     }
 
@@ -1594,59 +2114,23 @@ static LRESULT CALLBACK TimerPopupWndProc(
 static bool ShowTimerPopup(
     HWND owner)
 {
-    static bool classRegistered = false;
-
-    if (!classRegistered) {
-        WNDCLASSW wc{};
-
-        wc.lpfnWndProc =
-            TimerPopupWndProc;
-
-        wc.hInstance =
-            GetModuleHandleW(nullptr);
-
-        wc.lpszClassName =
-            L"TaskbarCountdownTimerPopup";
-
-        wc.hCursor =
-            LoadCursorW(
-                nullptr,
-                IDC_ARROW
-            );
-
-        wc.hbrBackground =
-            reinterpret_cast<HBRUSH>(
-                COLOR_WINDOW + 1
-            );
-
-        if (!RegisterClassW(&wc) &&
-            GetLastError() !=
-                ERROR_CLASS_ALREADY_EXISTS)
-        {
-            Wh_Log(
-                L"ERROR: Could not register popup class"
-            );
-
-            return false;
-        }
-
-        classRegistered = true;
-    }
+    UINT dpi =
+        GetPopupDpi(owner);
 
     HWND hWnd = CreateWindowExW(
         WS_EX_TOOLWINDOW |
             WS_EX_TOPMOST,
-        L"TaskbarCountdownTimerPopup",
+        kTimerPopupClass,
         L"Timer",
         WS_POPUP |
             WS_BORDER,
         CW_USEDEFAULT,
         CW_USEDEFAULT,
-        380,
-        235,
-        owner,
+        ScaleByDpi(380, dpi),
+        ScaleByDpi(235, dpi),
         nullptr,
-        GetModuleHandleW(nullptr),
+        nullptr,
+        g_modInstance,
         nullptr
     );
 
@@ -1663,8 +2147,6 @@ static bool ShowTimerPopup(
     );
 
     g_timerPopup = hWnd;
-    g_timerPopupThreadId =
-        GetCurrentThreadId();
 
     CreateWindowExW(
         0,
@@ -1674,15 +2156,12 @@ static bool ShowTimerPopup(
             WS_VISIBLE |
             WS_TABSTOP |
             BS_FLAT,
-        338,
-        8,
-        24,
-        24,
+        0, 0, 0, 0,
         hWnd,
         reinterpret_cast<HMENU>(
             IDC_CLOSE_TIMER
         ),
-        GetModuleHandleW(nullptr),
+        g_modInstance,
         nullptr
     );
 
@@ -1692,15 +2171,12 @@ static bool ShowTimerPopup(
         L"Reminder:",
         WS_CHILD |
             WS_VISIBLE,
-        20,
-        20,
-        300,
-        20,
+        0, 0, 0, 0,
         hWnd,
         reinterpret_cast<HMENU>(
             IDC_REMINDER_LABEL
         ),
-        GetModuleHandleW(nullptr),
+        g_modInstance,
         nullptr
     );
 
@@ -1712,15 +2188,12 @@ static bool ShowTimerPopup(
             WS_VISIBLE |
             WS_TABSTOP |
             ES_AUTOHSCROLL,
-        20,
-        45,
-        340,
-        30,
+        0, 0, 0, 0,
         hWnd,
         reinterpret_cast<HMENU>(
             IDC_REMINDER
         ),
-        GetModuleHandleW(nullptr),
+        g_modInstance,
         nullptr
     );
 
@@ -1730,15 +2203,12 @@ static bool ShowTimerPopup(
         L"Minutes:",
         WS_CHILD |
             WS_VISIBLE,
-        20,
-        90,
-        150,
-        20,
+        0, 0, 0, 0,
         hWnd,
         reinterpret_cast<HMENU>(
             IDC_MINUTES_LABEL
         ),
-        GetModuleHandleW(nullptr),
+        g_modInstance,
         nullptr
     );
 
@@ -1750,15 +2220,12 @@ static bool ShowTimerPopup(
             WS_VISIBLE |
             WS_TABSTOP |
             ES_NUMBER,
-        20,
-        115,
-        110,
-        30,
+        0, 0, 0, 0,
         hWnd,
         reinterpret_cast<HMENU>(
             IDC_MINUTES
         ),
-        GetModuleHandleW(nullptr),
+        g_modInstance,
         nullptr
     );
 
@@ -1770,15 +2237,12 @@ static bool ShowTimerPopup(
             WS_VISIBLE |
             WS_TABSTOP |
             BS_PUSHBUTTON,
-        20,
-        165,
-        150,
-        35,
+        0, 0, 0, 0,
         hWnd,
         reinterpret_cast<HMENU>(
             IDC_START
         ),
-        GetModuleHandleW(nullptr),
+        g_modInstance,
         nullptr
     );
 
@@ -1791,68 +2255,31 @@ static bool ShowTimerPopup(
                 WS_VISIBLE |
                 WS_TABSTOP |
                 BS_PUSHBUTTON,
-            195,
-            165,
-            165,
-            34,
+            0, 0, 0, 0,
             hWnd,
             reinterpret_cast<HMENU>(
                 IDC_CANCEL_TIMER
             ),
-            GetModuleHandleW(nullptr),
+            g_modInstance,
             nullptr
         );
 
     EnableWindow(
         cancelButton,
-        g_secondsRemaining > 0
+        g_secondsRemaining.load() > 0
     );
 
-    for (int id : {
-             IDC_REMINDER_LABEL,
-             IDC_REMINDER,
-             IDC_MINUTES_LABEL,
-             IDC_MINUTES,
-             IDC_START,
-             IDC_CANCEL_TIMER,
-             IDC_CLOSE_TIMER})
-    {
-        ApplyPopupFont(
-            GetDlgItem(
-                hWnd,
-                id
-            )
-        );
-    }
-
-    RECT taskbarRect{};
-
-    GetWindowRect(
-        owner,
-        &taskbarRect
-    );
-
-    constexpr int width = 380;
-    constexpr int height = 235;
-
-    int x =
-        taskbarRect.right -
-        width -
-        20;
-
-    int y =
-        taskbarRect.top -
-        height -
-        10;
-
-    SetWindowPos(
+    LayoutTimerPopup(
         hWnd,
-        HWND_TOPMOST,
-        x,
-        y,
-        width,
-        height,
-        SWP_SHOWWINDOW
+        dpi
+    );
+
+    PositionPopupNearTaskbar(
+        hWnd,
+        owner,
+        380,
+        235,
+        dpi
     );
 
     ShowWindow(
@@ -1872,21 +2299,78 @@ static DWORD WINAPI TimerPopupThreadProc(
     HWND taskbar =
         reinterpret_cast<HWND>(param);
 
-    if (!ShowTimerPopup(taskbar)) {
+    MSG msg{};
+
+    // Force creation of this thread's message queue before signalling readiness.
+    PeekMessageW(
+        &msg,
+        nullptr,
+        WM_USER,
+        WM_USER,
+        PM_NOREMOVE
+    );
+
+    if (g_popupThreadReadyEvent) {
+        SetEvent(
+            g_popupThreadReadyEvent
+        );
+    }
+
+    if (g_unloading.load()) {
         return 0;
     }
 
-    MSG msg{};
+    if (!RegisterPopupClasses()) {
+        return 0;
+    }
 
-    while (GetMessageW(
+    if (!ShowTimerPopup(taskbar)) {
+        UnregisterPopupClasses();
+        return 0;
+    }
+
+    while (!g_unloading.load() &&
+           GetMessageW(
                &msg,
                nullptr,
                0,
                0) > 0)
     {
-        TranslateMessage(&msg);
-        DispatchMessageW(&msg);
+        HWND dialog =
+            g_finishedPopup
+                ? g_finishedPopup
+                : g_timerPopup;
+
+        if (!dialog ||
+            !IsDialogMessageW(
+                dialog,
+                &msg))
+        {
+            TranslateMessage(&msg);
+            DispatchMessageW(&msg);
+        }
     }
+
+    if (g_finishedPopup &&
+        IsWindow(g_finishedPopup))
+    {
+        DestroyWindow(
+            g_finishedPopup
+        );
+    }
+
+    if (g_timerPopup &&
+        IsWindow(g_timerPopup))
+    {
+        DestroyWindow(
+            g_timerPopup
+        );
+    }
+
+    g_finishedPopup = nullptr;
+    g_timerPopup = nullptr;
+
+    UnregisterPopupClasses();
 
     return 0;
 }
@@ -1895,7 +2379,13 @@ static DWORD WINAPI TimerPopupThreadProc(
 static void OpenTimerPopup(
     HWND taskbar)
 {
-    if (g_timerPopup) {
+    if (g_unloading.load()) {
+        return;
+    }
+
+    if (g_timerPopup &&
+        IsWindow(g_timerPopup))
+    {
         PostMessageW(
             g_timerPopup,
             WM_APP_TIMER_SHOW,
@@ -1918,11 +2408,38 @@ static void OpenTimerPopup(
 
             g_timerPopupThread =
                 nullptr;
+
+            g_timerPopupThreadId =
+                0;
         }
         else {
-            // The thread is still starting.
             return;
         }
+    }
+
+    if (g_popupThreadReadyEvent) {
+        CloseHandle(
+            g_popupThreadReadyEvent
+        );
+
+        g_popupThreadReadyEvent =
+            nullptr;
+    }
+
+    g_popupThreadReadyEvent =
+        CreateEventW(
+            nullptr,
+            TRUE,
+            FALSE,
+            nullptr
+        );
+
+    if (!g_popupThreadReadyEvent) {
+        Wh_Log(
+            L"ERROR: Could not create popup ready event"
+        );
+
+        return;
     }
 
     g_timerPopupThread =
@@ -1932,14 +2449,31 @@ static void OpenTimerPopup(
             TimerPopupThreadProc,
             taskbar,
             0,
-            nullptr
+            &g_timerPopupThreadId
         );
 
     if (!g_timerPopupThread) {
+        CloseHandle(
+            g_popupThreadReadyEvent
+        );
+
+        g_popupThreadReadyEvent =
+            nullptr;
+
+        g_timerPopupThreadId =
+            0;
+
         Wh_Log(
             L"ERROR: Could not create popup thread"
         );
+
+        return;
     }
+
+    WaitForSingleObject(
+        g_popupThreadReadyEvent,
+        INFINITE
+    );
 }
 
 
@@ -1950,6 +2484,10 @@ static void OpenTimerPopup(
 static void AddTimerButton(
     void* param)
 {
+    if (g_unloading.load()) {
+        return;
+    }
+
     HWND taskbar =
         reinterpret_cast<HWND>(param);
 
@@ -1957,10 +2495,6 @@ static void AddTimerButton(
         GetTaskbarXamlRoot(taskbar);
 
     if (!xamlRoot) {
-        Wh_Log(
-            L"ERROR: Taskbar XamlRoot not obtained"
-        );
-
         return;
     }
 
@@ -1969,16 +2503,9 @@ static void AddTimerButton(
             .try_as<FrameworkElement>();
 
     if (!content) {
-        Wh_Log(
-            L"ERROR: XamlRoot content unavailable"
-        );
-
         return;
     }
 
-    // SystemTrayFrameGrid is the live layout container for the notification
-    // area. On recent Windows 11 builds it can be a StackPanel instead of a
-    // Grid, while keeping the same element name.
     auto tray =
         FindChildRecursive(
             content,
@@ -1991,10 +2518,6 @@ static void AddTimerButton(
         );
 
     if (!tray) {
-        Wh_Log(
-            L"ERROR: SystemTrayFrameGrid not found"
-        );
-
         return;
     }
 
@@ -2002,14 +2525,9 @@ static void AddTimerButton(
         tray.try_as<Panel>();
 
     if (!panel) {
-        Wh_Log(
-            L"ERROR: SystemTrayFrameGrid is not a Panel"
-        );
-
         return;
     }
 
-    // Remove a leftover instance if this mod was reloaded.
     auto existing =
         FindChildRecursive(
             tray,
@@ -2021,26 +2539,35 @@ static void AddTimerButton(
             }
         );
 
+    // The current XAML tree already has our button.
     if (existing) {
-        auto parent =
-            VisualTreeHelper::GetParent(
-                existing
-            ).try_as<Panel>();
-
-        if (parent) {
-            auto children =
-                parent.Children();
-
-            uint32_t index = 0;
-
-            if (children.IndexOf(
-                    existing,
-                    index))
-            {
-                children.RemoveAt(index);
-            }
-        }
+        return;
     }
+
+    // If the taskbar XAML tree was rebuilt, release the old XAML objects on
+    // the taskbar UI thread before creating replacements.
+    if (g_countdownTimer) {
+        g_countdownTimer.Stop();
+
+        g_countdownTimer.Tick(
+            g_timerTickToken
+        );
+
+        g_countdownTimer =
+            nullptr;
+    }
+
+    if (g_timerButton) {
+        g_timerButton.Click(
+            g_timerButtonClickToken
+        );
+
+        g_timerButton =
+            nullptr;
+    }
+
+    g_timerText =
+        nullptr;
 
     g_timerButton = Button();
     g_timerText = TextBlock();
@@ -2049,8 +2576,15 @@ static void AddTimerButton(
         L"TaskbarCountdownTimerButton"
     );
 
+    int secondsRemaining =
+        g_secondsRemaining.load();
+
     g_timerText.Text(
-        L"⏱ Timer"
+        secondsRemaining > 0
+            ? FormatCountdown(
+                  secondsRemaining
+              )
+            : L"⏱ Timer"
     );
 
     g_timerText.VerticalAlignment(
@@ -2079,11 +2613,9 @@ static void AddTimerButton(
                 HWND taskbar =
                     FindCurrentProcessTaskbarWnd();
 
-                if (!taskbar) {
-                    Wh_Log(
-                        L"ERROR: Taskbar not found for popup"
-                    );
-
+                if (!taskbar ||
+                    g_unloading.load())
+                {
                     return;
                 }
 
@@ -2106,44 +2638,72 @@ static void AddTimerButton(
                 winrt::Windows::Foundation::
                     IInspectable const&)
             {
-                if (g_secondsRemaining <= 0) {
-                    g_countdownTimer.Stop();
+                ULONGLONG deadline =
+                    g_deadlineTick.load();
+
+                if (!deadline) {
+                    g_secondsRemaining.store(0);
+
+                    if (g_countdownTimer) {
+                        g_countdownTimer.Stop();
+                    }
+
                     return;
                 }
 
-                g_secondsRemaining--;
+                ULONGLONG now =
+                    GetTickCount64();
 
-                if (g_secondsRemaining > 0) {
+                if (now >= deadline) {
+                    g_deadlineTick.store(0);
+                    g_secondsRemaining.store(0);
+
+                    if (g_countdownTimer) {
+                        g_countdownTimer.Stop();
+                    }
+
                     if (g_timerText) {
                         g_timerText.Text(
-                            FormatCountdown(
-                                g_secondsRemaining
-                            )
+                            L"⏱ Timer"
+                        );
+                    }
+
+                    Wh_Log(
+                        L"Timer finished: '%s'",
+                        g_reminder
+                    );
+
+                    if (g_timerPopup &&
+                        IsWindow(g_timerPopup))
+                    {
+                        PostMessageW(
+                            g_timerPopup,
+                            WM_APP_TIMER_FINISHED,
+                            0,
+                            0
                         );
                     }
 
                     return;
                 }
 
-                g_countdownTimer.Stop();
+                int remaining =
+                    static_cast<int>(
+                        (deadline -
+                         now +
+                         999ULL) /
+                        1000ULL
+                    );
+
+                g_secondsRemaining.store(
+                    remaining
+                );
 
                 if (g_timerText) {
                     g_timerText.Text(
-                        L"⏱ Timer"
-                    );
-                }
-
-                Wh_Log(
-                    L"Timer finished: '%s'",
-                    g_reminder
-                );
-
-                if (g_timerPopup) {
-                    PostMessageW(
-                        g_timerPopup,
-                        WM_APP_TIMER_FINISHED,
-                        0,
-                        0
+                        FormatCountdown(
+                            remaining
+                        )
                     );
                 }
             }
@@ -2155,14 +2715,6 @@ static void AddTimerButton(
     auto trayClass =
         winrt::get_class_name(tray);
 
-    Wh_Log(
-        L"SystemTrayFrameGrid class: %s",
-        trayClass.c_str()
-    );
-
-    // "Before notification icons": on current Windows 11 builds the tray
-    // container is a StackPanel, so inserting at index 0 gives the timer its
-    // own layout slot instead of overlaying the hidden-icons button.
     if (trayClass ==
         L"Windows.UI.Xaml.Controls.StackPanel")
     {
@@ -2170,25 +2722,36 @@ static void AddTimerButton(
             0,
             g_timerButton
         );
-
-        Wh_Log(
-            L"Timer button inserted at start of tray StackPanel"
-        );
-
-        return;
     }
+    else {
+        auto trayGrid =
+            tray.try_as<Grid>();
 
-    // Fallback for builds where SystemTrayFrameGrid is still a Grid.
-    // Put the button in a new Auto column at the start and shift the existing
-    // children one column to the right.
-    auto trayGrid =
-        tray.try_as<Grid>();
+        if (!trayGrid) {
+            Wh_Log(
+                L"ERROR: Unsupported SystemTrayFrameGrid layout class: %s",
+                trayClass.c_str()
+            );
 
-    if (trayGrid) {
+            g_timerButton.Click(
+                g_timerButtonClickToken
+            );
+
+            g_timerButton = nullptr;
+            g_timerText = nullptr;
+            g_countdownTimer.Tick(
+                g_timerTickToken
+            );
+            g_countdownTimer = nullptr;
+
+            return;
+        }
+
         auto columns =
             trayGrid.ColumnDefinitions();
 
         ColumnDefinition timerColumn;
+
         timerColumn.Width(
             GridLengthHelper::Auto()
         );
@@ -2210,12 +2773,9 @@ static void AddTimerButton(
                 continue;
             }
 
-            int currentColumn =
-                Grid::GetColumn(child);
-
             Grid::SetColumn(
                 child,
-                currentColumn + 1
+                Grid::GetColumn(child) + 1
             );
         }
 
@@ -2228,17 +2788,56 @@ static void AddTimerButton(
             0,
             g_timerButton
         );
+    }
 
-        Wh_Log(
-            L"Timer button inserted in new leading tray Grid column"
-        );
+    // Re-arm display refresh after a taskbar XAML rebuild.
+    ULONGLONG deadline =
+        g_deadlineTick.load();
 
-        return;
+    if (deadline) {
+        ULONGLONG now =
+            GetTickCount64();
+
+        if (now < deadline) {
+            int remaining =
+                static_cast<int>(
+                    (deadline -
+                     now +
+                     999ULL) /
+                    1000ULL
+                );
+
+            g_secondsRemaining.store(
+                remaining
+            );
+
+            g_timerText.Text(
+                FormatCountdown(
+                    remaining
+                )
+            );
+
+            g_countdownTimer.Start();
+        }
+        else {
+            g_deadlineTick.store(0);
+            g_secondsRemaining.store(0);
+
+            if (g_timerPopup &&
+                IsWindow(g_timerPopup))
+            {
+                PostMessageW(
+                    g_timerPopup,
+                    WM_APP_TIMER_FINISHED,
+                    0,
+                    0
+                );
+            }
+        }
     }
 
     Wh_Log(
-        L"ERROR: Unsupported SystemTrayFrameGrid layout class: %s",
-        trayClass.c_str()
+        L"Timer button added to taskbar"
     );
 }
 
@@ -2255,8 +2854,6 @@ static void RemoveTimerButton(
         g_countdownTimer =
             nullptr;
     }
-
-    g_secondsRemaining = 0;
 
     if (g_timerButton) {
         g_timerButton.Click(
@@ -2284,8 +2881,6 @@ static void RemoveTimerButton(
                 children.RemoveAt(index);
             }
 
-            // If the tray container is a Grid, v0.7 added one leading Auto
-            // column. Restore the original column indexes and remove it.
             auto parentGrid =
                 parentElement.try_as<Grid>();
 
@@ -2328,6 +2923,50 @@ static void RemoveTimerButton(
 }
 
 
+static void ApplyTimerButtonIfAvailable()
+{
+    if (g_unloading.load()) {
+        return;
+    }
+
+    HWND taskbar =
+        FindCurrentProcessTaskbarWnd();
+
+    if (!taskbar) {
+        return;
+    }
+
+    RunFromWindowThread(
+        taskbar,
+        AddTimerButton,
+        taskbar
+    );
+}
+
+
+static DWORD WINAPI RetryThreadProc(
+    LPVOID)
+{
+    while (!g_unloading.load()) {
+        ApplyTimerButtonIfAvailable();
+
+        DWORD waitResult =
+            WaitForSingleObject(
+                g_retryStopEvent,
+                5000
+            );
+
+        if (waitResult !=
+            WAIT_TIMEOUT)
+        {
+            break;
+        }
+    }
+
+    return 0;
+}
+
+
 // -----------------------------------------------------------------------------
 // Windhawk
 // -----------------------------------------------------------------------------
@@ -2338,16 +2977,29 @@ BOOL Wh_ModInit()
         L"Taskbar Countdown Timer loading"
     );
 
-    HWND taskbar =
-        FindCurrentProcessTaskbarWnd();
+    g_unloading.store(false);
 
-    if (!taskbar) {
+    HMODULE module = nullptr;
+
+    if (!GetModuleHandleExW(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            reinterpret_cast<LPCWSTR>(
+                &g_modInstance
+            ),
+            &module))
+    {
         Wh_Log(
-            L"ERROR: Taskbar not found"
+            L"ERROR: Could not resolve mod module handle"
         );
 
         return FALSE;
     }
+
+    g_modInstance =
+        reinterpret_cast<HINSTANCE>(
+            module
+        );
 
     if (!HookTaskbarDllSymbols()) {
         Wh_Log(
@@ -2357,28 +3009,95 @@ BOOL Wh_ModInit()
         return FALSE;
     }
 
-    if (!RunFromWindowThread(
-            taskbar,
-            AddTimerButton,
-            taskbar))
-    {
-        Wh_Log(
-            L"ERROR: Could not access taskbar XAML thread"
+    return TRUE;
+}
+
+
+void Wh_ModAfterInit()
+{
+    g_retryStopEvent =
+        CreateEventW(
+            nullptr,
+            TRUE,
+            FALSE,
+            nullptr
         );
 
-        return FALSE;
+    if (!g_retryStopEvent) {
+        Wh_Log(
+            L"ERROR: Could not create retry stop event"
+        );
+
+        ApplyTimerButtonIfAvailable();
+
+        return;
     }
 
-    Wh_Log(
-        L"Taskbar Countdown Timer loaded"
-    );
+    g_retryThread =
+        CreateThread(
+            nullptr,
+            0,
+            RetryThreadProc,
+            nullptr,
+            0,
+            nullptr
+        );
 
-    return TRUE;
+    if (!g_retryThread) {
+        Wh_Log(
+            L"ERROR: Could not create taskbar retry thread"
+        );
+
+        ApplyTimerButtonIfAvailable();
+    }
+}
+
+
+void Wh_ModBeforeUninit()
+{
+    g_unloading.store(true);
+
+    if (g_retryStopEvent) {
+        SetEvent(
+            g_retryStopEvent
+        );
+    }
 }
 
 
 void Wh_ModUninit()
 {
+    g_unloading.store(true);
+
+    if (g_retryStopEvent) {
+        SetEvent(
+            g_retryStopEvent
+        );
+    }
+
+    if (g_retryThread) {
+        WaitForSingleObject(
+            g_retryThread,
+            INFINITE
+        );
+
+        CloseHandle(
+            g_retryThread
+        );
+
+        g_retryThread =
+            nullptr;
+    }
+
+    if (g_retryStopEvent) {
+        CloseHandle(
+            g_retryStopEvent
+        );
+
+        g_retryStopEvent =
+            nullptr;
+    }
+
     HWND taskbar =
         FindCurrentProcessTaskbarWnd();
 
@@ -2390,7 +3109,9 @@ void Wh_ModUninit()
         );
     }
 
-    if (g_finishedPopup) {
+    if (g_finishedPopup &&
+        IsWindow(g_finishedPopup))
+    {
         PostMessageW(
             g_finishedPopup,
             WM_CLOSE,
@@ -2399,7 +3120,9 @@ void Wh_ModUninit()
         );
     }
 
-    if (g_timerPopup) {
+    if (g_timerPopup &&
+        IsWindow(g_timerPopup))
+    {
         PostMessageW(
             g_timerPopup,
             WM_APP_TIMER_SHUTDOWN,
@@ -2409,9 +3132,25 @@ void Wh_ModUninit()
     }
 
     if (g_timerPopupThread) {
+        if (g_popupThreadReadyEvent) {
+            WaitForSingleObject(
+                g_popupThreadReadyEvent,
+                INFINITE
+            );
+        }
+
+        if (g_timerPopupThreadId) {
+            PostThreadMessageW(
+                g_timerPopupThreadId,
+                WM_QUIT,
+                0,
+                0
+            );
+        }
+
         WaitForSingleObject(
             g_timerPopupThread,
-            2000
+            INFINITE
         );
 
         CloseHandle(
@@ -2422,16 +3161,28 @@ void Wh_ModUninit()
             nullptr;
     }
 
+    if (g_popupThreadReadyEvent) {
+        CloseHandle(
+            g_popupThreadReadyEvent
+        );
+
+        g_popupThreadReadyEvent =
+            nullptr;
+    }
+
     g_finishedPopup = nullptr;
     g_timerPopup = nullptr;
     g_timerPopupThreadId = 0;
 
+    // Popup classes are unregistered by the popup thread before it exits.
+    // GDI objects are destroyed only after that thread is fully joined.
     if (g_popupFont) {
         DeleteObject(
             g_popupFont
         );
 
         g_popupFont = nullptr;
+        g_popupFontDpi = 0;
     }
 
     if (g_popupEditBrush) {

--- a/mods/taskbar-countdown-timer.wh.cpp
+++ b/mods/taskbar-countdown-timer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-countdown-timer
 // @name            Taskbar Countdown Timer
 // @description     A simple countdown timer integrated into the Windows 11 taskbar (Windows 11 only)
-// @version         1.15
+// @version         1.16
 // @author          Richi
 // @github          https://github.com/richilp
 // @include         explorer.exe
@@ -27,6 +27,8 @@ Adds a compact countdown timer directly to the Windows 11 taskbar.
 - Completion sound
 - Reliable completion alert that doesn't depend on the taskbar XAML tree
 - Timer state survives Explorer restarts and mod reloads
+- Persisted timers use the Windows wall clock; changing the system time can shift an active timer
+- Missed reminders older than 6 hours are discarded on restore
 - Native XAML flyout for timer configuration
 - Completion alert follows the Windows light/dark app theme
 - No external application required
@@ -169,11 +171,17 @@ static std::atomic<HWND> g_taskbarWnd{nullptr};
 static std::atomic<DWORD> g_taskbarThreadId{0};
 static std::atomic_bool g_systemTrayModuleHooked{false};
 static std::atomic<HMODULE> g_systemTrayModuleAttempted{nullptr};
+static std::atomic_bool g_taskbarDllHooked{false};
+static std::atomic<HMODULE> g_taskbarDllAttempted{nullptr};
+
+static SRWLOCK g_shellRuntimeLock = SRWLOCK_INIT;
+static bool g_shellRuntimeStarted = false;
 
 static std::atomic_bool g_unloading{false};
 static std::atomic_bool g_xamlTornDown{false};
 
 static void ApplyTimerButtonIfAvailable();
+static bool EnsureShellRuntimeStarted();
 
 // -----------------------------------------------------------------------------
 // XAML helpers
@@ -344,24 +352,16 @@ static void WINAPI TrayUI_StartTaskbar_Hook(
     }
 
     if (!g_unloading.load()) {
+        EnsureShellRuntimeStarted();
         ApplyTimerButtonIfAvailable();
     }
 }
 
 
-static bool HookTaskbarDllSymbols()
+static bool HookTaskbarDllSymbols(
+    HMODULE module)
 {
-    HMODULE module = LoadLibraryExW(
-        L"taskbar.dll",
-        nullptr,
-        LOAD_LIBRARY_SEARCH_SYSTEM32
-    );
-
     if (!module) {
-        Wh_Log(
-            L"ERROR: Could not load taskbar.dll"
-        );
-
         return false;
     }
 
@@ -1164,6 +1164,7 @@ static void BuildTimerFlyout()
     reminderBox.PlaceholderText(
         L"What should I remind you about?"
     );
+    reminderBox.MaxLength(255);
     reminderBox.Margin(
         Thickness{0, 0, 0, 10}
     );
@@ -1758,11 +1759,6 @@ static LRESULT CALLBACK FinishedAlertWndProc(
             dpi = 96;
         }
 
-        ApplyFinishedAlertTheme(
-            hWnd,
-            dpi
-        );
-
         CreateWindowExW(
             0,
             L"STATIC",
@@ -1830,6 +1826,11 @@ static LRESULT CALLBACK FinishedAlertWndProc(
             reinterpret_cast<HMENU>(IDC_ALERT_DISMISS),
             nullptr,
             nullptr
+        );
+
+        ApplyFinishedAlertTheme(
+            hWnd,
+            dpi
         );
 
         LayoutFinishedAlert(
@@ -2287,6 +2288,21 @@ static DWORD WINAPI FinishedAlertThreadProc(LPVOID param)
     }
 
 ExitLoop:
+    MSG pending{};
+
+    while (PeekMessageW(
+               &pending,
+               hWnd,
+               WM_APP_ALERT_REFRESH,
+               WM_APP_ALERT_REFRESH,
+               PM_REMOVE))
+    {
+        delete reinterpret_cast<
+            FinishedAlertData*>(
+                pending.lParam
+            );
+    }
+
     if (IsWindow(hWnd)) {
         DestroyWindow(hWnd);
     }
@@ -2318,6 +2334,15 @@ static void CloseFinishedAlertThreadIfExited()
 static bool ShowFinishedAlertLocked(const wchar_t* reminder)
 {
     if (g_unloading.load()) {
+        return false;
+    }
+
+    if (!g_finishedAlertClassRegistered &&
+        !RegisterFinishedAlertClass())
+    {
+        Wh_Log(
+            L"ERROR: Completion alert class isn't available"
+        );
         return false;
     }
 
@@ -2750,7 +2775,7 @@ static void CleanupTimerObjects()
 }
 
 
-static bool StartTimerWorkerFromInit()
+static bool StartTimerWorker()
 {
     g_timerStopEvent =
         CreateEventW(
@@ -2817,6 +2842,53 @@ static bool StartTimerWorkerFromInit()
 
     g_timerWorkerThread =
         thread;
+
+    return true;
+}
+
+
+static bool EnsureShellRuntimeStarted()
+{
+    AcquireSRWLockExclusive(
+        &g_shellRuntimeLock
+    );
+
+    if (g_unloading.load()) {
+        ReleaseSRWLockExclusive(
+            &g_shellRuntimeLock
+        );
+        return false;
+    }
+
+    if (g_shellRuntimeStarted) {
+        ReleaseSRWLockExclusive(
+            &g_shellRuntimeLock
+        );
+        return true;
+    }
+
+    if (!g_finishedAlertClassRegistered &&
+        !RegisterFinishedAlertClass())
+    {
+        Wh_Log(
+            L"WARNING: Completion alert class could not be registered"
+        );
+    }
+
+    if (!StartTimerWorker()) {
+        ReleaseSRWLockExclusive(
+            &g_shellRuntimeLock
+        );
+        return false;
+    }
+
+    g_shellRuntimeStarted = true;
+
+    RestorePersistedTimer();
+
+    ReleaseSRWLockExclusive(
+        &g_shellRuntimeLock
+    );
 
     return true;
 }
@@ -2977,22 +3049,6 @@ static void AddTimerButtonImpl(
         return;
     }
 
-    // Fast path which is safe across in-process tray rebuilds: only keep the
-    // current button if it still belongs to the *current* taskbar XamlRoot.
-    if (g_timerButton) {
-        auto buttonRoot =
-            g_timerButton.XamlRoot();
-
-        if (buttonRoot &&
-            SameWinrtObject(
-                buttonRoot,
-                xamlRoot))
-        {
-            g_taskbarWnd.store(taskbar);
-            return;
-        }
-    }
-
     auto content =
         xamlRoot.Content()
             .try_as<FrameworkElement>();
@@ -3014,6 +3070,22 @@ static void AddTimerButtonImpl(
 
     if (!tray) {
         return;
+    }
+
+    if (g_timerButton) {
+        auto currentParent =
+            VisualTreeHelper::GetParent(
+                g_timerButton
+            ).try_as<FrameworkElement>();
+
+        if (currentParent &&
+            SameWinrtObject(
+                currentParent,
+                tray))
+        {
+            g_taskbarWnd.store(taskbar);
+            return;
+        }
     }
 
     auto panel =
@@ -3490,11 +3562,6 @@ static HMODULE GetSystemTrayModuleHandle()
         {
             return module;
         }
-
-        Wh_Log(
-            L"Skipping Taskbar.View.dll version %u",
-            moduleMajor
-        );
     }
 
     return GetModuleHandleW(
@@ -3592,6 +3659,47 @@ static bool HookSystemTraySymbols(
 }
 
 
+static void HandleLoadedModuleIfTaskbar(
+    HMODULE module)
+{
+    if (g_unloading.load() ||
+        g_taskbarDllHooked.load())
+    {
+        return;
+    }
+
+    HMODULE current =
+        GetModuleHandleW(
+            L"taskbar.dll"
+        );
+
+    if (!current ||
+        current != module)
+    {
+        return;
+    }
+
+    HMODULE previous =
+        g_taskbarDllAttempted.exchange(
+            module
+        );
+
+    if (previous == module) {
+        return;
+    }
+
+    if (HookTaskbarDllSymbols(module)) {
+        g_taskbarDllHooked.store(true);
+        Wh_ApplyHookOperations();
+    }
+    else {
+        Wh_Log(
+            L"ERROR: Failed to hook taskbar.dll symbols"
+        );
+    }
+}
+
+
 static void HandleLoadedModuleIfSystemTray(
     HMODULE module)
 {
@@ -3639,6 +3747,7 @@ static HMODULE WINAPI LoadLibraryExW_Hook(
         );
 
     if (module) {
+        HandleLoadedModuleIfTaskbar(module);
         HandleLoadedModuleIfSystemTray(module);
     }
 
@@ -3697,38 +3806,32 @@ BOOL Wh_ModInit()
 
     LoadSettings();
 
-    if (!RegisterFinishedAlertClass()) {
-        return FALSE;
-    }
+    bool taskbarHookedAtInit = false;
 
-    if (!StartTimerWorkerFromInit()) {
-        UnregisterFinishedAlertClass();
-        return FALSE;
-    }
-
-    if (!HookTaskbarDllSymbols()) {
-        StopTimerWorker();
-
-        if (g_timerWorkerThread) {
-            PumpWaitForThread(
-                g_timerWorkerThread
-            );
-
-            CloseHandle(
-                g_timerWorkerThread
-            );
-
-            g_timerWorkerThread = nullptr;
-        }
-
-        CleanupTimerObjects();
-
-        UnregisterFinishedAlertClass();
-        Wh_Log(
-            L"ERROR: Failed to resolve taskbar.dll symbols"
+    if (HMODULE taskbar =
+            GetModuleHandleW(
+                L"taskbar.dll"))
+    {
+        g_taskbarDllAttempted.store(
+            taskbar
         );
 
-        return FALSE;
+        taskbarHookedAtInit =
+            HookTaskbarDllSymbols(
+                taskbar
+            );
+
+        if (taskbarHookedAtInit) {
+            g_taskbarDllHooked.store(
+                true
+            );
+        }
+        else {
+            Wh_Log(
+                L"ERROR: Failed to resolve taskbar.dll symbols"
+            );
+            return FALSE;
+        }
     }
 
     bool systemTrayHookedAtInit = false;
@@ -3757,7 +3860,9 @@ BOOL Wh_ModInit()
         }
     }
 
-    if (!systemTrayHookedAtInit) {
+    if (!taskbarHookedAtInit ||
+        !systemTrayHookedAtInit)
+    {
         HMODULE kernelbase =
             GetModuleHandleW(
                 L"kernelbase.dll"
@@ -3781,15 +3886,26 @@ BOOL Wh_ModInit()
                 &LoadLibraryExW_Original
             );
         }
+        else {
+            Wh_Log(
+                L"ERROR: Could not resolve LoadLibraryExW"
+            );
+        }
     }
 
     return TRUE;
 }
 
-
 void Wh_ModAfterInit()
 {
-    RestorePersistedTimer();
+    if (HMODULE taskbar =
+            GetModuleHandleW(
+                L"taskbar.dll"))
+    {
+        HandleLoadedModuleIfTaskbar(
+            taskbar
+        );
+    }
 
     if (HMODULE systemTray =
             GetSystemTrayModuleHandle())
@@ -3799,9 +3915,11 @@ void Wh_ModAfterInit()
         );
     }
 
-    ApplyTimerButtonIfAvailable();
+    if (FindCurrentProcessTaskbarWnd()) {
+        EnsureShellRuntimeStarted();
+        ApplyTimerButtonIfAvailable();
+    }
 }
-
 
 static void StopTimerWorker()
 {
@@ -3815,7 +3933,15 @@ static void StopTimerWorker()
 
 void Wh_ModBeforeUninit()
 {
+    AcquireSRWLockExclusive(
+        &g_shellRuntimeLock
+    );
+
     g_unloading.store(true);
+
+    ReleaseSRWLockExclusive(
+        &g_shellRuntimeLock
+    );
 
     StopTimerWorker();
 
@@ -3940,6 +4066,14 @@ void Wh_ModUninit()
     }
 
     UnregisterFinishedAlertClass();
+
+    AcquireSRWLockExclusive(
+        &g_shellRuntimeLock
+    );
+    g_shellRuntimeStarted = false;
+    ReleaseSRWLockExclusive(
+        &g_shellRuntimeLock
+    );
 
     Wh_Log(
         L"Taskbar Countdown Timer unloaded"

--- a/mods/taskbar-countdown-timer.wh.cpp
+++ b/mods/taskbar-countdown-timer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-countdown-timer
 // @name            Taskbar Countdown Timer
 // @description     A simple countdown timer integrated into the Windows 11 taskbar (Windows 11 only)
-// @version         1.12
+// @version         1.14
 // @author          Richi
 // @github          https://github.com/richilp
 // @include         explorer.exe
@@ -334,9 +334,11 @@ static TrayUI_StartTaskbar_t
 static void WINAPI TrayUI_StartTaskbar_Hook(
     void* pThis)
 {
-    TrayUI_StartTaskbar_Original(
-        pThis
-    );
+    if (TrayUI_StartTaskbar_Original) {
+        TrayUI_StartTaskbar_Original(
+            pThis
+        );
+    }
 
     if (!g_unloading.load()) {
         ApplyTimerButtonIfAvailable();
@@ -1382,6 +1384,9 @@ static HFONT g_finishedAlertFont = nullptr;
 static HBRUSH g_finishedAlertBackgroundBrush = nullptr;
 static HBRUSH g_finishedAlertEditBrush = nullptr;
 static bool g_finishedAlertDark = true;
+static COLORREF g_finishedAlertBackgroundColor = RGB(32, 32, 32);
+static COLORREF g_finishedAlertEditBackgroundColor = RGB(45, 45, 45);
+static COLORREF g_finishedAlertTextColor = RGB(245, 245, 245);
 
 static bool AppsUseLightTheme()
 {
@@ -1406,48 +1411,50 @@ static bool AppsUseLightTheme()
     return value != 0;
 }
 
-static void EnsureFinishedAlertResources(
+struct FinishedAlertOldResources
+{
+    HFONT font = nullptr;
+    HBRUSH backgroundBrush = nullptr;
+    HBRUSH editBrush = nullptr;
+};
+
+
+static FinishedAlertOldResources CreateFinishedAlertResources(
     UINT dpi)
 {
+    FinishedAlertOldResources old{
+        g_finishedAlertFont,
+        g_finishedAlertBackgroundBrush,
+        g_finishedAlertEditBrush,
+    };
+
     g_finishedAlertDark =
         !AppsUseLightTheme();
 
-    if (g_finishedAlertBackgroundBrush) {
-        DeleteObject(
-            g_finishedAlertBackgroundBrush
-        );
-        g_finishedAlertBackgroundBrush = nullptr;
-    }
-
-    if (g_finishedAlertEditBrush) {
-        DeleteObject(
-            g_finishedAlertEditBrush
-        );
-        g_finishedAlertEditBrush = nullptr;
-    }
-
-    COLORREF background =
+    g_finishedAlertBackgroundColor =
         g_finishedAlertDark
             ? RGB(32, 32, 32)
             : RGB(249, 249, 249);
 
-    COLORREF editBackground =
+    g_finishedAlertEditBackgroundColor =
         g_finishedAlertDark
             ? RGB(45, 45, 45)
             : RGB(255, 255, 255);
 
+    g_finishedAlertTextColor =
+        g_finishedAlertDark
+            ? RGB(245, 245, 245)
+            : RGB(25, 25, 25);
+
     g_finishedAlertBackgroundBrush =
-        CreateSolidBrush(background);
+        CreateSolidBrush(
+            g_finishedAlertBackgroundColor
+        );
 
     g_finishedAlertEditBrush =
-        CreateSolidBrush(editBackground);
-
-    if (g_finishedAlertFont) {
-        DeleteObject(
-            g_finishedAlertFont
+        CreateSolidBrush(
+            g_finishedAlertEditBackgroundColor
         );
-        g_finishedAlertFont = nullptr;
-    }
 
     g_finishedAlertFont =
         CreateFontW(
@@ -1470,13 +1477,40 @@ static void EnsureFinishedAlertResources(
             DEFAULT_PITCH | FF_DONTCARE,
             L"Segoe UI"
         );
+
+    return old;
 }
+
+
+static void DeleteFinishedAlertResources(
+    FinishedAlertOldResources const& resources)
+{
+    if (resources.font) {
+        DeleteObject(resources.font);
+    }
+
+    if (resources.backgroundBrush) {
+        DeleteObject(resources.backgroundBrush);
+    }
+
+    if (resources.editBrush) {
+        DeleteObject(resources.editBrush);
+    }
+}
+
+
+static void ThemeFinishedAlertChild(
+    HWND child);
+
 
 static void ApplyFinishedAlertTheme(
     HWND hWnd,
     UINT dpi)
 {
-    EnsureFinishedAlertResources(dpi);
+    FinishedAlertOldResources old =
+        CreateFinishedAlertResources(
+            dpi
+        );
 
     constexpr DWORD DWMWA_USE_IMMERSIVE_DARK_MODE_LOCAL = 20;
     constexpr DWORD DWMWA_WINDOW_CORNER_PREFERENCE_LOCAL = 33;
@@ -1503,7 +1537,18 @@ static void ApplyFinishedAlertTheme(
         &corner,
         sizeof(corner)
     );
+
+    InvalidateRect(
+        hWnd,
+        nullptr,
+        TRUE
+    );
+
+    DeleteFinishedAlertResources(
+        old
+    );
 }
+
 
 static void ThemeFinishedAlertChild(
     HWND child)
@@ -1571,6 +1616,30 @@ static int ScaleAlertValue(int value, UINT dpi)
     return MulDiv(value, dpi ? dpi : 96, 96);
 }
 
+static SIZE GetFinishedAlertWindowSize(
+    UINT dpi)
+{
+    RECT rect{
+        0,
+        0,
+        ScaleAlertValue(380, dpi),
+        ScaleAlertValue(220, dpi)
+    };
+
+    AdjustWindowRectExForDpi(
+        &rect,
+        WS_POPUP | WS_CAPTION | WS_SYSMENU,
+        FALSE,
+        WS_EX_TOOLWINDOW | WS_EX_TOPMOST,
+        dpi ? dpi : 96
+    );
+
+    return SIZE{
+        rect.right - rect.left,
+        rect.bottom - rect.top
+    };
+}
+
 static void PositionFinishedAlert(HWND hWnd, UINT dpi)
 {
     HWND taskbar = g_taskbarWnd.load();
@@ -1587,8 +1656,11 @@ static void PositionFinishedAlert(HWND hWnd, UINT dpi)
         return;
     }
 
-    int width = ScaleAlertValue(380, dpi);
-    int height = ScaleAlertValue(220, dpi);
+    SIZE windowSize =
+        GetFinishedAlertWindowSize(dpi);
+
+    int width = windowSize.cx;
+    int height = windowSize.cy;
     int margin = ScaleAlertValue(10, dpi);
 
     SetWindowPos(
@@ -1739,21 +1811,6 @@ static LRESULT CALLBACK FinishedAlertWndProc(
             nullptr
         );
 
-        EnumChildWindows(
-            hWnd,
-            [](
-                HWND child,
-                LPARAM) -> BOOL
-            {
-                ThemeFinishedAlertChild(
-                    child
-                );
-
-                return TRUE;
-            },
-            0
-        );
-
         LayoutFinishedAlert(
             hWnd,
             dpi
@@ -1782,21 +1839,6 @@ static LRESULT CALLBACK FinishedAlertWndProc(
             dpi
         );
 
-        EnumChildWindows(
-            hWnd,
-            [](
-                HWND child,
-                LPARAM) -> BOOL
-            {
-                ThemeFinishedAlertChild(
-                    child
-                );
-
-                return TRUE;
-            },
-            0
-        );
-
         LayoutFinishedAlert(
             hWnd,
             dpi
@@ -1810,11 +1852,13 @@ static LRESULT CALLBACK FinishedAlertWndProc(
         RECT rect{};
         GetClientRect(hWnd, &rect);
 
-        FillRect(
-            reinterpret_cast<HDC>(wParam),
-            &rect,
-            g_finishedAlertBackgroundBrush
-        );
+        if (g_finishedAlertBackgroundBrush) {
+            FillRect(
+                reinterpret_cast<HDC>(wParam),
+                &rect,
+                g_finishedAlertBackgroundBrush
+            );
+        }
 
         return 1;
     }
@@ -1824,24 +1868,14 @@ static LRESULT CALLBACK FinishedAlertWndProc(
         HDC hdc =
             reinterpret_cast<HDC>(wParam);
 
-        COLORREF textColor =
-            g_finishedAlertDark
-                ? RGB(245, 245, 245)
-                : RGB(25, 25, 25);
-
-        COLORREF background =
-            g_finishedAlertDark
-                ? RGB(32, 32, 32)
-                : RGB(249, 249, 249);
-
         SetTextColor(
             hdc,
-            textColor
+            g_finishedAlertTextColor
         );
 
         SetBkColor(
             hdc,
-            background
+            g_finishedAlertBackgroundColor
         );
 
         return reinterpret_cast<LRESULT>(
@@ -1854,30 +1888,42 @@ static LRESULT CALLBACK FinishedAlertWndProc(
         HDC hdc =
             reinterpret_cast<HDC>(wParam);
 
-        COLORREF textColor =
-            g_finishedAlertDark
-                ? RGB(245, 245, 245)
-                : RGB(25, 25, 25);
-
-        COLORREF background =
-            g_finishedAlertDark
-                ? RGB(45, 45, 45)
-                : RGB(255, 255, 255);
-
         SetTextColor(
             hdc,
-            textColor
+            g_finishedAlertTextColor
         );
 
         SetBkColor(
             hdc,
-            background
+            g_finishedAlertEditBackgroundColor
         );
 
         return reinterpret_cast<LRESULT>(
             g_finishedAlertEditBrush
         );
     }
+
+    case WM_THEMECHANGED:
+        ApplyFinishedAlertTheme(
+            hWnd,
+            GetDpiForWindow(hWnd)
+        );
+        return 0;
+
+    case WM_SETTINGCHANGE:
+        if (lParam &&
+            _wcsicmp(
+                reinterpret_cast<LPCWSTR>(
+                    lParam
+                ),
+                L"ImmersiveColorSet") == 0)
+        {
+            ApplyFinishedAlertTheme(
+                hWnd,
+                GetDpiForWindow(hWnd)
+            );
+        }
+        return 0;
 
     case WM_COMMAND:
     {
@@ -2072,8 +2118,8 @@ static DWORD WINAPI FinishedAlertThreadProc(LPVOID param)
             WS_POPUP | WS_CAPTION | WS_SYSMENU,
             CW_USEDEFAULT,
             CW_USEDEFAULT,
-            ScaleAlertValue(380, dpi),
-            ScaleAlertValue(220, dpi),
+            GetFinishedAlertWindowSize(dpi).cx,
+            GetFinishedAlertWindowSize(dpi).cy,
             nullptr,
             nullptr,
             g_modInstance,
@@ -2092,13 +2138,13 @@ static DWORD WINAPI FinishedAlertThreadProc(LPVOID param)
     g_finishedAlertWnd.store(hWnd);
 
     PositionFinishedAlert(hWnd, dpi);
-    ShowWindow(hWnd, SW_SHOWNORMAL);
+    ShowWindow(hWnd, SW_SHOWNOACTIVATE);
 
     SetWindowPos(
         hWnd,
         HWND_TOPMOST,
         0, 0, 0, 0,
-        SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW
+        SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW | SWP_NOACTIVATE
     );
 
     FlashWindow(hWnd, TRUE);
@@ -2180,7 +2226,6 @@ static bool ShowFinishedAlert(const wchar_t* reminder)
 
     if (HWND existing = g_finishedAlertWnd.load()) {
         if (IsWindow(existing)) {
-            SetForegroundWindow(existing);
             FlashWindow(existing, TRUE);
             return true;
         }
@@ -2296,7 +2341,13 @@ static void HandleTimerExpiredFromWorker()
     }
 
     if (GetUtcFileTimeNow() < expected) {
-        SignalTimerWorker();
+        if (WaitForSingleObject(
+                g_timerStopEvent,
+                250) == WAIT_TIMEOUT)
+        {
+            SignalTimerWorker();
+        }
+
         return;
     }
 
@@ -2510,6 +2561,38 @@ static void RestorePersistedTimer()
 }
 
 
+static void CleanupTimerObjects()
+{
+    if (g_timerWaitable) {
+        CloseHandle(
+            g_timerWaitable
+        );
+        g_timerWaitable = nullptr;
+    }
+
+    if (g_timerRearmEvent) {
+        CloseHandle(
+            g_timerRearmEvent
+        );
+        g_timerRearmEvent = nullptr;
+    }
+
+    if (g_timerStopEvent) {
+        CloseHandle(
+            g_timerStopEvent
+        );
+        g_timerStopEvent = nullptr;
+    }
+
+    if (g_finishedAlertStopEvent) {
+        CloseHandle(
+            g_finishedAlertStopEvent
+        );
+        g_finishedAlertStopEvent = nullptr;
+    }
+}
+
+
 static bool StartTimerWorkerFromInit()
 {
     g_timerStopEvent =
@@ -2552,6 +2635,7 @@ static bool StartTimerWorkerFromInit()
             L"ERROR: Could not create timer synchronization objects"
         );
 
+        CleanupTimerObjects();
         return false;
     }
 
@@ -2570,6 +2654,7 @@ static bool StartTimerWorkerFromInit()
             L"ERROR: Could not create timer worker thread"
         );
 
+        CleanupTimerObjects();
         return false;
     }
 
@@ -2630,95 +2715,10 @@ static void ReleaseOwnedXamlForRebuild()
 }
 
 
-static void RemoveStaleNamedButton(
-    Panel const& panel,
-    FrameworkElement const& stale)
-{
-    if (!panel || !stale) {
-        return;
-    }
-
-    auto children =
-        panel.Children();
-
-    uint32_t staleIndex = 0;
-
-    if (!children.IndexOf(
-            stale,
-            staleIndex))
-    {
-        return;
-    }
-
-    auto grid =
-        panel.try_as<Grid>();
-
-    int staleColumn =
-        grid
-            ? Grid::GetColumn(stale)
-            : -1;
-
-    children.RemoveAt(
-        staleIndex
-    );
-
-    if (!grid ||
-        staleColumn < 0)
-    {
-        return;
-    }
-
-    auto columns =
-        grid.ColumnDefinitions();
-
-    if (static_cast<uint32_t>(staleColumn) >=
-        columns.Size())
-    {
-        return;
-    }
-
-    for (uint32_t i = 0;
-         i < children.Size();
-         i++)
-    {
-        auto child =
-            children.GetAt(i)
-                .try_as<FrameworkElement>();
-
-        if (!child) {
-            continue;
-        }
-
-        int column =
-            Grid::GetColumn(child);
-
-        if (column > staleColumn) {
-            Grid::SetColumn(
-                child,
-                column - 1
-            );
-        }
-    }
-
-    columns.RemoveAt(
-        static_cast<uint32_t>(
-            staleColumn
-        )
-    );
-}
-
-
 static void AddTimerButtonImpl(
     void* param)
 {
     if (g_unloading.load()) {
-        return;
-    }
-
-    if (g_timerButton &&
-        VisualTreeHelper::GetParent(
-            g_timerButton))
-    {
         return;
     }
 
@@ -2730,6 +2730,22 @@ static void AddTimerButtonImpl(
 
     if (!xamlRoot) {
         return;
+    }
+
+    // Fast path which is safe across in-process tray rebuilds: only keep the
+    // current button if it still belongs to the *current* taskbar XamlRoot.
+    if (g_timerButton) {
+        auto buttonRoot =
+            g_timerButton.XamlRoot();
+
+        if (buttonRoot &&
+            SameWinrtObject(
+                buttonRoot,
+                xamlRoot))
+        {
+            g_taskbarWnd.store(taskbar);
+            return;
+        }
     }
 
     auto content =
@@ -2796,13 +2812,10 @@ static void AddTimerButtonImpl(
 
     if (existing) {
         Wh_Log(
-            L"Removing stale timer button from a previous mod instance"
+            L"WARNING: A foreign TaskbarCountdownTimerButton already exists; "
+            L"leaving it untouched for safety"
         );
-
-        RemoveStaleNamedButton(
-            panel,
-            existing
-        );
+        return;
     }
 
     ReleaseOwnedXamlForRebuild();
@@ -3001,9 +3014,21 @@ static void AddTimerButton(
 }
 
 
-static void RemoveTimerButtonImpl(
-    void*)
+struct RemoveTimerButtonRequest
 {
+    bool callbacksRevoked = false;
+};
+
+
+static void RemoveTimerButtonImpl(
+    void* param)
+{
+    auto* request =
+        reinterpret_cast<
+            RemoveTimerButtonRequest*>(
+            param
+        );
+
     // Revoke every callback into this mod first. Nothing below this point is
     // allowed to throw while leaving a live delegate behind.
     if (g_loadedRevokers) {
@@ -3024,6 +3049,10 @@ static void RemoveTimerButtonImpl(
         g_timerButton.Click(
             g_timerButtonClickToken
         );
+    }
+
+    if (request) {
+        request->callbacksRevoked = true;
     }
 
     // Best-effort visual-tree detachment follows after all callbacks are gone.
@@ -3144,11 +3173,17 @@ static bool TryRemoveTimerXaml()
         return false;
     }
 
-    return RunFromWindowThread(
-        target,
-        RemoveTimerButton,
-        nullptr
-    );
+    RemoveTimerButtonRequest request{};
+
+    if (!RunFromWindowThread(
+            target,
+            RemoveTimerButton,
+            &request))
+    {
+        return false;
+    }
+
+    return request.callbacksRevoked;
 }
 
 
@@ -3345,7 +3380,7 @@ static void* WINAPI IconView_IconView_Hook(
                 }
 
                 // A new IconView means the tray may have rebuilt its XAML tree.
-                            ApplyTimerButtonIfAvailable();
+                ApplyTimerButtonIfAvailable();
             }
         );
     }
@@ -3385,7 +3420,9 @@ static bool HookSystemTraySymbols(
 static void HandleLoadedModuleIfSystemTray(
     HMODULE module)
 {
-    if (g_systemTrayModuleHooked.load()) {
+    if (g_unloading.load() ||
+        g_systemTrayModuleHooked.load())
+    {
         return;
     }
 
@@ -3508,35 +3545,8 @@ BOOL Wh_ModInit()
             g_timerWorkerThread = nullptr;
         }
 
-        if (g_timerWaitable) {
-            CloseHandle(
-                g_timerWaitable
-            );
-            g_timerWaitable = nullptr;
-        }
+        CleanupTimerObjects();
 
-        if (g_timerRearmEvent) {
-            CloseHandle(
-                g_timerRearmEvent
-            );
-            g_timerRearmEvent = nullptr;
-        }
-
-        if (g_timerStopEvent) {
-            CloseHandle(
-                g_timerStopEvent
-            );
-            g_timerStopEvent = nullptr;
-        }
-
-        if (g_finishedAlertStopEvent) {
-            CloseHandle(
-                g_finishedAlertStopEvent
-            );
-            g_finishedAlertStopEvent = nullptr;
-        }
-
-        UnregisterFinishedAlertClass();
         UnregisterFinishedAlertClass();
         Wh_Log(
             L"ERROR: Failed to resolve taskbar.dll symbols"
@@ -3565,10 +3575,6 @@ BOOL Wh_ModInit()
             );
         }
         else {
-            g_systemTrayModuleAttempted.store(
-                nullptr
-            );
-
             Wh_Log(
                 L"ERROR: Failed to hook system tray symbols"
             );
@@ -3700,40 +3706,17 @@ void Wh_ModUninit()
         );
     }
 
-    // Final best-effort XAML teardown after all worker activity is stopped.
-    if (!TryRemoveTimerXaml()) {
+    // Final best-effort XAML teardown only if the first attempt left an
+    // owned button behind.
+    if (g_timerButton &&
+        !TryRemoveTimerXaml())
+    {
         Wh_Log(
             L"ERROR: Could not dispatch final timer XAML teardown"
         );
     }
 
-    if (g_timerWaitable) {
-        CloseHandle(
-            g_timerWaitable
-        );
-        g_timerWaitable = nullptr;
-    }
-
-    if (g_timerRearmEvent) {
-        CloseHandle(
-            g_timerRearmEvent
-        );
-        g_timerRearmEvent = nullptr;
-    }
-
-    if (g_timerStopEvent) {
-        CloseHandle(
-            g_timerStopEvent
-        );
-        g_timerStopEvent = nullptr;
-    }
-
-    if (g_finishedAlertStopEvent) {
-        CloseHandle(
-            g_finishedAlertStopEvent
-        );
-        g_finishedAlertStopEvent = nullptr;
-    }
+    CleanupTimerObjects();
 
     if (g_finishedAlertFont) {
         DeleteObject(
@@ -3795,3 +3778,4 @@ void Wh_ModSettingsChanged()
         );
     }
 }
+

--- a/mods/taskbar-countdown-timer.wh.cpp
+++ b/mods/taskbar-countdown-timer.wh.cpp
@@ -1,13 +1,13 @@
 // ==WindhawkMod==
 // @id              taskbar-countdown-timer
 // @name            Taskbar Countdown Timer
-// @description     A simple countdown timer integrated into the Windows taskbar
-// @version         1.4
+// @description     A simple countdown timer integrated into the Windows 11 taskbar (Windows 11 only)
+// @version         1.5
 // @author          Richi
 // @github          https://github.com/richilp
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lole32 -loleaut32 -lruntimeobject -ldwmapi -lgdi32
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -ldwmapi -lgdi32 -lversion
 // @license         MIT
 // ==/WindhawkMod==
 
@@ -98,6 +98,7 @@ static std::atomic<DWORD> g_timerPopupThreadId{0};
 static std::atomic<HANDLE> g_timerPopupThread{nullptr};
 static HANDLE g_popupThreadReadyEvent = nullptr;
 static std::atomic<HWND> g_taskbarWnd{nullptr};
+static std::atomic<DWORD> g_taskbarThreadId{0};
 static std::atomic_bool g_buttonInjected{false};
 static std::atomic_bool g_systemTrayModuleHooked{false};
 
@@ -718,6 +719,44 @@ static HWND FindCurrentProcessTaskbarWnd()
             }
 
             return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&result)
+    );
+
+    if (result) {
+        DWORD threadId = GetWindowThreadProcessId(
+            result,
+            nullptr
+        );
+
+        if (threadId) {
+            g_taskbarThreadId.store(threadId);
+        }
+    }
+
+    return result;
+}
+
+
+static HWND FindAnyWindowOnTaskbarThread()
+{
+    DWORD threadId =
+        g_taskbarThreadId.load();
+
+    if (!threadId) {
+        return nullptr;
+    }
+
+    HWND result = nullptr;
+
+    EnumThreadWindows(
+        threadId,
+        [](HWND hWnd, LPARAM lParam) -> BOOL
+        {
+            *reinterpret_cast<HWND*>(lParam) =
+                hWnd;
+
+            return FALSE;
         },
         reinterpret_cast<LPARAM>(&result)
     );
@@ -2974,6 +3013,33 @@ static void RemoveTimerButton(
 }
 
 
+static bool TryRemoveTimerXaml()
+{
+    HWND target =
+        g_taskbarWnd.load();
+
+    if (!target || !IsWindow(target)) {
+        target =
+            FindCurrentProcessTaskbarWnd();
+    }
+
+    if (!target) {
+        target =
+            FindAnyWindowOnTaskbarThread();
+    }
+
+    if (!target) {
+        return false;
+    }
+
+    return RunFromWindowThread(
+        target,
+        RemoveTimerButton,
+        nullptr
+    );
+}
+
+
 static void ApplyTimerButtonIfAvailable()
 {
     if (g_unloading.load()) {
@@ -3044,6 +3110,56 @@ static LoadLibraryExW_t
     LoadLibraryExW_Original = nullptr;
 
 
+static VS_FIXEDFILEINFO* GetModuleVersionInfo(
+    HMODULE module)
+{
+    HRSRC resource =
+        FindResourceW(
+            module,
+            MAKEINTRESOURCEW(VS_VERSION_INFO),
+            RT_VERSION
+        );
+
+    if (!resource) {
+        return nullptr;
+    }
+
+    HGLOBAL loaded =
+        LoadResource(
+            module,
+            resource
+        );
+
+    if (!loaded) {
+        return nullptr;
+    }
+
+    void* data =
+        LockResource(loaded);
+
+    if (!data) {
+        return nullptr;
+    }
+
+    void* fixedInfo = nullptr;
+    UINT fixedInfoSize = 0;
+
+    if (!VerQueryValueW(
+            data,
+            L"\\",
+            &fixedInfo,
+            &fixedInfoSize) ||
+        !fixedInfoSize)
+    {
+        return nullptr;
+    }
+
+    return reinterpret_cast<VS_FIXEDFILEINFO*>(
+        fixedInfo
+    );
+}
+
+
 static HMODULE GetSystemTrayModuleHandle()
 {
     if (HMODULE module =
@@ -3055,7 +3171,26 @@ static HMODULE GetSystemTrayModuleHandle()
     if (HMODULE module =
             GetModuleHandleW(L"Taskbar.View.dll"))
     {
-        return module;
+        // First known Taskbar.View.dll version without SystemTray symbols:
+        // 2604.8002.200.6000. Newer builds use SystemTray.dll instead.
+        VS_FIXEDFILEINFO* fixedInfo =
+            GetModuleVersionInfo(module);
+
+        WORD moduleMajor =
+            fixedInfo
+                ? HIWORD(fixedInfo->dwFileVersionMS)
+                : 0;
+
+        if (moduleMajor &&
+            moduleMajor < 2604)
+        {
+            return module;
+        }
+
+        Wh_Log(
+            L"Skipping Taskbar.View.dll version %u",
+            moduleMajor
+        );
     }
 
     return GetModuleHandleW(
@@ -3114,7 +3249,8 @@ static void* WINAPI IconView_IconView_Hook(
 static bool HookSystemTraySymbols(
     HMODULE module)
 {
-    WindhawkUtils::SYMBOL_HOOK systemTrayDllHooks[] = {{
+    // SystemTray.dll, Taskbar.View.dll, ExplorerExtensions.dll
+    WindhawkUtils::SYMBOL_HOOK systemTrayHooks[] = {{
         {
             LR"(public: __cdecl winrt::SystemTray::implementation::IconView::IconView(void))"
         },
@@ -3124,8 +3260,8 @@ static bool HookSystemTraySymbols(
 
     return WindhawkUtils::HookSymbols(
         module,
-        systemTrayDllHooks,
-        ARRAYSIZE(systemTrayDllHooks)
+        systemTrayHooks,
+        ARRAYSIZE(systemTrayHooks)
     );
 }
 
@@ -3142,7 +3278,9 @@ static void HandleLoadedModuleIfSystemTray(
             Wh_ApplyHookOperations();
         }
         else {
-            g_systemTrayModuleHooked.store(false);
+            Wh_Log(
+                L"ERROR: Failed to hook system tray symbols"
+            );
         }
     }
 }
@@ -3243,12 +3381,26 @@ BOOL Wh_ModInit()
         return FALSE;
     }
 
-    if (HMODULE systemTray = GetSystemTrayModuleHandle()) {
-        if (HookSystemTraySymbols(systemTray)) {
-            g_systemTrayModuleHooked.store(true);
+    bool systemTrayHookedAtInit = false;
+
+    if (HMODULE systemTray =
+            GetSystemTrayModuleHandle())
+    {
+        g_systemTrayModuleHooked.store(true);
+
+        systemTrayHookedAtInit =
+            HookSystemTraySymbols(
+                systemTray
+            );
+
+        if (!systemTrayHookedAtInit) {
+            Wh_Log(
+                L"ERROR: Failed to hook system tray symbols"
+            );
         }
     }
-    else {
+
+    if (!systemTrayHookedAtInit) {
         HMODULE kernelbase =
             GetModuleHandleW(L"kernelbase.dll");
 
@@ -3342,6 +3494,15 @@ void Wh_ModBeforeUninit()
             g_retryStopEvent
         );
     }
+
+    // First teardown attempt while taskbar hooks are still available.
+    if (!TryRemoveTimerXaml() &&
+        g_buttonInjected.load())
+    {
+        Wh_Log(
+            L"Timer XAML teardown will be retried in Wh_ModUninit"
+        );
+    }
 }
 
 
@@ -3364,31 +3525,24 @@ void Wh_ModUninit()
         g_retryStopEvent = nullptr;
     }
 
-    bool removed = false;
+    bool removed =
+        !g_buttonInjected.load();
 
     for (int attempt = 0;
-         attempt < 5 && !removed;
+         attempt < 10 && !removed;
          attempt++)
     {
-        HWND taskbar = g_taskbarWnd.load();
-        if (!taskbar || !IsWindow(taskbar)) {
-            taskbar = FindCurrentProcessTaskbarWnd();
-        }
-
-        if (taskbar) {
-            removed = RunFromWindowThread(
-                taskbar,
-                RemoveTimerButton,
-                nullptr
-            );
-        }
+        removed =
+            TryRemoveTimerXaml();
 
         if (!removed) {
             Sleep(50);
         }
     }
 
-    if (!removed && g_buttonInjected.load()) {
+    if (!removed &&
+        g_buttonInjected.load())
+    {
         Wh_Log(
             L"ERROR: Could not remove timer XAML objects before unload"
         );

--- a/mods/taskbar-countdown-timer.wh.cpp
+++ b/mods/taskbar-countdown-timer.wh.cpp
@@ -2,13 +2,13 @@
 // @id              taskbar-countdown-timer
 // @name            Taskbar Countdown Timer
 // @description     A simple countdown timer integrated into the Windows 11 taskbar (Windows 11 only)
-// @version         1.9.1
+// @version         1.10
 // @author          Richi
 // @github          https://github.com/richilp
 // @include         explorer.exe
 // @architecture    x86-64
 // @compilerOptions -lole32 -loleaut32 -lruntimeobject -lversion -ldwmapi -lgdi32 -luxtheme
-// @license         MIT
+// @license         GPL-3.0
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -71,6 +71,13 @@ The mod supports one active timer at a time and currently places its button on t
 // ==/WindhawkModSettings==
 
 
+
+// Portions of the taskbar/XAML integration are adapted from Windhawk's
+// taskbar-multirow and taskbar-notification-icon-spacing mods by m417z,
+// both licensed under GPL-3.0:
+// https://github.com/ramensoftware/windhawk-mods/blob/main/mods/taskbar-multirow.wh.cpp
+// https://github.com/ramensoftware/windhawk-mods/blob/main/mods/taskbar-notification-icon-spacing.wh.cpp
+
 #ifdef GetCurrentTime
 #undef GetCurrentTime
 #endif
@@ -124,10 +131,10 @@ namespace Controls = winrt::Windows::UI::Xaml::Controls;
 
 static winrt::event_token g_timerButtonClickToken{};
 static winrt::event_token g_timerTickToken{};
+static winrt::event_token g_timerStartButtonClickToken{};
+static winrt::event_token g_timerCancelButtonClickToken{};
 
-static std::atomic<int> g_secondsRemaining{0};
 static std::atomic<ULONGLONG> g_deadlineUtc100ns{0};
-static std::atomic_bool g_pendingFinished{false};
 
 static SRWLOCK g_reminderLock = SRWLOCK_INIT;
 static wchar_t g_reminder[256]{};
@@ -153,6 +160,8 @@ static std::atomic_bool g_timerWorkerStarted{false};
 static std::atomic<HWND> g_finishedAlertWnd{nullptr};
 static std::atomic<HANDLE> g_finishedAlertThread{nullptr};
 static HANDLE g_finishedAlertStopEvent = nullptr;
+static HINSTANCE g_modInstance = nullptr;
+static bool g_finishedAlertClassRegistered = false;
 
 static std::atomic<HWND> g_taskbarWnd{nullptr};
 static std::atomic<DWORD> g_taskbarThreadId{0};
@@ -465,7 +474,7 @@ static XamlRoot GetTaskbarXamlRoot(
         return nullptr;
     }
 
-    size_t offset = 0x48;
+    size_t offset;
 
 #if defined(_M_X64)
     const BYTE* code =
@@ -676,20 +685,6 @@ static void LoadSettings()
 {
     ModSettings updated;
 
-    updated.defaultMinutes =
-        std::clamp(
-            Wh_GetIntSetting(L"defaultMinutes"),
-            1,
-            1440
-        );
-
-    updated.defaultSnoozeMinutes =
-        std::clamp(
-            Wh_GetIntSetting(L"defaultSnoozeMinutes"),
-            1,
-            1440
-        );
-
     updated.maximumMinutes =
         std::clamp(
             Wh_GetIntSetting(L"maximumMinutes"),
@@ -697,13 +692,19 @@ static void LoadSettings()
             10080
         );
 
-    if (updated.defaultMinutes > updated.maximumMinutes) {
-        updated.defaultMinutes = updated.maximumMinutes;
-    }
+    updated.defaultMinutes =
+        std::clamp(
+            Wh_GetIntSetting(L"defaultMinutes"),
+            1,
+            updated.maximumMinutes
+        );
 
-    if (updated.defaultSnoozeMinutes > updated.maximumMinutes) {
-        updated.defaultSnoozeMinutes = updated.maximumMinutes;
-    }
+    updated.defaultSnoozeMinutes =
+        std::clamp(
+            Wh_GetIntSetting(L"defaultSnoozeMinutes"),
+            1,
+            updated.maximumMinutes
+        );
 
     updated.completionSound =
         Wh_GetIntSetting(L"completionSound") != 0;
@@ -711,7 +712,7 @@ static void LoadSettings()
     PCWSTR label =
         Wh_GetStringSetting(L"buttonLabel");
 
-    if (label && label[0]) {
+    if (label[0]) {
         updated.buttonLabel = label;
     }
 
@@ -896,8 +897,6 @@ static void RefreshTaskbarCountdown()
     int remaining =
         RemainingSeconds(deadline);
 
-    g_secondsRemaining.store(remaining);
-
     if (remaining > 0) {
         g_timerText.Text(
             FormatCountdown(remaining)
@@ -911,6 +910,19 @@ static void RefreshTaskbarCountdown()
 
 static void HideAndReleaseFlyouts()
 {
+    // Revoke delegates before hiding/releasing the flyout tree.
+    if (g_timerStartButton) {
+        g_timerStartButton.Click(
+            g_timerStartButtonClickToken
+        );
+    }
+
+    if (g_timerCancelButton) {
+        g_timerCancelButton.Click(
+            g_timerCancelButtonClickToken
+        );
+    }
+
     if (g_timerFlyout) {
         g_timerFlyout.Hide();
     }
@@ -1005,16 +1017,6 @@ static bool ArmTimer(
     SetSharedReminder(reminderToUse);
 
     g_deadlineUtc100ns.store(deadline);
-    g_secondsRemaining.store(
-        static_cast<int>(
-            std::min<ULONGLONG>(
-                seconds,
-                static_cast<ULONGLONG>(INT_MAX)
-            )
-        )
-    );
-
-    g_pendingFinished.store(false);
 
     PersistTimer(
         deadline,
@@ -1066,8 +1068,6 @@ static bool ArmTimer(
 static void CancelTimer()
 {
     g_deadlineUtc100ns.store(0);
-    g_secondsRemaining.store(0);
-    g_pendingFinished.store(false);
 
     ClearPersistedTimer();
     SignalTimerWorker();
@@ -1190,7 +1190,8 @@ static void BuildTimerFlyout()
         actions
     );
 
-    startButton.Click(
+    g_timerStartButtonClickToken =
+        startButton.Click(
         [](
             auto const&,
             RoutedEventArgs const&)
@@ -1235,7 +1236,8 @@ static void BuildTimerFlyout()
         }
     );
 
-    cancelButton.Click(
+    g_timerCancelButtonClickToken =
+        cancelButton.Click(
         [](
             auto const&,
             RoutedEventArgs const&)
@@ -1356,6 +1358,9 @@ constexpr int IDC_ALERT_DISMISS = 2104;
 
 static constexpr wchar_t kFinishedAlertClass[] =
     L"TaskbarCountdownTimerFinishedAlert";
+
+static bool RegisterFinishedAlertClass();
+static void UnregisterFinishedAlertClass();
 
 static HFONT g_finishedAlertFont = nullptr;
 static HBRUSH g_finishedAlertBackgroundBrush = nullptr;
@@ -1917,14 +1922,11 @@ static LRESULT CALLBACK FinishedAlertWndProc(
                 MessageBeep(MB_ICONERROR);
                 return 0;
             }
-
-            g_pendingFinished.store(false);
             DestroyWindow(hWnd);
             return 0;
         }
 
         if (id == IDC_ALERT_DISMISS) {
-            g_pendingFinished.store(false);
             DestroyWindow(hWnd);
             return 0;
         }
@@ -1933,7 +1935,6 @@ static LRESULT CALLBACK FinishedAlertWndProc(
     }
 
     case WM_CLOSE:
-        g_pendingFinished.store(false);
         DestroyWindow(hWnd);
         return 0;
 
@@ -1946,20 +1947,28 @@ static LRESULT CALLBACK FinishedAlertWndProc(
     return DefWindowProcW(hWnd, msg, wParam, lParam);
 }
 
-static DWORD WINAPI FinishedAlertThreadProc(LPVOID param)
+static bool RegisterFinishedAlertClass()
 {
-    std::unique_ptr<FinishedAlertData> data(
-        reinterpret_cast<FinishedAlertData*>(param)
-    );
+    if (g_finishedAlertClassRegistered) {
+        return true;
+    }
 
     HMODULE modInstance = nullptr;
 
-    GetModuleHandleExW(
-        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
-            GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-        reinterpret_cast<LPCWSTR>(FinishedAlertWndProc),
-        &modInstance
-    );
+    if (!GetModuleHandleExW(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            reinterpret_cast<LPCWSTR>(
+                FinishedAlertWndProc
+            ),
+            &modInstance))
+    {
+        Wh_Log(
+            L"ERROR: Could not get mod module handle for alert class"
+        );
+
+        return false;
+    }
 
     WNDCLASSEXW wc{sizeof(wc)};
     wc.lpfnWndProc = FinishedAlertWndProc;
@@ -1967,18 +1976,61 @@ static DWORD WINAPI FinishedAlertThreadProc(LPVOID param)
     wc.lpszClassName = kFinishedAlertClass;
     wc.hCursor = LoadCursorW(nullptr, IDC_ARROW);
     wc.hbrBackground =
-        reinterpret_cast<HBRUSH>(COLOR_WINDOW + 1);
+        reinterpret_cast<HBRUSH>(
+            COLOR_WINDOW + 1
+        );
 
     if (!RegisterClassExW(&wc)) {
-        DWORD error = GetLastError();
+        Wh_Log(
+            L"ERROR: Could not register completion alert class: %u",
+            GetLastError()
+        );
 
-        if (error != ERROR_CLASS_ALREADY_EXISTS) {
-            Wh_Log(
-                L"ERROR: Could not register completion alert class: %u",
-                error
-            );
-            return 0;
-        }
+        return false;
+    }
+
+    g_modInstance = modInstance;
+    g_finishedAlertClassRegistered = true;
+    return true;
+}
+
+
+static void UnregisterFinishedAlertClass()
+{
+    if (!g_finishedAlertClassRegistered ||
+        !g_modInstance)
+    {
+        return;
+    }
+
+    if (!UnregisterClassW(
+            kFinishedAlertClass,
+            g_modInstance))
+    {
+        Wh_Log(
+            L"ERROR: Could not unregister completion alert class: %u",
+            GetLastError()
+        );
+    }
+
+    g_finishedAlertClassRegistered = false;
+    g_modInstance = nullptr;
+}
+
+
+static DWORD WINAPI FinishedAlertThreadProc(LPVOID param)
+{
+    std::unique_ptr<FinishedAlertData> data(
+        reinterpret_cast<FinishedAlertData*>(param)
+    );
+    if (!g_finishedAlertClassRegistered ||
+        !g_modInstance)
+    {
+        Wh_Log(
+            L"ERROR: Completion alert class isn't registered"
+        );
+
+        return 0;
     }
 
     HWND taskbar = g_taskbarWnd.load();
@@ -2000,7 +2052,7 @@ static DWORD WINAPI FinishedAlertThreadProc(LPVOID param)
             ScaleAlertValue(220, dpi),
             nullptr,
             nullptr,
-            modInstance,
+            g_modInstance,
             data.get()
         );
 
@@ -2010,7 +2062,6 @@ static DWORD WINAPI FinishedAlertThreadProc(LPVOID param)
             GetLastError()
         );
 
-        UnregisterClassW(kFinishedAlertClass, modInstance);
         return 0;
     }
 
@@ -2072,7 +2123,6 @@ ExitLoop:
     }
 
     g_finishedAlertWnd.store(nullptr);
-    UnregisterClassW(kFinishedAlertClass, modInstance);
     return 0;
 }
 
@@ -2098,6 +2148,10 @@ static void CloseFinishedAlertThreadIfExited()
 
 static bool ShowFinishedAlert(const wchar_t* reminder)
 {
+    if (g_unloading.load()) {
+        return false;
+    }
+
     CloseFinishedAlertThreadIfExited();
 
     if (HWND existing = g_finishedAlertWnd.load()) {
@@ -2225,8 +2279,6 @@ static void HandleTimerExpiredFromWorker()
     }
 
     g_deadlineUtc100ns.store(0);
-    g_secondsRemaining.store(0);
-    g_pendingFinished.store(true);
 
     ClearPersistedTimer();
 
@@ -2386,12 +2438,6 @@ static void RestorePersistedTimer()
             deadline
         );
 
-        g_secondsRemaining.store(
-            remaining
-        );
-
-        g_pendingFinished.store(false);
-
         SignalTimerWorker();
 
         Wh_Log(
@@ -2401,8 +2447,22 @@ static void RestorePersistedTimer()
     }
     else {
         g_deadlineUtc100ns.store(0);
-        g_secondsRemaining.store(0);
-        g_pendingFinished.store(true);
+
+        ULONGLONG now = GetUtcFileTimeNow();
+        constexpr ULONGLONG kRestoreStaleCutoff =
+            6ULL * 60ULL * 60ULL * 10000000ULL;
+
+        if (now > deadline &&
+            now - deadline > kRestoreStaleCutoff)
+        {
+            ClearPersistedTimer();
+
+            Wh_Log(
+                L"Ignoring stale expired timer from more than 6 hours ago"
+            );
+
+            return;
+        }
 
         ClearPersistedTimer();
 
@@ -2527,6 +2587,29 @@ static bool EnsureTimerWorkerStarted()
 // -----------------------------------------------------------------------------
 // Add/remove taskbar button
 // -----------------------------------------------------------------------------
+
+
+template <typename T1, typename T2>
+static bool SameWinrtObject(
+    T1 const& a,
+    T2 const& b)
+{
+    if (!a || !b) {
+        return false;
+    }
+
+    auto aUnknown =
+        a.template as<
+            winrt::Windows::Foundation::IUnknown>();
+
+    auto bUnknown =
+        b.template as<
+            winrt::Windows::Foundation::IUnknown>();
+
+    return winrt::get_abi(aUnknown) ==
+           winrt::get_abi(bUnknown);
+}
+
 
 static void ReleaseOwnedXamlForRebuild()
 {
@@ -2701,7 +2784,9 @@ static void AddTimerButtonImpl(
 
     if (existing &&
         g_timerButton &&
-        existing == g_timerButton)
+        SameWinrtObject(
+            existing,
+            g_timerButton))
     {
         g_taskbarWnd.store(taskbar);
         g_buttonInjected.store(true);
@@ -2785,10 +2870,6 @@ static void AddTimerButtonImpl(
                     RemainingSeconds(
                         g_deadlineUtc100ns.load()
                     );
-
-                g_secondsRemaining.store(
-                    remaining
-                );
 
                 if (remaining > 0) {
                     if (g_timerText) {
@@ -2891,10 +2972,6 @@ static void AddTimerButtonImpl(
         RemainingSeconds(
             g_deadlineUtc100ns.load()
         );
-
-    g_secondsRemaining.store(
-        remaining
-    );
 
     if (remaining > 0 &&
         g_countdownTimer)
@@ -3443,7 +3520,12 @@ BOOL Wh_ModInit()
 
     LoadSettings();
 
+    if (!RegisterFinishedAlertClass()) {
+        return FALSE;
+    }
+
     if (!HookTaskbarDllSymbols()) {
+        UnregisterFinishedAlertClass();
         Wh_Log(
             L"ERROR: Failed to resolve taskbar.dll symbols"
         );
@@ -3586,21 +3668,7 @@ void Wh_ModUninit()
 
     StopTimerWorker();
 
-    if (g_finishedAlertStopEvent) {
-        SetEvent(g_finishedAlertStopEvent);
-    }
-
-    if (HWND alert = g_finishedAlertWnd.load()) {
-        PostMessageW(alert, WM_CLOSE, 0, 0);
-    }
-
-    if (HANDLE alertThread =
-            g_finishedAlertThread.exchange(nullptr))
-    {
-        PumpWaitForThread(alertThread);
-        CloseHandle(alertThread);
-    }
-
+    // First stop and join every thread that can still create/use alert UI.
     if (g_retryThread) {
         PumpWaitForThread(
             g_retryThread
@@ -3627,27 +3695,42 @@ void Wh_ModUninit()
 
     g_timerWorkerStarted.store(false);
 
-    // Retry after all worker activity has stopped. We don't use
-    // g_buttonInjected as a shortcut because Loaded revokers can exist even
-    // when button injection never completed.
-    bool removed = false;
-
-    for (int attempt = 0;
-         attempt < 10 &&
-         !removed;
-         attempt++)
-    {
-        removed =
-            TryRemoveTimerXaml();
-
-        if (!removed) {
-            Sleep(50);
-        }
+    // Only after the timer worker is gone can no new alert thread be created.
+    if (g_finishedAlertStopEvent) {
+        SetEvent(
+            g_finishedAlertStopEvent
+        );
     }
 
-    if (!removed) {
+    if (HWND alert =
+            g_finishedAlertWnd.load())
+    {
+        PostMessageW(
+            alert,
+            WM_CLOSE,
+            0,
+            0
+        );
+    }
+
+    if (HANDLE alertThread =
+            g_finishedAlertThread.exchange(
+                nullptr
+            ))
+    {
+        PumpWaitForThread(
+            alertThread
+        );
+
+        CloseHandle(
+            alertThread
+        );
+    }
+
+    // Final best-effort XAML teardown after all worker activity is stopped.
+    if (!TryRemoveTimerXaml()) {
         Wh_Log(
-            L"ERROR: Could not verify timer XAML teardown before unload"
+            L"ERROR: Could not dispatch final timer XAML teardown"
         );
     }
 
@@ -3673,22 +3756,30 @@ void Wh_ModUninit()
     }
 
     if (g_finishedAlertStopEvent) {
-        CloseHandle(g_finishedAlertStopEvent);
+        CloseHandle(
+            g_finishedAlertStopEvent
+        );
         g_finishedAlertStopEvent = nullptr;
     }
 
     if (g_finishedAlertFont) {
-        DeleteObject(g_finishedAlertFont);
+        DeleteObject(
+            g_finishedAlertFont
+        );
         g_finishedAlertFont = nullptr;
     }
 
     if (g_finishedAlertEditBrush) {
-        DeleteObject(g_finishedAlertEditBrush);
+        DeleteObject(
+            g_finishedAlertEditBrush
+        );
         g_finishedAlertEditBrush = nullptr;
     }
 
     if (g_finishedAlertBackgroundBrush) {
-        DeleteObject(g_finishedAlertBackgroundBrush);
+        DeleteObject(
+            g_finishedAlertBackgroundBrush
+        );
         g_finishedAlertBackgroundBrush = nullptr;
     }
 
@@ -3698,6 +3789,8 @@ void Wh_ModUninit()
         );
         g_retryStopEvent = nullptr;
     }
+
+    UnregisterFinishedAlertClass();
 
     Wh_Log(
         L"Taskbar Countdown Timer unloaded"
@@ -3736,3 +3829,4 @@ void Wh_ModSettingsChanged()
         );
     }
 }
+

--- a/mods/taskbar-countdown-timer.wh.cpp
+++ b/mods/taskbar-countdown-timer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-countdown-timer
 // @name            Taskbar Countdown Timer
 // @description     A simple countdown timer integrated into the Windows taskbar
-// @version         1.3
+// @version         1.4
 // @author          Richi
 // @github          https://github.com/richilp
 // @include         explorer.exe
@@ -529,7 +529,7 @@ static void PositionPopupNearTaskbar(
         y,
         width,
         height,
-        SWP_SHOWWINDOW
+        SWP_NOACTIVATE
     );
 }
 
@@ -1470,7 +1470,7 @@ static LRESULT CALLBACK FinishedPopupWndProc(
             GetWindowTextW(
                 GetDlgItem(
                     hWnd,
-                    IDC_FINISHED_REMINDER
+                    IDC_FINISHED_TEXT
                 ),
                 finishedReminder,
                 ARRAYSIZE(finishedReminder)
@@ -1647,11 +1647,17 @@ static void ShowFinishedPopup(
     HWND owner,
     const wchar_t* reminderText)
 {
-    if (g_finishedPopup.load()) {
-        SetForegroundWindow(
-            g_finishedPopup
-        );
+    if (HWND existing = g_finishedPopup.load()) {
+        if (HWND text = GetDlgItem(existing, IDC_FINISHED_TEXT)) {
+            SetWindowTextW(
+                text,
+                reminderText && reminderText[0]
+                    ? reminderText
+                    : L"Timer finished"
+            );
+        }
 
+        SetForegroundWindow(existing);
         return;
     }
 
@@ -2090,6 +2096,16 @@ static LRESULT CALLBACK TimerPopupWndProc(
             reinterpret_cast<std::wstring*>(lParam)
         );
 
+        HWND taskbar = g_taskbarWnd.load();
+        if (!taskbar || !IsWindow(taskbar)) {
+            taskbar = FindCurrentProcessTaskbarWnd();
+            if (taskbar) {
+                g_taskbarWnd.store(taskbar);
+            }
+        }
+
+        UINT dpi = GetPopupDpi(taskbar);
+
         ResetPopupForNewTimer(
             hWnd,
             activeReminder ? activeReminder->c_str() : nullptr
@@ -2097,7 +2113,15 @@ static LRESULT CALLBACK TimerPopupWndProc(
 
         LayoutTimerPopup(
             hWnd,
-            GetDpiForWindow(hWnd)
+            dpi
+        );
+
+        PositionPopupNearTaskbar(
+            hWnd,
+            taskbar,
+            380,
+            235,
+            dpi
         );
 
         ShowWindow(
@@ -2336,14 +2360,6 @@ static bool ShowTimerPopup(
 
     LayoutTimerPopup(
         hWnd,
-        dpi
-    );
-
-    PositionPopupNearTaskbar(
-        hWnd,
-        owner,
-        380,
-        235,
         dpi
     );
 
@@ -2701,11 +2717,10 @@ static void AddTimerButton(
                     if (g_timerPopup.load() &&
                         IsWindow(g_timerPopup.load()))
                     {
-                        PostMessageW(
-            g_timerPopup.load(),
+                        PostStringMessage(
+                            g_timerPopup.load(),
                             WM_APP_TIMER_FINISHED,
-                            0,
-                            0
+                            g_reminder
                         );
                     }
 
@@ -3118,15 +3133,17 @@ static bool HookSystemTraySymbols(
 static void HandleLoadedModuleIfSystemTray(
     HMODULE module)
 {
-    if (g_systemTrayModuleHooked.load() ||
-        GetSystemTrayModuleHandle() != module)
-    {
+    if (GetSystemTrayModuleHandle() != module) {
         return;
     }
 
-    if (HookSystemTraySymbols(module)) {
-        g_systemTrayModuleHooked.store(true);
-        Wh_ApplyHookOperations();
+    if (!g_systemTrayModuleHooked.exchange(true)) {
+        if (HookSystemTraySymbols(module)) {
+            Wh_ApplyHookOperations();
+        }
+        else {
+            g_systemTrayModuleHooked.store(false);
+        }
     }
 }
 
@@ -3256,6 +3273,10 @@ BOOL Wh_ModInit()
 
 void Wh_ModAfterInit()
 {
+    if (HMODULE systemTray = GetSystemTrayModuleHandle()) {
+        HandleLoadedModuleIfSystemTray(systemTray);
+    }
+
     ApplyTimerButtonIfAvailable();
 
     g_retryStopEvent =

--- a/mods/taskbar-countdown-timer.wh.cpp
+++ b/mods/taskbar-countdown-timer.wh.cpp
@@ -771,7 +771,7 @@ static bool HookTaskbarDllSymbols()
         return false;
     }
 
-    WindhawkUtils::SYMBOL_HOOK hooks[] = {
+    WindhawkUtils::SYMBOL_HOOK taskbarDllHooks[] = {
         {
             {
                 LR"(const CTaskBand::`vftable'{for `ITaskListWndSite'})"
@@ -800,8 +800,8 @@ static bool HookTaskbarDllSymbols()
 
     return WindhawkUtils::HookSymbols(
         module,
-        hooks,
-        ARRAYSIZE(hooks)
+        taskbarDllHooks,
+        ARRAYSIZE(taskbarDllHooks)
     );
 }
 
@@ -3099,7 +3099,7 @@ static void* WINAPI IconView_IconView_Hook(
 static bool HookSystemTraySymbols(
     HMODULE module)
 {
-    WindhawkUtils::SYMBOL_HOOK hooks[] = {{
+    WindhawkUtils::SYMBOL_HOOK systemTrayDllHooks[] = {{
         {
             LR"(public: __cdecl winrt::SystemTray::implementation::IconView::IconView(void))"
         },
@@ -3109,8 +3109,8 @@ static bool HookSystemTraySymbols(
 
     return WindhawkUtils::HookSymbols(
         module,
-        hooks,
-        ARRAYSIZE(hooks)
+        systemTrayDllHooks,
+        ARRAYSIZE(systemTrayDllHooks)
     );
 }
 

--- a/mods/taskbar-countdown-timer.wh.cpp
+++ b/mods/taskbar-countdown-timer.wh.cpp
@@ -1,0 +1,2456 @@
+// ==WindhawkMod==
+// @id              taskbar-countdown-timer
+// @name            Taskbar Countdown Timer
+// @description     A simple countdown timer integrated into the Windows taskbar
+// @version         1.1
+// @author          Richi
+// @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -ldwmapi -lgdi32
+// @license         MIT
+// @github          richilp
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Taskbar Countdown Timer
+
+A lightweight countdown timer integrated directly into the Windows 11 taskbar.
+
+Click **⏱ Timer** to create a countdown with a custom reminder and duration.
+While the timer is running, the remaining time is shown directly on the taskbar.
+
+## Features
+
+- Countdown timer directly in the Windows 11 taskbar
+- Custom reminder text
+- Live remaining time in the taskbar
+- Cancel an active timer
+- Snooze a finished timer for a custom number of minutes
+- Separate completion popup with sound
+- Modern Windows 11-style popup interface
+- Close button on timer and completion popups
+- No external application required
+
+## How to use
+
+1. Click **⏱ Timer** on the taskbar.
+2. Enter a reminder, for example `Take pizza out of the oven`.
+3. Enter the duration in minutes.
+4. Click **Start**.
+5. When the countdown finishes, choose **Snooze** or **Dismiss**.
+
+## Screenshot
+
+![Taskbar Countdown Timer](https://raw.githubusercontent.com/richilp/taskbar-countdown-timer/main/16c5364b-0834-4a83-8796-1f6b1df4f702.png)
+
+*/
+// ==/WindhawkModReadme==
+
+
+#ifdef GetCurrentTime
+#undef GetCurrentTime
+#endif
+
+#include <chrono>
+#include <functional>
+#include <string>
+#include <dwmapi.h>
+#include <windhawk_utils.h>
+
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.UI.Xaml.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
+
+using namespace winrt::Windows::UI::Xaml;
+using namespace winrt::Windows::UI::Xaml::Controls;
+using namespace winrt::Windows::UI::Xaml::Media;
+
+
+// -----------------------------------------------------------------------------
+// Globals
+// -----------------------------------------------------------------------------
+
+static Button g_timerButton{nullptr};
+static TextBlock g_timerText{nullptr};
+static DispatcherTimer g_countdownTimer{nullptr};
+
+static winrt::event_token g_timerButtonClickToken{};
+static winrt::event_token g_timerTickToken{};
+
+static int g_secondsRemaining = 0;
+static wchar_t g_reminder[256]{};
+
+static HWND g_timerPopup = nullptr;
+static HWND g_finishedPopup = nullptr;
+static DWORD g_timerPopupThreadId = 0;
+static HANDLE g_timerPopupThread = nullptr;
+
+
+// -----------------------------------------------------------------------------
+// Modern popup styling
+// -----------------------------------------------------------------------------
+
+static HBRUSH g_popupBackgroundBrush = nullptr;
+static HBRUSH g_popupEditBrush = nullptr;
+static HFONT g_popupFont = nullptr;
+
+static constexpr COLORREF kPopupBackground =
+    RGB(32, 32, 32);
+
+static constexpr COLORREF kPopupEditBackground =
+    RGB(45, 45, 45);
+
+static constexpr COLORREF kPopupText =
+    RGB(245, 245, 245);
+
+static constexpr COLORREF kPopupMutedText =
+    RGB(190, 190, 190);
+
+
+static void EnsurePopupResources()
+{
+    if (!g_popupBackgroundBrush) {
+        g_popupBackgroundBrush =
+            CreateSolidBrush(
+                kPopupBackground
+            );
+    }
+
+    if (!g_popupEditBrush) {
+        g_popupEditBrush =
+            CreateSolidBrush(
+                kPopupEditBackground
+            );
+    }
+
+    if (!g_popupFont) {
+        g_popupFont =
+            CreateFontW(
+                -16,
+                0,
+                0,
+                0,
+                FW_NORMAL,
+                FALSE,
+                FALSE,
+                FALSE,
+                DEFAULT_CHARSET,
+                OUT_DEFAULT_PRECIS,
+                CLIP_DEFAULT_PRECIS,
+                CLEARTYPE_QUALITY,
+                DEFAULT_PITCH |
+                    FF_DONTCARE,
+                L"Segoe UI"
+            );
+    }
+}
+
+
+static void ApplyModernWindowStyle(
+    HWND hWnd)
+{
+    EnsurePopupResources();
+
+    // Rounded Windows 11 corners.
+    constexpr DWORD DWMWA_WINDOW_CORNER_PREFERENCE_LOCAL = 33;
+    constexpr int DWMWCP_ROUND_LOCAL = 2;
+
+    int cornerPreference =
+        DWMWCP_ROUND_LOCAL;
+
+    DwmSetWindowAttribute(
+        hWnd,
+        DWMWA_WINDOW_CORNER_PREFERENCE_LOCAL,
+        &cornerPreference,
+        sizeof(cornerPreference)
+    );
+
+    // Dark title / non-client rendering where supported.
+    constexpr DWORD DWMWA_USE_IMMERSIVE_DARK_MODE_LOCAL = 20;
+
+    BOOL darkMode = TRUE;
+
+    DwmSetWindowAttribute(
+        hWnd,
+        DWMWA_USE_IMMERSIVE_DARK_MODE_LOCAL,
+        &darkMode,
+        sizeof(darkMode)
+    );
+
+    // Add a subtle system shadow without a classic caption.
+    MARGINS margins{
+        1,
+        1,
+        1,
+        1
+    };
+
+    DwmExtendFrameIntoClientArea(
+        hWnd,
+        &margins
+    );
+}
+
+
+static void ApplyPopupFont(
+    HWND hWnd)
+{
+    if (!hWnd) {
+        return;
+    }
+
+    SendMessageW(
+        hWnd,
+        WM_SETFONT,
+        reinterpret_cast<WPARAM>(
+            g_popupFont
+        ),
+        TRUE
+    );
+}
+
+
+// -----------------------------------------------------------------------------
+// Popup constants
+// -----------------------------------------------------------------------------
+
+constexpr int IDC_REMINDER_LABEL = 1000;
+constexpr int IDC_REMINDER       = 1001;
+constexpr int IDC_MINUTES_LABEL  = 1002;
+constexpr int IDC_MINUTES        = 1003;
+constexpr int IDC_START          = 1004;
+constexpr int IDC_CANCEL_TIMER   = 1005;
+constexpr int IDC_CLOSE_TIMER    = 1006;
+
+constexpr int IDC_SNOOZE_LABEL   = 1100;
+constexpr int IDC_SNOOZE_MINUTES = 1101;
+constexpr int IDC_SNOOZE         = 1102;
+constexpr int IDC_DISMISS        = 1103;
+constexpr int IDC_CLOSE_FINISHED = 1104;
+
+constexpr UINT WM_APP_TIMER_SHOW =
+    WM_APP + 1;
+
+constexpr UINT WM_APP_TIMER_FINISHED =
+    WM_APP + 2;
+
+constexpr UINT WM_APP_TIMER_SHUTDOWN =
+    WM_APP + 3;
+
+
+// -----------------------------------------------------------------------------
+// XAML helpers
+// -----------------------------------------------------------------------------
+
+static FrameworkElement FindChildRecursive(
+    FrameworkElement element,
+    const std::function<bool(FrameworkElement)>& callback,
+    int maxDepth = 20)
+{
+    if (!element || maxDepth <= 0) {
+        return nullptr;
+    }
+
+    int count = VisualTreeHelper::GetChildrenCount(element);
+
+    for (int i = 0; i < count; i++) {
+        auto child =
+            VisualTreeHelper::GetChild(element, i)
+                .try_as<FrameworkElement>();
+
+        if (!child) {
+            continue;
+        }
+
+        if (callback(child)) {
+            return child;
+        }
+
+        auto found =
+            FindChildRecursive(
+                child,
+                callback,
+                maxDepth - 1
+            );
+
+        if (found) {
+            return found;
+        }
+    }
+
+    return nullptr;
+}
+
+
+// -----------------------------------------------------------------------------
+// Taskbar window
+// -----------------------------------------------------------------------------
+
+static HWND FindCurrentProcessTaskbarWnd()
+{
+    HWND result = nullptr;
+
+    EnumWindows(
+        [](HWND hWnd, LPARAM lParam) -> BOOL
+        {
+            DWORD pid = 0;
+            WCHAR className[32];
+
+            if (GetWindowThreadProcessId(
+                    hWnd,
+                    &pid) &&
+                pid == GetCurrentProcessId() &&
+                GetClassNameW(
+                    hWnd,
+                    className,
+                    ARRAYSIZE(className)) &&
+                _wcsicmp(
+                    className,
+                    L"Shell_TrayWnd") == 0)
+            {
+                *reinterpret_cast<HWND*>(lParam) =
+                    hWnd;
+
+                return FALSE;
+            }
+
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&result)
+    );
+
+    return result;
+}
+
+
+// -----------------------------------------------------------------------------
+// taskbar.dll symbols
+// -----------------------------------------------------------------------------
+
+using CTaskBand_GetTaskbarHost_t =
+    void* (WINAPI*)(void* pThis, void* result);
+
+static CTaskBand_GetTaskbarHost_t
+    CTaskBand_GetTaskbarHost_Original = nullptr;
+
+
+using TaskbarHost_FrameHeight_t =
+    int (WINAPI*)(void* pThis);
+
+static TaskbarHost_FrameHeight_t
+    TaskbarHost_FrameHeight_Original = nullptr;
+
+
+using std__Ref_count_base__Decref_t =
+    void (WINAPI*)(void* pThis);
+
+static std__Ref_count_base__Decref_t
+    std__Ref_count_base__Decref_Original = nullptr;
+
+
+static void* CTaskBand_ITaskListWndSite_vftable =
+    nullptr;
+
+
+static bool HookTaskbarDllSymbols()
+{
+    HMODULE module = LoadLibraryExW(
+        L"taskbar.dll",
+        nullptr,
+        LOAD_LIBRARY_SEARCH_SYSTEM32
+    );
+
+    if (!module) {
+        Wh_Log(
+            L"ERROR: Could not load taskbar.dll"
+        );
+
+        return false;
+    }
+
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {
+        {
+            {
+                LR"(const CTaskBand::`vftable'{for `ITaskListWndSite'})"
+            },
+            &CTaskBand_ITaskListWndSite_vftable
+        },
+        {
+            {
+                LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CTaskBand::GetTaskbarHost(void)const )"
+            },
+            &CTaskBand_GetTaskbarHost_Original
+        },
+        {
+            {
+                LR"(public: int __cdecl TaskbarHost::FrameHeight(void)const )"
+            },
+            &TaskbarHost_FrameHeight_Original
+        },
+        {
+            {
+                LR"(public: void __cdecl std::_Ref_count_base::_Decref(void))"
+            },
+            &std__Ref_count_base__Decref_Original
+        },
+    };
+
+    return WindhawkUtils::HookSymbols(
+        module,
+        hooks,
+        ARRAYSIZE(hooks)
+    );
+}
+
+
+// -----------------------------------------------------------------------------
+// Get taskbar XAML root
+// -----------------------------------------------------------------------------
+
+static XamlRoot GetTaskbarXamlRoot(
+    HWND hTaskbarWnd)
+{
+    if (!CTaskBand_GetTaskbarHost_Original ||
+        !TaskbarHost_FrameHeight_Original ||
+        !std__Ref_count_base__Decref_Original ||
+        !CTaskBand_ITaskListWndSite_vftable)
+    {
+        Wh_Log(
+            L"ERROR: Required symbols are missing"
+        );
+
+        return nullptr;
+    }
+
+    HWND hTaskSwWnd =
+        reinterpret_cast<HWND>(
+            GetPropW(
+                hTaskbarWnd,
+                L"TaskbandHWND"
+            )
+        );
+
+    if (!hTaskSwWnd) {
+        Wh_Log(
+            L"ERROR: TaskbandHWND not found"
+        );
+
+        return nullptr;
+    }
+
+    void* taskBand =
+        reinterpret_cast<void*>(
+            GetWindowLongPtrW(
+                hTaskSwWnd,
+                0
+            )
+        );
+
+    if (!taskBand) {
+        Wh_Log(
+            L"ERROR: CTaskBand object not found"
+        );
+
+        return nullptr;
+    }
+
+    void* taskBandForSite = taskBand;
+
+    for (int i = 0;
+         *reinterpret_cast<void**>(
+             taskBandForSite) !=
+             CTaskBand_ITaskListWndSite_vftable;
+         i++)
+    {
+        if (i == 20) {
+            Wh_Log(
+                L"ERROR: ITaskListWndSite vftable not found"
+            );
+
+            return nullptr;
+        }
+
+        taskBandForSite =
+            reinterpret_cast<void**>(
+                taskBandForSite) + 1;
+    }
+
+    void* taskbarHostSharedPtr[2]{};
+
+    CTaskBand_GetTaskbarHost_Original(
+        taskBandForSite,
+        taskbarHostSharedPtr
+    );
+
+    if (!taskbarHostSharedPtr[0] ||
+        !taskbarHostSharedPtr[1])
+    {
+        if (taskbarHostSharedPtr[1]) {
+            std__Ref_count_base__Decref_Original(
+                taskbarHostSharedPtr[1]
+            );
+        }
+
+        Wh_Log(
+            L"ERROR: TaskbarHost not obtained"
+        );
+
+        return nullptr;
+    }
+
+    size_t offset = 0x10;
+
+    const BYTE* code =
+        reinterpret_cast<const BYTE*>(
+            TaskbarHost_FrameHeight_Original
+        );
+
+    if (code[0] == 0x48 &&
+        code[1] == 0x83 &&
+        code[2] == 0xEC &&
+        code[4] == 0x48 &&
+        code[5] == 0x83 &&
+        code[6] == 0xC1 &&
+        code[7] <= 0x7F)
+    {
+        offset = code[7];
+    }
+    else {
+        Wh_Log(
+            L"ERROR: Unsupported TaskbarHost::FrameHeight"
+        );
+
+        std__Ref_count_base__Decref_Original(
+            taskbarHostSharedPtr[1]
+        );
+
+        return nullptr;
+    }
+
+    auto* unknown =
+        *reinterpret_cast<IUnknown**>(
+            reinterpret_cast<BYTE*>(
+                taskbarHostSharedPtr[0]
+            ) + offset
+        );
+
+    if (!unknown) {
+        Wh_Log(
+            L"ERROR: Taskbar XAML object not found"
+        );
+
+        std__Ref_count_base__Decref_Original(
+            taskbarHostSharedPtr[1]
+        );
+
+        return nullptr;
+    }
+
+    FrameworkElement taskbarElement = nullptr;
+
+    unknown->QueryInterface(
+        winrt::guid_of<FrameworkElement>(),
+        winrt::put_abi(taskbarElement)
+    );
+
+    auto result =
+        taskbarElement
+            ? taskbarElement.XamlRoot()
+            : nullptr;
+
+    std__Ref_count_base__Decref_Original(
+        taskbarHostSharedPtr[1]
+    );
+
+    return result;
+}
+
+
+// -----------------------------------------------------------------------------
+// Execute code on taskbar XAML thread
+// -----------------------------------------------------------------------------
+
+using RunFromWindowThreadProc_t =
+    void (*)(void*);
+
+static bool RunFromWindowThread(
+    HWND hWnd,
+    RunFromWindowThreadProc_t proc,
+    void* procParam)
+{
+    static const UINT message =
+        RegisterWindowMessageW(
+            L"Windhawk_RunFromWindowThread_" WH_MOD_ID
+        );
+
+    struct Param
+    {
+        RunFromWindowThreadProc_t proc;
+        void* procParam;
+    };
+
+    DWORD threadId =
+        GetWindowThreadProcessId(
+            hWnd,
+            nullptr
+        );
+
+    if (!threadId) {
+        return false;
+    }
+
+    if (threadId == GetCurrentThreadId()) {
+        proc(procParam);
+        return true;
+    }
+
+    HHOOK hook = SetWindowsHookExW(
+        WH_CALLWNDPROC,
+        [](int nCode,
+           WPARAM wParam,
+           LPARAM lParam) -> LRESULT
+        {
+            if (nCode == HC_ACTION) {
+                const CWPSTRUCT* cwp =
+                    reinterpret_cast<
+                        const CWPSTRUCT*>(
+                            lParam
+                        );
+
+                const UINT message =
+                    RegisterWindowMessageW(
+                        L"Windhawk_RunFromWindowThread_"
+                        WH_MOD_ID
+                    );
+
+                if (cwp->message == message) {
+                    auto* param =
+                        reinterpret_cast<Param*>(
+                            cwp->lParam
+                        );
+
+                    param->proc(
+                        param->procParam
+                    );
+                }
+            }
+
+            return CallNextHookEx(
+                nullptr,
+                nCode,
+                wParam,
+                lParam
+            );
+        },
+        nullptr,
+        threadId
+    );
+
+    if (!hook) {
+        return false;
+    }
+
+    Param param{
+        proc,
+        procParam
+    };
+
+    SendMessageW(
+        hWnd,
+        message,
+        0,
+        reinterpret_cast<LPARAM>(&param)
+    );
+
+    UnhookWindowsHookEx(hook);
+
+    return true;
+}
+
+
+// -----------------------------------------------------------------------------
+// Countdown
+// -----------------------------------------------------------------------------
+
+static std::wstring FormatCountdown(
+    int totalSeconds)
+{
+    if (totalSeconds < 0) {
+        totalSeconds = 0;
+    }
+
+    int minutes = totalSeconds / 60;
+    int seconds = totalSeconds % 60;
+
+    wchar_t text[64]{};
+
+    swprintf_s(
+        text,
+        L"⏱ %02d:%02d",
+        minutes,
+        seconds
+    );
+
+    return text;
+}
+
+
+struct StartTimerRequest
+{
+    int seconds;
+    wchar_t reminder[256];
+};
+
+
+static void StartCountdownOnTaskbarThread(
+    void* param)
+{
+    auto* request =
+        reinterpret_cast<StartTimerRequest*>(
+            param
+        );
+
+    if (!request ||
+        !g_timerText ||
+        !g_countdownTimer)
+    {
+        return;
+    }
+
+    g_countdownTimer.Stop();
+
+    g_secondsRemaining =
+        request->seconds;
+
+    wcsncpy_s(
+        g_reminder,
+        request->reminder,
+        _TRUNCATE
+    );
+
+    g_timerText.Text(
+        FormatCountdown(
+            g_secondsRemaining
+        )
+    );
+
+    g_countdownTimer.Start();
+
+    Wh_Log(
+        L"Timer started: '%s' - %d seconds",
+        g_reminder,
+        g_secondsRemaining
+    );
+}
+
+
+static void CancelCountdownOnTaskbarThread(
+    void*)
+{
+    if (g_countdownTimer) {
+        g_countdownTimer.Stop();
+    }
+
+    g_secondsRemaining = 0;
+
+    if (g_timerText) {
+        g_timerText.Text(
+            L"⏱ Timer"
+        );
+    }
+
+    Wh_Log(
+        L"Timer cancelled"
+    );
+}
+
+
+// -----------------------------------------------------------------------------
+// Timer popup
+// -----------------------------------------------------------------------------
+
+static void ResetPopupForNewTimer(
+    HWND hWnd)
+{
+    SetWindowTextW(
+        hWnd,
+        L"Timer"
+    );
+
+    HWND reminder =
+        GetDlgItem(
+            hWnd,
+            IDC_REMINDER
+        );
+
+    HWND minutes =
+        GetDlgItem(
+            hWnd,
+            IDC_MINUTES
+        );
+
+    HWND start =
+        GetDlgItem(
+            hWnd,
+            IDC_START
+        );
+
+    HWND cancel =
+        GetDlgItem(
+            hWnd,
+            IDC_CANCEL_TIMER
+        );
+
+    const bool timerRunning =
+        g_secondsRemaining > 0;
+
+    if (timerRunning) {
+        SetWindowTextW(
+            reminder,
+            g_reminder[0]
+                ? g_reminder
+                : L"Timer"
+        );
+
+        // The input accepts whole minutes, so show the remaining time
+        // rounded up to the next minute.
+        int remainingMinutes =
+            (g_secondsRemaining + 59) / 60;
+
+        wchar_t minutesText[32]{};
+
+        swprintf_s(
+            minutesText,
+            L"%d",
+            remainingMinutes
+        );
+
+        SetWindowTextW(
+            minutes,
+            minutesText
+        );
+
+        // While a timer is active, this popup is for viewing/cancelling it.
+        EnableWindow(reminder, FALSE);
+        EnableWindow(minutes, FALSE);
+        EnableWindow(start, FALSE);
+        EnableWindow(cancel, TRUE);
+    }
+    else {
+        SetWindowTextW(
+            reminder,
+            L""
+        );
+
+        SetWindowTextW(
+            minutes,
+            L"20"
+        );
+
+        EnableWindow(reminder, TRUE);
+        EnableWindow(minutes, TRUE);
+        EnableWindow(start, TRUE);
+        EnableWindow(cancel, FALSE);
+    }
+
+    SetWindowTextW(
+        start,
+        L"Start"
+    );
+}
+
+
+// -----------------------------------------------------------------------------
+// Finished / snooze popup
+// -----------------------------------------------------------------------------
+
+static LRESULT CALLBACK FinishedPopupWndProc(
+    HWND hWnd,
+    UINT msg,
+    WPARAM wParam,
+    LPARAM lParam)
+{
+    switch (msg)
+    {
+    case WM_ERASEBKGND:
+    {
+        RECT rect{};
+        GetClientRect(
+            hWnd,
+            &rect
+        );
+
+        FillRect(
+            reinterpret_cast<HDC>(wParam),
+            &rect,
+            g_popupBackgroundBrush
+        );
+
+        return 1;
+    }
+
+    case WM_CTLCOLORSTATIC:
+    {
+        HDC hdc =
+            reinterpret_cast<HDC>(wParam);
+
+        SetTextColor(
+            hdc,
+            kPopupText
+        );
+
+        SetBkColor(
+            hdc,
+            kPopupBackground
+        );
+
+        return reinterpret_cast<LRESULT>(
+            g_popupBackgroundBrush
+        );
+    }
+
+    case WM_CTLCOLOREDIT:
+    {
+        HDC hdc =
+            reinterpret_cast<HDC>(wParam);
+
+        SetTextColor(
+            hdc,
+            kPopupText
+        );
+
+        SetBkColor(
+            hdc,
+            kPopupEditBackground
+        );
+
+        return reinterpret_cast<LRESULT>(
+            g_popupEditBrush
+        );
+    }
+
+    case WM_COMMAND:
+        if (LOWORD(wParam) == IDC_SNOOZE &&
+            HIWORD(wParam) == BN_CLICKED)
+        {
+            wchar_t minutesText[32]{};
+
+            GetWindowTextW(
+                GetDlgItem(
+                    hWnd,
+                    IDC_SNOOZE_MINUTES
+                ),
+                minutesText,
+                ARRAYSIZE(minutesText)
+            );
+
+            int minutes =
+                _wtoi(minutesText);
+
+            if (minutes <= 0 ||
+                minutes > 1440)
+            {
+                MessageBoxW(
+                    hWnd,
+                    L"Enter a number of minutes between 1 and 1440.",
+                    L"Snooze timer",
+                    MB_OK |
+                        MB_ICONWARNING
+                );
+
+                return 0;
+            }
+
+            HWND taskbar =
+                FindCurrentProcessTaskbarWnd();
+
+            if (!taskbar) {
+                Wh_Log(
+                    L"ERROR: Taskbar not found while snoozing timer"
+                );
+
+                return 0;
+            }
+
+            StartTimerRequest request{};
+            request.seconds =
+                minutes * 60;
+
+            wcsncpy_s(
+                request.reminder,
+                g_reminder[0]
+                    ? g_reminder
+                    : L"Timer finished",
+                _TRUNCATE
+            );
+
+            if (!RunFromWindowThread(
+                    taskbar,
+                    StartCountdownOnTaskbarThread,
+                    &request))
+            {
+                Wh_Log(
+                    L"ERROR: Could not snooze timer"
+                );
+
+                return 0;
+            }
+
+            Wh_Log(
+                L"Timer snoozed for %d minutes",
+                minutes
+            );
+
+            DestroyWindow(hWnd);
+            return 0;
+        }
+
+        if (LOWORD(wParam) == IDC_DISMISS &&
+            HIWORD(wParam) == BN_CLICKED)
+        {
+            DestroyWindow(hWnd);
+            return 0;
+        }
+
+        if (LOWORD(wParam) == IDC_CLOSE_FINISHED &&
+            HIWORD(wParam) == BN_CLICKED)
+        {
+            DestroyWindow(hWnd);
+            return 0;
+        }
+
+        break;
+
+
+    case WM_CLOSE:
+        DestroyWindow(hWnd);
+        return 0;
+
+
+    case WM_DESTROY:
+        g_finishedPopup = nullptr;
+        return 0;
+    }
+
+    return DefWindowProcW(
+        hWnd,
+        msg,
+        wParam,
+        lParam
+    );
+}
+
+
+static void ShowFinishedPopup(
+    HWND owner)
+{
+    static bool classRegistered = false;
+
+    if (g_finishedPopup) {
+        SetForegroundWindow(
+            g_finishedPopup
+        );
+
+        return;
+    }
+
+    if (!classRegistered) {
+        WNDCLASSW wc{};
+
+        wc.lpfnWndProc =
+            FinishedPopupWndProc;
+
+        wc.hInstance =
+            GetModuleHandleW(nullptr);
+
+        wc.lpszClassName =
+            L"TaskbarCountdownTimerFinishedPopup";
+
+        wc.hCursor =
+            LoadCursorW(
+                nullptr,
+                IDC_ARROW
+            );
+
+        wc.hbrBackground =
+            reinterpret_cast<HBRUSH>(
+                COLOR_WINDOW + 1
+            );
+
+        if (!RegisterClassW(&wc) &&
+            GetLastError() !=
+                ERROR_CLASS_ALREADY_EXISTS)
+        {
+            Wh_Log(
+                L"ERROR: Could not register finished popup class"
+            );
+
+            return;
+        }
+
+        classRegistered = true;
+    }
+
+    HWND hWnd = CreateWindowExW(
+        WS_EX_TOOLWINDOW |
+            WS_EX_TOPMOST,
+        L"TaskbarCountdownTimerFinishedPopup",
+        L"Timer finished",
+        WS_POPUP |
+            WS_BORDER,
+        CW_USEDEFAULT,
+        CW_USEDEFAULT,
+        380,
+        220,
+        owner,
+        nullptr,
+        GetModuleHandleW(nullptr),
+        nullptr
+    );
+
+    if (!hWnd) {
+        Wh_Log(
+            L"ERROR: Could not create finished popup"
+        );
+
+        return;
+    }
+
+    ApplyModernWindowStyle(
+        hWnd
+    );
+
+    g_finishedPopup = hWnd;
+
+    CreateWindowExW(
+        0,
+        L"BUTTON",
+        L"×",
+        WS_CHILD |
+            WS_VISIBLE |
+            WS_TABSTOP |
+            BS_FLAT,
+        338,
+        8,
+        24,
+        24,
+        hWnd,
+        reinterpret_cast<HMENU>(
+            IDC_CLOSE_FINISHED
+        ),
+        GetModuleHandleW(nullptr),
+        nullptr
+    );
+
+    CreateWindowExW(
+        0,
+        L"STATIC",
+        g_reminder[0]
+            ? g_reminder
+            : L"Timer finished",
+        WS_CHILD |
+            WS_VISIBLE |
+            SS_CENTER,
+        20,
+        20,
+        340,
+        45,
+        hWnd,
+        nullptr,
+        GetModuleHandleW(nullptr),
+        nullptr
+    );
+
+    CreateWindowExW(
+        0,
+        L"STATIC",
+        L"Snooze minutes:",
+        WS_CHILD |
+            WS_VISIBLE,
+        20,
+        82,
+        160,
+        20,
+        hWnd,
+        reinterpret_cast<HMENU>(
+            IDC_SNOOZE_LABEL
+        ),
+        GetModuleHandleW(nullptr),
+        nullptr
+    );
+
+    CreateWindowExW(
+        WS_EX_CLIENTEDGE,
+        L"EDIT",
+        L"5",
+        WS_CHILD |
+            WS_VISIBLE |
+            WS_TABSTOP |
+            ES_NUMBER,
+        190,
+        78,
+        70,
+        30,
+        hWnd,
+        reinterpret_cast<HMENU>(
+            IDC_SNOOZE_MINUTES
+        ),
+        GetModuleHandleW(nullptr),
+        nullptr
+    );
+
+    CreateWindowExW(
+        0,
+        L"BUTTON",
+        L"Snooze",
+        WS_CHILD |
+            WS_VISIBLE |
+            WS_TABSTOP |
+            BS_PUSHBUTTON,
+        20,
+        135,
+        165,
+        34,
+        hWnd,
+        reinterpret_cast<HMENU>(
+            IDC_SNOOZE
+        ),
+        GetModuleHandleW(nullptr),
+        nullptr
+    );
+
+    CreateWindowExW(
+        0,
+        L"BUTTON",
+        L"Dismiss",
+        WS_CHILD |
+            WS_VISIBLE |
+            WS_TABSTOP |
+            BS_PUSHBUTTON,
+        195,
+        135,
+        165,
+        34,
+        hWnd,
+        reinterpret_cast<HMENU>(
+            IDC_DISMISS
+        ),
+        GetModuleHandleW(nullptr),
+        nullptr
+    );
+
+    for (int id : {
+             IDC_SNOOZE_LABEL,
+             IDC_SNOOZE_MINUTES,
+             IDC_SNOOZE,
+             IDC_DISMISS,
+             IDC_CLOSE_FINISHED})
+    {
+        ApplyPopupFont(
+            GetDlgItem(
+                hWnd,
+                id
+            )
+        );
+    }
+
+    RECT taskbarRect{};
+    GetWindowRect(
+        owner,
+        &taskbarRect
+    );
+
+    constexpr int width = 380;
+    constexpr int height = 220;
+
+    int x =
+        taskbarRect.right -
+        width -
+        20;
+
+    int y =
+        taskbarRect.top -
+        height -
+        10;
+
+    SetWindowPos(
+        hWnd,
+        HWND_TOPMOST,
+        x,
+        y,
+        width,
+        height,
+        SWP_SHOWWINDOW
+    );
+
+    MessageBeep(
+        MB_ICONEXCLAMATION
+    );
+
+    ShowWindow(
+        hWnd,
+        SW_SHOW
+    );
+
+    UpdateWindow(hWnd);
+
+    SetForegroundWindow(hWnd);
+
+    SetFocus(
+        GetDlgItem(
+            hWnd,
+            IDC_SNOOZE_MINUTES
+        )
+    );
+}
+
+
+static LRESULT CALLBACK TimerPopupWndProc(
+    HWND hWnd,
+    UINT msg,
+    WPARAM wParam,
+    LPARAM lParam)
+{
+    switch (msg)
+    {
+    case WM_ERASEBKGND:
+    {
+        RECT rect{};
+        GetClientRect(
+            hWnd,
+            &rect
+        );
+
+        FillRect(
+            reinterpret_cast<HDC>(wParam),
+            &rect,
+            g_popupBackgroundBrush
+        );
+
+        return 1;
+    }
+
+    case WM_CTLCOLORSTATIC:
+    {
+        HDC hdc =
+            reinterpret_cast<HDC>(wParam);
+
+        SetTextColor(
+            hdc,
+            kPopupText
+        );
+
+        SetBkColor(
+            hdc,
+            kPopupBackground
+        );
+
+        return reinterpret_cast<LRESULT>(
+            g_popupBackgroundBrush
+        );
+    }
+
+    case WM_CTLCOLOREDIT:
+    {
+        HDC hdc =
+            reinterpret_cast<HDC>(wParam);
+
+        SetTextColor(
+            hdc,
+            kPopupText
+        );
+
+        SetBkColor(
+            hdc,
+            kPopupEditBackground
+        );
+
+        return reinterpret_cast<LRESULT>(
+            g_popupEditBrush
+        );
+    }
+
+    case WM_COMMAND:
+        if (LOWORD(wParam) == IDC_START &&
+            HIWORD(wParam) == BN_CLICKED)
+        {
+            wchar_t reminder[256]{};
+            wchar_t minutesText[32]{};
+
+            GetWindowTextW(
+                GetDlgItem(
+                    hWnd,
+                    IDC_REMINDER
+                ),
+                reminder,
+                ARRAYSIZE(reminder)
+            );
+
+            GetWindowTextW(
+                GetDlgItem(
+                    hWnd,
+                    IDC_MINUTES
+                ),
+                minutesText,
+                ARRAYSIZE(minutesText)
+            );
+
+            int minutes =
+                _wtoi(minutesText);
+
+            if (minutes <= 0 ||
+                minutes > 1440)
+            {
+                MessageBoxW(
+                    hWnd,
+                    L"Enter a number of minutes between 1 and 1440.",
+                    L"Timer",
+                    MB_OK |
+                        MB_ICONWARNING
+                );
+
+                return 0;
+            }
+
+            if (!reminder[0]) {
+                wcsncpy_s(
+                    reminder,
+                    L"Timer finished",
+                    _TRUNCATE
+                );
+            }
+
+            HWND taskbar =
+                FindCurrentProcessTaskbarWnd();
+
+            if (!taskbar) {
+                Wh_Log(
+                    L"ERROR: Taskbar not found while starting timer"
+                );
+
+                return 0;
+            }
+
+            StartTimerRequest request{};
+            request.seconds =
+                minutes * 60;
+
+            wcsncpy_s(
+                request.reminder,
+                reminder,
+                _TRUNCATE
+            );
+
+            if (!RunFromWindowThread(
+                    taskbar,
+                    StartCountdownOnTaskbarThread,
+                    &request))
+            {
+                Wh_Log(
+                    L"ERROR: Could not start timer on taskbar thread"
+                );
+
+                return 0;
+            }
+
+            ShowWindow(
+                hWnd,
+                SW_HIDE
+            );
+
+            return 0;
+        }
+
+        if (LOWORD(wParam) == IDC_CLOSE_TIMER &&
+            HIWORD(wParam) == BN_CLICKED)
+        {
+            ShowWindow(
+                hWnd,
+                SW_HIDE
+            );
+
+            return 0;
+        }
+
+        if (LOWORD(wParam) == IDC_CANCEL_TIMER &&
+            HIWORD(wParam) == BN_CLICKED)
+        {
+            HWND taskbar =
+                FindCurrentProcessTaskbarWnd();
+
+            if (!taskbar) {
+                Wh_Log(
+                    L"ERROR: Taskbar not found while cancelling timer"
+                );
+
+                return 0;
+            }
+
+            if (!RunFromWindowThread(
+                    taskbar,
+                    CancelCountdownOnTaskbarThread,
+                    nullptr))
+            {
+                Wh_Log(
+                    L"ERROR: Could not cancel timer"
+                );
+
+                return 0;
+            }
+
+            ShowWindow(
+                hWnd,
+                SW_HIDE
+            );
+
+            return 0;
+        }
+
+        break;
+
+
+    case WM_APP_TIMER_SHOW:
+        ResetPopupForNewTimer(
+            hWnd
+        );
+
+        ShowWindow(
+            hWnd,
+            SW_SHOWNORMAL
+        );
+
+        SetWindowPos(
+            hWnd,
+            HWND_TOPMOST,
+            0,
+            0,
+            0,
+            0,
+            SWP_NOMOVE |
+                SWP_NOSIZE |
+                SWP_SHOWWINDOW
+        );
+
+        SetForegroundWindow(hWnd);
+
+        SetFocus(
+            GetDlgItem(
+                hWnd,
+                IDC_REMINDER
+            )
+        );
+
+        return 0;
+
+
+    case WM_APP_TIMER_FINISHED:
+        ShowWindow(
+            hWnd,
+            SW_HIDE
+        );
+
+        ShowFinishedPopup(
+            FindCurrentProcessTaskbarWnd()
+        );
+
+        return 0;
+
+
+    case WM_APP_TIMER_SHUTDOWN:
+        DestroyWindow(hWnd);
+        return 0;
+
+
+    case WM_CLOSE:
+        ShowWindow(
+            hWnd,
+            SW_HIDE
+        );
+
+        return 0;
+
+
+    case WM_DESTROY:
+        g_timerPopup = nullptr;
+        g_timerPopupThreadId = 0;
+
+        PostQuitMessage(0);
+        return 0;
+    }
+
+    return DefWindowProcW(
+        hWnd,
+        msg,
+        wParam,
+        lParam
+    );
+}
+
+
+static bool ShowTimerPopup(
+    HWND owner)
+{
+    static bool classRegistered = false;
+
+    if (!classRegistered) {
+        WNDCLASSW wc{};
+
+        wc.lpfnWndProc =
+            TimerPopupWndProc;
+
+        wc.hInstance =
+            GetModuleHandleW(nullptr);
+
+        wc.lpszClassName =
+            L"TaskbarCountdownTimerPopup";
+
+        wc.hCursor =
+            LoadCursorW(
+                nullptr,
+                IDC_ARROW
+            );
+
+        wc.hbrBackground =
+            reinterpret_cast<HBRUSH>(
+                COLOR_WINDOW + 1
+            );
+
+        if (!RegisterClassW(&wc) &&
+            GetLastError() !=
+                ERROR_CLASS_ALREADY_EXISTS)
+        {
+            Wh_Log(
+                L"ERROR: Could not register popup class"
+            );
+
+            return false;
+        }
+
+        classRegistered = true;
+    }
+
+    HWND hWnd = CreateWindowExW(
+        WS_EX_TOOLWINDOW |
+            WS_EX_TOPMOST,
+        L"TaskbarCountdownTimerPopup",
+        L"Timer",
+        WS_POPUP |
+            WS_BORDER,
+        CW_USEDEFAULT,
+        CW_USEDEFAULT,
+        380,
+        235,
+        owner,
+        nullptr,
+        GetModuleHandleW(nullptr),
+        nullptr
+    );
+
+    if (!hWnd) {
+        Wh_Log(
+            L"ERROR: Could not create timer popup"
+        );
+
+        return false;
+    }
+
+    ApplyModernWindowStyle(
+        hWnd
+    );
+
+    g_timerPopup = hWnd;
+    g_timerPopupThreadId =
+        GetCurrentThreadId();
+
+    CreateWindowExW(
+        0,
+        L"BUTTON",
+        L"×",
+        WS_CHILD |
+            WS_VISIBLE |
+            WS_TABSTOP |
+            BS_FLAT,
+        338,
+        8,
+        24,
+        24,
+        hWnd,
+        reinterpret_cast<HMENU>(
+            IDC_CLOSE_TIMER
+        ),
+        GetModuleHandleW(nullptr),
+        nullptr
+    );
+
+    CreateWindowExW(
+        0,
+        L"STATIC",
+        L"Reminder:",
+        WS_CHILD |
+            WS_VISIBLE,
+        20,
+        20,
+        300,
+        20,
+        hWnd,
+        reinterpret_cast<HMENU>(
+            IDC_REMINDER_LABEL
+        ),
+        GetModuleHandleW(nullptr),
+        nullptr
+    );
+
+    CreateWindowExW(
+        WS_EX_CLIENTEDGE,
+        L"EDIT",
+        L"",
+        WS_CHILD |
+            WS_VISIBLE |
+            WS_TABSTOP |
+            ES_AUTOHSCROLL,
+        20,
+        45,
+        340,
+        30,
+        hWnd,
+        reinterpret_cast<HMENU>(
+            IDC_REMINDER
+        ),
+        GetModuleHandleW(nullptr),
+        nullptr
+    );
+
+    CreateWindowExW(
+        0,
+        L"STATIC",
+        L"Minutes:",
+        WS_CHILD |
+            WS_VISIBLE,
+        20,
+        90,
+        150,
+        20,
+        hWnd,
+        reinterpret_cast<HMENU>(
+            IDC_MINUTES_LABEL
+        ),
+        GetModuleHandleW(nullptr),
+        nullptr
+    );
+
+    CreateWindowExW(
+        WS_EX_CLIENTEDGE,
+        L"EDIT",
+        L"20",
+        WS_CHILD |
+            WS_VISIBLE |
+            WS_TABSTOP |
+            ES_NUMBER,
+        20,
+        115,
+        110,
+        30,
+        hWnd,
+        reinterpret_cast<HMENU>(
+            IDC_MINUTES
+        ),
+        GetModuleHandleW(nullptr),
+        nullptr
+    );
+
+    CreateWindowExW(
+        0,
+        L"BUTTON",
+        L"Start",
+        WS_CHILD |
+            WS_VISIBLE |
+            WS_TABSTOP |
+            BS_PUSHBUTTON,
+        20,
+        165,
+        150,
+        35,
+        hWnd,
+        reinterpret_cast<HMENU>(
+            IDC_START
+        ),
+        GetModuleHandleW(nullptr),
+        nullptr
+    );
+
+    HWND cancelButton =
+        CreateWindowExW(
+            0,
+            L"BUTTON",
+            L"Cancel timer",
+            WS_CHILD |
+                WS_VISIBLE |
+                WS_TABSTOP |
+                BS_PUSHBUTTON,
+            195,
+            165,
+            165,
+            34,
+            hWnd,
+            reinterpret_cast<HMENU>(
+                IDC_CANCEL_TIMER
+            ),
+            GetModuleHandleW(nullptr),
+            nullptr
+        );
+
+    EnableWindow(
+        cancelButton,
+        g_secondsRemaining > 0
+    );
+
+    for (int id : {
+             IDC_REMINDER_LABEL,
+             IDC_REMINDER,
+             IDC_MINUTES_LABEL,
+             IDC_MINUTES,
+             IDC_START,
+             IDC_CANCEL_TIMER,
+             IDC_CLOSE_TIMER})
+    {
+        ApplyPopupFont(
+            GetDlgItem(
+                hWnd,
+                id
+            )
+        );
+    }
+
+    RECT taskbarRect{};
+
+    GetWindowRect(
+        owner,
+        &taskbarRect
+    );
+
+    constexpr int width = 380;
+    constexpr int height = 235;
+
+    int x =
+        taskbarRect.right -
+        width -
+        20;
+
+    int y =
+        taskbarRect.top -
+        height -
+        10;
+
+    SetWindowPos(
+        hWnd,
+        HWND_TOPMOST,
+        x,
+        y,
+        width,
+        height,
+        SWP_SHOWWINDOW
+    );
+
+    ShowWindow(
+        hWnd,
+        SW_SHOW
+    );
+
+    UpdateWindow(hWnd);
+
+    return true;
+}
+
+
+static DWORD WINAPI TimerPopupThreadProc(
+    LPVOID param)
+{
+    HWND taskbar =
+        reinterpret_cast<HWND>(param);
+
+    if (!ShowTimerPopup(taskbar)) {
+        return 0;
+    }
+
+    MSG msg{};
+
+    while (GetMessageW(
+               &msg,
+               nullptr,
+               0,
+               0) > 0)
+    {
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+
+    return 0;
+}
+
+
+static void OpenTimerPopup(
+    HWND taskbar)
+{
+    if (g_timerPopup) {
+        PostMessageW(
+            g_timerPopup,
+            WM_APP_TIMER_SHOW,
+            0,
+            0
+        );
+
+        return;
+    }
+
+    if (g_timerPopupThread) {
+        if (WaitForSingleObject(
+                g_timerPopupThread,
+                0) ==
+            WAIT_OBJECT_0)
+        {
+            CloseHandle(
+                g_timerPopupThread
+            );
+
+            g_timerPopupThread =
+                nullptr;
+        }
+        else {
+            // The thread is still starting.
+            return;
+        }
+    }
+
+    g_timerPopupThread =
+        CreateThread(
+            nullptr,
+            0,
+            TimerPopupThreadProc,
+            taskbar,
+            0,
+            nullptr
+        );
+
+    if (!g_timerPopupThread) {
+        Wh_Log(
+            L"ERROR: Could not create popup thread"
+        );
+    }
+}
+
+
+// -----------------------------------------------------------------------------
+// Add/remove taskbar button
+// -----------------------------------------------------------------------------
+
+static void AddTimerButton(
+    void* param)
+{
+    HWND taskbar =
+        reinterpret_cast<HWND>(param);
+
+    auto xamlRoot =
+        GetTaskbarXamlRoot(taskbar);
+
+    if (!xamlRoot) {
+        Wh_Log(
+            L"ERROR: Taskbar XamlRoot not obtained"
+        );
+
+        return;
+    }
+
+    auto content =
+        xamlRoot.Content()
+            .try_as<FrameworkElement>();
+
+    if (!content) {
+        Wh_Log(
+            L"ERROR: XamlRoot content unavailable"
+        );
+
+        return;
+    }
+
+    // SystemTrayFrameGrid is the live layout container for the notification
+    // area. On recent Windows 11 builds it can be a StackPanel instead of a
+    // Grid, while keeping the same element name.
+    auto tray =
+        FindChildRecursive(
+            content,
+            [](FrameworkElement element)
+            {
+                return
+                    element.Name() ==
+                    L"SystemTrayFrameGrid";
+            }
+        );
+
+    if (!tray) {
+        Wh_Log(
+            L"ERROR: SystemTrayFrameGrid not found"
+        );
+
+        return;
+    }
+
+    auto panel =
+        tray.try_as<Panel>();
+
+    if (!panel) {
+        Wh_Log(
+            L"ERROR: SystemTrayFrameGrid is not a Panel"
+        );
+
+        return;
+    }
+
+    // Remove a leftover instance if this mod was reloaded.
+    auto existing =
+        FindChildRecursive(
+            tray,
+            [](FrameworkElement element)
+            {
+                return
+                    element.Name() ==
+                    L"TaskbarCountdownTimerButton";
+            }
+        );
+
+    if (existing) {
+        auto parent =
+            VisualTreeHelper::GetParent(
+                existing
+            ).try_as<Panel>();
+
+        if (parent) {
+            auto children =
+                parent.Children();
+
+            uint32_t index = 0;
+
+            if (children.IndexOf(
+                    existing,
+                    index))
+            {
+                children.RemoveAt(index);
+            }
+        }
+    }
+
+    g_timerButton = Button();
+    g_timerText = TextBlock();
+
+    g_timerButton.Name(
+        L"TaskbarCountdownTimerButton"
+    );
+
+    g_timerText.Text(
+        L"⏱ Timer"
+    );
+
+    g_timerText.VerticalAlignment(
+        VerticalAlignment::Center
+    );
+
+    g_timerButton.Content(
+        g_timerText
+    );
+
+    g_timerButton.VerticalAlignment(
+        VerticalAlignment::Stretch
+    );
+
+    g_timerButton.Padding(
+        Thickness{8, 0, 8, 0}
+    );
+
+    g_timerButtonClickToken =
+        g_timerButton.Click(
+            [](
+                winrt::Windows::Foundation::
+                    IInspectable const&,
+                RoutedEventArgs const&)
+            {
+                HWND taskbar =
+                    FindCurrentProcessTaskbarWnd();
+
+                if (!taskbar) {
+                    Wh_Log(
+                        L"ERROR: Taskbar not found for popup"
+                    );
+
+                    return;
+                }
+
+                OpenTimerPopup(taskbar);
+            }
+        );
+
+    g_countdownTimer =
+        DispatcherTimer();
+
+    g_countdownTimer.Interval(
+        std::chrono::seconds(1)
+    );
+
+    g_timerTickToken =
+        g_countdownTimer.Tick(
+            [](
+                winrt::Windows::Foundation::
+                    IInspectable const&,
+                winrt::Windows::Foundation::
+                    IInspectable const&)
+            {
+                if (g_secondsRemaining <= 0) {
+                    g_countdownTimer.Stop();
+                    return;
+                }
+
+                g_secondsRemaining--;
+
+                if (g_secondsRemaining > 0) {
+                    if (g_timerText) {
+                        g_timerText.Text(
+                            FormatCountdown(
+                                g_secondsRemaining
+                            )
+                        );
+                    }
+
+                    return;
+                }
+
+                g_countdownTimer.Stop();
+
+                if (g_timerText) {
+                    g_timerText.Text(
+                        L"⏱ Timer"
+                    );
+                }
+
+                Wh_Log(
+                    L"Timer finished: '%s'",
+                    g_reminder
+                );
+
+                if (g_timerPopup) {
+                    PostMessageW(
+                        g_timerPopup,
+                        WM_APP_TIMER_FINISHED,
+                        0,
+                        0
+                    );
+                }
+            }
+        );
+
+    auto children =
+        panel.Children();
+
+    auto trayClass =
+        winrt::get_class_name(tray);
+
+    Wh_Log(
+        L"SystemTrayFrameGrid class: %s",
+        trayClass.c_str()
+    );
+
+    // "Before notification icons": on current Windows 11 builds the tray
+    // container is a StackPanel, so inserting at index 0 gives the timer its
+    // own layout slot instead of overlaying the hidden-icons button.
+    if (trayClass ==
+        L"Windows.UI.Xaml.Controls.StackPanel")
+    {
+        children.InsertAt(
+            0,
+            g_timerButton
+        );
+
+        Wh_Log(
+            L"Timer button inserted at start of tray StackPanel"
+        );
+
+        return;
+    }
+
+    // Fallback for builds where SystemTrayFrameGrid is still a Grid.
+    // Put the button in a new Auto column at the start and shift the existing
+    // children one column to the right.
+    auto trayGrid =
+        tray.try_as<Grid>();
+
+    if (trayGrid) {
+        auto columns =
+            trayGrid.ColumnDefinitions();
+
+        ColumnDefinition timerColumn;
+        timerColumn.Width(
+            GridLengthHelper::Auto()
+        );
+
+        columns.InsertAt(
+            0,
+            timerColumn
+        );
+
+        for (uint32_t i = 0;
+             i < children.Size();
+             i++)
+        {
+            auto child =
+                children.GetAt(i)
+                    .try_as<FrameworkElement>();
+
+            if (!child) {
+                continue;
+            }
+
+            int currentColumn =
+                Grid::GetColumn(child);
+
+            Grid::SetColumn(
+                child,
+                currentColumn + 1
+            );
+        }
+
+        Grid::SetColumn(
+            g_timerButton,
+            0
+        );
+
+        children.InsertAt(
+            0,
+            g_timerButton
+        );
+
+        Wh_Log(
+            L"Timer button inserted in new leading tray Grid column"
+        );
+
+        return;
+    }
+
+    Wh_Log(
+        L"ERROR: Unsupported SystemTrayFrameGrid layout class: %s",
+        trayClass.c_str()
+    );
+}
+
+static void RemoveTimerButton(
+    void*)
+{
+    if (g_countdownTimer) {
+        g_countdownTimer.Stop();
+
+        g_countdownTimer.Tick(
+            g_timerTickToken
+        );
+
+        g_countdownTimer =
+            nullptr;
+    }
+
+    g_secondsRemaining = 0;
+
+    if (g_timerButton) {
+        g_timerButton.Click(
+            g_timerButtonClickToken
+        );
+
+        auto parentElement =
+            VisualTreeHelper::GetParent(
+                g_timerButton
+            ).try_as<FrameworkElement>();
+
+        auto parent =
+            parentElement.try_as<Panel>();
+
+        if (parent) {
+            auto children =
+                parent.Children();
+
+            uint32_t index = 0;
+
+            if (children.IndexOf(
+                    g_timerButton,
+                    index))
+            {
+                children.RemoveAt(index);
+            }
+
+            // If the tray container is a Grid, v0.7 added one leading Auto
+            // column. Restore the original column indexes and remove it.
+            auto parentGrid =
+                parentElement.try_as<Grid>();
+
+            if (parentGrid) {
+                for (uint32_t i = 0;
+                     i < children.Size();
+                     i++)
+                {
+                    auto child =
+                        children.GetAt(i)
+                            .try_as<FrameworkElement>();
+
+                    if (!child) {
+                        continue;
+                    }
+
+                    int currentColumn =
+                        Grid::GetColumn(child);
+
+                    if (currentColumn > 0) {
+                        Grid::SetColumn(
+                            child,
+                            currentColumn - 1
+                        );
+                    }
+                }
+
+                auto columns =
+                    parentGrid.ColumnDefinitions();
+
+                if (columns.Size() > 0) {
+                    columns.RemoveAt(0);
+                }
+            }
+        }
+    }
+
+    g_timerText = nullptr;
+    g_timerButton = nullptr;
+}
+
+
+// -----------------------------------------------------------------------------
+// Windhawk
+// -----------------------------------------------------------------------------
+
+BOOL Wh_ModInit()
+{
+    Wh_Log(
+        L"Taskbar Countdown Timer loading"
+    );
+
+    HWND taskbar =
+        FindCurrentProcessTaskbarWnd();
+
+    if (!taskbar) {
+        Wh_Log(
+            L"ERROR: Taskbar not found"
+        );
+
+        return FALSE;
+    }
+
+    if (!HookTaskbarDllSymbols()) {
+        Wh_Log(
+            L"ERROR: Failed to resolve taskbar.dll symbols"
+        );
+
+        return FALSE;
+    }
+
+    if (!RunFromWindowThread(
+            taskbar,
+            AddTimerButton,
+            taskbar))
+    {
+        Wh_Log(
+            L"ERROR: Could not access taskbar XAML thread"
+        );
+
+        return FALSE;
+    }
+
+    Wh_Log(
+        L"Taskbar Countdown Timer loaded"
+    );
+
+    return TRUE;
+}
+
+
+void Wh_ModUninit()
+{
+    HWND taskbar =
+        FindCurrentProcessTaskbarWnd();
+
+    if (taskbar) {
+        RunFromWindowThread(
+            taskbar,
+            RemoveTimerButton,
+            nullptr
+        );
+    }
+
+    if (g_finishedPopup) {
+        PostMessageW(
+            g_finishedPopup,
+            WM_CLOSE,
+            0,
+            0
+        );
+    }
+
+    if (g_timerPopup) {
+        PostMessageW(
+            g_timerPopup,
+            WM_APP_TIMER_SHUTDOWN,
+            0,
+            0
+        );
+    }
+
+    if (g_timerPopupThread) {
+        WaitForSingleObject(
+            g_timerPopupThread,
+            2000
+        );
+
+        CloseHandle(
+            g_timerPopupThread
+        );
+
+        g_timerPopupThread =
+            nullptr;
+    }
+
+    g_finishedPopup = nullptr;
+    g_timerPopup = nullptr;
+    g_timerPopupThreadId = 0;
+
+    if (g_popupFont) {
+        DeleteObject(
+            g_popupFont
+        );
+
+        g_popupFont = nullptr;
+    }
+
+    if (g_popupEditBrush) {
+        DeleteObject(
+            g_popupEditBrush
+        );
+
+        g_popupEditBrush = nullptr;
+    }
+
+    if (g_popupBackgroundBrush) {
+        DeleteObject(
+            g_popupBackgroundBrush
+        );
+
+        g_popupBackgroundBrush = nullptr;
+    }
+
+    Wh_Log(
+        L"Taskbar Countdown Timer unloaded"
+    );
+}

--- a/mods/taskbar-countdown-timer.wh.cpp
+++ b/mods/taskbar-countdown-timer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-countdown-timer
 // @name            Taskbar Countdown Timer
 // @description     A simple countdown timer integrated into the Windows 11 taskbar (Windows 11 only)
-// @version         1.6
+// @version         1.7
 // @author          Richi
 // @github          https://github.com/richilp
 // @include         explorer.exe
@@ -91,7 +91,10 @@ static winrt::event_token g_timerTickToken{};
 
 static std::atomic<int> g_secondsRemaining{0};
 static std::atomic<ULONGLONG> g_deadlineTick{0};
-static wchar_t g_reminder[256]{};  // taskbar UI thread only
+static SRWLOCK g_reminderLock = SRWLOCK_INIT;
+static wchar_t g_reminder[256]{};
+
+static UINT_PTR g_deadlineThreadTimerId = 0;
 
 static std::atomic<HWND> g_timerPopup{nullptr};
 static std::atomic<HWND> g_finishedPopup{nullptr};
@@ -311,13 +314,6 @@ constexpr int IDC_FINISHED_TEXT   = 1105;
 
 constexpr UINT WM_APP_TIMER_SHOW =
     WM_APP + 1;
-
-constexpr UINT WM_APP_TIMER_FINISHED =
-    WM_APP + 2;
-
-constexpr UINT WM_APP_TIMER_SHUTDOWN =
-    WM_APP + 3;
-
 
 // -----------------------------------------------------------------------------
 // Popup DPI/layout helpers
@@ -1138,6 +1134,44 @@ static bool RunFromWindowThread(
 // Countdown
 // -----------------------------------------------------------------------------
 
+static void SetSharedReminder(
+    const wchar_t* reminder)
+{
+    AcquireSRWLockExclusive(
+        &g_reminderLock
+    );
+
+    wcsncpy_s(
+        g_reminder,
+        reminder ? reminder : L"",
+        _TRUNCATE
+    );
+
+    ReleaseSRWLockExclusive(
+        &g_reminderLock
+    );
+}
+
+
+static void GetSharedReminder(
+    wchar_t (&buffer)[256])
+{
+    AcquireSRWLockShared(
+        &g_reminderLock
+    );
+
+    wcsncpy_s(
+        buffer,
+        g_reminder,
+        _TRUNCATE
+    );
+
+    ReleaseSRWLockShared(
+        &g_reminderLock
+    );
+}
+
+
 static std::wstring FormatCountdown(
     int totalSeconds)
 {
@@ -1161,18 +1195,20 @@ static std::wstring FormatCountdown(
 }
 
 
-struct StartTimerRequest
+struct DisplayTimerRequest
 {
+    bool running;
     int seconds;
     wchar_t reminder[256];
+    bool succeeded;
 };
 
 
-static void StartCountdownOnTaskbarThread(
+static void UpdateCountdownDisplayOnTaskbarThread(
     void* param)
 {
     auto* request =
-        reinterpret_cast<StartTimerRequest*>(
+        reinterpret_cast<DisplayTimerRequest*>(
             param
         );
 
@@ -1185,57 +1221,278 @@ static void StartCountdownOnTaskbarThread(
 
     g_countdownTimer.Stop();
 
-    g_secondsRemaining.store(
-        request->seconds
-    );
+    if (request->running) {
+        g_timerText.Text(
+            FormatCountdown(
+                request->seconds
+            )
+        );
 
-    g_deadlineTick.store(
-        GetTickCount64() +
-        static_cast<ULONGLONG>(
-            request->seconds
-        ) * 1000ULL
-    );
-
-    wcsncpy_s(
-        g_reminder,
-        request->reminder,
-        _TRUNCATE
-    );
-
-    g_timerText.Text(
-        FormatCountdown(
-            request->seconds
-        )
-    );
-
-    g_countdownTimer.Start();
-
-    Wh_Log(
-        L"Timer started: '%s' - %d seconds",
-        g_reminder,
-        request->seconds
-    );
-}
-
-
-static void CancelCountdownOnTaskbarThread(
-    void*)
-{
-    if (g_countdownTimer) {
-        g_countdownTimer.Stop();
+        g_countdownTimer.Start();
     }
-
-    g_secondsRemaining.store(0);
-    g_deadlineTick.store(0);
-
-    if (g_timerText) {
+    else {
         g_timerText.Text(
             L"⏱ Timer"
         );
     }
 
+    request->succeeded = true;
+}
+
+
+static bool SyncCountdownDisplayToTaskbar(
+    bool running,
+    int seconds,
+    const wchar_t* reminder)
+{
+    HWND taskbar =
+        g_taskbarWnd.load();
+
+    if (!taskbar ||
+        !IsWindow(taskbar))
+    {
+        taskbar =
+            FindCurrentProcessTaskbarWnd();
+
+        if (taskbar) {
+            g_taskbarWnd.store(taskbar);
+        }
+    }
+
+    if (!taskbar) {
+        return false;
+    }
+
+    DisplayTimerRequest request{};
+    request.running = running;
+    request.seconds = seconds;
+    request.succeeded = false;
+
+    wcsncpy_s(
+        request.reminder,
+        reminder ? reminder : L"",
+        _TRUNCATE
+    );
+
+    if (!RunFromWindowThread(
+            taskbar,
+            UpdateCountdownDisplayOnTaskbarThread,
+            &request))
+    {
+        return false;
+    }
+
+    return request.succeeded;
+}
+
+
+static void ShowFinishedPopup(
+    HWND owner,
+    const wchar_t* reminderText);
+
+
+static bool StartAuthoritativeTimer(
+    int seconds,
+    const wchar_t* reminder)
+{
+    if (seconds <= 0 ||
+        g_unloading.load())
+    {
+        return false;
+    }
+
+    if (g_deadlineThreadTimerId) {
+        KillTimer(
+            nullptr,
+            g_deadlineThreadTimerId
+        );
+
+        g_deadlineThreadTimerId = 0;
+    }
+
+    ULONGLONG deadline =
+        GetTickCount64() +
+        static_cast<ULONGLONG>(
+            seconds
+        ) * 1000ULL;
+
+    g_deadlineTick.store(
+        deadline
+    );
+
+    g_secondsRemaining.store(
+        seconds
+    );
+
+    SetSharedReminder(
+        reminder && reminder[0]
+            ? reminder
+            : L"Timer finished"
+    );
+
+    g_deadlineThreadTimerId =
+        SetTimer(
+            nullptr,
+            0,
+            250,
+            nullptr
+        );
+
+    if (!g_deadlineThreadTimerId) {
+        g_deadlineTick.store(0);
+        g_secondsRemaining.store(0);
+
+        Wh_Log(
+            L"ERROR: Could not create authoritative timer"
+        );
+
+        return false;
+    }
+
+    wchar_t reminderCopy[256]{};
+    GetSharedReminder(
+        reminderCopy
+    );
+
+    if (!SyncCountdownDisplayToTaskbar(
+            true,
+            seconds,
+            reminderCopy))
+    {
+        Wh_Log(
+            L"WARNING: Timer armed, but taskbar display couldn't be updated"
+        );
+    }
+
+    Wh_Log(
+        L"Timer started: '%s' - %d seconds",
+        reminderCopy,
+        seconds
+    );
+
+    return true;
+}
+
+
+static bool CancelAuthoritativeTimer()
+{
+    if (g_deadlineThreadTimerId) {
+        KillTimer(
+            nullptr,
+            g_deadlineThreadTimerId
+        );
+
+        g_deadlineThreadTimerId = 0;
+    }
+
+    g_deadlineTick.store(0);
+    g_secondsRemaining.store(0);
+
+    wchar_t reminderCopy[256]{};
+    GetSharedReminder(
+        reminderCopy
+    );
+
+    if (!SyncCountdownDisplayToTaskbar(
+            false,
+            0,
+            reminderCopy))
+    {
+        Wh_Log(
+            L"WARNING: Timer cancelled, but taskbar display couldn't be updated"
+        );
+    }
+
     Wh_Log(
         L"Timer cancelled"
+    );
+
+    return true;
+}
+
+
+static void HandleAuthoritativeTimerTick()
+{
+    ULONGLONG deadline =
+        g_deadlineTick.load();
+
+    if (!deadline) {
+        if (g_deadlineThreadTimerId) {
+            KillTimer(
+                nullptr,
+                g_deadlineThreadTimerId
+            );
+
+            g_deadlineThreadTimerId = 0;
+        }
+
+        return;
+    }
+
+    ULONGLONG now =
+        GetTickCount64();
+
+    if (now < deadline) {
+        int remaining =
+            static_cast<int>(
+                (deadline -
+                 now +
+                 999ULL) /
+                1000ULL
+            );
+
+        g_secondsRemaining.store(
+            remaining
+        );
+
+        return;
+    }
+
+    if (g_deadlineThreadTimerId) {
+        KillTimer(
+            nullptr,
+            g_deadlineThreadTimerId
+        );
+
+        g_deadlineThreadTimerId = 0;
+    }
+
+    g_deadlineTick.store(0);
+    g_secondsRemaining.store(0);
+
+    wchar_t reminderCopy[256]{};
+    GetSharedReminder(
+        reminderCopy
+    );
+
+    // The alarm is owned by the popup thread. XAML is display-only now.
+    if (!SyncCountdownDisplayToTaskbar(
+            false,
+            0,
+            reminderCopy))
+    {
+        Wh_Log(
+            L"WARNING: Timer finished while taskbar display was unavailable"
+        );
+    }
+
+    Wh_Log(
+        L"Timer finished: '%s'",
+        reminderCopy
+    );
+
+    if (HWND timerPopup = g_timerPopup.load()) {
+        ShowWindow(
+            timerPopup,
+            SW_HIDE
+        );
+    }
+
+    ShowFinishedPopup(
+        g_taskbarWnd.load(),
+        reminderCopy[0]
+            ? reminderCopy
+            : L"Timer finished"
     );
 }
 
@@ -1496,21 +1753,6 @@ static LRESULT CALLBACK FinishedPopupWndProc(
                 L"Snooze minutes:"
             );
 
-            HWND taskbar =
-                FindCurrentProcessTaskbarWnd();
-
-            if (!taskbar) {
-                Wh_Log(
-                    L"ERROR: Taskbar not found while snoozing timer"
-                );
-
-                return 0;
-            }
-
-            StartTimerRequest request{};
-            request.seconds =
-                minutes * 60;
-
             wchar_t finishedReminder[256]{};
             GetWindowTextW(
                 GetDlgItem(
@@ -1521,18 +1763,11 @@ static LRESULT CALLBACK FinishedPopupWndProc(
                 ARRAYSIZE(finishedReminder)
             );
 
-            wcsncpy_s(
-                request.reminder,
-                finishedReminder[0]
-                    ? finishedReminder
-                    : L"Timer finished",
-                _TRUNCATE
-            );
-
-            if (!RunFromWindowThread(
-                    taskbar,
-                    StartCountdownOnTaskbarThread,
-                    &request))
+            if (!StartAuthoritativeTimer(
+                    minutes * 60,
+                    finishedReminder[0]
+                        ? finishedReminder
+                        : L"Timer finished"))
             {
                 Wh_Log(
                     L"ERROR: Could not snooze timer"
@@ -2047,34 +2282,12 @@ static LRESULT CALLBACK TimerPopupWndProc(
                 );
             }
 
-            HWND taskbar =
-                FindCurrentProcessTaskbarWnd();
-
-            if (!taskbar) {
-                Wh_Log(
-                    L"ERROR: Taskbar not found while starting timer"
-                );
-
-                return 0;
-            }
-
-            StartTimerRequest request{};
-            request.seconds =
-                minutes * 60;
-
-            wcsncpy_s(
-                request.reminder,
-                reminder,
-                _TRUNCATE
-            );
-
-            if (!RunFromWindowThread(
-                    taskbar,
-                    StartCountdownOnTaskbarThread,
-                    &request))
+            if (!StartAuthoritativeTimer(
+                    minutes * 60,
+                    reminder))
             {
                 Wh_Log(
-                    L"ERROR: Could not start timer on taskbar thread"
+                    L"ERROR: Could not start timer"
                 );
 
                 return 0;
@@ -2102,22 +2315,7 @@ static LRESULT CALLBACK TimerPopupWndProc(
         if (LOWORD(wParam) == IDC_CANCEL_TIMER &&
             HIWORD(wParam) == BN_CLICKED)
         {
-            HWND taskbar =
-                FindCurrentProcessTaskbarWnd();
-
-            if (!taskbar) {
-                Wh_Log(
-                    L"ERROR: Taskbar not found while cancelling timer"
-                );
-
-                return 0;
-            }
-
-            if (!RunFromWindowThread(
-                    taskbar,
-                    CancelCountdownOnTaskbarThread,
-                    nullptr))
-            {
+            if (!CancelAuthoritativeTimer()) {
                 Wh_Log(
                     L"ERROR: Could not cancel timer"
                 );
@@ -2197,28 +2395,6 @@ static LRESULT CALLBACK TimerPopupWndProc(
 
         return 0;
     }
-
-    case WM_APP_TIMER_FINISHED:
-    {
-        std::unique_ptr<std::wstring> finishedReminder(
-            reinterpret_cast<std::wstring*>(lParam)
-        );
-        ShowWindow(
-            hWnd,
-            SW_HIDE
-        );
-
-        ShowFinishedPopup(
-            g_taskbarWnd.load(),
-            finishedReminder ? finishedReminder->c_str() : L"Timer finished"
-        );
-
-        return 0;
-    }
-
-    case WM_APP_TIMER_SHUTDOWN:
-        DestroyWindow(hWnd);
-        return 0;
 
     case WM_CLOSE:
         ShowWindow(
@@ -2490,6 +2666,15 @@ static DWORD WINAPI TimerPopupThreadProc(
     while (!g_unloading.load() &&
            GetMessageW(&msg, nullptr, 0, 0) > 0)
     {
+        if (!msg.hwnd &&
+            msg.message == WM_TIMER &&
+            g_deadlineThreadTimerId &&
+            msg.wParam == g_deadlineThreadTimerId)
+        {
+            HandleAuthoritativeTimerTick();
+            continue;
+        }
+
         bool handled = false;
 
         if (HWND finished = g_finishedPopup.load()) {
@@ -2506,6 +2691,15 @@ static DWORD WINAPI TimerPopupThreadProc(
             TranslateMessage(&msg);
             DispatchMessageW(&msg);
         }
+    }
+
+    if (g_deadlineThreadTimerId) {
+        KillTimer(
+            nullptr,
+            g_deadlineThreadTimerId
+        );
+
+        g_deadlineThreadTimerId = 0;
     }
 
     if (HWND finished = g_finishedPopup.load()) {
@@ -2534,13 +2728,20 @@ static void OpenTimerPopup(
     HWND popup = g_timerPopup.load();
 
     if (popup) {
+        wchar_t reminderCopy[256]{};
+
+        if (g_secondsRemaining.load() > 0) {
+            GetSharedReminder(
+                reminderCopy
+            );
+        }
+
         PostStringMessage(
             popup,
             WM_APP_TIMER_SHOW,
-            g_secondsRemaining.load() > 0
-                ? g_reminder
-                : L""
+            reminderCopy
         );
+
         return;
     }
 
@@ -2734,6 +2935,12 @@ static void AddTimerButtonImpl(
                         g_countdownTimer.Stop();
                     }
 
+                    if (g_timerText) {
+                        g_timerText.Text(
+                            L"⏱ Timer"
+                        );
+                    }
+
                     return;
                 }
 
@@ -2741,9 +2948,6 @@ static void AddTimerButtonImpl(
                     GetTickCount64();
 
                 if (now >= deadline) {
-                    g_deadlineTick.store(0);
-                    g_secondsRemaining.store(0);
-
                     if (g_countdownTimer) {
                         g_countdownTimer.Stop();
                     }
@@ -2751,21 +2955,6 @@ static void AddTimerButtonImpl(
                     if (g_timerText) {
                         g_timerText.Text(
                             L"⏱ Timer"
-                        );
-                    }
-
-                    Wh_Log(
-                        L"Timer finished: '%s'",
-                        g_reminder
-                    );
-
-                    if (g_timerPopup.load() &&
-                        IsWindow(g_timerPopup.load()))
-                    {
-                        PostStringMessage(
-                            g_timerPopup.load(),
-                            WM_APP_TIMER_FINISHED,
-                            g_reminder
                         );
                     }
 
@@ -2905,18 +3094,10 @@ static void AddTimerButtonImpl(
             g_countdownTimer.Start();
         }
         else {
-            g_deadlineTick.store(0);
-            g_secondsRemaining.store(0);
-
-            if (g_timerPopup.load() &&
-                IsWindow(g_timerPopup.load()))
-            {
-                PostStringMessage(
-                    g_timerPopup.load(),
-                    WM_APP_TIMER_FINISHED,
-                    g_reminder
-                );
-            }
+            // The popup thread is authoritative and will deliver the alarm.
+            g_timerText.Text(
+                L"⏱ Timer"
+            );
         }
     }
 

--- a/mods/taskbar-countdown-timer.wh.cpp
+++ b/mods/taskbar-countdown-timer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-countdown-timer
 // @name            Taskbar Countdown Timer
 // @description     A simple countdown timer integrated into the Windows 11 taskbar (Windows 11 only)
-// @version         1.11
+// @version         1.12
 // @author          Richi
 // @github          https://github.com/richilp
 // @include         explorer.exe
@@ -155,7 +155,6 @@ static HANDLE g_timerStopEvent = nullptr;
 static HANDLE g_timerRearmEvent = nullptr;
 static HANDLE g_timerWaitable = nullptr;
 static HANDLE g_timerWorkerThread = nullptr;
-static std::atomic_bool g_timerWorkerStarted{false};
 
 // Completion alert is independent from the taskbar XAML tree.
 static std::atomic<HWND> g_finishedAlertWnd{nullptr};
@@ -166,14 +165,12 @@ static bool g_finishedAlertClassRegistered = false;
 
 static std::atomic<HWND> g_taskbarWnd{nullptr};
 static std::atomic<DWORD> g_taskbarThreadId{0};
-static std::atomic_bool g_buttonInjected{false};
 static std::atomic_bool g_systemTrayModuleHooked{false};
 static std::atomic<HMODULE> g_systemTrayModuleAttempted{nullptr};
 
 static std::atomic_bool g_unloading{false};
 
 static void ApplyTimerButtonIfAvailable();
-static bool EnsureTimerWorkerStarted();
 
 // -----------------------------------------------------------------------------
 // XAML helpers
@@ -1017,14 +1014,6 @@ static bool ArmTimer(
         minutes > settings.maximumMinutes ||
         g_unloading.load())
     {
-        return false;
-    }
-
-    if (!EnsureTimerWorkerStarted()) {
-        Wh_Log(
-            L"ERROR: Timer worker isn't available"
-        );
-
         return false;
     }
 
@@ -1940,6 +1929,14 @@ static LRESULT CALLBACK FinishedAlertWndProc(
                 return 0;
             }
 
+            SetWindowTextW(
+                GetDlgItem(
+                    hWnd,
+                    IDC_ALERT_SNOOZE_LABEL
+                ),
+                L"Snooze minutes:"
+            );
+
             const wchar_t* reminder =
                 data && data->reminder[0]
                     ? data->reminder
@@ -2198,15 +2195,10 @@ static bool ShowFinishedAlert(const wchar_t* reminder)
     }
 
     if (!g_finishedAlertStopEvent) {
-        g_finishedAlertStopEvent =
-            CreateEventW(nullptr, TRUE, FALSE, nullptr);
-
-        if (!g_finishedAlertStopEvent) {
-            Wh_Log(
-                L"ERROR: Could not create completion alert stop event"
-            );
-            return false;
-        }
+        Wh_Log(
+            L"ERROR: Completion alert stop event isn't available"
+        );
+        return false;
     }
 
     ResetEvent(g_finishedAlertStopEvent);
@@ -2518,16 +2510,8 @@ static void RestorePersistedTimer()
 }
 
 
-static bool EnsureTimerWorkerStarted()
+static bool StartTimerWorkerFromInit()
 {
-    if (g_timerWorkerStarted.load()) {
-        return true;
-    }
-
-    if (g_unloading.load()) {
-        return false;
-    }
-
     g_timerStopEvent =
         CreateEventW(
             nullptr,
@@ -2551,28 +2535,22 @@ static bool EnsureTimerWorkerStarted()
             nullptr
         );
 
-    if (!g_timerStopEvent ||
-        !g_timerRearmEvent ||
-        !g_timerWaitable)
-    {
-        Wh_Log(
-            L"ERROR: Could not create timer worker objects"
+    g_finishedAlertStopEvent =
+        CreateEventW(
+            nullptr,
+            TRUE,
+            FALSE,
+            nullptr
         );
 
-        if (g_timerWaitable) {
-            CloseHandle(g_timerWaitable);
-            g_timerWaitable = nullptr;
-        }
-
-        if (g_timerRearmEvent) {
-            CloseHandle(g_timerRearmEvent);
-            g_timerRearmEvent = nullptr;
-        }
-
-        if (g_timerStopEvent) {
-            CloseHandle(g_timerStopEvent);
-            g_timerStopEvent = nullptr;
-        }
+    if (!g_timerStopEvent ||
+        !g_timerRearmEvent ||
+        !g_timerWaitable ||
+        !g_finishedAlertStopEvent)
+    {
+        Wh_Log(
+            L"ERROR: Could not create timer synchronization objects"
+        );
 
         return false;
     }
@@ -2592,24 +2570,11 @@ static bool EnsureTimerWorkerStarted()
             L"ERROR: Could not create timer worker thread"
         );
 
-        CloseHandle(g_timerWaitable);
-        g_timerWaitable = nullptr;
-
-        CloseHandle(g_timerRearmEvent);
-        g_timerRearmEvent = nullptr;
-
-        CloseHandle(g_timerStopEvent);
-        g_timerStopEvent = nullptr;
-
         return false;
     }
 
     g_timerWorkerThread =
         thread;
-
-    g_timerWorkerStarted.store(true);
-
-    RestorePersistedTimer();
 
     return true;
 }
@@ -2754,7 +2719,6 @@ static void AddTimerButtonImpl(
         VisualTreeHelper::GetParent(
             g_timerButton))
     {
-        g_buttonInjected.store(true);
         return;
     }
 
@@ -2827,7 +2791,6 @@ static void AddTimerButtonImpl(
             g_timerButton))
     {
         g_taskbarWnd.store(taskbar);
-        g_buttonInjected.store(true);
         return;
     }
 
@@ -2998,13 +2961,6 @@ static void AddTimerButtonImpl(
     }
 
     g_taskbarWnd.store(taskbar);
-    g_buttonInjected.store(true);
-
-    if (!EnsureTimerWorkerStarted()) {
-        Wh_Log(
-            L"ERROR: Timer worker could not be started"
-        );
-    }
 
     int remaining =
         RemainingSeconds(
@@ -3146,7 +3102,6 @@ static void RemoveTimerButtonImpl(
     g_timerColumn = nullptr;
     g_timerText = nullptr;
     g_timerButton = nullptr;
-    g_buttonInjected.store(false);
 }
 
 
@@ -3390,8 +3345,7 @@ static void* WINAPI IconView_IconView_Hook(
                 }
 
                 // A new IconView means the tray may have rebuilt its XAML tree.
-                g_buttonInjected.store(false);
-                ApplyTimerButtonIfAvailable();
+                            ApplyTimerButtonIfAvailable();
             }
         );
     }
@@ -3517,6 +3471,9 @@ static DWORD PumpWaitForThread(
 // Windhawk
 // -----------------------------------------------------------------------------
 
+static void StopTimerWorker();
+
+
 BOOL Wh_ModInit()
 {
     Wh_Log(
@@ -3531,7 +3488,55 @@ BOOL Wh_ModInit()
         return FALSE;
     }
 
+    if (!StartTimerWorkerFromInit()) {
+        UnregisterFinishedAlertClass();
+        return FALSE;
+    }
+
     if (!HookTaskbarDllSymbols()) {
+        StopTimerWorker();
+
+        if (g_timerWorkerThread) {
+            PumpWaitForThread(
+                g_timerWorkerThread
+            );
+
+            CloseHandle(
+                g_timerWorkerThread
+            );
+
+            g_timerWorkerThread = nullptr;
+        }
+
+        if (g_timerWaitable) {
+            CloseHandle(
+                g_timerWaitable
+            );
+            g_timerWaitable = nullptr;
+        }
+
+        if (g_timerRearmEvent) {
+            CloseHandle(
+                g_timerRearmEvent
+            );
+            g_timerRearmEvent = nullptr;
+        }
+
+        if (g_timerStopEvent) {
+            CloseHandle(
+                g_timerStopEvent
+            );
+            g_timerStopEvent = nullptr;
+        }
+
+        if (g_finishedAlertStopEvent) {
+            CloseHandle(
+                g_finishedAlertStopEvent
+            );
+            g_finishedAlertStopEvent = nullptr;
+        }
+
+        UnregisterFinishedAlertClass();
         UnregisterFinishedAlertClass();
         Wh_Log(
             L"ERROR: Failed to resolve taskbar.dll symbols"
@@ -3541,13 +3546,10 @@ BOOL Wh_ModInit()
     }
 
     bool systemTrayHookedAtInit = false;
-    bool systemTrayModuleLoadedAtInit = false;
 
     if (HMODULE systemTray =
             GetSystemTrayModuleHandle())
     {
-        systemTrayModuleLoadedAtInit = true;
-
         g_systemTrayModuleAttempted.store(
             systemTray
         );
@@ -3563,13 +3565,17 @@ BOOL Wh_ModInit()
             );
         }
         else {
+            g_systemTrayModuleAttempted.store(
+                nullptr
+            );
+
             Wh_Log(
                 L"ERROR: Failed to hook system tray symbols"
             );
         }
     }
 
-    if (!systemTrayModuleLoadedAtInit) {
+    if (!systemTrayHookedAtInit) {
         HMODULE kernelbase =
             GetModuleHandleW(
                 L"kernelbase.dll"
@@ -3601,6 +3607,8 @@ BOOL Wh_ModInit()
 
 void Wh_ModAfterInit()
 {
+    RestorePersistedTimer();
+
     if (HMODULE systemTray =
             GetSystemTrayModuleHandle())
     {
@@ -3629,7 +3637,8 @@ void Wh_ModBeforeUninit()
 
     StopTimerWorker();
 
-    // First teardown attempt while the taskbar thread is still available.
+    // Primary teardown attempt while the taskbar thread is still available.
+    // Wh_ModUninit performs one final best-effort retry after worker threads stop.
     if (!TryRemoveTimerXaml()) {
         Wh_Log(
             L"Timer XAML teardown will be retried in Wh_ModUninit"
@@ -3658,7 +3667,6 @@ void Wh_ModUninit()
         g_timerWorkerThread = nullptr;
     }
 
-    g_timerWorkerStarted.store(false);
 
     // Only after the timer worker is gone can no new alert thread be created.
     if (g_finishedAlertStopEvent) {
@@ -3787,4 +3795,3 @@ void Wh_ModSettingsChanged()
         );
     }
 }
-

--- a/mods/taskbar-countdown-timer.wh.cpp
+++ b/mods/taskbar-countdown-timer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-countdown-timer
 // @name            Taskbar Countdown Timer
 // @description     A simple countdown timer integrated into the Windows 11 taskbar (Windows 11 only)
-// @version         1.14
+// @version         1.15
 // @author          Richi
 // @github          https://github.com/richilp
 // @include         explorer.exe
@@ -93,6 +93,7 @@ The mod supports one active timer at a time and currently places its button on t
 #include <functional>
 #include <list>
 #include <memory>
+#include <new>
 #include <optional>
 #include <cwchar>
 #include <string>
@@ -160,6 +161,7 @@ static HANDLE g_timerWorkerThread = nullptr;
 static std::atomic<HWND> g_finishedAlertWnd{nullptr};
 static std::atomic<HANDLE> g_finishedAlertThread{nullptr};
 static HANDLE g_finishedAlertStopEvent = nullptr;
+static SRWLOCK g_finishedAlertLock = SRWLOCK_INIT;
 static HINSTANCE g_modInstance = nullptr;
 static bool g_finishedAlertClassRegistered = false;
 
@@ -169,6 +171,7 @@ static std::atomic_bool g_systemTrayModuleHooked{false};
 static std::atomic<HMODULE> g_systemTrayModuleAttempted{nullptr};
 
 static std::atomic_bool g_unloading{false};
+static std::atomic_bool g_xamlTornDown{false};
 
 static void ApplyTimerButtonIfAvailable();
 
@@ -1373,6 +1376,7 @@ constexpr int IDC_ALERT_SNOOZE_LABEL = 2101;
 constexpr int IDC_ALERT_SNOOZE_MINUTES = 2102;
 constexpr int IDC_ALERT_SNOOZE = 2103;
 constexpr int IDC_ALERT_DISMISS = 2104;
+constexpr UINT WM_APP_ALERT_REFRESH = WM_APP + 20;
 
 static constexpr wchar_t kFinishedAlertClass[] =
     L"TaskbarCountdownTimerFinishedAlert";
@@ -1536,6 +1540,23 @@ static void ApplyFinishedAlertTheme(
         DWMWA_WINDOW_CORNER_PREFERENCE_LOCAL,
         &corner,
         sizeof(corner)
+    );
+
+    // Point every child at the new font/theme before deleting the old GDI
+    // resources they may still reference.
+    EnumChildWindows(
+        hWnd,
+        [](
+            HWND child,
+            LPARAM) -> BOOL
+        {
+            ThemeFinishedAlertChild(
+                child
+            );
+
+            return TRUE;
+        },
+        0
     );
 
     InvalidateRect(
@@ -1878,8 +1899,15 @@ static LRESULT CALLBACK FinishedAlertWndProc(
             g_finishedAlertBackgroundColor
         );
 
-        return reinterpret_cast<LRESULT>(
+        HBRUSH brush =
             g_finishedAlertBackgroundBrush
+                ? g_finishedAlertBackgroundBrush
+                : GetSysColorBrush(
+                      COLOR_WINDOW
+                  );
+
+        return reinterpret_cast<LRESULT>(
+            brush
         );
     }
 
@@ -1898,8 +1926,15 @@ static LRESULT CALLBACK FinishedAlertWndProc(
             g_finishedAlertEditBackgroundColor
         );
 
-        return reinterpret_cast<LRESULT>(
+        HBRUSH brush =
             g_finishedAlertEditBrush
+                ? g_finishedAlertEditBrush
+                : GetSysColorBrush(
+                      COLOR_WINDOW
+                  );
+
+        return reinterpret_cast<LRESULT>(
+            brush
         );
     }
 
@@ -1924,6 +1959,65 @@ static LRESULT CALLBACK FinishedAlertWndProc(
             );
         }
         return 0;
+
+    case WM_APP_ALERT_REFRESH:
+    {
+        auto* incoming =
+            reinterpret_cast<
+                FinishedAlertData*>(
+                lParam
+            );
+
+        if (incoming) {
+            auto* current =
+                reinterpret_cast<
+                    FinishedAlertData*>(
+                    GetWindowLongPtrW(
+                        hWnd,
+                        GWLP_USERDATA
+                    )
+                );
+
+            if (current) {
+                *current =
+                    *incoming;
+
+                SetWindowTextW(
+                    GetDlgItem(
+                        hWnd,
+                        IDC_ALERT_REMINDER
+                    ),
+                    current->reminder[0]
+                        ? current->reminder
+                        : L"Timer finished"
+                );
+
+                wchar_t snoozeText[32]{};
+                swprintf_s(
+                    snoozeText,
+                    L"%d",
+                    current->defaultSnoozeMinutes
+                );
+
+                SetWindowTextW(
+                    GetDlgItem(
+                        hWnd,
+                        IDC_ALERT_SNOOZE_MINUTES
+                    ),
+                    snoozeText
+                );
+            }
+
+            delete incoming;
+        }
+
+        FlashWindow(
+            hWnd,
+            TRUE
+        );
+
+        return 0;
+    }
 
     case WM_COMMAND:
     {
@@ -2110,6 +2204,11 @@ static DWORD WINAPI FinishedAlertThreadProc(LPVOID param)
         dpi = 96;
     }
 
+    SIZE windowSize =
+        GetFinishedAlertWindowSize(
+            dpi
+        );
+
     HWND hWnd =
         CreateWindowExW(
             WS_EX_TOOLWINDOW | WS_EX_TOPMOST,
@@ -2118,8 +2217,8 @@ static DWORD WINAPI FinishedAlertThreadProc(LPVOID param)
             WS_POPUP | WS_CAPTION | WS_SYSMENU,
             CW_USEDEFAULT,
             CW_USEDEFAULT,
-            GetFinishedAlertWindowSize(dpi).cx,
-            GetFinishedAlertWindowSize(dpi).cy,
+            windowSize.cx,
+            windowSize.cy,
             nullptr,
             nullptr,
             g_modInstance,
@@ -2216,7 +2315,7 @@ static void CloseFinishedAlertThreadIfExited()
     }
 }
 
-static bool ShowFinishedAlert(const wchar_t* reminder)
+static bool ShowFinishedAlertLocked(const wchar_t* reminder)
 {
     if (g_unloading.load()) {
         return false;
@@ -2226,6 +2325,40 @@ static bool ShowFinishedAlert(const wchar_t* reminder)
 
     if (HWND existing = g_finishedAlertWnd.load()) {
         if (IsWindow(existing)) {
+            auto* refresh =
+                new (std::nothrow)
+                    FinishedAlertData{};
+
+            if (refresh) {
+                wcsncpy_s(
+                    refresh->reminder,
+                    reminder && reminder[0]
+                        ? reminder
+                        : L"Timer finished",
+                    _TRUNCATE
+                );
+
+                ModSettings settings =
+                    GetSettingsSnapshot();
+
+                refresh->defaultSnoozeMinutes =
+                    settings.defaultSnoozeMinutes;
+
+                refresh->maximumMinutes =
+                    settings.maximumMinutes;
+
+                if (!PostMessageW(
+                        existing,
+                        WM_APP_ALERT_REFRESH,
+                        0,
+                        reinterpret_cast<LPARAM>(
+                            refresh
+                        )))
+                {
+                    delete refresh;
+                }
+            }
+
             FlashWindow(existing, TRUE);
             return true;
         }
@@ -2283,6 +2416,30 @@ static bool ShowFinishedAlert(const wchar_t* reminder)
     g_finishedAlertThread.store(thread);
     return true;
 }
+
+static bool ShowFinishedAlert(
+    const wchar_t* reminder)
+{
+    AcquireSRWLockExclusive(
+        &g_finishedAlertLock
+    );
+
+    bool result = false;
+
+    if (!g_unloading.load()) {
+        result =
+            ShowFinishedAlertLocked(
+                reminder
+            );
+    }
+
+    ReleaseSRWLockExclusive(
+        &g_finishedAlertLock
+    );
+
+    return result;
+}
+
 
 static void TimerExpiredOnTaskbarThread(void*)
 {
@@ -2691,6 +2848,92 @@ static bool SameWinrtObject(
 }
 
 
+static void DetachOwnedTimerVisuals()
+{
+    if (!g_timerButton) {
+        return;
+    }
+
+    auto parentElement =
+        VisualTreeHelper::GetParent(
+            g_timerButton
+        ).try_as<FrameworkElement>();
+
+    auto parent =
+        parentElement.try_as<Panel>();
+
+    if (!parent) {
+        return;
+    }
+
+    auto children =
+        parent.Children();
+
+    uint32_t buttonIndex = 0;
+
+    if (children.IndexOf(
+            g_timerButton,
+            buttonIndex))
+    {
+        children.RemoveAt(
+            buttonIndex
+        );
+    }
+
+    auto parentGrid =
+        parentElement.try_as<Grid>();
+
+    if (!parentGrid ||
+        !g_timerColumn)
+    {
+        return;
+    }
+
+    auto columns =
+        parentGrid.ColumnDefinitions();
+
+    uint32_t columnIndex = 0;
+
+    if (!columns.IndexOf(
+            g_timerColumn,
+            columnIndex))
+    {
+        return;
+    }
+
+    for (uint32_t i = 0;
+         i < children.Size();
+         i++)
+    {
+        auto child =
+            children.GetAt(i)
+                .try_as<FrameworkElement>();
+
+        if (!child) {
+            continue;
+        }
+
+        int currentColumn =
+            Grid::GetColumn(child);
+
+        if (currentColumn >
+            static_cast<int>(
+                columnIndex
+            ))
+        {
+            Grid::SetColumn(
+                child,
+                currentColumn - 1
+            );
+        }
+    }
+
+    columns.RemoveAt(
+        columnIndex
+    );
+}
+
+
 static void ReleaseOwnedXamlForRebuild()
 {
     HideAndReleaseFlyouts();
@@ -2707,9 +2950,11 @@ static void ReleaseOwnedXamlForRebuild()
         g_timerButton.Click(
             g_timerButtonClickToken
         );
-        g_timerButton = nullptr;
     }
 
+    DetachOwnedTimerVisuals();
+
+    g_timerButton = nullptr;
     g_timerText = nullptr;
     g_timerColumn = nullptr;
 }
@@ -3056,77 +3301,7 @@ static void RemoveTimerButtonImpl(
     }
 
     // Best-effort visual-tree detachment follows after all callbacks are gone.
-    if (g_timerButton) {
-        auto parentElement =
-            VisualTreeHelper::GetParent(
-                g_timerButton
-            ).try_as<FrameworkElement>();
-
-        auto parent =
-            parentElement.try_as<Panel>();
-
-        if (parent) {
-            auto children =
-                parent.Children();
-
-            uint32_t index = 0;
-
-            if (children.IndexOf(
-                    g_timerButton,
-                    index))
-            {
-                children.RemoveAt(index);
-            }
-
-            auto parentGrid =
-                parentElement.try_as<Grid>();
-
-            if (parentGrid &&
-                g_timerColumn)
-            {
-                auto columns =
-                    parentGrid.ColumnDefinitions();
-
-                uint32_t columnIndex = 0;
-
-                if (columns.IndexOf(
-                        g_timerColumn,
-                        columnIndex))
-                {
-                    for (uint32_t i = 0;
-                         i < children.Size();
-                         i++)
-                    {
-                        auto child =
-                            children.GetAt(i)
-                                .try_as<FrameworkElement>();
-
-                        if (!child) {
-                            continue;
-                        }
-
-                        int currentColumn =
-                            Grid::GetColumn(child);
-
-                        if (currentColumn >
-                            static_cast<int>(
-                                columnIndex
-                            ))
-                        {
-                            Grid::SetColumn(
-                                child,
-                                currentColumn - 1
-                            );
-                        }
-                    }
-
-                    columns.RemoveAt(
-                        columnIndex
-                    );
-                }
-            }
-        }
-    }
+    DetachOwnedTimerVisuals();
 
     g_timerColumn = nullptr;
     g_timerText = nullptr;
@@ -3518,6 +3693,7 @@ BOOL Wh_ModInit()
     );
 
     g_unloading.store(false);
+    g_xamlTornDown.store(false);
 
     LoadSettings();
 
@@ -3643,11 +3819,17 @@ void Wh_ModBeforeUninit()
 
     StopTimerWorker();
 
-    // Primary teardown attempt while the taskbar thread is still available.
-    // Wh_ModUninit performs one final best-effort retry after worker threads stop.
-    if (!TryRemoveTimerXaml()) {
+    // Primary teardown attempt while the taskbar UI thread is still available.
+    bool tornDown =
+        TryRemoveTimerXaml();
+
+    g_xamlTornDown.store(
+        tornDown
+    );
+
+    if (!tornDown) {
         Wh_Log(
-            L"Timer XAML teardown will be retried in Wh_ModUninit"
+            L"Initial timer XAML teardown failed; will retry in Wh_ModUninit"
         );
     }
 }
@@ -3674,7 +3856,13 @@ void Wh_ModUninit()
     }
 
 
-    // Only after the timer worker is gone can no new alert thread be created.
+    // Only after the timer worker is gone can no new alert be requested by it.
+    // Serialize ownership with ShowFinishedAlert in case another caller is
+    // concurrently leaving the initialization path.
+    AcquireSRWLockExclusive(
+        &g_finishedAlertLock
+    );
+
     if (g_finishedAlertStopEvent) {
         SetEvent(
             g_finishedAlertStopEvent
@@ -3692,11 +3880,16 @@ void Wh_ModUninit()
         );
     }
 
-    if (HANDLE alertThread =
-            g_finishedAlertThread.exchange(
-                nullptr
-            ))
-    {
+    HANDLE alertThread =
+        g_finishedAlertThread.exchange(
+            nullptr
+        );
+
+    ReleaseSRWLockExclusive(
+        &g_finishedAlertLock
+    );
+
+    if (alertThread) {
         PumpWaitForThread(
             alertThread
         );
@@ -3706,14 +3899,21 @@ void Wh_ModUninit()
         );
     }
 
-    // Final best-effort XAML teardown only if the first attempt left an
-    // owned button behind.
-    if (g_timerButton &&
-        !TryRemoveTimerXaml())
-    {
-        Wh_Log(
-            L"ERROR: Could not dispatch final timer XAML teardown"
+    // Retry whenever the first teardown didn't complete. Loaded revokers can
+    // exist even when no timer button was ever created.
+    if (!g_xamlTornDown.load()) {
+        bool tornDown =
+            TryRemoveTimerXaml();
+
+        g_xamlTornDown.store(
+            tornDown
         );
+
+        if (!tornDown) {
+            Wh_Log(
+                L"ERROR: Could not complete final timer XAML teardown"
+            );
+        }
     }
 
     CleanupTimerObjects();

--- a/mods/taskbar-countdown-timer.wh.cpp
+++ b/mods/taskbar-countdown-timer.wh.cpp
@@ -2,12 +2,12 @@
 // @id              taskbar-countdown-timer
 // @name            Taskbar Countdown Timer
 // @description     A simple countdown timer integrated into the Windows 11 taskbar (Windows 11 only)
-// @version         1.7
+// @version         1.9.1
 // @author          Richi
 // @github          https://github.com/richilp
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lole32 -loleaut32 -lruntimeobject -ldwmapi -lgdi32 -lversion
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lversion -ldwmapi -lgdi32 -luxtheme
 // @license         MIT
 // ==/WindhawkMod==
 
@@ -15,37 +15,60 @@
 /*
 # Taskbar Countdown Timer
 
-A lightweight countdown timer integrated directly into the Windows 11 taskbar.
-
-Click **⏱ Timer** to create a countdown with a custom reminder and duration.
-While the timer is running, the remaining time is shown directly on the taskbar.
+Adds a compact countdown timer directly to the Windows 11 taskbar.
 
 ## Features
 
-- Countdown timer directly in the Windows 11 taskbar
-- Custom reminder text
-- Live remaining time in the taskbar
+- Create a countdown in minutes from the taskbar
+- Add a custom reminder message
+- Live countdown display in the taskbar
 - Cancel an active timer
-- Snooze a finished timer for a custom number of minutes
-- Separate completion popup with sound
-- Modern Windows 11-style popup interface
-- Close button on timer and completion popups
+- Snooze a completed timer
+- Completion sound
+- Reliable completion alert that doesn't depend on the taskbar XAML tree
+- Timer state survives Explorer restarts and mod reloads
+- Native XAML flyout for timer configuration
+- Completion alert follows the Windows light/dark app theme
 - No external application required
 
 ## How to use
 
 1. Click **⏱ Timer** on the taskbar.
-2. Enter a reminder, for example `Take pizza out of the oven`.
-3. Enter the duration in minutes.
-4. Click **Start**.
-5. When the countdown finishes, choose **Snooze** or **Dismiss**.
+2. Enter a reminder and duration.
+3. Click **Start**.
+4. The taskbar button shows the remaining time.
+5. When the countdown finishes, a completion alert appears with **Snooze** and **Dismiss**.
 
-## Screenshot
+The mod supports one active timer at a time and currently places its button on the primary taskbar.
 
 ![Taskbar Countdown Timer](https://raw.githubusercontent.com/richilp/taskbar-countdown-timer/main/16c5364b-0834-4a83-8796-1f6b1df4f702.png)
-
 */
 // ==/WindhawkModReadme==
+
+
+// ==WindhawkModSettings==
+/*
+- defaultMinutes: 20
+  $name: Default timer duration (minutes)
+  $description: Default duration shown when creating a new timer.
+
+- defaultSnoozeMinutes: 5
+  $name: Default snooze duration (minutes)
+  $description: Default duration shown in the snooze field.
+
+- maximumMinutes: 1440
+  $name: Maximum duration (minutes)
+  $description: Maximum value accepted for timers and snoozes.
+
+- buttonLabel: "⏱ Timer"
+  $name: Idle taskbar button label
+  $description: Text shown on the taskbar when no timer is running.
+
+- completionSound: true
+  $name: Play completion sound
+  $description: Play a Windows notification sound when the timer finishes.
+*/
+// ==/WindhawkModSettings==
 
 
 #ifdef GetCurrentTime
@@ -55,15 +78,16 @@ While the timer is running, the remaining time is shown directly on the taskbar.
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <climits>
+#include <dwmapi.h>
+#include <uxtheme.h>
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
 #include <list>
-#include <memory>
 #include <optional>
 #include <cwchar>
 #include <string>
-#include <dwmapi.h>
 #include <windhawk_utils.h>
 
 #include <winrt/Windows.Foundation.h>
@@ -76,6 +100,7 @@ While the timer is running, the remaining time is shown directly on the taskbar.
 using namespace winrt::Windows::UI::Xaml;
 using namespace winrt::Windows::UI::Xaml::Controls;
 using namespace winrt::Windows::UI::Xaml::Media;
+namespace Controls = winrt::Windows::UI::Xaml::Controls;
 
 
 // -----------------------------------------------------------------------------
@@ -85,560 +110,62 @@ using namespace winrt::Windows::UI::Xaml::Media;
 [[clang::no_destroy]] static Button g_timerButton{nullptr};
 [[clang::no_destroy]] static TextBlock g_timerText{nullptr};
 [[clang::no_destroy]] static DispatcherTimer g_countdownTimer{nullptr};
+[[clang::no_destroy]] static ColumnDefinition g_timerColumn{nullptr};
+
+[[clang::no_destroy]] static Flyout g_timerFlyout{nullptr};
+[[clang::no_destroy]] static TextBox g_timerReminderBox{nullptr};
+[[clang::no_destroy]] static TextBox g_timerMinutesBox{nullptr};
+[[clang::no_destroy]] static Button g_timerStartButton{nullptr};
+[[clang::no_destroy]] static Button g_timerCancelButton{nullptr};
+
+[[clang::no_destroy]] static std::optional<
+    std::list<FrameworkElement::Loaded_revoker>>
+    g_loadedRevokers{std::in_place};
 
 static winrt::event_token g_timerButtonClickToken{};
 static winrt::event_token g_timerTickToken{};
 
 static std::atomic<int> g_secondsRemaining{0};
-static std::atomic<ULONGLONG> g_deadlineTick{0};
+static std::atomic<ULONGLONG> g_deadlineUtc100ns{0};
+static std::atomic_bool g_pendingFinished{false};
+
 static SRWLOCK g_reminderLock = SRWLOCK_INIT;
 static wchar_t g_reminder[256]{};
 
-static UINT_PTR g_deadlineThreadTimerId = 0;
+struct ModSettings {
+    int defaultMinutes = 20;
+    int defaultSnoozeMinutes = 5;
+    int maximumMinutes = 1440;
+    bool completionSound = true;
+    std::wstring buttonLabel = L"⏱ Timer";
+};
 
-static std::atomic<HWND> g_timerPopup{nullptr};
-static std::atomic<HWND> g_finishedPopup{nullptr};
-static std::atomic<DWORD> g_timerPopupThreadId{0};
-static std::atomic<HANDLE> g_timerPopupThread{nullptr};
-static HANDLE g_popupThreadReadyEvent = nullptr;
+static SRWLOCK g_settingsLock = SRWLOCK_INIT;
+static ModSettings g_settings;
+
+static HANDLE g_timerStopEvent = nullptr;
+static HANDLE g_timerRearmEvent = nullptr;
+static HANDLE g_timerWaitable = nullptr;
+static HANDLE g_timerWorkerThread = nullptr;
+static std::atomic_bool g_timerWorkerStarted{false};
+
+// Completion alert is independent from the taskbar XAML tree.
+static std::atomic<HWND> g_finishedAlertWnd{nullptr};
+static std::atomic<HANDLE> g_finishedAlertThread{nullptr};
+static HANDLE g_finishedAlertStopEvent = nullptr;
+
 static std::atomic<HWND> g_taskbarWnd{nullptr};
 static std::atomic<DWORD> g_taskbarThreadId{0};
 static std::atomic_bool g_buttonInjected{false};
 static std::atomic_bool g_systemTrayModuleHooked{false};
-
-[[clang::no_destroy]] static ColumnDefinition g_timerColumn{nullptr};
-[[clang::no_destroy]] static std::optional<
-    std::list<FrameworkElement::Loaded_revoker>>
-    g_loadedRevokers{std::in_place};
-
-static HINSTANCE g_modInstance = nullptr;
+static std::atomic<HMODULE> g_systemTrayModuleAttempted{nullptr};
 
 static std::atomic_bool g_unloading{false};
 static HANDLE g_retryStopEvent = nullptr;
 static HANDLE g_retryThread = nullptr;
 
-
 static void ApplyTimerButtonIfAvailable();
-
-// -----------------------------------------------------------------------------
-// Modern popup styling
-// -----------------------------------------------------------------------------
-
-static HBRUSH g_popupBackgroundBrush = nullptr;
-static HBRUSH g_popupEditBrush = nullptr;
-static HFONT g_popupFont = nullptr;
-static UINT g_popupFontDpi = 0;
-
-static constexpr COLORREF kPopupBackground =
-    RGB(32, 32, 32);
-
-static constexpr COLORREF kPopupEditBackground =
-    RGB(45, 45, 45);
-
-static constexpr COLORREF kPopupText =
-    RGB(245, 245, 245);
-
-static constexpr COLORREF kPopupMutedText =
-    RGB(190, 190, 190);
-
-
-static void EnsurePopupResources(
-    UINT dpi = 96)
-{
-    if (!g_popupBackgroundBrush) {
-        g_popupBackgroundBrush =
-            CreateSolidBrush(kPopupBackground);
-    }
-
-    if (!g_popupEditBrush) {
-        g_popupEditBrush =
-            CreateSolidBrush(kPopupEditBackground);
-    }
-
-    if (!dpi) {
-        dpi = 96;
-    }
-
-    if (!g_popupFont ||
-        g_popupFontDpi != dpi)
-    {
-        HFONT newFont =
-            CreateFontW(
-                -MulDiv(12, dpi, 72),
-                0, 0, 0,
-                FW_NORMAL,
-                FALSE, FALSE, FALSE,
-                DEFAULT_CHARSET,
-                OUT_DEFAULT_PRECIS,
-                CLIP_DEFAULT_PRECIS,
-                CLEARTYPE_QUALITY,
-                DEFAULT_PITCH | FF_DONTCARE,
-                L"Segoe UI"
-            );
-
-        if (newFont) {
-            HFONT oldFont = g_popupFont;
-            g_popupFont = newFont;
-            g_popupFontDpi = dpi;
-
-            auto reapply = [](HWND wnd) {
-                if (!wnd || !g_popupFont) {
-                    return;
-                }
-
-                EnumChildWindows(
-                    wnd,
-                    [](HWND child, LPARAM) -> BOOL {
-                        SendMessageW(
-                            child,
-                            WM_SETFONT,
-                            reinterpret_cast<WPARAM>(g_popupFont),
-                            TRUE
-                        );
-                        return TRUE;
-                    },
-                    0
-                );
-            };
-
-            reapply(g_timerPopup.load());
-            reapply(g_finishedPopup.load());
-
-            if (oldFont) {
-                DeleteObject(oldFont);
-            }
-        }
-    }
-}
-
-
-static void ApplyModernWindowStyle(
-    HWND hWnd)
-{
-    UINT dpi =
-        GetDpiForWindow(hWnd);
-
-    EnsurePopupResources(
-        dpi ? dpi : 96
-    );
-
-    constexpr DWORD
-        DWMWA_WINDOW_CORNER_PREFERENCE_LOCAL = 33;
-
-    constexpr int
-        DWMWCP_ROUND_LOCAL = 2;
-
-    int cornerPreference =
-        DWMWCP_ROUND_LOCAL;
-
-    DwmSetWindowAttribute(
-        hWnd,
-        DWMWA_WINDOW_CORNER_PREFERENCE_LOCAL,
-        &cornerPreference,
-        sizeof(cornerPreference)
-    );
-
-    constexpr DWORD
-        DWMWA_USE_IMMERSIVE_DARK_MODE_LOCAL = 20;
-
-    BOOL darkMode = TRUE;
-
-    DwmSetWindowAttribute(
-        hWnd,
-        DWMWA_USE_IMMERSIVE_DARK_MODE_LOCAL,
-        &darkMode,
-        sizeof(darkMode)
-    );
-
-    MARGINS margins{
-        1,
-        1,
-        1,
-        1
-    };
-
-    DwmExtendFrameIntoClientArea(
-        hWnd,
-        &margins
-    );
-}
-
-
-static void ApplyPopupFont(
-    HWND hWnd,
-    UINT dpi = 0)
-{
-    if (!hWnd) {
-        return;
-    }
-
-    if (!dpi) {
-        dpi =
-            GetDpiForWindow(hWnd);
-    }
-
-    EnsurePopupResources(
-        dpi ? dpi : 96
-    );
-
-    SendMessageW(
-        hWnd,
-        WM_SETFONT,
-        reinterpret_cast<WPARAM>(
-            g_popupFont
-        ),
-        TRUE
-    );
-}
-
-
-// -----------------------------------------------------------------------------
-// Popup constants
-// -----------------------------------------------------------------------------
-
-constexpr int IDC_REMINDER_LABEL = 1000;
-constexpr int IDC_REMINDER       = 1001;
-constexpr int IDC_MINUTES_LABEL  = 1002;
-constexpr int IDC_MINUTES        = 1003;
-constexpr int IDC_START          = 1004;
-constexpr int IDC_CANCEL_TIMER   = 1005;
-constexpr int IDC_CLOSE_TIMER    = 1006;
-
-constexpr int IDC_FINISHED_REMINDER = 1099;
-constexpr int IDC_SNOOZE_LABEL   = 1100;
-constexpr int IDC_SNOOZE_MINUTES = 1101;
-constexpr int IDC_SNOOZE         = 1102;
-constexpr int IDC_DISMISS        = 1103;
-constexpr int IDC_CLOSE_FINISHED = 1104;
-constexpr int IDC_FINISHED_TEXT   = 1105;
-
-constexpr UINT WM_APP_TIMER_SHOW =
-    WM_APP + 1;
-
-// -----------------------------------------------------------------------------
-// Popup DPI/layout helpers
-// -----------------------------------------------------------------------------
-
-static int ScaleByDpi(
-    int value,
-    UINT dpi)
-{
-    return MulDiv(
-        value,
-        dpi ? dpi : 96,
-        96
-    );
-}
-
-
-static UINT GetPopupDpi(
-    HWND owner)
-{
-    UINT dpi =
-        owner
-            ? GetDpiForWindow(owner)
-            : 0;
-
-    return dpi ? dpi : 96;
-}
-
-
-static void PositionPopupNearTaskbar(
-    HWND hWnd,
-    HWND taskbar,
-    int baseWidth,
-    int baseHeight,
-    UINT dpi)
-{
-    int width =
-        ScaleByDpi(
-            baseWidth,
-            dpi
-        );
-
-    int height =
-        ScaleByDpi(
-            baseHeight,
-            dpi
-        );
-
-    int margin =
-        ScaleByDpi(
-            10,
-            dpi
-        );
-
-    HMONITOR monitor =
-        MonitorFromWindow(
-            taskbar ? taskbar : hWnd,
-            MONITOR_DEFAULTTONEAREST
-        );
-
-    MONITORINFO monitorInfo{
-        sizeof(monitorInfo)
-    };
-
-    if (!GetMonitorInfoW(
-            monitor,
-            &monitorInfo))
-    {
-        SetWindowPos(
-            hWnd,
-            HWND_TOPMOST,
-            0,
-            0,
-            width,
-            height,
-            SWP_SHOWWINDOW
-        );
-
-        return;
-    }
-
-    RECT work =
-        monitorInfo.rcWork;
-
-    RECT monitorRect =
-        monitorInfo.rcMonitor;
-
-    RECT taskbarRect{};
-
-    bool haveTaskbar =
-        taskbar &&
-        GetWindowRect(
-            taskbar,
-            &taskbarRect
-        );
-
-    int x =
-        work.right -
-        width -
-        margin;
-
-    int y =
-        work.bottom -
-        height -
-        margin;
-
-    if (haveTaskbar) {
-        const int taskbarWidth =
-            taskbarRect.right -
-            taskbarRect.left;
-
-        const int taskbarHeight =
-            taskbarRect.bottom -
-            taskbarRect.top;
-
-        const bool horizontal =
-            taskbarWidth >= taskbarHeight;
-
-        if (horizontal) {
-            // A horizontal taskbar spans the monitor width, so its left/right
-            // edges also touch the monitor. Determine top vs bottom only.
-            const int topDistance =
-                std::abs(
-                    taskbarRect.top -
-                    monitorRect.top
-                );
-
-            const int bottomDistance =
-                std::abs(
-                    monitorRect.bottom -
-                    taskbarRect.bottom
-                );
-
-            if (topDistance < bottomDistance) {
-                y =
-                    work.top +
-                    margin;
-            }
-            else {
-                y =
-                    work.bottom -
-                    height -
-                    margin;
-            }
-
-            // Keep the popup aligned to the right side, matching the timer
-            // button/system tray area.
-            x =
-                work.right -
-                width -
-                margin;
-        }
-        else {
-            // Vertical taskbar: determine left vs right only.
-            const int leftDistance =
-                std::abs(
-                    taskbarRect.left -
-                    monitorRect.left
-                );
-
-            const int rightDistance =
-                std::abs(
-                    monitorRect.right -
-                    taskbarRect.right
-                );
-
-            if (leftDistance < rightDistance) {
-                x =
-                    work.left +
-                    margin;
-            }
-            else {
-                x =
-                    work.right -
-                    width -
-                    margin;
-            }
-
-            y =
-                work.bottom -
-                height -
-                margin;
-        }
-    }
-
-    x =
-        std::max<int>(
-            static_cast<int>(work.left),
-            std::min<int>(
-                x,
-                static_cast<int>(
-                    work.right
-                ) - width
-            )
-        );
-
-    y =
-        std::max<int>(
-            static_cast<int>(work.top),
-            std::min<int>(
-                y,
-                static_cast<int>(
-                    work.bottom
-                ) - height
-            )
-        );
-
-    SetWindowPos(
-        hWnd,
-        HWND_TOPMOST,
-        x,
-        y,
-        width,
-        height,
-        SWP_NOACTIVATE
-    );
-}
-
-
-static void LayoutTimerPopup(
-    HWND hWnd,
-    UINT dpi)
-{
-    struct Item {
-        int id;
-        int x;
-        int y;
-        int w;
-        int h;
-    };
-
-    constexpr Item items[] = {
-        {IDC_CLOSE_TIMER,      338,   8,  24, 24},
-        {IDC_REMINDER_LABEL,    20,  20, 300, 20},
-        {IDC_REMINDER,          20,  45, 340, 30},
-        {IDC_MINUTES_LABEL,     20,  90, 150, 20},
-        {IDC_MINUTES,           20, 115, 110, 30},
-        {IDC_START,             20, 165, 165, 34},
-        {IDC_CANCEL_TIMER,     195, 165, 165, 34},
-    };
-
-    EnsurePopupResources(dpi);
-
-    for (const auto& item : items) {
-        HWND child =
-            GetDlgItem(
-                hWnd,
-                item.id
-            );
-
-        if (!child) {
-            continue;
-        }
-
-        SetWindowPos(
-            child,
-            nullptr,
-            ScaleByDpi(item.x, dpi),
-            ScaleByDpi(item.y, dpi),
-            ScaleByDpi(item.w, dpi),
-            ScaleByDpi(item.h, dpi),
-            SWP_NOZORDER |
-                SWP_NOACTIVATE
-        );
-
-        ApplyPopupFont(
-            child,
-            dpi
-        );
-    }
-}
-
-
-static void LayoutFinishedPopup(
-    HWND hWnd,
-    UINT dpi)
-{
-    struct Item {
-        int id;
-        int x;
-        int y;
-        int w;
-        int h;
-    };
-
-    constexpr Item items[] = {
-        {IDC_CLOSE_FINISHED,   338,   8,  24, 24},
-        {IDC_FINISHED_TEXT,     20,  20, 340, 45},
-        {IDC_SNOOZE_LABEL,      20,  82, 160, 20},
-        {IDC_SNOOZE_MINUTES,   190,  78,  70, 30},
-        {IDC_SNOOZE,            20, 135, 165, 34},
-        {IDC_DISMISS,          195, 135, 165, 34},
-    };
-
-    EnsurePopupResources(dpi);
-
-    for (const auto& item : items) {
-        HWND child =
-            GetDlgItem(
-                hWnd,
-                item.id
-            );
-
-        if (!child) {
-            continue;
-        }
-
-        SetWindowPos(
-            child,
-            nullptr,
-            ScaleByDpi(item.x, dpi),
-            ScaleByDpi(item.y, dpi),
-            ScaleByDpi(item.w, dpi),
-            ScaleByDpi(item.h, dpi),
-            SWP_NOZORDER |
-                SWP_NOACTIVATE
-        );
-
-        ApplyPopupFont(
-            child,
-            dpi
-        );
-    }
-}
-
+static bool EnsureTimerWorkerStarted();
 
 // -----------------------------------------------------------------------------
 // XAML helpers
@@ -1088,11 +615,13 @@ static bool RunFromWindowThread(
                             cwp->lParam
                         );
 
-                    param->proc(
-                        param->procParam
-                    );
+                    if (!param->invoked) {
+                        param->proc(
+                            param->procParam
+                        );
 
-                    param->invoked = true;
+                        param->invoked = true;
+                    }
                 }
             }
 
@@ -1131,15 +660,86 @@ static bool RunFromWindowThread(
 
 
 // -----------------------------------------------------------------------------
-// Countdown
+// Settings and persistent timer state
 // -----------------------------------------------------------------------------
+
+static ModSettings GetSettingsSnapshot()
+{
+    AcquireSRWLockShared(&g_settingsLock);
+    ModSettings result = g_settings;
+    ReleaseSRWLockShared(&g_settingsLock);
+    return result;
+}
+
+
+static void LoadSettings()
+{
+    ModSettings updated;
+
+    updated.defaultMinutes =
+        std::clamp(
+            Wh_GetIntSetting(L"defaultMinutes"),
+            1,
+            1440
+        );
+
+    updated.defaultSnoozeMinutes =
+        std::clamp(
+            Wh_GetIntSetting(L"defaultSnoozeMinutes"),
+            1,
+            1440
+        );
+
+    updated.maximumMinutes =
+        std::clamp(
+            Wh_GetIntSetting(L"maximumMinutes"),
+            1,
+            10080
+        );
+
+    if (updated.defaultMinutes > updated.maximumMinutes) {
+        updated.defaultMinutes = updated.maximumMinutes;
+    }
+
+    if (updated.defaultSnoozeMinutes > updated.maximumMinutes) {
+        updated.defaultSnoozeMinutes = updated.maximumMinutes;
+    }
+
+    updated.completionSound =
+        Wh_GetIntSetting(L"completionSound") != 0;
+
+    PCWSTR label =
+        Wh_GetStringSetting(L"buttonLabel");
+
+    if (label && label[0]) {
+        updated.buttonLabel = label;
+    }
+
+    Wh_FreeStringSetting(label);
+
+    AcquireSRWLockExclusive(&g_settingsLock);
+    g_settings = updated;
+    ReleaseSRWLockExclusive(&g_settingsLock);
+}
+
+
+static ULONGLONG GetUtcFileTimeNow()
+{
+    FILETIME ft{};
+    GetSystemTimeAsFileTime(&ft);
+
+    ULARGE_INTEGER value{};
+    value.LowPart = ft.dwLowDateTime;
+    value.HighPart = ft.dwHighDateTime;
+
+    return value.QuadPart;
+}
+
 
 static void SetSharedReminder(
     const wchar_t* reminder)
 {
-    AcquireSRWLockExclusive(
-        &g_reminderLock
-    );
+    AcquireSRWLockExclusive(&g_reminderLock);
 
     wcsncpy_s(
         g_reminder,
@@ -1147,18 +747,14 @@ static void SetSharedReminder(
         _TRUNCATE
     );
 
-    ReleaseSRWLockExclusive(
-        &g_reminderLock
-    );
+    ReleaseSRWLockExclusive(&g_reminderLock);
 }
 
 
 static void GetSharedReminder(
     wchar_t (&buffer)[256])
 {
-    AcquireSRWLockShared(
-        &g_reminderLock
-    );
+    AcquireSRWLockShared(&g_reminderLock);
 
     wcsncpy_s(
         buffer,
@@ -1166,8 +762,67 @@ static void GetSharedReminder(
         _TRUNCATE
     );
 
-    ReleaseSRWLockShared(
-        &g_reminderLock
+    ReleaseSRWLockShared(&g_reminderLock);
+}
+
+
+static void ClearPersistedTimer()
+{
+    Wh_DeleteValue(L"deadlineUtc100ns");
+    Wh_DeleteValue(L"reminder");
+}
+
+
+static void PersistTimer(
+    ULONGLONG deadline,
+    const wchar_t* reminder)
+{
+    wchar_t deadlineText[32]{};
+
+    swprintf_s(
+        deadlineText,
+        L"%llu",
+        static_cast<unsigned long long>(deadline)
+    );
+
+    Wh_SetStringValue(
+        L"deadlineUtc100ns",
+        deadlineText
+    );
+
+    Wh_SetStringValue(
+        L"reminder",
+        reminder ? reminder : L""
+    );
+}
+
+
+static int RemainingSeconds(
+    ULONGLONG deadline)
+{
+    if (!deadline) {
+        return 0;
+    }
+
+    ULONGLONG now =
+        GetUtcFileTimeNow();
+
+    if (now >= deadline) {
+        return 0;
+    }
+
+    ULONGLONG delta =
+        deadline - now;
+
+    ULONGLONG seconds =
+        (delta + 9999999ULL) /
+        10000000ULL;
+
+    return static_cast<int>(
+        std::min<ULONGLONG>(
+            seconds,
+            static_cast<ULONGLONG>(INT_MAX)
+        )
     );
 }
 
@@ -1179,72 +834,195 @@ static std::wstring FormatCountdown(
         totalSeconds = 0;
     }
 
-    int minutes = totalSeconds / 60;
-    int seconds = totalSeconds % 60;
-
     wchar_t text[64]{};
 
-    swprintf_s(
-        text,
-        L"⏱ %02d:%02d",
-        minutes,
-        seconds
-    );
+    if (totalSeconds >= 3600) {
+        int hours = totalSeconds / 3600;
+        int minutes = (totalSeconds % 3600) / 60;
+        int seconds = totalSeconds % 60;
+
+        swprintf_s(
+            text,
+            L"⏱ %d:%02d:%02d",
+            hours,
+            minutes,
+            seconds
+        );
+    }
+    else {
+        int minutes = totalSeconds / 60;
+        int seconds = totalSeconds % 60;
+
+        swprintf_s(
+            text,
+            L"⏱ %02d:%02d",
+            minutes,
+            seconds
+        );
+    }
 
     return text;
 }
 
 
-struct DisplayTimerRequest
+// -----------------------------------------------------------------------------
+// XAML timer display and flyouts
+// -----------------------------------------------------------------------------
+
+static void SetIdleTaskbarText()
 {
-    bool running;
-    int seconds;
-    wchar_t reminder[256];
-    bool succeeded;
-};
-
-
-static void UpdateCountdownDisplayOnTaskbarThread(
-    void* param)
-{
-    auto* request =
-        reinterpret_cast<DisplayTimerRequest*>(
-            param
-        );
-
-    if (!request ||
-        !g_timerText ||
-        !g_countdownTimer)
-    {
+    if (!g_timerText) {
         return;
     }
 
-    g_countdownTimer.Stop();
+    ModSettings settings =
+        GetSettingsSnapshot();
 
-    if (request->running) {
-        g_timerText.Text(
-            FormatCountdown(
-                request->seconds
-            )
-        );
-
-        g_countdownTimer.Start();
-    }
-    else {
-        g_timerText.Text(
-            L"⏱ Timer"
-        );
-    }
-
-    request->succeeded = true;
+    g_timerText.Text(
+        settings.buttonLabel
+    );
 }
 
 
-static bool SyncCountdownDisplayToTaskbar(
-    bool running,
-    int seconds,
+static void RefreshTaskbarCountdown()
+{
+    if (!g_timerText) {
+        return;
+    }
+
+    ULONGLONG deadline =
+        g_deadlineUtc100ns.load();
+
+    int remaining =
+        RemainingSeconds(deadline);
+
+    g_secondsRemaining.store(remaining);
+
+    if (remaining > 0) {
+        g_timerText.Text(
+            FormatCountdown(remaining)
+        );
+    }
+    else {
+        SetIdleTaskbarText();
+    }
+}
+
+
+static void HideAndReleaseFlyouts()
+{
+    if (g_timerFlyout) {
+        g_timerFlyout.Hide();
+    }
+
+    g_timerReminderBox = nullptr;
+    g_timerMinutesBox = nullptr;
+    g_timerStartButton = nullptr;
+    g_timerCancelButton = nullptr;
+    g_timerFlyout = nullptr;
+}
+
+
+static bool ParseMinutes(
+    TextBox const& box,
+    int maximum,
+    int& minutes)
+{
+    if (!box) {
+        return false;
+    }
+
+    std::wstring value =
+        box.Text().c_str();
+
+    wchar_t* end = nullptr;
+    long parsed =
+        wcstol(
+            value.c_str(),
+            &end,
+            10
+        );
+
+    if (!end ||
+        end == value.c_str() ||
+        *end != L'\0' ||
+        parsed <= 0 ||
+        parsed > maximum)
+    {
+        return false;
+    }
+
+    minutes =
+        static_cast<int>(parsed);
+
+    return true;
+}
+
+
+static void SignalTimerWorker()
+{
+    if (g_timerRearmEvent) {
+        SetEvent(g_timerRearmEvent);
+    }
+}
+
+
+static bool ArmTimer(
+    int minutes,
     const wchar_t* reminder)
 {
+    ModSettings settings =
+        GetSettingsSnapshot();
+
+    if (minutes <= 0 ||
+        minutes > settings.maximumMinutes ||
+        g_unloading.load())
+    {
+        return false;
+    }
+
+    if (!EnsureTimerWorkerStarted()) {
+        Wh_Log(
+            L"ERROR: Timer worker isn't available"
+        );
+
+        return false;
+    }
+
+    ULONGLONG seconds =
+        static_cast<ULONGLONG>(minutes) *
+        60ULL;
+
+    ULONGLONG deadline =
+        GetUtcFileTimeNow() +
+        seconds * 10000000ULL;
+
+    const wchar_t* reminderToUse =
+        reminder && reminder[0]
+            ? reminder
+            : L"Timer finished";
+
+    SetSharedReminder(reminderToUse);
+
+    g_deadlineUtc100ns.store(deadline);
+    g_secondsRemaining.store(
+        static_cast<int>(
+            std::min<ULONGLONG>(
+                seconds,
+                static_cast<ULONGLONG>(INT_MAX)
+            )
+        )
+    );
+
+    g_pendingFinished.store(false);
+
+    PersistTimer(
+        deadline,
+        reminderToUse
+    );
+
+    SignalTimerWorker();
+
     HWND taskbar =
         g_taskbarWnd.load();
 
@@ -1259,1511 +1037,1598 @@ static bool SyncCountdownDisplayToTaskbar(
         }
     }
 
-    if (!taskbar) {
-        return false;
+    if (taskbar) {
+        RunFromWindowThread(
+            taskbar,
+            [](
+                void*)
+            {
+                if (g_countdownTimer) {
+                    g_countdownTimer.Start();
+                }
+
+                RefreshTaskbarCountdown();
+            },
+            nullptr
+        );
     }
 
-    DisplayTimerRequest request{};
-    request.running = running;
-    request.seconds = seconds;
-    request.succeeded = false;
-
-    wcsncpy_s(
-        request.reminder,
-        reminder ? reminder : L"",
-        _TRUNCATE
+    Wh_Log(
+        L"Timer armed: '%s' - %d minute(s)",
+        reminderToUse,
+        minutes
     );
 
-    if (!RunFromWindowThread(
-            taskbar,
-            UpdateCountdownDisplayOnTaskbarThread,
-            &request))
-    {
-        return false;
-    }
-
-    return request.succeeded;
+    return true;
 }
 
 
-static void ShowFinishedPopup(
-    HWND owner,
-    const wchar_t* reminderText);
-
-
-static bool StartAuthoritativeTimer(
-    int seconds,
-    const wchar_t* reminder)
+static void CancelTimer()
 {
-    if (seconds <= 0 ||
+    g_deadlineUtc100ns.store(0);
+    g_secondsRemaining.store(0);
+    g_pendingFinished.store(false);
+
+    ClearPersistedTimer();
+    SignalTimerWorker();
+
+    if (g_countdownTimer) {
+        g_countdownTimer.Stop();
+    }
+
+    SetIdleTaskbarText();
+
+    Wh_Log(L"Timer cancelled");
+}
+
+
+static StackPanel MakeFlyoutPanel()
+{
+    StackPanel panel;
+    panel.Width(340);
+    panel.Margin(Thickness{16, 14, 16, 14});
+    return panel;
+}
+
+
+static TextBlock MakeLabel(
+    const wchar_t* text)
+{
+    TextBlock label;
+    label.Text(text);
+    label.Margin(Thickness{0, 0, 0, 4});
+    return label;
+}
+
+
+static Button MakeActionButton(
+    const wchar_t* text)
+{
+    Button button;
+    button.Content(
+        winrt::box_value(text)
+    );
+    button.MinWidth(120);
+    button.Margin(
+        Thickness{0, 8, 8, 0}
+    );
+    return button;
+}
+
+
+static void BuildTimerFlyout()
+{
+    if (g_timerFlyout) {
+        return;
+    }
+
+    Flyout flyout;
+    flyout.Placement(
+        Controls::Primitives::
+            FlyoutPlacementMode::Top
+    );
+    flyout.ShouldConstrainToRootBounds(false);
+
+    StackPanel panel =
+        MakeFlyoutPanel();
+
+    auto reminderLabel =
+        MakeLabel(L"Reminder");
+
+    panel.Children().Append(
+        reminderLabel
+    );
+
+    TextBox reminderBox;
+    reminderBox.PlaceholderText(
+        L"What should I remind you about?"
+    );
+    reminderBox.Margin(
+        Thickness{0, 0, 0, 10}
+    );
+
+    panel.Children().Append(
+        reminderBox
+    );
+
+    auto minutesLabel =
+        MakeLabel(L"Minutes");
+
+    panel.Children().Append(
+        minutesLabel
+    );
+
+    TextBox minutesBox;
+    minutesBox.Margin(
+        Thickness{0, 0, 0, 4}
+    );
+
+    panel.Children().Append(
+        minutesBox
+    );
+
+    StackPanel actions;
+    actions.Orientation(
+        Orientation::Horizontal
+    );
+
+    Button startButton =
+        MakeActionButton(L"Start");
+
+    Button cancelButton =
+        MakeActionButton(L"Cancel timer");
+
+    actions.Children().Append(
+        startButton
+    );
+
+    actions.Children().Append(
+        cancelButton
+    );
+
+    panel.Children().Append(
+        actions
+    );
+
+    startButton.Click(
+        [](
+            auto const&,
+            RoutedEventArgs const&)
+        {
+            if (g_unloading.load() ||
+                !g_timerReminderBox ||
+                !g_timerMinutesBox)
+            {
+                return;
+            }
+
+            ModSettings settings =
+                GetSettingsSnapshot();
+
+            int minutes = 0;
+
+            if (!ParseMinutes(
+                    g_timerMinutesBox,
+                    settings.maximumMinutes,
+                    minutes))
+            {
+                g_timerMinutesBox.SelectAll();
+                g_timerMinutesBox.Focus(
+                    FocusState::Programmatic
+                );
+                return;
+            }
+
+            std::wstring reminder =
+                g_timerReminderBox.Text().c_str();
+
+            if (!ArmTimer(
+                    minutes,
+                    reminder.c_str()))
+            {
+                return;
+            }
+
+            if (g_timerFlyout) {
+                g_timerFlyout.Hide();
+            }
+        }
+    );
+
+    cancelButton.Click(
+        [](
+            auto const&,
+            RoutedEventArgs const&)
+        {
+            if (g_unloading.load()) {
+                return;
+            }
+
+            CancelTimer();
+
+            if (g_timerFlyout) {
+                g_timerFlyout.Hide();
+            }
+        }
+    );
+
+    flyout.Content(panel);
+
+    g_timerReminderBox =
+        reminderBox;
+    g_timerMinutesBox =
+        minutesBox;
+    g_timerStartButton =
+        startButton;
+    g_timerCancelButton =
+        cancelButton;
+    g_timerFlyout =
+        flyout;
+}
+
+
+static void ShowTimerFlyout()
+{
+    if (!g_timerButton ||
         g_unloading.load())
     {
+        return;
+    }
+
+    BuildTimerFlyout();
+
+    if (!g_timerFlyout ||
+        !g_timerReminderBox ||
+        !g_timerMinutesBox ||
+        !g_timerStartButton ||
+        !g_timerCancelButton)
+    {
+        return;
+    }
+
+    ModSettings settings =
+        GetSettingsSnapshot();
+
+    int remaining =
+        RemainingSeconds(
+            g_deadlineUtc100ns.load()
+        );
+
+    if (remaining > 0) {
+        wchar_t reminder[256]{};
+        GetSharedReminder(reminder);
+
+        g_timerReminderBox.Text(
+            reminder
+        );
+
+        wchar_t minutesText[32]{};
+        swprintf_s(
+            minutesText,
+            L"%d",
+            (remaining + 59) / 60
+        );
+
+        g_timerMinutesBox.Text(
+            minutesText
+        );
+
+        g_timerReminderBox.IsEnabled(false);
+        g_timerMinutesBox.IsEnabled(false);
+        g_timerStartButton.IsEnabled(false);
+        g_timerCancelButton.IsEnabled(true);
+    }
+    else {
+        g_timerReminderBox.Text(L"");
+
+        wchar_t minutesText[32]{};
+        swprintf_s(
+            minutesText,
+            L"%d",
+            settings.defaultMinutes
+        );
+
+        g_timerMinutesBox.Text(
+            minutesText
+        );
+
+        g_timerReminderBox.IsEnabled(true);
+        g_timerMinutesBox.IsEnabled(true);
+        g_timerStartButton.IsEnabled(true);
+        g_timerCancelButton.IsEnabled(false);
+    }
+
+    g_timerFlyout.ShowAt(
+        g_timerButton
+    );
+}
+
+
+// -----------------------------------------------------------------------------
+// Reliable completion alert
+// -----------------------------------------------------------------------------
+
+constexpr int IDC_ALERT_REMINDER = 2100;
+constexpr int IDC_ALERT_SNOOZE_LABEL = 2101;
+constexpr int IDC_ALERT_SNOOZE_MINUTES = 2102;
+constexpr int IDC_ALERT_SNOOZE = 2103;
+constexpr int IDC_ALERT_DISMISS = 2104;
+
+static constexpr wchar_t kFinishedAlertClass[] =
+    L"TaskbarCountdownTimerFinishedAlert";
+
+static HFONT g_finishedAlertFont = nullptr;
+static HBRUSH g_finishedAlertBackgroundBrush = nullptr;
+static HBRUSH g_finishedAlertEditBrush = nullptr;
+static bool g_finishedAlertDark = true;
+
+static bool AppsUseLightTheme()
+{
+    DWORD value = 0;
+    DWORD size = sizeof(value);
+
+    LONG result =
+        RegGetValueW(
+            HKEY_CURRENT_USER,
+            L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+            L"AppsUseLightTheme",
+            RRF_RT_REG_DWORD,
+            nullptr,
+            &value,
+            &size
+        );
+
+    if (result != ERROR_SUCCESS) {
         return false;
     }
 
-    if (g_deadlineThreadTimerId) {
-        KillTimer(
-            nullptr,
-            g_deadlineThreadTimerId
-        );
+    return value != 0;
+}
 
-        g_deadlineThreadTimerId = 0;
+static void EnsureFinishedAlertResources(
+    UINT dpi)
+{
+    g_finishedAlertDark =
+        !AppsUseLightTheme();
+
+    if (g_finishedAlertBackgroundBrush) {
+        DeleteObject(
+            g_finishedAlertBackgroundBrush
+        );
+        g_finishedAlertBackgroundBrush = nullptr;
     }
 
-    ULONGLONG deadline =
-        GetTickCount64() +
-        static_cast<ULONGLONG>(
-            seconds
-        ) * 1000ULL;
+    if (g_finishedAlertEditBrush) {
+        DeleteObject(
+            g_finishedAlertEditBrush
+        );
+        g_finishedAlertEditBrush = nullptr;
+    }
 
-    g_deadlineTick.store(
-        deadline
+    COLORREF background =
+        g_finishedAlertDark
+            ? RGB(32, 32, 32)
+            : RGB(249, 249, 249);
+
+    COLORREF editBackground =
+        g_finishedAlertDark
+            ? RGB(45, 45, 45)
+            : RGB(255, 255, 255);
+
+    g_finishedAlertBackgroundBrush =
+        CreateSolidBrush(background);
+
+    g_finishedAlertEditBrush =
+        CreateSolidBrush(editBackground);
+
+    if (g_finishedAlertFont) {
+        DeleteObject(
+            g_finishedAlertFont
+        );
+        g_finishedAlertFont = nullptr;
+    }
+
+    g_finishedAlertFont =
+        CreateFontW(
+            -MulDiv(
+                11,
+                dpi ? dpi : 96,
+                72
+            ),
+            0,
+            0,
+            0,
+            FW_NORMAL,
+            FALSE,
+            FALSE,
+            FALSE,
+            DEFAULT_CHARSET,
+            OUT_DEFAULT_PRECIS,
+            CLIP_DEFAULT_PRECIS,
+            CLEARTYPE_QUALITY,
+            DEFAULT_PITCH | FF_DONTCARE,
+            L"Segoe UI"
+        );
+}
+
+static void ApplyFinishedAlertTheme(
+    HWND hWnd,
+    UINT dpi)
+{
+    EnsureFinishedAlertResources(dpi);
+
+    constexpr DWORD DWMWA_USE_IMMERSIVE_DARK_MODE_LOCAL = 20;
+    constexpr DWORD DWMWA_WINDOW_CORNER_PREFERENCE_LOCAL = 33;
+    constexpr int DWMWCP_ROUND_LOCAL = 2;
+
+    BOOL dark =
+        g_finishedAlertDark
+            ? TRUE
+            : FALSE;
+
+    DwmSetWindowAttribute(
+        hWnd,
+        DWMWA_USE_IMMERSIVE_DARK_MODE_LOCAL,
+        &dark,
+        sizeof(dark)
     );
 
-    g_secondsRemaining.store(
-        seconds
+    int corner =
+        DWMWCP_ROUND_LOCAL;
+
+    DwmSetWindowAttribute(
+        hWnd,
+        DWMWA_WINDOW_CORNER_PREFERENCE_LOCAL,
+        &corner,
+        sizeof(corner)
+    );
+}
+
+static void ThemeFinishedAlertChild(
+    HWND child)
+{
+    if (!child) {
+        return;
+    }
+
+    if (g_finishedAlertFont) {
+        SendMessageW(
+            child,
+            WM_SETFONT,
+            reinterpret_cast<WPARAM>(
+                g_finishedAlertFont
+            ),
+            TRUE
+        );
+    }
+
+    wchar_t className[32]{};
+
+    if (!GetClassNameW(
+            child,
+            className,
+            ARRAYSIZE(className)))
+    {
+        return;
+    }
+
+    if (_wcsicmp(
+            className,
+            L"Button") == 0)
+    {
+        SetWindowTheme(
+            child,
+            g_finishedAlertDark
+                ? L"DarkMode_Explorer"
+                : L"Explorer",
+            nullptr
+        );
+    }
+    else if (_wcsicmp(
+                 className,
+                 L"Edit") == 0)
+    {
+        SetWindowTheme(
+            child,
+            g_finishedAlertDark
+                ? L"DarkMode_CFD"
+                : L"Explorer",
+            nullptr
+        );
+    }
+}
+
+struct FinishedAlertData
+{
+    wchar_t reminder[256];
+    int defaultSnoozeMinutes;
+    int maximumMinutes;
+};
+
+static int ScaleAlertValue(int value, UINT dpi)
+{
+    return MulDiv(value, dpi ? dpi : 96, 96);
+}
+
+static void PositionFinishedAlert(HWND hWnd, UINT dpi)
+{
+    HWND taskbar = g_taskbarWnd.load();
+
+    HMONITOR monitor =
+        MonitorFromWindow(
+            taskbar ? taskbar : hWnd,
+            MONITOR_DEFAULTTONEAREST
+        );
+
+    MONITORINFO info{sizeof(info)};
+
+    if (!GetMonitorInfoW(monitor, &info)) {
+        return;
+    }
+
+    int width = ScaleAlertValue(380, dpi);
+    int height = ScaleAlertValue(220, dpi);
+    int margin = ScaleAlertValue(10, dpi);
+
+    SetWindowPos(
+        hWnd,
+        HWND_TOPMOST,
+        info.rcWork.right - width - margin,
+        info.rcWork.bottom - height - margin,
+        width,
+        height,
+        SWP_NOACTIVATE
+    );
+}
+
+static void LayoutFinishedAlert(HWND hWnd, UINT dpi)
+{
+    struct Item {
+        int id, x, y, w, h;
+    };
+
+    constexpr Item items[] = {
+        {IDC_ALERT_REMINDER,        20,  22, 340, 46},
+        {IDC_ALERT_SNOOZE_LABEL,    20,  88, 155, 22},
+        {IDC_ALERT_SNOOZE_MINUTES, 184,  84,  78, 30},
+        {IDC_ALERT_SNOOZE,          20, 145, 160, 36},
+        {IDC_ALERT_DISMISS,        200, 145, 160, 36},
+    };
+
+    for (const auto& item : items) {
+        HWND child = GetDlgItem(hWnd, item.id);
+
+        if (!child) {
+            continue;
+        }
+
+        SetWindowPos(
+            child,
+            nullptr,
+            ScaleAlertValue(item.x, dpi),
+            ScaleAlertValue(item.y, dpi),
+            ScaleAlertValue(item.w, dpi),
+            ScaleAlertValue(item.h, dpi),
+            SWP_NOZORDER | SWP_NOACTIVATE
+        );
+    }
+}
+
+static LRESULT CALLBACK FinishedAlertWndProc(
+    HWND hWnd,
+    UINT msg,
+    WPARAM wParam,
+    LPARAM lParam)
+{
+    switch (msg) {
+    case WM_CREATE:
+    {
+        auto* create =
+            reinterpret_cast<CREATESTRUCTW*>(lParam);
+
+        auto* data =
+            reinterpret_cast<FinishedAlertData*>(
+                create->lpCreateParams
+            );
+
+        SetWindowLongPtrW(
+            hWnd,
+            GWLP_USERDATA,
+            reinterpret_cast<LONG_PTR>(data)
+        );
+
+        UINT dpi =
+            GetDpiForWindow(hWnd);
+
+        if (!dpi) {
+            dpi = 96;
+        }
+
+        ApplyFinishedAlertTheme(
+            hWnd,
+            dpi
+        );
+
+        CreateWindowExW(
+            0,
+            L"STATIC",
+            data && data->reminder[0]
+                ? data->reminder
+                : L"Timer finished",
+            WS_CHILD | WS_VISIBLE | SS_CENTER,
+            0, 0, 0, 0,
+            hWnd,
+            reinterpret_cast<HMENU>(IDC_ALERT_REMINDER),
+            nullptr,
+            nullptr
+        );
+
+        CreateWindowExW(
+            0,
+            L"STATIC",
+            L"Snooze minutes:",
+            WS_CHILD | WS_VISIBLE,
+            0, 0, 0, 0,
+            hWnd,
+            reinterpret_cast<HMENU>(IDC_ALERT_SNOOZE_LABEL),
+            nullptr,
+            nullptr
+        );
+
+        wchar_t snoozeText[32]{};
+        swprintf_s(
+            snoozeText,
+            L"%d",
+            data ? data->defaultSnoozeMinutes : 5
+        );
+
+        CreateWindowExW(
+            0,
+            L"EDIT",
+            snoozeText,
+            WS_CHILD | WS_VISIBLE | WS_TABSTOP | ES_NUMBER,
+            0, 0, 0, 0,
+            hWnd,
+            reinterpret_cast<HMENU>(IDC_ALERT_SNOOZE_MINUTES),
+            nullptr,
+            nullptr
+        );
+
+        CreateWindowExW(
+            0,
+            L"BUTTON",
+            L"Snooze",
+            WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_DEFPUSHBUTTON,
+            0, 0, 0, 0,
+            hWnd,
+            reinterpret_cast<HMENU>(IDC_ALERT_SNOOZE),
+            nullptr,
+            nullptr
+        );
+
+        CreateWindowExW(
+            0,
+            L"BUTTON",
+            L"Dismiss",
+            WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_PUSHBUTTON,
+            0, 0, 0, 0,
+            hWnd,
+            reinterpret_cast<HMENU>(IDC_ALERT_DISMISS),
+            nullptr,
+            nullptr
+        );
+
+        EnumChildWindows(
+            hWnd,
+            [](
+                HWND child,
+                LPARAM) -> BOOL
+            {
+                ThemeFinishedAlertChild(
+                    child
+                );
+
+                return TRUE;
+            },
+            0
+        );
+
+        LayoutFinishedAlert(
+            hWnd,
+            dpi
+        );
+
+        return 0;
+    }
+
+    case WM_DPICHANGED:
+    {
+        UINT dpi = HIWORD(wParam);
+        auto* suggested = reinterpret_cast<RECT*>(lParam);
+
+        SetWindowPos(
+            hWnd,
+            nullptr,
+            suggested->left,
+            suggested->top,
+            suggested->right - suggested->left,
+            suggested->bottom - suggested->top,
+            SWP_NOZORDER | SWP_NOACTIVATE
+        );
+
+        ApplyFinishedAlertTheme(
+            hWnd,
+            dpi
+        );
+
+        EnumChildWindows(
+            hWnd,
+            [](
+                HWND child,
+                LPARAM) -> BOOL
+            {
+                ThemeFinishedAlertChild(
+                    child
+                );
+
+                return TRUE;
+            },
+            0
+        );
+
+        LayoutFinishedAlert(
+            hWnd,
+            dpi
+        );
+
+        return 0;
+    }
+
+    case WM_ERASEBKGND:
+    {
+        RECT rect{};
+        GetClientRect(hWnd, &rect);
+
+        FillRect(
+            reinterpret_cast<HDC>(wParam),
+            &rect,
+            g_finishedAlertBackgroundBrush
+        );
+
+        return 1;
+    }
+
+    case WM_CTLCOLORSTATIC:
+    {
+        HDC hdc =
+            reinterpret_cast<HDC>(wParam);
+
+        COLORREF textColor =
+            g_finishedAlertDark
+                ? RGB(245, 245, 245)
+                : RGB(25, 25, 25);
+
+        COLORREF background =
+            g_finishedAlertDark
+                ? RGB(32, 32, 32)
+                : RGB(249, 249, 249);
+
+        SetTextColor(
+            hdc,
+            textColor
+        );
+
+        SetBkColor(
+            hdc,
+            background
+        );
+
+        return reinterpret_cast<LRESULT>(
+            g_finishedAlertBackgroundBrush
+        );
+    }
+
+    case WM_CTLCOLOREDIT:
+    {
+        HDC hdc =
+            reinterpret_cast<HDC>(wParam);
+
+        COLORREF textColor =
+            g_finishedAlertDark
+                ? RGB(245, 245, 245)
+                : RGB(25, 25, 25);
+
+        COLORREF background =
+            g_finishedAlertDark
+                ? RGB(45, 45, 45)
+                : RGB(255, 255, 255);
+
+        SetTextColor(
+            hdc,
+            textColor
+        );
+
+        SetBkColor(
+            hdc,
+            background
+        );
+
+        return reinterpret_cast<LRESULT>(
+            g_finishedAlertEditBrush
+        );
+    }
+
+    case WM_COMMAND:
+    {
+        int id = LOWORD(wParam);
+
+        if (id == IDOK) {
+            id = IDC_ALERT_SNOOZE;
+        } else if (id == IDCANCEL) {
+            id = IDC_ALERT_DISMISS;
+        }
+
+        if (id == IDC_ALERT_SNOOZE) {
+            auto* data =
+                reinterpret_cast<FinishedAlertData*>(
+                    GetWindowLongPtrW(hWnd, GWLP_USERDATA)
+                );
+
+            wchar_t minutesText[32]{};
+
+            GetWindowTextW(
+                GetDlgItem(hWnd, IDC_ALERT_SNOOZE_MINUTES),
+                minutesText,
+                ARRAYSIZE(minutesText)
+            );
+
+            int minutes = _wtoi(minutesText);
+            int maximum = data ? data->maximumMinutes : 1440;
+
+            if (minutes <= 0 || minutes > maximum) {
+                wchar_t label[96]{};
+
+                swprintf_s(
+                    label,
+                    L"Snooze minutes (1-%d):",
+                    maximum
+                );
+
+                SetWindowTextW(
+                    GetDlgItem(hWnd, IDC_ALERT_SNOOZE_LABEL),
+                    label
+                );
+
+                HWND edit =
+                    GetDlgItem(hWnd, IDC_ALERT_SNOOZE_MINUTES);
+
+                SetFocus(edit);
+                SendMessageW(edit, EM_SETSEL, 0, -1);
+                MessageBeep(MB_ICONWARNING);
+                return 0;
+            }
+
+            const wchar_t* reminder =
+                data && data->reminder[0]
+                    ? data->reminder
+                    : L"Timer finished";
+
+            if (!ArmTimer(minutes, reminder)) {
+                MessageBeep(MB_ICONERROR);
+                return 0;
+            }
+
+            g_pendingFinished.store(false);
+            DestroyWindow(hWnd);
+            return 0;
+        }
+
+        if (id == IDC_ALERT_DISMISS) {
+            g_pendingFinished.store(false);
+            DestroyWindow(hWnd);
+            return 0;
+        }
+
+        break;
+    }
+
+    case WM_CLOSE:
+        g_pendingFinished.store(false);
+        DestroyWindow(hWnd);
+        return 0;
+
+    case WM_DESTROY:
+        g_finishedAlertWnd.store(nullptr);
+        PostQuitMessage(0);
+        return 0;
+    }
+
+    return DefWindowProcW(hWnd, msg, wParam, lParam);
+}
+
+static DWORD WINAPI FinishedAlertThreadProc(LPVOID param)
+{
+    std::unique_ptr<FinishedAlertData> data(
+        reinterpret_cast<FinishedAlertData*>(param)
+    );
+
+    HMODULE modInstance = nullptr;
+
+    GetModuleHandleExW(
+        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+            GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+        reinterpret_cast<LPCWSTR>(FinishedAlertWndProc),
+        &modInstance
+    );
+
+    WNDCLASSEXW wc{sizeof(wc)};
+    wc.lpfnWndProc = FinishedAlertWndProc;
+    wc.hInstance = modInstance;
+    wc.lpszClassName = kFinishedAlertClass;
+    wc.hCursor = LoadCursorW(nullptr, IDC_ARROW);
+    wc.hbrBackground =
+        reinterpret_cast<HBRUSH>(COLOR_WINDOW + 1);
+
+    if (!RegisterClassExW(&wc)) {
+        DWORD error = GetLastError();
+
+        if (error != ERROR_CLASS_ALREADY_EXISTS) {
+            Wh_Log(
+                L"ERROR: Could not register completion alert class: %u",
+                error
+            );
+            return 0;
+        }
+    }
+
+    HWND taskbar = g_taskbarWnd.load();
+    UINT dpi = taskbar ? GetDpiForWindow(taskbar) : 96;
+
+    if (!dpi) {
+        dpi = 96;
+    }
+
+    HWND hWnd =
+        CreateWindowExW(
+            WS_EX_TOOLWINDOW | WS_EX_TOPMOST,
+            kFinishedAlertClass,
+            L"Timer finished",
+            WS_POPUP | WS_CAPTION | WS_SYSMENU,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            ScaleAlertValue(380, dpi),
+            ScaleAlertValue(220, dpi),
+            nullptr,
+            nullptr,
+            modInstance,
+            data.get()
+        );
+
+    if (!hWnd) {
+        Wh_Log(
+            L"ERROR: Could not create completion alert: %u",
+            GetLastError()
+        );
+
+        UnregisterClassW(kFinishedAlertClass, modInstance);
+        return 0;
+    }
+
+    g_finishedAlertWnd.store(hWnd);
+
+    PositionFinishedAlert(hWnd, dpi);
+    ShowWindow(hWnd, SW_SHOWNORMAL);
+
+    SetWindowPos(
+        hWnd,
+        HWND_TOPMOST,
+        0, 0, 0, 0,
+        SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW
+    );
+
+    FlashWindow(hWnd, TRUE);
+
+    MSG msg{};
+
+    while (!g_unloading.load()) {
+        DWORD wait =
+            MsgWaitForMultipleObjects(
+                1,
+                &g_finishedAlertStopEvent,
+                FALSE,
+                INFINITE,
+                QS_ALLINPUT
+            );
+
+        if (wait == WAIT_OBJECT_0) {
+            break;
+        }
+
+        if (wait != WAIT_OBJECT_0 + 1) {
+            break;
+        }
+
+        while (PeekMessageW(
+                   &msg,
+                   nullptr,
+                   0,
+                   0,
+                   PM_REMOVE))
+        {
+            if (msg.message == WM_QUIT) {
+                goto ExitLoop;
+            }
+
+            if (!IsDialogMessageW(hWnd, &msg)) {
+                TranslateMessage(&msg);
+                DispatchMessageW(&msg);
+            }
+        }
+    }
+
+ExitLoop:
+    if (IsWindow(hWnd)) {
+        DestroyWindow(hWnd);
+    }
+
+    g_finishedAlertWnd.store(nullptr);
+    UnregisterClassW(kFinishedAlertClass, modInstance);
+    return 0;
+}
+
+static void CloseFinishedAlertThreadIfExited()
+{
+    HANDLE thread = g_finishedAlertThread.load();
+
+    if (!thread) {
+        return;
+    }
+
+    if (WaitForSingleObject(thread, 0) != WAIT_OBJECT_0) {
+        return;
+    }
+
+    if (g_finishedAlertThread.compare_exchange_strong(
+            thread,
+            nullptr))
+    {
+        CloseHandle(thread);
+    }
+}
+
+static bool ShowFinishedAlert(const wchar_t* reminder)
+{
+    CloseFinishedAlertThreadIfExited();
+
+    if (HWND existing = g_finishedAlertWnd.load()) {
+        if (IsWindow(existing)) {
+            SetForegroundWindow(existing);
+            FlashWindow(existing, TRUE);
+            return true;
+        }
+    }
+
+    HANDLE existingThread = g_finishedAlertThread.load();
+
+    if (existingThread &&
+        WaitForSingleObject(existingThread, 0) != WAIT_OBJECT_0)
+    {
+        return true;
+    }
+
+    if (!g_finishedAlertStopEvent) {
+        g_finishedAlertStopEvent =
+            CreateEventW(nullptr, TRUE, FALSE, nullptr);
+
+        if (!g_finishedAlertStopEvent) {
+            Wh_Log(
+                L"ERROR: Could not create completion alert stop event"
+            );
+            return false;
+        }
+    }
+
+    ResetEvent(g_finishedAlertStopEvent);
+
+    auto data = std::make_unique<FinishedAlertData>();
+
+    wcsncpy_s(
+        data->reminder,
+        reminder && reminder[0]
+            ? reminder
+            : L"Timer finished",
+        _TRUNCATE
+    );
+
+    ModSettings settings = GetSettingsSnapshot();
+    data->defaultSnoozeMinutes = settings.defaultSnoozeMinutes;
+    data->maximumMinutes = settings.maximumMinutes;
+
+    HANDLE thread =
+        CreateThread(
+            nullptr,
+            0,
+            FinishedAlertThreadProc,
+            data.get(),
+            0,
+            nullptr
+        );
+
+    if (!thread) {
+        Wh_Log(
+            L"ERROR: Could not create completion alert thread"
+        );
+        return false;
+    }
+
+    data.release();
+    g_finishedAlertThread.store(thread);
+    return true;
+}
+
+static void TimerExpiredOnTaskbarThread(void*)
+{
+    if (g_unloading.load()) {
+        return;
+    }
+
+    if (g_countdownTimer) {
+        g_countdownTimer.Stop();
+    }
+
+    SetIdleTaskbarText();
+}
+
+static void DispatchTimerExpiredToTaskbar()
+{
+    HWND taskbar = g_taskbarWnd.load();
+
+    if (!taskbar ||
+        !IsWindow(taskbar))
+    {
+        taskbar = FindCurrentProcessTaskbarWnd();
+
+        if (taskbar) {
+            g_taskbarWnd.store(taskbar);
+        }
+    }
+
+    if (!taskbar) {
+        return;
+    }
+
+    RunFromWindowThread(
+        taskbar,
+        TimerExpiredOnTaskbarThread,
+        nullptr
+    );
+}
+
+
+// -----------------------------------------------------------------------------
+// Authoritative worker timer
+// -----------------------------------------------------------------------------
+
+static void HandleTimerExpiredFromWorker()
+{
+    if (g_unloading.load()) {
+        return;
+    }
+
+    ULONGLONG expected =
+        g_deadlineUtc100ns.load();
+
+    if (!expected ||
+        GetUtcFileTimeNow() < expected)
+    {
+        return;
+    }
+
+    g_deadlineUtc100ns.store(0);
+    g_secondsRemaining.store(0);
+    g_pendingFinished.store(true);
+
+    ClearPersistedTimer();
+
+    ModSettings settings =
+        GetSettingsSnapshot();
+
+    if (settings.completionSound) {
+        MessageBeep(
+            MB_ICONEXCLAMATION
+        );
+    }
+
+    DispatchTimerExpiredToTaskbar();
+
+    wchar_t reminder[256]{};
+    GetSharedReminder(reminder);
+
+    if (!ShowFinishedAlert(
+            reminder[0]
+                ? reminder
+                : L"Timer finished"))
+    {
+        Wh_Log(
+            L"ERROR: Completion alert couldn't be shown"
+        );
+    }
+}
+
+
+static DWORD WINAPI TimerWorkerThreadProc(
+    LPVOID)
+{
+    HANDLE handles[] = {
+        g_timerStopEvent,
+        g_timerRearmEvent,
+        g_timerWaitable,
+    };
+
+    while (!g_unloading.load()) {
+        DWORD wait =
+            WaitForMultipleObjects(
+                ARRAYSIZE(handles),
+                handles,
+                FALSE,
+                INFINITE
+            );
+
+        if (wait == WAIT_OBJECT_0) {
+            break;
+        }
+
+        if (wait == WAIT_OBJECT_0 + 1) {
+            ULONGLONG deadline =
+                g_deadlineUtc100ns.load();
+
+            if (!deadline) {
+                CancelWaitableTimer(
+                    g_timerWaitable
+                );
+
+                continue;
+            }
+
+            LARGE_INTEGER due{};
+            due.QuadPart =
+                static_cast<LONGLONG>(
+                    deadline
+                );
+
+            if (!SetWaitableTimer(
+                    g_timerWaitable,
+                    &due,
+                    0,
+                    nullptr,
+                    nullptr,
+                    FALSE))
+            {
+                Wh_Log(
+                    L"ERROR: SetWaitableTimer failed: %u",
+                    GetLastError()
+                );
+            }
+
+            continue;
+        }
+
+        if (wait == WAIT_OBJECT_0 + 2) {
+            HandleTimerExpiredFromWorker();
+            continue;
+        }
+
+        break;
+    }
+
+    CancelWaitableTimer(
+        g_timerWaitable
+    );
+
+    return 0;
+}
+
+
+static void RestorePersistedTimer()
+{
+    wchar_t deadlineText[32]{};
+
+    if (!Wh_GetStringValue(
+            L"deadlineUtc100ns",
+            deadlineText,
+            ARRAYSIZE(deadlineText)))
+    {
+        return;
+    }
+
+    wchar_t* end = nullptr;
+
+    unsigned long long parsed =
+        wcstoull(
+            deadlineText,
+            &end,
+            10
+        );
+
+    if (!end ||
+        end == deadlineText ||
+        *end != L'\0' ||
+        !parsed)
+    {
+        ClearPersistedTimer();
+        return;
+    }
+
+    wchar_t reminder[256]{};
+
+    Wh_GetStringValue(
+        L"reminder",
+        reminder,
+        ARRAYSIZE(reminder)
     );
 
     SetSharedReminder(
-        reminder && reminder[0]
+        reminder[0]
             ? reminder
             : L"Timer finished"
     );
 
-    g_deadlineThreadTimerId =
-        SetTimer(
-            nullptr,
-            0,
-            250,
-            nullptr
-        );
-
-    if (!g_deadlineThreadTimerId) {
-        g_deadlineTick.store(0);
-        g_secondsRemaining.store(0);
-
-        Wh_Log(
-            L"ERROR: Could not create authoritative timer"
-        );
-
-        return false;
-    }
-
-    wchar_t reminderCopy[256]{};
-    GetSharedReminder(
-        reminderCopy
-    );
-
-    if (!SyncCountdownDisplayToTaskbar(
-            true,
-            seconds,
-            reminderCopy))
-    {
-        Wh_Log(
-            L"WARNING: Timer armed, but taskbar display couldn't be updated"
-        );
-    }
-
-    Wh_Log(
-        L"Timer started: '%s' - %d seconds",
-        reminderCopy,
-        seconds
-    );
-
-    return true;
-}
-
-
-static bool CancelAuthoritativeTimer()
-{
-    if (g_deadlineThreadTimerId) {
-        KillTimer(
-            nullptr,
-            g_deadlineThreadTimerId
-        );
-
-        g_deadlineThreadTimerId = 0;
-    }
-
-    g_deadlineTick.store(0);
-    g_secondsRemaining.store(0);
-
-    wchar_t reminderCopy[256]{};
-    GetSharedReminder(
-        reminderCopy
-    );
-
-    if (!SyncCountdownDisplayToTaskbar(
-            false,
-            0,
-            reminderCopy))
-    {
-        Wh_Log(
-            L"WARNING: Timer cancelled, but taskbar display couldn't be updated"
-        );
-    }
-
-    Wh_Log(
-        L"Timer cancelled"
-    );
-
-    return true;
-}
-
-
-static void HandleAuthoritativeTimerTick()
-{
     ULONGLONG deadline =
-        g_deadlineTick.load();
+        static_cast<ULONGLONG>(
+            parsed
+        );
 
-    if (!deadline) {
-        if (g_deadlineThreadTimerId) {
-            KillTimer(
-                nullptr,
-                g_deadlineThreadTimerId
-            );
+    int remaining =
+        RemainingSeconds(deadline);
 
-            g_deadlineThreadTimerId = 0;
-        }
-
-        return;
-    }
-
-    ULONGLONG now =
-        GetTickCount64();
-
-    if (now < deadline) {
-        int remaining =
-            static_cast<int>(
-                (deadline -
-                 now +
-                 999ULL) /
-                1000ULL
-            );
+    if (remaining > 0) {
+        g_deadlineUtc100ns.store(
+            deadline
+        );
 
         g_secondsRemaining.store(
             remaining
         );
 
-        return;
-    }
+        g_pendingFinished.store(false);
 
-    if (g_deadlineThreadTimerId) {
-        KillTimer(
-            nullptr,
-            g_deadlineThreadTimerId
-        );
+        SignalTimerWorker();
 
-        g_deadlineThreadTimerId = 0;
-    }
-
-    g_deadlineTick.store(0);
-    g_secondsRemaining.store(0);
-
-    wchar_t reminderCopy[256]{};
-    GetSharedReminder(
-        reminderCopy
-    );
-
-    // The alarm is owned by the popup thread. XAML is display-only now.
-    if (!SyncCountdownDisplayToTaskbar(
-            false,
-            0,
-            reminderCopy))
-    {
         Wh_Log(
-            L"WARNING: Timer finished while taskbar display was unavailable"
+            L"Restored running timer with %d second(s) remaining",
+            remaining
         );
-    }
-
-    Wh_Log(
-        L"Timer finished: '%s'",
-        reminderCopy
-    );
-
-    if (HWND timerPopup = g_timerPopup.load()) {
-        ShowWindow(
-            timerPopup,
-            SW_HIDE
-        );
-    }
-
-    ShowFinishedPopup(
-        g_taskbarWnd.load(),
-        reminderCopy[0]
-            ? reminderCopy
-            : L"Timer finished"
-    );
-}
-
-
-// -----------------------------------------------------------------------------
-// Timer popup
-// -----------------------------------------------------------------------------
-
-static void ResetPopupForNewTimer(
-    HWND hWnd,
-    const wchar_t* activeReminder = nullptr)
-{
-    SetWindowTextW(
-        hWnd,
-        L"Timer"
-    );
-
-    HWND reminder =
-        GetDlgItem(
-            hWnd,
-            IDC_REMINDER
-        );
-
-    HWND minutes =
-        GetDlgItem(
-            hWnd,
-            IDC_MINUTES
-        );
-
-    HWND start =
-        GetDlgItem(
-            hWnd,
-            IDC_START
-        );
-
-    HWND cancel =
-        GetDlgItem(
-            hWnd,
-            IDC_CANCEL_TIMER
-        );
-
-    const int secondsRemaining =
-        g_secondsRemaining.load();
-
-    const bool timerRunning =
-        secondsRemaining > 0;
-
-    if (timerRunning) {
-        SetWindowTextW(
-            reminder,
-            activeReminder && activeReminder[0]
-                ? activeReminder
-                : L"Timer"
-        );
-
-        // The input accepts whole minutes, so show the remaining time
-        // rounded up to the next minute.
-        int remainingMinutes =
-            (secondsRemaining + 59) / 60;
-
-        wchar_t minutesText[32]{};
-
-        swprintf_s(
-            minutesText,
-            L"%d",
-            remainingMinutes
-        );
-
-        SetWindowTextW(
-            minutes,
-            minutesText
-        );
-
-        // While a timer is active, this popup is for viewing/cancelling it.
-        EnableWindow(reminder, FALSE);
-        EnableWindow(minutes, FALSE);
-        EnableWindow(start, FALSE);
-        EnableWindow(cancel, TRUE);
     }
     else {
-        SetWindowTextW(
-            reminder,
-            L""
+        g_deadlineUtc100ns.store(0);
+        g_secondsRemaining.store(0);
+        g_pendingFinished.store(true);
+
+        ClearPersistedTimer();
+
+        ModSettings settings =
+            GetSettingsSnapshot();
+
+        if (settings.completionSound) {
+            MessageBeep(
+                MB_ICONEXCLAMATION
+            );
+        }
+
+        Wh_Log(
+            L"Restored expired timer"
         );
 
-        SetWindowTextW(
-            minutes,
-            L"20"
+        ShowFinishedAlert(
+            reminder[0]
+                ? reminder
+                : L"Timer finished"
         );
-
-        EnableWindow(reminder, TRUE);
-        EnableWindow(minutes, TRUE);
-        EnableWindow(start, TRUE);
-        EnableWindow(cancel, FALSE);
     }
-
-    SetWindowTextW(
-        start,
-        L"Start"
-    );
 }
 
 
-// -----------------------------------------------------------------------------
-// Finished / snooze popup
-// -----------------------------------------------------------------------------
-
-static LRESULT CALLBACK FinishedPopupWndProc(
-    HWND hWnd,
-    UINT msg,
-    WPARAM wParam,
-    LPARAM lParam)
+static bool EnsureTimerWorkerStarted()
 {
-    switch (msg)
-    {
-    case WM_ERASEBKGND:
-    {
-        RECT rect{};
-
-        GetClientRect(
-            hWnd,
-            &rect
-        );
-
-        FillRect(
-            reinterpret_cast<HDC>(wParam),
-            &rect,
-            g_popupBackgroundBrush
-        );
-
-        return 1;
-    }
-
-    case WM_CTLCOLORSTATIC:
-    case WM_CTLCOLORBTN:
-    {
-        HDC hdc =
-            reinterpret_cast<HDC>(wParam);
-
-        SetTextColor(
-            hdc,
-            kPopupText
-        );
-
-        SetBkColor(
-            hdc,
-            kPopupBackground
-        );
-
-        return reinterpret_cast<LRESULT>(
-            g_popupBackgroundBrush
-        );
-    }
-
-    case WM_CTLCOLOREDIT:
-    {
-        HDC hdc =
-            reinterpret_cast<HDC>(wParam);
-
-        SetTextColor(
-            hdc,
-            kPopupText
-        );
-
-        SetBkColor(
-            hdc,
-            kPopupEditBackground
-        );
-
-        return reinterpret_cast<LRESULT>(
-            g_popupEditBrush
-        );
-    }
-
-    case WM_DPICHANGED:
-    {
-        UINT dpi =
-            HIWORD(wParam);
-
-        RECT* suggested =
-            reinterpret_cast<RECT*>(
-                lParam
-            );
-
-        SetWindowPos(
-            hWnd,
-            nullptr,
-            suggested->left,
-            suggested->top,
-            suggested->right -
-                suggested->left,
-            suggested->bottom -
-                suggested->top,
-            SWP_NOZORDER |
-                SWP_NOACTIVATE
-        );
-
-        LayoutFinishedPopup(
-            hWnd,
-            dpi
-        );
-
-        return 0;
-    }
-
-    case WM_COMMAND:
-        if (LOWORD(wParam) == IDC_SNOOZE &&
-            HIWORD(wParam) == BN_CLICKED)
-        {
-            wchar_t minutesText[32]{};
-
-            GetWindowTextW(
-                GetDlgItem(
-                    hWnd,
-                    IDC_SNOOZE_MINUTES
-                ),
-                minutesText,
-                ARRAYSIZE(minutesText)
-            );
-
-            int minutes =
-                _wtoi(minutesText);
-
-            if (minutes <= 0 ||
-                minutes > 1440)
-            {
-                SetWindowTextW(
-                    GetDlgItem(
-                        hWnd,
-                        IDC_SNOOZE_LABEL
-                    ),
-                    L"Snooze minutes (1-1440):"
-                );
-
-                HWND edit =
-                    GetDlgItem(
-                        hWnd,
-                        IDC_SNOOZE_MINUTES
-                    );
-
-                SetFocus(edit);
-
-                SendMessageW(
-                    edit,
-                    EM_SETSEL,
-                    0,
-                    -1
-                );
-
-                return 0;
-            }
-
-            SetWindowTextW(
-                GetDlgItem(
-                    hWnd,
-                    IDC_SNOOZE_LABEL
-                ),
-                L"Snooze minutes:"
-            );
-
-            wchar_t finishedReminder[256]{};
-            GetWindowTextW(
-                GetDlgItem(
-                    hWnd,
-                    IDC_FINISHED_TEXT
-                ),
-                finishedReminder,
-                ARRAYSIZE(finishedReminder)
-            );
-
-            if (!StartAuthoritativeTimer(
-                    minutes * 60,
-                    finishedReminder[0]
-                        ? finishedReminder
-                        : L"Timer finished"))
-            {
-                Wh_Log(
-                    L"ERROR: Could not snooze timer"
-                );
-
-                return 0;
-            }
-
-            Wh_Log(
-                L"Timer snoozed for %d minutes",
-                minutes
-            );
-
-            DestroyWindow(hWnd);
-            return 0;
-        }
-
-        if ((LOWORD(wParam) == IDC_DISMISS ||
-             LOWORD(wParam) == IDC_CLOSE_FINISHED) &&
-            HIWORD(wParam) == BN_CLICKED)
-        {
-            DestroyWindow(hWnd);
-            return 0;
-        }
-
-        break;
-
-    case WM_CLOSE:
-        DestroyWindow(hWnd);
-        return 0;
-
-    case WM_DESTROY:
-        g_finishedPopup.store(nullptr);
-        return 0;
-    }
-
-    return DefWindowProcW(
-        hWnd,
-        msg,
-        wParam,
-        lParam
-    );
-}
-
-
-static LRESULT CALLBACK TimerPopupWndProc(
-    HWND hWnd,
-    UINT msg,
-    WPARAM wParam,
-    LPARAM lParam);
-
-
-static constexpr wchar_t kTimerPopupClass[] =
-    L"TaskbarCountdownTimerPopup";
-
-static constexpr wchar_t kFinishedPopupClass[] =
-    L"TaskbarCountdownTimerFinishedPopup";
-
-
-static bool RegisterOnePopupClass(
-    const wchar_t* className,
-    WNDPROC wndProc)
-{
-    WNDCLASSEXW wc{
-        sizeof(wc)
-    };
-
-    wc.lpfnWndProc =
-        wndProc;
-
-    wc.hInstance =
-        g_modInstance;
-
-    wc.lpszClassName =
-        className;
-
-    wc.hCursor =
-        LoadCursorW(
-            nullptr,
-            IDC_ARROW
-        );
-
-    wc.hbrBackground =
-        reinterpret_cast<HBRUSH>(
-            COLOR_WINDOW + 1
-        );
-
-    if (RegisterClassExW(&wc)) {
+    if (g_timerWorkerStarted.load()) {
         return true;
     }
 
-    if (GetLastError() !=
-        ERROR_CLASS_ALREADY_EXISTS)
-    {
+    if (g_unloading.load()) {
         return false;
     }
 
-    if (!UnregisterClassW(
-            className,
-            g_modInstance))
-    {
-        return false;
-    }
-
-    return RegisterClassExW(&wc) != 0;
-}
-
-
-static bool RegisterPopupClasses()
-{
-    if (!RegisterOnePopupClass(
-            kTimerPopupClass,
-            TimerPopupWndProc))
-    {
-        Wh_Log(
-            L"ERROR: Could not register timer popup class"
-        );
-
-        return false;
-    }
-
-    if (!RegisterOnePopupClass(
-            kFinishedPopupClass,
-            FinishedPopupWndProc))
-    {
-        UnregisterClassW(
-            kTimerPopupClass,
-            g_modInstance
-        );
-
-        Wh_Log(
-            L"ERROR: Could not register finished popup class"
-        );
-
-        return false;
-    }
-
-    return true;
-}
-
-
-static void UnregisterPopupClasses()
-{
-    UnregisterClassW(
-        kFinishedPopupClass,
-        g_modInstance
-    );
-
-    UnregisterClassW(
-        kTimerPopupClass,
-        g_modInstance
-    );
-}
-
-
-static void ShowFinishedPopup(
-    HWND owner,
-    const wchar_t* reminderText)
-{
-    if (HWND existing = g_finishedPopup.load()) {
-        if (HWND text = GetDlgItem(existing, IDC_FINISHED_TEXT)) {
-            SetWindowTextW(
-                text,
-                reminderText && reminderText[0]
-                    ? reminderText
-                    : L"Timer finished"
-            );
-        }
-
-        SetForegroundWindow(existing);
-        return;
-    }
-
-    UINT dpi =
-        GetPopupDpi(owner);
-
-    HWND hWnd = CreateWindowExW(
-        WS_EX_TOOLWINDOW |
-            WS_EX_TOPMOST,
-        kFinishedPopupClass,
-        L"Timer finished",
-        WS_POPUP |
-            WS_BORDER,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        ScaleByDpi(380, dpi),
-        ScaleByDpi(220, dpi),
-        nullptr,
-        nullptr,
-        g_modInstance,
-        nullptr
-    );
-
-    if (!hWnd) {
-        Wh_Log(
-            L"ERROR: Could not create finished popup"
-        );
-
-        return;
-    }
-
-    ApplyModernWindowStyle(
-        hWnd
-    );
-
-    g_finishedPopup.store(hWnd);
-
-    CreateWindowExW(
-        0,
-        L"BUTTON",
-        L"×",
-        WS_CHILD |
-            WS_VISIBLE |
-            WS_TABSTOP |
-            BS_FLAT,
-        0, 0, 0, 0,
-        hWnd,
-        reinterpret_cast<HMENU>(
-            IDC_CLOSE_FINISHED
-        ),
-        g_modInstance,
-        nullptr
-    );
-
-    CreateWindowExW(
-        0,
-        L"STATIC",
-        reminderText && reminderText[0]
-            ? reminderText
-            : L"Timer finished",
-        WS_CHILD |
-            WS_VISIBLE |
-            SS_CENTER,
-        0, 0, 0, 0,
-        hWnd,
-        reinterpret_cast<HMENU>(
-            IDC_FINISHED_TEXT
-        ),
-        g_modInstance,
-        nullptr
-    );
-
-    CreateWindowExW(
-        0,
-        L"STATIC",
-        L"Snooze minutes:",
-        WS_CHILD |
-            WS_VISIBLE,
-        0, 0, 0, 0,
-        hWnd,
-        reinterpret_cast<HMENU>(
-            IDC_SNOOZE_LABEL
-        ),
-        g_modInstance,
-        nullptr
-    );
-
-    CreateWindowExW(
-        WS_EX_CLIENTEDGE,
-        L"EDIT",
-        L"5",
-        WS_CHILD |
-            WS_VISIBLE |
-            WS_TABSTOP |
-            ES_NUMBER,
-        0, 0, 0, 0,
-        hWnd,
-        reinterpret_cast<HMENU>(
-            IDC_SNOOZE_MINUTES
-        ),
-        g_modInstance,
-        nullptr
-    );
-
-    CreateWindowExW(
-        0,
-        L"BUTTON",
-        L"Snooze",
-        WS_CHILD |
-            WS_VISIBLE |
-            WS_TABSTOP |
-            BS_PUSHBUTTON,
-        0, 0, 0, 0,
-        hWnd,
-        reinterpret_cast<HMENU>(
-            IDC_SNOOZE
-        ),
-        g_modInstance,
-        nullptr
-    );
-
-    CreateWindowExW(
-        0,
-        L"BUTTON",
-        L"Dismiss",
-        WS_CHILD |
-            WS_VISIBLE |
-            WS_TABSTOP |
-            BS_PUSHBUTTON,
-        0, 0, 0, 0,
-        hWnd,
-        reinterpret_cast<HMENU>(
-            IDC_DISMISS
-        ),
-        g_modInstance,
-        nullptr
-    );
-
-    LayoutFinishedPopup(
-        hWnd,
-        dpi
-    );
-
-    PositionPopupNearTaskbar(
-        hWnd,
-        owner,
-        380,
-        220,
-        dpi
-    );
-
-    MessageBeep(
-        MB_ICONEXCLAMATION
-    );
-
-    ShowWindow(
-        hWnd,
-        SW_SHOW
-    );
-
-    UpdateWindow(hWnd);
-
-    SetForegroundWindow(hWnd);
-
-    SetFocus(
-        GetDlgItem(
-            hWnd,
-            IDC_SNOOZE_MINUTES
-        )
-    );
-}
-
-
-static LRESULT CALLBACK TimerPopupWndProc(
-    HWND hWnd,
-    UINT msg,
-    WPARAM wParam,
-    LPARAM lParam)
-{
-    switch (msg)
-    {
-    case WM_ERASEBKGND:
-    {
-        RECT rect{};
-
-        GetClientRect(
-            hWnd,
-            &rect
-        );
-
-        FillRect(
-            reinterpret_cast<HDC>(wParam),
-            &rect,
-            g_popupBackgroundBrush
-        );
-
-        return 1;
-    }
-
-    case WM_CTLCOLORSTATIC:
-    case WM_CTLCOLORBTN:
-    {
-        HDC hdc =
-            reinterpret_cast<HDC>(wParam);
-
-        SetTextColor(
-            hdc,
-            kPopupText
-        );
-
-        SetBkColor(
-            hdc,
-            kPopupBackground
-        );
-
-        return reinterpret_cast<LRESULT>(
-            g_popupBackgroundBrush
-        );
-    }
-
-    case WM_CTLCOLOREDIT:
-    {
-        HDC hdc =
-            reinterpret_cast<HDC>(wParam);
-
-        SetTextColor(
-            hdc,
-            kPopupText
-        );
-
-        SetBkColor(
-            hdc,
-            kPopupEditBackground
-        );
-
-        return reinterpret_cast<LRESULT>(
-            g_popupEditBrush
-        );
-    }
-
-    case WM_DPICHANGED:
-    {
-        UINT dpi =
-            HIWORD(wParam);
-
-        RECT* suggested =
-            reinterpret_cast<RECT*>(
-                lParam
-            );
-
-        SetWindowPos(
-            hWnd,
+    g_timerStopEvent =
+        CreateEventW(
             nullptr,
-            suggested->left,
-            suggested->top,
-            suggested->right -
-                suggested->left,
-            suggested->bottom -
-                suggested->top,
-            SWP_NOZORDER |
-                SWP_NOACTIVATE
-        );
-
-        LayoutTimerPopup(
-            hWnd,
-            dpi
-        );
-
-        return 0;
-    }
-
-    case WM_COMMAND:
-        if (LOWORD(wParam) == IDC_START &&
-            HIWORD(wParam) == BN_CLICKED)
-        {
-            wchar_t reminder[256]{};
-            wchar_t minutesText[32]{};
-
-            GetWindowTextW(
-                GetDlgItem(
-                    hWnd,
-                    IDC_REMINDER
-                ),
-                reminder,
-                ARRAYSIZE(reminder)
-            );
-
-            GetWindowTextW(
-                GetDlgItem(
-                    hWnd,
-                    IDC_MINUTES
-                ),
-                minutesText,
-                ARRAYSIZE(minutesText)
-            );
-
-            int minutes =
-                _wtoi(minutesText);
-
-            if (minutes <= 0 ||
-                minutes > 1440)
-            {
-                SetWindowTextW(
-                    GetDlgItem(
-                        hWnd,
-                        IDC_MINUTES_LABEL
-                    ),
-                    L"Minutes (1-1440):"
-                );
-
-                HWND edit =
-                    GetDlgItem(
-                        hWnd,
-                        IDC_MINUTES
-                    );
-
-                SetFocus(edit);
-
-                SendMessageW(
-                    edit,
-                    EM_SETSEL,
-                    0,
-                    -1
-                );
-
-                return 0;
-            }
-
-            SetWindowTextW(
-                GetDlgItem(
-                    hWnd,
-                    IDC_MINUTES_LABEL
-                ),
-                L"Minutes:"
-            );
-
-            if (!reminder[0]) {
-                wcsncpy_s(
-                    reminder,
-                    L"Timer finished",
-                    _TRUNCATE
-                );
-            }
-
-            if (!StartAuthoritativeTimer(
-                    minutes * 60,
-                    reminder))
-            {
-                Wh_Log(
-                    L"ERROR: Could not start timer"
-                );
-
-                return 0;
-            }
-
-            ShowWindow(
-                hWnd,
-                SW_HIDE
-            );
-
-            return 0;
-        }
-
-        if (LOWORD(wParam) == IDC_CLOSE_TIMER &&
-            HIWORD(wParam) == BN_CLICKED)
-        {
-            ShowWindow(
-                hWnd,
-                SW_HIDE
-            );
-
-            return 0;
-        }
-
-        if (LOWORD(wParam) == IDC_CANCEL_TIMER &&
-            HIWORD(wParam) == BN_CLICKED)
-        {
-            if (!CancelAuthoritativeTimer()) {
-                Wh_Log(
-                    L"ERROR: Could not cancel timer"
-                );
-
-                return 0;
-            }
-
-            ShowWindow(
-                hWnd,
-                SW_HIDE
-            );
-
-            return 0;
-        }
-
-        break;
-
-    case WM_APP_TIMER_SHOW:
-    {
-        std::unique_ptr<std::wstring> activeReminder(
-            reinterpret_cast<std::wstring*>(lParam)
-        );
-
-        HWND taskbar = g_taskbarWnd.load();
-        if (!taskbar || !IsWindow(taskbar)) {
-            taskbar = FindCurrentProcessTaskbarWnd();
-            if (taskbar) {
-                g_taskbarWnd.store(taskbar);
-            }
-        }
-
-        UINT dpi = GetPopupDpi(taskbar);
-
-        ResetPopupForNewTimer(
-            hWnd,
-            activeReminder ? activeReminder->c_str() : nullptr
-        );
-
-        LayoutTimerPopup(
-            hWnd,
-            dpi
-        );
-
-        PositionPopupNearTaskbar(
-            hWnd,
-            taskbar,
-            380,
-            235,
-            dpi
-        );
-
-        ShowWindow(
-            hWnd,
-            SW_SHOWNORMAL
-        );
-
-        SetWindowPos(
-            hWnd,
-            HWND_TOPMOST,
-            0,
-            0,
-            0,
-            0,
-            SWP_NOMOVE |
-                SWP_NOSIZE |
-                SWP_SHOWWINDOW
-        );
-
-        SetForegroundWindow(hWnd);
-
-        SetFocus(
-            GetDlgItem(
-                hWnd,
-                IDC_REMINDER
-            )
-        );
-
-        return 0;
-    }
-
-    case WM_CLOSE:
-        ShowWindow(
-            hWnd,
-            SW_HIDE
-        );
-
-        return 0;
-
-    case WM_DESTROY:
-        g_timerPopup.store(nullptr);
-
-        PostQuitMessage(0);
-
-        return 0;
-    }
-
-    return DefWindowProcW(
-        hWnd,
-        msg,
-        wParam,
-        lParam
-    );
-}
-
-
-static bool ShowTimerPopup(
-    HWND owner)
-{
-    UINT dpi =
-        GetPopupDpi(owner);
-
-    HWND hWnd = CreateWindowExW(
-        WS_EX_TOOLWINDOW |
-            WS_EX_TOPMOST,
-        kTimerPopupClass,
-        L"Timer",
-        WS_POPUP |
-            WS_BORDER,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        ScaleByDpi(380, dpi),
-        ScaleByDpi(235, dpi),
-        nullptr,
-        nullptr,
-        g_modInstance,
-        nullptr
-    );
-
-    if (!hWnd) {
-        Wh_Log(
-            L"ERROR: Could not create timer popup"
-        );
-
-        return false;
-    }
-
-    ApplyModernWindowStyle(
-        hWnd
-    );
-
-    g_timerPopup.store(hWnd);
-
-    CreateWindowExW(
-        0,
-        L"BUTTON",
-        L"×",
-        WS_CHILD |
-            WS_VISIBLE |
-            WS_TABSTOP |
-            BS_FLAT,
-        0, 0, 0, 0,
-        hWnd,
-        reinterpret_cast<HMENU>(
-            IDC_CLOSE_TIMER
-        ),
-        g_modInstance,
-        nullptr
-    );
-
-    CreateWindowExW(
-        0,
-        L"STATIC",
-        L"Reminder:",
-        WS_CHILD |
-            WS_VISIBLE,
-        0, 0, 0, 0,
-        hWnd,
-        reinterpret_cast<HMENU>(
-            IDC_REMINDER_LABEL
-        ),
-        g_modInstance,
-        nullptr
-    );
-
-    CreateWindowExW(
-        WS_EX_CLIENTEDGE,
-        L"EDIT",
-        L"",
-        WS_CHILD |
-            WS_VISIBLE |
-            WS_TABSTOP |
-            ES_AUTOHSCROLL,
-        0, 0, 0, 0,
-        hWnd,
-        reinterpret_cast<HMENU>(
-            IDC_REMINDER
-        ),
-        g_modInstance,
-        nullptr
-    );
-
-    CreateWindowExW(
-        0,
-        L"STATIC",
-        L"Minutes:",
-        WS_CHILD |
-            WS_VISIBLE,
-        0, 0, 0, 0,
-        hWnd,
-        reinterpret_cast<HMENU>(
-            IDC_MINUTES_LABEL
-        ),
-        g_modInstance,
-        nullptr
-    );
-
-    CreateWindowExW(
-        WS_EX_CLIENTEDGE,
-        L"EDIT",
-        L"20",
-        WS_CHILD |
-            WS_VISIBLE |
-            WS_TABSTOP |
-            ES_NUMBER,
-        0, 0, 0, 0,
-        hWnd,
-        reinterpret_cast<HMENU>(
-            IDC_MINUTES
-        ),
-        g_modInstance,
-        nullptr
-    );
-
-    CreateWindowExW(
-        0,
-        L"BUTTON",
-        L"Start",
-        WS_CHILD |
-            WS_VISIBLE |
-            WS_TABSTOP |
-            BS_PUSHBUTTON,
-        0, 0, 0, 0,
-        hWnd,
-        reinterpret_cast<HMENU>(
-            IDC_START
-        ),
-        g_modInstance,
-        nullptr
-    );
-
-    HWND cancelButton =
-        CreateWindowExW(
-            0,
-            L"BUTTON",
-            L"Cancel timer",
-            WS_CHILD |
-                WS_VISIBLE |
-                WS_TABSTOP |
-                BS_PUSHBUTTON,
-            0, 0, 0, 0,
-            hWnd,
-            reinterpret_cast<HMENU>(
-                IDC_CANCEL_TIMER
-            ),
-            g_modInstance,
+            TRUE,
+            FALSE,
             nullptr
         );
 
-    EnableWindow(
-        cancelButton,
-        g_secondsRemaining.load() > 0
-    );
-
-    LayoutTimerPopup(
-        hWnd,
-        dpi
-    );
-
-    ShowWindow(
-        hWnd,
-        SW_HIDE
-    );
-
-    UpdateWindow(hWnd);
-
-    return true;
-}
-
-
-static bool PostStringMessage(
-    HWND hWnd,
-    UINT message,
-    const wchar_t* text)
-{
-    if (!hWnd) {
-        return false;
-    }
-
-    auto payload =
-        new (std::nothrow) std::wstring(
-            text ? text : L""
-        );
-
-    if (!payload) {
-        return false;
-    }
-
-    if (!PostMessageW(
-            hWnd,
-            message,
-            0,
-            reinterpret_cast<LPARAM>(payload)))
-    {
-        delete payload;
-        return false;
-    }
-
-    return true;
-}
-
-
-static DWORD WINAPI TimerPopupThreadProc(
-    LPVOID)
-{
-    MSG msg{};
-
-    PeekMessageW(
-        &msg,
-        nullptr,
-        WM_USER,
-        WM_USER,
-        PM_NOREMOVE
-    );
-
-    if (g_popupThreadReadyEvent) {
-        SetEvent(g_popupThreadReadyEvent);
-    }
-
-    if (g_unloading.load()) {
-        return 0;
-    }
-
-    if (!RegisterPopupClasses()) {
-        return 0;
-    }
-
-    if (!ShowTimerPopup(nullptr)) {
-        UnregisterPopupClasses();
-        return 0;
-    }
-
-    // The configuration window is created up front but remains hidden until
-    // the taskbar button is clicked.
-    if (HWND popup = g_timerPopup.load()) {
-        ShowWindow(popup, SW_HIDE);
-    }
-
-    while (!g_unloading.load() &&
-           GetMessageW(&msg, nullptr, 0, 0) > 0)
-    {
-        if (!msg.hwnd &&
-            msg.message == WM_TIMER &&
-            g_deadlineThreadTimerId &&
-            msg.wParam == g_deadlineThreadTimerId)
-        {
-            HandleAuthoritativeTimerTick();
-            continue;
-        }
-
-        bool handled = false;
-
-        if (HWND finished = g_finishedPopup.load()) {
-            handled = IsDialogMessageW(finished, &msg) != FALSE;
-        }
-
-        if (!handled) {
-            if (HWND timer = g_timerPopup.load()) {
-                handled = IsDialogMessageW(timer, &msg) != FALSE;
-            }
-        }
-
-        if (!handled) {
-            TranslateMessage(&msg);
-            DispatchMessageW(&msg);
-        }
-    }
-
-    if (g_deadlineThreadTimerId) {
-        KillTimer(
+    g_timerRearmEvent =
+        CreateEventW(
             nullptr,
-            g_deadlineThreadTimerId
+            FALSE,
+            FALSE,
+            nullptr
         );
 
-        g_deadlineThreadTimerId = 0;
-    }
+    g_timerWaitable =
+        CreateWaitableTimerW(
+            nullptr,
+            FALSE,
+            nullptr
+        );
 
-    if (HWND finished = g_finishedPopup.load()) {
-        DestroyWindow(finished);
-    }
+    if (!g_timerStopEvent ||
+        !g_timerRearmEvent ||
+        !g_timerWaitable)
+    {
+        Wh_Log(
+            L"ERROR: Could not create timer worker objects"
+        );
 
-    if (HWND timer = g_timerPopup.load()) {
-        DestroyWindow(timer);
-    }
-
-    g_finishedPopup.store(nullptr);
-    g_timerPopup.store(nullptr);
-
-    UnregisterPopupClasses();
-    return 0;
-}
-
-
-static void OpenTimerPopup(
-    HWND taskbar)
-{
-    if (g_unloading.load()) {
-        return;
-    }
-
-    HWND popup = g_timerPopup.load();
-
-    if (popup) {
-        wchar_t reminderCopy[256]{};
-
-        if (g_secondsRemaining.load() > 0) {
-            GetSharedReminder(
-                reminderCopy
-            );
+        if (g_timerWaitable) {
+            CloseHandle(g_timerWaitable);
+            g_timerWaitable = nullptr;
         }
 
-        PostStringMessage(
-            popup,
-            WM_APP_TIMER_SHOW,
-            reminderCopy
+        if (g_timerRearmEvent) {
+            CloseHandle(g_timerRearmEvent);
+            g_timerRearmEvent = nullptr;
+        }
+
+        if (g_timerStopEvent) {
+            CloseHandle(g_timerStopEvent);
+            g_timerStopEvent = nullptr;
+        }
+
+        return false;
+    }
+
+    HANDLE thread =
+        CreateThread(
+            nullptr,
+            0,
+            TimerWorkerThreadProc,
+            nullptr,
+            0,
+            nullptr
         );
 
-        return;
-    }
-
-    HANDLE thread = g_timerPopupThread.load();
     if (!thread) {
-        Wh_Log(L"Popup thread isn't available yet");
-        return;
+        Wh_Log(
+            L"ERROR: Could not create timer worker thread"
+        );
+
+        CloseHandle(g_timerWaitable);
+        g_timerWaitable = nullptr;
+
+        CloseHandle(g_timerRearmEvent);
+        g_timerRearmEvent = nullptr;
+
+        CloseHandle(g_timerStopEvent);
+        g_timerStopEvent = nullptr;
+
+        return false;
     }
 
-    // Don't block the taskbar UI thread waiting for the popup thread.
-    if (WaitForSingleObject(thread, 0) == WAIT_OBJECT_0) {
-        Wh_Log(L"Popup thread exited unexpectedly");
-        return;
-    }
+    g_timerWorkerThread =
+        thread;
 
-    Wh_Log(L"Popup thread is still starting; try again");
+    g_timerWorkerStarted.store(true);
+
+    RestorePersistedTimer();
+
+    return true;
 }
-
 
 // -----------------------------------------------------------------------------
 // Add/remove taskbar button
 // -----------------------------------------------------------------------------
+
+static void ReleaseOwnedXamlForRebuild()
+{
+    HideAndReleaseFlyouts();
+
+    if (g_countdownTimer) {
+        g_countdownTimer.Stop();
+        g_countdownTimer.Tick(
+            g_timerTickToken
+        );
+        g_countdownTimer = nullptr;
+    }
+
+    if (g_timerButton) {
+        g_timerButton.Click(
+            g_timerButtonClickToken
+        );
+        g_timerButton = nullptr;
+    }
+
+    g_timerText = nullptr;
+    g_timerColumn = nullptr;
+}
+
+
+static void RemoveStaleNamedButton(
+    Panel const& panel,
+    FrameworkElement const& stale)
+{
+    if (!panel || !stale) {
+        return;
+    }
+
+    auto children =
+        panel.Children();
+
+    uint32_t staleIndex = 0;
+
+    if (!children.IndexOf(
+            stale,
+            staleIndex))
+    {
+        return;
+    }
+
+    auto grid =
+        panel.try_as<Grid>();
+
+    int staleColumn =
+        grid
+            ? Grid::GetColumn(stale)
+            : -1;
+
+    children.RemoveAt(
+        staleIndex
+    );
+
+    if (!grid ||
+        staleColumn < 0)
+    {
+        return;
+    }
+
+    auto columns =
+        grid.ColumnDefinitions();
+
+    if (static_cast<uint32_t>(staleColumn) >=
+        columns.Size())
+    {
+        return;
+    }
+
+    for (uint32_t i = 0;
+         i < children.Size();
+         i++)
+    {
+        auto child =
+            children.GetAt(i)
+                .try_as<FrameworkElement>();
+
+        if (!child) {
+            continue;
+        }
+
+        int column =
+            Grid::GetColumn(child);
+
+        if (column > staleColumn) {
+            Grid::SetColumn(
+                child,
+                column - 1
+            );
+        }
+    }
+
+    columns.RemoveAt(
+        static_cast<uint32_t>(
+            staleColumn
+        )
+    );
+}
+
 
 static void AddTimerButtonImpl(
     void* param)
@@ -2812,49 +2677,49 @@ static void AddTimerButtonImpl(
         return;
     }
 
-    auto existing =
-        FindChildRecursive(
-            tray,
-            [](FrameworkElement element)
-            {
-                return
-                    element.Name() ==
-                    L"TaskbarCountdownTimerButton";
-            }
-        );
+    auto children =
+        panel.Children();
 
-    // The current XAML tree already has our button.
-    if (existing) {
+    FrameworkElement existing{nullptr};
+
+    for (uint32_t i = 0;
+         i < children.Size();
+         i++)
+    {
+        auto child =
+            children.GetAt(i)
+                .try_as<FrameworkElement>();
+
+        if (child &&
+            child.Name() ==
+                L"TaskbarCountdownTimerButton")
+        {
+            existing = child;
+            break;
+        }
+    }
+
+    if (existing &&
+        g_timerButton &&
+        existing == g_timerButton)
+    {
         g_taskbarWnd.store(taskbar);
         g_buttonInjected.store(true);
         return;
     }
 
-    // If the taskbar XAML tree was rebuilt, release the old XAML objects on
-    // the taskbar UI thread before creating replacements.
-    if (g_countdownTimer) {
-        g_countdownTimer.Stop();
-
-        g_countdownTimer.Tick(
-            g_timerTickToken
+    if (existing) {
+        Wh_Log(
+            L"Removing stale timer button from a previous mod instance"
         );
 
-        g_countdownTimer =
-            nullptr;
-    }
-
-    if (g_timerButton) {
-        g_timerButton.Click(
-            g_timerButtonClickToken
+        RemoveStaleNamedButton(
+            panel,
+            existing
         );
-
-        g_timerButton =
-            nullptr;
     }
 
-    g_timerText =
-        nullptr;
-    g_timerColumn = nullptr;
+    ReleaseOwnedXamlForRebuild();
 
     g_timerButton = Button();
     g_timerText = TextBlock();
@@ -2863,15 +2728,16 @@ static void AddTimerButtonImpl(
         L"TaskbarCountdownTimerButton"
     );
 
-    int secondsRemaining =
-        g_secondsRemaining.load();
-
-    g_timerText.Text(
-        secondsRemaining > 0
-            ? FormatCountdown(
-                  secondsRemaining
-              )
-            : L"⏱ Timer"
+    g_timerButton.MinWidth(0);
+    g_timerButton.MinHeight(0);
+    g_timerButton.BorderThickness(
+        Thickness{0, 0, 0, 0}
+    );
+    g_timerButton.Padding(
+        Thickness{8, 0, 8, 0}
+    );
+    g_timerButton.VerticalAlignment(
+        VerticalAlignment::Stretch
     );
 
     g_timerText.VerticalAlignment(
@@ -2882,31 +2748,19 @@ static void AddTimerButtonImpl(
         g_timerText
     );
 
-    g_timerButton.VerticalAlignment(
-        VerticalAlignment::Stretch
-    );
-
-    g_timerButton.Padding(
-        Thickness{8, 0, 8, 0}
-    );
+    RefreshTaskbarCountdown();
 
     g_timerButtonClickToken =
         g_timerButton.Click(
             [](
-                winrt::Windows::Foundation::
-                    IInspectable const&,
+                auto const&,
                 RoutedEventArgs const&)
             {
-                HWND taskbar =
-                    FindCurrentProcessTaskbarWnd();
-
-                if (!taskbar ||
-                    g_unloading.load())
-                {
+                if (g_unloading.load()) {
                     return;
                 }
 
-                OpenTimerPopup(taskbar);
+                ShowTimerFlyout();
             }
         );
 
@@ -2920,71 +2774,40 @@ static void AddTimerButtonImpl(
     g_timerTickToken =
         g_countdownTimer.Tick(
             [](
-                winrt::Windows::Foundation::
-                    IInspectable const&,
-                winrt::Windows::Foundation::
-                    IInspectable const&)
+                auto const&,
+                auto const&)
             {
-                ULONGLONG deadline =
-                    g_deadlineTick.load();
-
-                if (!deadline) {
-                    g_secondsRemaining.store(0);
-
-                    if (g_countdownTimer) {
-                        g_countdownTimer.Stop();
-                    }
-
-                    if (g_timerText) {
-                        g_timerText.Text(
-                            L"⏱ Timer"
-                        );
-                    }
-
-                    return;
-                }
-
-                ULONGLONG now =
-                    GetTickCount64();
-
-                if (now >= deadline) {
-                    if (g_countdownTimer) {
-                        g_countdownTimer.Stop();
-                    }
-
-                    if (g_timerText) {
-                        g_timerText.Text(
-                            L"⏱ Timer"
-                        );
-                    }
-
+                if (g_unloading.load()) {
                     return;
                 }
 
                 int remaining =
-                    static_cast<int>(
-                        (deadline -
-                         now +
-                         999ULL) /
-                        1000ULL
+                    RemainingSeconds(
+                        g_deadlineUtc100ns.load()
                     );
 
                 g_secondsRemaining.store(
                     remaining
                 );
 
-                if (g_timerText) {
-                    g_timerText.Text(
-                        FormatCountdown(
-                            remaining
-                        )
-                    );
+                if (remaining > 0) {
+                    if (g_timerText) {
+                        g_timerText.Text(
+                            FormatCountdown(
+                                remaining
+                            )
+                        );
+                    }
+                }
+                else {
+                    if (g_countdownTimer) {
+                        g_countdownTimer.Stop();
+                    }
+
+                    SetIdleTaskbarText();
                 }
             }
         );
-
-    auto children =
-        panel.Children();
 
     auto trayClass =
         winrt::get_class_name(tray);
@@ -3007,24 +2830,15 @@ static void AddTimerButtonImpl(
                 trayClass.c_str()
             );
 
-            g_timerButton.Click(
-                g_timerButtonClickToken
-            );
-
-            g_timerButton = nullptr;
-            g_timerText = nullptr;
-            g_countdownTimer.Tick(
-                g_timerTickToken
-            );
-            g_countdownTimer = nullptr;
-
+            ReleaseOwnedXamlForRebuild();
             return;
         }
 
         auto columns =
             trayGrid.ColumnDefinitions();
 
-        g_timerColumn = ColumnDefinition();
+        g_timerColumn =
+            ColumnDefinition();
 
         g_timerColumn.Width(
             GridLengthHelper::Auto()
@@ -3064,45 +2878,33 @@ static void AddTimerButtonImpl(
         );
     }
 
-    // Re-arm display refresh after a taskbar XAML rebuild.
-    ULONGLONG deadline =
-        g_deadlineTick.load();
-
-    if (deadline) {
-        ULONGLONG now =
-            GetTickCount64();
-
-        if (now < deadline) {
-            int remaining =
-                static_cast<int>(
-                    (deadline -
-                     now +
-                     999ULL) /
-                    1000ULL
-                );
-
-            g_secondsRemaining.store(
-                remaining
-            );
-
-            g_timerText.Text(
-                FormatCountdown(
-                    remaining
-                )
-            );
-
-            g_countdownTimer.Start();
-        }
-        else {
-            // The popup thread is authoritative and will deliver the alarm.
-            g_timerText.Text(
-                L"⏱ Timer"
-            );
-        }
-    }
-
     g_taskbarWnd.store(taskbar);
     g_buttonInjected.store(true);
+
+    if (!EnsureTimerWorkerStarted()) {
+        Wh_Log(
+            L"ERROR: Timer worker could not be started"
+        );
+    }
+
+    int remaining =
+        RemainingSeconds(
+            g_deadlineUtc100ns.load()
+        );
+
+    g_secondsRemaining.store(
+        remaining
+    );
+
+    if (remaining > 0 &&
+        g_countdownTimer)
+    {
+        RefreshTaskbarCountdown();
+        g_countdownTimer.Start();
+    }
+    else {
+        SetIdleTaskbarText();
+    }
 
     Wh_Log(
         L"Timer button added to taskbar"
@@ -3117,7 +2919,8 @@ static void AddTimerButton(
         AddTimerButtonImpl(param);
     }
     catch (...) {
-        HRESULT error = winrt::to_hresult();
+        HRESULT error =
+            winrt::to_hresult();
 
         Wh_Log(
             L"Applying timer button failed: %08X",
@@ -3130,22 +2933,30 @@ static void AddTimerButton(
 static void RemoveTimerButtonImpl(
     void*)
 {
+    // Revoke every callback into this mod first. Nothing below this point is
+    // allowed to throw while leaving a live delegate behind.
+    if (g_loadedRevokers) {
+        g_loadedRevokers.reset();
+    }
+
+    HideAndReleaseFlyouts();
+
     if (g_countdownTimer) {
         g_countdownTimer.Stop();
-
         g_countdownTimer.Tick(
             g_timerTickToken
         );
-
-        g_countdownTimer =
-            nullptr;
+        g_countdownTimer = nullptr;
     }
 
     if (g_timerButton) {
         g_timerButton.Click(
             g_timerButtonClickToken
         );
+    }
 
+    // Best-effort visual-tree detachment follows after all callbacks are gone.
+    if (g_timerButton) {
         auto parentElement =
             VisualTreeHelper::GetParent(
                 g_timerButton
@@ -3170,11 +2981,14 @@ static void RemoveTimerButtonImpl(
             auto parentGrid =
                 parentElement.try_as<Grid>();
 
-            if (parentGrid && g_timerColumn) {
+            if (parentGrid &&
+                g_timerColumn)
+            {
                 auto columns =
                     parentGrid.ColumnDefinitions();
 
                 uint32_t columnIndex = 0;
+
                 if (columns.IndexOf(
                         g_timerColumn,
                         columnIndex))
@@ -3195,7 +3009,9 @@ static void RemoveTimerButtonImpl(
                             Grid::GetColumn(child);
 
                         if (currentColumn >
-                            static_cast<int>(columnIndex))
+                            static_cast<int>(
+                                columnIndex
+                            ))
                         {
                             Grid::SetColumn(
                                 child,
@@ -3204,14 +3020,12 @@ static void RemoveTimerButtonImpl(
                         }
                     }
 
-                    columns.RemoveAt(columnIndex);
+                    columns.RemoveAt(
+                        columnIndex
+                    );
                 }
             }
         }
-    }
-
-    if (g_loadedRevokers) {
-        g_loadedRevokers.reset();
     }
 
     g_timerColumn = nullptr;
@@ -3228,7 +3042,8 @@ static void RemoveTimerButton(
         RemoveTimerButtonImpl(param);
     }
     catch (...) {
-        HRESULT error = winrt::to_hresult();
+        HRESULT error =
+            winrt::to_hresult();
 
         Wh_Log(
             L"Removing timer button failed: %08X",
@@ -3243,7 +3058,9 @@ static bool TryRemoveTimerXaml()
     HWND target =
         g_taskbarWnd.load();
 
-    if (!target || !IsWindow(target)) {
+    if (!target ||
+        !IsWindow(target))
+    {
         target =
             FindCurrentProcessTaskbarWnd();
     }
@@ -3272,7 +3089,14 @@ static void ApplyTimerButtonIfAvailable()
     }
 
     HWND taskbar =
-        FindCurrentProcessTaskbarWnd();
+        g_taskbarWnd.load();
+
+    if (!taskbar ||
+        !IsWindow(taskbar))
+    {
+        taskbar =
+            FindCurrentProcessTaskbarWnd();
+    }
 
     if (!taskbar) {
         return;
@@ -3285,7 +3109,9 @@ static void ApplyTimerButtonIfAvailable()
             AddTimerButton,
             taskbar))
     {
-        Wh_Log(L"Could not access taskbar UI thread");
+        Wh_Log(
+            L"Could not access taskbar UI thread"
+        );
     }
 }
 
@@ -3294,7 +3120,8 @@ static DWORD WINAPI RetryThreadProc(
     LPVOID)
 {
     for (int i = 0;
-         i < 5 && !g_unloading.load();
+         i < 5 &&
+         !g_unloading.load();
          i++)
     {
         if (WaitForSingleObject(
@@ -3310,13 +3137,16 @@ static DWORD WINAPI RetryThreadProc(
             break;
         }
 
-        Wh_Log(L"Taskbar injection retry %d", i + 1);
+        Wh_Log(
+            L"Taskbar injection retry %d",
+            i + 1
+        );
+
         ApplyTimerButtonIfAvailable();
     }
 
     return 0;
 }
-
 
 // -----------------------------------------------------------------------------
 // System tray rebuild hook
@@ -3517,19 +3347,31 @@ static bool HookSystemTraySymbols(
 static void HandleLoadedModuleIfSystemTray(
     HMODULE module)
 {
+    if (g_systemTrayModuleHooked.load()) {
+        return;
+    }
+
     if (GetSystemTrayModuleHandle() != module) {
         return;
     }
 
-    if (!g_systemTrayModuleHooked.exchange(true)) {
-        if (HookSystemTraySymbols(module)) {
-            Wh_ApplyHookOperations();
-        }
-        else {
-            Wh_Log(
-                L"ERROR: Failed to hook system tray symbols"
-            );
-        }
+    HMODULE previous =
+        g_systemTrayModuleAttempted.exchange(
+            module
+        );
+
+    if (previous == module) {
+        return;
+    }
+
+    if (HookSystemTraySymbols(module)) {
+        g_systemTrayModuleHooked.store(true);
+        Wh_ApplyHookOperations();
+    }
+    else {
+        Wh_Log(
+            L"ERROR: Failed to hook system tray symbols"
+        );
     }
 }
 
@@ -3599,27 +3441,7 @@ BOOL Wh_ModInit()
 
     g_unloading.store(false);
 
-    HMODULE module = nullptr;
-
-    if (!GetModuleHandleExW(
-            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
-                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-            reinterpret_cast<LPCWSTR>(
-                &g_modInstance
-            ),
-            &module))
-    {
-        Wh_Log(
-            L"ERROR: Could not resolve mod module handle"
-        );
-
-        return FALSE;
-    }
-
-    g_modInstance =
-        reinterpret_cast<HINSTANCE>(
-            module
-        );
+    LoadSettings();
 
     if (!HookTaskbarDllSymbols()) {
         Wh_Log(
@@ -3634,14 +3456,21 @@ BOOL Wh_ModInit()
     if (HMODULE systemTray =
             GetSystemTrayModuleHandle())
     {
-        g_systemTrayModuleHooked.store(true);
+        g_systemTrayModuleAttempted.store(
+            systemTray
+        );
 
         systemTrayHookedAtInit =
             HookSystemTraySymbols(
                 systemTray
             );
 
-        if (!systemTrayHookedAtInit) {
+        if (systemTrayHookedAtInit) {
+            g_systemTrayModuleHooked.store(
+                true
+            );
+        }
+        else {
             Wh_Log(
                 L"ERROR: Failed to hook system tray symbols"
             );
@@ -3650,13 +3479,20 @@ BOOL Wh_ModInit()
 
     if (!systemTrayHookedAtInit) {
         HMODULE kernelbase =
-            GetModuleHandleW(L"kernelbase.dll");
+            GetModuleHandleW(
+                L"kernelbase.dll"
+            );
 
-        auto loadLibraryExW = kernelbase
-            ? reinterpret_cast<LoadLibraryExW_t>(
-                  GetProcAddress(kernelbase, "LoadLibraryExW")
-              )
-            : nullptr;
+        auto loadLibraryExW =
+            kernelbase
+                ? reinterpret_cast<
+                      LoadLibraryExW_t>(
+                      GetProcAddress(
+                          kernelbase,
+                          "LoadLibraryExW"
+                      )
+                  )
+                : nullptr;
 
         if (loadLibraryExW) {
             WindhawkUtils::SetFunctionHook(
@@ -3673,8 +3509,12 @@ BOOL Wh_ModInit()
 
 void Wh_ModAfterInit()
 {
-    if (HMODULE systemTray = GetSystemTrayModuleHandle()) {
-        HandleLoadedModuleIfSystemTray(systemTray);
+    if (HMODULE systemTray =
+            GetSystemTrayModuleHandle())
+    {
+        HandleLoadedModuleIfSystemTray(
+            systemTray
+        );
     }
 
     ApplyTimerButtonIfAvailable();
@@ -3687,7 +3527,9 @@ void Wh_ModAfterInit()
             nullptr
         );
 
-    if (g_retryStopEvent) {
+    if (g_retryStopEvent &&
+        !g_buttonInjected.load())
+    {
         g_retryThread =
             CreateThread(
                 nullptr,
@@ -3698,37 +3540,15 @@ void Wh_ModAfterInit()
                 nullptr
             );
     }
+}
 
-    g_popupThreadReadyEvent =
-        CreateEventW(
-            nullptr,
-            TRUE,
-            FALSE,
-            nullptr
+
+static void StopTimerWorker()
+{
+    if (g_timerStopEvent) {
+        SetEvent(
+            g_timerStopEvent
         );
-
-    if (g_popupThreadReadyEvent) {
-        DWORD threadId = 0;
-        HANDLE thread =
-            CreateThread(
-                nullptr,
-                0,
-                TimerPopupThreadProc,
-                nullptr,
-                0,
-                &threadId
-            );
-
-        if (thread) {
-            g_timerPopupThread.store(thread);
-            g_timerPopupThreadId.store(threadId);
-
-            // Bounded wait: initialization must never block indefinitely.
-            WaitForSingleObject(
-                g_popupThreadReadyEvent,
-                2000
-            );
-        }
     }
 }
 
@@ -3743,10 +3563,10 @@ void Wh_ModBeforeUninit()
         );
     }
 
-    // First teardown attempt while taskbar hooks are still available.
-    if (!TryRemoveTimerXaml() &&
-        g_buttonInjected.load())
-    {
+    StopTimerWorker();
+
+    // First teardown attempt while the taskbar thread is still available.
+    if (!TryRemoveTimerXaml()) {
         Wh_Log(
             L"Timer XAML teardown will be retried in Wh_ModUninit"
         );
@@ -3759,24 +3579,62 @@ void Wh_ModUninit()
     g_unloading.store(true);
 
     if (g_retryStopEvent) {
-        SetEvent(g_retryStopEvent);
+        SetEvent(
+            g_retryStopEvent
+        );
+    }
+
+    StopTimerWorker();
+
+    if (g_finishedAlertStopEvent) {
+        SetEvent(g_finishedAlertStopEvent);
+    }
+
+    if (HWND alert = g_finishedAlertWnd.load()) {
+        PostMessageW(alert, WM_CLOSE, 0, 0);
+    }
+
+    if (HANDLE alertThread =
+            g_finishedAlertThread.exchange(nullptr))
+    {
+        PumpWaitForThread(alertThread);
+        CloseHandle(alertThread);
     }
 
     if (g_retryThread) {
-        PumpWaitForThread(g_retryThread);
-        CloseHandle(g_retryThread);
+        PumpWaitForThread(
+            g_retryThread
+        );
+
+        CloseHandle(
+            g_retryThread
+        );
+
         g_retryThread = nullptr;
     }
 
-    if (g_retryStopEvent) {
-        CloseHandle(g_retryStopEvent);
-        g_retryStopEvent = nullptr;
+    if (g_timerWorkerThread) {
+        PumpWaitForThread(
+            g_timerWorkerThread
+        );
+
+        CloseHandle(
+            g_timerWorkerThread
+        );
+
+        g_timerWorkerThread = nullptr;
     }
 
+    g_timerWorkerStarted.store(false);
+
+    // Retry after all worker activity has stopped. We don't use
+    // g_buttonInjected as a shortcut because Loaded revokers can exist even
+    // when button injection never completed.
     bool removed = false;
 
     for (int attempt = 0;
-         attempt < 10 && !removed;
+         attempt < 10 &&
+         !removed;
          attempt++)
     {
         removed =
@@ -3787,75 +3645,94 @@ void Wh_ModUninit()
         }
     }
 
-    if (!removed &&
-        g_buttonInjected.load())
-    {
+    if (!removed) {
         Wh_Log(
-            L"ERROR: Could not remove timer XAML objects before unload"
+            L"ERROR: Could not verify timer XAML teardown before unload"
         );
     }
 
-    DWORD popupThreadId =
-        g_timerPopupThreadId.load();
-
-    HANDLE popupThread =
-        g_timerPopupThread.load();
-
-    if (popupThread &&
-        popupThreadId)
-    {
-        // WM_QUIT must be delivered before the infinite join below. If the
-        // thread's message queue isn't ready yet, retry until it is or until
-        // the thread has already exited.
-        while (!PostThreadMessageW(
-                    popupThreadId,
-                    WM_QUIT,
-                    0,
-                    0))
-        {
-            if (WaitForSingleObject(
-                    popupThread,
-                    50) == WAIT_OBJECT_0)
-            {
-                break;
-            }
-        }
+    if (g_timerWaitable) {
+        CloseHandle(
+            g_timerWaitable
+        );
+        g_timerWaitable = nullptr;
     }
 
-    if (popupThread) {
-        PumpWaitForThread(popupThread);
-        CloseHandle(popupThread);
-        g_timerPopupThread.store(nullptr);
+    if (g_timerRearmEvent) {
+        CloseHandle(
+            g_timerRearmEvent
+        );
+        g_timerRearmEvent = nullptr;
     }
 
-    if (g_popupThreadReadyEvent) {
-        CloseHandle(g_popupThreadReadyEvent);
-        g_popupThreadReadyEvent = nullptr;
+    if (g_timerStopEvent) {
+        CloseHandle(
+            g_timerStopEvent
+        );
+        g_timerStopEvent = nullptr;
     }
 
-    g_timerPopupThreadId.store(0);
-    g_finishedPopup.store(nullptr);
-    g_timerPopup.store(nullptr);
-
-    // Popup thread is gone, so no controls can still reference these objects.
-    if (g_popupFont) {
-        DeleteObject(g_popupFont);
-        g_popupFont = nullptr;
+    if (g_finishedAlertStopEvent) {
+        CloseHandle(g_finishedAlertStopEvent);
+        g_finishedAlertStopEvent = nullptr;
     }
 
-    if (g_popupEditBrush) {
-        DeleteObject(g_popupEditBrush);
-        g_popupEditBrush = nullptr;
+    if (g_finishedAlertFont) {
+        DeleteObject(g_finishedAlertFont);
+        g_finishedAlertFont = nullptr;
     }
 
-    if (g_popupBackgroundBrush) {
-        DeleteObject(g_popupBackgroundBrush);
-        g_popupBackgroundBrush = nullptr;
+    if (g_finishedAlertEditBrush) {
+        DeleteObject(g_finishedAlertEditBrush);
+        g_finishedAlertEditBrush = nullptr;
     }
 
-    g_popupFontDpi = 0;
+    if (g_finishedAlertBackgroundBrush) {
+        DeleteObject(g_finishedAlertBackgroundBrush);
+        g_finishedAlertBackgroundBrush = nullptr;
+    }
+
+    if (g_retryStopEvent) {
+        CloseHandle(
+            g_retryStopEvent
+        );
+        g_retryStopEvent = nullptr;
+    }
 
     Wh_Log(
         L"Taskbar Countdown Timer unloaded"
     );
+}
+
+
+static void UpdateIdleLabelOnTaskbarThread(
+    void*)
+{
+    if (!g_deadlineUtc100ns.load()) {
+        SetIdleTaskbarText();
+    }
+}
+
+
+void Wh_ModSettingsChanged()
+{
+    LoadSettings();
+
+    HWND taskbar =
+        g_taskbarWnd.load();
+
+    if (!taskbar ||
+        !IsWindow(taskbar))
+    {
+        taskbar =
+            FindCurrentProcessTaskbarWnd();
+    }
+
+    if (taskbar) {
+        RunFromWindowThread(
+            taskbar,
+            UpdateIdleLabelOnTaskbarThread,
+            nullptr
+        );
+    }
 }

--- a/mods/taskbar-countdown-timer.wh.cpp
+++ b/mods/taskbar-countdown-timer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-countdown-timer
 // @name            Taskbar Countdown Timer
 // @description     A simple countdown timer integrated into the Windows 11 taskbar (Windows 11 only)
-// @version         1.10
+// @version         1.11
 // @author          Richi
 // @github          https://github.com/richilp
 // @include         explorer.exe
@@ -58,7 +58,7 @@ The mod supports one active timer at a time and currently places its button on t
 
 - maximumMinutes: 1440
   $name: Maximum duration (minutes)
-  $description: Maximum value accepted for timers and snoozes.
+  $description: Maximum value accepted for timers and snoozes, up to 10080 minutes (7 days).
 
 - buttonLabel: "⏱ Timer"
   $name: Idle taskbar button label
@@ -92,6 +92,7 @@ The mod supports one active timer at a time and currently places its button on t
 #include <cstdlib>
 #include <functional>
 #include <list>
+#include <memory>
 #include <optional>
 #include <cwchar>
 #include <string>
@@ -170,8 +171,6 @@ static std::atomic_bool g_systemTrayModuleHooked{false};
 static std::atomic<HMODULE> g_systemTrayModuleAttempted{nullptr};
 
 static std::atomic_bool g_unloading{false};
-static HANDLE g_retryStopEvent = nullptr;
-static HANDLE g_retryThread = nullptr;
 
 static void ApplyTimerButtonIfAvailable();
 static bool EnsureTimerWorkerStarted();
@@ -328,6 +327,26 @@ static void* CTaskBand_ITaskListWndSite_vftable =
     nullptr;
 
 
+
+using TrayUI_StartTaskbar_t =
+    void(WINAPI*)(void* pThis);
+
+static TrayUI_StartTaskbar_t
+    TrayUI_StartTaskbar_Original = nullptr;
+
+static void WINAPI TrayUI_StartTaskbar_Hook(
+    void* pThis)
+{
+    TrayUI_StartTaskbar_Original(
+        pThis
+    );
+
+    if (!g_unloading.load()) {
+        ApplyTimerButtonIfAvailable();
+    }
+}
+
+
 static bool HookTaskbarDllSymbols()
 {
     HMODULE module = LoadLibraryExW(
@@ -345,6 +364,13 @@ static bool HookTaskbarDllSymbols()
     }
 
     WindhawkUtils::SYMBOL_HOOK taskbarDllHooks[] = {
+        {
+            {
+                LR"(public: virtual void __cdecl TrayUI::StartTaskbar(void))",
+            },
+            &TrayUI_StartTaskbar_Original,
+            TrayUI_StartTaskbar_Hook,
+        },
         {
             {
                 LR"(const CTaskBand::`vftable'{for `ITaskListWndSite'})"
@@ -709,14 +735,15 @@ static void LoadSettings()
     updated.completionSound =
         Wh_GetIntSetting(L"completionSound") != 0;
 
-    PCWSTR label =
-        Wh_GetStringSetting(L"buttonLabel");
+    auto label =
+        WindhawkUtils::StringSetting::make(
+            L"buttonLabel"
+        );
 
-    if (label[0]) {
-        updated.buttonLabel = label;
+    if (*label) {
+        updated.buttonLabel =
+            label.get();
     }
-
-    Wh_FreeStringSetting(label);
 
     AcquireSRWLockExclusive(&g_settingsLock);
     g_settings = updated;
@@ -2272,9 +2299,12 @@ static void HandleTimerExpiredFromWorker()
     ULONGLONG expected =
         g_deadlineUtc100ns.load();
 
-    if (!expected ||
-        GetUtcFileTimeNow() < expected)
-    {
+    if (!expected) {
+        return;
+    }
+
+    if (GetUtcFileTimeNow() < expected) {
+        SignalTimerWorker();
         return;
     }
 
@@ -2717,6 +2747,14 @@ static void AddTimerButtonImpl(
     void* param)
 {
     if (g_unloading.load()) {
+        return;
+    }
+
+    if (g_timerButton &&
+        VisualTreeHelper::GetParent(
+            g_timerButton))
+    {
+        g_buttonInjected.store(true);
         return;
     }
 
@@ -3193,37 +3231,6 @@ static void ApplyTimerButtonIfAvailable()
 }
 
 
-static DWORD WINAPI RetryThreadProc(
-    LPVOID)
-{
-    for (int i = 0;
-         i < 5 &&
-         !g_unloading.load();
-         i++)
-    {
-        if (WaitForSingleObject(
-                g_retryStopEvent,
-                2000) != WAIT_TIMEOUT)
-        {
-            break;
-        }
-
-        if (g_buttonInjected.load() ||
-            g_unloading.load())
-        {
-            break;
-        }
-
-        Wh_Log(
-            L"Taskbar injection retry %d",
-            i + 1
-        );
-
-        ApplyTimerButtonIfAvailable();
-    }
-
-    return 0;
-}
 
 // -----------------------------------------------------------------------------
 // System tray rebuild hook
@@ -3534,10 +3541,13 @@ BOOL Wh_ModInit()
     }
 
     bool systemTrayHookedAtInit = false;
+    bool systemTrayModuleLoadedAtInit = false;
 
     if (HMODULE systemTray =
             GetSystemTrayModuleHandle())
     {
+        systemTrayModuleLoadedAtInit = true;
+
         g_systemTrayModuleAttempted.store(
             systemTray
         );
@@ -3559,7 +3569,7 @@ BOOL Wh_ModInit()
         }
     }
 
-    if (!systemTrayHookedAtInit) {
+    if (!systemTrayModuleLoadedAtInit) {
         HMODULE kernelbase =
             GetModuleHandleW(
                 L"kernelbase.dll"
@@ -3600,28 +3610,6 @@ void Wh_ModAfterInit()
     }
 
     ApplyTimerButtonIfAvailable();
-
-    g_retryStopEvent =
-        CreateEventW(
-            nullptr,
-            TRUE,
-            FALSE,
-            nullptr
-        );
-
-    if (g_retryStopEvent &&
-        !g_buttonInjected.load())
-    {
-        g_retryThread =
-            CreateThread(
-                nullptr,
-                0,
-                RetryThreadProc,
-                nullptr,
-                0,
-                nullptr
-            );
-    }
 }
 
 
@@ -3639,12 +3627,6 @@ void Wh_ModBeforeUninit()
 {
     g_unloading.store(true);
 
-    if (g_retryStopEvent) {
-        SetEvent(
-            g_retryStopEvent
-        );
-    }
-
     StopTimerWorker();
 
     // First teardown attempt while the taskbar thread is still available.
@@ -3660,26 +3642,9 @@ void Wh_ModUninit()
 {
     g_unloading.store(true);
 
-    if (g_retryStopEvent) {
-        SetEvent(
-            g_retryStopEvent
-        );
-    }
-
     StopTimerWorker();
 
     // First stop and join every thread that can still create/use alert UI.
-    if (g_retryThread) {
-        PumpWaitForThread(
-            g_retryThread
-        );
-
-        CloseHandle(
-            g_retryThread
-        );
-
-        g_retryThread = nullptr;
-    }
 
     if (g_timerWorkerThread) {
         PumpWaitForThread(
@@ -3781,13 +3746,6 @@ void Wh_ModUninit()
             g_finishedAlertBackgroundBrush
         );
         g_finishedAlertBackgroundBrush = nullptr;
-    }
-
-    if (g_retryStopEvent) {
-        CloseHandle(
-            g_retryStopEvent
-        );
-        g_retryStopEvent = nullptr;
     }
 
     UnregisterFinishedAlertClass();

--- a/mods/taskbar-countdown-timer.wh.cpp
+++ b/mods/taskbar-countdown-timer.wh.cpp
@@ -2,11 +2,11 @@
 // @id              taskbar-countdown-timer
 // @name            Taskbar Countdown Timer
 // @description     A simple countdown timer integrated into the Windows taskbar
-// @version         1.2
+// @version         1.3
 // @author          Richi
 // @github          https://github.com/richilp
 // @include         explorer.exe
-// @architecture    amd64
+// @architecture    x86-64
 // @compilerOptions -lole32 -loleaut32 -lruntimeobject -ldwmapi -lgdi32
 // @license         MIT
 // ==/WindhawkMod==
@@ -58,6 +58,9 @@ While the timer is running, the remaining time is shown directly on the taskbar.
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
+#include <list>
+#include <memory>
+#include <cwchar>
 #include <string>
 #include <dwmapi.h>
 #include <windhawk_utils.h>
@@ -87,13 +90,20 @@ static winrt::event_token g_timerTickToken{};
 
 static std::atomic<int> g_secondsRemaining{0};
 static std::atomic<ULONGLONG> g_deadlineTick{0};
-static wchar_t g_reminder[256]{};
+static wchar_t g_reminder[256]{};  // taskbar UI thread only
 
-static HWND g_timerPopup = nullptr;
-static HWND g_finishedPopup = nullptr;
-static DWORD g_timerPopupThreadId = 0;
-static HANDLE g_timerPopupThread = nullptr;
+static std::atomic<HWND> g_timerPopup{nullptr};
+static std::atomic<HWND> g_finishedPopup{nullptr};
+static std::atomic<DWORD> g_timerPopupThreadId{0};
+static std::atomic<HANDLE> g_timerPopupThread{nullptr};
 static HANDLE g_popupThreadReadyEvent = nullptr;
+static std::atomic<HWND> g_taskbarWnd{nullptr};
+static std::atomic_bool g_buttonInjected{false};
+static std::atomic_bool g_systemTrayModuleHooked{false};
+
+[[clang::no_destroy]] static ColumnDefinition g_timerColumn{nullptr};
+[[clang::no_destroy]] static std::list<FrameworkElement::Loaded_revoker>
+    g_loadedRevokers;
 
 static HINSTANCE g_modInstance = nullptr;
 
@@ -101,6 +111,8 @@ static std::atomic_bool g_unloading{false};
 static HANDLE g_retryStopEvent = nullptr;
 static HANDLE g_retryThread = nullptr;
 
+
+static void ApplyTimerButtonIfAvailable();
 
 // -----------------------------------------------------------------------------
 // Modern popup styling
@@ -129,16 +141,12 @@ static void EnsurePopupResources(
 {
     if (!g_popupBackgroundBrush) {
         g_popupBackgroundBrush =
-            CreateSolidBrush(
-                kPopupBackground
-            );
+            CreateSolidBrush(kPopupBackground);
     }
 
     if (!g_popupEditBrush) {
         g_popupEditBrush =
-            CreateSolidBrush(
-                kPopupEditBackground
-            );
+            CreateSolidBrush(kPopupEditBackground);
     }
 
     if (!dpi) {
@@ -148,38 +156,52 @@ static void EnsurePopupResources(
     if (!g_popupFont ||
         g_popupFontDpi != dpi)
     {
-        if (g_popupFont) {
-            DeleteObject(
-                g_popupFont
-            );
-
-            g_popupFont = nullptr;
-        }
-
-        g_popupFont =
+        HFONT newFont =
             CreateFontW(
-                -MulDiv(
-                    12,
-                    dpi,
-                    72
-                ),
-                0,
-                0,
-                0,
+                -MulDiv(12, dpi, 72),
+                0, 0, 0,
                 FW_NORMAL,
-                FALSE,
-                FALSE,
-                FALSE,
+                FALSE, FALSE, FALSE,
                 DEFAULT_CHARSET,
                 OUT_DEFAULT_PRECIS,
                 CLIP_DEFAULT_PRECIS,
                 CLEARTYPE_QUALITY,
-                DEFAULT_PITCH |
-                    FF_DONTCARE,
+                DEFAULT_PITCH | FF_DONTCARE,
                 L"Segoe UI"
             );
 
-        g_popupFontDpi = dpi;
+        if (newFont) {
+            HFONT oldFont = g_popupFont;
+            g_popupFont = newFont;
+            g_popupFontDpi = dpi;
+
+            auto reapply = [](HWND wnd) {
+                if (!wnd || !g_popupFont) {
+                    return;
+                }
+
+                EnumChildWindows(
+                    wnd,
+                    [](HWND child, LPARAM) -> BOOL {
+                        SendMessageW(
+                            child,
+                            WM_SETFONT,
+                            reinterpret_cast<WPARAM>(g_popupFont),
+                            TRUE
+                        );
+                        return TRUE;
+                    },
+                    0
+                );
+            };
+
+            reapply(g_timerPopup.load());
+            reapply(g_finishedPopup.load());
+
+            if (oldFont) {
+                DeleteObject(oldFont);
+            }
+        }
     }
 }
 
@@ -276,6 +298,7 @@ constexpr int IDC_START          = 1004;
 constexpr int IDC_CANCEL_TIMER   = 1005;
 constexpr int IDC_CLOSE_TIMER    = 1006;
 
+constexpr int IDC_FINISHED_REMINDER = 1099;
 constexpr int IDC_SNOOZE_LABEL   = 1100;
 constexpr int IDC_SNOOZE_MINUTES = 1101;
 constexpr int IDC_SNOOZE         = 1102;
@@ -898,8 +921,34 @@ static XamlRoot GetTaskbarXamlRoot(
     }
     else {
         Wh_Log(
-            L"Unsupported TaskbarHost::FrameHeight, using default offset"
+            L"Unsupported TaskbarHost::FrameHeight"
         );
+        std__Ref_count_base__Decref_Original(
+            taskbarHostSharedPtr[1]
+        );
+        return nullptr;
+    }
+#elif defined(_M_ARM64)
+    const DWORD* p =
+        reinterpret_cast<const DWORD*>(
+            TaskbarHost_FrameHeight_Original
+        );
+
+    if (p[0] == 0xD503237F &&
+        (p[1] & 0xFFC07FFF) == 0xA9807BFD &&
+        p[2] == 0x910003FD &&
+        (p[3] & 0xFFF00FE0) == 0xF8400C00)
+    {
+        offset = (p[3] >> 12) & 0xFF;
+    }
+    else {
+        Wh_Log(
+            L"Unsupported TaskbarHost::FrameHeight"
+        );
+        std__Ref_count_base__Decref_Original(
+            taskbarHostSharedPtr[1]
+        );
+        return nullptr;
     }
 #else
 #error "Unsupported architecture"
@@ -1151,7 +1200,8 @@ static void CancelCountdownOnTaskbarThread(
 // -----------------------------------------------------------------------------
 
 static void ResetPopupForNewTimer(
-    HWND hWnd)
+    HWND hWnd,
+    const wchar_t* activeReminder = nullptr)
 {
     SetWindowTextW(
         hWnd,
@@ -1191,8 +1241,8 @@ static void ResetPopupForNewTimer(
     if (timerRunning) {
         SetWindowTextW(
             reminder,
-            g_reminder[0]
-                ? g_reminder
+            activeReminder && activeReminder[0]
+                ? activeReminder
                 : L"Timer"
         );
 
@@ -1254,10 +1304,6 @@ static LRESULT CALLBACK FinishedPopupWndProc(
     WPARAM wParam,
     LPARAM lParam)
 {
-    EnsurePopupResources(
-        96
-    );
-
     switch (msg)
     {
     case WM_ERASEBKGND:
@@ -1420,10 +1466,20 @@ static LRESULT CALLBACK FinishedPopupWndProc(
             request.seconds =
                 minutes * 60;
 
+            wchar_t finishedReminder[256]{};
+            GetWindowTextW(
+                GetDlgItem(
+                    hWnd,
+                    IDC_FINISHED_REMINDER
+                ),
+                finishedReminder,
+                ARRAYSIZE(finishedReminder)
+            );
+
             wcsncpy_s(
                 request.reminder,
-                g_reminder[0]
-                    ? g_reminder
+                finishedReminder[0]
+                    ? finishedReminder
                     : L"Timer finished",
                 _TRUNCATE
             );
@@ -1464,7 +1520,7 @@ static LRESULT CALLBACK FinishedPopupWndProc(
         return 0;
 
     case WM_DESTROY:
-        g_finishedPopup = nullptr;
+        g_finishedPopup.store(nullptr);
         return 0;
     }
 
@@ -1485,21 +1541,16 @@ static LRESULT CALLBACK TimerPopupWndProc(
 
 
 static constexpr wchar_t kTimerPopupClass[] =
-    L"TaskbarCountdownTimerPopup_v12";
+    L"TaskbarCountdownTimerPopup";
 
 static constexpr wchar_t kFinishedPopupClass[] =
-    L"TaskbarCountdownTimerFinishedPopup_v12";
+    L"TaskbarCountdownTimerFinishedPopup";
 
 
 static bool RegisterOnePopupClass(
     const wchar_t* className,
     WNDPROC wndProc)
 {
-    // No window exists yet at class-registration time.
-    EnsurePopupResources(
-        96
-    );
-
     WNDCLASSEXW wc{
         sizeof(wc)
     };
@@ -1593,9 +1644,10 @@ static void UnregisterPopupClasses()
 
 
 static void ShowFinishedPopup(
-    HWND owner)
+    HWND owner,
+    const wchar_t* reminderText)
 {
-    if (g_finishedPopup) {
+    if (g_finishedPopup.load()) {
         SetForegroundWindow(
             g_finishedPopup
         );
@@ -1635,7 +1687,7 @@ static void ShowFinishedPopup(
         hWnd
     );
 
-    g_finishedPopup = hWnd;
+    g_finishedPopup.store(hWnd);
 
     CreateWindowExW(
         0,
@@ -1657,8 +1709,8 @@ static void ShowFinishedPopup(
     CreateWindowExW(
         0,
         L"STATIC",
-        g_reminder[0]
-            ? g_reminder
+        reminderText && reminderText[0]
+            ? reminderText
             : L"Timer finished",
         WS_CHILD |
             WS_VISIBLE |
@@ -2033,8 +2085,14 @@ static LRESULT CALLBACK TimerPopupWndProc(
         break;
 
     case WM_APP_TIMER_SHOW:
+    {
+        std::unique_ptr<std::wstring> activeReminder(
+            reinterpret_cast<std::wstring*>(lParam)
+        );
+
         ResetPopupForNewTimer(
-            hWnd
+            hWnd,
+            activeReminder ? activeReminder->c_str() : nullptr
         );
 
         LayoutTimerPopup(
@@ -2069,18 +2127,25 @@ static LRESULT CALLBACK TimerPopupWndProc(
         );
 
         return 0;
+    }
 
     case WM_APP_TIMER_FINISHED:
+    {
+        std::unique_ptr<std::wstring> finishedReminder(
+            reinterpret_cast<std::wstring*>(lParam)
+        );
         ShowWindow(
             hWnd,
             SW_HIDE
         );
 
         ShowFinishedPopup(
-            FindCurrentProcessTaskbarWnd()
+            g_taskbarWnd.load(),
+            finishedReminder ? finishedReminder->c_str() : L"Timer finished"
         );
 
         return 0;
+    }
 
     case WM_APP_TIMER_SHUTDOWN:
         DestroyWindow(hWnd);
@@ -2095,7 +2160,7 @@ static LRESULT CALLBACK TimerPopupWndProc(
         return 0;
 
     case WM_DESTROY:
-        g_timerPopup = nullptr;
+        g_timerPopup.store(nullptr);
 
         PostQuitMessage(0);
 
@@ -2146,7 +2211,7 @@ static bool ShowTimerPopup(
         hWnd
     );
 
-    g_timerPopup = hWnd;
+    g_timerPopup.store(hWnd);
 
     CreateWindowExW(
         0,
@@ -2284,7 +2349,7 @@ static bool ShowTimerPopup(
 
     ShowWindow(
         hWnd,
-        SW_SHOW
+        SW_HIDE
     );
 
     UpdateWindow(hWnd);
@@ -2293,15 +2358,43 @@ static bool ShowTimerPopup(
 }
 
 
-static DWORD WINAPI TimerPopupThreadProc(
-    LPVOID param)
+static bool PostStringMessage(
+    HWND hWnd,
+    UINT message,
+    const wchar_t* text)
 {
-    HWND taskbar =
-        reinterpret_cast<HWND>(param);
+    if (!hWnd) {
+        return false;
+    }
 
+    auto payload =
+        new (std::nothrow) std::wstring(
+            text ? text : L""
+        );
+
+    if (!payload) {
+        return false;
+    }
+
+    if (!PostMessageW(
+            hWnd,
+            message,
+            0,
+            reinterpret_cast<LPARAM>(payload)))
+    {
+        delete payload;
+        return false;
+    }
+
+    return true;
+}
+
+
+static DWORD WINAPI TimerPopupThreadProc(
+    LPVOID)
+{
     MSG msg{};
 
-    // Force creation of this thread's message queue before signalling readiness.
     PeekMessageW(
         &msg,
         nullptr,
@@ -2311,9 +2404,7 @@ static DWORD WINAPI TimerPopupThreadProc(
     );
 
     if (g_popupThreadReadyEvent) {
-        SetEvent(
-            g_popupThreadReadyEvent
-        );
+        SetEvent(g_popupThreadReadyEvent);
     }
 
     if (g_unloading.load()) {
@@ -2324,54 +2415,50 @@ static DWORD WINAPI TimerPopupThreadProc(
         return 0;
     }
 
-    if (!ShowTimerPopup(taskbar)) {
+    if (!ShowTimerPopup(nullptr)) {
         UnregisterPopupClasses();
         return 0;
     }
 
-    while (!g_unloading.load() &&
-           GetMessageW(
-               &msg,
-               nullptr,
-               0,
-               0) > 0)
-    {
-        HWND dialog =
-            g_finishedPopup
-                ? g_finishedPopup
-                : g_timerPopup;
+    // The configuration window is created up front but remains hidden until
+    // the taskbar button is clicked.
+    if (HWND popup = g_timerPopup.load()) {
+        ShowWindow(popup, SW_HIDE);
+    }
 
-        if (!dialog ||
-            !IsDialogMessageW(
-                dialog,
-                &msg))
-        {
+    while (!g_unloading.load() &&
+           GetMessageW(&msg, nullptr, 0, 0) > 0)
+    {
+        bool handled = false;
+
+        if (HWND finished = g_finishedPopup.load()) {
+            handled = IsDialogMessageW(finished, &msg) != FALSE;
+        }
+
+        if (!handled) {
+            if (HWND timer = g_timerPopup.load()) {
+                handled = IsDialogMessageW(timer, &msg) != FALSE;
+            }
+        }
+
+        if (!handled) {
             TranslateMessage(&msg);
             DispatchMessageW(&msg);
         }
     }
 
-    if (g_finishedPopup &&
-        IsWindow(g_finishedPopup))
-    {
-        DestroyWindow(
-            g_finishedPopup
-        );
+    if (HWND finished = g_finishedPopup.load()) {
+        DestroyWindow(finished);
     }
 
-    if (g_timerPopup &&
-        IsWindow(g_timerPopup))
-    {
-        DestroyWindow(
-            g_timerPopup
-        );
+    if (HWND timer = g_timerPopup.load()) {
+        DestroyWindow(timer);
     }
 
-    g_finishedPopup = nullptr;
-    g_timerPopup = nullptr;
+    g_finishedPopup.store(nullptr);
+    g_timerPopup.store(nullptr);
 
     UnregisterPopupClasses();
-
     return 0;
 }
 
@@ -2383,97 +2470,32 @@ static void OpenTimerPopup(
         return;
     }
 
-    if (g_timerPopup &&
-        IsWindow(g_timerPopup))
-    {
-        PostMessageW(
-            g_timerPopup,
+    HWND popup = g_timerPopup.load();
+
+    if (popup) {
+        PostStringMessage(
+            popup,
             WM_APP_TIMER_SHOW,
-            0,
-            0
+            g_secondsRemaining.load() > 0
+                ? g_reminder
+                : L""
         );
-
         return;
     }
 
-    if (g_timerPopupThread) {
-        if (WaitForSingleObject(
-                g_timerPopupThread,
-                0) ==
-            WAIT_OBJECT_0)
-        {
-            CloseHandle(
-                g_timerPopupThread
-            );
-
-            g_timerPopupThread =
-                nullptr;
-
-            g_timerPopupThreadId =
-                0;
-        }
-        else {
-            return;
-        }
-    }
-
-    if (g_popupThreadReadyEvent) {
-        CloseHandle(
-            g_popupThreadReadyEvent
-        );
-
-        g_popupThreadReadyEvent =
-            nullptr;
-    }
-
-    g_popupThreadReadyEvent =
-        CreateEventW(
-            nullptr,
-            TRUE,
-            FALSE,
-            nullptr
-        );
-
-    if (!g_popupThreadReadyEvent) {
-        Wh_Log(
-            L"ERROR: Could not create popup ready event"
-        );
-
+    HANDLE thread = g_timerPopupThread.load();
+    if (!thread) {
+        Wh_Log(L"Popup thread isn't available yet");
         return;
     }
 
-    g_timerPopupThread =
-        CreateThread(
-            nullptr,
-            0,
-            TimerPopupThreadProc,
-            taskbar,
-            0,
-            &g_timerPopupThreadId
-        );
-
-    if (!g_timerPopupThread) {
-        CloseHandle(
-            g_popupThreadReadyEvent
-        );
-
-        g_popupThreadReadyEvent =
-            nullptr;
-
-        g_timerPopupThreadId =
-            0;
-
-        Wh_Log(
-            L"ERROR: Could not create popup thread"
-        );
-
+    // Don't block the taskbar UI thread waiting for the popup thread.
+    if (WaitForSingleObject(thread, 0) == WAIT_OBJECT_0) {
+        Wh_Log(L"Popup thread exited unexpectedly");
         return;
     }
 
-    WaitForSingleObject(
-        g_popupThreadReadyEvent,
-        INFINITE
-    );
+    Wh_Log(L"Popup thread is still starting; try again");
 }
 
 
@@ -2541,6 +2563,8 @@ static void AddTimerButton(
 
     // The current XAML tree already has our button.
     if (existing) {
+        g_taskbarWnd.store(taskbar);
+        g_buttonInjected.store(true);
         return;
     }
 
@@ -2568,6 +2592,7 @@ static void AddTimerButton(
 
     g_timerText =
         nullptr;
+    g_timerColumn = nullptr;
 
     g_timerButton = Button();
     g_timerText = TextBlock();
@@ -2673,11 +2698,11 @@ static void AddTimerButton(
                         g_reminder
                     );
 
-                    if (g_timerPopup &&
-                        IsWindow(g_timerPopup))
+                    if (g_timerPopup.load() &&
+                        IsWindow(g_timerPopup.load()))
                     {
                         PostMessageW(
-                            g_timerPopup,
+            g_timerPopup.load(),
                             WM_APP_TIMER_FINISHED,
                             0,
                             0
@@ -2750,15 +2775,15 @@ static void AddTimerButton(
         auto columns =
             trayGrid.ColumnDefinitions();
 
-        ColumnDefinition timerColumn;
+        g_timerColumn = ColumnDefinition();
 
-        timerColumn.Width(
+        g_timerColumn.Width(
             GridLengthHelper::Auto()
         );
 
         columns.InsertAt(
             0,
-            timerColumn
+            g_timerColumn
         );
 
         for (uint32_t i = 0;
@@ -2823,18 +2848,20 @@ static void AddTimerButton(
             g_deadlineTick.store(0);
             g_secondsRemaining.store(0);
 
-            if (g_timerPopup &&
-                IsWindow(g_timerPopup))
+            if (g_timerPopup.load() &&
+                IsWindow(g_timerPopup.load()))
             {
-                PostMessageW(
-                    g_timerPopup,
+                PostStringMessage(
+                    g_timerPopup.load(),
                     WM_APP_TIMER_FINISHED,
-                    0,
-                    0
+                    g_reminder
                 );
             }
         }
     }
+
+    g_taskbarWnd.store(taskbar);
+    g_buttonInjected.store(true);
 
     Wh_Log(
         L"Timer button added to taskbar"
@@ -2884,42 +2911,51 @@ static void RemoveTimerButton(
             auto parentGrid =
                 parentElement.try_as<Grid>();
 
-            if (parentGrid) {
-                for (uint32_t i = 0;
-                     i < children.Size();
-                     i++)
-                {
-                    auto child =
-                        children.GetAt(i)
-                            .try_as<FrameworkElement>();
-
-                    if (!child) {
-                        continue;
-                    }
-
-                    int currentColumn =
-                        Grid::GetColumn(child);
-
-                    if (currentColumn > 0) {
-                        Grid::SetColumn(
-                            child,
-                            currentColumn - 1
-                        );
-                    }
-                }
-
+            if (parentGrid && g_timerColumn) {
                 auto columns =
                     parentGrid.ColumnDefinitions();
 
-                if (columns.Size() > 0) {
-                    columns.RemoveAt(0);
+                uint32_t columnIndex = 0;
+                if (columns.IndexOf(
+                        g_timerColumn,
+                        columnIndex))
+                {
+                    for (uint32_t i = 0;
+                         i < children.Size();
+                         i++)
+                    {
+                        auto child =
+                            children.GetAt(i)
+                                .try_as<FrameworkElement>();
+
+                        if (!child) {
+                            continue;
+                        }
+
+                        int currentColumn =
+                            Grid::GetColumn(child);
+
+                        if (currentColumn >
+                            static_cast<int>(columnIndex))
+                        {
+                            Grid::SetColumn(
+                                child,
+                                currentColumn - 1
+                            );
+                        }
+                    }
+
+                    columns.RemoveAt(columnIndex);
                 }
             }
         }
     }
 
+    g_loadedRevokers.clear();
+    g_timerColumn = nullptr;
     g_timerText = nullptr;
     g_timerButton = nullptr;
+    g_buttonInjected.store(false);
 }
 
 
@@ -2936,34 +2972,215 @@ static void ApplyTimerButtonIfAvailable()
         return;
     }
 
-    RunFromWindowThread(
-        taskbar,
-        AddTimerButton,
-        taskbar
-    );
+    g_taskbarWnd.store(taskbar);
+
+    if (!RunFromWindowThread(
+            taskbar,
+            AddTimerButton,
+            taskbar))
+    {
+        Wh_Log(L"Could not access taskbar UI thread");
+    }
 }
 
 
 static DWORD WINAPI RetryThreadProc(
     LPVOID)
 {
-    while (!g_unloading.load()) {
-        ApplyTimerButtonIfAvailable();
-
-        DWORD waitResult =
-            WaitForSingleObject(
+    for (int i = 0;
+         i < 5 && !g_unloading.load();
+         i++)
+    {
+        if (WaitForSingleObject(
                 g_retryStopEvent,
-                5000
-            );
-
-        if (waitResult !=
-            WAIT_TIMEOUT)
+                2000) != WAIT_TIMEOUT)
         {
             break;
         }
+
+        if (g_buttonInjected.load() ||
+            g_unloading.load())
+        {
+            break;
+        }
+
+        Wh_Log(L"Taskbar injection retry %d", i + 1);
+        ApplyTimerButtonIfAvailable();
     }
 
     return 0;
+}
+
+
+// -----------------------------------------------------------------------------
+// System tray rebuild hook
+// -----------------------------------------------------------------------------
+
+using IconView_IconView_t =
+    void* (WINAPI*)(void* pThis);
+
+static IconView_IconView_t
+    IconView_IconView_Original = nullptr;
+
+using LoadLibraryExW_t =
+    HMODULE (WINAPI*)(LPCWSTR, HANDLE, DWORD);
+
+static LoadLibraryExW_t
+    LoadLibraryExW_Original = nullptr;
+
+
+static HMODULE GetSystemTrayModuleHandle()
+{
+    if (HMODULE module =
+            GetModuleHandleW(L"SystemTray.dll"))
+    {
+        return module;
+    }
+
+    if (HMODULE module =
+            GetModuleHandleW(L"Taskbar.View.dll"))
+    {
+        return module;
+    }
+
+    return GetModuleHandleW(
+        L"ExplorerExtensions.dll"
+    );
+}
+
+
+static void* WINAPI IconView_IconView_Hook(
+    void* pThis)
+{
+    auto result =
+        IconView_IconView_Original(pThis);
+
+    if (g_unloading.load()) {
+        return result;
+    }
+
+    FrameworkElement iconView = nullptr;
+
+    reinterpret_cast<IUnknown**>(pThis)[1]
+        ->QueryInterface(
+            winrt::guid_of<FrameworkElement>(),
+            winrt::put_abi(iconView)
+        );
+
+    if (!iconView) {
+        return result;
+    }
+
+    g_loadedRevokers.emplace_back();
+    auto it = std::prev(g_loadedRevokers.end());
+
+    *it = iconView.Loaded(
+        winrt::auto_revoke_t{},
+        [it](
+            winrt::Windows::Foundation::IInspectable const&,
+            RoutedEventArgs const&)
+        {
+            g_loadedRevokers.erase(it);
+
+            if (g_unloading.load()) {
+                return;
+            }
+
+            // A new IconView means the tray may have rebuilt its XAML tree.
+            g_buttonInjected.store(false);
+            ApplyTimerButtonIfAvailable();
+        }
+    );
+
+    return result;
+}
+
+
+static bool HookSystemTraySymbols(
+    HMODULE module)
+{
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {{
+        {
+            LR"(public: __cdecl winrt::SystemTray::implementation::IconView::IconView(void))"
+        },
+        &IconView_IconView_Original,
+        IconView_IconView_Hook,
+    }};
+
+    return WindhawkUtils::HookSymbols(
+        module,
+        hooks,
+        ARRAYSIZE(hooks)
+    );
+}
+
+
+static void HandleLoadedModuleIfSystemTray(
+    HMODULE module)
+{
+    if (g_systemTrayModuleHooked.load() ||
+        GetSystemTrayModuleHandle() != module)
+    {
+        return;
+    }
+
+    if (HookSystemTraySymbols(module)) {
+        g_systemTrayModuleHooked.store(true);
+        Wh_ApplyHookOperations();
+    }
+}
+
+
+static HMODULE WINAPI LoadLibraryExW_Hook(
+    LPCWSTR fileName,
+    HANDLE file,
+    DWORD flags)
+{
+    HMODULE module =
+        LoadLibraryExW_Original(
+            fileName,
+            file,
+            flags
+        );
+
+    if (module) {
+        HandleLoadedModuleIfSystemTray(module);
+    }
+
+    return module;
+}
+
+
+static DWORD PumpWaitForThread(
+    HANDLE thread)
+{
+    if (!thread) {
+        return WAIT_OBJECT_0;
+    }
+
+    DWORD result;
+    do {
+        result = MsgWaitForMultipleObjects(
+            1,
+            &thread,
+            FALSE,
+            INFINITE,
+            QS_SENDMESSAGE
+        );
+
+        if (result == WAIT_OBJECT_0 + 1) {
+            MSG message;
+            PeekMessageW(
+                &message,
+                nullptr,
+                0,
+                0,
+                PM_NOREMOVE
+            );
+        }
+    } while (result == WAIT_OBJECT_0 + 1);
+
+    return result;
 }
 
 
@@ -3009,12 +3226,38 @@ BOOL Wh_ModInit()
         return FALSE;
     }
 
+    if (HMODULE systemTray = GetSystemTrayModuleHandle()) {
+        if (HookSystemTraySymbols(systemTray)) {
+            g_systemTrayModuleHooked.store(true);
+        }
+    }
+    else {
+        HMODULE kernelbase =
+            GetModuleHandleW(L"kernelbase.dll");
+
+        auto loadLibraryExW = kernelbase
+            ? reinterpret_cast<LoadLibraryExW_t>(
+                  GetProcAddress(kernelbase, "LoadLibraryExW")
+              )
+            : nullptr;
+
+        if (loadLibraryExW) {
+            WindhawkUtils::SetFunctionHook(
+                loadLibraryExW,
+                LoadLibraryExW_Hook,
+                &LoadLibraryExW_Original
+            );
+        }
+    }
+
     return TRUE;
 }
 
 
 void Wh_ModAfterInit()
 {
+    ApplyTimerButtonIfAvailable();
+
     g_retryStopEvent =
         CreateEventW(
             nullptr,
@@ -3023,32 +3266,48 @@ void Wh_ModAfterInit()
             nullptr
         );
 
-    if (!g_retryStopEvent) {
-        Wh_Log(
-            L"ERROR: Could not create retry stop event"
-        );
-
-        ApplyTimerButtonIfAvailable();
-
-        return;
+    if (g_retryStopEvent) {
+        g_retryThread =
+            CreateThread(
+                nullptr,
+                0,
+                RetryThreadProc,
+                nullptr,
+                0,
+                nullptr
+            );
     }
 
-    g_retryThread =
-        CreateThread(
+    g_popupThreadReadyEvent =
+        CreateEventW(
             nullptr,
-            0,
-            RetryThreadProc,
-            nullptr,
-            0,
+            TRUE,
+            FALSE,
             nullptr
         );
 
-    if (!g_retryThread) {
-        Wh_Log(
-            L"ERROR: Could not create taskbar retry thread"
-        );
+    if (g_popupThreadReadyEvent) {
+        DWORD threadId = 0;
+        HANDLE thread =
+            CreateThread(
+                nullptr,
+                0,
+                TimerPopupThreadProc,
+                nullptr,
+                0,
+                &threadId
+            );
 
-        ApplyTimerButtonIfAvailable();
+        if (thread) {
+            g_timerPopupThread.store(thread);
+            g_timerPopupThreadId.store(threadId);
+
+            // Bounded wait: initialization must never block indefinitely.
+            WaitForSingleObject(
+                g_popupThreadReadyEvent,
+                2000
+            );
+        }
     }
 }
 
@@ -3070,136 +3329,105 @@ void Wh_ModUninit()
     g_unloading.store(true);
 
     if (g_retryStopEvent) {
-        SetEvent(
-            g_retryStopEvent
-        );
+        SetEvent(g_retryStopEvent);
     }
 
     if (g_retryThread) {
-        WaitForSingleObject(
-            g_retryThread,
-            INFINITE
-        );
-
-        CloseHandle(
-            g_retryThread
-        );
-
-        g_retryThread =
-            nullptr;
+        PumpWaitForThread(g_retryThread);
+        CloseHandle(g_retryThread);
+        g_retryThread = nullptr;
     }
 
     if (g_retryStopEvent) {
-        CloseHandle(
-            g_retryStopEvent
-        );
-
-        g_retryStopEvent =
-            nullptr;
+        CloseHandle(g_retryStopEvent);
+        g_retryStopEvent = nullptr;
     }
 
-    HWND taskbar =
-        FindCurrentProcessTaskbarWnd();
+    bool removed = false;
 
-    if (taskbar) {
-        RunFromWindowThread(
-            taskbar,
-            RemoveTimerButton,
-            nullptr
-        );
-    }
-
-    if (g_finishedPopup &&
-        IsWindow(g_finishedPopup))
+    for (int attempt = 0;
+         attempt < 5 && !removed;
+         attempt++)
     {
-        PostMessageW(
-            g_finishedPopup,
-            WM_CLOSE,
-            0,
-            0
+        HWND taskbar = g_taskbarWnd.load();
+        if (!taskbar || !IsWindow(taskbar)) {
+            taskbar = FindCurrentProcessTaskbarWnd();
+        }
+
+        if (taskbar) {
+            removed = RunFromWindowThread(
+                taskbar,
+                RemoveTimerButton,
+                nullptr
+            );
+        }
+
+        if (!removed) {
+            Sleep(50);
+        }
+    }
+
+    if (!removed && g_buttonInjected.load()) {
+        Wh_Log(
+            L"ERROR: Could not remove timer XAML objects before unload"
         );
     }
 
-    if (g_timerPopup &&
-        IsWindow(g_timerPopup))
-    {
-        PostMessageW(
-            g_timerPopup,
-            WM_APP_TIMER_SHUTDOWN,
-            0,
-            0
-        );
-    }
+    DWORD popupThreadId =
+        g_timerPopupThreadId.load();
 
-    if (g_timerPopupThread) {
+    if (popupThreadId) {
+        // The queue-ready event is created once and never recycled.
         if (g_popupThreadReadyEvent) {
             WaitForSingleObject(
                 g_popupThreadReadyEvent,
-                INFINITE
+                2000
             );
         }
 
-        if (g_timerPopupThreadId) {
-            PostThreadMessageW(
-                g_timerPopupThreadId,
-                WM_QUIT,
-                0,
-                0
-            );
-        }
-
-        WaitForSingleObject(
-            g_timerPopupThread,
-            INFINITE
+        PostThreadMessageW(
+            popupThreadId,
+            WM_QUIT,
+            0,
+            0
         );
+    }
 
-        CloseHandle(
-            g_timerPopupThread
-        );
+    HANDLE popupThread =
+        g_timerPopupThread.load();
 
-        g_timerPopupThread =
-            nullptr;
+    if (popupThread) {
+        PumpWaitForThread(popupThread);
+        CloseHandle(popupThread);
+        g_timerPopupThread.store(nullptr);
     }
 
     if (g_popupThreadReadyEvent) {
-        CloseHandle(
-            g_popupThreadReadyEvent
-        );
-
-        g_popupThreadReadyEvent =
-            nullptr;
+        CloseHandle(g_popupThreadReadyEvent);
+        g_popupThreadReadyEvent = nullptr;
     }
 
-    g_finishedPopup = nullptr;
-    g_timerPopup = nullptr;
-    g_timerPopupThreadId = 0;
+    g_timerPopupThreadId.store(0);
+    g_finishedPopup.store(nullptr);
+    g_timerPopup.store(nullptr);
 
-    // Popup classes are unregistered by the popup thread before it exits.
-    // GDI objects are destroyed only after that thread is fully joined.
+    // Popup thread is gone, so no controls can still reference these objects.
     if (g_popupFont) {
-        DeleteObject(
-            g_popupFont
-        );
-
+        DeleteObject(g_popupFont);
         g_popupFont = nullptr;
-        g_popupFontDpi = 0;
     }
 
     if (g_popupEditBrush) {
-        DeleteObject(
-            g_popupEditBrush
-        );
-
+        DeleteObject(g_popupEditBrush);
         g_popupEditBrush = nullptr;
     }
 
     if (g_popupBackgroundBrush) {
-        DeleteObject(
-            g_popupBackgroundBrush
-        );
-
+        DeleteObject(g_popupBackgroundBrush);
         g_popupBackgroundBrush = nullptr;
     }
+
+    g_popupFontDpi = 0;
 
     Wh_Log(
         L"Taskbar Countdown Timer unloaded"

--- a/mods/taskbar-countdown-timer.wh.cpp
+++ b/mods/taskbar-countdown-timer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-countdown-timer
 // @name            Taskbar Countdown Timer
 // @description     A simple countdown timer integrated into the Windows 11 taskbar (Windows 11 only)
-// @version         1.5
+// @version         1.6
 // @author          Richi
 // @github          https://github.com/richilp
 // @include         explorer.exe
@@ -60,6 +60,7 @@ While the timer is running, the remaining time is shown directly on the taskbar.
 #include <functional>
 #include <list>
 #include <memory>
+#include <optional>
 #include <cwchar>
 #include <string>
 #include <dwmapi.h>
@@ -103,8 +104,9 @@ static std::atomic_bool g_buttonInjected{false};
 static std::atomic_bool g_systemTrayModuleHooked{false};
 
 [[clang::no_destroy]] static ColumnDefinition g_timerColumn{nullptr};
-[[clang::no_destroy]] static std::list<FrameworkElement::Loaded_revoker>
-    g_loadedRevokers;
+[[clang::no_destroy]] static std::optional<
+    std::list<FrameworkElement::Loaded_revoker>>
+    g_loadedRevokers{std::in_place};
 
 static HINSTANCE g_modInstance = nullptr;
 
@@ -1053,6 +1055,7 @@ static bool RunFromWindowThread(
     {
         RunFromWindowThreadProc_t proc;
         void* procParam;
+        bool invoked;
     };
 
     DWORD threadId =
@@ -1092,6 +1095,8 @@ static bool RunFromWindowThread(
                     param->proc(
                         param->procParam
                     );
+
+                    param->invoked = true;
                 }
             }
 
@@ -1112,7 +1117,8 @@ static bool RunFromWindowThread(
 
     Param param{
         proc,
-        procParam
+        procParam,
+        false
     };
 
     SendMessageW(
@@ -1124,7 +1130,7 @@ static bool RunFromWindowThread(
 
     UnhookWindowsHookEx(hook);
 
-    return true;
+    return param.invoked;
 }
 
 
@@ -2558,7 +2564,7 @@ static void OpenTimerPopup(
 // Add/remove taskbar button
 // -----------------------------------------------------------------------------
 
-static void AddTimerButton(
+static void AddTimerButtonImpl(
     void* param)
 {
     if (g_unloading.load()) {
@@ -2922,7 +2928,25 @@ static void AddTimerButton(
     );
 }
 
-static void RemoveTimerButton(
+
+static void AddTimerButton(
+    void* param)
+{
+    try {
+        AddTimerButtonImpl(param);
+    }
+    catch (...) {
+        HRESULT error = winrt::to_hresult();
+
+        Wh_Log(
+            L"Applying timer button failed: %08X",
+            static_cast<unsigned>(error)
+        );
+    }
+}
+
+
+static void RemoveTimerButtonImpl(
     void*)
 {
     if (g_countdownTimer) {
@@ -3005,11 +3029,31 @@ static void RemoveTimerButton(
         }
     }
 
-    g_loadedRevokers.clear();
+    if (g_loadedRevokers) {
+        g_loadedRevokers.reset();
+    }
+
     g_timerColumn = nullptr;
     g_timerText = nullptr;
     g_timerButton = nullptr;
     g_buttonInjected.store(false);
+}
+
+
+static void RemoveTimerButton(
+    void* param)
+{
+    try {
+        RemoveTimerButtonImpl(param);
+    }
+    catch (...) {
+        HRESULT error = winrt::to_hresult();
+
+        Wh_Log(
+            L"Removing timer button failed: %08X",
+            static_cast<unsigned>(error)
+        );
+    }
 }
 
 
@@ -3205,42 +3249,65 @@ static void* WINAPI IconView_IconView_Hook(
     auto result =
         IconView_IconView_Original(pThis);
 
-    if (g_unloading.load()) {
+    if (g_unloading.load() ||
+        !g_loadedRevokers)
+    {
         return result;
     }
 
-    FrameworkElement iconView = nullptr;
+    try {
+        FrameworkElement iconView = nullptr;
 
-    reinterpret_cast<IUnknown**>(pThis)[1]
-        ->QueryInterface(
-            winrt::guid_of<FrameworkElement>(),
-            winrt::put_abi(iconView)
-        );
+        reinterpret_cast<IUnknown**>(pThis)[1]
+            ->QueryInterface(
+                winrt::guid_of<FrameworkElement>(),
+                winrt::put_abi(iconView)
+            );
 
-    if (!iconView) {
-        return result;
-    }
-
-    g_loadedRevokers.emplace_back();
-    auto it = std::prev(g_loadedRevokers.end());
-
-    *it = iconView.Loaded(
-        winrt::auto_revoke_t{},
-        [it](
-            winrt::Windows::Foundation::IInspectable const&,
-            RoutedEventArgs const&)
+        if (!iconView ||
+            !g_loadedRevokers)
         {
-            g_loadedRevokers.erase(it);
-
-            if (g_unloading.load()) {
-                return;
-            }
-
-            // A new IconView means the tray may have rebuilt its XAML tree.
-            g_buttonInjected.store(false);
-            ApplyTimerButtonIfAvailable();
+            return result;
         }
-    );
+
+        g_loadedRevokers->emplace_back();
+        auto it =
+            std::prev(
+                g_loadedRevokers->end()
+            );
+
+        *it = iconView.Loaded(
+            winrt::auto_revoke_t{},
+            [it](
+                winrt::Windows::Foundation::IInspectable const&,
+                RoutedEventArgs const&)
+            {
+                if (!g_loadedRevokers) {
+                    return;
+                }
+
+                g_loadedRevokers->erase(it);
+
+                if (g_unloading.load() ||
+                    !g_loadedRevokers)
+                {
+                    return;
+                }
+
+                // A new IconView means the tray may have rebuilt its XAML tree.
+                g_buttonInjected.store(false);
+                ApplyTimerButtonIfAvailable();
+            }
+        );
+    }
+    catch (...) {
+        HRESULT error = winrt::to_hresult();
+
+        Wh_Log(
+            L"IconView hook XAML work failed: %08X",
+            static_cast<unsigned>(error)
+        );
+    }
 
     return result;
 }
@@ -3525,8 +3592,7 @@ void Wh_ModUninit()
         g_retryStopEvent = nullptr;
     }
 
-    bool removed =
-        !g_buttonInjected.load();
+    bool removed = false;
 
     for (int attempt = 0;
          attempt < 10 && !removed;
@@ -3551,25 +3617,29 @@ void Wh_ModUninit()
     DWORD popupThreadId =
         g_timerPopupThreadId.load();
 
-    if (popupThreadId) {
-        // The queue-ready event is created once and never recycled.
-        if (g_popupThreadReadyEvent) {
-            WaitForSingleObject(
-                g_popupThreadReadyEvent,
-                2000
-            );
-        }
-
-        PostThreadMessageW(
-            popupThreadId,
-            WM_QUIT,
-            0,
-            0
-        );
-    }
-
     HANDLE popupThread =
         g_timerPopupThread.load();
+
+    if (popupThread &&
+        popupThreadId)
+    {
+        // WM_QUIT must be delivered before the infinite join below. If the
+        // thread's message queue isn't ready yet, retry until it is or until
+        // the thread has already exited.
+        while (!PostThreadMessageW(
+                    popupThreadId,
+                    WM_QUIT,
+                    0,
+                    0))
+        {
+            if (WaitForSingleObject(
+                    popupThread,
+                    50) == WAIT_OBJECT_0)
+            {
+                break;
+            }
+        }
+    }
 
     if (popupThread) {
         PumpWaitForThread(popupThread);


### PR DESCRIPTION
Adds a lightweight countdown timer directly to the Windows 11 taskbar.

Features:
- Custom reminder text
- Live countdown displayed in the taskbar
- Cancel active timer
- Snooze for a custom number of minutes
- Completion popup with sound
- Modern Windows 11-style popup UI
- No external application required

Tested on Windows 11 25H2 build 26200.9168.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

Not applicable — this pull request introduces a new mod.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [x] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.