### PR TITLE
Add Windows 11 Native Four Column Snap Layout mod

### DIFF
--- a/mods/windows-11-native-four-column-snap-layout.wh.cpp
+++ b/mods/windows-11-native-four-column-snap-layout.wh.cpp
@@ -71,14 +71,12 @@ thread_local bool g_inSnapBarLoad = false;
 thread_local bool g_snapBarCustomAdded = false;
 
 // Set after the normal flyout path successfully appends the custom layout.
-// Thread-local for consistency with the Snap Bar state.
 thread_local bool g_flyoutCustomAdded = false;
 
 // Keep track of SnapLayout.dll so a reference acquired by this mod can be
-// released again when the mod unloads.
+// released when the mod unloads.
 HMODULE g_snapLayoutModule = nullptr;
 bool g_loadedSnapLayoutModule = false;
-
 
 // -----------------------------------------------------------------------------
 // Native functions resolved from SnapLayout.dll
@@ -91,7 +89,6 @@ using Layouts_t = RawVector* (__cdecl*)(
 
 Layouts_t Layouts_Original = nullptr;
 
-
 using EmplaceLayout_t = void* (__cdecl*)(
     void* vectorThis,
     const void* sourceLayout
@@ -99,14 +96,12 @@ using EmplaceLayout_t = void* (__cdecl*)(
 
 EmplaceLayout_t EmplaceLayout_Original = nullptr;
 
-
 using PickerHeight_t = int (__cdecl*)(
     void* thisPtr,
     int* value
 );
 
 PickerHeight_t PickerHeight_Original = nullptr;
-
 
 using SnapBarLoadLayouts_t = void (__cdecl*)(
     void* thisPtr,
@@ -116,7 +111,6 @@ using SnapBarLoadLayouts_t = void (__cdecl*)(
 );
 
 SnapBarLoadLayouts_t SnapBarLoadLayouts_Original = nullptr;
-
 
 // This pass-through hook exists so Windhawk resolves the private vector helper
 // and exposes a callable original/trampoline pointer.
@@ -129,7 +123,6 @@ void* __cdecl EmplaceLayout_Hook(
         sourceLayout
     );
 }
-
 
 int __cdecl PickerHeight_Hook(
     void* thisPtr,
@@ -154,7 +147,6 @@ int __cdecl PickerHeight_Hook(
 
     return hr;
 }
-
 
 void __cdecl SnapBarLoadLayouts_Hook(
     void* thisPtr,
@@ -184,7 +176,6 @@ void __cdecl SnapBarLoadLayouts_Hook(
     g_snapBarCustomAdded =
         previousCustomAdded;
 }
-
 
 // -----------------------------------------------------------------------------
 // Raw SnapLayout / SnapZone helpers
@@ -227,7 +218,6 @@ SIZE_T GetVectorCount(
 
     return bytes / elementSize;
 }
-
 
 SIZE_T GetZoneCount(
     const void* layout)
@@ -281,7 +271,6 @@ SIZE_T GetZoneCount(
     return bytes / kSnapZoneSize;
 }
 
-
 void WriteU32(
     void* base,
     SIZE_T offset,
@@ -293,7 +282,6 @@ void WriteU32(
         sizeof(value)
     );
 }
-
 
 bool IsExpectedSourceLayout(
     const void* layout)
@@ -322,7 +310,6 @@ bool IsExpectedSourceLayout(
         rows == 2 &&
         GetZoneCount(layout) == 4;
 }
-
 
 // -----------------------------------------------------------------------------
 // Convert copied native quadrant layout into four equal columns
@@ -362,8 +349,7 @@ bool PatchToFourColumns(
         return false;
     }
 
-    // SnapLayout grid:
-    // 4 columns × 1 row.
+    // SnapLayout grid: four columns, one row.
     WriteU32(layout, 0x20, 4);
     WriteU32(layout, 0x24, 1);
 
@@ -379,41 +365,20 @@ bool PatchToFourColumns(
     //
     // | 0 | 1 | 2 | 3 |
     //
-    // with each zone spanning exactly one column.
+    // Each zone occupies one equal column.
     for (unsigned int i = 0; i < 4; i++) {
-
         BYTE* zone =
             reinterpret_cast<BYTE*>(zoneFirst) +
             i * kSnapZoneSize;
 
-        WriteU32(
-            zone,
-            0x20,
-            i
-        );
-
-        WriteU32(
-            zone,
-            0x24,
-            0
-        );
-
-        WriteU32(
-            zone,
-            0x28,
-            1
-        );
-
-        WriteU32(
-            zone,
-            0x2C,
-            1
-        );
+        WriteU32(zone, 0x20, i);
+        WriteU32(zone, 0x24, 0);
+        WriteU32(zone, 0x28, 1);
+        WriteU32(zone, 0x2C, 1);
     }
 
     return true;
 }
-
 
 // -----------------------------------------------------------------------------
 // Deep-copy and append one native layout
@@ -436,7 +401,7 @@ bool CloneAndAppendFourColumn(
         );
 
     // Safety check:
-    // this build is expected to return six native layouts.
+    // the supported build is expected to return six native layouts.
     if (count != kNativeLayoutCount ||
         sourceIndex >= count)
     {
@@ -453,7 +418,7 @@ bool CloneAndAppendFourColumn(
         return false;
     }
 
-    // Use SnapLayout.dll's own std::vector insertion helper.
+    // Use SnapLayout.dll's own vector insertion helper.
     //
     // SnapLayout contains non-trivial members such as std::wstring and
     // std::vector<SnapZone>, so a raw memcpy clone would duplicate ownership
@@ -480,7 +445,6 @@ bool CloneAndAppendFourColumn(
         newLayout
     );
 }
-
 
 // -----------------------------------------------------------------------------
 // SnapModel::Layouts hook
@@ -539,7 +503,6 @@ RawVector* __cdecl Layouts_Hook(
 
 }  // namespace
 
-
 // -----------------------------------------------------------------------------
 // Windhawk lifecycle
 // -----------------------------------------------------------------------------
@@ -578,8 +541,7 @@ BOOL Wh_ModInit()
         return FALSE;
     }
 
-    // SnapLayout.dll
-    WindhawkUtils::SYMBOL_HOOK snapLayoutDllHooks[] = {
+    WindhawkUtils::SYMBOL_HOOK snapLayoutHooks[] = {
 
         {
             {
@@ -620,8 +582,8 @@ BOOL Wh_ModInit()
 
     if (!WindhawkUtils::HookSymbols(
             g_snapLayoutModule,
-            snapLayoutDllHooks,
-            ARRAYSIZE(snapLayoutDllHooks)))
+            snapLayoutHooks,
+            ARRAYSIZE(snapLayoutHooks)))
     {
         Wh_Log(
             L"Failed to resolve one or more SnapLayout.dll symbols"
@@ -641,7 +603,6 @@ BOOL Wh_ModInit()
 
     return TRUE;
 }
-
 
 void Wh_ModUninit()
 {

--- a/mods/windows-11-native-four-column-snap-layout.wh.cpp
+++ b/mods/windows-11-native-four-column-snap-layout.wh.cpp
@@ -578,7 +578,8 @@ BOOL Wh_ModInit()
         return FALSE;
     }
 
-    WindhawkUtils::SYMBOL_HOOK hooks[] = {
+    // SnapLayout.dll
+    WindhawkUtils::SYMBOL_HOOK snapLayoutDllHooks[] = {
 
         {
             {
@@ -619,8 +620,8 @@ BOOL Wh_ModInit()
 
     if (!WindhawkUtils::HookSymbols(
             g_snapLayoutModule,
-            hooks,
-            ARRAYSIZE(hooks)))
+            snapLayoutDllHooks,
+            ARRAYSIZE(snapLayoutDllHooks)))
     {
         Wh_Log(
             L"Failed to resolve one or more SnapLayout.dll symbols"

--- a/mods/windows-11-native-four-column-snap-layout.wh.cpp
+++ b/mods/windows-11-native-four-column-snap-layout.wh.cpp
@@ -5,6 +5,7 @@
 // @version      1.0
 // @author       Hoffelhas
 // @github       https://github.com/Hoffelhas
+// @license      MIT
 // @include      explorer.exe
 // @architecture x86-64
 // ==/WindhawkMod==
@@ -17,46 +18,58 @@ Adds an extra native Windows 11 Snap Layout with four equal vertical columns:
 
 `| 25% | 25% | 25% | 25% |`
 
-The layout is integrated into Windows' own Snap Layout UI and appears in:
+![Windows 11 four-column Snap Layout](https://i.imgur.com/a3sGZSk.png)
 
-- **Win+Z**
-- **Maximize-button hover**
-- **Snap Bar** when dragging a window to the top of the screen
+## What it does
 
-Because the mod extends the native Snap Layout model, snapping continues to use
-Windows' normal Snap Assist and Snap Groups behavior.
+- Adds the four-column layout as an additional option without replacing the
+  existing Windows layouts.
+- Appears in **Win+Z**, **maximize-button hover**, and the **Snap Bar** shown
+  when dragging a window to the top of the screen.
+- Integrates with Windows' native Snap Layout model, so Snap Assist and Snap
+  Groups continue to work normally.
 
 ## Compatibility
 
 This mod relies on undocumented Windows internals and private symbols from
 `SnapLayout.dll`. Windows updates can change these implementation details.
 
-The mod contains structural checks before modifying a layout. If the expected
-native layout structure isn't found, it leaves that layout set unchanged rather
-than patching an unknown structure.
+The mod searches the layouts provided by Windows for a compatible native
+four-zone quadrant layout before creating the additional layout. If a compatible
+source layout isn't found, that layout set is left unchanged.
 
 Developed and tested on Windows 11 build **26200.9445** on x86-64.
 
-If a Windows update changes the relevant private symbols, Windhawk may be unable
-to load the mod until it is updated.
+Currently tested only on x86-64 Windows. ARM64 compatibility has not been
+verified.
+
+If a Windows update changes the relevant private symbols or internal structure,
+Windhawk may be unable to load the mod until it is updated.
 */
 // ==/WindhawkModReadme==
 
-// Source code is published under the MIT License.
-
 #include <windhawk_utils.h>
+
 #include <windows.h>
+
+#include <atomic>
 #include <cstring>
 
 namespace {
 
 constexpr SIZE_T kSnapLayoutSize = 0x50;
 constexpr SIZE_T kSnapZoneSize = 0x38;
-constexpr SIZE_T kNativeLayoutCount = 6;
-constexpr SIZE_T kCustomLayoutCount = 7;
 
-constexpr int kNativePickerHeight = 244;
+// Sanity limits for data obtained through undocumented internal structures.
+constexpr SIZE_T kMaxReasonableLayoutCount = 32;
+constexpr SIZE_T kMaxReasonableZoneCount = 16;
+
+// Adding one more item can create an additional row in the Win+Z/maximize
+// picker. 80 logical pixels is the row-height increase observed on the tested
+// Windows build.
 constexpr int kExtraPickerHeight = 80;
+constexpr int kMinReasonablePickerHeight = 160;
+constexpr int kMaxReasonablePickerHeight = 400;
 
 struct RawVector {
     void* first;
@@ -64,141 +77,72 @@ struct RawVector {
     void* end;
 };
 
+// SnapBarViewModel asks SnapModel::Layouts() more than once during one load.
+// These flags identify that path and prevent the additional layout from being
+// inserted more than once into the Snap Bar load operation.
 thread_local bool g_inSnapBarLoad = false;
 thread_local bool g_snapBarCustomAdded = false;
+
+// Updated for every normal flyout Layouts() call. PickerHeight_Hook uses this
+// to increase the picker height only when the custom layout was actually added.
 thread_local bool g_flyoutCustomAdded = false;
 
-HMODULE g_snapLayoutModule = nullptr;
-bool g_loadedSnapLayoutModule = false;
+// 0 = SnapLayout.dll hooks not registered.
+// 1 = registration is currently in progress or has completed.
+//
+// A single flag prevents simultaneous LoadLibraryExW calls from trying to
+// resolve the same private symbols at the same time. It's reset if symbol
+// resolution fails, allowing a later load notification to retry.
+std::atomic<bool> g_snapLayoutHookClaimed{false};
 
 // -----------------------------------------------------------------------------
-// Native functions resolved from SnapLayout.dll
+// Native SnapLayout.dll functions
 // -----------------------------------------------------------------------------
 
-using Layouts_t = RawVector* (__cdecl*)(
-    void* thisPtr,
-    RawVector* returnBuffer
-);
-
+using Layouts_t =
+    RawVector*(__cdecl*)(void* thisPtr, RawVector* returnBuffer);
 Layouts_t Layouts_Original = nullptr;
 
-using EmplaceLayout_t = void* (__cdecl*)(
-    void* vectorThis,
-    const void* sourceLayout
-);
-
+using EmplaceLayout_t =
+    void*(__cdecl*)(void* vectorThis, const void* sourceLayout);
 EmplaceLayout_t EmplaceLayout_Original = nullptr;
 
-using PickerHeight_t = int (__cdecl*)(
-    void* thisPtr,
-    int* value
-);
-
+using PickerHeight_t = int(__cdecl*)(void* thisPtr, int* value);
 PickerHeight_t PickerHeight_Original = nullptr;
 
-using SnapBarLoadLayouts_t = void (__cdecl*)(
-    void* thisPtr,
-    double scale,
-    int options,
-    bool flag
-);
-
+using SnapBarLoadLayouts_t =
+    void(__cdecl*)(void* thisPtr, double scale, int options, bool flag);
 SnapBarLoadLayouts_t SnapBarLoadLayouts_Original = nullptr;
 
-void* __cdecl EmplaceLayout_Hook(
-    void* vectorThis,
-    const void* sourceLayout)
-{
-    return EmplaceLayout_Original(
-        vectorThis,
-        sourceLayout
-    );
-}
+// -----------------------------------------------------------------------------
+// kernelbase!LoadLibraryExW
+// -----------------------------------------------------------------------------
 
-int __cdecl PickerHeight_Hook(
-    void* thisPtr,
-    int* value)
-{
-    int hr =
-        PickerHeight_Original(
-            thisPtr,
-            value
-        );
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+LoadLibraryExW_t LoadLibraryExW_Original = nullptr;
 
-    if (hr == 0 &&
-        value &&
-        g_flyoutCustomAdded &&
-        *value == kNativePickerHeight)
-    {
-        *value += kExtraPickerHeight;
-    }
-
-    return hr;
-}
-
-void __cdecl SnapBarLoadLayouts_Hook(
-    void* thisPtr,
-    double scale,
-    int options,
-    bool flag)
-{
-    const bool previousInSnapBarLoad =
-        g_inSnapBarLoad;
-
-    const bool previousCustomAdded =
-        g_snapBarCustomAdded;
-
-    g_inSnapBarLoad = true;
-    g_snapBarCustomAdded = false;
-
-    SnapBarLoadLayouts_Original(
-        thisPtr,
-        scale,
-        options,
-        flag
-    );
-
-    g_inSnapBarLoad =
-        previousInSnapBarLoad;
-
-    g_snapBarCustomAdded =
-        previousCustomAdded;
-}
+// Forward declaration.
+bool HookSnapLayoutDll(HMODULE module, bool applyHookOperations);
 
 // -----------------------------------------------------------------------------
 // Raw SnapLayout / SnapZone helpers
 // -----------------------------------------------------------------------------
 
-SIZE_T GetVectorCount(
-    const RawVector* vec,
-    SIZE_T elementSize)
-{
-    if (!vec ||
-        !vec->first ||
-        !vec->last ||
-        elementSize == 0)
-    {
+SIZE_T GetVectorCount(const RawVector* vec, SIZE_T elementSize) {
+    if (!vec || !vec->first || !vec->last || !vec->end ||
+        elementSize == 0) {
         return 0;
     }
 
-    const auto* first =
-        reinterpret_cast<const BYTE*>(
-            vec->first
-        );
+    const auto* first = reinterpret_cast<const BYTE*>(vec->first);
+    const auto* last = reinterpret_cast<const BYTE*>(vec->last);
+    const auto* end = reinterpret_cast<const BYTE*>(vec->end);
 
-    const auto* last =
-        reinterpret_cast<const BYTE*>(
-            vec->last
-        );
-
-    if (last < first) {
+    if (last < first || end < last) {
         return 0;
     }
 
-    const SIZE_T bytes =
-        static_cast<SIZE_T>(
-            last - first
-        );
+    const SIZE_T bytes = static_cast<SIZE_T>(last - first);
 
     if (bytes % elementSize != 0) {
         return 0;
@@ -207,69 +151,81 @@ SIZE_T GetVectorCount(
     return bytes / elementSize;
 }
 
-SIZE_T GetZoneCount(
-    const void* layout)
-{
-    if (!layout) {
-        return 0;
+bool GetZoneVector(const void* layout,
+                   BYTE** firstOut,
+                   BYTE** lastOut,
+                   SIZE_T* countOut) {
+    if (!layout || !firstOut || !lastOut || !countOut) {
+        return false;
     }
 
     void* first = nullptr;
     void* last = nullptr;
+    void* end = nullptr;
 
-    memcpy(
-        &first,
-        reinterpret_cast<const BYTE*>(layout) + 0x28,
-        sizeof(first)
-    );
+    const auto* layoutBytes = reinterpret_cast<const BYTE*>(layout);
 
-    memcpy(
-        &last,
-        reinterpret_cast<const BYTE*>(layout) + 0x30,
-        sizeof(last)
-    );
+    memcpy(&first, layoutBytes + 0x28, sizeof(first));
+    memcpy(&last, layoutBytes + 0x30, sizeof(last));
+    memcpy(&end, layoutBytes + 0x38, sizeof(end));
 
-    if (!first || !last) {
-        return 0;
+    if (!first || !last || !end) {
+        return false;
     }
 
-    const auto* firstBytes =
-        reinterpret_cast<const BYTE*>(first);
+    auto* firstBytes = reinterpret_cast<BYTE*>(first);
+    auto* lastBytes = reinterpret_cast<BYTE*>(last);
+    auto* endBytes = reinterpret_cast<BYTE*>(end);
 
-    const auto* lastBytes =
-        reinterpret_cast<const BYTE*>(last);
-
-    if (lastBytes < firstBytes) {
-        return 0;
+    if (lastBytes < firstBytes || endBytes < lastBytes) {
+        return false;
     }
 
-    const SIZE_T bytes =
-        static_cast<SIZE_T>(
-            lastBytes - firstBytes
-        );
+    const SIZE_T bytes = static_cast<SIZE_T>(lastBytes - firstBytes);
 
     if (bytes % kSnapZoneSize != 0) {
-        return 0;
+        return false;
     }
 
-    return bytes / kSnapZoneSize;
+    const SIZE_T count = bytes / kSnapZoneSize;
+
+    if (count > kMaxReasonableZoneCount) {
+        return false;
+    }
+
+    *firstOut = firstBytes;
+    *lastOut = lastBytes;
+    *countOut = count;
+
+    return true;
 }
 
-void WriteU32(
-    void* base,
-    SIZE_T offset,
-    unsigned int value)
-{
-    memcpy(
-        reinterpret_cast<BYTE*>(base) + offset,
-        &value,
-        sizeof(value)
-    );
+void WriteU32(void* base, SIZE_T offset, unsigned int value) {
+    memcpy(reinterpret_cast<BYTE*>(base) + offset, &value, sizeof(value));
 }
 
-bool IsExpectedSourceLayout(
-    const void* layout)
-{
+bool ReadU32(const void* base, SIZE_T offset, unsigned int* value) {
+    if (!base || !value) {
+        return false;
+    }
+
+    memcpy(value, reinterpret_cast<const BYTE*>(base) + offset,
+           sizeof(*value));
+
+    return true;
+}
+
+// Verify that the candidate isn't merely "2x2 with four zones", but actually
+// represents the normal four-quadrant Windows layout:
+//
+// +---+---+
+// | 0 | 1 |
+// +---+---+
+// | 2 | 3 |
+// +---+---+
+//
+// Zone ordering itself doesn't matter.
+bool IsNativeQuadrantLayout(const void* layout) {
     if (!layout) {
         return false;
     }
@@ -277,69 +233,83 @@ bool IsExpectedSourceLayout(
     unsigned int columns = 0;
     unsigned int rows = 0;
 
-    memcpy(
-        &columns,
-        reinterpret_cast<const BYTE*>(layout) + 0x20,
-        sizeof(columns)
-    );
+    if (!ReadU32(layout, 0x20, &columns) ||
+        !ReadU32(layout, 0x24, &rows) || columns != 2 || rows != 2) {
+        return false;
+    }
 
-    memcpy(
-        &rows,
-        reinterpret_cast<const BYTE*>(layout) + 0x24,
-        sizeof(rows)
-    );
+    BYTE* zoneFirst = nullptr;
+    BYTE* zoneLast = nullptr;
+    SIZE_T zoneCount = 0;
 
-    return
-        columns == 2 &&
-        rows == 2 &&
-        GetZoneCount(layout) == 4;
+    if (!GetZoneVector(layout, &zoneFirst, &zoneLast, &zoneCount) ||
+        zoneCount != 4) {
+        return false;
+    }
+
+    bool found[2][2] = {};
+
+    for (SIZE_T i = 0; i < zoneCount; i++) {
+        const BYTE* zone = zoneFirst + i * kSnapZoneSize;
+
+        unsigned int originColumn = 0;
+        unsigned int originRow = 0;
+        unsigned int columnSpan = 0;
+        unsigned int rowSpan = 0;
+
+        if (!ReadU32(zone, 0x20, &originColumn) ||
+            !ReadU32(zone, 0x24, &originRow) ||
+            !ReadU32(zone, 0x28, &columnSpan) ||
+            !ReadU32(zone, 0x2C, &rowSpan)) {
+            return false;
+        }
+
+        if (originColumn >= 2 || originRow >= 2 || columnSpan != 1 ||
+            rowSpan != 1 || found[originRow][originColumn]) {
+            return false;
+        }
+
+        found[originRow][originColumn] = true;
+    }
+
+    return found[0][0] && found[0][1] && found[1][0] && found[1][1];
 }
 
 // -----------------------------------------------------------------------------
-// Convert copied native quadrant layout into four equal columns
+// Convert a copied quadrant layout to four equal vertical columns
 // -----------------------------------------------------------------------------
 
-bool PatchToFourColumns(
-    void* layout)
-{
-    if (!IsExpectedSourceLayout(layout)) {
+bool PatchToFourColumns(void* layout) {
+    if (!IsNativeQuadrantLayout(layout)) {
+        Wh_Log(L"Copied source layout no longer matches the expected "
+               L"2x2 four-quadrant structure");
         return false;
     }
 
-    void* zoneFirst = nullptr;
-    void* zoneLast = nullptr;
+    BYTE* zoneFirst = nullptr;
+    BYTE* zoneLast = nullptr;
+    SIZE_T zoneCount = 0;
 
-    memcpy(
-        &zoneFirst,
-        reinterpret_cast<BYTE*>(layout) + 0x28,
-        sizeof(zoneFirst)
-    );
-
-    memcpy(
-        &zoneLast,
-        reinterpret_cast<BYTE*>(layout) + 0x30,
-        sizeof(zoneLast)
-    );
-
-    if (!zoneFirst || !zoneLast) {
+    if (!GetZoneVector(layout, &zoneFirst, &zoneLast, &zoneCount) ||
+        zoneCount != 4) {
+        Wh_Log(L"Unexpected zone vector while patching custom layout");
         return false;
     }
 
-    const SIZE_T zoneBytes =
-        reinterpret_cast<BYTE*>(zoneLast) -
-        reinterpret_cast<BYTE*>(zoneFirst);
-
-    if (zoneBytes != 4 * kSnapZoneSize) {
-        return false;
-    }
-
+    // SnapLayout:
+    // +0x20 = column count
+    // +0x24 = row count
     WriteU32(layout, 0x20, 4);
     WriteU32(layout, 0x24, 1);
 
+    // SnapZone:
+    // +0x20 OriginColumn
+    // +0x24 OriginRow
+    // +0x28 ColumnSpan
+    // +0x2C RowSpan
+    // +0x30 GridUnitType -- preserved from the native source layout.
     for (unsigned int i = 0; i < 4; i++) {
-        BYTE* zone =
-            reinterpret_cast<BYTE*>(zoneFirst) +
-            i * kSnapZoneSize;
+        BYTE* zone = zoneFirst + i * kSnapZoneSize;
 
         WriteU32(zone, 0x20, i);
         WriteU32(zone, 0x24, 0);
@@ -351,132 +321,155 @@ bool PatchToFourColumns(
 }
 
 // -----------------------------------------------------------------------------
-// Deep-copy and append one native layout
+// Find, deep-copy, and append the native quadrant layout
 // -----------------------------------------------------------------------------
 
-bool CloneAndAppendFourColumn(
-    RawVector* vec,
-    SIZE_T sourceIndex)
-{
-    if (!vec ||
-        !EmplaceLayout_Original)
-    {
+bool CloneAndAppendFourColumn(RawVector* vec) {
+    if (!vec || !EmplaceLayout_Original) {
+        Wh_Log(L"Can't append custom layout: invalid vector or unresolved "
+               L"emplace helper");
         return false;
     }
 
-    const SIZE_T count =
-        GetVectorCount(
-            vec,
-            kSnapLayoutSize
-        );
+    const SIZE_T count = GetVectorCount(vec, kSnapLayoutSize);
 
-    if (count != kNativeLayoutCount ||
-        sourceIndex >= count)
-    {
+    if (count == 0 || count > kMaxReasonableLayoutCount) {
+        Wh_Log(L"Can't inspect Snap Layout set: invalid layout count %zu",
+               count);
         return false;
     }
 
-    BYTE* source =
-        reinterpret_cast<BYTE*>(
-            vec->first
-        ) +
-        sourceIndex * kSnapLayoutSize;
+    const BYTE* vectorFirst =
+        reinterpret_cast<const BYTE*>(vec->first);
 
-    if (!IsExpectedSourceLayout(source)) {
+    SIZE_T sourceIndex = count;
+
+    for (SIZE_T i = 0; i < count; i++) {
+        const BYTE* candidate = vectorFirst + i * kSnapLayoutSize;
+
+        if (IsNativeQuadrantLayout(candidate)) {
+            sourceIndex = i;
+            break;
+        }
+    }
+
+    if (sourceIndex == count) {
+        Wh_Log(L"No compatible 2x2 four-quadrant source layout among %zu "
+               L"native layouts",
+               count);
         return false;
     }
 
-    void* newLayout =
-        EmplaceLayout_Original(
-            vec,
-            source
-        );
+    // Save the source pointer only until insertion. The insertion operation can
+    // reallocate the vector, so neither this pointer nor vec->first may be used
+    // afterwards to refer to the old storage.
+    const void* source =
+        vectorFirst + sourceIndex * kSnapLayoutSize;
+
+    // Use SnapLayout.dll's own std::vector insertion implementation.
+    //
+    // SnapLayout owns non-trivial members including std::wstring and
+    // std::vector<SnapZone>, so copying its bytes directly would duplicate
+    // ownership pointers and be unsafe.
+    void* newLayout = EmplaceLayout_Original(vec, source);
 
     if (!newLayout) {
+        Wh_Log(L"Failed to clone native Snap Layout");
         return false;
     }
 
-    if (GetVectorCount(
-            vec,
-            kSnapLayoutSize) !=
-        kCustomLayoutCount)
-    {
+    if (!PatchToFourColumns(newLayout)) {
+        // This should be unreachable after the source-layout validation and
+        // native deep copy above. If Windows changes the copy semantics, log it
+        // rather than modifying any other object.
+        Wh_Log(L"Native Snap Layout clone couldn't be converted");
         return false;
     }
 
-    return PatchToFourColumns(
-        newLayout
-    );
+    Wh_Log(L"Added four-column Snap Layout using native source index %zu",
+           sourceIndex);
+
+    return true;
 }
 
 // -----------------------------------------------------------------------------
-// SnapModel::Layouts hook
+// SnapLayout.dll hooks
 // -----------------------------------------------------------------------------
 
-RawVector* __cdecl Layouts_Hook(
-    void* thisPtr,
-    RawVector* returnBuffer)
-{
-    RawVector* result =
-        Layouts_Original(
-            thisPtr,
-            returnBuffer
-        );
+RawVector* __cdecl Layouts_Hook(void* thisPtr, RawVector* returnBuffer) {
+    RawVector* result = Layouts_Original(thisPtr, returnBuffer);
 
     if (!returnBuffer) {
         return result;
     }
 
     if (g_inSnapBarLoad) {
-        if (!g_snapBarCustomAdded &&
-            CloneAndAppendFourColumn(
-                returnBuffer,
-                3))
-        {
-            g_snapBarCustomAdded = true;
+        // SnapBarViewModel requests a fresh Layouts() vector more than once
+        // during a single load operation. Modifying only the first one is the
+        // behavior verified on the tested Windows build.
+        if (!g_snapBarCustomAdded) {
+            g_snapBarCustomAdded =
+                CloneAndAppendFourColumn(returnBuffer);
         }
 
         return result;
     }
 
-    if (CloneAndAppendFourColumn(
-            returnBuffer,
-            4))
-    {
-        g_flyoutCustomAdded = true;
-    }
+    // Don't latch this state permanently. If a later Layouts() call returns a
+    // layout set we can't safely extend, PickerHeight_Hook must not enlarge its
+    // picker.
+    g_flyoutCustomAdded =
+        CloneAndAppendFourColumn(returnBuffer);
 
     return result;
 }
 
-}  // namespace
+int __cdecl PickerHeight_Hook(void* thisPtr, int* value) {
+    const int hr = PickerHeight_Original(thisPtr, value);
 
-BOOL Wh_ModInit()
-{
-    g_snapLayoutModule =
-        GetModuleHandleW(
-            L"SnapLayout.dll"
-        );
-
-    if (!g_snapLayoutModule) {
-        g_snapLayoutModule =
-            LoadLibraryExW(
-                L"C:\\WINDOWS\\SystemApps\\MicrosoftWindows.Client.Core_cw5n1h2txyewy\\SnapLayout.dll",
-                nullptr,
-                LOAD_WITH_ALTERED_SEARCH_PATH
-            );
-
-        if (g_snapLayoutModule) {
-            g_loadedSnapLayoutModule = true;
-        }
+    // Adding one item can add one further row to the picker. Avoid pinning this
+    // to the exact 244-pixel value observed on one build, but retain a sanity
+    // range so an unexpected ABI/semantic change isn't blindly modified.
+    if (hr == 0 && value && g_flyoutCustomAdded &&
+        *value >= kMinReasonablePickerHeight &&
+        *value <= kMaxReasonablePickerHeight) {
+        *value += kExtraPickerHeight;
     }
 
-    if (!g_snapLayoutModule) {
-        Wh_Log(
-            L"Failed to load SnapLayout.dll"
-        );
+    return hr;
+}
 
-        return FALSE;
+void __cdecl SnapBarLoadLayouts_Hook(void* thisPtr,
+                                     double scale,
+                                     int options,
+                                     bool flag) {
+    const bool previousInSnapBarLoad = g_inSnapBarLoad;
+    const bool previousCustomAdded = g_snapBarCustomAdded;
+
+    g_inSnapBarLoad = true;
+    g_snapBarCustomAdded = false;
+
+    SnapBarLoadLayouts_Original(thisPtr, scale, options, flag);
+
+    g_inSnapBarLoad = previousInSnapBarLoad;
+    g_snapBarCustomAdded = previousCustomAdded;
+}
+
+// -----------------------------------------------------------------------------
+// Late loading of SnapLayout.dll
+// -----------------------------------------------------------------------------
+
+bool HookSnapLayoutDll(HMODULE module, bool applyHookOperations) {
+    if (!module) {
+        return false;
+    }
+
+    bool expected = false;
+
+    if (!g_snapLayoutHookClaimed.compare_exchange_strong(expected, true)) {
+        // Another call is already resolving the symbols, or they were resolved
+        // successfully earlier.
+        return true;
     }
 
     WindhawkUtils::SYMBOL_HOOK snapLayoutDllHooks[] = {
@@ -492,7 +485,7 @@ BOOL Wh_ModInit()
                 LR"(private: struct SnapLayout & __cdecl std::vector<struct SnapLayout,class std::allocator<struct SnapLayout> >::_Emplace_one_at_back<struct SnapLayout const &>(struct SnapLayout const &))",
             },
             &EmplaceLayout_Original,
-            EmplaceLayout_Hook,
+            nullptr,
         },
         {
             {
@@ -511,39 +504,110 @@ BOOL Wh_ModInit()
     };
 
     if (!WindhawkUtils::HookSymbols(
-            g_snapLayoutModule,
+            module,
             snapLayoutDllHooks,
-            ARRAYSIZE(snapLayoutDllHooks)))
-    {
-        Wh_Log(
-            L"Failed to resolve one or more SnapLayout.dll symbols"
-        );
+            ARRAYSIZE(snapLayoutDllHooks))) {
+        Wh_Log(L"Failed to resolve one or more SnapLayout.dll symbols");
 
-        if (g_loadedSnapLayoutModule) {
-            FreeLibrary(
-                g_snapLayoutModule
-            );
+        // Permit a later attempt if this was a transient failure.
+        g_snapLayoutHookClaimed = false;
+        return false;
+    }
 
-            g_snapLayoutModule = nullptr;
-            g_loadedSnapLayoutModule = false;
+    Wh_Log(L"SnapLayout.dll symbols resolved successfully");
+
+    // Hooks registered after Wh_ModInit() aren't applied automatically until
+    // requested. This path is used when SnapLayout.dll loads naturally later
+    // in Explorer's lifetime.
+    if (applyHookOperations && !Wh_ApplyHookOperations()) {
+        Wh_Log(L"Failed to apply SnapLayout.dll hook operations");
+        return false;
+    }
+
+    return true;
+}
+
+void HandleSnapLayoutDllIfLoaded(bool applyHookOperations) {
+    if (g_snapLayoutHookClaimed.load()) {
+        return;
+    }
+
+    HMODULE module = GetModuleHandleW(L"SnapLayout.dll");
+
+    if (module) {
+        HookSnapLayoutDll(module, applyHookOperations);
+    }
+}
+
+HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
+                                   HANDLE hFile,
+                                   DWORD dwFlags) {
+    HMODULE module =
+        LoadLibraryExW_Original(lpLibFileName, hFile, dwFlags);
+
+    if (module && !g_snapLayoutHookClaimed.load()) {
+        // Check the module handle rather than matching lpLibFileName. This also
+        // catches SnapLayout.dll arriving as a dependency of another DLL.
+        HandleSnapLayoutDllIfLoaded(true);
+    }
+
+    return module;
+}
+
+}  // namespace
+
+// -----------------------------------------------------------------------------
+// Windhawk lifecycle
+// -----------------------------------------------------------------------------
+
+BOOL Wh_ModInit() {
+    // If SnapLayout.dll is already present, register its hooks now. Windhawk
+    // will apply them automatically after Wh_ModInit returns.
+    if (HMODULE snapLayoutModule = GetModuleHandleW(L"SnapLayout.dll")) {
+        if (!HookSnapLayoutDll(snapLayoutModule, false)) {
+            return FALSE;
         }
 
+        return TRUE;
+    }
+
+    // SnapLayout.dll hasn't loaded yet. Intercept kernelbase!LoadLibraryExW so
+    // it can be hooked when Windows naturally loads the Snap UI component.
+    HMODULE kernelBaseModule = GetModuleHandleW(L"kernelbase.dll");
+
+    if (!kernelBaseModule) {
+        Wh_Log(L"Failed to get kernelbase.dll");
         return FALSE;
     }
+
+    auto pKernelBaseLoadLibraryExW =
+        reinterpret_cast<decltype(&LoadLibraryExW)>(
+            GetProcAddress(kernelBaseModule, "LoadLibraryExW"));
+
+    if (!pKernelBaseLoadLibraryExW) {
+        Wh_Log(L"Failed to resolve kernelbase!LoadLibraryExW");
+        return FALSE;
+    }
+
+    if (!WindhawkUtils::SetFunctionHook(
+            pKernelBaseLoadLibraryExW,
+            LoadLibraryExW_Hook,
+            &LoadLibraryExW_Original)) {
+        Wh_Log(L"Failed to hook kernelbase!LoadLibraryExW");
+        return FALSE;
+    }
+
+    Wh_Log(L"SnapLayout.dll isn't loaded yet; waiting for Windows to load it");
 
     return TRUE;
 }
 
-void Wh_ModUninit()
-{
-    if (g_loadedSnapLayoutModule &&
-        g_snapLayoutModule)
-    {
-        FreeLibrary(
-            g_snapLayoutModule
-        );
+void Wh_ModAfterInit() {
+    // Close the small race where SnapLayout.dll loads after the initial module
+    // check but before the LoadLibraryExW hook becomes active. It also catches
+    // cases where it was introduced as a static dependency.
+    HandleSnapLayoutDllIfLoaded(true);
+}
 
-        g_snapLayoutModule = nullptr;
-        g_loadedSnapLayoutModule = false;
-    }
+void Wh_ModUninit() {
 }

--- a/mods/windows-11-native-four-column-snap-layout.wh.cpp
+++ b/mods/windows-11-native-four-column-snap-layout.wh.cpp
@@ -1,0 +1,657 @@
+// ==WindhawkMod==
+// @id           windows-11-native-four-column-snap-layout
+// @name         Windows 11 Native Four Column Snap Layout
+// @description  Adds an extra native Windows 11 Snap Layout with four equal vertical columns
+// @version      1.0
+// @author       Hoffelhas
+// @github       https://github.com/Hoffelhas
+// @include      explorer.exe
+// @architecture amd64
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Windows 11 Native Four Column Snap Layout
+
+Adds an extra native Windows 11 Snap Layout with four equal vertical columns:
+
+`| 25% | 25% | 25% | 25% |`
+
+The layout is integrated into Windows' own Snap Layout UI and appears in:
+
+- **Win+Z**
+- **Maximize-button hover**
+- **Snap Bar** when dragging a window to the top of the screen
+
+Because the mod extends the native Snap Layout model, snapping continues to use
+Windows' normal Snap Assist and Snap Groups behavior.
+
+## Compatibility
+
+This mod relies on undocumented Windows internals and private symbols from
+`SnapLayout.dll`. Windows updates can change these implementation details.
+
+The mod contains structural checks before modifying a layout. If the expected
+native layout structure isn't found, it leaves that layout set unchanged rather
+than patching an unknown structure.
+
+Developed and tested on Windows 11 build **26200.9445** on x86-64.
+
+If a Windows update changes the relevant private symbols, Windhawk may be unable
+to load the mod until it is updated.
+*/
+// ==/WindhawkModReadme==
+
+// Source code is published under the MIT License.
+
+#include <windhawk_utils.h>
+#include <windows.h>
+#include <cstring>
+
+namespace {
+
+constexpr SIZE_T kSnapLayoutSize = 0x50;
+constexpr SIZE_T kSnapZoneSize = 0x38;
+constexpr SIZE_T kNativeLayoutCount = 6;
+constexpr SIZE_T kCustomLayoutCount = 7;
+
+constexpr int kNativePickerHeight = 244;
+constexpr int kExtraPickerHeight = 80;
+
+struct RawVector {
+    void* first;
+    void* last;
+    void* end;
+};
+
+// The Snap Bar asks SnapModel::Layouts() more than once while loading.
+// These thread-local flags distinguish that path from the Win+Z/maximize
+// flyout path and avoid appending the custom layout more than once per load.
+thread_local bool g_inSnapBarLoad = false;
+thread_local bool g_snapBarCustomAdded = false;
+
+// Set after the normal flyout path successfully appends the custom layout.
+// Thread-local for consistency with the Snap Bar state.
+thread_local bool g_flyoutCustomAdded = false;
+
+// Keep track of SnapLayout.dll so a reference acquired by this mod can be
+// released again when the mod unloads.
+HMODULE g_snapLayoutModule = nullptr;
+bool g_loadedSnapLayoutModule = false;
+
+
+// -----------------------------------------------------------------------------
+// Native functions resolved from SnapLayout.dll
+// -----------------------------------------------------------------------------
+
+using Layouts_t = RawVector* (__cdecl*)(
+    void* thisPtr,
+    RawVector* returnBuffer
+);
+
+Layouts_t Layouts_Original = nullptr;
+
+
+using EmplaceLayout_t = void* (__cdecl*)(
+    void* vectorThis,
+    const void* sourceLayout
+);
+
+EmplaceLayout_t EmplaceLayout_Original = nullptr;
+
+
+using PickerHeight_t = int (__cdecl*)(
+    void* thisPtr,
+    int* value
+);
+
+PickerHeight_t PickerHeight_Original = nullptr;
+
+
+using SnapBarLoadLayouts_t = void (__cdecl*)(
+    void* thisPtr,
+    double scale,
+    int options,
+    bool flag
+);
+
+SnapBarLoadLayouts_t SnapBarLoadLayouts_Original = nullptr;
+
+
+// This pass-through hook exists so Windhawk resolves the private vector helper
+// and exposes a callable original/trampoline pointer.
+void* __cdecl EmplaceLayout_Hook(
+    void* vectorThis,
+    const void* sourceLayout)
+{
+    return EmplaceLayout_Original(
+        vectorThis,
+        sourceLayout
+    );
+}
+
+
+int __cdecl PickerHeight_Hook(
+    void* thisPtr,
+    int* value)
+{
+    int hr =
+        PickerHeight_Original(
+            thisPtr,
+            value
+        );
+
+    // The extra flyout item occupies one more row.
+    // Only adjust the exact native height observed on the supported build,
+    // and only after the custom flyout layout was actually added.
+    if (hr == 0 &&
+        value &&
+        g_flyoutCustomAdded &&
+        *value == kNativePickerHeight)
+    {
+        *value += kExtraPickerHeight;
+    }
+
+    return hr;
+}
+
+
+void __cdecl SnapBarLoadLayouts_Hook(
+    void* thisPtr,
+    double scale,
+    int options,
+    bool flag)
+{
+    const bool previousInSnapBarLoad =
+        g_inSnapBarLoad;
+
+    const bool previousCustomAdded =
+        g_snapBarCustomAdded;
+
+    g_inSnapBarLoad = true;
+    g_snapBarCustomAdded = false;
+
+    SnapBarLoadLayouts_Original(
+        thisPtr,
+        scale,
+        options,
+        flag
+    );
+
+    g_inSnapBarLoad =
+        previousInSnapBarLoad;
+
+    g_snapBarCustomAdded =
+        previousCustomAdded;
+}
+
+
+// -----------------------------------------------------------------------------
+// Raw SnapLayout / SnapZone helpers
+// -----------------------------------------------------------------------------
+
+SIZE_T GetVectorCount(
+    const RawVector* vec,
+    SIZE_T elementSize)
+{
+    if (!vec ||
+        !vec->first ||
+        !vec->last ||
+        elementSize == 0)
+    {
+        return 0;
+    }
+
+    const auto* first =
+        reinterpret_cast<const BYTE*>(
+            vec->first
+        );
+
+    const auto* last =
+        reinterpret_cast<const BYTE*>(
+            vec->last
+        );
+
+    if (last < first) {
+        return 0;
+    }
+
+    const SIZE_T bytes =
+        static_cast<SIZE_T>(
+            last - first
+        );
+
+    if (bytes % elementSize != 0) {
+        return 0;
+    }
+
+    return bytes / elementSize;
+}
+
+
+SIZE_T GetZoneCount(
+    const void* layout)
+{
+    if (!layout) {
+        return 0;
+    }
+
+    void* first = nullptr;
+    void* last = nullptr;
+
+    memcpy(
+        &first,
+        reinterpret_cast<const BYTE*>(layout) + 0x28,
+        sizeof(first)
+    );
+
+    memcpy(
+        &last,
+        reinterpret_cast<const BYTE*>(layout) + 0x30,
+        sizeof(last)
+    );
+
+    if (!first || !last) {
+        return 0;
+    }
+
+    const auto* firstBytes =
+        reinterpret_cast<const BYTE*>(
+            first
+        );
+
+    const auto* lastBytes =
+        reinterpret_cast<const BYTE*>(
+            last
+        );
+
+    if (lastBytes < firstBytes) {
+        return 0;
+    }
+
+    const SIZE_T bytes =
+        static_cast<SIZE_T>(
+            lastBytes - firstBytes
+        );
+
+    if (bytes % kSnapZoneSize != 0) {
+        return 0;
+    }
+
+    return bytes / kSnapZoneSize;
+}
+
+
+void WriteU32(
+    void* base,
+    SIZE_T offset,
+    unsigned int value)
+{
+    memcpy(
+        reinterpret_cast<BYTE*>(base) + offset,
+        &value,
+        sizeof(value)
+    );
+}
+
+
+bool IsExpectedSourceLayout(
+    const void* layout)
+{
+    if (!layout) {
+        return false;
+    }
+
+    unsigned int columns = 0;
+    unsigned int rows = 0;
+
+    memcpy(
+        &columns,
+        reinterpret_cast<const BYTE*>(layout) + 0x20,
+        sizeof(columns)
+    );
+
+    memcpy(
+        &rows,
+        reinterpret_cast<const BYTE*>(layout) + 0x24,
+        sizeof(rows)
+    );
+
+    return
+        columns == 2 &&
+        rows == 2 &&
+        GetZoneCount(layout) == 4;
+}
+
+
+// -----------------------------------------------------------------------------
+// Convert copied native quadrant layout into four equal columns
+// -----------------------------------------------------------------------------
+
+bool PatchToFourColumns(
+    void* layout)
+{
+    if (!IsExpectedSourceLayout(layout)) {
+        return false;
+    }
+
+    void* zoneFirst = nullptr;
+    void* zoneLast = nullptr;
+
+    memcpy(
+        &zoneFirst,
+        reinterpret_cast<BYTE*>(layout) + 0x28,
+        sizeof(zoneFirst)
+    );
+
+    memcpy(
+        &zoneLast,
+        reinterpret_cast<BYTE*>(layout) + 0x30,
+        sizeof(zoneLast)
+    );
+
+    if (!zoneFirst || !zoneLast) {
+        return false;
+    }
+
+    const SIZE_T zoneBytes =
+        reinterpret_cast<BYTE*>(zoneLast) -
+        reinterpret_cast<BYTE*>(zoneFirst);
+
+    if (zoneBytes != 4 * kSnapZoneSize) {
+        return false;
+    }
+
+    // SnapLayout grid:
+    // 4 columns × 1 row.
+    WriteU32(layout, 0x20, 4);
+    WriteU32(layout, 0x24, 1);
+
+    // Relevant SnapZone fields:
+    //
+    // +0x20 OriginColumn
+    // +0x24 OriginRow
+    // +0x28 ColumnSpan
+    // +0x2C RowSpan
+    // +0x30 GridUnitType (preserved)
+    //
+    // Result:
+    //
+    // | 0 | 1 | 2 | 3 |
+    //
+    // with each zone spanning exactly one column.
+    for (unsigned int i = 0; i < 4; i++) {
+
+        BYTE* zone =
+            reinterpret_cast<BYTE*>(zoneFirst) +
+            i * kSnapZoneSize;
+
+        WriteU32(
+            zone,
+            0x20,
+            i
+        );
+
+        WriteU32(
+            zone,
+            0x24,
+            0
+        );
+
+        WriteU32(
+            zone,
+            0x28,
+            1
+        );
+
+        WriteU32(
+            zone,
+            0x2C,
+            1
+        );
+    }
+
+    return true;
+}
+
+
+// -----------------------------------------------------------------------------
+// Deep-copy and append one native layout
+// -----------------------------------------------------------------------------
+
+bool CloneAndAppendFourColumn(
+    RawVector* vec,
+    SIZE_T sourceIndex)
+{
+    if (!vec ||
+        !EmplaceLayout_Original)
+    {
+        return false;
+    }
+
+    const SIZE_T count =
+        GetVectorCount(
+            vec,
+            kSnapLayoutSize
+        );
+
+    // Safety check:
+    // this build is expected to return six native layouts.
+    if (count != kNativeLayoutCount ||
+        sourceIndex >= count)
+    {
+        return false;
+    }
+
+    BYTE* source =
+        reinterpret_cast<BYTE*>(
+            vec->first
+        ) +
+        sourceIndex * kSnapLayoutSize;
+
+    if (!IsExpectedSourceLayout(source)) {
+        return false;
+    }
+
+    // Use SnapLayout.dll's own std::vector insertion helper.
+    //
+    // SnapLayout contains non-trivial members such as std::wstring and
+    // std::vector<SnapZone>, so a raw memcpy clone would duplicate ownership
+    // pointers and would be unsafe.
+    void* newLayout =
+        EmplaceLayout_Original(
+            vec,
+            source
+        );
+
+    if (!newLayout) {
+        return false;
+    }
+
+    if (GetVectorCount(
+            vec,
+            kSnapLayoutSize) !=
+        kCustomLayoutCount)
+    {
+        return false;
+    }
+
+    return PatchToFourColumns(
+        newLayout
+    );
+}
+
+
+// -----------------------------------------------------------------------------
+// SnapModel::Layouts hook
+// -----------------------------------------------------------------------------
+
+RawVector* __cdecl Layouts_Hook(
+    void* thisPtr,
+    RawVector* returnBuffer)
+{
+    RawVector* result =
+        Layouts_Original(
+            thisPtr,
+            returnBuffer
+        );
+
+    if (!returnBuffer) {
+        return result;
+    }
+
+    if (g_inSnapBarLoad) {
+
+        // Snap Bar ordering observed on the supported build:
+        //
+        // 0: 2x1 / 2 zones
+        // 1: 3x1 / 2 zones
+        // 2: 2x2 / 3 zones
+        // 3: 2x2 / 4 zones  <-- source
+        // 4: 3x1 / 3 zones
+        // 5: 4x1 / 3 zones
+        //
+        // SnapBar asks for SnapModel::Layouts() more than once while loading,
+        // so append the custom layout only once for that load.
+        if (!g_snapBarCustomAdded &&
+            CloneAndAppendFourColumn(
+                returnBuffer,
+                3))
+        {
+            g_snapBarCustomAdded = true;
+        }
+
+        return result;
+    }
+
+    // Win+Z / maximize-hover ordering observed on the supported build:
+    //
+    // Element 4 is the native 2x2 / four-zone source layout.
+    if (CloneAndAppendFourColumn(
+            returnBuffer,
+            4))
+    {
+        g_flyoutCustomAdded = true;
+    }
+
+    return result;
+}
+
+}  // namespace
+
+
+// -----------------------------------------------------------------------------
+// Windhawk lifecycle
+// -----------------------------------------------------------------------------
+
+BOOL Wh_ModInit()
+{
+    g_snapLayoutModule =
+        GetModuleHandleW(
+            L"SnapLayout.dll"
+        );
+
+    if (!g_snapLayoutModule) {
+
+        // On the tested Windows 11 build, SnapLayout.dll is part of the
+        // MicrosoftWindows.Client.Core system app.
+        //
+        // Load it explicitly if Explorer hasn't loaded it yet so Windhawk can
+        // resolve and install the private-symbol hooks.
+        g_snapLayoutModule =
+            LoadLibraryExW(
+                L"C:\\WINDOWS\\SystemApps\\MicrosoftWindows.Client.Core_cw5n1h2txyewy\\SnapLayout.dll",
+                nullptr,
+                LOAD_WITH_ALTERED_SEARCH_PATH
+            );
+
+        if (g_snapLayoutModule) {
+            g_loadedSnapLayoutModule = true;
+        }
+    }
+
+    if (!g_snapLayoutModule) {
+        Wh_Log(
+            L"Failed to load SnapLayout.dll"
+        );
+
+        return FALSE;
+    }
+
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {
+
+        {
+            {
+                LR"(public: class std::vector<struct SnapLayout,class std::allocator<struct SnapLayout> > __cdecl SnapModel::Layouts(void)const )",
+            },
+
+            &Layouts_Original,
+            Layouts_Hook,
+        },
+
+        {
+            {
+                LR"(private: struct SnapLayout & __cdecl std::vector<struct SnapLayout,class std::allocator<struct SnapLayout> >::_Emplace_one_at_back<struct SnapLayout const &>(struct SnapLayout const &))",
+            },
+
+            &EmplaceLayout_Original,
+            EmplaceLayout_Hook,
+        },
+
+        {
+            {
+                LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::SnapLayout::implementation::SnapLayoutPickerViewModel,struct winrt::SnapLayout::ISnapLayoutPickerViewModel>::get_PickerHeight(int *))",
+            },
+
+            &PickerHeight_Original,
+            PickerHeight_Hook,
+        },
+
+        {
+            {
+                LR"(public: void __cdecl winrt::SnapLayout::implementation::SnapBarViewModel::LoadLayouts(double,enum winrt::SnapLayout::SnapModelOptions,bool))",
+            },
+
+            &SnapBarLoadLayouts_Original,
+            SnapBarLoadLayouts_Hook,
+        },
+    };
+
+    if (!WindhawkUtils::HookSymbols(
+            g_snapLayoutModule,
+            hooks,
+            ARRAYSIZE(hooks)))
+    {
+        Wh_Log(
+            L"Failed to resolve one or more SnapLayout.dll symbols"
+        );
+
+        if (g_loadedSnapLayoutModule) {
+            FreeLibrary(
+                g_snapLayoutModule
+            );
+
+            g_snapLayoutModule = nullptr;
+            g_loadedSnapLayoutModule = false;
+        }
+
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+
+void Wh_ModUninit()
+{
+    if (g_loadedSnapLayoutModule &&
+        g_snapLayoutModule)
+    {
+        FreeLibrary(
+            g_snapLayoutModule
+        );
+
+        g_snapLayoutModule = nullptr;
+        g_loadedSnapLayoutModule = false;
+    }
+}

--- a/mods/windows-11-native-four-column-snap-layout.wh.cpp
+++ b/mods/windows-11-native-four-column-snap-layout.wh.cpp
@@ -16,8 +16,6 @@
 
 Adds an extra native Windows 11 Snap Layout with four equal vertical columns:
 
-`| 25% | 25% | 25% | 25% |`
-
 ![Windows 11 four-column Snap Layout](https://i.imgur.com/a3sGZSk.png)
 
 ## What it does

--- a/mods/windows-11-native-four-column-snap-layout.wh.cpp
+++ b/mods/windows-11-native-four-column-snap-layout.wh.cpp
@@ -14,7 +14,8 @@
 /*
 # Windows 11 Native Four Column Snap Layout
 
-Add an extra native Windows 11 Snap Layout with four equal vertical columns
+Add an extra native Windows 11 Snap Layout with four equal vertical columns. This is especially useful on ultrawide monitors, where four equal vertical
+zones make better use of the available horizontal screen space.
 
 ![Windows 11 four-column Snap Layout](https://i.imgur.com/a3sGZSk.png)
 

--- a/mods/windows-11-native-four-column-snap-layout.wh.cpp
+++ b/mods/windows-11-native-four-column-snap-layout.wh.cpp
@@ -14,7 +14,7 @@
 /*
 # Windows 11 Native Four Column Snap Layout
 
-Adds an extra native Windows 11 Snap Layout with four equal vertical columns:
+Add an extra native Windows 11 Snap Layout with four equal vertical columns
 
 ![Windows 11 four-column Snap Layout](https://i.imgur.com/a3sGZSk.png)
 

--- a/mods/windows-11-native-four-column-snap-layout.wh.cpp
+++ b/mods/windows-11-native-four-column-snap-layout.wh.cpp
@@ -6,7 +6,7 @@
 // @author       Hoffelhas
 // @github       https://github.com/Hoffelhas
 // @include      explorer.exe
-// @architecture amd64
+// @architecture x86-64
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==

--- a/mods/windows-11-native-four-column-snap-layout.wh.cpp
+++ b/mods/windows-11-native-four-column-snap-layout.wh.cpp
@@ -14,8 +14,7 @@
 /*
 # Windows 11 Native Four Column Snap Layout
 
-Add an extra native Windows 11 Snap Layout with four equal vertical columns. This is especially useful on ultrawide monitors, where four equal vertical
-zones make better use of the available horizontal screen space.
+Add an extra native Windows 11 Snap Layout with four equal vertical columns. This is especially useful on ultrawide monitors, where four equal vertical zones make better use of the available horizontal screen space.
 
 ![Windows 11 four-column Snap Layout](https://i.imgur.com/a3sGZSk.png)
 
@@ -39,8 +38,10 @@ source layout isn't found, that layout set is left unchanged.
 
 Developed and tested on Windows 11 build **26200.9445** on x86-64.
 
-Currently tested only on x86-64 Windows. ARM64 compatibility has not been
-verified.
+The mod is currently tested only on x86-64 Windows. Because Windhawk's
+`x86-64` architecture setting also allows loading into predefined native shell
+processes on ARM64 Windows, ARM64 may attempt to load the mod, but compatibility
+there has not been verified.
 
 If a Windows update changes the relevant private symbols or internal structure,
 Windhawk may be unable to load the mod until it is updated.
@@ -59,16 +60,12 @@ namespace {
 constexpr SIZE_T kSnapLayoutSize = 0x50;
 constexpr SIZE_T kSnapZoneSize = 0x38;
 
-// Sanity limits for data obtained through undocumented internal structures.
 constexpr SIZE_T kMaxReasonableLayoutCount = 32;
 constexpr SIZE_T kMaxReasonableZoneCount = 16;
 
-// Adding one more item can create an additional row in the Win+Z/maximize
-// picker. 80 logical pixels is the row-height increase observed on the tested
-// Windows build.
-constexpr int kExtraPickerHeight = 80;
-constexpr int kMinReasonablePickerHeight = 160;
-constexpr int kMaxReasonablePickerHeight = 400;
+// The native Win+Z/maximize-button picker displays two layout previews per row
+// on the Windows implementation observed during development.
+constexpr SIZE_T kItemsPerRow = 2;
 
 struct RawVector {
     void* first;
@@ -77,21 +74,19 @@ struct RawVector {
 };
 
 // SnapBarViewModel asks SnapModel::Layouts() more than once during one load.
-// These flags identify that path and prevent the additional layout from being
-// inserted more than once into the Snap Bar load operation.
+// Keep this state thread-local because it describes one synchronous Snap Bar
+// load operation on the current thread.
 thread_local bool g_inSnapBarLoad = false;
 thread_local bool g_snapBarCustomAdded = false;
 
-// Updated for every normal flyout Layouts() call. PickerHeight_Hook uses this
-// to increase the picker height only when the custom layout was actually added.
+// The picker height is requested after its Layouts() call on the same thread
+// on the Windows implementation observed during development.
 thread_local bool g_flyoutCustomAdded = false;
+thread_local SIZE_T g_flyoutLayoutsBefore = 0;
+thread_local SIZE_T g_flyoutLayoutsAfter = 0;
 
-// 0 = SnapLayout.dll hooks not registered.
-// 1 = registration is currently in progress or has completed.
-//
-// A single flag prevents simultaneous LoadLibraryExW calls from trying to
-// resolve the same private symbols at the same time. It's reset if symbol
-// resolution fails, allowing a later load notification to retry.
+// Prevent duplicate SnapLayout.dll symbol-hook registration if multiple DLL
+// loads occur concurrently.
 std::atomic<bool> g_snapLayoutHookClaimed{false};
 
 // -----------------------------------------------------------------------------
@@ -120,16 +115,40 @@ SnapBarLoadLayouts_t SnapBarLoadLayouts_Original = nullptr;
 using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 LoadLibraryExW_t LoadLibraryExW_Original = nullptr;
 
-// Forward declaration.
 bool HookSnapLayoutDll(HMODULE module, bool applyHookOperations);
+
+// -----------------------------------------------------------------------------
+// Scope guard for Snap Bar thread-local state
+// -----------------------------------------------------------------------------
+
+class ScopedSnapBarState {
+  public:
+    ScopedSnapBarState()
+        : previousInSnapBarLoad_(g_inSnapBarLoad),
+          previousCustomAdded_(g_snapBarCustomAdded) {
+        g_inSnapBarLoad = true;
+        g_snapBarCustomAdded = false;
+    }
+
+    ~ScopedSnapBarState() {
+        g_inSnapBarLoad = previousInSnapBarLoad_;
+        g_snapBarCustomAdded = previousCustomAdded_;
+    }
+
+    ScopedSnapBarState(const ScopedSnapBarState&) = delete;
+    ScopedSnapBarState& operator=(const ScopedSnapBarState&) = delete;
+
+  private:
+    bool previousInSnapBarLoad_;
+    bool previousCustomAdded_;
+};
 
 // -----------------------------------------------------------------------------
 // Raw SnapLayout / SnapZone helpers
 // -----------------------------------------------------------------------------
 
 SIZE_T GetVectorCount(const RawVector* vec, SIZE_T elementSize) {
-    if (!vec || !vec->first || !vec->last || !vec->end ||
-        elementSize == 0) {
+    if (!vec || !vec->first || !vec->last || !vec->end) {
         return 0;
     }
 
@@ -150,11 +169,8 @@ SIZE_T GetVectorCount(const RawVector* vec, SIZE_T elementSize) {
     return bytes / elementSize;
 }
 
-bool GetZoneVector(const void* layout,
-                   BYTE** firstOut,
-                   BYTE** lastOut,
-                   SIZE_T* countOut) {
-    if (!layout || !firstOut || !lastOut || !countOut) {
+bool GetZoneVector(const void* layout, BYTE** firstOut, SIZE_T* countOut) {
+    if (!layout || !firstOut || !countOut) {
         return false;
     }
 
@@ -193,55 +209,41 @@ bool GetZoneVector(const void* layout,
     }
 
     *firstOut = firstBytes;
-    *lastOut = lastBytes;
     *countOut = count;
 
     return true;
 }
 
+unsigned int ReadU32(const void* base, SIZE_T offset) {
+    unsigned int value = 0;
+
+    memcpy(&value,
+           reinterpret_cast<const BYTE*>(base) + offset,
+           sizeof(value));
+
+    return value;
+}
+
 void WriteU32(void* base, SIZE_T offset, unsigned int value) {
-    memcpy(reinterpret_cast<BYTE*>(base) + offset, &value, sizeof(value));
+    memcpy(reinterpret_cast<BYTE*>(base) + offset,
+           &value,
+           sizeof(value));
 }
 
-bool ReadU32(const void* base, SIZE_T offset, unsigned int* value) {
-    if (!base || !value) {
-        return false;
-    }
-
-    memcpy(value, reinterpret_cast<const BYTE*>(base) + offset,
-           sizeof(*value));
-
-    return true;
-}
-
-// Verify that the candidate isn't merely "2x2 with four zones", but actually
-// represents the normal four-quadrant Windows layout:
-//
-// +---+---+
-// | 0 | 1 |
-// +---+---+
-// | 2 | 3 |
-// +---+---+
-//
-// Zone ordering itself doesn't matter.
 bool IsNativeQuadrantLayout(const void* layout) {
     if (!layout) {
         return false;
     }
 
-    unsigned int columns = 0;
-    unsigned int rows = 0;
-
-    if (!ReadU32(layout, 0x20, &columns) ||
-        !ReadU32(layout, 0x24, &rows) || columns != 2 || rows != 2) {
+    if (ReadU32(layout, 0x20) != 2 ||
+        ReadU32(layout, 0x24) != 2) {
         return false;
     }
 
     BYTE* zoneFirst = nullptr;
-    BYTE* zoneLast = nullptr;
     SIZE_T zoneCount = 0;
 
-    if (!GetZoneVector(layout, &zoneFirst, &zoneLast, &zoneCount) ||
+    if (!GetZoneVector(layout, &zoneFirst, &zoneCount) ||
         zoneCount != 4) {
         return false;
     }
@@ -249,49 +251,57 @@ bool IsNativeQuadrantLayout(const void* layout) {
     bool found[2][2] = {};
 
     for (SIZE_T i = 0; i < zoneCount; i++) {
-        const BYTE* zone = zoneFirst + i * kSnapZoneSize;
+        const BYTE* zone =
+            zoneFirst + i * kSnapZoneSize;
 
-        unsigned int originColumn = 0;
-        unsigned int originRow = 0;
-        unsigned int columnSpan = 0;
-        unsigned int rowSpan = 0;
+        const unsigned int originColumn =
+            ReadU32(zone, 0x20);
 
-        if (!ReadU32(zone, 0x20, &originColumn) ||
-            !ReadU32(zone, 0x24, &originRow) ||
-            !ReadU32(zone, 0x28, &columnSpan) ||
-            !ReadU32(zone, 0x2C, &rowSpan)) {
-            return false;
-        }
+        const unsigned int originRow =
+            ReadU32(zone, 0x24);
 
-        if (originColumn >= 2 || originRow >= 2 || columnSpan != 1 ||
-            rowSpan != 1 || found[originRow][originColumn]) {
+        const unsigned int columnSpan =
+            ReadU32(zone, 0x28);
+
+        const unsigned int rowSpan =
+            ReadU32(zone, 0x2C);
+
+        if (originColumn >= 2 ||
+            originRow >= 2 ||
+            columnSpan != 1 ||
+            rowSpan != 1 ||
+            found[originRow][originColumn]) {
             return false;
         }
 
         found[originRow][originColumn] = true;
     }
 
-    return found[0][0] && found[0][1] && found[1][0] && found[1][1];
+    return found[0][0] &&
+           found[0][1] &&
+           found[1][0] &&
+           found[1][1];
 }
 
 // -----------------------------------------------------------------------------
-// Convert a copied quadrant layout to four equal vertical columns
+// Convert a copied native quadrant layout to four equal vertical columns
 // -----------------------------------------------------------------------------
 
 bool PatchToFourColumns(void* layout) {
     if (!IsNativeQuadrantLayout(layout)) {
-        Wh_Log(L"Copied source layout no longer matches the expected "
-               L"2x2 four-quadrant structure");
+        Wh_Log(
+            L"Copied source layout no longer matches the expected "
+            L"2x2 four-quadrant structure");
         return false;
     }
 
     BYTE* zoneFirst = nullptr;
-    BYTE* zoneLast = nullptr;
     SIZE_T zoneCount = 0;
 
-    if (!GetZoneVector(layout, &zoneFirst, &zoneLast, &zoneCount) ||
+    if (!GetZoneVector(layout, &zoneFirst, &zoneCount) ||
         zoneCount != 4) {
-        Wh_Log(L"Unexpected zone vector while patching custom layout");
+        Wh_Log(
+            L"Unexpected zone vector while patching custom layout");
         return false;
     }
 
@@ -308,7 +318,8 @@ bool PatchToFourColumns(void* layout) {
     // +0x2C RowSpan
     // +0x30 GridUnitType -- preserved from the native source layout.
     for (unsigned int i = 0; i < 4; i++) {
-        BYTE* zone = zoneFirst + i * kSnapZoneSize;
+        BYTE* zone =
+            zoneFirst + i * kSnapZoneSize;
 
         WriteU32(zone, 0x20, i);
         WriteU32(zone, 0x24, 0);
@@ -325,16 +336,20 @@ bool PatchToFourColumns(void* layout) {
 
 bool CloneAndAppendFourColumn(RawVector* vec) {
     if (!vec || !EmplaceLayout_Original) {
-        Wh_Log(L"Can't append custom layout: invalid vector or unresolved "
-               L"emplace helper");
+        Wh_Log(
+            L"Can't append custom layout: invalid vector or unresolved "
+            L"emplace helper");
         return false;
     }
 
-    const SIZE_T count = GetVectorCount(vec, kSnapLayoutSize);
+    const SIZE_T count =
+        GetVectorCount(vec, kSnapLayoutSize);
 
-    if (count == 0 || count > kMaxReasonableLayoutCount) {
-        Wh_Log(L"Can't inspect Snap Layout set: invalid layout count %zu",
-               count);
+    if (count == 0 ||
+        count > kMaxReasonableLayoutCount) {
+        Wh_Log(
+            L"Can't inspect Snap Layout set: invalid layout count %zu",
+            count);
         return false;
     }
 
@@ -344,7 +359,8 @@ bool CloneAndAppendFourColumn(RawVector* vec) {
     SIZE_T sourceIndex = count;
 
     for (SIZE_T i = 0; i < count; i++) {
-        const BYTE* candidate = vectorFirst + i * kSnapLayoutSize;
+        const BYTE* candidate =
+            vectorFirst + i * kSnapLayoutSize;
 
         if (IsNativeQuadrantLayout(candidate)) {
             sourceIndex = i;
@@ -353,40 +369,42 @@ bool CloneAndAppendFourColumn(RawVector* vec) {
     }
 
     if (sourceIndex == count) {
-        Wh_Log(L"No compatible 2x2 four-quadrant source layout among %zu "
-               L"native layouts",
-               count);
+        Wh_Log(
+            L"No compatible 2x2 four-quadrant source layout among %zu "
+            L"native layouts",
+            count);
         return false;
     }
 
-    // Save the source pointer only until insertion. The insertion operation can
-    // reallocate the vector, so neither this pointer nor vec->first may be used
-    // afterwards to refer to the old storage.
+    // This pointer is valid only until the insertion below. The native vector
+    // helper may reallocate the vector's backing storage.
     const void* source =
         vectorFirst + sourceIndex * kSnapLayoutSize;
 
-    // Use SnapLayout.dll's own std::vector insertion implementation.
-    //
-    // SnapLayout owns non-trivial members including std::wstring and
-    // std::vector<SnapZone>, so copying its bytes directly would duplicate
-    // ownership pointers and be unsafe.
-    void* newLayout = EmplaceLayout_Original(vec, source);
+    // Use SnapLayout.dll's own native vector helper so all non-trivial members,
+    // including the nested std::wstring and std::vector<SnapZone>, are copied
+    // with the correct allocator and ownership semantics.
+    void* newLayout =
+        EmplaceLayout_Original(vec, source);
 
     if (!newLayout) {
-        Wh_Log(L"Failed to clone native Snap Layout");
+        Wh_Log(
+            L"Failed to clone native Snap Layout");
         return false;
     }
 
+    // The source is fully validated immediately before the native deep copy,
+    // so failure here isn't expected. If it does happen, the clone remains in
+    // the vector because no verified erase helper is currently available.
     if (!PatchToFourColumns(newLayout)) {
-        // This should be unreachable after the source-layout validation and
-        // native deep copy above. If Windows changes the copy semantics, log it
-        // rather than modifying any other object.
-        Wh_Log(L"Native Snap Layout clone couldn't be converted");
+        Wh_Log(
+            L"Native Snap Layout clone couldn't be converted");
         return false;
     }
 
-    Wh_Log(L"Added four-column Snap Layout using native source index %zu",
-           sourceIndex);
+    Wh_Log(
+        L"Added four-column Snap Layout using native source index %zu",
+        sourceIndex);
 
     return true;
 }
@@ -395,79 +413,109 @@ bool CloneAndAppendFourColumn(RawVector* vec) {
 // SnapLayout.dll hooks
 // -----------------------------------------------------------------------------
 
-RawVector* __cdecl Layouts_Hook(void* thisPtr, RawVector* returnBuffer) {
-    RawVector* result = Layouts_Original(thisPtr, returnBuffer);
+RawVector* __cdecl Layouts_Hook(
+    void* thisPtr,
+    RawVector* returnBuffer) {
+    RawVector* result =
+        Layouts_Original(thisPtr, returnBuffer);
 
-    if (!returnBuffer) {
+    if (!result) {
         return result;
     }
 
     if (g_inSnapBarLoad) {
-        // SnapBarViewModel requests a fresh Layouts() vector more than once
-        // during a single load operation. Modifying only the first one is the
-        // behavior verified on the tested Windows build.
         if (!g_snapBarCustomAdded) {
             g_snapBarCustomAdded =
-                CloneAndAppendFourColumn(returnBuffer);
+                CloneAndAppendFourColumn(result);
         }
 
         return result;
     }
 
-    // Don't latch this state permanently. If a later Layouts() call returns a
-    // layout set we can't safely extend, PickerHeight_Hook must not enlarge its
-    // picker.
+    g_flyoutLayoutsBefore =
+        GetVectorCount(result, kSnapLayoutSize);
+
     g_flyoutCustomAdded =
-        CloneAndAppendFourColumn(returnBuffer);
+        CloneAndAppendFourColumn(result);
+
+    g_flyoutLayoutsAfter =
+        g_flyoutCustomAdded
+            ? GetVectorCount(result, kSnapLayoutSize)
+            : g_flyoutLayoutsBefore;
 
     return result;
 }
 
-int __cdecl PickerHeight_Hook(void* thisPtr, int* value) {
-    const int hr = PickerHeight_Original(thisPtr, value);
+int __cdecl PickerHeight_Hook(
+    void* thisPtr,
+    int* value) {
+    const int hr =
+        PickerHeight_Original(thisPtr, value);
 
-    // Adding one item can add one further row to the picker. Avoid pinning this
-    // to the exact 244-pixel value observed on one build, but retain a sanity
-    // range so an unexpected ABI/semantic change isn't blindly modified.
-    if (hr == 0 && value && g_flyoutCustomAdded &&
-        *value >= kMinReasonablePickerHeight &&
-        *value <= kMaxReasonablePickerHeight) {
-        *value += kExtraPickerHeight;
+    // Layouts() and get_PickerHeight() are observed to execute synchronously on
+    // the same thread for the native Win+Z/maximize-button picker.
+    //
+    // Scale the complete native picker height proportionally rather than
+    // adding a fixed pixel count. This automatically follows display scaling.
+    if (hr == 0 &&
+        value &&
+        g_flyoutCustomAdded &&
+        g_flyoutLayoutsBefore > 0 &&
+        g_flyoutLayoutsAfter > g_flyoutLayoutsBefore) {
+        const SIZE_T rowsBefore =
+            (g_flyoutLayoutsBefore +
+             kItemsPerRow - 1) /
+            kItemsPerRow;
+
+        const SIZE_T rowsAfter =
+            (g_flyoutLayoutsAfter +
+             kItemsPerRow - 1) /
+            kItemsPerRow;
+
+        if (rowsAfter > rowsBefore) {
+            *value =
+                MulDiv(
+                    *value,
+                    static_cast<int>(rowsAfter),
+                    static_cast<int>(rowsBefore));
+        }
     }
 
     return hr;
 }
 
-void __cdecl SnapBarLoadLayouts_Hook(void* thisPtr,
-                                     double scale,
-                                     int options,
-                                     bool flag) {
-    const bool previousInSnapBarLoad = g_inSnapBarLoad;
-    const bool previousCustomAdded = g_snapBarCustomAdded;
+void __cdecl SnapBarLoadLayouts_Hook(
+    void* thisPtr,
+    double scale,
+    int options,
+    bool flag) {
+    // Restore thread-local state even if the native C++/WinRT implementation
+    // exits via an exception.
+    ScopedSnapBarState scopedState;
 
-    g_inSnapBarLoad = true;
-    g_snapBarCustomAdded = false;
-
-    SnapBarLoadLayouts_Original(thisPtr, scale, options, flag);
-
-    g_inSnapBarLoad = previousInSnapBarLoad;
-    g_snapBarCustomAdded = previousCustomAdded;
+    SnapBarLoadLayouts_Original(
+        thisPtr,
+        scale,
+        options,
+        flag);
 }
 
 // -----------------------------------------------------------------------------
 // Late loading of SnapLayout.dll
 // -----------------------------------------------------------------------------
 
-bool HookSnapLayoutDll(HMODULE module, bool applyHookOperations) {
+bool HookSnapLayoutDll(
+    HMODULE module,
+    bool applyHookOperations) {
     if (!module) {
         return false;
     }
 
     bool expected = false;
 
-    if (!g_snapLayoutHookClaimed.compare_exchange_strong(expected, true)) {
-        // Another call is already resolving the symbols, or they were resolved
-        // successfully earlier.
+    if (!g_snapLayoutHookClaimed.compare_exchange_strong(
+            expected,
+            true)) {
         return true;
     }
 
@@ -506,47 +554,56 @@ bool HookSnapLayoutDll(HMODULE module, bool applyHookOperations) {
             module,
             snapLayoutDllHooks,
             ARRAYSIZE(snapLayoutDllHooks))) {
-        Wh_Log(L"Failed to resolve one or more SnapLayout.dll symbols");
+        Wh_Log(
+            L"Failed to resolve one or more SnapLayout.dll symbols");
 
-        // Permit a later attempt if this was a transient failure.
         g_snapLayoutHookClaimed = false;
         return false;
     }
 
-    Wh_Log(L"SnapLayout.dll symbols resolved successfully");
+    Wh_Log(
+        L"SnapLayout.dll symbols resolved successfully");
 
-    // Hooks registered after Wh_ModInit() aren't applied automatically until
-    // requested. This path is used when SnapLayout.dll loads naturally later
-    // in Explorer's lifetime.
-    if (applyHookOperations && !Wh_ApplyHookOperations()) {
-        Wh_Log(L"Failed to apply SnapLayout.dll hook operations");
+    if (applyHookOperations &&
+        !Wh_ApplyHookOperations()) {
+        Wh_Log(
+            L"Failed to apply SnapLayout.dll hook operations");
         return false;
     }
 
     return true;
 }
 
-void HandleSnapLayoutDllIfLoaded(bool applyHookOperations) {
+void HandleSnapLayoutDllIfLoaded(
+    bool applyHookOperations) {
     if (g_snapLayoutHookClaimed.load()) {
         return;
     }
 
-    HMODULE module = GetModuleHandleW(L"SnapLayout.dll");
+    HMODULE module =
+        GetModuleHandleW(L"SnapLayout.dll");
 
     if (module) {
-        HookSnapLayoutDll(module, applyHookOperations);
+        HookSnapLayoutDll(
+            module,
+            applyHookOperations);
     }
 }
 
-HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
-                                   HANDLE hFile,
-                                   DWORD dwFlags) {
+HMODULE WINAPI LoadLibraryExW_Hook(
+    LPCWSTR lpLibFileName,
+    HANDLE hFile,
+    DWORD dwFlags) {
     HMODULE module =
-        LoadLibraryExW_Original(lpLibFileName, hFile, dwFlags);
+        LoadLibraryExW_Original(
+            lpLibFileName,
+            hFile,
+            dwFlags);
 
-    if (module && !g_snapLayoutHookClaimed.load()) {
-        // Check the module handle rather than matching lpLibFileName. This also
-        // catches SnapLayout.dll arriving as a dependency of another DLL.
+    if (module &&
+        !g_snapLayoutHookClaimed.load()) {
+        // Check the loaded-module state rather than relying on the filename
+        // passed to this call. SnapLayout.dll may also arrive as a dependency.
         HandleSnapLayoutDllIfLoaded(true);
     }
 
@@ -560,31 +617,35 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
 // -----------------------------------------------------------------------------
 
 BOOL Wh_ModInit() {
-    // If SnapLayout.dll is already present, register its hooks now. Windhawk
-    // will apply them automatically after Wh_ModInit returns.
-    if (HMODULE snapLayoutModule = GetModuleHandleW(L"SnapLayout.dll")) {
-        if (!HookSnapLayoutDll(snapLayoutModule, false)) {
+    if (HMODULE snapLayoutModule =
+            GetModuleHandleW(L"SnapLayout.dll")) {
+        if (!HookSnapLayoutDll(
+                snapLayoutModule,
+                false)) {
             return FALSE;
         }
 
         return TRUE;
     }
 
-    // SnapLayout.dll hasn't loaded yet. Intercept kernelbase!LoadLibraryExW so
-    // it can be hooked when Windows naturally loads the Snap UI component.
-    HMODULE kernelBaseModule = GetModuleHandleW(L"kernelbase.dll");
+    HMODULE kernelBaseModule =
+        GetModuleHandleW(L"kernelbase.dll");
 
     if (!kernelBaseModule) {
-        Wh_Log(L"Failed to get kernelbase.dll");
+        Wh_Log(
+            L"Failed to get kernelbase.dll");
         return FALSE;
     }
 
     auto pKernelBaseLoadLibraryExW =
         reinterpret_cast<decltype(&LoadLibraryExW)>(
-            GetProcAddress(kernelBaseModule, "LoadLibraryExW"));
+            GetProcAddress(
+                kernelBaseModule,
+                "LoadLibraryExW"));
 
     if (!pKernelBaseLoadLibraryExW) {
-        Wh_Log(L"Failed to resolve kernelbase!LoadLibraryExW");
+        Wh_Log(
+            L"Failed to resolve kernelbase!LoadLibraryExW");
         return FALSE;
     }
 
@@ -592,21 +653,19 @@ BOOL Wh_ModInit() {
             pKernelBaseLoadLibraryExW,
             LoadLibraryExW_Hook,
             &LoadLibraryExW_Original)) {
-        Wh_Log(L"Failed to hook kernelbase!LoadLibraryExW");
+        Wh_Log(
+            L"Failed to hook kernelbase!LoadLibraryExW");
         return FALSE;
     }
 
-    Wh_Log(L"SnapLayout.dll isn't loaded yet; waiting for Windows to load it");
+    Wh_Log(
+        L"SnapLayout.dll isn't loaded yet; waiting for Windows to load it");
 
     return TRUE;
 }
 
 void Wh_ModAfterInit() {
-    // Close the small race where SnapLayout.dll loads after the initial module
-    // check but before the LoadLibraryExW hook becomes active. It also catches
-    // cases where it was introduced as a static dependency.
+    // Close the race where SnapLayout.dll loads after the initial check but
+    // before the LoadLibraryExW hook becomes active.
     HandleSnapLayoutDllIfLoaded(true);
-}
-
-void Wh_ModUninit() {
 }

--- a/mods/windows-11-native-four-column-snap-layout.wh.cpp
+++ b/mods/windows-11-native-four-column-snap-layout.wh.cpp
@@ -557,7 +557,6 @@ bool HookSnapLayoutDll(
         Wh_Log(
             L"Failed to resolve one or more SnapLayout.dll symbols");
 
-        g_snapLayoutHookClaimed = false;
         return false;
     }
 

--- a/mods/windows-11-native-four-column-snap-layout.wh.cpp
+++ b/mods/windows-11-native-four-column-snap-layout.wh.cpp
@@ -64,17 +64,10 @@ struct RawVector {
     void* end;
 };
 
-// The Snap Bar asks SnapModel::Layouts() more than once while loading.
-// These thread-local flags distinguish that path from the Win+Z/maximize
-// flyout path and avoid appending the custom layout more than once per load.
 thread_local bool g_inSnapBarLoad = false;
 thread_local bool g_snapBarCustomAdded = false;
-
-// Set after the normal flyout path successfully appends the custom layout.
 thread_local bool g_flyoutCustomAdded = false;
 
-// Keep track of SnapLayout.dll so a reference acquired by this mod can be
-// released when the mod unloads.
 HMODULE g_snapLayoutModule = nullptr;
 bool g_loadedSnapLayoutModule = false;
 
@@ -112,8 +105,6 @@ using SnapBarLoadLayouts_t = void (__cdecl*)(
 
 SnapBarLoadLayouts_t SnapBarLoadLayouts_Original = nullptr;
 
-// This pass-through hook exists so Windhawk resolves the private vector helper
-// and exposes a callable original/trampoline pointer.
 void* __cdecl EmplaceLayout_Hook(
     void* vectorThis,
     const void* sourceLayout)
@@ -134,9 +125,6 @@ int __cdecl PickerHeight_Hook(
             value
         );
 
-    // The extra flyout item occupies one more row.
-    // Only adjust the exact native height observed on the supported build,
-    // and only after the custom flyout layout was actually added.
     if (hr == 0 &&
         value &&
         g_flyoutCustomAdded &&
@@ -246,14 +234,10 @@ SIZE_T GetZoneCount(
     }
 
     const auto* firstBytes =
-        reinterpret_cast<const BYTE*>(
-            first
-        );
+        reinterpret_cast<const BYTE*>(first);
 
     const auto* lastBytes =
-        reinterpret_cast<const BYTE*>(
-            last
-        );
+        reinterpret_cast<const BYTE*>(last);
 
     if (lastBytes < firstBytes) {
         return 0;
@@ -349,23 +333,9 @@ bool PatchToFourColumns(
         return false;
     }
 
-    // SnapLayout grid: four columns, one row.
     WriteU32(layout, 0x20, 4);
     WriteU32(layout, 0x24, 1);
 
-    // Relevant SnapZone fields:
-    //
-    // +0x20 OriginColumn
-    // +0x24 OriginRow
-    // +0x28 ColumnSpan
-    // +0x2C RowSpan
-    // +0x30 GridUnitType (preserved)
-    //
-    // Result:
-    //
-    // | 0 | 1 | 2 | 3 |
-    //
-    // Each zone occupies one equal column.
     for (unsigned int i = 0; i < 4; i++) {
         BYTE* zone =
             reinterpret_cast<BYTE*>(zoneFirst) +
@@ -400,8 +370,6 @@ bool CloneAndAppendFourColumn(
             kSnapLayoutSize
         );
 
-    // Safety check:
-    // the supported build is expected to return six native layouts.
     if (count != kNativeLayoutCount ||
         sourceIndex >= count)
     {
@@ -418,11 +386,6 @@ bool CloneAndAppendFourColumn(
         return false;
     }
 
-    // Use SnapLayout.dll's own vector insertion helper.
-    //
-    // SnapLayout contains non-trivial members such as std::wstring and
-    // std::vector<SnapZone>, so a raw memcpy clone would duplicate ownership
-    // pointers and would be unsafe.
     void* newLayout =
         EmplaceLayout_Original(
             vec,
@@ -465,18 +428,6 @@ RawVector* __cdecl Layouts_Hook(
     }
 
     if (g_inSnapBarLoad) {
-
-        // Snap Bar ordering observed on the supported build:
-        //
-        // 0: 2x1 / 2 zones
-        // 1: 3x1 / 2 zones
-        // 2: 2x2 / 3 zones
-        // 3: 2x2 / 4 zones  <-- source
-        // 4: 3x1 / 3 zones
-        // 5: 4x1 / 3 zones
-        //
-        // SnapBar asks for SnapModel::Layouts() more than once while loading,
-        // so append the custom layout only once for that load.
         if (!g_snapBarCustomAdded &&
             CloneAndAppendFourColumn(
                 returnBuffer,
@@ -488,9 +439,6 @@ RawVector* __cdecl Layouts_Hook(
         return result;
     }
 
-    // Win+Z / maximize-hover ordering observed on the supported build:
-    //
-    // Element 4 is the native 2x2 / four-zone source layout.
     if (CloneAndAppendFourColumn(
             returnBuffer,
             4))
@@ -503,10 +451,6 @@ RawVector* __cdecl Layouts_Hook(
 
 }  // namespace
 
-// -----------------------------------------------------------------------------
-// Windhawk lifecycle
-// -----------------------------------------------------------------------------
-
 BOOL Wh_ModInit()
 {
     g_snapLayoutModule =
@@ -515,12 +459,6 @@ BOOL Wh_ModInit()
         );
 
     if (!g_snapLayoutModule) {
-
-        // On the tested Windows 11 build, SnapLayout.dll is part of the
-        // MicrosoftWindows.Client.Core system app.
-        //
-        // Load it explicitly if Explorer hasn't loaded it yet so Windhawk can
-        // resolve and install the private-symbol hooks.
         g_snapLayoutModule =
             LoadLibraryExW(
                 L"C:\\WINDOWS\\SystemApps\\MicrosoftWindows.Client.Core_cw5n1h2txyewy\\SnapLayout.dll",
@@ -541,40 +479,32 @@ BOOL Wh_ModInit()
         return FALSE;
     }
 
-    WindhawkUtils::SYMBOL_HOOK snapLayoutHooks[] = {
-
+    WindhawkUtils::SYMBOL_HOOK snapLayoutDllHooks[] = {
         {
             {
                 LR"(public: class std::vector<struct SnapLayout,class std::allocator<struct SnapLayout> > __cdecl SnapModel::Layouts(void)const )",
             },
-
             &Layouts_Original,
             Layouts_Hook,
         },
-
         {
             {
                 LR"(private: struct SnapLayout & __cdecl std::vector<struct SnapLayout,class std::allocator<struct SnapLayout> >::_Emplace_one_at_back<struct SnapLayout const &>(struct SnapLayout const &))",
             },
-
             &EmplaceLayout_Original,
             EmplaceLayout_Hook,
         },
-
         {
             {
                 LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::SnapLayout::implementation::SnapLayoutPickerViewModel,struct winrt::SnapLayout::ISnapLayoutPickerViewModel>::get_PickerHeight(int *))",
             },
-
             &PickerHeight_Original,
             PickerHeight_Hook,
         },
-
         {
             {
                 LR"(public: void __cdecl winrt::SnapLayout::implementation::SnapBarViewModel::LoadLayouts(double,enum winrt::SnapLayout::SnapModelOptions,bool))",
             },
-
             &SnapBarLoadLayouts_Original,
             SnapBarLoadLayouts_Hook,
         },
@@ -582,8 +512,8 @@ BOOL Wh_ModInit()
 
     if (!WindhawkUtils::HookSymbols(
             g_snapLayoutModule,
-            snapLayoutHooks,
-            ARRAYSIZE(snapLayoutHooks)))
+            snapLayoutDllHooks,
+            ARRAYSIZE(snapLayoutDllHooks)))
     {
         Wh_Log(
             L"Failed to resolve one or more SnapLayout.dll symbols"


### PR DESCRIPTION
# Windows 11 Native Four Column Snap Layout

Add an extra native Windows 11 Snap Layout with four equal vertical columns. This is especially useful on ultrawide monitors, where four equal vertical zones make better use of the available horizontal screen space.

![Windows 11 four-column Snap Layout](https://i.imgur.com/a3sGZSk.png)

## What it does

- Adds the four-column layout as an additional option without replacing the
  existing Windows layouts.
- Appears in **Win+Z**, **maximize-button hover**, and the **Snap Bar** shown
  when dragging a window to the top of the screen.
- Integrates with Windows' native Snap Layout model, so Snap Assist and Snap
  Groups continue to work normally.

Developed and tested on Windows 11 build **26200.9445** on x86-64.

## Mod authorship

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [x] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 