### PR TITLE
Translucent Windows v1.8.2: do not style console windows of other processes

### DIFF
--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -80,7 +80,7 @@ This is caused by default by the AccentBlur API.❕
 
 * ✨The mod works best on the default dark theme.✨
 
-* ⚠️Console windows (cmd.exe, Windows PowerShell 5.1, anything not hosted by Windows Terminal) are styled by the conhost.exe that hosts them.
+* ⚠️Console windows (cmd.exe, Windows PowerShell 5.1, anything not hosted by Windows Terminal) are styled only by the conhost.exe that hosts them.
 To leave them unstyled, add a process rule for conhost.exe with Background translucent effects set to Default and Windows theme custom rendering disabled, or exclude conhost.exe in Windhawk's process exclusion list.⚠️
 
 */
@@ -179,7 +179,7 @@ To leave them unstyled, add a process rule for conhost.exe with Background trans
 #include <cmath>
 #include <string>
 #include <array>
-#include <vector>
+#include <unordered_set>
 #include <d2d1.h>
 #include <wrl.h>
 #include <ShellScalingApi.h>
@@ -252,6 +252,7 @@ BOOL g_InsideTaskMgrProc = FALSE;
 
 BOOL g_InsideExplorerProc = FALSE;
 BOOL g_InsideConhostProc = FALSE;
+HWND g_hConsoleWnd = NULL; // conhost.exe: the console window this process created, once known
 
 using PUNICODE_STRING = PVOID;
 constexpr auto MENUPOPUP_CLASS = L"#32768";
@@ -467,9 +468,9 @@ std::wstring GetWindowClass(HWND hWnd)
 {
     if (!hWnd)
         return L"";
-    WCHAR buffer[MAX_PATH] = {};
-    GetClassNameW(hWnd, buffer, MAX_PATH);
-    return buffer;
+    WCHAR buffer[MAX_PATH];
+    int length = GetClassNameW(hWnd, buffer, MAX_PATH);
+    return std::wstring(buffer, length);
 }
 
 BOOL IsWindowClass(HWND hWnd, LPCWSTR className)
@@ -5402,38 +5403,38 @@ VOID RestoreWindowCustomizations(HWND hWnd)
     }
 }
 
-struct FindThreadWindowContext
-{
-    HWND hWnd;
-    BOOL found;
-};
-
-static BOOL CALLBACK FindThreadWindowProc(HWND hWnd, LPARAM lParam)
-{
-    auto* ctx = reinterpret_cast<FindThreadWindowContext*>(lParam);
-    if (hWnd != ctx->hWnd)
-        return TRUE;
-    ctx->found = TRUE;
-    return FALSE;
-}
-
-// Per-pass state of ApplyForExistingWindows. The thread IDs of this process are
-// collected lazily and at most once per pass: the system-wide thread snapshot
-// is expensive, and only conhost.exe ever needs it (see IsOwnConsoleWindow).
+// Per-sweep state of ApplyForExistingWindows. The windows created by the
+// threads of this process are collected lazily and at most once per sweep: the
+// thread snapshot is system-wide, and only conhost.exe ever needs it (see
+// IsOwnConsoleWindow).
 struct ExistingWindowsContext
 {
-    std::vector<DWORD> threadIds;
-    BOOL threadIdsCollected = FALSE;
+    std::unordered_set<HWND> threadWindows;
+    BOOL threadWindowsAttempted = FALSE;
+    BOOL threadWindowsCollected = FALSE;
+    UINT consoleWindowsSeen = 0;
 };
 
