### PR TITLE
Add Taskbar Volume Percentage Indicator mod

### DIFF
--- a/mods/taskbar-volume-percentage.wh.cpp
+++ b/mods/taskbar-volume-percentage.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-volume-percentage
 // @name            Taskbar Volume Percentage Indicator
 // @description     Displays the exact master volume percentage in the system tray natively inside the Windows 11 volume button with real-time sync.
-// @version         1.2.0
+// @version         1.3.0
 // @author          gilnett
 // @github          https://github.com/gilnett
 // @include         explorer.exe
@@ -20,6 +20,7 @@ Replaces the Windows 11 taskbar volume icon with the current volume level in rea
 
 - **Display styles**: Percentage (`50%`), number only (`50`), custom prefix (`Vol 50%`), emoji (`🔊 50%`), or default icon.
 - **Mute indicator**: Customizable mute display (`MUT`, `Mute`, `0%`, `✕`, `🔇`, or native glyph).
+- **Zero-Jitter Structural Stabilization**: Locks the XAML container minimum width (`IFrameworkElement::put_MinWidth`) to prevent neighboring system tray icons from shifting during volume changes.
 
 ## Credits
 
@@ -38,6 +39,16 @@ Replaces the Windows 11 taskbar volume icon with the current volume level in rea
     - prefix: Prefix and Percentage (e.g. Vol 50%)
     - emoji: Icon and Percentage (e.g. 🔊 50%)
     - vanilla: Windows Default (exact vanilla Windows speaker icon)
+- padStyle: none
+  $name: Number Padding
+  $description: Format padding to minimize icon movement during volume changes.
+  $options:
+    - none: No Padding (e.g. 50%)
+    - space: Space Padded (e.g. " 50%")
+    - zero: Zero Padded (e.g. 050%)
+- fixedContainerWidth: 0
+  $name: Fixed Container Width
+  $description: Minimum width in pixels for the volume container to eliminate layout jitter. Set to 0 for automatic optimal width based on style (e.g. 42 for percentage), or enter a custom width (e.g. 42). Set to -1 to disable.
 - customPrefix: "Vol "
   $name: Custom Prefix
   $description: Prefix text used when the display style is set to 'Prefix and Percentage'.
@@ -61,12 +72,11 @@ Replaces the Windows 11 taskbar volume icon with the current volume level in rea
 #include <windows.h>
 #include <shlwapi.h>
 #include <winver.h>
-#include <mmdeviceapi.h>
-#include <endpointvolume.h>
 
 #include <atomic>
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 #include <mutex>
 #include <string>
 #include <string_view>
@@ -128,6 +138,12 @@ enum class DisplayStyle {
     Vanilla,
 };
 
