### PR TITLE
Translucent Windows v1.8.2

### DIFF
--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -998,7 +998,7 @@ BOOL ExtTextOutCalcRect(HDC hdc, POINT point, UINT options, RECT& textRect, LPCR
         if (!ExtTextOutAlignRect(hdc, point, textSize, textRect))
             return FALSE;
     }
-    else if (options && GetTextExtentPoint32W(hdc, lpString, c, &textSize))
+    else if (GetTextExtentPoint32W(hdc, lpString, c, &textSize))
     {
         if (lpDx)
             textSize.cx = ExtTextOutDxWidth(options, lpDx, c);
@@ -1007,7 +1007,7 @@ BOOL ExtTextOutCalcRect(HDC hdc, POINT point, UINT options, RECT& textRect, LPCR
     }
     else
         return FALSE;
-     
+    
     if (RECTWIDTH(&textRect) <= 0 || RECTHEIGHT(&textRect) <= 0)
         return FALSE;
 
@@ -1398,7 +1398,7 @@ VOID ColorizeSysColors()
 HRESULT WINAPI HookedGetColorTheme(HTHEME hTheme, INT iPartId, INT iStateId, INT iPropId, COLORREF *pColor) 
 {
     HRESULT hr = GetThemeColor_orig(hTheme, iPartId, iStateId, iPropId, pColor);
-    std::wstring ThemeClassName = GetThemeClass(hTheme);  
+    std::wstring ThemeClassName = GetThemeClass(hTheme);
 
     if (ThemeClassName == L"ItemsView" && iPropId == TMT_TEXTCOLOR && ((iPartId == 4 && iStateId == 1) || iPartId == 5))
     {
@@ -5835,7 +5835,7 @@ VOID User32Hooks(BOOL areSysColorsApplied)
             &DrawCommandRectangle_orig,
             Hooked_DrawCommandRectangle,
             FALSE
-        }
+        },
     };
 
     HMODULE hUser32 = LoadLibraryEx(L"user32.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
@@ -6362,6 +6362,43 @@ VOID Comdlg32Hooks()
         Wh_Log(L"Failed to hook one or more symbol functions in comdlg32.dll");
         return;
     }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+
+static decltype(&DrawEdge) DrawEdge_orig = nullptr;
+static decltype(&DrawFrameControl) DrawFrameControl_orig = nullptr;
+static decltype(&DrawStateW) DrawStateW_orig = nullptr;
+
+BOOL WINAPI HookedDrawEdge(HDC hdc, LPRECT qrc, UINT edge, UINT grfFlags)
+{
+    Wh_Log(L"DrawEdge edge:0x%08x flags:0x%08x", edge, grfFlags);
+    BOOL ret = DrawEdge_orig(hdc, qrc, edge, grfFlags);
+    return ret;
+}
+
+BOOL WINAPI HookedDrawFrameControl(HDC hdc, LPRECT lprect, UINT uType, UINT uState)
+{
+    Wh_Log(L"DrawFrameControl Type:0x%08x State:0x%08x", uType, uState);
+    BOOL ret = DrawFrameControl_orig(hdc, lprect, uType, uState);
+    return ret;
+}
+
+typedef __int64(WINAPI* pDrawFrame)(HDC, int*, int, int);
+static auto DrawFrame = (pDrawFrame)GetProcAddress(GetModuleHandle(L"user32.dll"), MAKEINTRESOURCEA(1720));
+
+__int64 WINAPI HookedDrawFrame(HDC hdc, int* edge, int a3, int a4)
+{
+    Wh_Log(L"DrawFrame");
+    __int64 ret = DrawFrame(hdc, edge, a3, a4);
+    return ret;
+}
+
+BOOL WINAPI HookedDrawStateW(HDC hdc, HBRUSH hbrFore, DRAWSTATEPROC qfnCallBack, LPARAM lData, WPARAM wData, int x, int y, int cx, int cy, UINT uFlags)
+{
+    Wh_Log(L"DrawStateW x:%d y:%d cx:%d cy:%d flags:0x%08x", x, y, cx, cy, uFlags);
+    BOOL ret = DrawStateW_orig(hdc, hbrFore, qfnCallBack, lData, wData, x, y, cx, cy, uFlags);
+    return ret;
 }
 
 VOID CustomRenderingHooks()

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -930,18 +930,14 @@ BOOL ExtTextOutComposition(HDC hdc, HPAINTBUFFER hpb, LPCRECT pTextRect)
     return TRUE;
 }
 