-static BOOL CollectCurrentProcessThreadIds(std::vector<DWORD>& threadIds)
+static BOOL CALLBACK CollectThreadWindowProc(HWND hWnd, LPARAM lParam)
 {
-    // The snapshot can fail transiently. A failure would make conhost.exe treat
-    // its own console as foreign, and after Wh_ModUninit nothing would restore
-    // the window, so retry a few times.
+    reinterpret_cast<std::unordered_set<HWND>*>(lParam)->insert(hWnd);
+    return TRUE;
+}
+
+// Collects the top-level windows created by the threads of this process.
+// Unlike GetWindowThreadProcessId, EnumThreadWindows reflects the creating
+// thread for console windows too.
+static BOOL CollectCurrentProcessThreadWindows(std::unordered_set<HWND>& windows)
+{
     HANDLE hSnapshot = INVALID_HANDLE_VALUE;
-    for (int attempt = 0; attempt < 3 && hSnapshot == INVALID_HANDLE_VALUE; attempt++)
+    for (int attempt = 0; attempt < 3; attempt++)
+    {
+        if (attempt > 0)
+            Sleep(0);
         hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
+        if (hSnapshot != INVALID_HANDLE_VALUE)
+            break;
+    }
     if (hSnapshot == INVALID_HANDLE_VALUE)
     {
         Wh_Log(L"CreateToolhelp32Snapshot failed, error 0x%08X", GetLastError());
@@ -5449,65 +5450,72 @@ static BOOL CollectCurrentProcessThreadIds(std::vector<DWORD>& threadIds)
         do
         {
             if (te.th32OwnerProcessID == dwProcessId)
-                threadIds.push_back(te.th32ThreadID);
+                EnumThreadWindows(te.th32ThreadID, CollectThreadWindowProc, reinterpret_cast<LPARAM>(&windows));
         } while (Thread32Next(hSnapshot, &te));
     }
+    else
+        Wh_Log(L"Thread32First failed, error 0x%08X", GetLastError());
     CloseHandle(hSnapshot);
     return result;
 }
 
-// Whether a thread of this process created the window. Unlike
-// GetWindowThreadProcessId, EnumThreadWindows reflects the creating thread for
-// console windows too.
+// Whether a thread of this process created the window.
 static BOOL IsWindowOfCurrentProcessThread(HWND hWnd, ExistingWindowsContext* ctx)
 {
-    if (!ctx->threadIdsCollected)
-        ctx->threadIdsCollected = CollectCurrentProcessThreadIds(ctx->threadIds);
-
-    FindThreadWindowContext find = { hWnd, FALSE };
-    for (DWORD dwThreadId : ctx->threadIds)
+    if (!ctx->threadWindowsAttempted)
     {
-        EnumThreadWindows(dwThreadId, FindThreadWindowProc, reinterpret_cast<LPARAM>(&find));
-        if (find.found)
-            break;
+        ctx->threadWindowsAttempted = TRUE;
+        ctx->threadWindowsCollected = CollectCurrentProcessThreadWindows(ctx->threadWindows);
     }
-    return find.found;
+    return ctx->threadWindows.count(hWnd) != 0;
 }
 
-// A console window reports the console's client process (e.g. cmd.exe) as its
-// owner, not the conhost.exe that created it. The client therefore passes the
-// same-process check in EnumWindowsProc on its own, while conhost.exe never
-// does. conhost.exe is started by csrss.exe, which Windhawk never injects, so
-// it only gets the mod after the window exists and the sweep is its only way
-// to style, and later restore, its console. Accept a console window only in
-// conhost.exe and only if a thread of this process created it; every other
-// console window belongs to another process and is left alone.
+// A console window reports the console's client process (e.g. cmd.exe) from
+// GetWindowThreadProcessId, not the conhost.exe that created it. The generic
+// same-process check in EnumWindowsProc therefore matches in the client, which
+// would re-style the console with the client's settings on every reload, and
+// never in conhost.exe, the real owner. conhost.exe is started by csrss.exe,
+// which Windhawk never injects, so it gets the mod after the window exists and
+// the sweep is its only way to style, and later restore, its console. Console
+// windows are handled by conhost.exe alone, and only the one that a thread of
+// this process created. A conhost.exe hosts a single console window, so it is
+// remembered once accepted and the unload sweep no longer depends on a
+// thread snapshot.
 static BOOL IsOwnConsoleWindow(HWND hWnd, ExistingWindowsContext* ctx)
 {
-    if (!g_InsideConhostProc || !IsWindowClass(hWnd, L"ConsoleWindowClass"))
+    if (!g_InsideConhostProc)
         return FALSE;
-    if (IsWindowOfCurrentProcessThread(hWnd, ctx))
-        return TRUE;
-    Wh_Log(L"Console window %p was not created by this process, skipped", hWnd);
-    return FALSE;
+    ctx->consoleWindowsSeen++;
+    if (g_hConsoleWnd)
+        return hWnd == g_hConsoleWnd;
+    if (!IsWindowOfCurrentProcessThread(hWnd, ctx))
+        return FALSE;
+    g_hConsoleWnd = hWnd;
+    return TRUE;
 }
 
 BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam) 
 {
-    DWORD dwProcessId = 0;
-    // Console windows are matched by IsOwnConsoleWindow, see the comment there.
-    if ((!GetWindowThreadProcessId(hWnd, &dwProcessId) || dwProcessId != GetCurrentProcessId()) && !IsOwnConsoleWindow(hWnd, reinterpret_cast<ExistingWindowsContext*>(lParam)))
-        return TRUE;
+    // Console windows are handled by conhost.exe alone, see IsOwnConsoleWindow
+    if (IsWindowClass(hWnd, L"ConsoleWindowClass"))
+    {
+        if (!IsOwnConsoleWindow(hWnd, reinterpret_cast<ExistingWindowsContext*>(lParam)))
+            return TRUE;
+    }
     else
     {
-        HWND hParentWnd = GetAncestor(hWnd, GA_PARENT);
-        if (hParentWnd && hParentWnd != GetDesktopWindow())
+        DWORD dwProcessId = 0;
+        if (!GetWindowThreadProcessId(hWnd, &dwProcessId) || dwProcessId != GetCurrentProcessId())
             return TRUE;
-        else if(g_settings.Unload)
-            RestoreWindowCustomizations(hWnd);
-        else
-            NewWindowShown(hWnd);
     }
+
+    HWND hParentWnd = GetAncestor(hWnd, GA_PARENT);
+    if (hParentWnd && hParentWnd != GetDesktopWindow())
+        return TRUE;
+    else if(g_settings.Unload)
+        RestoreWindowCustomizations(hWnd);
+    else
+        NewWindowShown(hWnd);
     return TRUE;
 }
 