+enum class PadStyle {
+    None,
+    Space,
+    Zero,
+};
+
 enum class MuteStyle {
     Mut,
     Mute,
@@ -140,12 +156,15 @@ enum class MuteStyle {
 
 struct Settings {
     DisplayStyle displayStyle;
+    PadStyle padStyle;
+    int fixedContainerWidth;
     std::wstring customPrefix;
     MuteStyle muteStyle;
     std::wstring customMuteText;
 };
 
 static Settings g_settings;
+static std::mutex g_settingsMutex;
 
 // Segoe Fluent Icons volume glyphs
 constexpr wchar_t GLYPH_MUTE  = 0xE74F; // Crossed-out speaker
@@ -158,15 +177,219 @@ static void* g_pVolumeDataModel = nullptr;
 static float g_lastVolumeLevel = 0.5f;
 static bool  g_lastIsMuted = false;
 static std::mutex g_dataModelMutex;
+
+static void* g_pVolumeIconView = nullptr;
+static std::mutex g_iconViewMutex;
+
 static std::atomic<bool> g_unloading{false};
 static std::atomic<bool> g_systemTrayModuleHooked{false};
 
-static std::wstring FormatMuteString(MuteStyle style, const std::wstring& customText) {
+// ---------------------------------------------------------------------------
+// WinRT ABI definitions for XAML FrameworkElement and SystemTray IconView
+// ---------------------------------------------------------------------------
+
+static inline bool IsValidUserPointer(const void* ptr) {
+    uintptr_t u = reinterpret_cast<uintptr_t>(ptr);
+    if ((u % sizeof(void*)) != 0) return false;
+#if defined(_WIN64) || defined(__x86_64__) || defined(_M_AMD64) || defined(__aarch64__)
+    return u >= 0x10000 && u < 0x00007FFFFFF00000ULL;
+#else
+    return u >= 0x10000 && u < 0x7FFF0000UL;
+#endif
+}
+
+// IFrameworkElement GUID: a391d09b-4a99-4b7c-9d8d-6fa5d01f6fbf
+static constexpr GUID IID_IFrameworkElement = {
+    0xa391d09b, 0x4a99, 0x4b7c, { 0x9d, 0x8d, 0x6f, 0xa5, 0xd0, 0x1f, 0x6f, 0xbf }
+};
+
+// VolumeSystemTrayIconDataModel unique identifier GUID in SystemTray.dll
+static constexpr GUID GUID_VolumeIcon = {
+    0x7820ae73, 0x23e3, 0x4229, { 0x82, 0xc1, 0xe4, 0x1c, 0xb6, 0x7d, 0x5b, 0x9c }
+};
+
+struct IFrameworkElementVtbl {
+    HRESULT (STDMETHODCALLTYPE* QueryInterface)(void* This, REFIID riid, void** ppvObject);
+    ULONG   (STDMETHODCALLTYPE* AddRef)(void* This);
+    ULONG   (STDMETHODCALLTYPE* Release)(void* This);
+    HRESULT (STDMETHODCALLTYPE* GetIids)(void* This, ULONG* iidCount, IID** iids);
+    HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(void* This, void** className);
+    HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(void* This, int* trustLevel);
+    HRESULT (STDMETHODCALLTYPE* get_Triggers)(void* This, void** value);
+    HRESULT (STDMETHODCALLTYPE* get_Resources)(void* This, void** value);
+    HRESULT (STDMETHODCALLTYPE* put_Resources)(void* This, void* value);
+    HRESULT (STDMETHODCALLTYPE* get_Tag)(void* This, void** value);
+    HRESULT (STDMETHODCALLTYPE* put_Tag)(void* This, void* value);
+    HRESULT (STDMETHODCALLTYPE* get_Language)(void* This, void** value);
+    HRESULT (STDMETHODCALLTYPE* put_Language)(void* This, void* value);
+    HRESULT (STDMETHODCALLTYPE* get_ActualWidth)(void* This, double* value);
+    HRESULT (STDMETHODCALLTYPE* get_ActualHeight)(void* This, double* value);
+    HRESULT (STDMETHODCALLTYPE* get_Width)(void* This, double* value);
+    HRESULT (STDMETHODCALLTYPE* put_Width)(void* This, double value);
+    HRESULT (STDMETHODCALLTYPE* get_Height)(void* This, double* value);
+    HRESULT (STDMETHODCALLTYPE* put_Height)(void* This, double value);
+    HRESULT (STDMETHODCALLTYPE* get_MinWidth)(void* This, double* value);
+    HRESULT (STDMETHODCALLTYPE* put_MinWidth)(void* This, double value);
+    HRESULT (STDMETHODCALLTYPE* get_MaxWidth)(void* This, double* value);
+    HRESULT (STDMETHODCALLTYPE* put_MaxWidth)(void* This, double value);
+};
+
+struct IFrameworkElementCustom {
+    IFrameworkElementVtbl* lpVtbl;
+};
+
+static double GetTargetContainerWidth(const Settings& settings) {
+    if (settings.fixedContainerWidth < 0) {
+        return 0.0; // Disabled
+    }
+    if (settings.fixedContainerWidth > 0) {
+        return static_cast<double>(settings.fixedContainerWidth);
+    }
+    // Optimal automatic width in DIPs based on display style
+    switch (settings.displayStyle) {
+        case DisplayStyle::Vanilla:
+            return 0.0; // Native auto-size
+        case DisplayStyle::Number:
+            return 30.0;
+        case DisplayStyle::Prefix:
+            return 72.0;
+        case DisplayStyle::Emoji:
+            return 66.0;
+        case DisplayStyle::Percentage:
+        default:
+            return 42.0;
+    }
+}
+
+static void ApplyVolumeContainerWidth(void* pIconView) {
+    if (!IsValidUserPointer(pIconView) || g_unloading.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    Settings settingsCopy;
+    {
+        std::lock_guard<std::mutex> lock(g_settingsMutex);
+        settingsCopy = g_settings;
+    }
+
+    double targetWidth = GetTargetContainerWidth(settingsCopy);
+
+    // Apply put_MinWidth on the IconView FrameworkElement
+    IUnknown* pUnk = reinterpret_cast<IUnknown*>(pIconView);
+    void* pFEVoid = nullptr;
+    if (SUCCEEDED(pUnk->QueryInterface(IID_IFrameworkElement, &pFEVoid)) && pFEVoid) {
+        IFrameworkElementCustom* pFE = reinterpret_cast<IFrameworkElementCustom*>(pFEVoid);
+        pFE->lpVtbl->put_MinWidth(pFE, targetWidth);
+        pFE->lpVtbl->Release(pFE);
+    }
+
+    // Also apply put_MinWidth on the hosted content element (Grid / TextIconContent) if present
+    if (targetWidth > 0.0) {
+        void* pHostedContent = *reinterpret_cast<void**>(reinterpret_cast<char*>(pIconView) + 0x1b0);
+        if (IsValidUserPointer(pHostedContent)) {
+            void* pHostedFEVoid = nullptr;
+            IUnknown* pHostedUnk = reinterpret_cast<IUnknown*>(pHostedContent);
+            if (SUCCEEDED(pHostedUnk->QueryInterface(IID_IFrameworkElement, &pHostedFEVoid)) && pHostedFEVoid) {
+                IFrameworkElementCustom* pHostedFE = reinterpret_cast<IFrameworkElementCustom*>(pHostedFEVoid);
+                pHostedFE->lpVtbl->put_MinWidth(pHostedFE, targetWidth);
+                pHostedFE->lpVtbl->Release(pHostedFE);
+            }
+        }
+    }
+}
+
+static bool IsVolumeIconViewModel(void* pIconViewModel) {
+    if (!IsValidUserPointer(pIconViewModel)) {
+        return false;
+    }
+
+    void* pInterface = *reinterpret_cast<void**>(pIconViewModel);
+    if (!IsValidUserPointer(pInterface)) {
+        pInterface = pIconViewModel;
+    }
+
+    if (!IsValidUserPointer(pInterface)) {
+        return false;
+    }
+
+    void** vtbl = *reinterpret_cast<void***>(pInterface);
+    if (!IsValidUserPointer(vtbl)) {
+        return false;
+    }
+
+    // Slot 6: get_Configuration(void** ppConfig)
+    using get_Configuration_t = HRESULT(STDMETHODCALLTYPE*)(void* This, void** ppConfig);
+    if (!IsValidUserPointer(reinterpret_cast<void*>(vtbl[6]))) {
+        return false;
+    }
+    auto get_Configuration = reinterpret_cast<get_Configuration_t>(vtbl[6]);
+
+    void* pConfig = nullptr;
+    if (FAILED(get_Configuration(pInterface, &pConfig)) || !IsValidUserPointer(pConfig)) {
+        return false;
+    }
+
+    void** configVtbl = *reinterpret_cast<void***>(pConfig);
+    bool isVolume = false;
+    if (IsValidUserPointer(configVtbl)) {
+        // Slot 9: get_Id(GUID* pGuid)
+        if (IsValidUserPointer(reinterpret_cast<void*>(configVtbl[9]))) {
+            using get_Id_t = HRESULT(STDMETHODCALLTYPE*)(void* This, GUID* pGuid);
+            auto get_Id = reinterpret_cast<get_Id_t>(configVtbl[9]);
+            GUID guid = {};
+            if (SUCCEEDED(get_Id(pConfig, &guid))) {
+                if (memcmp(&guid, &GUID_VolumeIcon, sizeof(GUID)) == 0) {
+                    isVolume = true;
+                }
+            }
+        }
+
+        // Also check Slot 6: get_DataModel(void** ppDataModel)
+        if (!isVolume && IsValidUserPointer(reinterpret_cast<void*>(configVtbl[6]))) {
+            using get_DataModel_t = HRESULT(STDMETHODCALLTYPE*)(void* This, void** ppDataModel);
+            auto get_DataModel = reinterpret_cast<get_DataModel_t>(configVtbl[6]);
+            void* pDataModel = nullptr;
+            if (SUCCEEDED(get_DataModel(pConfig, &pDataModel)) && pDataModel) {
+                {
+                    std::lock_guard<std::mutex> lock(g_dataModelMutex);
+                    if (pDataModel == g_pVolumeDataModel) {
+                        isVolume = true;
+                    }
+                }
+                reinterpret_cast<IUnknown*>(pDataModel)->Release();
+            }
+        }
+
+        reinterpret_cast<IUnknown*>(pConfig)->Release();
+    }
+
+    return isVolume;
+}
+
+// ---------------------------------------------------------------------------
+// Formatting logic
+// ---------------------------------------------------------------------------
+
+static std::wstring FormatDigits(int percentage, PadStyle padStyle) {
+    std::wstring s = std::to_wstring(percentage);
+    if (padStyle == PadStyle::None) {
+        return s;
+    }
+
+    constexpr size_t kTotalDigits = 3;
+    if (s.length() < kTotalDigits) {
+        wchar_t padChar = (padStyle == PadStyle::Zero) ? L'0' : L' ';
+        s.insert(0, kTotalDigits - s.length(), padChar);
+    }
+    return s;
+}
+
+static std::wstring FormatMuteString(MuteStyle style, const std::wstring& customText, PadStyle padStyle) {
     switch (style) {
         case MuteStyle::Mute:
             return L"Mute";
         case MuteStyle::Zero:
-            return L"0%";
+            return FormatDigits(0, padStyle) + L"%";
         case MuteStyle::Cross:
             return L"\u2715";
         case MuteStyle::Emoji:
@@ -182,13 +405,19 @@ static std::wstring FormatMuteString(MuteStyle style, const std::wstring& custom
 }
 
 static std::wstring FormatVolumeText(int percentage, bool isMuted) {
-    if (isMuted && g_settings.displayStyle != DisplayStyle::Vanilla) {
-        return FormatMuteString(g_settings.muteStyle, g_settings.customMuteText);
+    Settings settingsCopy;
+    {
+        std::lock_guard<std::mutex> lock(g_settingsMutex);
+        settingsCopy = g_settings;
     }
 
-    std::wstring s = std::to_wstring(percentage);
+    if (isMuted && settingsCopy.displayStyle != DisplayStyle::Vanilla) {
+        return FormatMuteString(settingsCopy.muteStyle, settingsCopy.customMuteText, settingsCopy.padStyle);
+    }
 
-    switch (g_settings.displayStyle) {
+    std::wstring s = FormatDigits(percentage, settingsCopy.padStyle);
+
+    switch (settingsCopy.displayStyle) {
         case DisplayStyle::Vanilla: {
             wchar_t glyph = GLYPH_MUTE;
             if (!isMuted) {
@@ -204,7 +433,7 @@ static std::wstring FormatVolumeText(int percentage, bool isMuted) {
             return s;
 
         case DisplayStyle::Prefix:
-            return g_settings.customPrefix + s + L"%";
+            return settingsCopy.customPrefix + s + L"%";
 
         case DisplayStyle::Emoji: {
             std::wstring prefix;
@@ -293,52 +522,25 @@ static void ApplyCustomVolumeText(void* pThis, float volumeLevel, bool isMuted) 
     shared_hstring_header** ppHeader = reinterpret_cast<shared_hstring_header**>(
         reinterpret_cast<char*>(pThis) + offset);
 
+    shared_hstring_header* oldHeader = *ppHeader;
+
+    // If the current header was already created by us and matches the desired text, reuse it
+    if (oldHeader && oldHeader->flags == 0 && oldHeader->padding1 == MOD_HSTRING_MAGIC &&
+        oldHeader->length == customText.length() && oldHeader->ptr &&
+        wcsncmp(oldHeader->ptr, customText.c_str(), customText.length()) == 0) {
+        return;
+    }
+
     shared_hstring_header* newHeader = CreateSharedHString(customText);
     if (!newHeader) {
         return;
     }
 
-    shared_hstring_header* oldHeader = *ppHeader;
     *ppHeader = newHeader;
 
     if (oldHeader && oldHeader != newHeader) {
         ReleaseSharedHString(oldHeader);
     }
-}
-
-static void QueryInitialSystemVolume(float* pLevel, bool* pMuted) {
-    *pLevel = 0.5f;
-    *pMuted = false;
-
-    IMMDeviceEnumerator* pEnumerator = nullptr;
-    HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr,
-                                  CLSCTX_INPROC_SERVER,
-                                  __uuidof(IMMDeviceEnumerator),
-                                  reinterpret_cast<void**>(&pEnumerator));
-    if (FAILED(hr) || !pEnumerator) {
-        return;
-    }
-
-    IMMDevice* pDevice = nullptr;
-    hr = pEnumerator->GetDefaultAudioEndpoint(eRender, eConsole, &pDevice);
-    if (SUCCEEDED(hr) && pDevice) {
-        IAudioEndpointVolume* pEndpoint = nullptr;
-        hr = pDevice->Activate(__uuidof(IAudioEndpointVolume), CLSCTX_INPROC_SERVER,
-                               nullptr, reinterpret_cast<void**>(&pEndpoint));
-        if (SUCCEEDED(hr) && pEndpoint) {
-            float masterVol = 0.5f;
-            BOOL bMute = FALSE;
-            if (SUCCEEDED(pEndpoint->GetMasterVolumeLevelScalar(&masterVol))) {
-                *pLevel = masterVol;
-            }
-            if (SUCCEEDED(pEndpoint->GetMute(&bMute))) {
-                *pMuted = (bMute != FALSE);
-            }
-            pEndpoint->Release();
-        }
-        pDevice->Release();
-    }
-    pEnumerator->Release();
 }
 
 static HWND FindCurrentProcessTaskbarWnd() {
@@ -406,9 +608,24 @@ static bool RunFromWindowThread(HWND hWnd, RunFromWindowThreadProc_t proc, void*
     RUN_FROM_WINDOW_THREAD_PARAM param;
     param.proc = proc;
     param.procParam = procParam;
-    SendMessage(hWnd, g_runFromWindowThreadMsg, 0, reinterpret_cast<LPARAM>(&param));
+
+    DWORD_PTR dwResult = 0;
+    LRESULT lr = SendMessageTimeout(
+        hWnd,
+        g_runFromWindowThreadMsg,
+        0,
+        reinterpret_cast<LPARAM>(&param),
+        SMTO_NORMAL | SMTO_ABORTIFHUNG,
+        2000,
+        &dwResult);
 
     UnhookWindowsHookEx(hook);
+
+    if (lr == 0) {
+        Wh_Log(L"SendMessageTimeout failed or timed out in RunFromWindowThread (error: %lu)", GetLastError());
+        return false;
+    }
+
     return true;
 }
 
@@ -440,7 +657,7 @@ static VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE hModule, UINT* puPtrLen) {
 }
 
 // ---------------------------------------------------------------------------
-// VolumeSystemTrayIconDataModel hooks
+// VolumeSystemTrayIconDataModel & IconView hooks
 // ---------------------------------------------------------------------------
 
 using VolumeSystemTrayIconDataModel_UpdateVolume_t = void(__cdecl*)(
@@ -457,12 +674,24 @@ using VolumeSystemTrayIconDataModel_dtor_t = void(__cdecl*)(void* pThis);
 static VolumeSystemTrayIconDataModel_dtor_t
     VolumeSystemTrayIconDataModel_dtor_Original = nullptr;
 
+using IconView_OnViewModelChanged_t = void(__cdecl*)(void* pThis, void* pIconViewModel);
+static IconView_OnViewModelChanged_t
+    IconView_OnViewModelChanged_Original = nullptr;
+
+using IconView_UpdateHostedContent_t = void(__cdecl*)(void* pThis);
+static IconView_UpdateHostedContent_t
+    IconView_UpdateHostedContent_Original = nullptr;
+
 static void __cdecl VolumeSystemTrayIconDataModel_dtor_Hook(void* pThis) {
     {
         std::lock_guard<std::mutex> lock(g_dataModelMutex);
         if (g_pVolumeDataModel == pThis) {
             g_pVolumeDataModel = nullptr;
         }
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_iconViewMutex);
+        g_pVolumeIconView = nullptr;
     }
     if (VolumeSystemTrayIconDataModel_dtor_Original) {
         VolumeSystemTrayIconDataModel_dtor_Original(pThis);
@@ -473,13 +702,27 @@ static void __cdecl VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
     void* pThis, float volumeLevel, bool isMuted, void* hstringIcon) {
     static thread_local bool s_inHook = false;
 
+    if (s_inHook || g_unloading.load(std::memory_order_relaxed)) {
+        if (VolumeSystemTrayIconDataModel_UpdateVolume_Original) {
+            VolumeSystemTrayIconDataModel_UpdateVolume_Original(
+                pThis, volumeLevel, isMuted, hstringIcon);
+        }
+        return;
+    }
+
+    // Skip redundant volume notifications if data model, volume, and mute status are strictly identical
+    {
+        std::lock_guard<std::mutex> lock(g_dataModelMutex);
+        if (g_pVolumeDataModel == pThis &&
+            g_lastVolumeLevel == volumeLevel &&
+            g_lastIsMuted == isMuted) {
+            return;
+        }
+    }
+
     if (VolumeSystemTrayIconDataModel_UpdateVolume_Original) {
         VolumeSystemTrayIconDataModel_UpdateVolume_Original(
             pThis, volumeLevel, isMuted, hstringIcon);
-    }
-
-    if (s_inHook || g_unloading.load(std::memory_order_relaxed)) {
-        return;
     }
 
     {
@@ -491,12 +734,72 @@ static void __cdecl VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
         ApplyCustomVolumeText(pThis, volumeLevel, isMuted);
     }
 
+    // Ensure volume container width constraint is active on UI
+    {
+        std::lock_guard<std::mutex> lock(g_iconViewMutex);
+        if (g_pVolumeIconView) {
+            ApplyVolumeContainerWidth(g_pVolumeIconView);
+        }
+    }
+
     // Trigger UI redraw via CurrentData property notification with recursion guard
     if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
         s_inHook = true;
         std::wstring_view propName = L"CurrentData";
         VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(pThis, &propName);
         s_inHook = false;
+    }
+}
+
+static void __cdecl IconView_OnViewModelChanged_Hook(void* pThis, void* pIconViewModel) {
+    if (IconView_OnViewModelChanged_Original) {
+        IconView_OnViewModelChanged_Original(pThis, pIconViewModel);
+    }
+
+    if (g_unloading.load(std::memory_order_relaxed) || !pThis) {
+        return;
+    }
+
+    if (IsVolumeIconViewModel(pIconViewModel)) {
+        {
+            std::lock_guard<std::mutex> lock(g_iconViewMutex);
+            g_pVolumeIconView = pThis;
+        }
+        ApplyVolumeContainerWidth(pThis);
+    }
+}
+
+static void __cdecl IconView_UpdateHostedContent_Hook(void* pThis) {
+    if (IconView_UpdateHostedContent_Original) {
+        IconView_UpdateHostedContent_Original(pThis);
+    }
+
+    if (g_unloading.load(std::memory_order_relaxed) || !pThis) {
+        return;
+    }
+
+    bool isVolume = false;
+    {
+        std::lock_guard<std::mutex> lock(g_iconViewMutex);
+        if (g_pVolumeIconView == pThis) {
+            isVolume = true;
+        }
+    }
+
+    if (!isVolume) {
+        // If g_pVolumeIconView was not yet captured, check IconView + 0x78 (IconViewModel)
+        void* pVM = *reinterpret_cast<void**>(reinterpret_cast<char*>(pThis) + 0x78);
+        if (pVM && IsVolumeIconViewModel(pVM)) {
+            {
+                std::lock_guard<std::mutex> lock(g_iconViewMutex);
+                g_pVolumeIconView = pThis;
+            }
+            isVolume = true;
+        }
+    }
+
+    if (isVolume) {
+        ApplyVolumeContainerWidth(pThis);
     }
 }
 
@@ -530,10 +833,35 @@ static bool HookSystemTraySymbols(HMODULE module) {
                 LR"(public: virtual __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::~VolumeSystemTrayIconDataModel(void))",
                 LR"(public: virtual __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::~VolumeSystemTrayIconDataModel(void) __ptr64)",
                 LR"(??1VolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@UEAA@XZ)",
+                LR"(??_GVolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@UEAAPEAXI@Z)",
+                LR"(??1VolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@UAE@XZ)",
+                LR"(??_GVolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@UAEPAXI@Z)",
                 LR"(winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::~VolumeSystemTrayIconDataModel)",
             },
             reinterpret_cast<void**>(&VolumeSystemTrayIconDataModel_dtor_Original),
             reinterpret_cast<void*>(VolumeSystemTrayIconDataModel_dtor_Hook),
+            true,
+        },
+        {
+            {
+                LR"(private: void __cdecl winrt::SystemTray::implementation::IconView::OnViewModelChanged(struct winrt::SystemTray::IconViewModel const &))",
+                LR"(private: void __cdecl winrt::SystemTray::implementation::IconView::OnViewModelChanged(struct winrt::SystemTray::IconViewModel const & __ptr64) __ptr64)",
+                LR"(?OnViewModelChanged@IconView@implementation@SystemTray@winrt@@AEAAXAEBUIconViewModel@34@@Z)",
+                LR"(winrt::SystemTray::implementation::IconView::OnViewModelChanged)",
+            },
+            reinterpret_cast<void**>(&IconView_OnViewModelChanged_Original),
+            reinterpret_cast<void*>(IconView_OnViewModelChanged_Hook),
+            true,
+        },
+        {
+            {
+                LR"(private: void __cdecl winrt::SystemTray::implementation::IconView::UpdateHostedContent(void))",
+                LR"(private: void __cdecl winrt::SystemTray::implementation::IconView::UpdateHostedContent(void) __ptr64)",
+                LR"(?UpdateHostedContent@IconView@implementation@SystemTray@winrt@@AEAAXXZ)",
+                LR"(winrt::SystemTray::implementation::IconView::UpdateHostedContent)",
+            },
+            reinterpret_cast<void**>(&IconView_UpdateHostedContent_Original),
+            reinterpret_cast<void*>(IconView_UpdateHostedContent_Hook),
             true,
         },
     };
@@ -541,6 +869,14 @@ static bool HookSystemTraySymbols(HMODULE module) {
     if (!WindhawkUtils::HookSymbols(module, systemTrayHooks, ARRAYSIZE(systemTrayHooks))) {
         Wh_Log(L"Failed to hook SystemTray volume symbols");
         return false;
+    }
+
+    if (!VolumeSystemTrayIconDataModel_dtor_Original) {
+        Wh_Log(L"Warning: VolumeSystemTrayIconDataModel destructor symbol could not be hooked; lifetime tracking will rely on validity checks");
+    }
+
+    if (IconView_OnViewModelChanged_Original) {
+        Wh_Log(L"Successfully hooked IconView::OnViewModelChanged for XAML container stabilization");
     }
 
     Wh_Log(L"Successfully hooked SystemTray volume symbols");
@@ -611,64 +947,87 @@ static HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
 // ---------------------------------------------------------------------------
 
 static void LoadSettings() {
+    Settings newSettings;
+
     auto displayStyleSetting = WindhawkUtils::StringSetting::make(L"displayStyle");
     PCWSTR displayStyleStr = displayStyleSetting.get();
     if (displayStyleStr) {
         if (wcscmp(displayStyleStr, L"vanilla") == 0 ||
             wcscmp(displayStyleStr, L"default") == 0 ||
             wcscmp(displayStyleStr, L"vanillaOnly") == 0) {
-            g_settings.displayStyle = DisplayStyle::Vanilla;
+            newSettings.displayStyle = DisplayStyle::Vanilla;
         } else if (wcscmp(displayStyleStr, L"number") == 0 ||
                    wcscmp(displayStyleStr, L"numberOnly") == 0) {
-            g_settings.displayStyle = DisplayStyle::Number;
+            newSettings.displayStyle = DisplayStyle::Number;
         } else if (wcscmp(displayStyleStr, L"prefix") == 0 ||
                    wcscmp(displayStyleStr, L"volPrefix") == 0) {
-            g_settings.displayStyle = DisplayStyle::Prefix;
+            newSettings.displayStyle = DisplayStyle::Prefix;
         } else if (wcscmp(displayStyleStr, L"emoji") == 0 ||
                    wcscmp(displayStyleStr, L"emojiAndPercent") == 0 ||
                    wcscmp(displayStyleStr, L"iconAndPercent") == 0) {
-            g_settings.displayStyle = DisplayStyle::Emoji;
+            newSettings.displayStyle = DisplayStyle::Emoji;
         } else {
-            g_settings.displayStyle = DisplayStyle::Percentage;
+            newSettings.displayStyle = DisplayStyle::Percentage;
         }
     } else {
-        g_settings.displayStyle = DisplayStyle::Percentage;
+        newSettings.displayStyle = DisplayStyle::Percentage;
     }
+
+    auto padStyleSetting = WindhawkUtils::StringSetting::make(L"padStyle");
+    PCWSTR padStyleStr = padStyleSetting.get();
+    if (padStyleStr) {
+        if (wcscmp(padStyleStr, L"zero") == 0) {
+            newSettings.padStyle = PadStyle::Zero;
+        } else if (wcscmp(padStyleStr, L"space") == 0) {
+            newSettings.padStyle = PadStyle::Space;
+        } else {
+            newSettings.padStyle = PadStyle::None;
+        }
+    } else {
+        newSettings.padStyle = PadStyle::None;
+    }
+
+    newSettings.fixedContainerWidth = Wh_GetIntSetting(L"fixedContainerWidth");
 
     auto prefixSetting = WindhawkUtils::StringSetting::make(L"customPrefix");
     if (prefixSetting.get()) {
-        g_settings.customPrefix = prefixSetting.get();
+        newSettings.customPrefix = prefixSetting.get();
     } else {
-        g_settings.customPrefix = L"Vol ";
+        newSettings.customPrefix = L"Vol ";
     }
 
     auto muteStyleSetting = WindhawkUtils::StringSetting::make(L"muteStyle");
     PCWSTR muteStyleStr = muteStyleSetting.get();
     if (muteStyleStr) {
         if (wcscmp(muteStyleStr, L"mute") == 0) {
-            g_settings.muteStyle = MuteStyle::Mute;
+            newSettings.muteStyle = MuteStyle::Mute;
         } else if (wcscmp(muteStyleStr, L"zero") == 0) {
-            g_settings.muteStyle = MuteStyle::Zero;
+            newSettings.muteStyle = MuteStyle::Zero;
         } else if (wcscmp(muteStyleStr, L"cross") == 0) {
-            g_settings.muteStyle = MuteStyle::Cross;
+            newSettings.muteStyle = MuteStyle::Cross;
         } else if (wcscmp(muteStyleStr, L"emoji") == 0) {
-            g_settings.muteStyle = MuteStyle::Emoji;
+            newSettings.muteStyle = MuteStyle::Emoji;
         } else if (wcscmp(muteStyleStr, L"glyph") == 0) {
-            g_settings.muteStyle = MuteStyle::Glyph;
+            newSettings.muteStyle = MuteStyle::Glyph;
         } else if (wcscmp(muteStyleStr, L"custom") == 0) {
-            g_settings.muteStyle = MuteStyle::Custom;
+            newSettings.muteStyle = MuteStyle::Custom;
         } else {
-            g_settings.muteStyle = MuteStyle::Mut;
+            newSettings.muteStyle = MuteStyle::Mut;
         }
     } else {
-        g_settings.muteStyle = MuteStyle::Mut;
+        newSettings.muteStyle = MuteStyle::Mut;
     }
 
     auto customMuteSetting = WindhawkUtils::StringSetting::make(L"customMuteText");
     if (customMuteSetting.get()) {
-        g_settings.customMuteText = customMuteSetting.get();
+        newSettings.customMuteText = customMuteSetting.get();
     } else {
-        g_settings.customMuteText = L"Mute";
+        newSettings.customMuteText = L"Mute";
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_settingsMutex);
+        g_settings = std::move(newSettings);
     }
 }
 
@@ -676,7 +1035,6 @@ BOOL Wh_ModInit() {
     Wh_Log(L"Initializing Taskbar Volume Percentage Indicator mod in explorer.exe");
 
     LoadSettings();
-    QueryInitialSystemVolume(&g_lastVolumeLevel, &g_lastIsMuted);
 
     bool hooked = false;
     if (HMODULE systemTrayModule = GetSystemTrayModuleHandle()) {
@@ -722,6 +1080,31 @@ void Wh_ModAfterInit() {
 }
 
 static void BeforeUninitOnUIThread(void* /*parameter*/) {
+    // Reset XAML container width to natural vanilla width (0.0)
+    {
+        std::lock_guard<std::mutex> lock(g_iconViewMutex);
+        if (g_pVolumeIconView) {
+            IUnknown* pUnk = reinterpret_cast<IUnknown*>(g_pVolumeIconView);
+            void* pFEVoid = nullptr;
+            if (SUCCEEDED(pUnk->QueryInterface(IID_IFrameworkElement, &pFEVoid)) && pFEVoid) {
+                IFrameworkElementCustom* pFE = reinterpret_cast<IFrameworkElementCustom*>(pFEVoid);
+                pFE->lpVtbl->put_MinWidth(pFE, 0.0);
+                pFE->lpVtbl->Release(pFE);
+            }
+            void* pHostedContent = *reinterpret_cast<void**>(reinterpret_cast<char*>(g_pVolumeIconView) + 0x1b0);
+            if (IsValidUserPointer(pHostedContent)) {
+                void* pHostedFEVoid = nullptr;
+                IUnknown* pHostedUnk = reinterpret_cast<IUnknown*>(pHostedContent);
+                if (SUCCEEDED(pHostedUnk->QueryInterface(IID_IFrameworkElement, &pHostedFEVoid)) && pHostedFEVoid) {
+                    IFrameworkElementCustom* pHostedFE = reinterpret_cast<IFrameworkElementCustom*>(pHostedFEVoid);
+                    pHostedFE->lpVtbl->put_MinWidth(pHostedFE, 0.0);
+                    pHostedFE->lpVtbl->Release(pHostedFE);
+                }
+            }
+            g_pVolumeIconView = nullptr;
+        }
+    }
+
     std::lock_guard<std::mutex> lock(g_dataModelMutex);
     if (g_pVolumeDataModel && (reinterpret_cast<uintptr_t>(g_pVolumeDataModel) % sizeof(void*)) == 0) {
         size_t offset = GetIconTextOffset(g_pVolumeDataModel);
@@ -751,7 +1134,7 @@ static void BeforeUninitOnUIThread(void* /*parameter*/) {
 }
 
 void Wh_ModBeforeUninit() {
-    Wh_Log(L"Preparing mod unload, restoring native icon");
+    Wh_Log(L"Preparing mod unload, restoring native icon and container size");
 
     g_unloading = true;
 
@@ -769,6 +1152,13 @@ void Wh_ModUninit() {
 }
 
 static void SettingsChangedOnUIThread(void* /*parameter*/) {
+    {
+        std::lock_guard<std::mutex> lock(g_iconViewMutex);
+        if (g_pVolumeIconView && !g_unloading.load(std::memory_order_relaxed)) {
+            ApplyVolumeContainerWidth(g_pVolumeIconView);
+        }
+    }
+
     std::lock_guard<std::mutex> lock(g_dataModelMutex);
     if (g_pVolumeDataModel && !g_unloading.load(std::memory_order_relaxed)) {
         ApplyCustomVolumeText(g_pVolumeDataModel, g_lastVolumeLevel, g_lastIsMuted);

--- a/mods/taskbar-volume-percentage.wh.cpp
+++ b/mods/taskbar-volume-percentage.wh.cpp
@@ -2,11 +2,11 @@
 // @id              taskbar-volume-percentage
 // @name            Taskbar Volume Percentage Indicator
 // @description     Displays the exact master volume percentage in the system tray natively inside the Windows 11 volume button with real-time sync.
-// @version         1.3.1
+// @version         1.3.2
 // @author          gilnett
 // @github          https://github.com/gilnett
 // @include         explorer.exe
-// @compilerOptions -lole32 -lshlwapi -lversion
+// @compilerOptions -lversion
 // @license         GPL-3.0
 // ==/WindhawkMod==
 
@@ -21,6 +21,7 @@ Replaces the Windows 11 taskbar volume icon with the current volume level in rea
 - **Display styles**: Percentage (`50%`), number only (`50`), custom prefix (`Vol 50%`), emoji (`🔊 50%`), or default icon.
 - **Mute indicator**: Customizable mute display (`MUT`, `Mute`, `0%`, `✕`, `🔇`, or native glyph).
 - **Zero-Jitter Structural Stabilization**: Locks the XAML container width and measure override (`TextIconContent::MeasureOverride` & `IFrameworkElement::put_MinWidth`) to eliminate layout jitter during volume changes without needing artificial padding.
+- **Robust Memory Validation**: Guards all WinRT visual tree inspections with multi-tier page commitment and COM vtable verification, preventing memory corruption or dangling pointer access.
 
 ## Credits
 
@@ -41,7 +42,7 @@ Replaces the Windows 11 taskbar volume icon with the current volume level in rea
     - vanilla: Windows Default (exact vanilla Windows speaker icon)
 - fixedContainerWidth: 0
   $name: Fixed Container Width
-  $description: Minimum width in pixels for the volume container to eliminate layout jitter. Set to 0 for automatic optimal width based on style (e.g. 42 for percentage), or enter a custom width (e.g. 42). Set to -1 to disable.
+  $description: Minimum width in pixels for the volume container to eliminate layout jitter. Set to 0 for automatic optimal width based on style (e.g. 42 for percentage), or enter a custom width (e.g. 50). Set to -1 to disable.
 - customPrefix: "Vol "
   $name: Custom Prefix
   $description: Prefix text used when the display style is set to 'Prefix and Percentage'.
@@ -63,7 +64,6 @@ Replaces the Windows 11 taskbar volume icon with the current volume level in rea
 // ==/WindhawkModSettings==
 
 #include <windows.h>
-#include <shlwapi.h>
 #include <winver.h>
 
 #include <atomic>
@@ -170,24 +170,74 @@ static std::mutex g_iconViewMutex;
 static void* g_pVolumeTextIcon = nullptr;
 static std::mutex g_textIconMutex;
 
+static std::atomic<double> g_lastAppliedTextIconWidth{-1.0};
+static std::atomic<double> g_lastAppliedIconViewWidth{-1.0};
+
 static std::atomic<bool> g_unloading{false};
 static std::atomic<bool> g_systemTrayModuleHooked{false};
 
 // ---------------------------------------------------------------------------
-// WinRT ABI definitions for XAML FrameworkElement and SystemTray IconView
+// Memory verification & WinRT ABI definitions
 // ---------------------------------------------------------------------------
 
-static inline bool IsValidUserPointer(const void* ptr) {
+static bool IsValidReadableMemory(const void* ptr, size_t size) {
+    if (!ptr || size == 0) return false;
     uintptr_t u = reinterpret_cast<uintptr_t>(ptr);
-    if ((u % sizeof(void*)) != 0) return false;
 #if defined(_WIN64) || defined(__x86_64__) || defined(_M_AMD64) || defined(__aarch64__)
-    return u >= 0x10000 && u < 0x00007FFFFFF00000ULL;
+    if (u < 0x10000 || u >= 0x00007FFFFFF00000ULL) return false;
 #else
-    return u >= 0x10000 && u < 0x7FFF0000UL;
+    if (u < 0x10000 || u >= 0x7FFF0000UL) return false;
 #endif
+
+    MEMORY_BASIC_INFORMATION mbi = {};
+    if (VirtualQuery(ptr, &mbi, sizeof(mbi)) != sizeof(mbi)) {
+        return false;
+    }
+
+    if (mbi.State != MEM_COMMIT) {
+        return false;
+    }
+
+    if (mbi.Protect & (PAGE_NOACCESS | PAGE_GUARD)) {
+        return false;
+    }
+
+    constexpr DWORD kReadable = PAGE_READONLY | PAGE_READWRITE |
+                                PAGE_WRITECOPY | PAGE_EXECUTE_READ |
+                                PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
+    if (!(mbi.Protect & kReadable)) {
+        return false;
+    }
+
+    uintptr_t regionEnd = reinterpret_cast<uintptr_t>(mbi.BaseAddress) + mbi.RegionSize;
+    if (u + size > regionEnd) {
+        return false;
+    }
+
+    return true;
+}
+
+static inline bool IsValidUserPointer(const void* ptr) {
+    if (!ptr || (reinterpret_cast<uintptr_t>(ptr) % sizeof(void*)) != 0) {
+        return false;
+    }
+    return IsValidReadableMemory(ptr, sizeof(void*));
+}
+
+static inline bool IsValidComObject(const void* ptr) {
+    if (!IsValidUserPointer(ptr)) {
+        return false;
+    }
+    const void* const* vtbl = *reinterpret_cast<const void* const* const*>(ptr);
+    if (!IsValidUserPointer(vtbl)) {
+        return false;
+    }
+    // QueryInterface (slot 0) must point to valid readable/executable code
+    return IsValidReadableMemory(vtbl[0], sizeof(void*));
 }
 
 // IFrameworkElement GUID: a391d09b-4a99-4b7c-9d8d-6fa5d01f6fbf
+// Matches official Windows SDK winrt::impl::guid_v<winrt::Windows::UI::Xaml::IFrameworkElement>
 static constexpr GUID IID_IFrameworkElement = {
     0xa391d09b, 0x4a99, 0x4b7c, { 0x9d, 0x8d, 0x6f, 0xa5, 0xd0, 0x1f, 0x6f, 0xbf }
 };
@@ -198,29 +248,27 @@ static constexpr GUID GUID_VolumeIcon = {
 };
 
 struct IFrameworkElementVtbl {
-    HRESULT (STDMETHODCALLTYPE* QueryInterface)(void* This, REFIID riid, void** ppvObject);
-    ULONG   (STDMETHODCALLTYPE* AddRef)(void* This);
-    ULONG   (STDMETHODCALLTYPE* Release)(void* This);
-    HRESULT (STDMETHODCALLTYPE* GetIids)(void* This, ULONG* iidCount, IID** iids);
-    HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(void* This, void** className);
-    HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(void* This, int* trustLevel);
-    HRESULT (STDMETHODCALLTYPE* get_Triggers)(void* This, void** value);
-    HRESULT (STDMETHODCALLTYPE* get_Resources)(void* This, void** value);
-    HRESULT (STDMETHODCALLTYPE* put_Resources)(void* This, void* value);
-    HRESULT (STDMETHODCALLTYPE* get_Tag)(void* This, void** value);
-    HRESULT (STDMETHODCALLTYPE* put_Tag)(void* This, void* value);
-    HRESULT (STDMETHODCALLTYPE* get_Language)(void* This, void** value);
-    HRESULT (STDMETHODCALLTYPE* put_Language)(void* This, void* value);
-    HRESULT (STDMETHODCALLTYPE* get_ActualWidth)(void* This, double* value);
-    HRESULT (STDMETHODCALLTYPE* get_ActualHeight)(void* This, double* value);
-    HRESULT (STDMETHODCALLTYPE* get_Width)(void* This, double* value);
-    HRESULT (STDMETHODCALLTYPE* put_Width)(void* This, double value);
-    HRESULT (STDMETHODCALLTYPE* get_Height)(void* This, double* value);
-    HRESULT (STDMETHODCALLTYPE* put_Height)(void* This, double value);
-    HRESULT (STDMETHODCALLTYPE* get_MinWidth)(void* This, double* value);
-    HRESULT (STDMETHODCALLTYPE* put_MinWidth)(void* This, double value);
-    HRESULT (STDMETHODCALLTYPE* get_MaxWidth)(void* This, double* value);
-    HRESULT (STDMETHODCALLTYPE* put_MaxWidth)(void* This, double value);
+    HRESULT (STDMETHODCALLTYPE* QueryInterface)(void* This, REFIID riid, void** ppvObject); // 0
+    ULONG   (STDMETHODCALLTYPE* AddRef)(void* This); // 1
+    ULONG   (STDMETHODCALLTYPE* Release)(void* This); // 2
+    HRESULT (STDMETHODCALLTYPE* GetIids)(void* This, ULONG* iidCount, IID** iids); // 3
+    HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(void* This, void** className); // 4
+    HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(void* This, int* trustLevel); // 5
+    HRESULT (STDMETHODCALLTYPE* get_Triggers)(void* This, void** value); // 6
+    HRESULT (STDMETHODCALLTYPE* get_Resources)(void* This, void** value); // 7
+    HRESULT (STDMETHODCALLTYPE* put_Resources)(void* This, void* value); // 8
+    HRESULT (STDMETHODCALLTYPE* get_Tag)(void* This, void** value); // 9
+    HRESULT (STDMETHODCALLTYPE* put_Tag)(void* This, void* value); // 10
+    HRESULT (STDMETHODCALLTYPE* get_Language)(void* This, void** value); // 11
+    HRESULT (STDMETHODCALLTYPE* put_Language)(void* This, void* value); // 12
+    HRESULT (STDMETHODCALLTYPE* get_ActualWidth)(void* This, double* value); // 13
+    HRESULT (STDMETHODCALLTYPE* get_ActualHeight)(void* This, double* value); // 14
+    HRESULT (STDMETHODCALLTYPE* get_Width)(void* This, double* value); // 15
+    HRESULT (STDMETHODCALLTYPE* put_Width)(void* This, double value); // 16
+    HRESULT (STDMETHODCALLTYPE* get_Height)(void* This, double* value); // 17
+    HRESULT (STDMETHODCALLTYPE* put_Height)(void* This, double value); // 18
+    HRESULT (STDMETHODCALLTYPE* get_MinWidth)(void* This, double* value); // 19
+    HRESULT (STDMETHODCALLTYPE* put_MinWidth)(void* This, double value); // 20
 };
 
 struct IFrameworkElementCustom {
@@ -256,7 +304,7 @@ static double GetTargetContainerWidth(const Settings& settings) {
 }
 
 static void ApplyElementMinWidth(void* pElement, double minWidth) {
-    if (!IsValidUserPointer(pElement)) {
+    if (!IsValidComObject(pElement)) {
         return;
     }
 
@@ -264,26 +312,32 @@ static void ApplyElementMinWidth(void* pElement, double minWidth) {
     IUnknown* pUnk = reinterpret_cast<IUnknown*>(pElement);
     void* pFEVoid = nullptr;
     if (SUCCEEDED(pUnk->QueryInterface(IID_IFrameworkElement, &pFEVoid)) && pFEVoid) {
-        IFrameworkElementCustom* pFE = reinterpret_cast<IFrameworkElementCustom*>(pFEVoid);
-        pFE->lpVtbl->put_MinWidth(pFE, minWidth);
-        pFE->lpVtbl->Release(pFE);
+        if (IsValidComObject(pFEVoid)) {
+            IFrameworkElementCustom* pFE = reinterpret_cast<IFrameworkElementCustom*>(pFEVoid);
+            pFE->lpVtbl->put_MinWidth(pFE, minWidth);
+            pFE->lpVtbl->Release(pFE);
+        }
     }
 
     // 2. Also check inner composable XAML object at offset +8 (for aggregated controls)
-    void* pInner = *reinterpret_cast<void**>(reinterpret_cast<char*>(pElement) + 8);
-    if (IsValidUserPointer(pInner)) {
-        void* pInnerFEVoid = nullptr;
-        IUnknown* pInnerUnk = reinterpret_cast<IUnknown*>(pInner);
-        if (SUCCEEDED(pInnerUnk->QueryInterface(IID_IFrameworkElement, &pInnerFEVoid)) && pInnerFEVoid) {
-            IFrameworkElementCustom* pInnerFE = reinterpret_cast<IFrameworkElementCustom*>(pInnerFEVoid);
-            pInnerFE->lpVtbl->put_MinWidth(pInnerFE, minWidth);
-            pInnerFE->lpVtbl->Release(pInnerFE);
+    if (IsValidReadableMemory(reinterpret_cast<const char*>(pElement) + 8, sizeof(void*))) {
+        void* pInner = *reinterpret_cast<void**>(reinterpret_cast<char*>(pElement) + 8);
+        if (IsValidComObject(pInner)) {
+            void* pInnerFEVoid = nullptr;
+            IUnknown* pInnerUnk = reinterpret_cast<IUnknown*>(pInner);
+            if (SUCCEEDED(pInnerUnk->QueryInterface(IID_IFrameworkElement, &pInnerFEVoid)) && pInnerFEVoid) {
+                if (IsValidComObject(pInnerFEVoid)) {
+                    IFrameworkElementCustom* pInnerFE = reinterpret_cast<IFrameworkElementCustom*>(pInnerFEVoid);
+                    pInnerFE->lpVtbl->put_MinWidth(pInnerFE, minWidth);
+                    pInnerFE->lpVtbl->Release(pInnerFE);
+                }
+            }
         }
     }
 }
 
 static void ApplyVolumeContainerWidth(void* pIconView) {
-    if (!IsValidUserPointer(pIconView) || g_unloading.load(std::memory_order_relaxed)) {
+    if (!IsValidComObject(pIconView) || g_unloading.load(std::memory_order_relaxed)) {
         return;
     }
 
@@ -294,47 +348,42 @@ static void ApplyVolumeContainerWidth(void* pIconView) {
     }
 
     double targetWidth = GetTargetContainerWidth(settingsCopy);
+    double prevWidth = g_lastAppliedIconViewWidth.load(std::memory_order_relaxed);
+    if (prevWidth != targetWidth) {
+        g_lastAppliedIconViewWidth.store(targetWidth, std::memory_order_relaxed);
+        ApplyElementMinWidth(pIconView, targetWidth);
 
-    // Apply put_MinWidth on the IconView FrameworkElement
-    ApplyElementMinWidth(pIconView, targetWidth);
-
-    // Also apply put_MinWidth on the hosted content element (Grid / TextIconContent) if present
-    if (targetWidth > 0.0) {
-        void* pHostedContent = *reinterpret_cast<void**>(reinterpret_cast<char*>(pIconView) + 0x1b0);
-        if (IsValidUserPointer(pHostedContent)) {
-            ApplyElementMinWidth(pHostedContent, targetWidth);
+        // Also apply put_MinWidth on the hosted content element if present
+        if (targetWidth > 0.0 && IsValidReadableMemory(reinterpret_cast<const char*>(pIconView) + 0x1b0, sizeof(void*))) {
+            void* pHostedContent = *reinterpret_cast<void**>(reinterpret_cast<char*>(pIconView) + 0x1b0);
+            if (IsValidComObject(pHostedContent)) {
+                ApplyElementMinWidth(pHostedContent, targetWidth);
+            }
         }
     }
 }
 
 static bool IsVolumeIconViewModel(void* pIconViewModel) {
-    if (!IsValidUserPointer(pIconViewModel)) {
+    if (!IsValidComObject(pIconViewModel)) {
         return false;
     }
 
-    void* pInterface = *reinterpret_cast<void**>(pIconViewModel);
-    if (!IsValidUserPointer(pInterface)) {
-        pInterface = pIconViewModel;
-    }
-
-    if (!IsValidUserPointer(pInterface)) {
-        return false;
-    }
-
+    void* pInterface = pIconViewModel;
     void** vtbl = *reinterpret_cast<void***>(pInterface);
-    if (!IsValidUserPointer(vtbl)) {
+    if (!IsValidUserPointer(vtbl) || !IsValidReadableMemory(reinterpret_cast<char*>(vtbl) + 6 * sizeof(void*), sizeof(void*))) {
         return false;
     }
 
     // Slot 6: get_Configuration(void** ppConfig)
-    using get_Configuration_t = HRESULT(STDMETHODCALLTYPE*)(void* This, void** ppConfig);
-    if (!IsValidUserPointer(reinterpret_cast<void*>(vtbl[6]))) {
+    void* pSlot6 = vtbl[6];
+    if (!IsValidReadableMemory(pSlot6, sizeof(void*))) {
         return false;
     }
-    auto get_Configuration = reinterpret_cast<get_Configuration_t>(vtbl[6]);
+    using get_Configuration_t = HRESULT(STDMETHODCALLTYPE*)(void* This, void** ppConfig);
+    auto get_Configuration = reinterpret_cast<get_Configuration_t>(pSlot6);
 
     void* pConfig = nullptr;
-    if (FAILED(get_Configuration(pInterface, &pConfig)) || !IsValidUserPointer(pConfig)) {
+    if (FAILED(get_Configuration(pInterface, &pConfig)) || !IsValidComObject(pConfig)) {
         return false;
     }
 
@@ -342,30 +391,34 @@ static bool IsVolumeIconViewModel(void* pIconViewModel) {
     bool isVolume = false;
     if (IsValidUserPointer(configVtbl)) {
         // Slot 9: get_Id(GUID* pGuid)
-        if (IsValidUserPointer(reinterpret_cast<void*>(configVtbl[9]))) {
-            using get_Id_t = HRESULT(STDMETHODCALLTYPE*)(void* This, GUID* pGuid);
-            auto get_Id = reinterpret_cast<get_Id_t>(configVtbl[9]);
-            GUID guid = {};
-            if (SUCCEEDED(get_Id(pConfig, &guid))) {
-                if (memcmp(&guid, &GUID_VolumeIcon, sizeof(GUID)) == 0) {
+        if (IsValidReadableMemory(reinterpret_cast<char*>(configVtbl) + 9 * sizeof(void*), sizeof(void*))) {
+            void* pSlot9 = configVtbl[9];
+            if (IsValidReadableMemory(pSlot9, sizeof(void*))) {
+                using get_Id_t = HRESULT(STDMETHODCALLTYPE*)(void* This, GUID* pGuid);
+                auto get_Id = reinterpret_cast<get_Id_t>(pSlot9);
+                GUID guid = {};
+                if (SUCCEEDED(get_Id(pConfig, &guid)) && memcmp(&guid, &GUID_VolumeIcon, sizeof(GUID)) == 0) {
                     isVolume = true;
                 }
             }
         }
 
         // Also check Slot 6: get_DataModel(void** ppDataModel)
-        if (!isVolume && IsValidUserPointer(reinterpret_cast<void*>(configVtbl[6]))) {
-            using get_DataModel_t = HRESULT(STDMETHODCALLTYPE*)(void* This, void** ppDataModel);
-            auto get_DataModel = reinterpret_cast<get_DataModel_t>(configVtbl[6]);
-            void* pDataModel = nullptr;
-            if (SUCCEEDED(get_DataModel(pConfig, &pDataModel)) && pDataModel) {
-                {
-                    std::lock_guard<std::mutex> lock(g_dataModelMutex);
-                    if (pDataModel == g_pVolumeDataModel) {
-                        isVolume = true;
+        if (!isVolume && IsValidReadableMemory(reinterpret_cast<char*>(configVtbl) + 6 * sizeof(void*), sizeof(void*))) {
+            void* pConfigSlot6 = configVtbl[6];
+            if (IsValidReadableMemory(pConfigSlot6, sizeof(void*))) {
+                using get_DataModel_t = HRESULT(STDMETHODCALLTYPE*)(void* This, void** ppDataModel);
+                auto get_DataModel = reinterpret_cast<get_DataModel_t>(pConfigSlot6);
+                void* pDataModel = nullptr;
+                if (SUCCEEDED(get_DataModel(pConfig, &pDataModel)) && pDataModel) {
+                    {
+                        std::lock_guard<std::mutex> lock(g_dataModelMutex);
+                        if (pDataModel == g_pVolumeDataModel) {
+                            isVolume = true;
+                        }
                     }
+                    reinterpret_cast<IUnknown*>(pDataModel)->Release();
                 }
-                reinterpret_cast<IUnknown*>(pDataModel)->Release();
             }
         }
 
@@ -390,22 +443,34 @@ static bool IsVolumeTextIcon(void* pThis) {
     // Check ViewModel at offsets 0x80 and 0x68
     const size_t vmOffsets[] = { 0x80, 0x68 };
     for (size_t offset : vmOffsets) {
+        if (!IsValidReadableMemory(reinterpret_cast<const char*>(pThis) + offset, sizeof(void*))) {
+            continue;
+        }
         void* pVM = *reinterpret_cast<void**>(reinterpret_cast<char*>(pThis) + offset);
-        if (IsValidUserPointer(pVM)) {
-            // 1. Direct GUID check at offset 0x38 in ViewModel
+        if (!IsValidUserPointer(pVM)) {
+            continue;
+        }
+
+        // 1. Direct GUID check at offset 0x38 in ViewModel
+        if (IsValidReadableMemory(reinterpret_cast<const char*>(pVM) + 0x38, sizeof(GUID))) {
             const GUID* pGuid = reinterpret_cast<const GUID*>(reinterpret_cast<const char*>(pVM) + 0x38);
             if (memcmp(pGuid, &GUID_VolumeIcon, sizeof(GUID)) == 0) {
                 return true;
             }
+        }
 
-            // 2. Check via slot 6 (ITextIconContentViewModel::get_Id)
+        // 2. Check via slot 6 (ITextIconContentViewModel::get_Id)
+        if (IsValidComObject(pVM)) {
             void** vtbl = *reinterpret_cast<void***>(pVM);
-            if (IsValidUserPointer(vtbl) && IsValidUserPointer(reinterpret_cast<void*>(vtbl[6]))) {
-                using get_Id_t = HRESULT(STDMETHODCALLTYPE*)(void* This, GUID* pGuidOut);
-                auto get_Id = reinterpret_cast<get_Id_t>(vtbl[6]);
-                GUID id = {};
-                if (SUCCEEDED(get_Id(pVM, &id)) && memcmp(&id, &GUID_VolumeIcon, sizeof(GUID)) == 0) {
-                    return true;
+            if (IsValidReadableMemory(reinterpret_cast<char*>(vtbl) + 6 * sizeof(void*), sizeof(void*))) {
+                void* pSlot6 = vtbl[6];
+                if (IsValidReadableMemory(pSlot6, sizeof(void*))) {
+                    using get_Id_t = HRESULT(STDMETHODCALLTYPE*)(void* This, GUID* pGuidOut);
+                    auto get_Id = reinterpret_cast<get_Id_t>(pSlot6);
+                    GUID id = {};
+                    if (SUCCEEDED(get_Id(pVM, &id)) && memcmp(&id, &GUID_VolumeIcon, sizeof(GUID)) == 0) {
+                        return true;
+                    }
                 }
             }
         }
@@ -492,7 +557,7 @@ static std::wstring FormatVolumeText(int percentage, bool isMuted) {
 }
 
 static size_t GetIconTextOffset(void* pThis) {
-    if (!pThis || (reinterpret_cast<uintptr_t>(pThis) % sizeof(void*)) != 0) {
+    if (!IsValidUserPointer(pThis)) {
         return 0;
     }
 
@@ -500,13 +565,10 @@ static size_t GetIconTextOffset(void* pThis) {
         if (!h || (reinterpret_cast<uintptr_t>(h) % sizeof(void*)) != 0) {
             return false;
         }
-        if (h->flags > 1) {
+        if (!IsValidReadableMemory(h, sizeof(shared_hstring_header))) {
             return false;
         }
-        if (h->length > 256) {
-            return false;
-        }
-        if (!h->ptr) {
+        if (h->flags > 1 || h->length > 256 || !h->ptr) {
             return false;
         }
         return true;
@@ -514,13 +576,18 @@ static size_t GetIconTextOffset(void* pThis) {
 
     // Primary offset in standard Windows 11 SystemTray builds is 0xB8
     constexpr size_t defaultOffset = 0xB8;
-    shared_hstring_header* defaultCandidate = *reinterpret_cast<shared_hstring_header**>(
-        reinterpret_cast<char*>(pThis) + defaultOffset);
-    if (isValidHeader(defaultCandidate)) {
-        return defaultOffset;
+    if (IsValidReadableMemory(reinterpret_cast<const char*>(pThis) + defaultOffset, sizeof(void*))) {
+        shared_hstring_header* defaultCandidate = *reinterpret_cast<shared_hstring_header**>(
+            reinterpret_cast<char*>(pThis) + defaultOffset);
+        if (isValidHeader(defaultCandidate)) {
+            return defaultOffset;
+        }
     }
 
     for (size_t offset = 0x40; offset <= 0x120; offset += sizeof(void*)) {
+        if (!IsValidReadableMemory(reinterpret_cast<const char*>(pThis) + offset, sizeof(void*))) {
+            continue;
+        }
         shared_hstring_header* candidate = *reinterpret_cast<shared_hstring_header**>(
             reinterpret_cast<char*>(pThis) + offset);
         if (isValidHeader(candidate)) {
@@ -541,7 +608,7 @@ static size_t GetIconTextOffset(void* pThis) {
 }
 
 static void ApplyCustomVolumeText(void* pThis, float volumeLevel, bool isMuted) {
-    if (!pThis || g_unloading.load(std::memory_order_relaxed)) {
+    if (!IsValidUserPointer(pThis) || g_unloading.load(std::memory_order_relaxed)) {
         return;
     }
 
@@ -720,10 +787,16 @@ using IconView_UpdateHostedContent_t = void(__cdecl*)(void* pThis);
 static IconView_UpdateHostedContent_t
     IconView_UpdateHostedContent_Original = nullptr;
 
+using IconView_dtor_t = void(__cdecl*)(void* pThis);
+static IconView_dtor_t IconView_dtor_Original = nullptr;
+
 using TextIconContent_MeasureOverride_t = WinRTSize*(__cdecl*)(
     void* pThis, WinRTSize* pResult, WinRTSize availableSize);
 static TextIconContent_MeasureOverride_t
     TextIconContent_MeasureOverride_Original = nullptr;
+
+using TextIconContent_dtor_t = void(__cdecl*)(void* pThis);
+static TextIconContent_dtor_t TextIconContent_dtor_Original = nullptr;
 
 static void __cdecl VolumeSystemTrayIconDataModel_dtor_Hook(void* pThis) {
     {
@@ -732,16 +805,34 @@ static void __cdecl VolumeSystemTrayIconDataModel_dtor_Hook(void* pThis) {
             g_pVolumeDataModel = nullptr;
         }
     }
-    {
-        std::lock_guard<std::mutex> lock(g_iconViewMutex);
-        g_pVolumeIconView = nullptr;
-    }
-    {
-        std::lock_guard<std::mutex> lock(g_textIconMutex);
-        g_pVolumeTextIcon = nullptr;
-    }
     if (VolumeSystemTrayIconDataModel_dtor_Original) {
         VolumeSystemTrayIconDataModel_dtor_Original(pThis);
+    }
+}
+
+static void __cdecl IconView_dtor_Hook(void* pThis) {
+    {
+        std::lock_guard<std::mutex> lock(g_iconViewMutex);
+        if (g_pVolumeIconView == pThis) {
+            g_pVolumeIconView = nullptr;
+            g_lastAppliedIconViewWidth.store(-1.0, std::memory_order_relaxed);
+        }
+    }
+    if (IconView_dtor_Original) {
+        IconView_dtor_Original(pThis);
+    }
+}
+
+static void __cdecl TextIconContent_dtor_Hook(void* pThis) {
+    {
+        std::lock_guard<std::mutex> lock(g_textIconMutex);
+        if (g_pVolumeTextIcon == pThis) {
+            g_pVolumeTextIcon = nullptr;
+            g_lastAppliedTextIconWidth.store(-1.0, std::memory_order_relaxed);
+        }
+    }
+    if (TextIconContent_dtor_Original) {
+        TextIconContent_dtor_Original(pThis);
     }
 }
 
@@ -749,36 +840,34 @@ static void __cdecl VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
     void* pThis, float volumeLevel, bool isMuted, void* hstringIcon) {
     static thread_local bool s_inHook = false;
 
-    if (s_inHook || g_unloading.load(std::memory_order_relaxed)) {
-        if (VolumeSystemTrayIconDataModel_UpdateVolume_Original) {
-            VolumeSystemTrayIconDataModel_UpdateVolume_Original(
-                pThis, volumeLevel, isMuted, hstringIcon);
-        }
-        return;
-    }
-
-    // Skip redundant volume notifications if data model, volume, and mute status are strictly identical
-    {
-        std::lock_guard<std::mutex> lock(g_dataModelMutex);
-        if (g_pVolumeDataModel == pThis &&
-            g_lastVolumeLevel == volumeLevel &&
-            g_lastIsMuted == isMuted) {
-            return;
-        }
-    }
-
+    // Point 1: Always invoke the original Windows system function first without condition
     if (VolumeSystemTrayIconDataModel_UpdateVolume_Original) {
         VolumeSystemTrayIconDataModel_UpdateVolume_Original(
             pThis, volumeLevel, isMuted, hstringIcon);
     }
 
+    if (s_inHook || g_unloading.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    bool changed = false;
     {
         std::lock_guard<std::mutex> lock(g_dataModelMutex);
+        changed = !(g_pVolumeDataModel == pThis &&
+                    g_lastVolumeLevel == volumeLevel &&
+                    g_lastIsMuted == isMuted);
         g_pVolumeDataModel = pThis;
         g_lastVolumeLevel = volumeLevel;
         g_lastIsMuted = isMuted;
 
-        ApplyCustomVolumeText(pThis, volumeLevel, isMuted);
+        if (changed) {
+            ApplyCustomVolumeText(pThis, volumeLevel, isMuted);
+        }
+    }
+
+    // Only skip our own redundant visual/layout updates when values have not changed
+    if (!changed) {
+        return;
     }
 
     // Ensure volume container width constraint is active on UI
@@ -786,18 +875,6 @@ static void __cdecl VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
         std::lock_guard<std::mutex> lock(g_iconViewMutex);
         if (g_pVolumeIconView) {
             ApplyVolumeContainerWidth(g_pVolumeIconView);
-        }
-    }
-    {
-        std::lock_guard<std::mutex> lock(g_textIconMutex);
-        if (g_pVolumeTextIcon) {
-            Settings settingsCopy;
-            {
-                std::lock_guard<std::mutex> lockSettings(g_settingsMutex);
-                settingsCopy = g_settings;
-            }
-            double targetWidth = GetTargetContainerWidth(settingsCopy);
-            ApplyElementMinWidth(g_pVolumeTextIcon, targetWidth);
         }
     }
 
@@ -812,9 +889,11 @@ static void __cdecl VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
 
 static WinRTSize* __cdecl TextIconContent_MeasureOverride_Hook(
     void* pThis, WinRTSize* pResult, WinRTSize availableSize) {
+    static thread_local bool s_inMeasureHook = false;
+
     WinRTSize* res = TextIconContent_MeasureOverride_Original(pThis, pResult, availableSize);
 
-    if (res && !g_unloading.load(std::memory_order_relaxed)) {
+    if (res && !s_inMeasureHook && !g_unloading.load(std::memory_order_relaxed)) {
         if (IsVolumeTextIcon(pThis)) {
             {
                 std::lock_guard<std::mutex> lock(g_textIconMutex);
@@ -833,7 +912,15 @@ static WinRTSize* __cdecl TextIconContent_MeasureOverride_Hook(
                 if (res->Width < targetWidthF) {
                     res->Width = targetWidthF;
                 }
-                ApplyElementMinWidth(pThis, targetWidth);
+
+                // Point 4 & 5: Apply MinWidth only when target value changes, with re-entrancy guard
+                double prevWidth = g_lastAppliedTextIconWidth.load(std::memory_order_relaxed);
+                if (prevWidth != targetWidth) {
+                    g_lastAppliedTextIconWidth.store(targetWidth, std::memory_order_relaxed);
+                    s_inMeasureHook = true;
+                    ApplyElementMinWidth(pThis, targetWidth);
+                    s_inMeasureHook = false;
+                }
             }
         }
     }
@@ -876,7 +963,7 @@ static void __cdecl IconView_UpdateHostedContent_Hook(void* pThis) {
         }
     }
 
-    if (!isVolume) {
+    if (!isVolume && IsValidReadableMemory(reinterpret_cast<const char*>(pThis) + 0x78, sizeof(void*))) {
         void* pVM = *reinterpret_cast<void**>(reinterpret_cast<char*>(pThis) + 0x78);
         if (pVM && IsVolumeIconViewModel(pVM)) {
             {
@@ -943,6 +1030,18 @@ static bool HookSystemTraySymbols(HMODULE module) {
         },
         {
             {
+                LR"(public: virtual __cdecl winrt::SystemTray::implementation::TextIconContent::~TextIconContent(void))",
+                LR"(public: virtual __cdecl winrt::SystemTray::implementation::TextIconContent::~TextIconContent(void) __ptr64)",
+                LR"(??1TextIconContent@implementation@SystemTray@winrt@@UEAA@XZ)",
+                LR"(??_GTextIconContent@implementation@SystemTray@winrt@@UEAAPEAXI@Z)",
+                LR"(winrt::SystemTray::implementation::TextIconContent::~TextIconContent)",
+            },
+            reinterpret_cast<void**>(&TextIconContent_dtor_Original),
+            reinterpret_cast<void*>(TextIconContent_dtor_Hook),
+            true,
+        },
+        {
+            {
                 LR"(private: void __cdecl winrt::SystemTray::implementation::IconView::OnViewModelChanged(struct winrt::SystemTray::IconViewModel const &))",
                 LR"(private: void __cdecl winrt::SystemTray::implementation::IconView::OnViewModelChanged(struct winrt::SystemTray::IconViewModel const & __ptr64) __ptr64)",
                 LR"(?OnViewModelChanged@IconView@implementation@SystemTray@winrt@@AEAAXAEBUIconViewModel@34@@Z)",
@@ -961,6 +1060,18 @@ static bool HookSystemTraySymbols(HMODULE module) {
             },
             reinterpret_cast<void**>(&IconView_UpdateHostedContent_Original),
             reinterpret_cast<void*>(IconView_UpdateHostedContent_Hook),
+            true,
+        },
+        {
+            {
+                LR"(public: virtual __cdecl winrt::SystemTray::implementation::IconView::~IconView(void))",
+                LR"(public: virtual __cdecl winrt::SystemTray::implementation::IconView::~IconView(void) __ptr64)",
+                LR"(??1IconView@implementation@SystemTray@winrt@@UEAA@XZ)",
+                LR"(??_GIconView@implementation@SystemTray@winrt@@UEAAPEAXI@Z)",
+                LR"(winrt::SystemTray::implementation::IconView::~IconView)",
+            },
+            reinterpret_cast<void**>(&IconView_dtor_Original),
+            reinterpret_cast<void*>(IconView_dtor_Hook),
             true,
         },
     };
@@ -1176,6 +1287,7 @@ static void BeforeUninitOnUIThread(void* /*parameter*/) {
             ApplyElementMinWidth(g_pVolumeTextIcon, 0.0);
             g_pVolumeTextIcon = nullptr;
         }
+        g_lastAppliedTextIconWidth.store(-1.0, std::memory_order_relaxed);
     }
 
     // Reset IconView container width to natural vanilla width (0.0)
@@ -1183,16 +1295,19 @@ static void BeforeUninitOnUIThread(void* /*parameter*/) {
         std::lock_guard<std::mutex> lock(g_iconViewMutex);
         if (g_pVolumeIconView) {
             ApplyElementMinWidth(g_pVolumeIconView, 0.0);
-            void* pHostedContent = *reinterpret_cast<void**>(reinterpret_cast<char*>(g_pVolumeIconView) + 0x1b0);
-            if (IsValidUserPointer(pHostedContent)) {
-                ApplyElementMinWidth(pHostedContent, 0.0);
+            if (IsValidReadableMemory(reinterpret_cast<const char*>(g_pVolumeIconView) + 0x1b0, sizeof(void*))) {
+                void* pHostedContent = *reinterpret_cast<void**>(reinterpret_cast<char*>(g_pVolumeIconView) + 0x1b0);
+                if (IsValidComObject(pHostedContent)) {
+                    ApplyElementMinWidth(pHostedContent, 0.0);
+                }
             }
             g_pVolumeIconView = nullptr;
         }
+        g_lastAppliedIconViewWidth.store(-1.0, std::memory_order_relaxed);
     }
 
     std::lock_guard<std::mutex> lock(g_dataModelMutex);
-    if (g_pVolumeDataModel && (reinterpret_cast<uintptr_t>(g_pVolumeDataModel) % sizeof(void*)) == 0) {
+    if (g_pVolumeDataModel && IsValidUserPointer(g_pVolumeDataModel)) {
         size_t offset = GetIconTextOffset(g_pVolumeDataModel);
         if (offset != 0) {
             wchar_t defaultGlyph = g_lastIsMuted ? GLYPH_MUTE : GLYPH_VOL_3;
@@ -1250,6 +1365,7 @@ static void SettingsChangedOnUIThread(void* /*parameter*/) {
     {
         std::lock_guard<std::mutex> lock(g_textIconMutex);
         if (g_pVolumeTextIcon && !g_unloading.load(std::memory_order_relaxed)) {
+            g_lastAppliedTextIconWidth.store(targetWidth, std::memory_order_relaxed);
             ApplyElementMinWidth(g_pVolumeTextIcon, targetWidth);
         }
     }
@@ -1258,6 +1374,7 @@ static void SettingsChangedOnUIThread(void* /*parameter*/) {
     {
         std::lock_guard<std::mutex> lock(g_iconViewMutex);
         if (g_pVolumeIconView && !g_unloading.load(std::memory_order_relaxed)) {
+            g_lastAppliedIconViewWidth.store(targetWidth, std::memory_order_relaxed);
             ApplyVolumeContainerWidth(g_pVolumeIconView);
         }
     }

--- a/mods/taskbar-volume-percentage.wh.cpp
+++ b/mods/taskbar-volume-percentage.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-volume-percentage
 // @name            Taskbar Volume Percentage Indicator
 // @description     Displays the exact master volume percentage in the system tray natively inside the Windows 11 volume button with real-time sync.
-// @version         1.3.7
+// @version         1.3.8
 // @author          gilnett
 // @github          https://github.com/gilnett
 // @include         explorer.exe
@@ -144,6 +144,12 @@ static winrt::weak_ref<FrameworkElement> g_volumeIconViewWeak;
 
 static std::atomic<bool> g_unloading{false};
 static std::atomic<bool> g_systemTrayModuleHooked{false};
+
+struct BoolScopeGuard {
+    bool& ref;
+    BoolScopeGuard(bool& var) : ref(var) { ref = true; }
+    ~BoolScopeGuard() { ref = false; }
+};
 
 static void InitMasterVolumeFromCoreAudio() {
     IMMDeviceEnumerator* pEnumerator = nullptr;
@@ -319,16 +325,20 @@ static bool IsVolumeIconElement(const FrameworkElement& iconView) {
             break;
         }
 
-        // Numeric percentage or raw number style (e.g. "50%", "50")
-        if (firstChar >= L'0' && firstChar <= L'9') {
+        // Already customized by mod with known formatted strings
+        if (textView.find(L'%') != std::wstring_view::npos ||
+            textView == L"MUT" ||
+            textView == L"Mute") {
             return true;
         }
 
-        // Already customized by mod with known prefixes / strings
-        if (textView.find(L'%') != std::wstring_view::npos ||
-            textView.find(L"MUT") != std::wstring_view::npos ||
-            textView.find(L"Mute") != std::wstring_view::npos ||
-            textView.find(L"Vol") != std::wstring_view::npos) {
+        Settings settingsCopy;
+        {
+            std::lock_guard<std::mutex> lock(g_settingsMutex);
+            settingsCopy = g_settings;
+        }
+        if (!settingsCopy.customPrefix.empty() &&
+            textView.rfind(settingsCopy.customPrefix, 0) == 0) {
             return true;
         }
     } catch (...) {
@@ -351,7 +361,9 @@ static void ApplyVolumeContainerWidth(const FrameworkElement& iconView) {
 
     double targetWidth = GetTargetContainerWidth(settingsCopy);
     try {
-        if (iconView.MinWidth() != targetWidth) {
+        if (targetWidth <= 0.0) {
+            iconView.as<DependencyObject>().ClearValue(FrameworkElement::MinWidthProperty());
+        } else if (iconView.MinWidth() != targetWidth) {
             iconView.MinWidth(targetWidth);
         }
     } catch (...) {
@@ -627,7 +639,7 @@ static size_t GetIconTextOffset(void* pThis) {
         }
     }
 
-    return 0x90; // Fallback to standard Windows 11 member offset
+    return 0; // Return 0 to bail out safely if no candidate matches
 }
 
 static void ApplyCustomVolumeText(void* pThis, float volumeLevel, bool isMuted) {
@@ -686,32 +698,29 @@ static void __cdecl VolumeSystemTrayIconDataModel_OnDataModelChanged_Hook(
 
     if (!s_inOnDataModelChanged && !g_unloading.load(std::memory_order_relaxed) &&
         pThis && propertyName && *propertyName == L"CurrentData") {
-        Settings settingsCopy;
-        {
-            std::lock_guard<std::mutex> lock(g_settingsMutex);
-            settingsCopy = g_settings;
-        }
-
-        if (settingsCopy.displayStyle != DisplayStyle::Vanilla) {
-            float volumeLevel = 0.0f;
-            bool isMuted = false;
+        if (g_hasReceivedVolumeUpdate.load(std::memory_order_relaxed)) {
+            Settings settingsCopy;
             {
-                std::lock_guard<std::mutex> lock(g_dataModelMutex);
-                volumeLevel = g_lastVolumeLevel;
-                isMuted = g_lastIsMuted;
+                std::lock_guard<std::mutex> lock(g_settingsMutex);
+                settingsCopy = g_settings;
             }
-            ApplyCustomVolumeText(pThis, volumeLevel, isMuted);
+
+            if (settingsCopy.displayStyle != DisplayStyle::Vanilla) {
+                float volumeLevel = 0.0f;
+                bool isMuted = false;
+                {
+                    std::lock_guard<std::mutex> lock(g_dataModelMutex);
+                    volumeLevel = g_lastVolumeLevel;
+                    isMuted = g_lastIsMuted;
+                }
+                ApplyCustomVolumeText(pThis, volumeLevel, isMuted);
+            }
         }
     }
 
     if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
-        s_inOnDataModelChanged = true;
-        try {
-            VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(pThis, propertyName);
-        } catch (...) {
-            Wh_Log(L"Exception in OnDataModelChanged_Original");
-        }
-        s_inOnDataModelChanged = false;
+        BoolScopeGuard guard(s_inOnDataModelChanged);
+        VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(pThis, propertyName);
     }
 }
 
@@ -732,16 +741,13 @@ static void __cdecl VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
         g_pVolumeDataModel = pThis;
         g_lastVolumeLevel = volumeLevel;
         g_lastIsMuted = isMuted;
+        g_hasReceivedVolumeUpdate.store(true, std::memory_order_relaxed);
     }
 
     // Always invoke the original Windows system function first
     if (VolumeSystemTrayIconDataModel_UpdateVolume_Original) {
-        try {
-            VolumeSystemTrayIconDataModel_UpdateVolume_Original(
-                pThis, volumeLevel, isMuted, hstringIcon);
-        } catch (...) {
-            Wh_Log(L"Exception in UpdateVolume_Original");
-        }
+        VolumeSystemTrayIconDataModel_UpdateVolume_Original(
+            pThis, volumeLevel, isMuted, hstringIcon);
     }
 
     if (s_inHook) {
@@ -770,24 +776,15 @@ static void __cdecl VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
 
     // Trigger UI redraw via CurrentData property notification with recursion guard
     if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
-        s_inHook = true;
-        try {
-            std::wstring_view propName = L"CurrentData";
-            VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(pThis, &propName);
-        } catch (...) {
-            Wh_Log(L"Exception re-triggering OnDataModelChanged");
-        }
-        s_inHook = false;
+        BoolScopeGuard guard(s_inHook);
+        std::wstring_view propName = L"CurrentData";
+        VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(pThis, &propName);
     }
 }
 
 static void __cdecl IconView_UpdateHostedContent_Hook(void* pThis) {
     if (IconView_UpdateHostedContent_Original) {
-        try {
-            IconView_UpdateHostedContent_Original(pThis);
-        } catch (...) {
-            Wh_Log(L"Exception in IconView_UpdateHostedContent_Original");
-        }
+        IconView_UpdateHostedContent_Original(pThis);
     }
 
     if (g_unloading.load(std::memory_order_relaxed) || !pThis) {
@@ -995,7 +992,7 @@ static void LoadSettings() {
 static void WINAPI BeforeUninitOnUIThread(void* /*parameter*/) {
     try {
         if (auto iconView = g_volumeIconViewWeak.get()) {
-            iconView.MinWidth(0.0);
+            iconView.as<DependencyObject>().ClearValue(FrameworkElement::MinWidthProperty());
         }
     } catch (...) {
         Wh_Log(L"Exception in BeforeUninitOnUIThread resetting width");
@@ -1150,11 +1147,21 @@ void Wh_ModSettingsChanged() {
     }
 }
 
+static void WINAPI InitMasterVolumeOnTaskbarThread(void* /*parameter*/) {
+    InitMasterVolumeFromCoreAudio();
+}
+
 BOOL Wh_ModInit() {
     Wh_Log(L"Initializing Taskbar Volume Percentage Indicator mod in explorer.exe");
 
     LoadSettings();
-    InitMasterVolumeFromCoreAudio();
+
+    HWND hTaskbarWnd = FindCurrentProcessTaskbarWnd();
+    if (hTaskbarWnd) {
+        RunFromWindowThread(hTaskbarWnd, InitMasterVolumeOnTaskbarThread, nullptr);
+    } else {
+        InitMasterVolumeFromCoreAudio();
+    }
 
     bool hooked = false;
     if (HMODULE systemTrayModule = GetSystemTrayModuleHandle()) {
@@ -1185,6 +1192,13 @@ BOOL Wh_ModInit() {
 }
 
 void Wh_ModAfterInit() {
+    if (!g_hasReceivedVolumeUpdate.load(std::memory_order_relaxed)) {
+        HWND hTaskbarWnd = FindCurrentProcessTaskbarWnd();
+        if (hTaskbarWnd) {
+            RunFromWindowThread(hTaskbarWnd, InitMasterVolumeOnTaskbarThread, nullptr);
+        }
+    }
+
     if (!g_systemTrayModuleHooked) {
         if (HMODULE systemTrayModule = GetSystemTrayModuleHandle()) {
             if (!g_systemTrayModuleHooked.exchange(true)) {

--- a/mods/taskbar-volume-percentage.wh.cpp
+++ b/mods/taskbar-volume-percentage.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-volume-percentage
 // @name            Taskbar Volume Percentage Indicator
 // @description     Displays the exact master volume percentage in the system tray natively inside the Windows 11 volume button with real-time sync.
-// @version         1.1.0
+// @version         1.2.0
 // @author          gilnett
 // @github          https://github.com/gilnett
 // @include         explorer.exe
@@ -14,37 +14,16 @@
 /*
 # Taskbar Volume Percentage Indicator
 
-Displays the master volume percentage directly inside the Windows 11 system tray volume icon in real time.
+Replaces the Windows 11 taskbar volume icon with the current volume level in real time.
 
-## Display styles
+## Features
 
-- **Percentage**: Displays the volume percentage (e.g. `50%`).
-- **Number only**: Displays the numerical volume level (e.g. `50`).
-- **Prefix and Percentage**: Displays a custom prefix before the percentage (e.g. `Vol 50%`).
-- **Icon and Percentage**: Displays a speaker icon with the percentage (e.g. `🔊 50%`).
-- **Windows Default**: Displays the vanilla native Windows 11 speaker icon with volume waves.
-
-## Jitter Prevention (Padding)
-
-Stabilizes the button width and prevents adjacent tray icons (Wi-Fi, Battery, Clock) from shifting when the volume level changes between 1, 2, or 3 digits:
-- **None**: Standard variable width (e.g. `5%`, `50%`, `100%`).
-- **Zero-padded**: Fixed 2-digit format (e.g. `05%`, `50%`, `100%`).
-- **Space-padded**: Balanced space format (e.g. ` 5%`, `50%`, `100%`).
-
-## Mute Display Styles
-
-Choose how the muted state is represented:
-- **MUT**: Standard abbreviation (`MUT`).
-- **Mute**: Full word (`Mute`).
-- **0%**: Zero volume representation (`0%` / `00%`).
-- **✕**: Modern fine cross symbol (`✕`).
-- **🔇**: Mute speaker emoji (`🔇`).
-- **Native Glyph**: Windows 11 Segoe Fluent crossed-out speaker glyph.
-- **Custom Text**: Custom user-defined string.
+- **Display styles**: Percentage (`50%`), number only (`50`), custom prefix (`Vol 50%`), emoji (`🔊 50%`), or default icon.
+- **Mute indicator**: Customizable mute display (`MUT`, `Mute`, `0%`, `✕`, `🔇`, or native glyph).
 
 ## Credits
 
-- Based on the [Windows 11 Taskbar Styler](https://windhawk.net/mods/windows-11-taskbar-styler) mod by [m417z](https://github.com/m417z).
+- Inspired by the taskbar visual customization concepts from [m417z](https://github.com/m417z).
 */
 // ==/WindhawkModReadme==
 
@@ -62,13 +41,6 @@ Choose how the muted state is represented:
 - customPrefix: "Vol "
   $name: Custom Prefix
   $description: Prefix text used when the display style is set to 'Prefix and Percentage'.
-- paddingMode: none
-  $name: Jitter Prevention (Padding)
-  $description: Stabilizes taskbar button width and prevents adjacent tray icons from shifting when volume changes between 1 and 2 digits.
-  $options:
-    - none: None (Standard width, e.g. 5%, 50%, 100%)
-    - zero: Zero-padded (Fixed 2 digits, e.g. 05%, 50%, 100%)
-    - space: Space-padded (Balanced space, e.g. ' 5%', '50%', '100%')
 - muteStyle: mut
   $name: Mute Display Style
   $description: Format shown when system master volume is muted.
@@ -116,6 +88,8 @@ struct shared_hstring_header : hstring_header {
     wchar_t buffer[1];
 };
 
+constexpr uint32_t MOD_HSTRING_MAGIC = 0x57484F4B; // "WHOK" tag to verify ownership before HeapFree
+
 static shared_hstring_header* CreateSharedHString(const std::wstring& str) {
     uint32_t len = static_cast<uint32_t>(str.length());
     size_t bytes = sizeof(shared_hstring_header) + sizeof(wchar_t) * len;
@@ -126,7 +100,7 @@ static shared_hstring_header* CreateSharedHString(const std::wstring& str) {
     }
     header->flags = 0;
     header->length = len;
-    header->padding1 = 0;
+    header->padding1 = MOD_HSTRING_MAGIC;
     header->padding2 = 0;
     header->ptr = header->buffer;
     header->count = 1;
@@ -138,9 +112,7 @@ static void ReleaseSharedHString(shared_hstring_header* header) {
     if (!header) {
         return;
     }
-    // Only heap-allocated strings (flags == 0) have an allocated reference count.
-    // Fast-pass / static string references (flags != 0) must never be freed.
-    if (header->flags != 0) {
+    if (header->flags != 0 || header->padding1 != MOD_HSTRING_MAGIC) {
         return;
     }
     if (InterlockedDecrement(reinterpret_cast<volatile LONG*>(&header->count)) == 0) {
@@ -156,12 +128,6 @@ enum class DisplayStyle {
     Vanilla,
 };
 
-enum class PaddingMode {
-    None,
-    Zero,
-    Space,
-};
-
 enum class MuteStyle {
     Mut,
     Mute,
@@ -172,125 +138,89 @@ enum class MuteStyle {
     Custom,
 };
 
-struct ModSettings {
+struct Settings {
     DisplayStyle displayStyle;
     std::wstring customPrefix;
-    PaddingMode paddingMode;
     MuteStyle muteStyle;
     std::wstring customMuteText;
 };
 
-static ModSettings g_settings;
+static Settings g_settings;
+
+// Segoe Fluent Icons volume glyphs
+constexpr wchar_t GLYPH_MUTE  = 0xE74F; // Crossed-out speaker
+constexpr wchar_t GLYPH_VOL_0 = 0xE992; // 0 bars
+constexpr wchar_t GLYPH_VOL_1 = 0xE993; // 1 bar
+constexpr wchar_t GLYPH_VOL_2 = 0xE994; // 2 bars
+constexpr wchar_t GLYPH_VOL_3 = 0xE995; // 3 bars
+
+static void* g_pVolumeDataModel = nullptr;
+static float g_lastVolumeLevel = 0.5f;
+static bool  g_lastIsMuted = false;
 static std::mutex g_dataModelMutex;
 static std::atomic<bool> g_unloading{false};
 static std::atomic<bool> g_systemTrayModuleHooked{false};
-static void* g_pVolumeDataModel = nullptr;
-static float g_lastVolumeLevel = 0.50f;
-static bool g_lastIsMuted = false;
 
-// Windows 11 Segoe Fluent Icons volume glyphs
-constexpr wchar_t GLYPH_MUTE = 0xE74F;
-constexpr wchar_t GLYPH_VOL_3 = 0xE995;
-
-static wchar_t GetVanillaVolumeGlyph(int percentage, bool isMuted) {
-    if (isMuted) {
-        return GLYPH_MUTE;
+static std::wstring FormatMuteString(MuteStyle style, const std::wstring& customText) {
+    switch (style) {
+        case MuteStyle::Mute:
+            return L"Mute";
+        case MuteStyle::Zero:
+            return L"0%";
+        case MuteStyle::Cross:
+            return L"\u2715";
+        case MuteStyle::Emoji:
+            return L"\xD83D\xDD07";
+        case MuteStyle::Glyph:
+            return std::wstring(1, GLYPH_MUTE);
+        case MuteStyle::Custom:
+            return customText.empty() ? L"Mute" : customText;
+        case MuteStyle::Mut:
+        default:
+            return L"MUT";
     }
-    if (percentage <= 0) {
-        return 0xE992;
-    }
-    if (percentage <= 33) {
-        return 0xE993;
-    }
-    if (percentage <= 66) {
-        return 0xE994;
-    }
-    return GLYPH_VOL_3;
 }
 
 static std::wstring FormatVolumeText(int percentage, bool isMuted) {
-    if (isMuted) {
-        if (g_settings.displayStyle == DisplayStyle::Vanilla) {
-            return std::wstring(1, GLYPH_MUTE);
-        }
-
-        std::wstring muteText;
-        switch (g_settings.muteStyle) {
-            case MuteStyle::Mute:
-                muteText = L"Mute";
-                break;
-            case MuteStyle::Zero:
-                if (g_settings.displayStyle == DisplayStyle::Number) {
-                    muteText = (g_settings.paddingMode == PaddingMode::Zero) ? L"00" :
-                               ((g_settings.paddingMode == PaddingMode::Space) ? L" 0" : L"0");
-                } else {
-                    muteText = (g_settings.paddingMode == PaddingMode::Zero) ? L"00%" :
-                               ((g_settings.paddingMode == PaddingMode::Space) ? L" 0%" : L"0%");
-                }
-                break;
-            case MuteStyle::Cross:
-                muteText = L"\x2715"; // ✕
-                break;
-            case MuteStyle::Emoji:
-                muteText = L"\xD83D\xDD07"; // 🔇
-                break;
-            case MuteStyle::Glyph:
-                muteText = std::wstring(1, GLYPH_MUTE);
-                break;
-            case MuteStyle::Custom:
-                muteText = g_settings.customMuteText;
-                break;
-            case MuteStyle::Mut:
-            default:
-                muteText = L"MUT";
-                break;
-        }
-
-        if (g_settings.displayStyle == DisplayStyle::Prefix) {
-            return g_settings.customPrefix + muteText;
-        }
-        if (g_settings.displayStyle == DisplayStyle::Emoji && g_settings.muteStyle != MuteStyle::Emoji) {
-            return L"\xD83D\xDD07 " + muteText;
-        }
-        return muteText;
+    if (isMuted && g_settings.displayStyle != DisplayStyle::Vanilla) {
+        return FormatMuteString(g_settings.muteStyle, g_settings.customMuteText);
     }
 
-    if (g_settings.displayStyle == DisplayStyle::Vanilla) {
-        return std::wstring(1, GetVanillaVolumeGlyph(percentage, false));
-    }
-
-    std::wstring numStr = std::to_wstring(percentage);
-    if (percentage < 10) {
-        if (g_settings.paddingMode == PaddingMode::Zero) {
-            numStr = L"0" + numStr;
-        } else if (g_settings.paddingMode == PaddingMode::Space) {
-            numStr = L" " + numStr;
-        }
-    }
+    std::wstring s = std::to_wstring(percentage);
 
     switch (g_settings.displayStyle) {
+        case DisplayStyle::Vanilla: {
+            wchar_t glyph = GLYPH_MUTE;
+            if (!isMuted) {
+                if (percentage == 0)      glyph = GLYPH_VOL_0;
+                else if (percentage < 33) glyph = GLYPH_VOL_1;
+                else if (percentage < 66) glyph = GLYPH_VOL_2;
+                else                      glyph = GLYPH_VOL_3;
+            }
+            return std::wstring(1, glyph);
+        }
+
         case DisplayStyle::Number:
-            return numStr;
+            return s;
 
         case DisplayStyle::Prefix:
-            return g_settings.customPrefix + numStr + L"%";
+            return g_settings.customPrefix + s + L"%";
 
         case DisplayStyle::Emoji: {
-            std::wstring s;
-            if (percentage <= 0) {
-                s = L"\xD83D\xDD08 ";
+            std::wstring prefix;
+            if (percentage == 0) {
+                prefix = L"\xD83D\xDD08 ";
             } else if (percentage <= 50) {
-                s = L"\xD83D\xDD09 ";
+                prefix = L"\xD83D\xDD09 ";
             } else {
-                s = L"\xD83D\xDD0A ";
+                prefix = L"\xD83D\xDD0A ";
             }
-            s += numStr + L"%";
-            return s;
+            return prefix + s + L"%";
         }
 
         case DisplayStyle::Percentage:
         default:
-            return numStr + L"%";
+            return s + L"%";
     }
 }
 
@@ -306,16 +236,17 @@ static size_t GetIconTextOffset(void* pThis) {
         if (h->flags > 1) {
             return false;
         }
-        if (h->length == 0 || h->length > 64) {
+        if (h->length > 256) {
             return false;
         }
-        if (h->ptr != h->buffer) {
+        if (!h->ptr) {
             return false;
         }
         return true;
     };
 
-    const size_t defaultOffset = sizeof(void*) == 8 ? 0x90 : 0x48;
+    // Primary offset in standard Windows 11 SystemTray builds is 0xB8
+    constexpr size_t defaultOffset = 0xB8;
     shared_hstring_header* defaultCandidate = *reinterpret_cast<shared_hstring_header**>(
         reinterpret_cast<char*>(pThis) + defaultOffset);
     if (isValidHeader(defaultCandidate)) {
@@ -332,6 +263,7 @@ static size_t GetIconTextOffset(void* pThis) {
                 (firstChar >= L'a' && firstChar <= L'z') ||
                 (firstChar >= L'A' && firstChar <= L'Z') ||
                 firstChar == L' ' || firstChar == 0x2715 ||
+                firstChar == 0x2007 || firstChar == 0x00A0 ||
                 firstChar == 0xD83D) {
                 return offset;
             }
@@ -374,110 +306,82 @@ static void ApplyCustomVolumeText(void* pThis, float volumeLevel, bool isMuted) 
     }
 }
 
-static void QueryInitialSystemVolume(float* pVolumeLevel, bool* pIsMuted) {
-    HRESULT hrCo = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+static void QueryInitialSystemVolume(float* pLevel, bool* pMuted) {
+    *pLevel = 0.5f;
+    *pMuted = false;
 
     IMMDeviceEnumerator* pEnumerator = nullptr;
-    HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
-                                  __uuidof(IMMDeviceEnumerator), (void**)&pEnumerator);
-    if (SUCCEEDED(hr) && pEnumerator) {
-        IMMDevice* pDevice = nullptr;
-        hr = pEnumerator->GetDefaultAudioEndpoint(eRender, eMultimedia, &pDevice);
-        if (SUCCEEDED(hr) && pDevice) {
-            IAudioEndpointVolume* pEndpointVolume = nullptr;
-            hr = pDevice->Activate(__uuidof(IAudioEndpointVolume), CLSCTX_ALL, nullptr, (void**)&pEndpointVolume);
-            if (SUCCEEDED(hr) && pEndpointVolume) {
-                float vol = 0.0f;
-                if (SUCCEEDED(pEndpointVolume->GetMasterVolumeLevelScalar(&vol))) {
-                    *pVolumeLevel = vol;
-                }
-                BOOL mute = FALSE;
-                if (SUCCEEDED(pEndpointVolume->GetMute(&mute))) {
-                    *pIsMuted = (mute != FALSE);
-                }
-                pEndpointVolume->Release();
+    HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr,
+                                  CLSCTX_INPROC_SERVER,
+                                  __uuidof(IMMDeviceEnumerator),
+                                  reinterpret_cast<void**>(&pEnumerator));
+    if (FAILED(hr) || !pEnumerator) {
+        return;
+    }
+
+    IMMDevice* pDevice = nullptr;
+    hr = pEnumerator->GetDefaultAudioEndpoint(eRender, eConsole, &pDevice);
+    if (SUCCEEDED(hr) && pDevice) {
+        IAudioEndpointVolume* pEndpoint = nullptr;
+        hr = pDevice->Activate(__uuidof(IAudioEndpointVolume), CLSCTX_INPROC_SERVER,
+                               nullptr, reinterpret_cast<void**>(&pEndpoint));
+        if (SUCCEEDED(hr) && pEndpoint) {
+            float masterVol = 0.5f;
+            BOOL bMute = FALSE;
+            if (SUCCEEDED(pEndpoint->GetMasterVolumeLevelScalar(&masterVol))) {
+                *pLevel = masterVol;
             }
-            pDevice->Release();
+            if (SUCCEEDED(pEndpoint->GetMute(&bMute))) {
+                *pMuted = (bMute != FALSE);
+            }
+            pEndpoint->Release();
         }
-        pEnumerator->Release();
+        pDevice->Release();
     }
-
-    if (SUCCEEDED(hrCo)) {
-        CoUninitialize();
-    }
-}
-
-static VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE hModule, UINT* puPtrLen) {
-    HRSRC hResource = FindResource(hModule, MAKEINTRESOURCE(VS_VERSION_INFO), RT_VERSION);
-    if (!hResource) {
-        return nullptr;
-    }
-    HGLOBAL hGlobal = LoadResource(hModule, hResource);
-    if (!hGlobal) {
-        return nullptr;
-    }
-    void* pData = LockResource(hGlobal);
-    if (!pData) {
-        return nullptr;
-    }
-    void* pFixedFileInfo = nullptr;
-    UINT uPtrLen = 0;
-    if (!VerQueryValue(pData, L"\\", &pFixedFileInfo, &uPtrLen) || uPtrLen == 0) {
-        return nullptr;
-    }
-    if (puPtrLen) {
-        *puPtrLen = uPtrLen;
-    }
-    return static_cast<VS_FIXEDFILEINFO*>(pFixedFileInfo);
-}
-
-// Window thread marshaling to ensure 100% thread affinity with Explorer's taskbar UI
-static BOOL CALLBACK EnumWindowsTaskbarProc(HWND hWnd, LPARAM lParam) {
-    DWORD dwProcessId = 0;
-    WCHAR className[64];
-    if (GetWindowThreadProcessId(hWnd, &dwProcessId) &&
-        dwProcessId == GetCurrentProcessId() &&
-        GetClassName(hWnd, className, ARRAYSIZE(className)) &&
-        _wcsicmp(className, L"Shell_TrayWnd") == 0) {
-        *reinterpret_cast<HWND*>(lParam) = hWnd;
-        return FALSE;
-    }
-    return TRUE;
+    pEnumerator->Release();
 }
 
 static HWND FindCurrentProcessTaskbarWnd() {
+    DWORD currentProcessId = GetCurrentProcessId();
     HWND hTaskbarWnd = nullptr;
-    EnumWindows(EnumWindowsTaskbarProc, reinterpret_cast<LPARAM>(&hTaskbarWnd));
-    return hTaskbarWnd;
+
+    while ((hTaskbarWnd = FindWindowEx(nullptr, hTaskbarWnd, L"Shell_TrayWnd", nullptr)) != nullptr) {
+        DWORD processId = 0;
+        GetWindowThreadProcessId(hTaskbarWnd, &processId);
+        if (processId == currentProcessId) {
+            return hTaskbarWnd;
+        }
+    }
+
+    return nullptr;
 }
 
-using RunFromWindowThreadProc_t = void (*)(void* parameter);
+using RunFromWindowThreadProc_t = void (*)(void* param);
 
 struct RUN_FROM_WINDOW_THREAD_PARAM {
     RunFromWindowThreadProc_t proc;
     void* procParam;
 };
 
-static UINT g_runFromWindowThreadRegisteredMsg = 0;
+static UINT g_runFromWindowThreadMsg = 0;
 
-static LRESULT CALLBACK CallWndProcHook(int nCode, WPARAM wParam, LPARAM lParam) {
-    (void)wParam;
-    if (nCode == HC_ACTION) {
+static LRESULT CALLBACK RunFromWindowThreadHookProc(int nCode, WPARAM wParam, LPARAM lParam) {
+    if (nCode == HC_ACTION && g_runFromWindowThreadMsg != 0) {
         const CWPSTRUCT* cwp = reinterpret_cast<const CWPSTRUCT*>(lParam);
-        if (cwp->message == g_runFromWindowThreadRegisteredMsg) {
+        if (cwp->message == g_runFromWindowThreadMsg) {
             auto* param = reinterpret_cast<RUN_FROM_WINDOW_THREAD_PARAM*>(cwp->lParam);
-            param->proc(param->procParam);
+            if (param && param->proc) {
+                param->proc(param->procParam);
+            }
         }
     }
-    return CallNextHookEx(nullptr, nCode, 0, lParam);
+    return CallNextHookEx(nullptr, nCode, wParam, lParam);
 }
 
-static bool RunFromWindowThread(HWND hWnd,
-                                RunFromWindowThreadProc_t proc,
-                                void* procParam) {
-    if (g_runFromWindowThreadRegisteredMsg == 0) {
-        g_runFromWindowThreadRegisteredMsg =
-            RegisterWindowMessage(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
+static bool RunFromWindowThread(HWND hWnd, RunFromWindowThreadProc_t proc, void* procParam) {
+    if (g_runFromWindowThreadMsg == 0) {
+        g_runFromWindowThreadMsg = RegisterWindowMessage(
+            L"Windhawk_RunFromWindowThread_taskbar-volume-percentage");
     }
 
     DWORD dwThreadId = GetWindowThreadProcessId(hWnd, nullptr);
@@ -492,64 +396,89 @@ static bool RunFromWindowThread(HWND hWnd,
 
     HHOOK hook = SetWindowsHookEx(
         WH_CALLWNDPROC,
-        CallWndProcHook,
+        RunFromWindowThreadHookProc,
         nullptr,
         dwThreadId);
-
     if (!hook) {
         return false;
     }
 
-    RUN_FROM_WINDOW_THREAD_PARAM param = {proc, procParam};
-    SendMessage(hWnd, g_runFromWindowThreadRegisteredMsg, 0, reinterpret_cast<LPARAM>(&param));
+    RUN_FROM_WINDOW_THREAD_PARAM param;
+    param.proc = proc;
+    param.procParam = procParam;
+    SendMessage(hWnd, g_runFromWindowThreadMsg, 0, reinterpret_cast<LPARAM>(&param));
+
     UnhookWindowsHookEx(hook);
     return true;
 }
 
-// Hooks
+static VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE hModule, UINT* puPtrLen) {
+    void* pFixedFileInfo = nullptr;
+    UINT uPtrLen = 0;
 
-using VolumeSystemTrayIconDataModel_dtor_t = void(WINAPI*)(void* pThis);
-static VolumeSystemTrayIconDataModel_dtor_t VolumeSystemTrayIconDataModel_dtor_Original = nullptr;
+    HRSRC hResource =
+        FindResource(hModule, MAKEINTRESOURCE(VS_VERSION_INFO), RT_VERSION);
+    if (hResource) {
+        HGLOBAL hGlobal = LoadResource(hModule, hResource);
+        if (hGlobal) {
+            void* pData = LockResource(hGlobal);
+            if (pData) {
+                if (!VerQueryValue(pData, L"\\", &pFixedFileInfo, &uPtrLen) ||
+                    uPtrLen == 0) {
+                    pFixedFileInfo = nullptr;
+                    uPtrLen = 0;
+                }
+            }
+        }
+    }
 
-static void WINAPI VolumeSystemTrayIconDataModel_dtor_Hook(void* pThis) {
+    if (puPtrLen) {
+        *puPtrLen = uPtrLen;
+    }
+
+    return reinterpret_cast<VS_FIXEDFILEINFO*>(pFixedFileInfo);
+}
+
+// ---------------------------------------------------------------------------
+// VolumeSystemTrayIconDataModel hooks
+// ---------------------------------------------------------------------------
+
+using VolumeSystemTrayIconDataModel_UpdateVolume_t = void(__cdecl*)(
+    void* pThis, float volumeLevel, bool isMuted, void* hstringIcon);
+static VolumeSystemTrayIconDataModel_UpdateVolume_t
+    VolumeSystemTrayIconDataModel_UpdateVolume_Original = nullptr;
+
+using VolumeSystemTrayIconDataModel_OnDataModelChanged_t = void(__cdecl*)(
+    void* pThis, const std::wstring_view* propertyName);
+static VolumeSystemTrayIconDataModel_OnDataModelChanged_t
+    VolumeSystemTrayIconDataModel_OnDataModelChanged_Original = nullptr;
+
+using VolumeSystemTrayIconDataModel_dtor_t = void(__cdecl*)(void* pThis);
+static VolumeSystemTrayIconDataModel_dtor_t
+    VolumeSystemTrayIconDataModel_dtor_Original = nullptr;
+
+static void __cdecl VolumeSystemTrayIconDataModel_dtor_Hook(void* pThis) {
     {
         std::lock_guard<std::mutex> lock(g_dataModelMutex);
         if (g_pVolumeDataModel == pThis) {
             g_pVolumeDataModel = nullptr;
         }
     }
-    VolumeSystemTrayIconDataModel_dtor_Original(pThis);
+    if (VolumeSystemTrayIconDataModel_dtor_Original) {
+        VolumeSystemTrayIconDataModel_dtor_Original(pThis);
+    }
 }
 
-using VolumeSystemTrayIconDataModel_UpdateVolume_t = void(WINAPI*)(
-    void* pThis,
-    float volumeLevel,
-    bool isMuted,
-    void* deviceName
-);
-static VolumeSystemTrayIconDataModel_UpdateVolume_t VolumeSystemTrayIconDataModel_UpdateVolume_Original = nullptr;
-
-using VolumeSystemTrayIconDataModel_OnDataModelChanged_t = void(WINAPI*)(
-    void* pThis,
-    const void* propertyName
-);
-static VolumeSystemTrayIconDataModel_OnDataModelChanged_t VolumeSystemTrayIconDataModel_OnDataModelChanged_Original = nullptr;
-
-static void WINAPI VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
-    void* pThis,
-    float volumeLevel,
-    bool isMuted,
-    void* deviceName)
-{
+static void __cdecl VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
+    void* pThis, float volumeLevel, bool isMuted, void* hstringIcon) {
     static thread_local bool s_inHook = false;
-    if (s_inHook) {
-        VolumeSystemTrayIconDataModel_UpdateVolume_Original(pThis, volumeLevel, isMuted, deviceName);
-        return;
+
+    if (VolumeSystemTrayIconDataModel_UpdateVolume_Original) {
+        VolumeSystemTrayIconDataModel_UpdateVolume_Original(
+            pThis, volumeLevel, isMuted, hstringIcon);
     }
 
-    VolumeSystemTrayIconDataModel_UpdateVolume_Original(pThis, volumeLevel, isMuted, deviceName);
-
-    if (g_unloading.load(std::memory_order_relaxed)) {
+    if (s_inHook || g_unloading.load(std::memory_order_relaxed)) {
         return;
     }
 
@@ -562,7 +491,7 @@ static void WINAPI VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
         ApplyCustomVolumeText(pThis, volumeLevel, isMuted);
     }
 
-    // Trigger UI redraw via CurrentData property notification
+    // Trigger UI redraw via CurrentData property notification with recursion guard
     if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
         s_inHook = true;
         std::wstring_view propName = L"CurrentData";
@@ -573,7 +502,7 @@ static void WINAPI VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
 
 static bool HookSystemTraySymbols(HMODULE module) {
     // SystemTray.dll, Taskbar.View.dll
-    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+    WindhawkUtils::SYMBOL_HOOK systemTrayHooks[] = {
         {
             {
                 LR"(public: void __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::UpdateVolume(float,bool,struct winrt::hstring))",
@@ -581,8 +510,8 @@ static bool HookSystemTraySymbols(HMODULE module) {
                 LR"(?UpdateVolume@VolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@QEAAXM_NUhstring@4@@Z)",
                 LR"(winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::UpdateVolume)",
             },
-            &VolumeSystemTrayIconDataModel_UpdateVolume_Original,
-            VolumeSystemTrayIconDataModel_UpdateVolume_Hook,
+            reinterpret_cast<void**>(&VolumeSystemTrayIconDataModel_UpdateVolume_Original),
+            reinterpret_cast<void*>(VolumeSystemTrayIconDataModel_UpdateVolume_Hook),
             false,
         },
         {
@@ -592,9 +521,9 @@ static bool HookSystemTraySymbols(HMODULE module) {
                 LR"(?OnDataModelChanged@VolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@AEAAXAEBV?$basic_string_view@_WU?$char_traits@_W@std@@@std@@@Z)",
                 LR"(winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::OnDataModelChanged)",
             },
-            &VolumeSystemTrayIconDataModel_OnDataModelChanged_Original,
+            reinterpret_cast<void**>(&VolumeSystemTrayIconDataModel_OnDataModelChanged_Original),
             nullptr, // Resolved for invocation only, not hooked
-            false,
+            true,
         },
         {
             {
@@ -603,13 +532,13 @@ static bool HookSystemTraySymbols(HMODULE module) {
                 LR"(??1VolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@UEAA@XZ)",
                 LR"(winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::~VolumeSystemTrayIconDataModel)",
             },
-            &VolumeSystemTrayIconDataModel_dtor_Original,
-            VolumeSystemTrayIconDataModel_dtor_Hook,
+            reinterpret_cast<void**>(&VolumeSystemTrayIconDataModel_dtor_Original),
+            reinterpret_cast<void*>(VolumeSystemTrayIconDataModel_dtor_Hook),
             true,
         },
     };
 
-    if (!WindhawkUtils::HookSymbols(module, symbolHooks, ARRAYSIZE(symbolHooks))) {
+    if (!WindhawkUtils::HookSymbols(module, systemTrayHooks, ARRAYSIZE(systemTrayHooks))) {
         Wh_Log(L"Failed to hook SystemTray volume symbols");
         return false;
     }
@@ -623,9 +552,6 @@ static HMODULE GetSystemTrayModuleHandle() {
     if (!module) {
         module = GetModuleHandle(L"Taskbar.View.dll");
         if (module) {
-            // Starting with Taskbar.View.dll 2604.8002.200.6000, the SystemTray
-            // types moved out of Taskbar.View.dll into SystemTray.dll, so don't
-            // hook Taskbar.View.dll at this version and above.
             VS_FIXEDFILEINFO* fixedFileInfo = GetModuleVersionInfo(module, nullptr);
             WORD moduleMajor = fixedFileInfo ? HIWORD(fixedFileInfo->dwFileVersionMS) : 0;
             if (!moduleMajor || moduleMajor >= 2604) {
@@ -680,10 +606,13 @@ static HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
     return hModule;
 }
 
+// ---------------------------------------------------------------------------
 // Settings & lifecycle
+// ---------------------------------------------------------------------------
 
 static void LoadSettings() {
-    PCWSTR displayStyleStr = Wh_GetStringSetting(L"displayStyle");
+    auto displayStyleSetting = WindhawkUtils::StringSetting::make(L"displayStyle");
+    PCWSTR displayStyleStr = displayStyleSetting.get();
     if (displayStyleStr) {
         if (wcscmp(displayStyleStr, L"vanilla") == 0 ||
             wcscmp(displayStyleStr, L"default") == 0 ||
@@ -702,34 +631,19 @@ static void LoadSettings() {
         } else {
             g_settings.displayStyle = DisplayStyle::Percentage;
         }
-        Wh_FreeStringSetting(displayStyleStr);
     } else {
         g_settings.displayStyle = DisplayStyle::Percentage;
     }
 
-    PCWSTR prefixStr = Wh_GetStringSetting(L"customPrefix");
-    if (prefixStr) {
-        g_settings.customPrefix = prefixStr;
-        Wh_FreeStringSetting(prefixStr);
+    auto prefixSetting = WindhawkUtils::StringSetting::make(L"customPrefix");
+    if (prefixSetting.get()) {
+        g_settings.customPrefix = prefixSetting.get();
     } else {
         g_settings.customPrefix = L"Vol ";
     }
 
-    PCWSTR paddingModeStr = Wh_GetStringSetting(L"paddingMode");
-    if (paddingModeStr) {
-        if (wcscmp(paddingModeStr, L"zero") == 0) {
-            g_settings.paddingMode = PaddingMode::Zero;
-        } else if (wcscmp(paddingModeStr, L"space") == 0) {
-            g_settings.paddingMode = PaddingMode::Space;
-        } else {
-            g_settings.paddingMode = PaddingMode::None;
-        }
-        Wh_FreeStringSetting(paddingModeStr);
-    } else {
-        g_settings.paddingMode = PaddingMode::None;
-    }
-
-    PCWSTR muteStyleStr = Wh_GetStringSetting(L"muteStyle");
+    auto muteStyleSetting = WindhawkUtils::StringSetting::make(L"muteStyle");
+    PCWSTR muteStyleStr = muteStyleSetting.get();
     if (muteStyleStr) {
         if (wcscmp(muteStyleStr, L"mute") == 0) {
             g_settings.muteStyle = MuteStyle::Mute;
@@ -746,15 +660,13 @@ static void LoadSettings() {
         } else {
             g_settings.muteStyle = MuteStyle::Mut;
         }
-        Wh_FreeStringSetting(muteStyleStr);
     } else {
         g_settings.muteStyle = MuteStyle::Mut;
     }
 
-    PCWSTR customMuteStr = Wh_GetStringSetting(L"customMuteText");
-    if (customMuteStr) {
-        g_settings.customMuteText = customMuteStr;
-        Wh_FreeStringSetting(customMuteStr);
+    auto customMuteSetting = WindhawkUtils::StringSetting::make(L"customMuteText");
+    if (customMuteSetting.get()) {
+        g_settings.customMuteText = customMuteSetting.get();
     } else {
         g_settings.customMuteText = L"Mute";
     }
@@ -843,7 +755,6 @@ void Wh_ModBeforeUninit() {
 
     g_unloading = true;
 
-    // Restore original native volume glyph safely on the UI thread before unloading
     HWND hTaskbarWnd = FindCurrentProcessTaskbarWnd();
     if (hTaskbarWnd) {
         RunFromWindowThread(hTaskbarWnd, BeforeUninitOnUIThread, nullptr);

--- a/mods/taskbar-volume-percentage.wh.cpp
+++ b/mods/taskbar-volume-percentage.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-volume-percentage
 // @name            Taskbar Volume Percentage Indicator
 // @description     Displays the exact master volume percentage in the system tray natively inside the Windows 11 volume button with real-time sync.
-// @version         1.3.6
+// @version         1.3.7
 // @author          gilnett
 // @github          https://github.com/gilnett
 // @include         explorer.exe
@@ -71,6 +71,8 @@ Only Windows 11 is supported.
 */
 // ==/WindhawkModSettings==
 
+#include <endpointvolume.h>
+#include <mmdeviceapi.h>
 #include <windows.h>
 #include <winstring.h>
 #include <winver.h>
@@ -135,13 +137,45 @@ constexpr wchar_t GLYPH_VOL_3 = 0xE995; // 3 bars
 static void* g_pVolumeDataModel = nullptr;
 static float g_lastVolumeLevel = 0.5f;
 static bool g_lastIsMuted = false;
+static std::atomic<bool> g_hasReceivedVolumeUpdate{false};
 static std::mutex g_dataModelMutex;
 
 static winrt::weak_ref<FrameworkElement> g_volumeIconViewWeak;
-static std::atomic<double> g_lastAppliedIconViewWidth{-1.0};
 
 static std::atomic<bool> g_unloading{false};
 static std::atomic<bool> g_systemTrayModuleHooked{false};
+
+static void InitMasterVolumeFromCoreAudio() {
+    IMMDeviceEnumerator* pEnumerator = nullptr;
+    HRESULT hr = CoCreateInstance(
+        __uuidof(MMDeviceEnumerator), nullptr,
+        CLSCTX_ALL, __uuidof(IMMDeviceEnumerator),
+        reinterpret_cast<void**>(&pEnumerator));
+    if (SUCCEEDED(hr) && pEnumerator) {
+        IMMDevice* pDevice = nullptr;
+        hr = pEnumerator->GetDefaultAudioEndpoint(eRender, eMultimedia, &pDevice);
+        if (SUCCEEDED(hr) && pDevice) {
+            IAudioEndpointVolume* pVolume = nullptr;
+            hr = pDevice->Activate(
+                __uuidof(IAudioEndpointVolume), CLSCTX_ALL,
+                nullptr, reinterpret_cast<void**>(&pVolume));
+            if (SUCCEEDED(hr) && pVolume) {
+                float masterVolume = 0.5f;
+                BOOL isMuted = FALSE;
+                if (SUCCEEDED(pVolume->GetMasterVolumeLevelScalar(&masterVolume)) &&
+                    SUCCEEDED(pVolume->GetMute(&isMuted))) {
+                    std::lock_guard<std::mutex> lock(g_dataModelMutex);
+                    g_lastVolumeLevel = masterVolume;
+                    g_lastIsMuted = (isMuted != FALSE);
+                    g_hasReceivedVolumeUpdate.store(true, std::memory_order_relaxed);
+                }
+                pVolume->Release();
+            }
+            pDevice->Release();
+        }
+        pEnumerator->Release();
+    }
+}
 
 static double GetTargetContainerWidth(const Settings& settings) {
     if (settings.fixedContainerWidth < 0) {
@@ -167,16 +201,20 @@ static double GetTargetContainerWidth(const Settings& settings) {
 }
 
 // ---------------------------------------------------------------------------
-// WinUI Visual Tree inspection helpers
+// WinUI Visual Tree inspection helpers (exception-safe)
 // ---------------------------------------------------------------------------
 
 static FrameworkElement GetParentElementByName(const FrameworkElement& element, PCWSTR name) {
-    auto parent = Media::VisualTreeHelper::GetParent(element).try_as<FrameworkElement>();
-    while (parent) {
-        if (parent.Name() == name) {
-            return parent;
+    try {
+        auto parent = Media::VisualTreeHelper::GetParent(element).try_as<FrameworkElement>();
+        while (parent) {
+            if (parent.Name() == name) {
+                return parent;
+            }
+            parent = Media::VisualTreeHelper::GetParent(parent).try_as<FrameworkElement>();
         }
-        parent = Media::VisualTreeHelper::GetParent(parent).try_as<FrameworkElement>();
+    } catch (...) {
+        Wh_Log(L"Exception in GetParentElementByName");
     }
     return nullptr;
 }
@@ -188,17 +226,20 @@ static bool IsChildOfElementByName(const FrameworkElement& element, PCWSTR name)
 static FrameworkElement EnumChildElements(
     const FrameworkElement& element,
     const std::function<bool(const FrameworkElement&)>& enumCallback) {
-    int childrenCount = Media::VisualTreeHelper::GetChildrenCount(element);
+    try {
+        int childrenCount = Media::VisualTreeHelper::GetChildrenCount(element);
+        for (int i = 0; i < childrenCount; i++) {
+            auto child = Media::VisualTreeHelper::GetChild(element, i).try_as<FrameworkElement>();
+            if (!child) {
+                continue;
+            }
 
-    for (int i = 0; i < childrenCount; i++) {
-        auto child = Media::VisualTreeHelper::GetChild(element, i).try_as<FrameworkElement>();
-        if (!child) {
-            continue;
+            if (enumCallback(child)) {
+                return child;
+            }
         }
-
-        if (enumCallback(child)) {
-            return child;
-        }
+    } catch (...) {
+        Wh_Log(L"Exception in EnumChildElements");
     }
 
     return nullptr;
@@ -217,70 +258,81 @@ static FrameworkElement FindChildByClassName(const FrameworkElement& element, PC
 }
 
 static bool IsVolumeIconElement(const FrameworkElement& iconView) {
-    auto containerGrid = FindChildByName(iconView, L"ContainerGrid");
-    if (!containerGrid) {
-        return false;
-    }
-    auto contentGrid = FindChildByName(containerGrid, L"ContentGrid");
-    if (!contentGrid) {
-        return false;
-    }
+    try {
+        auto containerGrid = FindChildByName(iconView, L"ContainerGrid");
+        if (!containerGrid) {
+            return false;
+        }
+        auto contentGrid = FindChildByName(containerGrid, L"ContentGrid");
+        if (!contentGrid) {
+            return false;
+        }
 
-    // Battery icon uses BatteryIconContent, not TextIconContent
-    if (FindChildByClassName(contentGrid, L"SystemTray.BatteryIconContent")) {
-        return false;
-    }
+        // Battery icon uses BatteryIconContent, not TextIconContent
+        if (FindChildByClassName(contentGrid, L"SystemTray.BatteryIconContent")) {
+            return false;
+        }
 
-    auto textIconContent = FindChildByClassName(contentGrid, L"SystemTray.TextIconContent");
-    if (!textIconContent) {
-        return false;
-    }
+        auto textIconContent = FindChildByClassName(contentGrid, L"SystemTray.TextIconContent");
+        if (!textIconContent) {
+            return false;
+        }
 
-    auto textContainer = FindChildByName(textIconContent, L"ContainerGrid");
-    if (!textContainer) {
-        return false;
-    }
-    auto baseGrid = FindChildByName(textContainer, L"Base");
-    if (!baseGrid) {
-        return false;
-    }
-    auto textBlockEl = FindChildByName(baseGrid, L"InnerTextBlock");
-    if (!textBlockEl) {
-        return false;
-    }
+        auto textContainer = FindChildByName(textIconContent, L"ContainerGrid");
+        if (!textContainer) {
+            return false;
+        }
+        auto baseGrid = FindChildByName(textContainer, L"Base");
+        if (!baseGrid) {
+            return false;
+        }
+        auto textBlockEl = FindChildByName(baseGrid, L"InnerTextBlock");
+        if (!textBlockEl) {
+            return false;
+        }
 
-    auto textBlock = textBlockEl.try_as<Controls::TextBlock>();
-    if (!textBlock) {
-        return false;
-    }
+        auto textBlock = textBlockEl.try_as<Controls::TextBlock>();
+        if (!textBlock) {
+            return false;
+        }
 
-    auto text = textBlock.Text();
-    if (text.empty()) {
-        return false;
-    }
+        auto text = textBlock.Text();
+        if (text.empty()) {
+            return false;
+        }
 
-    std::wstring_view textView = text;
+        std::wstring_view textView = text;
 
-    wchar_t firstChar = textView[0];
-    switch (firstChar) {
-    case GLYPH_MUTE:
-    case GLYPH_VOL_0:
-    case GLYPH_VOL_1:
-    case GLYPH_VOL_2:
-    case GLYPH_VOL_3:
-    case 0xEA85: // VolumeDisabled
-    case 0xEBC5: // VolumeBars
-        return true;
-    default:
-        break;
-    }
+        wchar_t firstChar = textView[0];
+        switch (firstChar) {
+        case GLYPH_MUTE:
+        case GLYPH_VOL_0:
+        case GLYPH_VOL_1:
+        case GLYPH_VOL_2:
+        case GLYPH_VOL_3:
+        case 0xEA85: // VolumeDisabled
+        case 0xEBC5: // VolumeBars
+        case 0x2715: // Mute cross
+        case 0xD83D: // Emoji lead surrogate (speaker / mute emoji)
+            return true;
+        default:
+            break;
+        }
 
-    // Already customized by mod
-    if (textView.find(L'%') != std::wstring_view::npos ||
-        textView.find(L"MUT") != std::wstring_view::npos ||
-        textView.find(L"Mute") != std::wstring_view::npos ||
-        textView.find(L"Vol") != std::wstring_view::npos) {
-        return true;
+        // Numeric percentage or raw number style (e.g. "50%", "50")
+        if (firstChar >= L'0' && firstChar <= L'9') {
+            return true;
+        }
+
+        // Already customized by mod with known prefixes / strings
+        if (textView.find(L'%') != std::wstring_view::npos ||
+            textView.find(L"MUT") != std::wstring_view::npos ||
+            textView.find(L"Mute") != std::wstring_view::npos ||
+            textView.find(L"Vol") != std::wstring_view::npos) {
+            return true;
+        }
+    } catch (...) {
+        Wh_Log(L"Exception in IsVolumeIconElement");
     }
 
     return false;
@@ -298,10 +350,12 @@ static void ApplyVolumeContainerWidth(const FrameworkElement& iconView) {
     }
 
     double targetWidth = GetTargetContainerWidth(settingsCopy);
-    double prevWidth = g_lastAppliedIconViewWidth.load(std::memory_order_relaxed);
-    if (prevWidth != targetWidth) {
-        g_lastAppliedIconViewWidth.store(targetWidth, std::memory_order_relaxed);
-        iconView.MinWidth(targetWidth);
+    try {
+        if (iconView.MinWidth() != targetWidth) {
+            iconView.MinWidth(targetWidth);
+        }
+    } catch (...) {
+        Wh_Log(L"Exception in ApplyVolumeContainerWidth");
     }
 }
 
@@ -520,9 +574,6 @@ using IconView_UpdateHostedContent_t = void(__cdecl*)(void* pThis);
 static IconView_UpdateHostedContent_t
     IconView_UpdateHostedContent_Original = nullptr;
 
-using IconView_dtor_t = void(__cdecl*)(void* pThis);
-static IconView_dtor_t IconView_dtor_Original = nullptr;
-
 static std::atomic<size_t> g_iconTextOffset{0x90};
 
 static size_t GetIconTextOffset(void* pThis) {
@@ -540,14 +591,23 @@ static size_t GetIconTextOffset(void* pThis) {
             return false;
         }
         wchar_t firstChar = raw[0];
-        return (firstChar >= 0xE700 && firstChar <= 0xE9FF) ||
-               (firstChar >= L'0' && firstChar <= L'9') ||
-               (firstChar >= L'a' && firstChar <= L'z') ||
-               (firstChar >= L'A' && firstChar <= L'Z') ||
-               firstChar == L' ' || firstChar == 0x2715 ||
-               firstChar == 0x2007 || firstChar == 0x00A0 ||
-               firstChar == 0xD83D || firstChar == 0xEA85 ||
-               firstChar == 0xEBC5;
+        if (firstChar >= 0xE700 && firstChar <= 0xE9FF) {
+            return true;
+        }
+        if (firstChar == 0xEA85 || firstChar == 0xEBC5 || firstChar == 0x2715 || firstChar == 0xD83D) {
+            return true;
+        }
+        if (firstChar >= L'0' && firstChar <= L'9') {
+            return true;
+        }
+        std::wstring_view sv(raw, len);
+        if (sv.find(L'%') != std::wstring_view::npos ||
+            sv.find(L"MUT") != std::wstring_view::npos ||
+            sv.find(L"Mute") != std::wstring_view::npos ||
+            sv.find(L"Vol") != std::wstring_view::npos) {
+            return true;
+        }
+        return false;
     };
 
     size_t cached = g_iconTextOffset.load(std::memory_order_relaxed);
@@ -567,7 +627,7 @@ static size_t GetIconTextOffset(void* pThis) {
         }
     }
 
-    return 0x90;
+    return 0x90; // Fallback to standard Windows 11 member offset
 }
 
 static void ApplyCustomVolumeText(void* pThis, float volumeLevel, bool isMuted) {
@@ -620,42 +680,37 @@ static void __cdecl VolumeSystemTrayIconDataModel_dtor_Hook(void* pThis) {
     }
 }
 
-static void __cdecl IconView_dtor_Hook(void* pThis) {
-    if (auto currentView = g_volumeIconViewWeak.get()) {
-        IUnknown* inner = pThis ? reinterpret_cast<IUnknown**>(pThis)[1] : nullptr;
-        if (inner) {
-            FrameworkElement thisElement = nullptr;
-            inner->QueryInterface(winrt::guid_of<FrameworkElement>(), winrt::put_abi(thisElement));
-            if (thisElement && thisElement == currentView) {
-                g_volumeIconViewWeak = nullptr;
-                g_lastAppliedIconViewWidth.store(-1.0, std::memory_order_relaxed);
-            }
-        }
-    }
-    if (IconView_dtor_Original) {
-        IconView_dtor_Original(pThis);
-    }
-}
-
 static void __cdecl VolumeSystemTrayIconDataModel_OnDataModelChanged_Hook(
     void* pThis, const std::wstring_view* propertyName) {
     static thread_local bool s_inOnDataModelChanged = false;
 
     if (!s_inOnDataModelChanged && !g_unloading.load(std::memory_order_relaxed) &&
         pThis && propertyName && *propertyName == L"CurrentData") {
-        float volumeLevel = 0.0f;
-        bool isMuted = false;
+        Settings settingsCopy;
         {
-            std::lock_guard<std::mutex> lock(g_dataModelMutex);
-            volumeLevel = g_lastVolumeLevel;
-            isMuted = g_lastIsMuted;
+            std::lock_guard<std::mutex> lock(g_settingsMutex);
+            settingsCopy = g_settings;
+        }
+
+        if (settingsCopy.displayStyle != DisplayStyle::Vanilla) {
+            float volumeLevel = 0.0f;
+            bool isMuted = false;
+            {
+                std::lock_guard<std::mutex> lock(g_dataModelMutex);
+                volumeLevel = g_lastVolumeLevel;
+                isMuted = g_lastIsMuted;
+            }
             ApplyCustomVolumeText(pThis, volumeLevel, isMuted);
         }
     }
 
     if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
         s_inOnDataModelChanged = true;
-        VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(pThis, propertyName);
+        try {
+            VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(pThis, propertyName);
+        } catch (...) {
+            Wh_Log(L"Exception in OnDataModelChanged_Original");
+        }
         s_inOnDataModelChanged = false;
     }
 }
@@ -681,8 +736,12 @@ static void __cdecl VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
 
     // Always invoke the original Windows system function first
     if (VolumeSystemTrayIconDataModel_UpdateVolume_Original) {
-        VolumeSystemTrayIconDataModel_UpdateVolume_Original(
-            pThis, volumeLevel, isMuted, hstringIcon);
+        try {
+            VolumeSystemTrayIconDataModel_UpdateVolume_Original(
+                pThis, volumeLevel, isMuted, hstringIcon);
+        } catch (...) {
+            Wh_Log(L"Exception in UpdateVolume_Original");
+        }
     }
 
     if (s_inHook) {
@@ -700,52 +759,69 @@ static void __cdecl VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
         ApplyCustomVolumeText(pThis, volumeLevel, isMuted);
     }
 
-    // Apply container width to volume icon if captured
-    if (auto iconView = g_volumeIconViewWeak.get()) {
-        ApplyVolumeContainerWidth(iconView);
+    // Apply container width to volume icon if captured (with XAML thread safety)
+    try {
+        if (auto iconView = g_volumeIconViewWeak.get()) {
+            ApplyVolumeContainerWidth(iconView);
+        }
+    } catch (...) {
+        Wh_Log(L"Exception in ApplyVolumeContainerWidth");
     }
 
     // Trigger UI redraw via CurrentData property notification with recursion guard
     if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
         s_inHook = true;
-        std::wstring_view propName = L"CurrentData";
-        VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(pThis, &propName);
+        try {
+            std::wstring_view propName = L"CurrentData";
+            VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(pThis, &propName);
+        } catch (...) {
+            Wh_Log(L"Exception re-triggering OnDataModelChanged");
+        }
         s_inHook = false;
     }
 }
 
 static void __cdecl IconView_UpdateHostedContent_Hook(void* pThis) {
     if (IconView_UpdateHostedContent_Original) {
-        IconView_UpdateHostedContent_Original(pThis);
+        try {
+            IconView_UpdateHostedContent_Original(pThis);
+        } catch (...) {
+            Wh_Log(L"Exception in IconView_UpdateHostedContent_Original");
+        }
     }
 
     if (g_unloading.load(std::memory_order_relaxed) || !pThis) {
         return;
     }
 
-    IUnknown* inner = reinterpret_cast<IUnknown**>(pThis)[1];
-    if (!inner) {
-        return;
-    }
+    try {
+        IUnknown* inner = reinterpret_cast<IUnknown**>(pThis)[1];
+        if (!inner) {
+            return;
+        }
 
-    FrameworkElement iconView = nullptr;
-    inner->QueryInterface(winrt::guid_of<FrameworkElement>(), winrt::put_abi(iconView));
-    if (!iconView || winrt::get_class_name(iconView) != L"SystemTray.IconView") {
-        return;
-    }
+        FrameworkElement iconView = nullptr;
+        inner->QueryInterface(winrt::guid_of<FrameworkElement>(), winrt::put_abi(iconView));
+        if (!iconView || winrt::get_class_name(iconView) != L"SystemTray.IconView") {
+            return;
+        }
 
-    if (!IsChildOfElementByName(iconView, L"ControlCenterButton")) {
-        return;
-    }
+        if (!IsChildOfElementByName(iconView, L"ControlCenterButton")) {
+            return;
+        }
 
-    if (IsVolumeIconElement(iconView)) {
-        g_volumeIconViewWeak = iconView;
-        ApplyVolumeContainerWidth(iconView);
+        if (IsVolumeIconElement(iconView)) {
+            g_volumeIconViewWeak = iconView;
+            ApplyVolumeContainerWidth(iconView);
+        }
+    } catch (...) {
+        Wh_Log(L"Exception inspecting IconView XAML tree");
     }
 }
 
 static bool HookSystemTraySymbols(HMODULE module) {
-    WindhawkUtils::SYMBOL_HOOK systemTrayDllHooks[] = {
+    // SystemTray.dll, Taskbar.View.dll
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {
         {
             {
                 LR"(public: void __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::UpdateVolume(float,bool,struct winrt::hstring))",
@@ -787,17 +863,9 @@ static bool HookSystemTraySymbols(HMODULE module) {
             reinterpret_cast<void*>(VolumeSystemTrayIconDataModel_dtor_Hook),
             true,
         },
-        {
-            {
-                LR"(??1IconView@implementation@SystemTray@winrt@@UEAA@XZ)",
-            },
-            reinterpret_cast<void**>(&IconView_dtor_Original),
-            reinterpret_cast<void*>(IconView_dtor_Hook),
-            true,
-        },
     };
 
-    return WindhawkUtils::HookSymbols(module, systemTrayDllHooks, ARRAYSIZE(systemTrayDllHooks));
+    return WindhawkUtils::HookSymbols(module, hooks, ARRAYSIZE(hooks));
 }
 
 static HMODULE GetSystemTrayModuleHandle() {
@@ -925,11 +993,14 @@ static void LoadSettings() {
 }
 
 static void WINAPI BeforeUninitOnUIThread(void* /*parameter*/) {
-    if (auto iconView = g_volumeIconViewWeak.get()) {
-        iconView.MinWidth(0.0);
+    try {
+        if (auto iconView = g_volumeIconViewWeak.get()) {
+            iconView.MinWidth(0.0);
+        }
+    } catch (...) {
+        Wh_Log(L"Exception in BeforeUninitOnUIThread resetting width");
     }
     g_volumeIconViewWeak = nullptr;
-    g_lastAppliedIconViewWidth.store(-1.0, std::memory_order_relaxed);
 
     void* dataModel = nullptr;
     float vol = 0.0f;
@@ -956,20 +1027,26 @@ static void WINAPI BeforeUninitOnUIThread(void* /*parameter*/) {
                 defaultGlyph = GLYPH_VOL_3;
         }
         std::wstring restoreStr(1, defaultGlyph);
-        size_t offset = g_iconTextOffset.load(std::memory_order_relaxed);
-        HSTRING* ppHString = reinterpret_cast<HSTRING*>(reinterpret_cast<char*>(dataModel) + offset);
-        HSTRING oldHString = *ppHString;
-        HSTRING newHString = nullptr;
-        if (SUCCEEDED(WindowsCreateString(restoreStr.c_str(), 1, &newHString))) {
-            *ppHString = newHString;
-            if (oldHString) {
-                WindowsDeleteString(oldHString);
+        size_t offset = GetIconTextOffset(dataModel);
+        if (offset != 0) {
+            HSTRING* ppHString = reinterpret_cast<HSTRING*>(reinterpret_cast<char*>(dataModel) + offset);
+            HSTRING oldHString = *ppHString;
+            HSTRING newHString = nullptr;
+            if (SUCCEEDED(WindowsCreateString(restoreStr.c_str(), 1, &newHString))) {
+                *ppHString = newHString;
+                if (oldHString) {
+                    WindowsDeleteString(oldHString);
+                }
             }
         }
 
         if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
-            std::wstring_view propName = L"CurrentData";
-            VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(dataModel, &propName);
+            try {
+                std::wstring_view propName = L"CurrentData";
+                VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(dataModel, &propName);
+            } catch (...) {
+                Wh_Log(L"Exception in BeforeUninitOnUIThread OnDataModelChanged");
+            }
         }
     }
 }
@@ -993,8 +1070,12 @@ void Wh_ModUninit() {
 }
 
 static void WINAPI SettingsChangedOnUIThread(void* /*parameter*/) {
-    if (auto iconView = g_volumeIconViewWeak.get()) {
-        ApplyVolumeContainerWidth(iconView);
+    try {
+        if (auto iconView = g_volumeIconViewWeak.get()) {
+            ApplyVolumeContainerWidth(iconView);
+        }
+    } catch (...) {
+        Wh_Log(L"Exception in SettingsChangedOnUIThread width");
     }
 
     void* dataModel = nullptr;
@@ -1028,14 +1109,16 @@ static void WINAPI SettingsChangedOnUIThread(void* /*parameter*/) {
                     defaultGlyph = GLYPH_VOL_3;
             }
             std::wstring restoreStr(1, defaultGlyph);
-            size_t offset = g_iconTextOffset.load(std::memory_order_relaxed);
-            HSTRING* ppHString = reinterpret_cast<HSTRING*>(reinterpret_cast<char*>(dataModel) + offset);
-            HSTRING oldHString = *ppHString;
-            HSTRING newHString = nullptr;
-            if (SUCCEEDED(WindowsCreateString(restoreStr.c_str(), 1, &newHString))) {
-                *ppHString = newHString;
-                if (oldHString) {
-                    WindowsDeleteString(oldHString);
+            size_t offset = GetIconTextOffset(dataModel);
+            if (offset != 0) {
+                HSTRING* ppHString = reinterpret_cast<HSTRING*>(reinterpret_cast<char*>(dataModel) + offset);
+                HSTRING oldHString = *ppHString;
+                HSTRING newHString = nullptr;
+                if (SUCCEEDED(WindowsCreateString(restoreStr.c_str(), 1, &newHString))) {
+                    *ppHString = newHString;
+                    if (oldHString) {
+                        WindowsDeleteString(oldHString);
+                    }
                 }
             }
         } else {
@@ -1043,8 +1126,12 @@ static void WINAPI SettingsChangedOnUIThread(void* /*parameter*/) {
         }
 
         if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
-            std::wstring_view propName = L"CurrentData";
-            VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(dataModel, &propName);
+            try {
+                std::wstring_view propName = L"CurrentData";
+                VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(dataModel, &propName);
+            } catch (...) {
+                Wh_Log(L"Exception in SettingsChangedOnUIThread OnDataModelChanged");
+            }
         }
     }
 }
@@ -1067,6 +1154,7 @@ BOOL Wh_ModInit() {
     Wh_Log(L"Initializing Taskbar Volume Percentage Indicator mod in explorer.exe");
 
     LoadSettings();
+    InitMasterVolumeFromCoreAudio();
 
     bool hooked = false;
     if (HMODULE systemTrayModule = GetSystemTrayModuleHandle()) {

--- a/mods/taskbar-volume-percentage.wh.cpp
+++ b/mods/taskbar-volume-percentage.wh.cpp
@@ -2,11 +2,11 @@
 // @id              taskbar-volume-percentage
 // @name            Taskbar Volume Percentage Indicator
 // @description     Displays the exact master volume percentage in the system tray natively inside the Windows 11 volume button with real-time sync.
-// @version         1.3.5
+// @version         1.3.6
 // @author          gilnett
 // @github          https://github.com/gilnett
 // @include         explorer.exe
-// @compilerOptions -lversion
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lversion
 // @license         GPL-3.0
 // ==/WindhawkMod==
 
@@ -16,11 +16,20 @@
 
 Replaces the default Windows 11 taskbar volume icon with the current volume level in real time directly inside the system tray button.
 
+![Taskbar Volume Percentage Preview 1](https://i.imgur.com/vjwali8.png)
+![Taskbar Volume Percentage Preview 2](https://i.imgur.com/XEf8m50.png)
+![Taskbar Volume Percentage Preview 3](https://i.imgur.com/27iyViO.png)
+![Taskbar Volume Percentage Preview 4](https://i.imgur.com/1alQd1j.png)
+
 ## How It Works
 
 - **Real-Time Volume Display**: Displays the current master audio level as a percentage (`50%`), pure number (`50`), with a custom prefix (`Vol 50%`), with an emoji (`🔊 50%`), or using the default Windows speaker icon.
 - **Mute Indicator**: When muted, automatically switches to a customizable mute display (`MUT`, `Mute`, `0%`, `✕`, `🔇`, native glyph, or custom text).
 - **Layout Stabilization**: Automatically sizes the container to fit the percentage text smoothly without shifting adjacent taskbar icons. A fixed container width can also be set manually in the settings.
+
+## Compatibility
+
+Only Windows 11 is supported.
 
 ## Credits
 
@@ -63,12 +72,13 @@ Replaces the default Windows 11 taskbar volume icon with the current volume leve
 // ==/WindhawkModSettings==
 
 #include <windows.h>
+#include <winstring.h>
 #include <winver.h>
 
 #include <atomic>
 #include <cmath>
-#include <cstdint>
 #include <cstring>
+#include <functional>
 #include <mutex>
 #include <string>
 #include <string_view>
@@ -76,51 +86,15 @@ Replaces the default Windows 11 taskbar volume icon with the current volume leve
 #include <windhawk_api.h>
 #include <windhawk_utils.h>
 
-// Reference: C++/WinRT base_string.h shared_hstring_header binary layout
-struct hstring_header {
-    uint32_t flags;
-    uint32_t length;
-    uint32_t padding1;
-    uint32_t padding2;
-    wchar_t const* ptr;
-};
+#undef GetCurrentTime
 
-struct shared_hstring_header : hstring_header {
-    int32_t count;
-    wchar_t buffer[1];
-};
+#include <winrt/base.h>
+#include <winrt/Windows.UI.Core.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
 
-constexpr uint32_t MOD_HSTRING_MAGIC = 0x57484F4B; // "WHOK" tag to verify ownership before HeapFree
-
-static shared_hstring_header* CreateSharedHString(const std::wstring& str) {
-    uint32_t len = static_cast<uint32_t>(str.length());
-    size_t bytes = sizeof(shared_hstring_header) + sizeof(wchar_t) * len;
-    shared_hstring_header* header = static_cast<shared_hstring_header*>(
-        HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, bytes));
-    if (!header) {
-        return nullptr;
-    }
-    header->flags = 0;
-    header->length = len;
-    header->padding1 = MOD_HSTRING_MAGIC;
-    header->padding2 = 0;
-    header->ptr = header->buffer;
-    header->count = 1;
-    memcpy(header->buffer, str.c_str(), sizeof(wchar_t) * (len + 1));
-    return header;
-}
-
-static void ReleaseSharedHString(shared_hstring_header* header) {
-    if (!header) {
-        return;
-    }
-    if (header->flags != 0 || header->padding1 != MOD_HSTRING_MAGIC) {
-        return;
-    }
-    if (InterlockedDecrement(reinterpret_cast<volatile LONG*>(&header->count)) == 0) {
-        HeapFree(GetProcessHeap(), 0, header);
-    }
-}
+using namespace winrt::Windows::UI::Xaml;
 
 enum class DisplayStyle {
     Percentage,
@@ -152,7 +126,7 @@ static Settings g_settings;
 static std::mutex g_settingsMutex;
 
 // Segoe Fluent Icons volume glyphs
-constexpr wchar_t GLYPH_MUTE  = 0xE74F; // Crossed-out speaker
+constexpr wchar_t GLYPH_MUTE = 0xE74F;  // Crossed-out speaker
 constexpr wchar_t GLYPH_VOL_0 = 0xE992; // 0 bars
 constexpr wchar_t GLYPH_VOL_1 = 0xE993; // 1 bar
 constexpr wchar_t GLYPH_VOL_2 = 0xE994; // 2 bars
@@ -160,124 +134,14 @@ constexpr wchar_t GLYPH_VOL_3 = 0xE995; // 3 bars
 
 static void* g_pVolumeDataModel = nullptr;
 static float g_lastVolumeLevel = 0.5f;
-static bool  g_lastIsMuted = false;
+static bool g_lastIsMuted = false;
 static std::mutex g_dataModelMutex;
 
-static void* g_pVolumeIconView = nullptr;
-static std::mutex g_iconViewMutex;
-
-static void* g_pVolumeTextIcon = nullptr;
-static std::mutex g_textIconMutex;
-
-static std::atomic<double> g_lastAppliedTextIconWidth{-1.0};
+static winrt::weak_ref<FrameworkElement> g_volumeIconViewWeak;
 static std::atomic<double> g_lastAppliedIconViewWidth{-1.0};
 
 static std::atomic<bool> g_unloading{false};
 static std::atomic<bool> g_systemTrayModuleHooked{false};
-
-// ---------------------------------------------------------------------------
-// Memory verification & WinRT ABI definitions
-// ---------------------------------------------------------------------------
-
-static bool IsValidReadableMemory(const void* ptr, size_t size) {
-    if (!ptr || size == 0) return false;
-    uintptr_t u = reinterpret_cast<uintptr_t>(ptr);
-#if defined(_WIN64) || defined(__x86_64__) || defined(_M_AMD64) || defined(__aarch64__)
-    if (u < 0x10000 || u >= 0x00007FFFFFF00000ULL) return false;
-#else
-    if (u < 0x10000 || u >= 0x7FFF0000UL) return false;
-#endif
-
-    MEMORY_BASIC_INFORMATION mbi = {};
-    if (VirtualQuery(ptr, &mbi, sizeof(mbi)) != sizeof(mbi)) {
-        return false;
-    }
-
-    if (mbi.State != MEM_COMMIT) {
-        return false;
-    }
-
-    if (mbi.Protect & (PAGE_NOACCESS | PAGE_GUARD)) {
-        return false;
-    }
-
-    constexpr DWORD kReadable = PAGE_READONLY | PAGE_READWRITE |
-                                PAGE_WRITECOPY | PAGE_EXECUTE_READ |
-                                PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
-    if (!(mbi.Protect & kReadable)) {
-        return false;
-    }
-
-    uintptr_t regionEnd = reinterpret_cast<uintptr_t>(mbi.BaseAddress) + mbi.RegionSize;
-    if (u + size > regionEnd) {
-        return false;
-    }
-
-    return true;
-}
-
-static inline bool IsValidUserPointer(const void* ptr) {
-    if (!ptr || (reinterpret_cast<uintptr_t>(ptr) % sizeof(void*)) != 0) {
-        return false;
-    }
-    return IsValidReadableMemory(ptr, sizeof(void*));
-}
-
-static inline bool IsValidComObject(const void* ptr) {
-    if (!IsValidUserPointer(ptr)) {
-        return false;
-    }
-    const void* const* vtbl = *reinterpret_cast<const void* const* const*>(ptr);
-    if (!IsValidUserPointer(vtbl)) {
-        return false;
-    }
-    // QueryInterface (slot 0) must point to valid readable/executable code
-    return IsValidReadableMemory(vtbl[0], sizeof(void*));
-}
-
-// IFrameworkElement GUID: a391d09b-4a99-4b7c-9d8d-6fa5d01f6fbf
-// Matches official Windows SDK winrt::impl::guid_v<winrt::Windows::UI::Xaml::IFrameworkElement>
-static constexpr GUID IID_IFrameworkElement = {
-    0xa391d09b, 0x4a99, 0x4b7c, { 0x9d, 0x8d, 0x6f, 0xa5, 0xd0, 0x1f, 0x6f, 0xbf }
-};
-
-// VolumeSystemTrayIconDataModel unique identifier GUID in SystemTray.dll
-static constexpr GUID GUID_VolumeIcon = {
-    0x7820ae73, 0x23e3, 0x4229, { 0x82, 0xc1, 0xe4, 0x1c, 0xb6, 0x7d, 0x5b, 0x9c }
-};
-
-struct IFrameworkElementVtbl {
-    HRESULT (STDMETHODCALLTYPE* QueryInterface)(void* This, REFIID riid, void** ppvObject); // 0
-    ULONG   (STDMETHODCALLTYPE* AddRef)(void* This); // 1
-    ULONG   (STDMETHODCALLTYPE* Release)(void* This); // 2
-    HRESULT (STDMETHODCALLTYPE* GetIids)(void* This, ULONG* iidCount, IID** iids); // 3
-    HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(void* This, void** className); // 4
-    HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(void* This, int* trustLevel); // 5
-    HRESULT (STDMETHODCALLTYPE* get_Triggers)(void* This, void** value); // 6
-    HRESULT (STDMETHODCALLTYPE* get_Resources)(void* This, void** value); // 7
-    HRESULT (STDMETHODCALLTYPE* put_Resources)(void* This, void* value); // 8
-    HRESULT (STDMETHODCALLTYPE* get_Tag)(void* This, void** value); // 9
-    HRESULT (STDMETHODCALLTYPE* put_Tag)(void* This, void* value); // 10
-    HRESULT (STDMETHODCALLTYPE* get_Language)(void* This, void** value); // 11
-    HRESULT (STDMETHODCALLTYPE* put_Language)(void* This, void* value); // 12
-    HRESULT (STDMETHODCALLTYPE* get_ActualWidth)(void* This, double* value); // 13
-    HRESULT (STDMETHODCALLTYPE* get_ActualHeight)(void* This, double* value); // 14
-    HRESULT (STDMETHODCALLTYPE* get_Width)(void* This, double* value); // 15
-    HRESULT (STDMETHODCALLTYPE* put_Width)(void* This, double value); // 16
-    HRESULT (STDMETHODCALLTYPE* get_Height)(void* This, double* value); // 17
-    HRESULT (STDMETHODCALLTYPE* put_Height)(void* This, double value); // 18
-    HRESULT (STDMETHODCALLTYPE* get_MinWidth)(void* This, double* value); // 19
-    HRESULT (STDMETHODCALLTYPE* put_MinWidth)(void* This, double value); // 20
-};
-
-struct IFrameworkElementCustom {
-    IFrameworkElementVtbl* lpVtbl;
-};
-
-struct WinRTSize {
-    float Width;
-    float Height;
-};
 
 static double GetTargetContainerWidth(const Settings& settings) {
     if (settings.fixedContainerWidth < 0) {
@@ -288,55 +152,142 @@ static double GetTargetContainerWidth(const Settings& settings) {
     }
     // Optimal automatic width in DIPs based on display style
     switch (settings.displayStyle) {
-        case DisplayStyle::Vanilla:
-            return 0.0; // Native auto-size
-        case DisplayStyle::Number:
-            return 30.0;
-        case DisplayStyle::Prefix:
-            return 72.0;
-        case DisplayStyle::Emoji:
-            return 66.0;
-        case DisplayStyle::Percentage:
-        default:
-            return 42.0;
+    case DisplayStyle::Vanilla:
+        return 0.0; // Native auto-size
+    case DisplayStyle::Number:
+        return 30.0;
+    case DisplayStyle::Prefix:
+        return 72.0;
+    case DisplayStyle::Emoji:
+        return 66.0;
+    case DisplayStyle::Percentage:
+    default:
+        return 42.0;
     }
 }
 
-static void ApplyElementMinWidth(void* pElement, double minWidth) {
-    if (!IsValidComObject(pElement)) {
-        return;
-    }
+// ---------------------------------------------------------------------------
+// WinUI Visual Tree inspection helpers
+// ---------------------------------------------------------------------------
 
-    // 1. QueryInterface directly on pElement
-    IUnknown* pUnk = reinterpret_cast<IUnknown*>(pElement);
-    void* pFEVoid = nullptr;
-    if (SUCCEEDED(pUnk->QueryInterface(IID_IFrameworkElement, &pFEVoid)) && pFEVoid) {
-        if (IsValidComObject(pFEVoid)) {
-            IFrameworkElementCustom* pFE = reinterpret_cast<IFrameworkElementCustom*>(pFEVoid);
-            pFE->lpVtbl->put_MinWidth(pFE, minWidth);
-            pFE->lpVtbl->Release(pFE);
+static FrameworkElement GetParentElementByName(const FrameworkElement& element, PCWSTR name) {
+    auto parent = Media::VisualTreeHelper::GetParent(element).try_as<FrameworkElement>();
+    while (parent) {
+        if (parent.Name() == name) {
+            return parent;
         }
+        parent = Media::VisualTreeHelper::GetParent(parent).try_as<FrameworkElement>();
     }
-
-    // 2. Also check inner composable XAML object at offset +8 (for aggregated controls)
-    if (IsValidReadableMemory(reinterpret_cast<const char*>(pElement) + 8, sizeof(void*))) {
-        void* pInner = *reinterpret_cast<void**>(reinterpret_cast<char*>(pElement) + 8);
-        if (IsValidComObject(pInner)) {
-            void* pInnerFEVoid = nullptr;
-            IUnknown* pInnerUnk = reinterpret_cast<IUnknown*>(pInner);
-            if (SUCCEEDED(pInnerUnk->QueryInterface(IID_IFrameworkElement, &pInnerFEVoid)) && pInnerFEVoid) {
-                if (IsValidComObject(pInnerFEVoid)) {
-                    IFrameworkElementCustom* pInnerFE = reinterpret_cast<IFrameworkElementCustom*>(pInnerFEVoid);
-                    pInnerFE->lpVtbl->put_MinWidth(pInnerFE, minWidth);
-                    pInnerFE->lpVtbl->Release(pInnerFE);
-                }
-            }
-        }
-    }
+    return nullptr;
 }
 
-static void ApplyVolumeContainerWidth(void* pIconView) {
-    if (!IsValidComObject(pIconView) || g_unloading.load(std::memory_order_relaxed)) {
+static bool IsChildOfElementByName(const FrameworkElement& element, PCWSTR name) {
+    return !!GetParentElementByName(element, name);
+}
+
+static FrameworkElement EnumChildElements(
+    const FrameworkElement& element,
+    const std::function<bool(const FrameworkElement&)>& enumCallback) {
+    int childrenCount = Media::VisualTreeHelper::GetChildrenCount(element);
+
+    for (int i = 0; i < childrenCount; i++) {
+        auto child = Media::VisualTreeHelper::GetChild(element, i).try_as<FrameworkElement>();
+        if (!child) {
+            continue;
+        }
+
+        if (enumCallback(child)) {
+            return child;
+        }
+    }
+
+    return nullptr;
+}
+
+static FrameworkElement FindChildByName(const FrameworkElement& element, PCWSTR name) {
+    return EnumChildElements(element, [name](const FrameworkElement& child) {
+        return child.Name() == name;
+    });
+}
+
+static FrameworkElement FindChildByClassName(const FrameworkElement& element, PCWSTR className) {
+    return EnumChildElements(element, [className](const FrameworkElement& child) {
+        return winrt::get_class_name(child) == className;
+    });
+}
+
+static bool IsVolumeIconElement(const FrameworkElement& iconView) {
+    auto containerGrid = FindChildByName(iconView, L"ContainerGrid");
+    if (!containerGrid) {
+        return false;
+    }
+    auto contentGrid = FindChildByName(containerGrid, L"ContentGrid");
+    if (!contentGrid) {
+        return false;
+    }
+
+    // Battery icon uses BatteryIconContent, not TextIconContent
+    if (FindChildByClassName(contentGrid, L"SystemTray.BatteryIconContent")) {
+        return false;
+    }
+
+    auto textIconContent = FindChildByClassName(contentGrid, L"SystemTray.TextIconContent");
+    if (!textIconContent) {
+        return false;
+    }
+
+    auto textContainer = FindChildByName(textIconContent, L"ContainerGrid");
+    if (!textContainer) {
+        return false;
+    }
+    auto baseGrid = FindChildByName(textContainer, L"Base");
+    if (!baseGrid) {
+        return false;
+    }
+    auto textBlockEl = FindChildByName(baseGrid, L"InnerTextBlock");
+    if (!textBlockEl) {
+        return false;
+    }
+
+    auto textBlock = textBlockEl.try_as<Controls::TextBlock>();
+    if (!textBlock) {
+        return false;
+    }
+
+    auto text = textBlock.Text();
+    if (text.empty()) {
+        return false;
+    }
+
+    std::wstring_view textView = text;
+
+    wchar_t firstChar = textView[0];
+    switch (firstChar) {
+    case GLYPH_MUTE:
+    case GLYPH_VOL_0:
+    case GLYPH_VOL_1:
+    case GLYPH_VOL_2:
+    case GLYPH_VOL_3:
+    case 0xEA85: // VolumeDisabled
+    case 0xEBC5: // VolumeBars
+        return true;
+    default:
+        break;
+    }
+
+    // Already customized by mod
+    if (textView.find(L'%') != std::wstring_view::npos ||
+        textView.find(L"MUT") != std::wstring_view::npos ||
+        textView.find(L"Mute") != std::wstring_view::npos ||
+        textView.find(L"Vol") != std::wstring_view::npos) {
+        return true;
+    }
+
+    return false;
+}
+
+static void ApplyVolumeContainerWidth(const FrameworkElement& iconView) {
+    if (!iconView || g_unloading.load(std::memory_order_relaxed)) {
         return;
     }
 
@@ -350,159 +301,48 @@ static void ApplyVolumeContainerWidth(void* pIconView) {
     double prevWidth = g_lastAppliedIconViewWidth.load(std::memory_order_relaxed);
     if (prevWidth != targetWidth) {
         g_lastAppliedIconViewWidth.store(targetWidth, std::memory_order_relaxed);
-        ApplyElementMinWidth(pIconView, targetWidth);
-
-        // Also apply put_MinWidth on the hosted content element if present
-        if (targetWidth > 0.0 && IsValidReadableMemory(reinterpret_cast<const char*>(pIconView) + 0x1b0, sizeof(void*))) {
-            void* pHostedContent = *reinterpret_cast<void**>(reinterpret_cast<char*>(pIconView) + 0x1b0);
-            if (IsValidComObject(pHostedContent)) {
-                ApplyElementMinWidth(pHostedContent, targetWidth);
-            }
-        }
+        iconView.MinWidth(targetWidth);
     }
-}
-
-static bool IsVolumeIconViewModel(void* pIconViewModel) {
-    if (!IsValidComObject(pIconViewModel)) {
-        return false;
-    }
-
-    void* pInterface = pIconViewModel;
-    void** vtbl = *reinterpret_cast<void***>(pInterface);
-    if (!IsValidUserPointer(vtbl) || !IsValidReadableMemory(reinterpret_cast<char*>(vtbl) + 6 * sizeof(void*), sizeof(void*))) {
-        return false;
-    }
-
-    // Slot 6: get_Configuration(void** ppConfig)
-    void* pSlot6 = vtbl[6];
-    if (!IsValidReadableMemory(pSlot6, sizeof(void*))) {
-        return false;
-    }
-    using get_Configuration_t = HRESULT(STDMETHODCALLTYPE*)(void* This, void** ppConfig);
-    auto get_Configuration = reinterpret_cast<get_Configuration_t>(pSlot6);
-
-    void* pConfig = nullptr;
-    if (FAILED(get_Configuration(pInterface, &pConfig)) || !IsValidComObject(pConfig)) {
-        return false;
-    }
-
-    void** configVtbl = *reinterpret_cast<void***>(pConfig);
-    bool isVolume = false;
-    if (IsValidUserPointer(configVtbl)) {
-        // Slot 9: get_Id(GUID* pGuid)
-        if (IsValidReadableMemory(reinterpret_cast<char*>(configVtbl) + 9 * sizeof(void*), sizeof(void*))) {
-            void* pSlot9 = configVtbl[9];
-            if (IsValidReadableMemory(pSlot9, sizeof(void*))) {
-                using get_Id_t = HRESULT(STDMETHODCALLTYPE*)(void* This, GUID* pGuid);
-                auto get_Id = reinterpret_cast<get_Id_t>(pSlot9);
-                GUID guid = {};
-                if (SUCCEEDED(get_Id(pConfig, &guid)) && memcmp(&guid, &GUID_VolumeIcon, sizeof(GUID)) == 0) {
-                    isVolume = true;
-                }
-            }
-        }
-
-        // Also check Slot 6: get_DataModel(void** ppDataModel)
-        if (!isVolume && IsValidReadableMemory(reinterpret_cast<char*>(configVtbl) + 6 * sizeof(void*), sizeof(void*))) {
-            void* pConfigSlot6 = configVtbl[6];
-            if (IsValidReadableMemory(pConfigSlot6, sizeof(void*))) {
-                using get_DataModel_t = HRESULT(STDMETHODCALLTYPE*)(void* This, void** ppDataModel);
-                auto get_DataModel = reinterpret_cast<get_DataModel_t>(pConfigSlot6);
-                void* pDataModel = nullptr;
-                if (SUCCEEDED(get_DataModel(pConfig, &pDataModel)) && pDataModel) {
-                    {
-                        std::lock_guard<std::mutex> lock(g_dataModelMutex);
-                        if (pDataModel == g_pVolumeDataModel) {
-                            isVolume = true;
-                        }
-                    }
-                    reinterpret_cast<IUnknown*>(pDataModel)->Release();
-                }
-            }
-        }
-
-        reinterpret_cast<IUnknown*>(pConfig)->Release();
-    }
-
-    return isVolume;
-}
-
-static bool IsVolumeTextIcon(void* pThis) {
-    if (!IsValidUserPointer(pThis)) {
-        return false;
-    }
-
-    {
-        std::lock_guard<std::mutex> lock(g_textIconMutex);
-        if (g_pVolumeTextIcon == pThis) {
-            return true;
-        }
-    }
-
-    // Check ViewModel at offsets 0x80 and 0x68
-    const size_t vmOffsets[] = { 0x80, 0x68 };
-    for (size_t offset : vmOffsets) {
-        if (!IsValidReadableMemory(reinterpret_cast<const char*>(pThis) + offset, sizeof(void*))) {
-            continue;
-        }
-        void* pVM = *reinterpret_cast<void**>(reinterpret_cast<char*>(pThis) + offset);
-        if (!IsValidUserPointer(pVM)) {
-            continue;
-        }
-
-        // 1. Direct GUID check at offset 0x38 in ViewModel
-        if (IsValidReadableMemory(reinterpret_cast<const char*>(pVM) + 0x38, sizeof(GUID))) {
-            const GUID* pGuid = reinterpret_cast<const GUID*>(reinterpret_cast<const char*>(pVM) + 0x38);
-            if (memcmp(pGuid, &GUID_VolumeIcon, sizeof(GUID)) == 0) {
-                return true;
-            }
-        }
-
-        // 2. Check via slot 6 (ITextIconContentViewModel::get_Id)
-        if (IsValidComObject(pVM)) {
-            void** vtbl = *reinterpret_cast<void***>(pVM);
-            if (IsValidReadableMemory(reinterpret_cast<char*>(vtbl) + 6 * sizeof(void*), sizeof(void*))) {
-                void* pSlot6 = vtbl[6];
-                if (IsValidReadableMemory(pSlot6, sizeof(void*))) {
-                    using get_Id_t = HRESULT(STDMETHODCALLTYPE*)(void* This, GUID* pGuidOut);
-                    auto get_Id = reinterpret_cast<get_Id_t>(pSlot6);
-                    GUID id = {};
-                    if (SUCCEEDED(get_Id(pVM, &id)) && memcmp(&id, &GUID_VolumeIcon, sizeof(GUID)) == 0) {
-                        return true;
-                    }
-                }
-            }
-        }
-    }
-
-    return false;
 }
 
 // ---------------------------------------------------------------------------
-// Formatting logic
+// Text Formatting
 // ---------------------------------------------------------------------------
 
-static inline std::wstring FormatDigits(int percentage) {
-    return std::to_wstring(percentage);
+static std::wstring FormatDigits(int value) {
+    if (value <= 0)
+        return L"0";
+    std::wstring result;
+    int temp = value;
+    while (temp > 0) {
+        result.push_back(static_cast<wchar_t>(L'0' + (temp % 10)));
+        temp /= 10;
+    }
+    for (size_t i = 0, j = result.length() - 1; i < j; ++i, --j) {
+        wchar_t c = result[i];
+        result[i] = result[j];
+        result[j] = c;
+    }
+    return result;
 }
 
 static std::wstring FormatMuteString(MuteStyle style, const std::wstring& customText) {
     switch (style) {
-        case MuteStyle::Mute:
-            return L"Mute";
-        case MuteStyle::Zero:
-            return L"0%";
-        case MuteStyle::Cross:
-            return L"\u2715";
-        case MuteStyle::Emoji:
-            return L"\xD83D\xDD07";
-        case MuteStyle::Glyph:
-            return std::wstring(1, GLYPH_MUTE);
-        case MuteStyle::Custom:
-            return customText.empty() ? L"Mute" : customText;
-        case MuteStyle::Mut:
-        default:
-            return L"MUT";
+    case MuteStyle::Mute:
+        return L"Mute";
+    case MuteStyle::Zero:
+        return L"0%";
+    case MuteStyle::Cross:
+        return L"\x2715"; // Unicode heavy multiplication x
+    case MuteStyle::Emoji:
+        return L"\xD83D\xDD07"; // Speaker with cancellation stroke
+    case MuteStyle::Glyph:
+        return std::wstring(1, GLYPH_MUTE);
+    case MuteStyle::Custom:
+        return customText.empty() ? L"Mute" : customText;
+    case MuteStyle::Mut:
+    default:
+        return L"MUT";
     }
 }
 
@@ -520,143 +360,46 @@ static std::wstring FormatVolumeText(int percentage, bool isMuted) {
     std::wstring s = FormatDigits(percentage);
 
     switch (settingsCopy.displayStyle) {
-        case DisplayStyle::Vanilla: {
-            wchar_t glyph = GLYPH_MUTE;
-            if (!isMuted) {
-                if (percentage == 0)      glyph = GLYPH_VOL_0;
-                else if (percentage < 33) glyph = GLYPH_VOL_1;
-                else if (percentage < 66) glyph = GLYPH_VOL_2;
-                else                      glyph = GLYPH_VOL_3;
-            }
-            return std::wstring(1, glyph);
+    case DisplayStyle::Vanilla: {
+        wchar_t glyph = GLYPH_MUTE;
+        if (!isMuted) {
+            if (percentage == 0)
+                glyph = GLYPH_VOL_0;
+            else if (percentage < 33)
+                glyph = GLYPH_VOL_1;
+            else if (percentage < 66)
+                glyph = GLYPH_VOL_2;
+            else
+                glyph = GLYPH_VOL_3;
         }
-
-        case DisplayStyle::Number:
-            return s;
-
-        case DisplayStyle::Prefix:
-            return settingsCopy.customPrefix + s + L"%";
-
-        case DisplayStyle::Emoji: {
-            std::wstring prefix;
-            if (percentage == 0) {
-                prefix = L"\xD83D\xDD08 ";
-            } else if (percentage <= 50) {
-                prefix = L"\xD83D\xDD09 ";
-            } else {
-                prefix = L"\xD83D\xDD0A ";
-            }
-            return prefix + s + L"%";
-        }
-
-        case DisplayStyle::Percentage:
-        default:
-            return s + L"%";
+        return std::wstring(1, glyph);
+    }
+    case DisplayStyle::Number:
+        return s;
+    case DisplayStyle::Prefix: {
+        std::wstring result = settingsCopy.customPrefix;
+        result += s;
+        result += L"%";
+        return result;
+    }
+    case DisplayStyle::Emoji: {
+        std::wstring result = L"\xD83D\xDD0A ";
+        result += s;
+        result += L"%";
+        return result;
+    }
+    case DisplayStyle::Percentage:
+    default: {
+        std::wstring result = s;
+        result += L"%";
+        return result;
+    }
     }
 }
 
-static size_t GetIconTextOffset(void* pThis) {
-    if (!IsValidUserPointer(pThis)) {
-        return 0;
-    }
-
-    auto isValidHeader = [](shared_hstring_header* h) -> bool {
-        if (!h || (reinterpret_cast<uintptr_t>(h) % sizeof(void*)) != 0) {
-            return false;
-        }
-        if (!IsValidReadableMemory(h, sizeof(shared_hstring_header))) {
-            return false;
-        }
-        if (h->flags > 1 || h->length > 256 || !h->ptr) {
-            return false;
-        }
-        if (!IsValidReadableMemory(h->ptr, sizeof(wchar_t))) {
-            return false;
-        }
-        return true;
-    };
-
-    auto matchesGlyphOrText = [&](shared_hstring_header* candidate) -> bool {
-        if (!isValidHeader(candidate)) {
-            return false;
-        }
-        // Read character from candidate->ptr, supporting both shared_hstring and HSTRING_REFERENCE
-        wchar_t firstChar = candidate->ptr[0];
-        return (firstChar >= 0xE700 && firstChar <= 0xE9FF) ||
-               (firstChar >= L'0' && firstChar <= L'9') ||
-               (firstChar >= L'a' && firstChar <= L'z') ||
-               (firstChar >= L'A' && firstChar <= L'Z') ||
-               firstChar == L' ' || firstChar == 0x2715 ||
-               firstChar == 0x2007 || firstChar == 0x00A0 ||
-               firstChar == 0xD83D;
-    };
-
-    // Primary offset in standard Windows 11 SystemTray builds is 0x90; fallback to 0xB8 and 0x88
-    const size_t preferredOffsets[] = { 0x90, 0xB8, 0x88 };
-    for (size_t prefOffset : preferredOffsets) {
-        if (IsValidReadableMemory(reinterpret_cast<const char*>(pThis) + prefOffset, sizeof(void*))) {
-            shared_hstring_header* candidate = *reinterpret_cast<shared_hstring_header**>(
-                reinterpret_cast<char*>(pThis) + prefOffset);
-            if (matchesGlyphOrText(candidate)) {
-                return prefOffset;
-            }
-        }
-    }
-
-    for (size_t offset = 0x40; offset <= 0x120; offset += sizeof(void*)) {
-        if (!IsValidReadableMemory(reinterpret_cast<const char*>(pThis) + offset, sizeof(void*))) {
-            continue;
-        }
-        shared_hstring_header* candidate = *reinterpret_cast<shared_hstring_header**>(
-            reinterpret_cast<char*>(pThis) + offset);
-        if (matchesGlyphOrText(candidate)) {
-            return offset;
-        }
-    }
-
-    return 0;
-}
-
-static void ApplyCustomVolumeText(void* pThis, float volumeLevel, bool isMuted) {
-    if (!IsValidUserPointer(pThis) || g_unloading.load(std::memory_order_relaxed)) {
-        return;
-    }
-
-    size_t offset = GetIconTextOffset(pThis);
-    if (offset == 0) {
-        Wh_Log(L"Could not safely locate icon text member in VolumeSystemTrayIconDataModel");
-        return;
-    }
-
-    int percentage = static_cast<int>(std::round(volumeLevel * 100.0f));
-    if (percentage < 0) percentage = 0;
-    if (percentage > 100) percentage = 100;
-
-    std::wstring customText = FormatVolumeText(percentage, isMuted);
-
-    shared_hstring_header** ppHeader = reinterpret_cast<shared_hstring_header**>(
-        reinterpret_cast<char*>(pThis) + offset);
-
-    shared_hstring_header* oldHeader = *ppHeader;
-
-    // If the current header was already created by us and matches the desired text, reuse it
-    if (oldHeader && oldHeader->flags == 0 && oldHeader->padding1 == MOD_HSTRING_MAGIC &&
-        oldHeader->length == customText.length() && oldHeader->ptr &&
-        wcsncmp(oldHeader->ptr, customText.c_str(), customText.length()) == 0) {
-        return;
-    }
-
-    shared_hstring_header* newHeader = CreateSharedHString(customText);
-    if (!newHeader) {
-        return;
-    }
-
-    *ppHeader = newHeader;
-
-    if (oldHeader && oldHeader != newHeader) {
-        ReleaseSharedHString(oldHeader);
-    }
-}
+// ---------------------------------------------------------------------------
+// Thread dispatching
+// ---------------------------------------------------------------------------
 
 static HWND FindCurrentProcessTaskbarWnd() {
     DWORD currentProcessId = GetCurrentProcessId();
@@ -673,32 +416,33 @@ static HWND FindCurrentProcessTaskbarWnd() {
     return nullptr;
 }
 
-using RunFromWindowThreadProc_t = void (*)(void* param);
+using RunFromWindowThreadProc_t = void(WINAPI*)(void* parameter);
+
+static UINT g_runFromWindowThreadRegisteredMsg = 0;
 
 struct RUN_FROM_WINDOW_THREAD_PARAM {
     RunFromWindowThreadProc_t proc;
     void* procParam;
 };
 
-static UINT g_runFromWindowThreadMsg = 0;
-
 static LRESULT CALLBACK RunFromWindowThreadHookProc(int nCode, WPARAM wParam, LPARAM lParam) {
-    if (nCode == HC_ACTION && g_runFromWindowThreadMsg != 0) {
-        const CWPSTRUCT* cwp = reinterpret_cast<const CWPSTRUCT*>(lParam);
-        if (cwp->message == g_runFromWindowThreadMsg) {
+    if (nCode == HC_ACTION && g_runFromWindowThreadRegisteredMsg != 0) {
+        const auto* cwp = reinterpret_cast<const CWPSTRUCT*>(lParam);
+        if (cwp->message == g_runFromWindowThreadRegisteredMsg) {
             auto* param = reinterpret_cast<RUN_FROM_WINDOW_THREAD_PARAM*>(cwp->lParam);
             if (param && param->proc) {
                 param->proc(param->procParam);
             }
         }
     }
+
     return CallNextHookEx(nullptr, nCode, wParam, lParam);
 }
 
 static bool RunFromWindowThread(HWND hWnd, RunFromWindowThreadProc_t proc, void* procParam) {
-    if (g_runFromWindowThreadMsg == 0) {
-        g_runFromWindowThreadMsg = RegisterWindowMessage(
-            L"Windhawk_RunFromWindowThread_taskbar-volume-percentage");
+    if (g_runFromWindowThreadRegisteredMsg == 0) {
+        g_runFromWindowThreadRegisteredMsg =
+            RegisterWindowMessage(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
     }
 
     DWORD dwThreadId = GetWindowThreadProcessId(hWnd, nullptr);
@@ -714,8 +458,7 @@ static bool RunFromWindowThread(HWND hWnd, RunFromWindowThreadProc_t proc, void*
     HHOOK hook = SetWindowsHookEx(
         WH_CALLWNDPROC,
         RunFromWindowThreadHookProc,
-        nullptr,
-        dwThreadId);
+        nullptr, dwThreadId);
     if (!hook) {
         return false;
     }
@@ -723,23 +466,9 @@ static bool RunFromWindowThread(HWND hWnd, RunFromWindowThreadProc_t proc, void*
     RUN_FROM_WINDOW_THREAD_PARAM param;
     param.proc = proc;
     param.procParam = procParam;
-
-    DWORD_PTR dwResult = 0;
-    LRESULT lr = SendMessageTimeout(
-        hWnd,
-        g_runFromWindowThreadMsg,
-        0,
-        reinterpret_cast<LPARAM>(&param),
-        SMTO_NORMAL | SMTO_ABORTIFHUNG,
-        2000,
-        &dwResult);
+    SendMessage(hWnd, g_runFromWindowThreadRegisteredMsg, 0, reinterpret_cast<LPARAM>(&param));
 
     UnhookWindowsHookEx(hook);
-
-    if (lr == 0) {
-        Wh_Log(L"SendMessageTimeout failed or timed out in RunFromWindowThread (error: %lu)", GetLastError());
-        return false;
-    }
 
     return true;
 }
@@ -748,15 +477,13 @@ static VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE hModule, UINT* puPtrLen) {
     void* pFixedFileInfo = nullptr;
     UINT uPtrLen = 0;
 
-    HRSRC hResource =
-        FindResource(hModule, MAKEINTRESOURCE(VS_VERSION_INFO), RT_VERSION);
+    HRSRC hResource = FindResource(hModule, MAKEINTRESOURCE(VS_VERSION_INFO), RT_VERSION);
     if (hResource) {
         HGLOBAL hGlobal = LoadResource(hModule, hResource);
         if (hGlobal) {
             void* pData = LockResource(hGlobal);
             if (pData) {
-                if (!VerQueryValue(pData, L"\\", &pFixedFileInfo, &uPtrLen) ||
-                    uPtrLen == 0) {
+                if (!VerQueryValue(pData, L"\\", &pFixedFileInfo, &uPtrLen) || uPtrLen == 0) {
                     pFixedFileInfo = nullptr;
                     uPtrLen = 0;
                 }
@@ -772,7 +499,7 @@ static VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE hModule, UINT* puPtrLen) {
 }
 
 // ---------------------------------------------------------------------------
-// VolumeSystemTrayIconDataModel, IconView & TextIconContent hooks
+// VolumeSystemTrayIconDataModel & IconView hooks
 // ---------------------------------------------------------------------------
 
 using VolumeSystemTrayIconDataModel_UpdateVolume_t = void(__cdecl*)(
@@ -789,10 +516,6 @@ using VolumeSystemTrayIconDataModel_dtor_t = void(__cdecl*)(void* pThis);
 static VolumeSystemTrayIconDataModel_dtor_t
     VolumeSystemTrayIconDataModel_dtor_Original = nullptr;
 
-using IconView_OnViewModelChanged_t = void(__cdecl*)(void* pThis, void* pIconViewModel);
-static IconView_OnViewModelChanged_t
-    IconView_OnViewModelChanged_Original = nullptr;
-
 using IconView_UpdateHostedContent_t = void(__cdecl*)(void* pThis);
 static IconView_UpdateHostedContent_t
     IconView_UpdateHostedContent_Original = nullptr;
@@ -800,13 +523,90 @@ static IconView_UpdateHostedContent_t
 using IconView_dtor_t = void(__cdecl*)(void* pThis);
 static IconView_dtor_t IconView_dtor_Original = nullptr;
 
-using TextIconContent_MeasureOverride_t = WinRTSize*(__cdecl*)(
-    void* pThis, WinRTSize* pResult, WinRTSize availableSize);
-static TextIconContent_MeasureOverride_t
-    TextIconContent_MeasureOverride_Original = nullptr;
+static std::atomic<size_t> g_iconTextOffset{0x90};
 
-using TextIconContent_dtor_t = void(__cdecl*)(void* pThis);
-static TextIconContent_dtor_t TextIconContent_dtor_Original = nullptr;
+static size_t GetIconTextOffset(void* pThis) {
+    if (!pThis) {
+        return 0;
+    }
+
+    auto matchesGlyphOrText = [](HSTRING hStr) -> bool {
+        if (!hStr) {
+            return false;
+        }
+        UINT32 len = 0;
+        PCWSTR raw = WindowsGetStringRawBuffer(hStr, &len);
+        if (!raw || len == 0) {
+            return false;
+        }
+        wchar_t firstChar = raw[0];
+        return (firstChar >= 0xE700 && firstChar <= 0xE9FF) ||
+               (firstChar >= L'0' && firstChar <= L'9') ||
+               (firstChar >= L'a' && firstChar <= L'z') ||
+               (firstChar >= L'A' && firstChar <= L'Z') ||
+               firstChar == L' ' || firstChar == 0x2715 ||
+               firstChar == 0x2007 || firstChar == 0x00A0 ||
+               firstChar == 0xD83D || firstChar == 0xEA85 ||
+               firstChar == 0xEBC5;
+    };
+
+    size_t cached = g_iconTextOffset.load(std::memory_order_relaxed);
+    if (cached != 0) {
+        HSTRING candidate = *reinterpret_cast<HSTRING*>(reinterpret_cast<char*>(pThis) + cached);
+        if (matchesGlyphOrText(candidate)) {
+            return cached;
+        }
+    }
+
+    const size_t preferredOffsets[] = {0x90, 0xB8, 0x88};
+    for (size_t prefOffset : preferredOffsets) {
+        HSTRING candidate = *reinterpret_cast<HSTRING*>(reinterpret_cast<char*>(pThis) + prefOffset);
+        if (matchesGlyphOrText(candidate)) {
+            g_iconTextOffset.store(prefOffset, std::memory_order_relaxed);
+            return prefOffset;
+        }
+    }
+
+    return 0x90;
+}
+
+static void ApplyCustomVolumeText(void* pThis, float volumeLevel, bool isMuted) {
+    if (!pThis || g_unloading.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    size_t offset = GetIconTextOffset(pThis);
+    if (offset == 0) {
+        return;
+    }
+
+    int percentage = static_cast<int>(std::round(volumeLevel * 100.0f));
+    if (percentage < 0)
+        percentage = 0;
+    if (percentage > 100)
+        percentage = 100;
+
+    std::wstring customText = FormatVolumeText(percentage, isMuted);
+
+    HSTRING* ppHString = reinterpret_cast<HSTRING*>(reinterpret_cast<char*>(pThis) + offset);
+    HSTRING oldHString = *ppHString;
+
+    if (oldHString) {
+        UINT32 len = 0;
+        PCWSTR raw = WindowsGetStringRawBuffer(oldHString, &len);
+        if (raw && len == customText.length() && wcsncmp(raw, customText.c_str(), len) == 0) {
+            return;
+        }
+    }
+
+    HSTRING newHString = nullptr;
+    if (SUCCEEDED(WindowsCreateString(customText.c_str(), static_cast<UINT32>(customText.length()), &newHString))) {
+        *ppHString = newHString;
+        if (oldHString) {
+            WindowsDeleteString(oldHString);
+        }
+    }
+}
 
 static void __cdecl VolumeSystemTrayIconDataModel_dtor_Hook(void* pThis) {
     {
@@ -821,28 +621,19 @@ static void __cdecl VolumeSystemTrayIconDataModel_dtor_Hook(void* pThis) {
 }
 
 static void __cdecl IconView_dtor_Hook(void* pThis) {
-    {
-        std::lock_guard<std::mutex> lock(g_iconViewMutex);
-        if (g_pVolumeIconView == pThis) {
-            g_pVolumeIconView = nullptr;
-            g_lastAppliedIconViewWidth.store(-1.0, std::memory_order_relaxed);
+    if (auto currentView = g_volumeIconViewWeak.get()) {
+        IUnknown* inner = pThis ? reinterpret_cast<IUnknown**>(pThis)[1] : nullptr;
+        if (inner) {
+            FrameworkElement thisElement = nullptr;
+            inner->QueryInterface(winrt::guid_of<FrameworkElement>(), winrt::put_abi(thisElement));
+            if (thisElement && thisElement == currentView) {
+                g_volumeIconViewWeak = nullptr;
+                g_lastAppliedIconViewWidth.store(-1.0, std::memory_order_relaxed);
+            }
         }
     }
     if (IconView_dtor_Original) {
         IconView_dtor_Original(pThis);
-    }
-}
-
-static void __cdecl TextIconContent_dtor_Hook(void* pThis) {
-    {
-        std::lock_guard<std::mutex> lock(g_textIconMutex);
-        if (g_pVolumeTextIcon == pThis) {
-            g_pVolumeTextIcon = nullptr;
-            g_lastAppliedTextIconWidth.store(-1.0, std::memory_order_relaxed);
-        }
-    }
-    if (TextIconContent_dtor_Original) {
-        TextIconContent_dtor_Original(pThis);
     }
 }
 
@@ -898,18 +689,20 @@ static void __cdecl VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
         return;
     }
 
-    // Ensure custom volume text is in place in case UpdateVolume_Original overwrote it
+    Settings settingsCopy;
     {
+        std::lock_guard<std::mutex> lock(g_settingsMutex);
+        settingsCopy = g_settings;
+    }
+
+    if (settingsCopy.displayStyle != DisplayStyle::Vanilla) {
         std::lock_guard<std::mutex> lock(g_dataModelMutex);
         ApplyCustomVolumeText(pThis, volumeLevel, isMuted);
     }
 
-    // Ensure volume container width constraint is active on UI
-    {
-        std::lock_guard<std::mutex> lock(g_iconViewMutex);
-        if (g_pVolumeIconView) {
-            ApplyVolumeContainerWidth(g_pVolumeIconView);
-        }
+    // Apply container width to volume icon if captured
+    if (auto iconView = g_volumeIconViewWeak.get()) {
+        ApplyVolumeContainerWidth(iconView);
     }
 
     // Trigger UI redraw via CurrentData property notification with recursion guard
@@ -918,65 +711,6 @@ static void __cdecl VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
         std::wstring_view propName = L"CurrentData";
         VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(pThis, &propName);
         s_inHook = false;
-    }
-}
-
-static WinRTSize* __cdecl TextIconContent_MeasureOverride_Hook(
-    void* pThis, WinRTSize* pResult, WinRTSize availableSize) {
-    static thread_local bool s_inMeasureHook = false;
-
-    WinRTSize* res = TextIconContent_MeasureOverride_Original(pThis, pResult, availableSize);
-
-    if (res && !s_inMeasureHook && !g_unloading.load(std::memory_order_relaxed)) {
-        if (IsVolumeTextIcon(pThis)) {
-            {
-                std::lock_guard<std::mutex> lock(g_textIconMutex);
-                g_pVolumeTextIcon = pThis;
-            }
-
-            Settings settingsCopy;
-            {
-                std::lock_guard<std::mutex> lock(g_settingsMutex);
-                settingsCopy = g_settings;
-            }
-
-            double targetWidth = GetTargetContainerWidth(settingsCopy);
-            if (targetWidth > 0.0) {
-                float targetWidthF = static_cast<float>(targetWidth);
-                if (res->Width < targetWidthF) {
-                    res->Width = targetWidthF;
-                }
-
-                // Point 4 & 5: Apply MinWidth only when target value changes, with re-entrancy guard
-                double prevWidth = g_lastAppliedTextIconWidth.load(std::memory_order_relaxed);
-                if (prevWidth != targetWidth) {
-                    g_lastAppliedTextIconWidth.store(targetWidth, std::memory_order_relaxed);
-                    s_inMeasureHook = true;
-                    ApplyElementMinWidth(pThis, targetWidth);
-                    s_inMeasureHook = false;
-                }
-            }
-        }
-    }
-
-    return res;
-}
-
-static void __cdecl IconView_OnViewModelChanged_Hook(void* pThis, void* pIconViewModel) {
-    if (IconView_OnViewModelChanged_Original) {
-        IconView_OnViewModelChanged_Original(pThis, pIconViewModel);
-    }
-
-    if (g_unloading.load(std::memory_order_relaxed) || !pThis) {
-        return;
-    }
-
-    if (IsVolumeIconViewModel(pIconViewModel)) {
-        {
-            std::lock_guard<std::mutex> lock(g_iconViewMutex);
-            g_pVolumeIconView = pThis;
-        }
-        ApplyVolumeContainerWidth(pThis);
     }
 }
 
@@ -989,33 +723,29 @@ static void __cdecl IconView_UpdateHostedContent_Hook(void* pThis) {
         return;
     }
 
-    bool isVolume = false;
-    {
-        std::lock_guard<std::mutex> lock(g_iconViewMutex);
-        if (g_pVolumeIconView == pThis) {
-            isVolume = true;
-        }
+    IUnknown* inner = reinterpret_cast<IUnknown**>(pThis)[1];
+    if (!inner) {
+        return;
     }
 
-    if (!isVolume && IsValidReadableMemory(reinterpret_cast<const char*>(pThis) + 0x78, sizeof(void*))) {
-        void* pVM = *reinterpret_cast<void**>(reinterpret_cast<char*>(pThis) + 0x78);
-        if (pVM && IsVolumeIconViewModel(pVM)) {
-            {
-                std::lock_guard<std::mutex> lock(g_iconViewMutex);
-                g_pVolumeIconView = pThis;
-            }
-            isVolume = true;
-        }
+    FrameworkElement iconView = nullptr;
+    inner->QueryInterface(winrt::guid_of<FrameworkElement>(), winrt::put_abi(iconView));
+    if (!iconView || winrt::get_class_name(iconView) != L"SystemTray.IconView") {
+        return;
     }
 
-    if (isVolume) {
-        ApplyVolumeContainerWidth(pThis);
+    if (!IsChildOfElementByName(iconView, L"ControlCenterButton")) {
+        return;
+    }
+
+    if (IsVolumeIconElement(iconView)) {
+        g_volumeIconViewWeak = iconView;
+        ApplyVolumeContainerWidth(iconView);
     }
 }
 
 static bool HookSystemTraySymbols(HMODULE module) {
-    // SystemTray.dll, Taskbar.View.dll
-    WindhawkUtils::SYMBOL_HOOK systemTrayHooks[] = {
+    WindhawkUtils::SYMBOL_HOOK systemTrayDllHooks[] = {
         {
             {
                 LR"(public: void __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::UpdateVolume(float,bool,struct winrt::hstring))",
@@ -1040,53 +770,6 @@ static bool HookSystemTraySymbols(HMODULE module) {
         },
         {
             {
-                LR"(public: virtual __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::~VolumeSystemTrayIconDataModel(void))",
-                LR"(public: virtual __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::~VolumeSystemTrayIconDataModel(void) __ptr64)",
-                LR"(??1VolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@UEAA@XZ)",
-                LR"(??_GVolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@UEAAPEAXI@Z)",
-                LR"(??1VolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@UAE@XZ)",
-                LR"(??_GVolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@UAEPAXI@Z)",
-                LR"(winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::~VolumeSystemTrayIconDataModel)",
-            },
-            reinterpret_cast<void**>(&VolumeSystemTrayIconDataModel_dtor_Original),
-            reinterpret_cast<void*>(VolumeSystemTrayIconDataModel_dtor_Hook),
-            true,
-        },
-        {
-            {
-                LR"(public: struct winrt::Windows::Foundation::Size __cdecl winrt::SystemTray::implementation::TextIconContent::MeasureOverride(struct winrt::Windows::Foundation::Size))",
-                LR"(public: struct winrt::Windows::Foundation::Size __cdecl winrt::SystemTray::implementation::TextIconContent::MeasureOverride(struct winrt::Windows::Foundation::Size) __ptr64)",
-                LR"(winrt::SystemTray::implementation::TextIconContent::MeasureOverride)",
-            },
-            reinterpret_cast<void**>(&TextIconContent_MeasureOverride_Original),
-            reinterpret_cast<void*>(TextIconContent_MeasureOverride_Hook),
-            true,
-        },
-        {
-            {
-                LR"(public: virtual __cdecl winrt::SystemTray::implementation::TextIconContent::~TextIconContent(void))",
-                LR"(public: virtual __cdecl winrt::SystemTray::implementation::TextIconContent::~TextIconContent(void) __ptr64)",
-                LR"(??1TextIconContent@implementation@SystemTray@winrt@@UEAA@XZ)",
-                LR"(??_GTextIconContent@implementation@SystemTray@winrt@@UEAAPEAXI@Z)",
-                LR"(winrt::SystemTray::implementation::TextIconContent::~TextIconContent)",
-            },
-            reinterpret_cast<void**>(&TextIconContent_dtor_Original),
-            reinterpret_cast<void*>(TextIconContent_dtor_Hook),
-            true,
-        },
-        {
-            {
-                LR"(private: void __cdecl winrt::SystemTray::implementation::IconView::OnViewModelChanged(struct winrt::SystemTray::IconViewModel const &))",
-                LR"(private: void __cdecl winrt::SystemTray::implementation::IconView::OnViewModelChanged(struct winrt::SystemTray::IconViewModel const & __ptr64) __ptr64)",
-                LR"(?OnViewModelChanged@IconView@implementation@SystemTray@winrt@@AEAAXAEBUIconViewModel@34@@Z)",
-                LR"(winrt::SystemTray::implementation::IconView::OnViewModelChanged)",
-            },
-            reinterpret_cast<void**>(&IconView_OnViewModelChanged_Original),
-            reinterpret_cast<void*>(IconView_OnViewModelChanged_Hook),
-            true,
-        },
-        {
-            {
                 LR"(private: void __cdecl winrt::SystemTray::implementation::IconView::UpdateHostedContent(void))",
                 LR"(private: void __cdecl winrt::SystemTray::implementation::IconView::UpdateHostedContent(void) __ptr64)",
                 LR"(?UpdateHostedContent@IconView@implementation@SystemTray@winrt@@AEAAXXZ)",
@@ -1098,11 +781,15 @@ static bool HookSystemTraySymbols(HMODULE module) {
         },
         {
             {
-                LR"(public: virtual __cdecl winrt::SystemTray::implementation::IconView::~IconView(void))",
-                LR"(public: virtual __cdecl winrt::SystemTray::implementation::IconView::~IconView(void) __ptr64)",
+                LR"(??1VolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@UEAA@XZ)",
+            },
+            reinterpret_cast<void**>(&VolumeSystemTrayIconDataModel_dtor_Original),
+            reinterpret_cast<void*>(VolumeSystemTrayIconDataModel_dtor_Hook),
+            true,
+        },
+        {
+            {
                 LR"(??1IconView@implementation@SystemTray@winrt@@UEAA@XZ)",
-                LR"(??_GIconView@implementation@SystemTray@winrt@@UEAAPEAXI@Z)",
-                LR"(winrt::SystemTray::implementation::IconView::~IconView)",
             },
             reinterpret_cast<void**>(&IconView_dtor_Original),
             reinterpret_cast<void*>(IconView_dtor_Hook),
@@ -1110,25 +797,7 @@ static bool HookSystemTraySymbols(HMODULE module) {
         },
     };
 
-    if (!WindhawkUtils::HookSymbols(module, systemTrayHooks, ARRAYSIZE(systemTrayHooks))) {
-        Wh_Log(L"Failed to hook SystemTray volume symbols");
-        return false;
-    }
-
-    if (!VolumeSystemTrayIconDataModel_dtor_Original) {
-        Wh_Log(L"Warning: VolumeSystemTrayIconDataModel destructor symbol could not be hooked; lifetime tracking will rely on validity checks");
-    }
-
-    if (TextIconContent_MeasureOverride_Original) {
-        Wh_Log(L"Successfully hooked TextIconContent::MeasureOverride for dynamic container width stabilization");
-    }
-
-    if (IconView_OnViewModelChanged_Original) {
-        Wh_Log(L"Successfully hooked IconView::OnViewModelChanged for XAML container stabilization");
-    }
-
-    Wh_Log(L"Successfully hooked SystemTray volume symbols");
-    return true;
+    return WindhawkUtils::HookSymbols(module, systemTrayDllHooks, ARRAYSIZE(systemTrayDllHooks));
 }
 
 static HMODULE GetSystemTrayModuleHandle() {
@@ -1151,8 +820,8 @@ using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 static LoadLibraryExW_t LoadLibraryExW_Original = nullptr;
 
 static HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
-                                         HANDLE hFile,
-                                         DWORD dwFlags) {
+                                          HANDLE hFile,
+                                          DWORD dwFlags) {
     HMODULE hModule = LoadLibraryExW_Original(lpLibFileName, hFile, dwFlags);
     if (!hModule || ((ULONG_PTR)hModule & 3)) {
         return hModule;
@@ -1191,59 +860,49 @@ static HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
 }
 
 // ---------------------------------------------------------------------------
-// Settings & lifecycle
+// Settings & Lifecycle
 // ---------------------------------------------------------------------------
 
 static void LoadSettings() {
     Settings newSettings;
 
     auto displayStyleSetting = WindhawkUtils::StringSetting::make(L"displayStyle");
-    PCWSTR displayStyleStr = displayStyleSetting.get();
-    if (displayStyleStr) {
-        if (wcscmp(displayStyleStr, L"vanilla") == 0 ||
-            wcscmp(displayStyleStr, L"default") == 0 ||
-            wcscmp(displayStyleStr, L"vanillaOnly") == 0) {
-            newSettings.displayStyle = DisplayStyle::Vanilla;
-        } else if (wcscmp(displayStyleStr, L"number") == 0 ||
-                   wcscmp(displayStyleStr, L"numberOnly") == 0) {
+    if (displayStyleSetting.get()) {
+        if (wcscmp(displayStyleSetting.get(), L"number") == 0) {
             newSettings.displayStyle = DisplayStyle::Number;
-        } else if (wcscmp(displayStyleStr, L"prefix") == 0 ||
-                   wcscmp(displayStyleStr, L"volPrefix") == 0) {
+        } else if (wcscmp(displayStyleSetting.get(), L"prefix") == 0) {
             newSettings.displayStyle = DisplayStyle::Prefix;
-        } else if (wcscmp(displayStyleStr, L"emoji") == 0 ||
-                   wcscmp(displayStyleStr, L"emojiAndPercent") == 0 ||
-                   wcscmp(displayStyleStr, L"iconAndPercent") == 0) {
+        } else if (wcscmp(displayStyleSetting.get(), L"emoji") == 0) {
             newSettings.displayStyle = DisplayStyle::Emoji;
+        } else if (wcscmp(displayStyleSetting.get(), L"vanilla") == 0) {
+            newSettings.displayStyle = DisplayStyle::Vanilla;
         } else {
             newSettings.displayStyle = DisplayStyle::Percentage;
         }
-    } else {
-        newSettings.displayStyle = DisplayStyle::Percentage;
     }
 
     newSettings.fixedContainerWidth = Wh_GetIntSetting(L"fixedContainerWidth");
 
-    auto prefixSetting = WindhawkUtils::StringSetting::make(L"customPrefix");
-    if (prefixSetting.get()) {
-        newSettings.customPrefix = prefixSetting.get();
+    auto customPrefixSetting = WindhawkUtils::StringSetting::make(L"customPrefix");
+    if (customPrefixSetting.get()) {
+        newSettings.customPrefix = customPrefixSetting.get();
     } else {
         newSettings.customPrefix = L"Vol ";
     }
 
     auto muteStyleSetting = WindhawkUtils::StringSetting::make(L"muteStyle");
-    PCWSTR muteStyleStr = muteStyleSetting.get();
-    if (muteStyleStr) {
-        if (wcscmp(muteStyleStr, L"mute") == 0) {
+    if (muteStyleSetting.get()) {
+        if (wcscmp(muteStyleSetting.get(), L"mute") == 0) {
             newSettings.muteStyle = MuteStyle::Mute;
-        } else if (wcscmp(muteStyleStr, L"zero") == 0) {
+        } else if (wcscmp(muteStyleSetting.get(), L"zero") == 0) {
             newSettings.muteStyle = MuteStyle::Zero;
-        } else if (wcscmp(muteStyleStr, L"cross") == 0) {
+        } else if (wcscmp(muteStyleSetting.get(), L"cross") == 0) {
             newSettings.muteStyle = MuteStyle::Cross;
-        } else if (wcscmp(muteStyleStr, L"emoji") == 0) {
+        } else if (wcscmp(muteStyleSetting.get(), L"emoji") == 0) {
             newSettings.muteStyle = MuteStyle::Emoji;
-        } else if (wcscmp(muteStyleStr, L"glyph") == 0) {
+        } else if (wcscmp(muteStyleSetting.get(), L"glyph") == 0) {
             newSettings.muteStyle = MuteStyle::Glyph;
-        } else if (wcscmp(muteStyleStr, L"custom") == 0) {
+        } else if (wcscmp(muteStyleSetting.get(), L"custom") == 0) {
             newSettings.muteStyle = MuteStyle::Custom;
         } else {
             newSettings.muteStyle = MuteStyle::Mut;
@@ -1262,6 +921,145 @@ static void LoadSettings() {
     {
         std::lock_guard<std::mutex> lock(g_settingsMutex);
         g_settings = std::move(newSettings);
+    }
+}
+
+static void WINAPI BeforeUninitOnUIThread(void* /*parameter*/) {
+    if (auto iconView = g_volumeIconViewWeak.get()) {
+        iconView.MinWidth(0.0);
+    }
+    g_volumeIconViewWeak = nullptr;
+    g_lastAppliedIconViewWidth.store(-1.0, std::memory_order_relaxed);
+
+    void* dataModel = nullptr;
+    float vol = 0.0f;
+    bool muted = false;
+    {
+        std::lock_guard<std::mutex> lock(g_dataModelMutex);
+        dataModel = g_pVolumeDataModel;
+        vol = g_lastVolumeLevel;
+        muted = g_lastIsMuted;
+        g_pVolumeDataModel = nullptr;
+    }
+
+    if (dataModel) {
+        wchar_t defaultGlyph = muted ? GLYPH_MUTE : GLYPH_VOL_3;
+        if (!muted) {
+            int percentage = static_cast<int>(std::round(vol * 100.0f));
+            if (percentage <= 0)
+                defaultGlyph = GLYPH_VOL_0;
+            else if (percentage < 33)
+                defaultGlyph = GLYPH_VOL_1;
+            else if (percentage < 66)
+                defaultGlyph = GLYPH_VOL_2;
+            else
+                defaultGlyph = GLYPH_VOL_3;
+        }
+        std::wstring restoreStr(1, defaultGlyph);
+        size_t offset = g_iconTextOffset.load(std::memory_order_relaxed);
+        HSTRING* ppHString = reinterpret_cast<HSTRING*>(reinterpret_cast<char*>(dataModel) + offset);
+        HSTRING oldHString = *ppHString;
+        HSTRING newHString = nullptr;
+        if (SUCCEEDED(WindowsCreateString(restoreStr.c_str(), 1, &newHString))) {
+            *ppHString = newHString;
+            if (oldHString) {
+                WindowsDeleteString(oldHString);
+            }
+        }
+
+        if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
+            std::wstring_view propName = L"CurrentData";
+            VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(dataModel, &propName);
+        }
+    }
+}
+
+void Wh_ModBeforeUninit() {
+    Wh_Log(L"Preparing mod unload, restoring native icon and container size");
+
+    g_unloading = true;
+
+    HWND hTaskbarWnd = FindCurrentProcessTaskbarWnd();
+    if (hTaskbarWnd) {
+        RunFromWindowThread(hTaskbarWnd, BeforeUninitOnUIThread, nullptr);
+    } else {
+        std::lock_guard<std::mutex> lock(g_dataModelMutex);
+        g_pVolumeDataModel = nullptr;
+    }
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L"Uninitializing Taskbar Volume Percentage Indicator mod");
+}
+
+static void WINAPI SettingsChangedOnUIThread(void* /*parameter*/) {
+    if (auto iconView = g_volumeIconViewWeak.get()) {
+        ApplyVolumeContainerWidth(iconView);
+    }
+
+    void* dataModel = nullptr;
+    float vol = 0.0f;
+    bool muted = false;
+    {
+        std::lock_guard<std::mutex> lock(g_dataModelMutex);
+        dataModel = g_pVolumeDataModel;
+        vol = g_lastVolumeLevel;
+        muted = g_lastIsMuted;
+    }
+
+    if (dataModel && !g_unloading.load(std::memory_order_relaxed)) {
+        Settings settingsCopy;
+        {
+            std::lock_guard<std::mutex> lock(g_settingsMutex);
+            settingsCopy = g_settings;
+        }
+
+        if (settingsCopy.displayStyle == DisplayStyle::Vanilla) {
+            wchar_t defaultGlyph = muted ? GLYPH_MUTE : GLYPH_VOL_3;
+            if (!muted) {
+                int percentage = static_cast<int>(std::round(vol * 100.0f));
+                if (percentage <= 0)
+                    defaultGlyph = GLYPH_VOL_0;
+                else if (percentage < 33)
+                    defaultGlyph = GLYPH_VOL_1;
+                else if (percentage < 66)
+                    defaultGlyph = GLYPH_VOL_2;
+                else
+                    defaultGlyph = GLYPH_VOL_3;
+            }
+            std::wstring restoreStr(1, defaultGlyph);
+            size_t offset = g_iconTextOffset.load(std::memory_order_relaxed);
+            HSTRING* ppHString = reinterpret_cast<HSTRING*>(reinterpret_cast<char*>(dataModel) + offset);
+            HSTRING oldHString = *ppHString;
+            HSTRING newHString = nullptr;
+            if (SUCCEEDED(WindowsCreateString(restoreStr.c_str(), 1, &newHString))) {
+                *ppHString = newHString;
+                if (oldHString) {
+                    WindowsDeleteString(oldHString);
+                }
+            }
+        } else {
+            ApplyCustomVolumeText(dataModel, vol, muted);
+        }
+
+        if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
+            std::wstring_view propName = L"CurrentData";
+            VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(dataModel, &propName);
+        }
+    }
+}
+
+void Wh_ModSettingsChanged() {
+    Wh_Log(L"Settings changed, reloading...");
+    LoadSettings();
+
+    if (g_unloading.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    HWND hTaskbarWnd = FindCurrentProcessTaskbarWnd();
+    if (hTaskbarWnd) {
+        RunFromWindowThread(hTaskbarWnd, SettingsChangedOnUIThread, nullptr);
     }
 }
 
@@ -1310,129 +1108,5 @@ void Wh_ModAfterInit() {
                 }
             }
         }
-    }
-}
-
-static void BeforeUninitOnUIThread(void* /*parameter*/) {
-    // Reset TextIconContent width to natural vanilla width (0.0)
-    {
-        std::lock_guard<std::mutex> lock(g_textIconMutex);
-        if (g_pVolumeTextIcon) {
-            ApplyElementMinWidth(g_pVolumeTextIcon, 0.0);
-            g_pVolumeTextIcon = nullptr;
-        }
-        g_lastAppliedTextIconWidth.store(-1.0, std::memory_order_relaxed);
-    }
-
-    // Reset IconView container width to natural vanilla width (0.0)
-    {
-        std::lock_guard<std::mutex> lock(g_iconViewMutex);
-        if (g_pVolumeIconView) {
-            ApplyElementMinWidth(g_pVolumeIconView, 0.0);
-            if (IsValidReadableMemory(reinterpret_cast<const char*>(g_pVolumeIconView) + 0x1b0, sizeof(void*))) {
-                void* pHostedContent = *reinterpret_cast<void**>(reinterpret_cast<char*>(g_pVolumeIconView) + 0x1b0);
-                if (IsValidComObject(pHostedContent)) {
-                    ApplyElementMinWidth(pHostedContent, 0.0);
-                }
-            }
-            g_pVolumeIconView = nullptr;
-        }
-        g_lastAppliedIconViewWidth.store(-1.0, std::memory_order_relaxed);
-    }
-
-    std::lock_guard<std::mutex> lock(g_dataModelMutex);
-    if (g_pVolumeDataModel && IsValidUserPointer(g_pVolumeDataModel)) {
-        size_t offset = GetIconTextOffset(g_pVolumeDataModel);
-        if (offset != 0) {
-            wchar_t defaultGlyph = g_lastIsMuted ? GLYPH_MUTE : GLYPH_VOL_3;
-            std::wstring restoreStr(1, defaultGlyph);
-
-            shared_hstring_header** ppHeader = reinterpret_cast<shared_hstring_header**>(
-                reinterpret_cast<char*>(g_pVolumeDataModel) + offset);
-
-            shared_hstring_header* oldHeader = *ppHeader;
-            shared_hstring_header* newHeader = CreateSharedHString(restoreStr);
-            if (newHeader) {
-                *ppHeader = newHeader;
-                if (oldHeader && oldHeader != newHeader) {
-                    ReleaseSharedHString(oldHeader);
-                }
-            }
-
-            if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
-                std::wstring_view propName = L"CurrentData";
-                VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(g_pVolumeDataModel, &propName);
-            }
-        }
-    }
-    g_pVolumeDataModel = nullptr;
-}
-
-void Wh_ModBeforeUninit() {
-    Wh_Log(L"Preparing mod unload, restoring native icon and container size");
-
-    g_unloading = true;
-
-    HWND hTaskbarWnd = FindCurrentProcessTaskbarWnd();
-    if (hTaskbarWnd) {
-        RunFromWindowThread(hTaskbarWnd, BeforeUninitOnUIThread, nullptr);
-    } else {
-        std::lock_guard<std::mutex> lock(g_dataModelMutex);
-        g_pVolumeDataModel = nullptr;
-    }
-}
-
-void Wh_ModUninit() {
-    Wh_Log(L"Uninitializing Taskbar Volume Percentage Indicator mod");
-}
-
-static void SettingsChangedOnUIThread(void* /*parameter*/) {
-    Settings settingsCopy;
-    {
-        std::lock_guard<std::mutex> lock(g_settingsMutex);
-        settingsCopy = g_settings;
-    }
-
-    double targetWidth = GetTargetContainerWidth(settingsCopy);
-
-    // Apply width to TextIconContent
-    {
-        std::lock_guard<std::mutex> lock(g_textIconMutex);
-        if (g_pVolumeTextIcon && !g_unloading.load(std::memory_order_relaxed)) {
-            g_lastAppliedTextIconWidth.store(targetWidth, std::memory_order_relaxed);
-            ApplyElementMinWidth(g_pVolumeTextIcon, targetWidth);
-        }
-    }
-
-    // Apply width to IconView if captured
-    {
-        std::lock_guard<std::mutex> lock(g_iconViewMutex);
-        if (g_pVolumeIconView && !g_unloading.load(std::memory_order_relaxed)) {
-            g_lastAppliedIconViewWidth.store(targetWidth, std::memory_order_relaxed);
-            ApplyVolumeContainerWidth(g_pVolumeIconView);
-        }
-    }
-
-    std::lock_guard<std::mutex> lock(g_dataModelMutex);
-    if (g_pVolumeDataModel && !g_unloading.load(std::memory_order_relaxed)) {
-        ApplyCustomVolumeText(g_pVolumeDataModel, g_lastVolumeLevel, g_lastIsMuted);
-        if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
-            std::wstring_view propName = L"CurrentData";
-            VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(g_pVolumeDataModel, &propName);
-        }
-    }
-}
-
-void Wh_ModSettingsChanged() {
-    Wh_Log(L"Settings changed, reloading...");
-    LoadSettings();
-
-    if (g_unloading.load(std::memory_order_relaxed)) {
-        return;
-    }
-
-    HWND hTaskbarWnd = FindCurrentProcessTaskbarWnd();
-    if (hTaskbarWnd) {
-        RunFromWindowThread(hTaskbarWnd, SettingsChangedOnUIThread, nullptr);
     }
 }

--- a/mods/taskbar-volume-percentage.wh.cpp
+++ b/mods/taskbar-volume-percentage.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-volume-percentage
 // @name            Taskbar Volume Percentage Indicator
 // @description     Displays the exact master volume percentage in the system tray natively inside the Windows 11 volume button with real-time sync.
-// @version         1.3.0
+// @version         1.3.1
 // @author          gilnett
 // @github          https://github.com/gilnett
 // @include         explorer.exe
@@ -20,7 +20,7 @@ Replaces the Windows 11 taskbar volume icon with the current volume level in rea
 
 - **Display styles**: Percentage (`50%`), number only (`50`), custom prefix (`Vol 50%`), emoji (`🔊 50%`), or default icon.
 - **Mute indicator**: Customizable mute display (`MUT`, `Mute`, `0%`, `✕`, `🔇`, or native glyph).
-- **Zero-Jitter Structural Stabilization**: Locks the XAML container minimum width (`IFrameworkElement::put_MinWidth`) to prevent neighboring system tray icons from shifting during volume changes.
+- **Zero-Jitter Structural Stabilization**: Locks the XAML container width and measure override (`TextIconContent::MeasureOverride` & `IFrameworkElement::put_MinWidth`) to eliminate layout jitter during volume changes without needing artificial padding.
 
 ## Credits
 
@@ -39,13 +39,6 @@ Replaces the Windows 11 taskbar volume icon with the current volume level in rea
     - prefix: Prefix and Percentage (e.g. Vol 50%)
     - emoji: Icon and Percentage (e.g. 🔊 50%)
     - vanilla: Windows Default (exact vanilla Windows speaker icon)
-- padStyle: none
-  $name: Number Padding
-  $description: Format padding to minimize icon movement during volume changes.
-  $options:
-    - none: No Padding (e.g. 50%)
-    - space: Space Padded (e.g. " 50%")
-    - zero: Zero Padded (e.g. 050%)
 - fixedContainerWidth: 0
   $name: Fixed Container Width
   $description: Minimum width in pixels for the volume container to eliminate layout jitter. Set to 0 for automatic optimal width based on style (e.g. 42 for percentage), or enter a custom width (e.g. 42). Set to -1 to disable.
@@ -138,12 +131,6 @@ enum class DisplayStyle {
     Vanilla,
 };
 
-enum class PadStyle {
-    None,
-    Space,
-    Zero,
-};
-
 enum class MuteStyle {
     Mut,
     Mute,
@@ -156,7 +143,6 @@ enum class MuteStyle {
 
 struct Settings {
     DisplayStyle displayStyle;
-    PadStyle padStyle;
     int fixedContainerWidth;
     std::wstring customPrefix;
     MuteStyle muteStyle;
@@ -180,6 +166,9 @@ static std::mutex g_dataModelMutex;
 
 static void* g_pVolumeIconView = nullptr;
 static std::mutex g_iconViewMutex;
+
+static void* g_pVolumeTextIcon = nullptr;
+static std::mutex g_textIconMutex;
 
 static std::atomic<bool> g_unloading{false};
 static std::atomic<bool> g_systemTrayModuleHooked{false};
@@ -238,6 +227,11 @@ struct IFrameworkElementCustom {
     IFrameworkElementVtbl* lpVtbl;
 };
 
+struct WinRTSize {
+    float Width;
+    float Height;
+};
+
 static double GetTargetContainerWidth(const Settings& settings) {
     if (settings.fixedContainerWidth < 0) {
         return 0.0; // Disabled
@@ -261,6 +255,33 @@ static double GetTargetContainerWidth(const Settings& settings) {
     }
 }
 
+static void ApplyElementMinWidth(void* pElement, double minWidth) {
+    if (!IsValidUserPointer(pElement)) {
+        return;
+    }
+
+    // 1. QueryInterface directly on pElement
+    IUnknown* pUnk = reinterpret_cast<IUnknown*>(pElement);
+    void* pFEVoid = nullptr;
+    if (SUCCEEDED(pUnk->QueryInterface(IID_IFrameworkElement, &pFEVoid)) && pFEVoid) {
+        IFrameworkElementCustom* pFE = reinterpret_cast<IFrameworkElementCustom*>(pFEVoid);
+        pFE->lpVtbl->put_MinWidth(pFE, minWidth);
+        pFE->lpVtbl->Release(pFE);
+    }
+
+    // 2. Also check inner composable XAML object at offset +8 (for aggregated controls)
+    void* pInner = *reinterpret_cast<void**>(reinterpret_cast<char*>(pElement) + 8);
+    if (IsValidUserPointer(pInner)) {
+        void* pInnerFEVoid = nullptr;
+        IUnknown* pInnerUnk = reinterpret_cast<IUnknown*>(pInner);
+        if (SUCCEEDED(pInnerUnk->QueryInterface(IID_IFrameworkElement, &pInnerFEVoid)) && pInnerFEVoid) {
+            IFrameworkElementCustom* pInnerFE = reinterpret_cast<IFrameworkElementCustom*>(pInnerFEVoid);
+            pInnerFE->lpVtbl->put_MinWidth(pInnerFE, minWidth);
+            pInnerFE->lpVtbl->Release(pInnerFE);
+        }
+    }
+}
+
 static void ApplyVolumeContainerWidth(void* pIconView) {
     if (!IsValidUserPointer(pIconView) || g_unloading.load(std::memory_order_relaxed)) {
         return;
@@ -275,25 +296,13 @@ static void ApplyVolumeContainerWidth(void* pIconView) {
     double targetWidth = GetTargetContainerWidth(settingsCopy);
 
     // Apply put_MinWidth on the IconView FrameworkElement
-    IUnknown* pUnk = reinterpret_cast<IUnknown*>(pIconView);
-    void* pFEVoid = nullptr;
-    if (SUCCEEDED(pUnk->QueryInterface(IID_IFrameworkElement, &pFEVoid)) && pFEVoid) {
-        IFrameworkElementCustom* pFE = reinterpret_cast<IFrameworkElementCustom*>(pFEVoid);
-        pFE->lpVtbl->put_MinWidth(pFE, targetWidth);
-        pFE->lpVtbl->Release(pFE);
-    }
+    ApplyElementMinWidth(pIconView, targetWidth);
 
     // Also apply put_MinWidth on the hosted content element (Grid / TextIconContent) if present
     if (targetWidth > 0.0) {
         void* pHostedContent = *reinterpret_cast<void**>(reinterpret_cast<char*>(pIconView) + 0x1b0);
         if (IsValidUserPointer(pHostedContent)) {
-            void* pHostedFEVoid = nullptr;
-            IUnknown* pHostedUnk = reinterpret_cast<IUnknown*>(pHostedContent);
-            if (SUCCEEDED(pHostedUnk->QueryInterface(IID_IFrameworkElement, &pHostedFEVoid)) && pHostedFEVoid) {
-                IFrameworkElementCustom* pHostedFE = reinterpret_cast<IFrameworkElementCustom*>(pHostedFEVoid);
-                pHostedFE->lpVtbl->put_MinWidth(pHostedFE, targetWidth);
-                pHostedFE->lpVtbl->Release(pHostedFE);
-            }
+            ApplyElementMinWidth(pHostedContent, targetWidth);
         }
     }
 }
@@ -366,30 +375,59 @@ static bool IsVolumeIconViewModel(void* pIconViewModel) {
     return isVolume;
 }
 
+static bool IsVolumeTextIcon(void* pThis) {
+    if (!IsValidUserPointer(pThis)) {
+        return false;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_textIconMutex);
+        if (g_pVolumeTextIcon == pThis) {
+            return true;
+        }
+    }
+
+    // Check ViewModel at offsets 0x80 and 0x68
+    const size_t vmOffsets[] = { 0x80, 0x68 };
+    for (size_t offset : vmOffsets) {
+        void* pVM = *reinterpret_cast<void**>(reinterpret_cast<char*>(pThis) + offset);
+        if (IsValidUserPointer(pVM)) {
+            // 1. Direct GUID check at offset 0x38 in ViewModel
+            const GUID* pGuid = reinterpret_cast<const GUID*>(reinterpret_cast<const char*>(pVM) + 0x38);
+            if (memcmp(pGuid, &GUID_VolumeIcon, sizeof(GUID)) == 0) {
+                return true;
+            }
+
+            // 2. Check via slot 6 (ITextIconContentViewModel::get_Id)
+            void** vtbl = *reinterpret_cast<void***>(pVM);
+            if (IsValidUserPointer(vtbl) && IsValidUserPointer(reinterpret_cast<void*>(vtbl[6]))) {
+                using get_Id_t = HRESULT(STDMETHODCALLTYPE*)(void* This, GUID* pGuidOut);
+                auto get_Id = reinterpret_cast<get_Id_t>(vtbl[6]);
+                GUID id = {};
+                if (SUCCEEDED(get_Id(pVM, &id)) && memcmp(&id, &GUID_VolumeIcon, sizeof(GUID)) == 0) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
 // ---------------------------------------------------------------------------
 // Formatting logic
 // ---------------------------------------------------------------------------
 
-static std::wstring FormatDigits(int percentage, PadStyle padStyle) {
-    std::wstring s = std::to_wstring(percentage);
-    if (padStyle == PadStyle::None) {
-        return s;
-    }
-
-    constexpr size_t kTotalDigits = 3;
-    if (s.length() < kTotalDigits) {
-        wchar_t padChar = (padStyle == PadStyle::Zero) ? L'0' : L' ';
-        s.insert(0, kTotalDigits - s.length(), padChar);
-    }
-    return s;
+static inline std::wstring FormatDigits(int percentage) {
+    return std::to_wstring(percentage);
 }
 
-static std::wstring FormatMuteString(MuteStyle style, const std::wstring& customText, PadStyle padStyle) {
+static std::wstring FormatMuteString(MuteStyle style, const std::wstring& customText) {
     switch (style) {
         case MuteStyle::Mute:
             return L"Mute";
         case MuteStyle::Zero:
-            return FormatDigits(0, padStyle) + L"%";
+            return L"0%";
         case MuteStyle::Cross:
             return L"\u2715";
         case MuteStyle::Emoji:
@@ -412,10 +450,10 @@ static std::wstring FormatVolumeText(int percentage, bool isMuted) {
     }
 
     if (isMuted && settingsCopy.displayStyle != DisplayStyle::Vanilla) {
-        return FormatMuteString(settingsCopy.muteStyle, settingsCopy.customMuteText, settingsCopy.padStyle);
+        return FormatMuteString(settingsCopy.muteStyle, settingsCopy.customMuteText);
     }
 
-    std::wstring s = FormatDigits(percentage, settingsCopy.padStyle);
+    std::wstring s = FormatDigits(percentage);
 
     switch (settingsCopy.displayStyle) {
         case DisplayStyle::Vanilla: {
@@ -657,7 +695,7 @@ static VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE hModule, UINT* puPtrLen) {
 }
 
 // ---------------------------------------------------------------------------
-// VolumeSystemTrayIconDataModel & IconView hooks
+// VolumeSystemTrayIconDataModel, IconView & TextIconContent hooks
 // ---------------------------------------------------------------------------
 
 using VolumeSystemTrayIconDataModel_UpdateVolume_t = void(__cdecl*)(
@@ -682,6 +720,11 @@ using IconView_UpdateHostedContent_t = void(__cdecl*)(void* pThis);
 static IconView_UpdateHostedContent_t
     IconView_UpdateHostedContent_Original = nullptr;
 
+using TextIconContent_MeasureOverride_t = WinRTSize*(__cdecl*)(
+    void* pThis, WinRTSize* pResult, WinRTSize availableSize);
+static TextIconContent_MeasureOverride_t
+    TextIconContent_MeasureOverride_Original = nullptr;
+
 static void __cdecl VolumeSystemTrayIconDataModel_dtor_Hook(void* pThis) {
     {
         std::lock_guard<std::mutex> lock(g_dataModelMutex);
@@ -692,6 +735,10 @@ static void __cdecl VolumeSystemTrayIconDataModel_dtor_Hook(void* pThis) {
     {
         std::lock_guard<std::mutex> lock(g_iconViewMutex);
         g_pVolumeIconView = nullptr;
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_textIconMutex);
+        g_pVolumeTextIcon = nullptr;
     }
     if (VolumeSystemTrayIconDataModel_dtor_Original) {
         VolumeSystemTrayIconDataModel_dtor_Original(pThis);
@@ -741,6 +788,18 @@ static void __cdecl VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
             ApplyVolumeContainerWidth(g_pVolumeIconView);
         }
     }
+    {
+        std::lock_guard<std::mutex> lock(g_textIconMutex);
+        if (g_pVolumeTextIcon) {
+            Settings settingsCopy;
+            {
+                std::lock_guard<std::mutex> lockSettings(g_settingsMutex);
+                settingsCopy = g_settings;
+            }
+            double targetWidth = GetTargetContainerWidth(settingsCopy);
+            ApplyElementMinWidth(g_pVolumeTextIcon, targetWidth);
+        }
+    }
 
     // Trigger UI redraw via CurrentData property notification with recursion guard
     if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
@@ -749,6 +808,37 @@ static void __cdecl VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
         VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(pThis, &propName);
         s_inHook = false;
     }
+}
+
+static WinRTSize* __cdecl TextIconContent_MeasureOverride_Hook(
+    void* pThis, WinRTSize* pResult, WinRTSize availableSize) {
+    WinRTSize* res = TextIconContent_MeasureOverride_Original(pThis, pResult, availableSize);
+
+    if (res && !g_unloading.load(std::memory_order_relaxed)) {
+        if (IsVolumeTextIcon(pThis)) {
+            {
+                std::lock_guard<std::mutex> lock(g_textIconMutex);
+                g_pVolumeTextIcon = pThis;
+            }
+
+            Settings settingsCopy;
+            {
+                std::lock_guard<std::mutex> lock(g_settingsMutex);
+                settingsCopy = g_settings;
+            }
+
+            double targetWidth = GetTargetContainerWidth(settingsCopy);
+            if (targetWidth > 0.0) {
+                float targetWidthF = static_cast<float>(targetWidth);
+                if (res->Width < targetWidthF) {
+                    res->Width = targetWidthF;
+                }
+                ApplyElementMinWidth(pThis, targetWidth);
+            }
+        }
+    }
+
+    return res;
 }
 
 static void __cdecl IconView_OnViewModelChanged_Hook(void* pThis, void* pIconViewModel) {
@@ -787,7 +877,6 @@ static void __cdecl IconView_UpdateHostedContent_Hook(void* pThis) {
     }
 
     if (!isVolume) {
-        // If g_pVolumeIconView was not yet captured, check IconView + 0x78 (IconViewModel)
         void* pVM = *reinterpret_cast<void**>(reinterpret_cast<char*>(pThis) + 0x78);
         if (pVM && IsVolumeIconViewModel(pVM)) {
             {
@@ -844,6 +933,16 @@ static bool HookSystemTraySymbols(HMODULE module) {
         },
         {
             {
+                LR"(public: struct winrt::Windows::Foundation::Size __cdecl winrt::SystemTray::implementation::TextIconContent::MeasureOverride(struct winrt::Windows::Foundation::Size))",
+                LR"(public: struct winrt::Windows::Foundation::Size __cdecl winrt::SystemTray::implementation::TextIconContent::MeasureOverride(struct winrt::Windows::Foundation::Size) __ptr64)",
+                LR"(winrt::SystemTray::implementation::TextIconContent::MeasureOverride)",
+            },
+            reinterpret_cast<void**>(&TextIconContent_MeasureOverride_Original),
+            reinterpret_cast<void*>(TextIconContent_MeasureOverride_Hook),
+            true,
+        },
+        {
+            {
                 LR"(private: void __cdecl winrt::SystemTray::implementation::IconView::OnViewModelChanged(struct winrt::SystemTray::IconViewModel const &))",
                 LR"(private: void __cdecl winrt::SystemTray::implementation::IconView::OnViewModelChanged(struct winrt::SystemTray::IconViewModel const & __ptr64) __ptr64)",
                 LR"(?OnViewModelChanged@IconView@implementation@SystemTray@winrt@@AEAAXAEBUIconViewModel@34@@Z)",
@@ -873,6 +972,10 @@ static bool HookSystemTraySymbols(HMODULE module) {
 
     if (!VolumeSystemTrayIconDataModel_dtor_Original) {
         Wh_Log(L"Warning: VolumeSystemTrayIconDataModel destructor symbol could not be hooked; lifetime tracking will rely on validity checks");
+    }
+
+    if (TextIconContent_MeasureOverride_Original) {
+        Wh_Log(L"Successfully hooked TextIconContent::MeasureOverride for dynamic container width stabilization");
     }
 
     if (IconView_OnViewModelChanged_Original) {
@@ -973,20 +1076,6 @@ static void LoadSettings() {
         newSettings.displayStyle = DisplayStyle::Percentage;
     }
 
-    auto padStyleSetting = WindhawkUtils::StringSetting::make(L"padStyle");
-    PCWSTR padStyleStr = padStyleSetting.get();
-    if (padStyleStr) {
-        if (wcscmp(padStyleStr, L"zero") == 0) {
-            newSettings.padStyle = PadStyle::Zero;
-        } else if (wcscmp(padStyleStr, L"space") == 0) {
-            newSettings.padStyle = PadStyle::Space;
-        } else {
-            newSettings.padStyle = PadStyle::None;
-        }
-    } else {
-        newSettings.padStyle = PadStyle::None;
-    }
-
     newSettings.fixedContainerWidth = Wh_GetIntSetting(L"fixedContainerWidth");
 
     auto prefixSetting = WindhawkUtils::StringSetting::make(L"customPrefix");
@@ -1080,26 +1169,23 @@ void Wh_ModAfterInit() {
 }
 
 static void BeforeUninitOnUIThread(void* /*parameter*/) {
-    // Reset XAML container width to natural vanilla width (0.0)
+    // Reset TextIconContent width to natural vanilla width (0.0)
+    {
+        std::lock_guard<std::mutex> lock(g_textIconMutex);
+        if (g_pVolumeTextIcon) {
+            ApplyElementMinWidth(g_pVolumeTextIcon, 0.0);
+            g_pVolumeTextIcon = nullptr;
+        }
+    }
+
+    // Reset IconView container width to natural vanilla width (0.0)
     {
         std::lock_guard<std::mutex> lock(g_iconViewMutex);
         if (g_pVolumeIconView) {
-            IUnknown* pUnk = reinterpret_cast<IUnknown*>(g_pVolumeIconView);
-            void* pFEVoid = nullptr;
-            if (SUCCEEDED(pUnk->QueryInterface(IID_IFrameworkElement, &pFEVoid)) && pFEVoid) {
-                IFrameworkElementCustom* pFE = reinterpret_cast<IFrameworkElementCustom*>(pFEVoid);
-                pFE->lpVtbl->put_MinWidth(pFE, 0.0);
-                pFE->lpVtbl->Release(pFE);
-            }
+            ApplyElementMinWidth(g_pVolumeIconView, 0.0);
             void* pHostedContent = *reinterpret_cast<void**>(reinterpret_cast<char*>(g_pVolumeIconView) + 0x1b0);
             if (IsValidUserPointer(pHostedContent)) {
-                void* pHostedFEVoid = nullptr;
-                IUnknown* pHostedUnk = reinterpret_cast<IUnknown*>(pHostedContent);
-                if (SUCCEEDED(pHostedUnk->QueryInterface(IID_IFrameworkElement, &pHostedFEVoid)) && pHostedFEVoid) {
-                    IFrameworkElementCustom* pHostedFE = reinterpret_cast<IFrameworkElementCustom*>(pHostedFEVoid);
-                    pHostedFE->lpVtbl->put_MinWidth(pHostedFE, 0.0);
-                    pHostedFE->lpVtbl->Release(pHostedFE);
-                }
+                ApplyElementMinWidth(pHostedContent, 0.0);
             }
             g_pVolumeIconView = nullptr;
         }
@@ -1152,6 +1238,23 @@ void Wh_ModUninit() {
 }
 
 static void SettingsChangedOnUIThread(void* /*parameter*/) {
+    Settings settingsCopy;
+    {
+        std::lock_guard<std::mutex> lock(g_settingsMutex);
+        settingsCopy = g_settings;
+    }
+
+    double targetWidth = GetTargetContainerWidth(settingsCopy);
+
+    // Apply width to TextIconContent
+    {
+        std::lock_guard<std::mutex> lock(g_textIconMutex);
+        if (g_pVolumeTextIcon && !g_unloading.load(std::memory_order_relaxed)) {
+            ApplyElementMinWidth(g_pVolumeTextIcon, targetWidth);
+        }
+    }
+
+    // Apply width to IconView if captured
     {
         std::lock_guard<std::mutex> lock(g_iconViewMutex);
         if (g_pVolumeIconView && !g_unloading.load(std::memory_order_relaxed)) {

--- a/mods/taskbar-volume-percentage.wh.cpp
+++ b/mods/taskbar-volume-percentage.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-volume-percentage
 // @name            Taskbar Volume Percentage Indicator
 // @description     Displays the exact master volume percentage in the system tray natively inside the Windows 11 volume button with real-time sync.
-// @version         1.3.2
+// @version         1.3.5
 // @author          gilnett
 // @github          https://github.com/gilnett
 // @include         explorer.exe
@@ -14,14 +14,13 @@
 /*
 # Taskbar Volume Percentage Indicator
 
-Replaces the Windows 11 taskbar volume icon with the current volume level in real time.
+Replaces the default Windows 11 taskbar volume icon with the current volume level in real time directly inside the system tray button.
 
-## Features
+## How It Works
 
-- **Display styles**: Percentage (`50%`), number only (`50`), custom prefix (`Vol 50%`), emoji (`🔊 50%`), or default icon.
-- **Mute indicator**: Customizable mute display (`MUT`, `Mute`, `0%`, `✕`, `🔇`, or native glyph).
-- **Zero-Jitter Structural Stabilization**: Locks the XAML container width and measure override (`TextIconContent::MeasureOverride` & `IFrameworkElement::put_MinWidth`) to eliminate layout jitter during volume changes without needing artificial padding.
-- **Robust Memory Validation**: Guards all WinRT visual tree inspections with multi-tier page commitment and COM vtable verification, preventing memory corruption or dangling pointer access.
+- **Real-Time Volume Display**: Displays the current master audio level as a percentage (`50%`), pure number (`50`), with a custom prefix (`Vol 50%`), with an emoji (`🔊 50%`), or using the default Windows speaker icon.
+- **Mute Indicator**: When muted, automatically switches to a customizable mute display (`MUT`, `Mute`, `0%`, `✕`, `🔇`, native glyph, or custom text).
+- **Layout Stabilization**: Automatically sizes the container to fit the percentage text smoothly without shifting adjacent taskbar icons. A fixed container width can also be set manually in the settings.
 
 ## Credits
 
@@ -142,11 +141,11 @@ enum class MuteStyle {
 };
 
 struct Settings {
-    DisplayStyle displayStyle;
-    int fixedContainerWidth;
-    std::wstring customPrefix;
-    MuteStyle muteStyle;
-    std::wstring customMuteText;
+    DisplayStyle displayStyle{DisplayStyle::Percentage};
+    int fixedContainerWidth{0};
+    std::wstring customPrefix{L"Vol "};
+    MuteStyle muteStyle{MuteStyle::Mut};
+    std::wstring customMuteText{L"Mute"};
 };
 
 static Settings g_settings;
@@ -571,16 +570,36 @@ static size_t GetIconTextOffset(void* pThis) {
         if (h->flags > 1 || h->length > 256 || !h->ptr) {
             return false;
         }
+        if (!IsValidReadableMemory(h->ptr, sizeof(wchar_t))) {
+            return false;
+        }
         return true;
     };
 
-    // Primary offset in standard Windows 11 SystemTray builds is 0xB8
-    constexpr size_t defaultOffset = 0xB8;
-    if (IsValidReadableMemory(reinterpret_cast<const char*>(pThis) + defaultOffset, sizeof(void*))) {
-        shared_hstring_header* defaultCandidate = *reinterpret_cast<shared_hstring_header**>(
-            reinterpret_cast<char*>(pThis) + defaultOffset);
-        if (isValidHeader(defaultCandidate)) {
-            return defaultOffset;
+    auto matchesGlyphOrText = [&](shared_hstring_header* candidate) -> bool {
+        if (!isValidHeader(candidate)) {
+            return false;
+        }
+        // Read character from candidate->ptr, supporting both shared_hstring and HSTRING_REFERENCE
+        wchar_t firstChar = candidate->ptr[0];
+        return (firstChar >= 0xE700 && firstChar <= 0xE9FF) ||
+               (firstChar >= L'0' && firstChar <= L'9') ||
+               (firstChar >= L'a' && firstChar <= L'z') ||
+               (firstChar >= L'A' && firstChar <= L'Z') ||
+               firstChar == L' ' || firstChar == 0x2715 ||
+               firstChar == 0x2007 || firstChar == 0x00A0 ||
+               firstChar == 0xD83D;
+    };
+
+    // Primary offset in standard Windows 11 SystemTray builds is 0x90; fallback to 0xB8 and 0x88
+    const size_t preferredOffsets[] = { 0x90, 0xB8, 0x88 };
+    for (size_t prefOffset : preferredOffsets) {
+        if (IsValidReadableMemory(reinterpret_cast<const char*>(pThis) + prefOffset, sizeof(void*))) {
+            shared_hstring_header* candidate = *reinterpret_cast<shared_hstring_header**>(
+                reinterpret_cast<char*>(pThis) + prefOffset);
+            if (matchesGlyphOrText(candidate)) {
+                return prefOffset;
+            }
         }
     }
 
@@ -590,17 +609,8 @@ static size_t GetIconTextOffset(void* pThis) {
         }
         shared_hstring_header* candidate = *reinterpret_cast<shared_hstring_header**>(
             reinterpret_cast<char*>(pThis) + offset);
-        if (isValidHeader(candidate)) {
-            wchar_t firstChar = candidate->buffer[0];
-            if ((firstChar >= 0xE700 && firstChar <= 0xE9FF) ||
-                (firstChar >= L'0' && firstChar <= L'9') ||
-                (firstChar >= L'a' && firstChar <= L'z') ||
-                (firstChar >= L'A' && firstChar <= L'Z') ||
-                firstChar == L' ' || firstChar == 0x2715 ||
-                firstChar == 0x2007 || firstChar == 0x00A0 ||
-                firstChar == 0xD83D) {
-                return offset;
-            }
+        if (matchesGlyphOrText(candidate)) {
+            return offset;
         }
     }
 
@@ -836,38 +846,62 @@ static void __cdecl TextIconContent_dtor_Hook(void* pThis) {
     }
 }
 
+static void __cdecl VolumeSystemTrayIconDataModel_OnDataModelChanged_Hook(
+    void* pThis, const std::wstring_view* propertyName) {
+    static thread_local bool s_inOnDataModelChanged = false;
+
+    if (!s_inOnDataModelChanged && !g_unloading.load(std::memory_order_relaxed) &&
+        pThis && propertyName && *propertyName == L"CurrentData") {
+        float volumeLevel = 0.0f;
+        bool isMuted = false;
+        {
+            std::lock_guard<std::mutex> lock(g_dataModelMutex);
+            volumeLevel = g_lastVolumeLevel;
+            isMuted = g_lastIsMuted;
+            ApplyCustomVolumeText(pThis, volumeLevel, isMuted);
+        }
+    }
+
+    if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
+        s_inOnDataModelChanged = true;
+        VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(pThis, propertyName);
+        s_inOnDataModelChanged = false;
+    }
+}
+
 static void __cdecl VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
     void* pThis, float volumeLevel, bool isMuted, void* hstringIcon) {
     static thread_local bool s_inHook = false;
 
-    // Point 1: Always invoke the original Windows system function first without condition
+    if (g_unloading.load(std::memory_order_relaxed)) {
+        if (VolumeSystemTrayIconDataModel_UpdateVolume_Original) {
+            VolumeSystemTrayIconDataModel_UpdateVolume_Original(
+                pThis, volumeLevel, isMuted, hstringIcon);
+        }
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_dataModelMutex);
+        g_pVolumeDataModel = pThis;
+        g_lastVolumeLevel = volumeLevel;
+        g_lastIsMuted = isMuted;
+    }
+
+    // Always invoke the original Windows system function first
     if (VolumeSystemTrayIconDataModel_UpdateVolume_Original) {
         VolumeSystemTrayIconDataModel_UpdateVolume_Original(
             pThis, volumeLevel, isMuted, hstringIcon);
     }
 
-    if (s_inHook || g_unloading.load(std::memory_order_relaxed)) {
+    if (s_inHook) {
         return;
     }
 
-    bool changed = false;
+    // Ensure custom volume text is in place in case UpdateVolume_Original overwrote it
     {
         std::lock_guard<std::mutex> lock(g_dataModelMutex);
-        changed = !(g_pVolumeDataModel == pThis &&
-                    g_lastVolumeLevel == volumeLevel &&
-                    g_lastIsMuted == isMuted);
-        g_pVolumeDataModel = pThis;
-        g_lastVolumeLevel = volumeLevel;
-        g_lastIsMuted = isMuted;
-
-        if (changed) {
-            ApplyCustomVolumeText(pThis, volumeLevel, isMuted);
-        }
-    }
-
-    // Only skip our own redundant visual/layout updates when values have not changed
-    if (!changed) {
-        return;
+        ApplyCustomVolumeText(pThis, volumeLevel, isMuted);
     }
 
     // Ensure volume container width constraint is active on UI
@@ -1001,7 +1035,7 @@ static bool HookSystemTraySymbols(HMODULE module) {
                 LR"(winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::OnDataModelChanged)",
             },
             reinterpret_cast<void**>(&VolumeSystemTrayIconDataModel_OnDataModelChanged_Original),
-            nullptr, // Resolved for invocation only, not hooked
+            reinterpret_cast<void*>(VolumeSystemTrayIconDataModel_OnDataModelChanged_Hook),
             true,
         },
         {

--- a/mods/taskbar-volume-percentage.wh.cpp
+++ b/mods/taskbar-volume-percentage.wh.cpp
@@ -2,12 +2,12 @@
 // @id              taskbar-volume-percentage
 // @name            Taskbar Volume Percentage Indicator
 // @description     Displays the exact master volume percentage in the system tray natively inside the Windows 11 volume button with real-time sync.
-// @version         2.0.0
+// @version         1.1.0
 // @author          gilnett
 // @github          https://github.com/gilnett
 // @include         explorer.exe
-// @compilerOptions -lole32 -loleaut32 -lshlwapi
-// @license         MIT
+// @compilerOptions -lole32 -lshlwapi -lversion
+// @license         GPL-3.0
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -23,6 +23,24 @@ Displays the master volume percentage directly inside the Windows 11 system tray
 - **Prefix and Percentage**: Displays a custom prefix before the percentage (e.g. `Vol 50%`).
 - **Icon and Percentage**: Displays a speaker icon with the percentage (e.g. `🔊 50%`).
 - **Windows Default**: Displays the vanilla native Windows 11 speaker icon with volume waves.
+
+## Jitter Prevention (Padding)
+
+Stabilizes the button width and prevents adjacent tray icons (Wi-Fi, Battery, Clock) from shifting when the volume level changes between 1, 2, or 3 digits:
+- **None**: Standard variable width (e.g. `5%`, `50%`, `100%`).
+- **Zero-padded**: Fixed 2-digit format (e.g. `05%`, `50%`, `100%`).
+- **Space-padded**: Balanced space format (e.g. ` 5%`, `50%`, `100%`).
+
+## Mute Display Styles
+
+Choose how the muted state is represented:
+- **MUT**: Standard abbreviation (`MUT`).
+- **Mute**: Full word (`Mute`).
+- **0%**: Zero volume representation (`0%` / `00%`).
+- **✕**: Modern fine cross symbol (`✕`).
+- **🔇**: Mute speaker emoji (`🔇`).
+- **Native Glyph**: Windows 11 Segoe Fluent crossed-out speaker glyph.
+- **Custom Text**: Custom user-defined string.
 
 ## Credits
 
@@ -44,11 +62,33 @@ Displays the master volume percentage directly inside the Windows 11 system tray
 - customPrefix: "Vol "
   $name: Custom Prefix
   $description: Prefix text used when the display style is set to 'Prefix and Percentage'.
+- paddingMode: none
+  $name: Jitter Prevention (Padding)
+  $description: Stabilizes taskbar button width and prevents adjacent tray icons from shifting when volume changes between 1 and 2 digits.
+  $options:
+    - none: None (Standard width, e.g. 5%, 50%, 100%)
+    - zero: Zero-padded (Fixed 2 digits, e.g. 05%, 50%, 100%)
+    - space: Space-padded (Balanced space, e.g. ' 5%', '50%', '100%')
+- muteStyle: mut
+  $name: Mute Display Style
+  $description: Format shown when system master volume is muted.
+  $options:
+    - mut: MUT (Standard abbreviation)
+    - mute: Mute (Full word)
+    - zero: 0% (Zero volume display)
+    - cross: "✕ (Cross symbol)"
+    - emoji: "🔇 (Mute emoji)"
+    - glyph: Native Glyph (Segoe Fluent crossed-out speaker icon)
+    - custom: Custom Text (Uses text specified below)
+- customMuteText: "Mute"
+  $name: Custom Mute Text
+  $description: Custom string displayed when Mute Display Style is set to 'Custom Text'.
 */
 // ==/WindhawkModSettings==
 
 #include <windows.h>
 #include <shlwapi.h>
+#include <winver.h>
 #include <mmdeviceapi.h>
 #include <endpointvolume.h>
 
@@ -116,9 +156,28 @@ enum class DisplayStyle {
     Vanilla,
 };
 
+enum class PaddingMode {
+    None,
+    Zero,
+    Space,
+};
+
+enum class MuteStyle {
+    Mut,
+    Mute,
+    Zero,
+    Cross,
+    Emoji,
+    Glyph,
+    Custom,
+};
+
 struct ModSettings {
     DisplayStyle displayStyle;
     std::wstring customPrefix;
+    PaddingMode paddingMode;
+    MuteStyle muteStyle;
+    std::wstring customMuteText;
 };
 
 static ModSettings g_settings;
@@ -151,29 +210,70 @@ static wchar_t GetVanillaVolumeGlyph(int percentage, bool isMuted) {
 
 static std::wstring FormatVolumeText(int percentage, bool isMuted) {
     if (isMuted) {
-        switch (g_settings.displayStyle) {
-            case DisplayStyle::Vanilla:
-                return std::wstring(1, GLYPH_MUTE);
-            case DisplayStyle::Emoji:
-                return L"\xD83D\xDD07 MUT";
-            case DisplayStyle::Prefix:
-                return g_settings.customPrefix + L"MUT";
-            case DisplayStyle::Number:
-            case DisplayStyle::Percentage:
+        if (g_settings.displayStyle == DisplayStyle::Vanilla) {
+            return std::wstring(1, GLYPH_MUTE);
+        }
+
+        std::wstring muteText;
+        switch (g_settings.muteStyle) {
+            case MuteStyle::Mute:
+                muteText = L"Mute";
+                break;
+            case MuteStyle::Zero:
+                if (g_settings.displayStyle == DisplayStyle::Number) {
+                    muteText = (g_settings.paddingMode == PaddingMode::Zero) ? L"00" :
+                               ((g_settings.paddingMode == PaddingMode::Space) ? L" 0" : L"0");
+                } else {
+                    muteText = (g_settings.paddingMode == PaddingMode::Zero) ? L"00%" :
+                               ((g_settings.paddingMode == PaddingMode::Space) ? L" 0%" : L"0%");
+                }
+                break;
+            case MuteStyle::Cross:
+                muteText = L"\x2715"; // ✕
+                break;
+            case MuteStyle::Emoji:
+                muteText = L"\xD83D\xDD07"; // 🔇
+                break;
+            case MuteStyle::Glyph:
+                muteText = std::wstring(1, GLYPH_MUTE);
+                break;
+            case MuteStyle::Custom:
+                muteText = g_settings.customMuteText;
+                break;
+            case MuteStyle::Mut:
             default:
-                return L"MUT";
+                muteText = L"MUT";
+                break;
+        }
+
+        if (g_settings.displayStyle == DisplayStyle::Prefix) {
+            return g_settings.customPrefix + muteText;
+        }
+        if (g_settings.displayStyle == DisplayStyle::Emoji && g_settings.muteStyle != MuteStyle::Emoji) {
+            return L"\xD83D\xDD07 " + muteText;
+        }
+        return muteText;
+    }
+
+    if (g_settings.displayStyle == DisplayStyle::Vanilla) {
+        return std::wstring(1, GetVanillaVolumeGlyph(percentage, false));
+    }
+
+    std::wstring numStr = std::to_wstring(percentage);
+    if (percentage < 10) {
+        if (g_settings.paddingMode == PaddingMode::Zero) {
+            numStr = L"0" + numStr;
+        } else if (g_settings.paddingMode == PaddingMode::Space) {
+            numStr = L" " + numStr;
         }
     }
 
     switch (g_settings.displayStyle) {
-        case DisplayStyle::Vanilla:
-            return std::wstring(1, GetVanillaVolumeGlyph(percentage, false));
-
         case DisplayStyle::Number:
-            return std::to_wstring(percentage);
+            return numStr;
 
         case DisplayStyle::Prefix:
-            return g_settings.customPrefix + std::to_wstring(percentage) + L"%";
+            return g_settings.customPrefix + numStr + L"%";
 
         case DisplayStyle::Emoji: {
             std::wstring s;
@@ -184,18 +284,71 @@ static std::wstring FormatVolumeText(int percentage, bool isMuted) {
             } else {
                 s = L"\xD83D\xDD0A ";
             }
-            s += std::to_wstring(percentage) + L"%";
+            s += numStr + L"%";
             return s;
         }
 
         case DisplayStyle::Percentage:
         default:
-            return std::to_wstring(percentage) + L"%";
+            return numStr + L"%";
     }
 }
 
+static size_t GetIconTextOffset(void* pThis) {
+    if (!pThis || (reinterpret_cast<uintptr_t>(pThis) % sizeof(void*)) != 0) {
+        return 0;
+    }
+
+    auto isValidHeader = [](shared_hstring_header* h) -> bool {
+        if (!h || (reinterpret_cast<uintptr_t>(h) % sizeof(void*)) != 0) {
+            return false;
+        }
+        if (h->flags > 1) {
+            return false;
+        }
+        if (h->length == 0 || h->length > 64) {
+            return false;
+        }
+        if (h->ptr != h->buffer) {
+            return false;
+        }
+        return true;
+    };
+
+    const size_t defaultOffset = sizeof(void*) == 8 ? 0x90 : 0x48;
+    shared_hstring_header* defaultCandidate = *reinterpret_cast<shared_hstring_header**>(
+        reinterpret_cast<char*>(pThis) + defaultOffset);
+    if (isValidHeader(defaultCandidate)) {
+        return defaultOffset;
+    }
+
+    for (size_t offset = 0x40; offset <= 0x120; offset += sizeof(void*)) {
+        shared_hstring_header* candidate = *reinterpret_cast<shared_hstring_header**>(
+            reinterpret_cast<char*>(pThis) + offset);
+        if (isValidHeader(candidate)) {
+            wchar_t firstChar = candidate->buffer[0];
+            if ((firstChar >= 0xE700 && firstChar <= 0xE9FF) ||
+                (firstChar >= L'0' && firstChar <= L'9') ||
+                (firstChar >= L'a' && firstChar <= L'z') ||
+                (firstChar >= L'A' && firstChar <= L'Z') ||
+                firstChar == L' ' || firstChar == 0x2715 ||
+                firstChar == 0xD83D) {
+                return offset;
+            }
+        }
+    }
+
+    return 0;
+}
+
 static void ApplyCustomVolumeText(void* pThis, float volumeLevel, bool isMuted) {
-    if (!pThis || g_unloading) {
+    if (!pThis || g_unloading.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    size_t offset = GetIconTextOffset(pThis);
+    if (offset == 0) {
+        Wh_Log(L"Could not safely locate icon text member in VolumeSystemTrayIconDataModel");
         return;
     }
 
@@ -205,9 +358,8 @@ static void ApplyCustomVolumeText(void* pThis, float volumeLevel, bool isMuted) 
 
     std::wstring customText = FormatVolumeText(percentage, isMuted);
 
-    // Offset 0x90 in VolumeSystemTrayIconDataModel points to the icon text shared_hstring_header.
     shared_hstring_header** ppHeader = reinterpret_cast<shared_hstring_header**>(
-        reinterpret_cast<char*>(pThis) + 0x90);
+        reinterpret_cast<char*>(pThis) + offset);
 
     shared_hstring_header* newHeader = CreateSharedHString(customText);
     if (!newHeader) {
@@ -222,7 +374,7 @@ static void ApplyCustomVolumeText(void* pThis, float volumeLevel, bool isMuted) 
     }
 }
 
-static void TriggerImmediateVolumeSync() {
+static void QueryInitialSystemVolume(float* pVolumeLevel, bool* pIsMuted) {
     HRESULT hrCo = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
 
     IMMDeviceEnumerator* pEnumerator = nullptr;
@@ -237,11 +389,11 @@ static void TriggerImmediateVolumeSync() {
             if (SUCCEEDED(hr) && pEndpointVolume) {
                 float vol = 0.0f;
                 if (SUCCEEDED(pEndpointVolume->GetMasterVolumeLevelScalar(&vol))) {
-                    // Temporarily nudge volume to force an audio state change notification
-                    float nudge = (vol > 0.01f) ? (vol - 0.0005f) : (vol + 0.0005f);
-                    pEndpointVolume->SetMasterVolumeLevelScalar(nudge, nullptr);
-                    pEndpointVolume->SetMasterVolumeLevelScalar(vol, nullptr);
-                    Wh_Log(L"Triggered immediate volume sync (vol=%.4f)", vol);
+                    *pVolumeLevel = vol;
+                }
+                BOOL mute = FALSE;
+                if (SUCCEEDED(pEndpointVolume->GetMute(&mute))) {
+                    *pIsMuted = (mute != FALSE);
                 }
                 pEndpointVolume->Release();
             }
@@ -255,19 +407,118 @@ static void TriggerImmediateVolumeSync() {
     }
 }
 
+static VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE hModule, UINT* puPtrLen) {
+    HRSRC hResource = FindResource(hModule, MAKEINTRESOURCE(VS_VERSION_INFO), RT_VERSION);
+    if (!hResource) {
+        return nullptr;
+    }
+    HGLOBAL hGlobal = LoadResource(hModule, hResource);
+    if (!hGlobal) {
+        return nullptr;
+    }
+    void* pData = LockResource(hGlobal);
+    if (!pData) {
+        return nullptr;
+    }
+    void* pFixedFileInfo = nullptr;
+    UINT uPtrLen = 0;
+    if (!VerQueryValue(pData, L"\\", &pFixedFileInfo, &uPtrLen) || uPtrLen == 0) {
+        return nullptr;
+    }
+    if (puPtrLen) {
+        *puPtrLen = uPtrLen;
+    }
+    return static_cast<VS_FIXEDFILEINFO*>(pFixedFileInfo);
+}
+
+// Window thread marshaling to ensure 100% thread affinity with Explorer's taskbar UI
+static BOOL CALLBACK EnumWindowsTaskbarProc(HWND hWnd, LPARAM lParam) {
+    DWORD dwProcessId = 0;
+    WCHAR className[64];
+    if (GetWindowThreadProcessId(hWnd, &dwProcessId) &&
+        dwProcessId == GetCurrentProcessId() &&
+        GetClassName(hWnd, className, ARRAYSIZE(className)) &&
+        _wcsicmp(className, L"Shell_TrayWnd") == 0) {
+        *reinterpret_cast<HWND*>(lParam) = hWnd;
+        return FALSE;
+    }
+    return TRUE;
+}
+
+static HWND FindCurrentProcessTaskbarWnd() {
+    HWND hTaskbarWnd = nullptr;
+    EnumWindows(EnumWindowsTaskbarProc, reinterpret_cast<LPARAM>(&hTaskbarWnd));
+    return hTaskbarWnd;
+}
+
+using RunFromWindowThreadProc_t = void (*)(void* parameter);
+
+struct RUN_FROM_WINDOW_THREAD_PARAM {
+    RunFromWindowThreadProc_t proc;
+    void* procParam;
+};
+
+static UINT g_runFromWindowThreadRegisteredMsg = 0;
+
+static LRESULT CALLBACK CallWndProcHook(int nCode, WPARAM wParam, LPARAM lParam) {
+    (void)wParam;
+    if (nCode == HC_ACTION) {
+        const CWPSTRUCT* cwp = reinterpret_cast<const CWPSTRUCT*>(lParam);
+        if (cwp->message == g_runFromWindowThreadRegisteredMsg) {
+            auto* param = reinterpret_cast<RUN_FROM_WINDOW_THREAD_PARAM*>(cwp->lParam);
+            param->proc(param->procParam);
+        }
+    }
+    return CallNextHookEx(nullptr, nCode, 0, lParam);
+}
+
+static bool RunFromWindowThread(HWND hWnd,
+                                RunFromWindowThreadProc_t proc,
+                                void* procParam) {
+    if (g_runFromWindowThreadRegisteredMsg == 0) {
+        g_runFromWindowThreadRegisteredMsg =
+            RegisterWindowMessage(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
+    }
+
+    DWORD dwThreadId = GetWindowThreadProcessId(hWnd, nullptr);
+    if (dwThreadId == 0) {
+        return false;
+    }
+
+    if (dwThreadId == GetCurrentThreadId()) {
+        proc(procParam);
+        return true;
+    }
+
+    HHOOK hook = SetWindowsHookEx(
+        WH_CALLWNDPROC,
+        CallWndProcHook,
+        nullptr,
+        dwThreadId);
+
+    if (!hook) {
+        return false;
+    }
+
+    RUN_FROM_WINDOW_THREAD_PARAM param = {proc, procParam};
+    SendMessage(hWnd, g_runFromWindowThreadRegisteredMsg, 0, reinterpret_cast<LPARAM>(&param));
+    UnhookWindowsHookEx(hook);
+    return true;
+}
+
 // Hooks
 
-using VolumeSystemTrayIconDataModel_ctor_t = void*(WINAPI*)(void* pThis);
-static VolumeSystemTrayIconDataModel_ctor_t VolumeSystemTrayIconDataModel_ctor_Original = nullptr;
+using VolumeSystemTrayIconDataModel_dtor_t = void(WINAPI*)(void* pThis);
+static VolumeSystemTrayIconDataModel_dtor_t VolumeSystemTrayIconDataModel_dtor_Original = nullptr;
 
-static void* WINAPI VolumeSystemTrayIconDataModel_ctor_Hook(void* pThis) {
-    void* result = VolumeSystemTrayIconDataModel_ctor_Original(pThis);
-    if (!g_unloading) {
+static void WINAPI VolumeSystemTrayIconDataModel_dtor_Hook(void* pThis) {
+    {
         std::lock_guard<std::mutex> lock(g_dataModelMutex);
-        g_pVolumeDataModel = pThis;
-        ApplyCustomVolumeText(pThis, g_lastVolumeLevel, g_lastIsMuted);
+        if (g_pVolumeDataModel == pThis) {
+            g_pVolumeDataModel = nullptr;
+        }
     }
-    return result;
+    VolumeSystemTrayIconDataModel_dtor_Original(pThis);
 }
 
 using VolumeSystemTrayIconDataModel_UpdateVolume_t = void(WINAPI*)(
@@ -290,9 +541,15 @@ static void WINAPI VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
     bool isMuted,
     void* deviceName)
 {
+    static thread_local bool s_inHook = false;
+    if (s_inHook) {
+        VolumeSystemTrayIconDataModel_UpdateVolume_Original(pThis, volumeLevel, isMuted, deviceName);
+        return;
+    }
+
     VolumeSystemTrayIconDataModel_UpdateVolume_Original(pThis, volumeLevel, isMuted, deviceName);
 
-    if (g_unloading) {
+    if (g_unloading.load(std::memory_order_relaxed)) {
         return;
     }
 
@@ -307,15 +564,16 @@ static void WINAPI VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
 
     // Trigger UI redraw via CurrentData property notification
     if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
+        s_inHook = true;
         std::wstring_view propName = L"CurrentData";
         VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(pThis, &propName);
+        s_inHook = false;
     }
 }
 
-// Symbol resolution & module detection
-
 static bool HookSystemTraySymbols(HMODULE module) {
-    WindhawkUtils::SYMBOL_HOOK systemTrayDllHooks[] = {
+    // SystemTray.dll, Taskbar.View.dll
+    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
             {
                 LR"(public: void __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::UpdateVolume(float,bool,struct winrt::hstring))",
@@ -336,25 +594,22 @@ static bool HookSystemTraySymbols(HMODULE module) {
             },
             &VolumeSystemTrayIconDataModel_OnDataModelChanged_Original,
             nullptr, // Resolved for invocation only, not hooked
-            true,
+            false,
         },
         {
             {
-                LR"(public: __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::VolumeSystemTrayIconDataModel(struct winrt::SystemTray::IIconDataModel const &))",
-                LR"(public: __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::VolumeSystemTrayIconDataModel(struct winrt::SystemTray::IIconDataModel const & __ptr64) __ptr64)",
-                LR"(?0VolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@QEAA@AEBUIIconDataModel@23@@Z)",
-                LR"(public: __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::VolumeSystemTrayIconDataModel(void))",
-                LR"(public: __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::VolumeSystemTrayIconDataModel(void) __ptr64)",
-                LR"(??0VolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@QEAA@XZ)",
-                LR"(winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::VolumeSystemTrayIconDataModel)",
+                LR"(public: virtual __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::~VolumeSystemTrayIconDataModel(void))",
+                LR"(public: virtual __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::~VolumeSystemTrayIconDataModel(void) __ptr64)",
+                LR"(??1VolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@UEAA@XZ)",
+                LR"(winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::~VolumeSystemTrayIconDataModel)",
             },
-            &VolumeSystemTrayIconDataModel_ctor_Original,
-            VolumeSystemTrayIconDataModel_ctor_Hook,
+            &VolumeSystemTrayIconDataModel_dtor_Original,
+            VolumeSystemTrayIconDataModel_dtor_Hook,
             true,
         },
     };
 
-    if (!WindhawkUtils::HookSymbols(module, systemTrayDllHooks, ARRAYSIZE(systemTrayDllHooks))) {
+    if (!WindhawkUtils::HookSymbols(module, symbolHooks, ARRAYSIZE(symbolHooks))) {
         Wh_Log(L"Failed to hook SystemTray volume symbols");
         return false;
     }
@@ -367,6 +622,17 @@ static HMODULE GetSystemTrayModuleHandle() {
     HMODULE module = GetModuleHandle(L"SystemTray.dll");
     if (!module) {
         module = GetModuleHandle(L"Taskbar.View.dll");
+        if (module) {
+            // Starting with Taskbar.View.dll 2604.8002.200.6000, the SystemTray
+            // types moved out of Taskbar.View.dll into SystemTray.dll, so don't
+            // hook Taskbar.View.dll at this version and above.
+            VS_FIXEDFILEINFO* fixedFileInfo = GetModuleVersionInfo(module, nullptr);
+            WORD moduleMajor = fixedFileInfo ? HIWORD(fixedFileInfo->dwFileVersionMS) : 0;
+            if (!moduleMajor || moduleMajor >= 2604) {
+                Wh_Log(L"Skipping Taskbar.View.dll version %u (SystemTray types moved to SystemTray.dll)", moduleMajor);
+                module = nullptr;
+            }
+        }
     }
     return module;
 }
@@ -385,13 +651,25 @@ static HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
     if (!g_systemTrayModuleHooked && lpLibFileName) {
         PCWSTR fileName = wcsrchr(lpLibFileName, L'\\');
         fileName = fileName ? fileName + 1 : lpLibFileName;
-        if (_wcsicmp(fileName, L"SystemTray.dll") == 0 ||
-            _wcsicmp(fileName, L"Taskbar.View.dll") == 0) {
+        bool isCandidate = false;
+
+        if (_wcsicmp(fileName, L"SystemTray.dll") == 0) {
+            isCandidate = true;
+        } else if (_wcsicmp(fileName, L"Taskbar.View.dll") == 0) {
+            VS_FIXEDFILEINFO* fixedFileInfo = GetModuleVersionInfo(hModule, nullptr);
+            WORD moduleMajor = fixedFileInfo ? HIWORD(fixedFileInfo->dwFileVersionMS) : 0;
+            if (moduleMajor && moduleMajor < 2604) {
+                isCandidate = true;
+            } else {
+                Wh_Log(L"Ignoring dynamically loaded Taskbar.View.dll (version %u >= 2604)", moduleMajor);
+            }
+        }
+
+        if (isCandidate) {
             if (!g_systemTrayModuleHooked.exchange(true)) {
                 Wh_Log(L"SystemTray module loaded dynamically: %s", lpLibFileName);
                 if (HookSystemTraySymbols(hModule)) {
                     Wh_ApplyHookOperations();
-                    TriggerImmediateVolumeSync();
                 } else {
                     g_systemTrayModuleHooked = false;
                 }
@@ -436,20 +714,68 @@ static void LoadSettings() {
     } else {
         g_settings.customPrefix = L"Vol ";
     }
+
+    PCWSTR paddingModeStr = Wh_GetStringSetting(L"paddingMode");
+    if (paddingModeStr) {
+        if (wcscmp(paddingModeStr, L"zero") == 0) {
+            g_settings.paddingMode = PaddingMode::Zero;
+        } else if (wcscmp(paddingModeStr, L"space") == 0) {
+            g_settings.paddingMode = PaddingMode::Space;
+        } else {
+            g_settings.paddingMode = PaddingMode::None;
+        }
+        Wh_FreeStringSetting(paddingModeStr);
+    } else {
+        g_settings.paddingMode = PaddingMode::None;
+    }
+
+    PCWSTR muteStyleStr = Wh_GetStringSetting(L"muteStyle");
+    if (muteStyleStr) {
+        if (wcscmp(muteStyleStr, L"mute") == 0) {
+            g_settings.muteStyle = MuteStyle::Mute;
+        } else if (wcscmp(muteStyleStr, L"zero") == 0) {
+            g_settings.muteStyle = MuteStyle::Zero;
+        } else if (wcscmp(muteStyleStr, L"cross") == 0) {
+            g_settings.muteStyle = MuteStyle::Cross;
+        } else if (wcscmp(muteStyleStr, L"emoji") == 0) {
+            g_settings.muteStyle = MuteStyle::Emoji;
+        } else if (wcscmp(muteStyleStr, L"glyph") == 0) {
+            g_settings.muteStyle = MuteStyle::Glyph;
+        } else if (wcscmp(muteStyleStr, L"custom") == 0) {
+            g_settings.muteStyle = MuteStyle::Custom;
+        } else {
+            g_settings.muteStyle = MuteStyle::Mut;
+        }
+        Wh_FreeStringSetting(muteStyleStr);
+    } else {
+        g_settings.muteStyle = MuteStyle::Mut;
+    }
+
+    PCWSTR customMuteStr = Wh_GetStringSetting(L"customMuteText");
+    if (customMuteStr) {
+        g_settings.customMuteText = customMuteStr;
+        Wh_FreeStringSetting(customMuteStr);
+    } else {
+        g_settings.customMuteText = L"Mute";
+    }
 }
 
 BOOL Wh_ModInit() {
     Wh_Log(L"Initializing Taskbar Volume Percentage Indicator mod in explorer.exe");
 
     LoadSettings();
+    QueryInitialSystemVolume(&g_lastVolumeLevel, &g_lastIsMuted);
 
+    bool hooked = false;
     if (HMODULE systemTrayModule = GetSystemTrayModuleHandle()) {
-        g_systemTrayModuleHooked = true;
-        if (!HookSystemTraySymbols(systemTrayModule)) {
-            g_systemTrayModuleHooked = false;
+        if (HookSystemTraySymbols(systemTrayModule)) {
+            g_systemTrayModuleHooked = true;
+            hooked = true;
         }
-    } else {
-        Wh_Log(L"System tray module not loaded yet, hooking LoadLibraryExW");
+    }
+
+    if (!hooked) {
+        Wh_Log(L"System tray symbols not hooked yet, hooking LoadLibraryExW");
         HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
         auto pKernelBaseLoadLibraryExW = (decltype(&LoadLibraryExW))GetProcAddress(
             kernelBaseModule, "LoadLibraryExW");
@@ -481,24 +807,18 @@ void Wh_ModAfterInit() {
             }
         }
     }
-
-    TriggerImmediateVolumeSync();
 }
 
-void Wh_ModBeforeUninit() {
-    Wh_Log(L"Preparing mod unload, restoring native icon");
-
-    g_unloading = true;
-
-    // Restore original native volume glyph before unloading
-    {
-        std::lock_guard<std::mutex> lock(g_dataModelMutex);
-        if (g_pVolumeDataModel && ((ULONG_PTR)g_pVolumeDataModel & (sizeof(void*) - 1)) == 0) {
+static void BeforeUninitOnUIThread(void* /*parameter*/) {
+    std::lock_guard<std::mutex> lock(g_dataModelMutex);
+    if (g_pVolumeDataModel && (reinterpret_cast<uintptr_t>(g_pVolumeDataModel) % sizeof(void*)) == 0) {
+        size_t offset = GetIconTextOffset(g_pVolumeDataModel);
+        if (offset != 0) {
             wchar_t defaultGlyph = g_lastIsMuted ? GLYPH_MUTE : GLYPH_VOL_3;
             std::wstring restoreStr(1, defaultGlyph);
 
             shared_hstring_header** ppHeader = reinterpret_cast<shared_hstring_header**>(
-                reinterpret_cast<char*>(g_pVolumeDataModel) + 0x90);
+                reinterpret_cast<char*>(g_pVolumeDataModel) + offset);
 
             shared_hstring_header* oldHeader = *ppHeader;
             shared_hstring_header* newHeader = CreateSharedHString(restoreStr);
@@ -514,6 +834,21 @@ void Wh_ModBeforeUninit() {
                 VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(g_pVolumeDataModel, &propName);
             }
         }
+    }
+    g_pVolumeDataModel = nullptr;
+}
+
+void Wh_ModBeforeUninit() {
+    Wh_Log(L"Preparing mod unload, restoring native icon");
+
+    g_unloading = true;
+
+    // Restore original native volume glyph safely on the UI thread before unloading
+    HWND hTaskbarWnd = FindCurrentProcessTaskbarWnd();
+    if (hTaskbarWnd) {
+        RunFromWindowThread(hTaskbarWnd, BeforeUninitOnUIThread, nullptr);
+    } else {
+        std::lock_guard<std::mutex> lock(g_dataModelMutex);
         g_pVolumeDataModel = nullptr;
     }
 }
@@ -522,28 +857,27 @@ void Wh_ModUninit() {
     Wh_Log(L"Uninitializing Taskbar Volume Percentage Indicator mod");
 }
 
+static void SettingsChangedOnUIThread(void* /*parameter*/) {
+    std::lock_guard<std::mutex> lock(g_dataModelMutex);
+    if (g_pVolumeDataModel && !g_unloading.load(std::memory_order_relaxed)) {
+        ApplyCustomVolumeText(g_pVolumeDataModel, g_lastVolumeLevel, g_lastIsMuted);
+        if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
+            std::wstring_view propName = L"CurrentData";
+            VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(g_pVolumeDataModel, &propName);
+        }
+    }
+}
+
 void Wh_ModSettingsChanged() {
     Wh_Log(L"Settings changed, reloading...");
     LoadSettings();
 
-    if (g_unloading) {
+    if (g_unloading.load(std::memory_order_relaxed)) {
         return;
     }
 
-    bool hasDataModel = false;
-    {
-        std::lock_guard<std::mutex> lock(g_dataModelMutex);
-        if (g_pVolumeDataModel) {
-            hasDataModel = true;
-            ApplyCustomVolumeText(g_pVolumeDataModel, g_lastVolumeLevel, g_lastIsMuted);
-            if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
-                std::wstring_view propName = L"CurrentData";
-                VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(g_pVolumeDataModel, &propName);
-            }
-        }
-    }
-
-    if (!hasDataModel) {
-        TriggerImmediateVolumeSync();
+    HWND hTaskbarWnd = FindCurrentProcessTaskbarWnd();
+    if (hTaskbarWnd) {
+        RunFromWindowThread(hTaskbarWnd, SettingsChangedOnUIThread, nullptr);
     }
 }

--- a/mods/taskbar-volume-percentage.wh.cpp
+++ b/mods/taskbar-volume-percentage.wh.cpp
@@ -1,0 +1,549 @@
+// ==WindhawkMod==
+// @id              taskbar-volume-percentage
+// @name            Taskbar Volume Percentage Indicator
+// @description     Displays the exact master volume percentage in the system tray natively inside the Windows 11 volume button with real-time sync.
+// @version         2.0.0
+// @author          gilnett
+// @github          https://github.com/gilnett
+// @include         explorer.exe
+// @compilerOptions -lole32 -loleaut32 -lshlwapi
+// @license         MIT
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Taskbar Volume Percentage Indicator
+
+Displays the master volume percentage directly inside the Windows 11 system tray volume icon in real time.
+
+## Display styles
+
+- **Percentage**: Displays the volume percentage (e.g. `50%`).
+- **Number only**: Displays the numerical volume level (e.g. `50`).
+- **Prefix and Percentage**: Displays a custom prefix before the percentage (e.g. `Vol 50%`).
+- **Icon and Percentage**: Displays a speaker icon with the percentage (e.g. `🔊 50%`).
+- **Windows Default**: Displays the vanilla native Windows 11 speaker icon with volume waves.
+
+## Credits
+
+- Based on the [Windows 11 Taskbar Styler](https://windhawk.net/mods/windows-11-taskbar-styler) mod by [m417z](https://github.com/m417z).
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- displayStyle: percentage
+  $name: Display Style
+  $description: Format of the volume indicator in the taskbar.
+  $options:
+    - percentage: Percentage (e.g. 50%)
+    - number: Number only (e.g. 50)
+    - prefix: Prefix and Percentage (e.g. Vol 50%)
+    - emoji: Icon and Percentage (e.g. 🔊 50%)
+    - vanilla: Windows Default (exact vanilla Windows speaker icon)
+- customPrefix: "Vol "
+  $name: Custom Prefix
+  $description: Prefix text used when the display style is set to 'Prefix and Percentage'.
+*/
+// ==/WindhawkModSettings==
+
+#include <windows.h>
+#include <shlwapi.h>
+#include <mmdeviceapi.h>
+#include <endpointvolume.h>
+
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <string_view>
+
+#include <windhawk_api.h>
+#include <windhawk_utils.h>
+
+// Reference: C++/WinRT base_string.h shared_hstring_header binary layout
+struct hstring_header {
+    uint32_t flags;
+    uint32_t length;
+    uint32_t padding1;
+    uint32_t padding2;
+    wchar_t const* ptr;
+};
+
+struct shared_hstring_header : hstring_header {
+    int32_t count;
+    wchar_t buffer[1];
+};
+
+static shared_hstring_header* CreateSharedHString(const std::wstring& str) {
+    uint32_t len = static_cast<uint32_t>(str.length());
+    size_t bytes = sizeof(shared_hstring_header) + sizeof(wchar_t) * len;
+    shared_hstring_header* header = static_cast<shared_hstring_header*>(
+        HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, bytes));
+    if (!header) {
+        return nullptr;
+    }
+    header->flags = 0;
+    header->length = len;
+    header->padding1 = 0;
+    header->padding2 = 0;
+    header->ptr = header->buffer;
+    header->count = 1;
+    memcpy(header->buffer, str.c_str(), sizeof(wchar_t) * (len + 1));
+    return header;
+}
+
+static void ReleaseSharedHString(shared_hstring_header* header) {
+    if (!header) {
+        return;
+    }
+    // Only heap-allocated strings (flags == 0) have an allocated reference count.
+    // Fast-pass / static string references (flags != 0) must never be freed.
+    if (header->flags != 0) {
+        return;
+    }
+    if (InterlockedDecrement(reinterpret_cast<volatile LONG*>(&header->count)) == 0) {
+        HeapFree(GetProcessHeap(), 0, header);
+    }
+}
+
+enum class DisplayStyle {
+    Percentage,
+    Number,
+    Prefix,
+    Emoji,
+    Vanilla,
+};
+
+struct ModSettings {
+    DisplayStyle displayStyle;
+    std::wstring customPrefix;
+};
+
+static ModSettings g_settings;
+static std::mutex g_dataModelMutex;
+static std::atomic<bool> g_unloading{false};
+static std::atomic<bool> g_systemTrayModuleHooked{false};
+static void* g_pVolumeDataModel = nullptr;
+static float g_lastVolumeLevel = 0.50f;
+static bool g_lastIsMuted = false;
+
+// Windows 11 Segoe Fluent Icons volume glyphs
+constexpr wchar_t GLYPH_MUTE = 0xE74F;
+constexpr wchar_t GLYPH_VOL_3 = 0xE995;
+
+static wchar_t GetVanillaVolumeGlyph(int percentage, bool isMuted) {
+    if (isMuted) {
+        return GLYPH_MUTE;
+    }
+    if (percentage <= 0) {
+        return 0xE992;
+    }
+    if (percentage <= 33) {
+        return 0xE993;
+    }
+    if (percentage <= 66) {
+        return 0xE994;
+    }
+    return GLYPH_VOL_3;
+}
+
+static std::wstring FormatVolumeText(int percentage, bool isMuted) {
+    if (isMuted) {
+        switch (g_settings.displayStyle) {
+            case DisplayStyle::Vanilla:
+                return std::wstring(1, GLYPH_MUTE);
+            case DisplayStyle::Emoji:
+                return L"\xD83D\xDD07 MUT";
+            case DisplayStyle::Prefix:
+                return g_settings.customPrefix + L"MUT";
+            case DisplayStyle::Number:
+            case DisplayStyle::Percentage:
+            default:
+                return L"MUT";
+        }
+    }
+
+    switch (g_settings.displayStyle) {
+        case DisplayStyle::Vanilla:
+            return std::wstring(1, GetVanillaVolumeGlyph(percentage, false));
+
+        case DisplayStyle::Number:
+            return std::to_wstring(percentage);
+
+        case DisplayStyle::Prefix:
+            return g_settings.customPrefix + std::to_wstring(percentage) + L"%";
+
+        case DisplayStyle::Emoji: {
+            std::wstring s;
+            if (percentage <= 0) {
+                s = L"\xD83D\xDD08 ";
+            } else if (percentage <= 50) {
+                s = L"\xD83D\xDD09 ";
+            } else {
+                s = L"\xD83D\xDD0A ";
+            }
+            s += std::to_wstring(percentage) + L"%";
+            return s;
+        }
+
+        case DisplayStyle::Percentage:
+        default:
+            return std::to_wstring(percentage) + L"%";
+    }
+}
+
+static void ApplyCustomVolumeText(void* pThis, float volumeLevel, bool isMuted) {
+    if (!pThis || g_unloading) {
+        return;
+    }
+
+    int percentage = static_cast<int>(std::round(volumeLevel * 100.0f));
+    if (percentage < 0) percentage = 0;
+    if (percentage > 100) percentage = 100;
+
+    std::wstring customText = FormatVolumeText(percentage, isMuted);
+
+    // Offset 0x90 in VolumeSystemTrayIconDataModel points to the icon text shared_hstring_header.
+    shared_hstring_header** ppHeader = reinterpret_cast<shared_hstring_header**>(
+        reinterpret_cast<char*>(pThis) + 0x90);
+
+    shared_hstring_header* newHeader = CreateSharedHString(customText);
+    if (!newHeader) {
+        return;
+    }
+
+    shared_hstring_header* oldHeader = *ppHeader;
+    *ppHeader = newHeader;
+
+    if (oldHeader && oldHeader != newHeader) {
+        ReleaseSharedHString(oldHeader);
+    }
+}
+
+static void TriggerImmediateVolumeSync() {
+    HRESULT hrCo = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+
+    IMMDeviceEnumerator* pEnumerator = nullptr;
+    HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
+                                  __uuidof(IMMDeviceEnumerator), (void**)&pEnumerator);
+    if (SUCCEEDED(hr) && pEnumerator) {
+        IMMDevice* pDevice = nullptr;
+        hr = pEnumerator->GetDefaultAudioEndpoint(eRender, eMultimedia, &pDevice);
+        if (SUCCEEDED(hr) && pDevice) {
+            IAudioEndpointVolume* pEndpointVolume = nullptr;
+            hr = pDevice->Activate(__uuidof(IAudioEndpointVolume), CLSCTX_ALL, nullptr, (void**)&pEndpointVolume);
+            if (SUCCEEDED(hr) && pEndpointVolume) {
+                float vol = 0.0f;
+                if (SUCCEEDED(pEndpointVolume->GetMasterVolumeLevelScalar(&vol))) {
+                    // Temporarily nudge volume to force an audio state change notification
+                    float nudge = (vol > 0.01f) ? (vol - 0.0005f) : (vol + 0.0005f);
+                    pEndpointVolume->SetMasterVolumeLevelScalar(nudge, nullptr);
+                    pEndpointVolume->SetMasterVolumeLevelScalar(vol, nullptr);
+                    Wh_Log(L"Triggered immediate volume sync (vol=%.4f)", vol);
+                }
+                pEndpointVolume->Release();
+            }
+            pDevice->Release();
+        }
+        pEnumerator->Release();
+    }
+
+    if (SUCCEEDED(hrCo)) {
+        CoUninitialize();
+    }
+}
+
+// Hooks
+
+using VolumeSystemTrayIconDataModel_ctor_t = void*(WINAPI*)(void* pThis);
+static VolumeSystemTrayIconDataModel_ctor_t VolumeSystemTrayIconDataModel_ctor_Original = nullptr;
+
+static void* WINAPI VolumeSystemTrayIconDataModel_ctor_Hook(void* pThis) {
+    void* result = VolumeSystemTrayIconDataModel_ctor_Original(pThis);
+    if (!g_unloading) {
+        std::lock_guard<std::mutex> lock(g_dataModelMutex);
+        g_pVolumeDataModel = pThis;
+        ApplyCustomVolumeText(pThis, g_lastVolumeLevel, g_lastIsMuted);
+    }
+    return result;
+}
+
+using VolumeSystemTrayIconDataModel_UpdateVolume_t = void(WINAPI*)(
+    void* pThis,
+    float volumeLevel,
+    bool isMuted,
+    void* deviceName
+);
+static VolumeSystemTrayIconDataModel_UpdateVolume_t VolumeSystemTrayIconDataModel_UpdateVolume_Original = nullptr;
+
+using VolumeSystemTrayIconDataModel_OnDataModelChanged_t = void(WINAPI*)(
+    void* pThis,
+    const void* propertyName
+);
+static VolumeSystemTrayIconDataModel_OnDataModelChanged_t VolumeSystemTrayIconDataModel_OnDataModelChanged_Original = nullptr;
+
+static void WINAPI VolumeSystemTrayIconDataModel_UpdateVolume_Hook(
+    void* pThis,
+    float volumeLevel,
+    bool isMuted,
+    void* deviceName)
+{
+    VolumeSystemTrayIconDataModel_UpdateVolume_Original(pThis, volumeLevel, isMuted, deviceName);
+
+    if (g_unloading) {
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_dataModelMutex);
+        g_pVolumeDataModel = pThis;
+        g_lastVolumeLevel = volumeLevel;
+        g_lastIsMuted = isMuted;
+
+        ApplyCustomVolumeText(pThis, volumeLevel, isMuted);
+    }
+
+    // Trigger UI redraw via CurrentData property notification
+    if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
+        std::wstring_view propName = L"CurrentData";
+        VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(pThis, &propName);
+    }
+}
+
+// Symbol resolution & module detection
+
+static bool HookSystemTraySymbols(HMODULE module) {
+    WindhawkUtils::SYMBOL_HOOK systemTrayDllHooks[] = {
+        {
+            {
+                LR"(public: void __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::UpdateVolume(float,bool,struct winrt::hstring))",
+                LR"(public: void __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::UpdateVolume(float,bool,struct winrt::hstring) __ptr64)",
+                LR"(?UpdateVolume@VolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@QEAAXM_NUhstring@4@@Z)",
+                LR"(winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::UpdateVolume)",
+            },
+            &VolumeSystemTrayIconDataModel_UpdateVolume_Original,
+            VolumeSystemTrayIconDataModel_UpdateVolume_Hook,
+            false,
+        },
+        {
+            {
+                LR"(private: void __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::OnDataModelChanged(class std::basic_string_view<wchar_t,struct std::char_traits<wchar_t> > const &))",
+                LR"(private: void __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::OnDataModelChanged(class std::basic_string_view<wchar_t,struct std::char_traits<wchar_t> > const & __ptr64) __ptr64)",
+                LR"(?OnDataModelChanged@VolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@AEAAXAEBV?$basic_string_view@_WU?$char_traits@_W@std@@@std@@@Z)",
+                LR"(winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::OnDataModelChanged)",
+            },
+            &VolumeSystemTrayIconDataModel_OnDataModelChanged_Original,
+            nullptr, // Resolved for invocation only, not hooked
+            true,
+        },
+        {
+            {
+                LR"(public: __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::VolumeSystemTrayIconDataModel(struct winrt::SystemTray::IIconDataModel const &))",
+                LR"(public: __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::VolumeSystemTrayIconDataModel(struct winrt::SystemTray::IIconDataModel const & __ptr64) __ptr64)",
+                LR"(?0VolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@QEAA@AEBUIIconDataModel@23@@Z)",
+                LR"(public: __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::VolumeSystemTrayIconDataModel(void))",
+                LR"(public: __cdecl winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::VolumeSystemTrayIconDataModel(void) __ptr64)",
+                LR"(??0VolumeSystemTrayIconDataModel@implementation@SystemTray@winrt@@QEAA@XZ)",
+                LR"(winrt::SystemTray::implementation::VolumeSystemTrayIconDataModel::VolumeSystemTrayIconDataModel)",
+            },
+            &VolumeSystemTrayIconDataModel_ctor_Original,
+            VolumeSystemTrayIconDataModel_ctor_Hook,
+            true,
+        },
+    };
+
+    if (!WindhawkUtils::HookSymbols(module, systemTrayDllHooks, ARRAYSIZE(systemTrayDllHooks))) {
+        Wh_Log(L"Failed to hook SystemTray volume symbols");
+        return false;
+    }
+
+    Wh_Log(L"Successfully hooked SystemTray volume symbols");
+    return true;
+}
+
+static HMODULE GetSystemTrayModuleHandle() {
+    HMODULE module = GetModuleHandle(L"SystemTray.dll");
+    if (!module) {
+        module = GetModuleHandle(L"Taskbar.View.dll");
+    }
+    return module;
+}
+
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+static LoadLibraryExW_t LoadLibraryExW_Original = nullptr;
+
+static HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
+                                         HANDLE hFile,
+                                         DWORD dwFlags) {
+    HMODULE hModule = LoadLibraryExW_Original(lpLibFileName, hFile, dwFlags);
+    if (!hModule || ((ULONG_PTR)hModule & 3)) {
+        return hModule;
+    }
+
+    if (!g_systemTrayModuleHooked && lpLibFileName) {
+        PCWSTR fileName = wcsrchr(lpLibFileName, L'\\');
+        fileName = fileName ? fileName + 1 : lpLibFileName;
+        if (_wcsicmp(fileName, L"SystemTray.dll") == 0 ||
+            _wcsicmp(fileName, L"Taskbar.View.dll") == 0) {
+            if (!g_systemTrayModuleHooked.exchange(true)) {
+                Wh_Log(L"SystemTray module loaded dynamically: %s", lpLibFileName);
+                if (HookSystemTraySymbols(hModule)) {
+                    Wh_ApplyHookOperations();
+                    TriggerImmediateVolumeSync();
+                } else {
+                    g_systemTrayModuleHooked = false;
+                }
+            }
+        }
+    }
+
+    return hModule;
+}
+
+// Settings & lifecycle
+
+static void LoadSettings() {
+    PCWSTR displayStyleStr = Wh_GetStringSetting(L"displayStyle");
+    if (displayStyleStr) {
+        if (wcscmp(displayStyleStr, L"vanilla") == 0 ||
+            wcscmp(displayStyleStr, L"default") == 0 ||
+            wcscmp(displayStyleStr, L"vanillaOnly") == 0) {
+            g_settings.displayStyle = DisplayStyle::Vanilla;
+        } else if (wcscmp(displayStyleStr, L"number") == 0 ||
+                   wcscmp(displayStyleStr, L"numberOnly") == 0) {
+            g_settings.displayStyle = DisplayStyle::Number;
+        } else if (wcscmp(displayStyleStr, L"prefix") == 0 ||
+                   wcscmp(displayStyleStr, L"volPrefix") == 0) {
+            g_settings.displayStyle = DisplayStyle::Prefix;
+        } else if (wcscmp(displayStyleStr, L"emoji") == 0 ||
+                   wcscmp(displayStyleStr, L"emojiAndPercent") == 0 ||
+                   wcscmp(displayStyleStr, L"iconAndPercent") == 0) {
+            g_settings.displayStyle = DisplayStyle::Emoji;
+        } else {
+            g_settings.displayStyle = DisplayStyle::Percentage;
+        }
+        Wh_FreeStringSetting(displayStyleStr);
+    } else {
+        g_settings.displayStyle = DisplayStyle::Percentage;
+    }
+
+    PCWSTR prefixStr = Wh_GetStringSetting(L"customPrefix");
+    if (prefixStr) {
+        g_settings.customPrefix = prefixStr;
+        Wh_FreeStringSetting(prefixStr);
+    } else {
+        g_settings.customPrefix = L"Vol ";
+    }
+}
+
+BOOL Wh_ModInit() {
+    Wh_Log(L"Initializing Taskbar Volume Percentage Indicator mod in explorer.exe");
+
+    LoadSettings();
+
+    if (HMODULE systemTrayModule = GetSystemTrayModuleHandle()) {
+        g_systemTrayModuleHooked = true;
+        if (!HookSystemTraySymbols(systemTrayModule)) {
+            g_systemTrayModuleHooked = false;
+        }
+    } else {
+        Wh_Log(L"System tray module not loaded yet, hooking LoadLibraryExW");
+        HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
+        auto pKernelBaseLoadLibraryExW = (decltype(&LoadLibraryExW))GetProcAddress(
+            kernelBaseModule, "LoadLibraryExW");
+        if (pKernelBaseLoadLibraryExW) {
+            WindhawkUtils::SetFunctionHook(pKernelBaseLoadLibraryExW,
+                                           LoadLibraryExW_Hook,
+                                           &LoadLibraryExW_Original);
+        } else {
+            WindhawkUtils::SetFunctionHook(LoadLibraryExW,
+                                           LoadLibraryExW_Hook,
+                                           &LoadLibraryExW_Original);
+        }
+    }
+
+    Wh_Log(L"Taskbar Volume Percentage Indicator mod initialized successfully");
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    if (!g_systemTrayModuleHooked) {
+        if (HMODULE systemTrayModule = GetSystemTrayModuleHandle()) {
+            if (!g_systemTrayModuleHooked.exchange(true)) {
+                Wh_Log(L"System tray module found in Wh_ModAfterInit");
+                if (HookSystemTraySymbols(systemTrayModule)) {
+                    Wh_ApplyHookOperations();
+                } else {
+                    g_systemTrayModuleHooked = false;
+                }
+            }
+        }
+    }
+
+    TriggerImmediateVolumeSync();
+}
+
+void Wh_ModBeforeUninit() {
+    Wh_Log(L"Preparing mod unload, restoring native icon");
+
+    g_unloading = true;
+
+    // Restore original native volume glyph before unloading
+    {
+        std::lock_guard<std::mutex> lock(g_dataModelMutex);
+        if (g_pVolumeDataModel && ((ULONG_PTR)g_pVolumeDataModel & (sizeof(void*) - 1)) == 0) {
+            wchar_t defaultGlyph = g_lastIsMuted ? GLYPH_MUTE : GLYPH_VOL_3;
+            std::wstring restoreStr(1, defaultGlyph);
+
+            shared_hstring_header** ppHeader = reinterpret_cast<shared_hstring_header**>(
+                reinterpret_cast<char*>(g_pVolumeDataModel) + 0x90);
+
+            shared_hstring_header* oldHeader = *ppHeader;
+            shared_hstring_header* newHeader = CreateSharedHString(restoreStr);
+            if (newHeader) {
+                *ppHeader = newHeader;
+                if (oldHeader && oldHeader != newHeader) {
+                    ReleaseSharedHString(oldHeader);
+                }
+            }
+
+            if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
+                std::wstring_view propName = L"CurrentData";
+                VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(g_pVolumeDataModel, &propName);
+            }
+        }
+        g_pVolumeDataModel = nullptr;
+    }
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L"Uninitializing Taskbar Volume Percentage Indicator mod");
+}
+
+void Wh_ModSettingsChanged() {
+    Wh_Log(L"Settings changed, reloading...");
+    LoadSettings();
+
+    if (g_unloading) {
+        return;
+    }
+
+    bool hasDataModel = false;
+    {
+        std::lock_guard<std::mutex> lock(g_dataModelMutex);
+        if (g_pVolumeDataModel) {
+            hasDataModel = true;
+            ApplyCustomVolumeText(g_pVolumeDataModel, g_lastVolumeLevel, g_lastIsMuted);
+            if (VolumeSystemTrayIconDataModel_OnDataModelChanged_Original) {
+                std::wstring_view propName = L"CurrentData";
+                VolumeSystemTrayIconDataModel_OnDataModelChanged_Original(g_pVolumeDataModel, &propName);
+            }
+        }
+    }
+
+    if (!hasDataModel) {
+        TriggerImmediateVolumeSync();
+    }
+}


### PR DESCRIPTION
Displays the volume percentage directly in the Windows 11 system tray volume icon.

Includes configurable display formats (percentage, number only, custom prefix, icon + percentage, or default).

Closes #4162

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

* Initial release.

## Mod authorship

This mod was created by:

- [ ] The submitter, without AI assistance
- [x] The submitter, with AI assistance
- [ ] Claude
- [ ] ChatGPT
- [x] Gemini
- [ ] Another AI (please specify): 
- [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
