### PR TITLE
Simplify hide-scrollbars description

### DIFF
--- a/mods/hide-scrollbars.wh.cpp
+++ b/mods/hide-scrollbars.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              hide-scrollbars
 // @name            Hide Scrollbars
-// @description     Hide vertical/horizontal scrollbars in selected processes (default: File Explorer) and reclaim the gutter space
-// @version         1.0.0
+// @description     Hides File Explorer's scrollbars and reclaims the gutter space
+// @version         1.0.1
 // @author          AmazingBodilyFluids
 // @github          https://github.com/AmazingBodilyFluids
 // @include         explorer.exe


### PR DESCRIPTION
Shortens the mod's `@description` metadata line; bumps to 1.0.1.

Before: "Hide vertical/horizontal scrollbars in selected processes (default: File Explorer) and reclaim the gutter space"
After: "Hides File Explorer's scrollbars and reclaims the gutter space"

🤖 Generated with [Claude Code](https://claude.com/claude-code)