@@ -5515,6 +5523,10 @@ VOID ApplyForExistingWindows()
 {
     ExistingWindowsContext ctx;
     EnumWindows(EnumWindowsProc, reinterpret_cast<LPARAM>(&ctx));
+    if (g_InsideConhostProc)
+        Wh_Log(L"Console sweep (%s): %u console windows seen, own window %p%s",
+               g_settings.Unload ? L"restore" : L"apply", ctx.consoleWindowsSeen, g_hConsoleWnd,
+               (ctx.threadWindowsAttempted && !ctx.threadWindowsCollected) ? L", thread snapshot failed" : L"");
 }
 
 BOOL GetColorSetting(LPCWSTR hexColor, COLORREF& outColor) 

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -2,7 +2,7 @@
 // @id              translucent-windows
 // @name            Translucent Windows
 // @description     Enables native translucent effects in Windows 11
-// @version         1.8.1
+// @version         1.8.2
 // @author          Undisputed00x
 // @github          https://github.com/Undisputed00x
 // @include         *
@@ -5395,8 +5395,9 @@ VOID RestoreWindowCustomizations(HWND hWnd)
 BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam) 
 {
     DWORD dwProcessId = 0;
-    // Pass console window, it might be called from other processes like Clink:https://github.com/chrisant996/clink
-    if ((!GetWindowThreadProcessId(hWnd, &dwProcessId) || dwProcessId != GetCurrentProcessId()) && !IsWindowClass(hWnd, L"ConsoleWindowClass")) 
+    // Pass only the console window attached to this process (Clink runs inside cmd.exe).
+    // Passing every ConsoleWindowClass window styled consoles owned by other processes.
+    if ((!GetWindowThreadProcessId(hWnd, &dwProcessId) || dwProcessId != GetCurrentProcessId()) && hWnd != GetConsoleWindow())
         return TRUE;
     else
     {

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -169,6 +169,7 @@ This is caused by default by the AccentBlur API.❕
 
 #include <windhawk_utils.h>
 #include <windowsx.h>
+#include <tlhelp32.h>
 #include <dwmapi.h>
 #include <vssym32.h>
 #include <uxtheme.h>
@@ -5392,12 +5393,67 @@ VOID RestoreWindowCustomizations(HWND hWnd)
     }
 }
 