-BOOL ExtTextOutAlignRect(HDC hdc, POINT point, SIZE textSize, RECT& textRect)
+BOOL ExtTextOutAlignRect(HDC hdc, POINT point, SIZE textSize, RECT& textRect, UINT textAlignment)
 {
-    UINT ta = GetTextAlign(hdc);
-    if (ta == GDI_ERROR || (ta & TA_UPDATECP))
-        return FALSE;
-
     // TA_BASELINE's bits are a superset of TA_BOTTOM's, and TA_CENTER's are
     // a superset of TA_RIGHT's - mask the field and compare for equality
     // rather than testing individual bits, or TA_CENTER/TA_BASELINE get
     // misread as TA_RIGHT/TA_BOTTOM.
-    UINT vAlign = ta & (TA_BOTTOM | TA_BASELINE);
-    UINT hAlign = ta & (TA_RIGHT | TA_CENTER);
+    UINT vAlign = textAlignment & (TA_BOTTOM | TA_BASELINE);
+    UINT hAlign = textAlignment & (TA_RIGHT | TA_CENTER);
 
     INT top = point.y;
     if (vAlign == TA_BASELINE)
@@ -987,6 +983,10 @@ static INT ExtTextOutDxWidth(UINT options, const INT* lpDx, UINT c)
 // Calculate text boundaries
 BOOL ExtTextOutCalcRect(HDC hdc, POINT point, UINT options, RECT& textRect, LPCRECT lprect, LPCWSTR lpString, UINT c, const INT* lpDx)
 {
+    UINT ta = GetTextAlign(hdc);
+    if (ta == GDI_ERROR || (ta & TA_UPDATECP))
+        return FALSE;
+
     SIZE textSize = {0};
 
     if (lprect)
@@ -995,14 +995,14 @@ BOOL ExtTextOutCalcRect(HDC hdc, POINT point, UINT options, RECT& textRect, LPCR
     {
         if (lpDx)
             textSize.cx = ExtTextOutDxWidth(options, lpDx, c);
-        if (!ExtTextOutAlignRect(hdc, point, textSize, textRect))
+        if (!ExtTextOutAlignRect(hdc, point, textSize, textRect, ta))
             return FALSE;
     }
-    else if (GetTextExtentPoint32W(hdc, lpString, c, &textSize))
+    else if (options && GetTextExtentPoint32W(hdc, lpString, c, &textSize))
     {
         if (lpDx)
             textSize.cx = ExtTextOutDxWidth(options, lpDx, c);
-        if (!ExtTextOutAlignRect(hdc, point, textSize, textRect))
+        if (!ExtTextOutAlignRect(hdc, point, textSize, textRect, ta))
             return FALSE;
     }
     else
@@ -1047,6 +1047,8 @@ BOOL WINAPI HookedExtTextOutW(
 
     SelectObject(memDC, GetCurrentObject(hdc, OBJ_FONT));
     SetTextAlign(memDC, GetTextAlign(hdc));
+    SetLayout(memDC, GetLayout(hdc));
+    SetMapMode(memDC, GetMapMode(hdc));
     SetBkMode(memDC, TRANSPARENT);
     SetTextColor(memDC, RGB(255, 255, 255)); // White text mask
 
@@ -1424,7 +1426,7 @@ HRESULT WINAPI HookedGetColorTheme(HTHEME hTheme, INT iPartId, INT iStateId, INT
         *pColor = g_IsSysThemeDarkMode ? RGB(255, 255, 255) : *pColor;
         return S_OK;
     }
-    if (iPropId == TMT_TEXTCOLOR && ThemeClassName == L"ControlPanel" && iPartId == CPANEL_HELPLINK) {
+    else if (iPropId == TMT_TEXTCOLOR && ThemeClassName == L"ControlPanel" && iPartId == CPANEL_HELPLINK) {
         *pColor = (g_settings.AccentColorize) ? g_settings.AccentColor : RGB(96,205,255);
         return S_OK;
     }  

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -2,7 +2,7 @@
 // @id              translucent-windows
 // @name            Translucent Windows
 // @description     Enables native translucent effects in Windows 11
-// @version         1.8.1
+// @version         1.8.2
 // @author          Undisputed00x
 // @github          https://github.com/Undisputed00x
 // @include         *
@@ -916,7 +916,7 @@ BOOL ExtTextOutComposition(HDC hdc, HPAINTBUFFER hpb, LPCRECT pTextRect)
                 continue;
             
             // Greyscale alpha
-            BYTE luma = (BYTE)((px.rgbBlue + (px.rgbGreen << 1) + px.rgbRed) >> 2);          
+            BYTE luma = (px.rgbBlue + (px.rgbGreen << 1) + px.rgbRed) >> 2;          
             // Gamma alpha correction
             BYTE txtA = g_textAlphaGammaLUT[luma];
             
@@ -930,8 +930,62 @@ BOOL ExtTextOutComposition(HDC hdc, HPAINTBUFFER hpb, LPCRECT pTextRect)
     return TRUE;
 }
 
+BOOL ExtTextOutAlignRect(HDC hdc, POINT point, SIZE textSize, RECT& textRect)
+{
+    UINT ta = GetTextAlign(hdc);
+    if (ta == GDI_ERROR || (ta & TA_UPDATECP))
+        return FALSE;
+
+    // TA_BASELINE's bits are a superset of TA_BOTTOM's, and TA_CENTER's are
+    // a superset of TA_RIGHT's - mask the field and compare for equality
+    // rather than testing individual bits, or TA_CENTER/TA_BASELINE get
+    // misread as TA_RIGHT/TA_BOTTOM.
+    UINT vAlign = ta & (TA_BOTTOM | TA_BASELINE);
+    UINT hAlign = ta & (TA_RIGHT | TA_CENTER);
+
+    INT top = point.y;
+    if (vAlign == TA_BASELINE)
+    {
+        TEXTMETRIC tm;
+        if (!GetTextMetrics(hdc, &tm))
+            return FALSE;
+        top = point.y - tm.tmAscent;
+    }
+    else if (vAlign == TA_BOTTOM)
+        top = point.y - textSize.cy;
+
+    INT left = point.x;
+    if (hAlign == TA_CENTER)
+        left = point.x - textSize.cx / 2;
+    else if (hAlign == TA_RIGHT)
+        left = point.x - textSize.cx;
+
+    textRect.left   = left;
+    textRect.top    = top;
+    textRect.right  = left + textSize.cx;
+    textRect.bottom = top + textSize.cy;
+
+    return TRUE;
+}
+
+// When the caller supplies explicit per-character advances, GDI positions
+// glyphs using those instead of the font's own design metrics -
+// GetTextExtentPoint32W/GetTextExtentPointI have no lpDx parameter and
+// always measure using natural advances, so their result can be far
+// narrower than what's actually drawn (e.g. a single glyph stretched into
+// a long underline via lpDx with c == 1). Recover the real width by
+// summing lpDx instead.
+static INT ExtTextOutDxWidth(UINT options, const INT* lpDx, UINT c)
+{
+    INT width = 0;
+    UINT stride = (options & ETO_PDY) ? 2 : 1; // ETO_PDY: lpDx holds (dx,dy) pairs
+    for (UINT i = 0; i < c; i++)
+        width += lpDx[i * stride];
+    return width;
+}
+
 // Calculate text boundaries
-BOOL ExtTextOutCalcRect(HDC hdc, POINT point, UINT options, RECT& textRect, LPCRECT lprect, LPCWSTR lpString, UINT c)
+BOOL ExtTextOutCalcRect(HDC hdc, POINT point, UINT options, RECT& textRect, LPCRECT lprect, LPCWSTR lpString, UINT c, const INT* lpDx)
 {
     SIZE textSize = {0};
 
@@ -939,24 +993,21 @@ BOOL ExtTextOutCalcRect(HDC hdc, POINT point, UINT options, RECT& textRect, LPCR
         textRect = *lprect;
     else if (options & ETO_GLYPH_INDEX && GetTextExtentPointI(hdc, (WORD*)lpString, c, &textSize))
     {
-        textRect.left   = point.x;
-        textRect.top    = point.y;
-        textRect.right  = point.x + textSize.cx;
-        textRect.bottom = point.y + textSize.cy;
-    }
-    else if (options == ETO_IGNORELANGUAGE) {
-        if(!GetClipBox(hdc, &textRect))
+        if (lpDx)
+            textSize.cx = ExtTextOutDxWidth(options, lpDx, c);
+        if (!ExtTextOutAlignRect(hdc, point, textSize, textRect))
             return FALSE;
     }
-    else if (options && GetTextExtentPoint32W(hdc, lpString, c, &textSize)) {
-        textRect.left   = point.x;
-        textRect.top    = point.y;
-        textRect.right  = point.x + textSize.cx;
-        textRect.bottom = point.y + textSize.cy; 
+    else if (options && GetTextExtentPoint32W(hdc, lpString, c, &textSize))
+    {
+        if (lpDx)
+            textSize.cx = ExtTextOutDxWidth(options, lpDx, c);
+        if (!ExtTextOutAlignRect(hdc, point, textSize, textRect))
+            return FALSE;
     }
     else
         return FALSE;
-    
+     
     if (RECTWIDTH(&textRect) <= 0 || RECTHEIGHT(&textRect) <= 0)
         return FALSE;
 
@@ -977,7 +1028,10 @@ BOOL WINAPI HookedExtTextOutW(
         return ExtTextOutW_orig(hdc, x, y, options, lprect, lpString, c, lpDx);
 
     RECT textRect {0};
-    if (!ExtTextOutCalcRect(hdc, {x, y}, options, textRect, lprect, lpString, c))
+    if (!ExtTextOutCalcRect(hdc, {x, y}, options, textRect, lprect, lpString, c, lpDx))
+        return ExtTextOutW_orig(hdc, x, y, options, lprect, lpString, c, lpDx);
+
+    if (!ExtTextOutBkPaint(hdc, lprect, options))
         return ExtTextOutW_orig(hdc, x, y, options, lprect, lpString, c, lpDx);
         
     // https://devblogs.microsoft.com/oldnewthing/20110520-00/?p=10613
@@ -995,11 +1049,6 @@ BOOL WINAPI HookedExtTextOutW(
     SetTextAlign(memDC, GetTextAlign(hdc));
     SetBkMode(memDC, TRANSPARENT);
     SetTextColor(memDC, RGB(255, 255, 255)); // White text mask
-
-    if (!ExtTextOutBkPaint(hdc, lprect, options)) {
-        EndBufferedPaint(hpb, FALSE);
-        return ExtTextOutW_orig(hdc, x, y, options, lprect, lpString, c, lpDx);
-    }
 
     // Remove default background painting operation, as it done by us
     WINBOOL res = ExtTextOutW_orig(memDC, x, y, options & ~ETO_OPAQUE, lprect, lpString, c, lpDx);
@@ -1349,7 +1398,7 @@ VOID ColorizeSysColors()
 HRESULT WINAPI HookedGetColorTheme(HTHEME hTheme, INT iPartId, INT iStateId, INT iPropId, COLORREF *pColor) 
 {
     HRESULT hr = GetThemeColor_orig(hTheme, iPartId, iStateId, iPropId, pColor);
-    std::wstring ThemeClassName = GetThemeClass(hTheme);
+    std::wstring ThemeClassName = GetThemeClass(hTheme);  
 
     if (ThemeClassName == L"ItemsView" && iPropId == TMT_TEXTCOLOR && ((iPartId == 4 && iStateId == 1) || iPartId == 5))
     {
@@ -1373,6 +1422,10 @@ HRESULT WINAPI HookedGetColorTheme(HTHEME hTheme, INT iPartId, INT iStateId, INT
     }
     else if (ThemeClassName == L"PreviewPane" && iPropId == TMT_TEXTCOLOR) {
         *pColor = g_IsSysThemeDarkMode ? RGB(255, 255, 255) : *pColor;
+        return S_OK;
+    }
+    if (iPropId == TMT_TEXTCOLOR && ThemeClassName == L"ControlPanel" && iPartId == CPANEL_HELPLINK) {
+        *pColor = (g_settings.AccentColorize) ? g_settings.AccentColor : RGB(96,205,255);
         return S_OK;
     }  
     else if (ThemeClassName == L"ControlPanelStyle" && iPropId == TMT_TEXTCOLOR)

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -5835,7 +5835,7 @@ VOID User32Hooks(BOOL areSysColorsApplied)
             &DrawCommandRectangle_orig,
             Hooked_DrawCommandRectangle,
             FALSE
-        },
+        }
     };
 
     HMODULE hUser32 = LoadLibraryEx(L"user32.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
@@ -6362,43 +6362,6 @@ VOID Comdlg32Hooks()
         Wh_Log(L"Failed to hook one or more symbol functions in comdlg32.dll");
         return;
     }
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////////
-
-static decltype(&DrawEdge) DrawEdge_orig = nullptr;
-static decltype(&DrawFrameControl) DrawFrameControl_orig = nullptr;
-static decltype(&DrawStateW) DrawStateW_orig = nullptr;
-
-BOOL WINAPI HookedDrawEdge(HDC hdc, LPRECT qrc, UINT edge, UINT grfFlags)
-{
-    Wh_Log(L"DrawEdge edge:0x%08x flags:0x%08x", edge, grfFlags);
-    BOOL ret = DrawEdge_orig(hdc, qrc, edge, grfFlags);
-    return ret;
-}
-
-BOOL WINAPI HookedDrawFrameControl(HDC hdc, LPRECT lprect, UINT uType, UINT uState)
-{
-    Wh_Log(L"DrawFrameControl Type:0x%08x State:0x%08x", uType, uState);
-    BOOL ret = DrawFrameControl_orig(hdc, lprect, uType, uState);
-    return ret;
-}
-
-typedef __int64(WINAPI* pDrawFrame)(HDC, int*, int, int);
-static auto DrawFrame = (pDrawFrame)GetProcAddress(GetModuleHandle(L"user32.dll"), MAKEINTRESOURCEA(1720));
-
-__int64 WINAPI HookedDrawFrame(HDC hdc, int* edge, int a3, int a4)
-{
-    Wh_Log(L"DrawFrame");
-    __int64 ret = DrawFrame(hdc, edge, a3, a4);
-    return ret;
-}
-
-BOOL WINAPI HookedDrawStateW(HDC hdc, HBRUSH hbrFore, DRAWSTATEPROC qfnCallBack, LPARAM lData, WPARAM wData, int x, int y, int cx, int cy, UINT uFlags)
-{
-    Wh_Log(L"DrawStateW x:%d y:%d cx:%d cy:%d flags:0x%08x", x, y, cx, cy, uFlags);
-    BOOL ret = DrawStateW_orig(hdc, hbrFore, qfnCallBack, lData, wData, x, y, cx, cy, uFlags);
-    return ret;
 }
 
 VOID CustomRenderingHooks()

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -1048,7 +1048,6 @@ BOOL WINAPI HookedExtTextOutW(
     SelectObject(memDC, GetCurrentObject(hdc, OBJ_FONT));
     SetTextAlign(memDC, GetTextAlign(hdc));
     SetLayout(memDC, GetLayout(hdc));
-    SetMapMode(memDC, GetMapMode(hdc));
     SetBkMode(memDC, TRANSPARENT);
     SetTextColor(memDC, RGB(255, 255, 255)); // White text mask
 


### PR DESCRIPTION
* Fixed text alignment bug reported in some programs (e.g. YASB, Telegram Desktop etc.) introduced in the previous update.
* Fix the mod's accent color when changing the system accent color.