+struct FindThreadWindowContext
+{
+    HWND hWnd;
+    BOOL found;
+};
+
+static BOOL CALLBACK FindThreadWindowProc(HWND hWnd, LPARAM lParam)
+{
+    auto* ctx = reinterpret_cast<FindThreadWindowContext*>(lParam);
+    if (hWnd != ctx->hWnd)
+        return TRUE;
+    ctx->found = TRUE;
+    return FALSE;
+}
+
+// Whether a thread of this process created the window. Unlike
+// GetWindowThreadProcessId, EnumThreadWindows reflects the creating thread for
+// console windows too. Only reached for console windows that are not reported
+// as ours, so the cost of the thread snapshot doesn't matter.
+static BOOL IsWindowOfCurrentProcessThread(HWND hWnd)
+{
+    HANDLE hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
+    if (hSnapshot == INVALID_HANDLE_VALUE)
+        return FALSE;
+
+    FindThreadWindowContext ctx = { hWnd, FALSE };
+    THREADENTRY32 te{};
+    te.dwSize = sizeof(te);
+    if (Thread32First(hSnapshot, &te))
+    {
+        do
+        {
+            if (te.th32OwnerProcessID == GetCurrentProcessId())
+                EnumThreadWindows(te.th32ThreadID, FindThreadWindowProc, reinterpret_cast<LPARAM>(&ctx));
+        } while (!ctx.found && Thread32Next(hSnapshot, &te));
+    }
+    CloseHandle(hSnapshot);
+    return ctx.found;
+}
+
+// A console window reports the console's client process (e.g. cmd.exe) as its
+// owner, not the conhost.exe that created it, so the same-process check in
+// EnumWindowsProc can't recognize this process's own console windows. Accept a
+// console window only if it is the console attached to this process, or if this
+// process created it (conhost.exe is started by csrss.exe, which Windhawk never
+// injects, so it gets the mod after the window already exists). Console windows
+// of other processes are left alone.
+static BOOL IsOwnConsoleWindow(HWND hWnd)
+{
+    if (!IsWindowClass(hWnd, L"ConsoleWindowClass"))
+        return FALSE;
+    if (hWnd == GetConsoleWindow())
+        return TRUE;
+    return IsWindowOfCurrentProcessThread(hWnd);
+}
+
 BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam) 
 {
     DWORD dwProcessId = 0;
-    // Pass only the console window attached to this process (Clink runs inside cmd.exe).
-    // Passing every ConsoleWindowClass window styled consoles owned by other processes.
-    if ((!GetWindowThreadProcessId(hWnd, &dwProcessId) || dwProcessId != GetCurrentProcessId()) && hWnd != GetConsoleWindow())
+    // Console windows are matched by IsOwnConsoleWindow, see the comment there.
+    if ((!GetWindowThreadProcessId(hWnd, &dwProcessId) || dwProcessId != GetCurrentProcessId()) && !IsOwnConsoleWindow(hWnd))
         return TRUE;
     else
     {

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -80,6 +80,9 @@ This is caused by default by the AccentBlur API.❕
 
 * ✨The mod works best on the default dark theme.✨
 
+* ⚠️Console windows (cmd.exe, Windows PowerShell 5.1, anything not hosted by Windows Terminal) are styled by the conhost.exe that hosts them.
+To keep console windows unstyled, exclude conhost.exe and the console programs in Windhawk's process exclusion list.⚠️
+
 */
 // ==/WindhawkModReadme==
 
@@ -176,6 +179,7 @@ This is caused by default by the AccentBlur API.❕
 #include <cmath>
 #include <string>
 #include <array>
+#include <vector>
 #include <d2d1.h>
 #include <wrl.h>
 #include <ShellScalingApi.h>
@@ -462,7 +466,7 @@ std::wstring GetWindowClass(HWND hWnd)
 {
     if (!hWnd)
         return L"";
-    WCHAR buffer[MAX_PATH];
+    WCHAR buffer[MAX_PATH] = {};
     GetClassNameW(hWnd, buffer, MAX_PATH);
     return buffer;
 }
@@ -5408,29 +5412,55 @@ static BOOL CALLBACK FindThreadWindowProc(HWND hWnd, LPARAM lParam)
     return FALSE;
 }
 
-// Whether a thread of this process created the window. Unlike
-// GetWindowThreadProcessId, EnumThreadWindows reflects the creating thread for
-// console windows too. Only reached for console windows that are not reported
-// as ours, so the cost of the thread snapshot doesn't matter.
-static BOOL IsWindowOfCurrentProcessThread(HWND hWnd)
+// Per-pass state of ApplyForExistingWindows. The thread IDs of this process are
+// collected lazily and at most once per pass: the system-wide thread snapshot
+// is expensive, and it is only needed for console windows that are not
+// reported as ours.
+struct ExistingWindowsContext
+{
+    std::vector<DWORD> threadIds;
+    BOOL threadIdsCollected = FALSE;
+};
+
+static VOID CollectCurrentProcessThreadIds(std::vector<DWORD>& threadIds)
 {
     HANDLE hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
     if (hSnapshot == INVALID_HANDLE_VALUE)
-        return FALSE;
+        return;
 
-    FindThreadWindowContext ctx = { hWnd, FALSE };
+    const DWORD dwProcessId = GetCurrentProcessId();
     THREADENTRY32 te{};
     te.dwSize = sizeof(te);
     if (Thread32First(hSnapshot, &te))
     {
         do
         {
-            if (te.th32OwnerProcessID == GetCurrentProcessId())
-                EnumThreadWindows(te.th32ThreadID, FindThreadWindowProc, reinterpret_cast<LPARAM>(&ctx));
-        } while (!ctx.found && Thread32Next(hSnapshot, &te));
+            if (te.th32OwnerProcessID == dwProcessId)
+                threadIds.push_back(te.th32ThreadID);
+        } while (Thread32Next(hSnapshot, &te));
     }
     CloseHandle(hSnapshot);
-    return ctx.found;
+}
+
+// Whether a thread of this process created the window. Unlike
+// GetWindowThreadProcessId, EnumThreadWindows reflects the creating thread for
+// console windows too.
+static BOOL IsWindowOfCurrentProcessThread(HWND hWnd, ExistingWindowsContext* ctx)
+{
+    if (!ctx->threadIdsCollected)
+    {
+        ctx->threadIdsCollected = TRUE;
+        CollectCurrentProcessThreadIds(ctx->threadIds);
+    }
+
+    FindThreadWindowContext find = { hWnd, FALSE };
+    for (DWORD dwThreadId : ctx->threadIds)
+    {
+        EnumThreadWindows(dwThreadId, FindThreadWindowProc, reinterpret_cast<LPARAM>(&find));
+        if (find.found)
+            break;
+    }
+    return find.found;
 }
 
 // A console window reports the console's client process (e.g. cmd.exe) as its
@@ -5440,20 +5470,23 @@ static BOOL IsWindowOfCurrentProcessThread(HWND hWnd)
 // process created it (conhost.exe is started by csrss.exe, which Windhawk never
 // injects, so it gets the mod after the window already exists). Console windows
 // of other processes are left alone.
-static BOOL IsOwnConsoleWindow(HWND hWnd)
+static BOOL IsOwnConsoleWindow(HWND hWnd, ExistingWindowsContext* ctx)
 {
     if (!IsWindowClass(hWnd, L"ConsoleWindowClass"))
         return FALSE;
     if (hWnd == GetConsoleWindow())
         return TRUE;
-    return IsWindowOfCurrentProcessThread(hWnd);
+    if (IsWindowOfCurrentProcessThread(hWnd, ctx))
+        return TRUE;
+    Wh_Log(L"Console window %p is neither attached to nor created by this process, skipped", hWnd);
+    return FALSE;
 }
 
 BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam) 
 {
     DWORD dwProcessId = 0;
     // Console windows are matched by IsOwnConsoleWindow, see the comment there.
-    if ((!GetWindowThreadProcessId(hWnd, &dwProcessId) || dwProcessId != GetCurrentProcessId()) && !IsOwnConsoleWindow(hWnd))
+    if ((!GetWindowThreadProcessId(hWnd, &dwProcessId) || dwProcessId != GetCurrentProcessId()) && !IsOwnConsoleWindow(hWnd, reinterpret_cast<ExistingWindowsContext*>(lParam)))
         return TRUE;
     else
     {
@@ -5470,7 +5503,8 @@ BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam)
 
 VOID ApplyForExistingWindows()
 {
-    EnumWindows(EnumWindowsProc, 0);
+    ExistingWindowsContext ctx;
+    EnumWindows(EnumWindowsProc, reinterpret_cast<LPARAM>(&ctx));
 }
 
 BOOL GetColorSetting(LPCWSTR hexColor, COLORREF& outColor) 

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -81,7 +81,7 @@ This is caused by default by the AccentBlur API.❕
 * ✨The mod works best on the default dark theme.✨
 
 * ⚠️Console windows (cmd.exe, Windows PowerShell 5.1, anything not hosted by Windows Terminal) are styled by the conhost.exe that hosts them.
-To keep console windows unstyled, exclude conhost.exe and the console programs in Windhawk's process exclusion list.⚠️
+To leave them unstyled, add a process rule for conhost.exe with Background translucent effects set to Default and Windows theme custom rendering disabled, or exclude conhost.exe in Windhawk's process exclusion list.⚠️
 
 */
 // ==/WindhawkModReadme==
@@ -251,6 +251,7 @@ std::wstring g_LastThemePath = GetCurrentWindowsThemePath();
 BOOL g_InsideTaskMgrProc = FALSE;
 
 BOOL g_InsideExplorerProc = FALSE;
+BOOL g_InsideConhostProc = FALSE;
 
 using PUNICODE_STRING = PVOID;
 constexpr auto MENUPOPUP_CLASS = L"#32768";
@@ -619,6 +620,10 @@ BOOL CheckExplorerProcess() {
 
 BOOL InTaskManagerProcess() {
     return GetCurrProcStr() == L"taskmgr.exe";
+}
+
+BOOL InConhostProcess() {
+    return GetCurrProcStr() == L"conhost.exe";
 }
 
 enum AccentColorShade
@@ -5414,24 +5419,32 @@ static BOOL CALLBACK FindThreadWindowProc(HWND hWnd, LPARAM lParam)
 
 // Per-pass state of ApplyForExistingWindows. The thread IDs of this process are
 // collected lazily and at most once per pass: the system-wide thread snapshot
-// is expensive, and it is only needed for console windows that are not
-// reported as ours.
+// is expensive, and only conhost.exe ever needs it (see IsOwnConsoleWindow).
 struct ExistingWindowsContext
 {
     std::vector<DWORD> threadIds;
     BOOL threadIdsCollected = FALSE;
 };
 
-static VOID CollectCurrentProcessThreadIds(std::vector<DWORD>& threadIds)
+static BOOL CollectCurrentProcessThreadIds(std::vector<DWORD>& threadIds)
 {
-    HANDLE hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
+    // The snapshot can fail transiently. A failure would make conhost.exe treat
+    // its own console as foreign, and after Wh_ModUninit nothing would restore
+    // the window, so retry a few times.
+    HANDLE hSnapshot = INVALID_HANDLE_VALUE;
+    for (int attempt = 0; attempt < 3 && hSnapshot == INVALID_HANDLE_VALUE; attempt++)
+        hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
     if (hSnapshot == INVALID_HANDLE_VALUE)
-        return;
+    {
+        Wh_Log(L"CreateToolhelp32Snapshot failed, error 0x%08X", GetLastError());
+        return FALSE;
+    }
 
     const DWORD dwProcessId = GetCurrentProcessId();
     THREADENTRY32 te{};
     te.dwSize = sizeof(te);
-    if (Thread32First(hSnapshot, &te))
+    BOOL result = Thread32First(hSnapshot, &te);
+    if (result)
     {
         do
         {
@@ -5440,6 +5453,7 @@ static VOID CollectCurrentProcessThreadIds(std::vector<DWORD>& threadIds)
         } while (Thread32Next(hSnapshot, &te));
     }
     CloseHandle(hSnapshot);
+    return result;
 }
 
 // Whether a thread of this process created the window. Unlike
@@ -5448,10 +5462,7 @@ static VOID CollectCurrentProcessThreadIds(std::vector<DWORD>& threadIds)
 static BOOL IsWindowOfCurrentProcessThread(HWND hWnd, ExistingWindowsContext* ctx)
 {
     if (!ctx->threadIdsCollected)
-    {
-        ctx->threadIdsCollected = TRUE;
-        CollectCurrentProcessThreadIds(ctx->threadIds);
-    }
+        ctx->threadIdsCollected = CollectCurrentProcessThreadIds(ctx->threadIds);
 
     FindThreadWindowContext find = { hWnd, FALSE };
     for (DWORD dwThreadId : ctx->threadIds)
@@ -5464,21 +5475,20 @@ static BOOL IsWindowOfCurrentProcessThread(HWND hWnd, ExistingWindowsContext* ct
 }
 
 // A console window reports the console's client process (e.g. cmd.exe) as its
-// owner, not the conhost.exe that created it, so the same-process check in
-// EnumWindowsProc can't recognize this process's own console windows. Accept a
-// console window only if it is the console attached to this process, or if this
-// process created it (conhost.exe is started by csrss.exe, which Windhawk never
-// injects, so it gets the mod after the window already exists). Console windows
-// of other processes are left alone.
+// owner, not the conhost.exe that created it. The client therefore passes the
+// same-process check in EnumWindowsProc on its own, while conhost.exe never
+// does. conhost.exe is started by csrss.exe, which Windhawk never injects, so
+// it only gets the mod after the window exists and the sweep is its only way
+// to style, and later restore, its console. Accept a console window only in
+// conhost.exe and only if a thread of this process created it; every other
+// console window belongs to another process and is left alone.
 static BOOL IsOwnConsoleWindow(HWND hWnd, ExistingWindowsContext* ctx)
 {
-    if (!IsWindowClass(hWnd, L"ConsoleWindowClass"))
+    if (!g_InsideConhostProc || !IsWindowClass(hWnd, L"ConsoleWindowClass"))
         return FALSE;
-    if (hWnd == GetConsoleWindow())
-        return TRUE;
     if (IsWindowOfCurrentProcessThread(hWnd, ctx))
         return TRUE;
-    Wh_Log(L"Console window %p is neither attached to nor created by this process, skipped", hWnd);
+    Wh_Log(L"Console window %p was not created by this process, skipped", hWnd);
     return FALSE;
 }
 
@@ -6635,6 +6645,7 @@ BOOL Wh_ModInit(VOID)
         g_explorerStylerNoBackgroundEffectAtom = AddAtom(L"WindhawkFileExplorerStylerNoBackgroundEffect");
     if (InTaskManagerProcess())
         g_InsideTaskMgrProc = TRUE;
+    g_InsideConhostProc = InConhostProcess();
 
     LoadSettings();
 


### PR DESCRIPTION
Fixes #5456.

### Problem

`EnumWindowsProc()` exempts every `ConsoleWindowClass` window from its process filter. Unrelated processes can therefore apply their effects to classic consoles during existing-window enumeration or reset them during unload, bypassing host exclusions and leaking per-process settings.

### Fix

Replace the class-wide exception with `IsOwnConsoleWindow()`: console windows are handled by conhost.exe alone, and only the one that a thread of the current process created (`EnumThreadWindows()`). Every other process skips console windows like any other foreign window, the console's own client included.

Why conhost: on Windows 11 build 26200 `GetWindowThreadProcessId()` on a console window returns the client's PID (cmd.exe), while `EnumThreadWindows()` finds the HWND on conhost's UI thread. The plain same-process check therefore matches in the client, which re-styled the console with the client's settings on every reload, and never in conhost, the real owner. conhost gets the mod only after its window exists (csrss.exe is never injected), so the sweep is its only way to style and later restore the console. The earlier `GetConsoleWindow()`-only patch missed this case.

Thread windows are collected at most once per sweep, lazily, via the `EnumWindows()` `lParam`, with retries on snapshot failure. conhost remembers its console once accepted, so the unload sweep does not depend on a snapshot. One log line per sweep in conhost reports the console windows seen and the one owned. `GetWindowClass()` uses the length `GetClassNameW()` returns, and the FAQ documents console styling.

Non-console handling and Windhawk's injection rules are unchanged.

### Repro

Exclude `conhost.exe` in Windhawk (with defaults it styles its own console and masks the bug), open cmd.exe, start any injected application: before, the console turns acrylic; after, it stays opaque.

### Verification

- Ownership behavior checked with standalone Win32 probes on live consoles. `GWLP_WNDPROC` access follows the reported owner as well, so it is no substitute for the thread check.
- x64 and x86 syntax checks passed with `clang++ -fsyntax-only -Wall -Wextra` using the Windhawk 1.7.3 toolchain, with no new warnings.
- The earlier one-line patch is running locally with `conhost.exe` and `cmd.exe` excluded. The current revision has not been tested as a loaded mod yet. Loaded-mod result to follow in the comments.

Not the mod author: @Undisputed00x, adopt or cherry-pick if you agree, or say what to change.

### Release notes

Fixed classic console windows being styled or reset by unrelated processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



