### PR TITLE
Start button colorizer v1.1

### DIFF
--- a/mods/taskbar-start-button-colorizer.wh.cpp
+++ b/mods/taskbar-start-button-colorizer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-start-button-colorizer
 // @name            Start button colorizer
 // @description     Recolor the Start button icon on the taskbar with a color preset or with hue, saturation, brightness and opacity effects, and change its size (Windows 11 only)
-// @version         1.0
+// @version         1.1
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -26,8 +26,8 @@
 
 Customize the Windows logo of the Start button on the taskbar:
 
-* **Color**: recolor the icon with one of the built-in colors, such as red,
-  green or pink.
+* **Color**: recolor the icon with the system accent color or with one of the
+  built-in colors, such as red, green or pink.
 * **Effects**: fine tune the icon with the hue, saturation, brightness and
   opacity effects.
 * **Size**: set the size of the icon.
@@ -47,9 +47,10 @@ Only Windows 11 is supported.
   $name: Color
   $description: >-
     Recolors the icon by setting the hue of its colors, keeping their original
-    saturation and brightness.
+    saturation and brightness. The system accent color sets the saturation too.
   $options:
   - none: Original
+  - accent: System accent color
   - red: Red
   - orange: Orange
   - yellow: Yellow
@@ -90,11 +91,15 @@ Only Windows 11 is supported.
 #include <cmath>
 #include <cstdint>
 #include <functional>
+#include <list>
+#include <optional>
 
 #undef GetCurrentTime
 
 #include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.Composition.h>
+#include <winrt/Windows.UI.ViewManagement.h>
 #include <winrt/Windows.UI.Xaml.Automation.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
@@ -104,10 +109,13 @@ Only Windows 11 is supported.
 using namespace winrt::Windows::UI::Xaml;
 
 namespace Composition = winrt::Windows::UI::Composition;
+namespace ViewManagement = winrt::Windows::UI::ViewManagement;
 
 struct {
     // The hue the icon is recolored to, or -1 to keep its original hue.
     int colorHue;
+    // Whether the icon is recolored to match the system accent color.
+    bool accentColor;
     int hue;
     double saturation;
     double brightness;
@@ -119,6 +127,12 @@ struct {
 
 std::atomic<bool> g_taskbarViewDllLoaded;
 std::atomic<bool> g_unloading;
+
+// The pending subscriptions to the Loaded event of the Start button icons.
+// Only accessed from the taskbar thread, which is also where they're revoked
+// on unload, rather than by the destructor at process exit.
+[[clang::no_destroy]] std::optional<std::list<FrameworkElement::Loaded_revoker>>
+    g_iconLoadedRevokers{std::in_place};
 
 HWND FindCurrentProcessTaskbarWnd() {
     HWND hTaskbarWnd = nullptr;
@@ -283,10 +297,62 @@ winrt::Windows::UI::Color HslToRgb(HslColor hsl, uint8_t alpha) {
     return {alpha, toByte(r), toByte(g), toByte(b)};
 }
 
+void ApplySettingsFromTaskbarThread();
+
+// The system accent color is tracked from the taskbar thread, which is the
+// thread the icon is customized from, starting the first time it's needed.
+[[clang::no_destroy]] ViewManagement::UISettings g_uiSettings{nullptr};
+winrt::event_token g_colorValuesChangedToken;
+HslColor g_accentColor;
+
+HslColor QueryAccentColor() {
+    return RgbToHsl(
+        g_uiSettings.GetColorValue(ViewManagement::UIColorType::Accent));
+}
+
+HslColor AccentColor() {
+    if (g_uiSettings) {
+        return g_accentColor;
+    }
+
+    g_uiSettings = ViewManagement::UISettings();
+    g_accentColor = QueryAccentColor();
+
+    // The event is raised on a worker thread.
+    g_colorValuesChangedToken = g_uiSettings.ColorValuesChanged(
+        [dispatcherQueue =
+             winrt::Windows::System::DispatcherQueue::GetForCurrentThread()](
+            auto&&, auto&&) {
+            dispatcherQueue.TryEnqueue([] {
+                Wh_Log(L">");
+
+                if (g_uiSettings) {
+                    g_accentColor = QueryAccentColor();
+                    ApplySettingsFromTaskbarThread();
+                }
+            });
+        });
+
+    return g_accentColor;
+}
+
+void StopTrackingAccentColor() {
+    if (g_uiSettings) {
+        g_uiSettings.ColorValuesChanged(g_colorValuesChangedToken);
+        g_uiSettings = nullptr;
+    }
+}
+
 winrt::Windows::UI::Color TransformColor(winrt::Windows::UI::Color color) {
     HslColor hsl = RgbToHsl(color);
 
-    if (g_settings.colorHue >= 0) {
+    if (g_settings.accentColor) {
+        // The saturation is matched as well, since the hue alone can't
+        // reproduce a gray accent color.
+        HslColor accentColor = AccentColor();
+        hsl.hue = accentColor.hue;
+        hsl.saturation *= accentColor.saturation;
+    } else if (g_settings.colorHue >= 0) {
         hsl.hue = g_settings.colorHue;
     }
 
@@ -376,6 +442,15 @@ void HookColorKeyFrameAnimation(Composition::Compositor compositor) {
     Wh_ApplyHookOperations();
 }
 
+void EnsureColorKeyFrameAnimationHooked(UIElement element) {
+    [[maybe_unused]] static bool hooked = [&element] {
+        HookColorKeyFrameAnimation(
+            Hosting::ElementCompositionPreview::GetElementVisual(element)
+                .Compositor());
+        return true;
+    }();
+}
+
 // The original color is kept in the property set of the brush or of the
 // gradient stop it belongs to, so that applying the effects again, as well as
 // restoring the icon, always start from it.
@@ -455,12 +530,7 @@ void EnumVisualBrushes(
 }
 
 void ApplyIconColors(FrameworkElement icon) {
-    [[maybe_unused]] static bool hooked = [&icon] {
-        HookColorKeyFrameAnimation(
-            Hosting::ElementCompositionPreview::GetElementVisual(icon)
-                .Compositor());
-        return true;
-    }();
+    EnsureColorKeyFrameAnimationHooked(icon);
 
     // The player hosts the animated visual as the child visual of the icon
     // element, not among the children of the visual which backs the element.
@@ -504,15 +574,24 @@ void ApplyIconScale(FrameworkElement icon) {
     scaleTransform.ScaleY(g_settings.size);
 }
 
-void ApplyStartButtonStyle(FrameworkElement startButton) {
+FrameworkElement FindStartButtonIcon(FrameworkElement startButton) {
     FrameworkElement icon = FindDescendantByName(startButton, L"Icon");
     if (!icon) {
         Wh_Log(L"Failed to find the Start button icon");
-        return;
     }
 
+    return icon;
+}
+
+void ApplyIconStyle(FrameworkElement icon) {
     ApplyIconColors(icon);
     ApplyIconScale(icon);
+}
+
+void ApplyStartButtonStyle(FrameworkElement startButton) {
+    if (FrameworkElement icon = FindStartButtonIcon(startButton)) {
+        ApplyIconStyle(icon);
+    }
 }
 
 bool ApplyStyle(XamlRoot xamlRoot) {
@@ -709,6 +788,14 @@ bool RunFromWindowThread(HWND hWnd,
 void ApplySettingsFromTaskbarThread() {
     Wh_Log(L"Applying settings");
 
+    if (g_unloading) {
+        g_iconLoadedRevokers.reset();
+    }
+
+    if (g_unloading || !g_settings.accentColor) {
+        StopTrackingAccentColor();
+    }
+
     EnumThreadWindows(
         GetCurrentThreadId(),
         [](HWND hWnd, LPARAM lParam) -> BOOL {
@@ -775,6 +862,24 @@ void WINAPI ExperienceToggleButton_UpdateVisualStates_Hook(void* pThis) {
     }
 }
 
+void ApplyIconStyleOnceLoaded(FrameworkElement icon) {
+    g_iconLoadedRevokers->emplace_back();
+    auto revokerIt = std::prev(g_iconLoadedRevokers->end());
+
+    *revokerIt = icon.Loaded(
+        winrt::auto_revoke,
+        [revokerIt](winrt::Windows::Foundation::IInspectable const& sender,
+                    RoutedEventArgs const&) {
+            Wh_Log(L">");
+
+            g_iconLoadedRevokers->erase(revokerIt);
+
+            if (auto icon = sender.try_as<FrameworkElement>()) {
+                ApplyIconStyle(icon);
+            }
+        });
+}
+
 // Runs when the icon is created, with the original colors.
 using ExperienceToggleButton_InitializeAnimatedVisualPlayer_t =
     void(WINAPI*)(void* pThis);
@@ -784,11 +889,36 @@ void WINAPI
 ExperienceToggleButton_InitializeAnimatedVisualPlayer_Hook(void* pThis) {
     Wh_Log(L">");
 
+    FrameworkElement startButton = GetStartButtonElement(pThis);
+
+    // The icon creates its animations for the first time in here.
+    if (startButton) {
+        EnsureColorKeyFrameAnimationHooked(startButton);
+    }
+
     ExperienceToggleButton_InitializeAnimatedVisualPlayer_Original(pThis);
 
-    if (auto startButton = GetStartButtonElement(pThis)) {
-        ApplyStartButtonStyle(startButton);
+    // Nothing to restore on a fresh icon while unloading, and no subscription
+    // may be added once the pending ones have been released.
+    if (!startButton || g_unloading) {
+        return;
     }
+
+    FrameworkElement icon = FindStartButtonIcon(startButton);
+    if (!icon) {
+        return;
+    }
+
+    // The player attaches the animated visual to the icon element only once
+    // the element is loaded, which is after the icon is initialized while the
+    // taskbar is being created.
+    if (!Hosting::ElementCompositionPreview::GetElementChildVisual(icon)) {
+        Wh_Log(L"Waiting for the icon to load");
+        ApplyIconStyleOnceLoaded(icon);
+        return;
+    }
+
+    ApplyIconStyle(icon);
 }
 
 // Runs whenever the icon recreates the animations which drive it, among them
@@ -937,6 +1067,7 @@ void LoadSettings() {
     };
 
     PCWSTR color = Wh_GetStringSetting(L"color");
+    g_settings.accentColor = wcscmp(color, L"accent") == 0;
     g_settings.colorHue = -1;
     for (const auto& [name, hue] : colors) {
         if (wcscmp(color, name) == 0) {
@@ -954,9 +1085,9 @@ void LoadSettings() {
     g_settings.size = Wh_GetIntSetting(L"size") / 100.0;
 
     g_settings.customizeColors =
-        g_settings.colorHue >= 0 || g_settings.hue != 0 ||
-        g_settings.saturation != 1 || g_settings.brightness != 1 ||
-        g_settings.opacity != 1;
+        g_settings.accentColor || g_settings.colorHue >= 0 ||
+        g_settings.hue != 0 || g_settings.saturation != 1 ||
+        g_settings.brightness != 1 || g_settings.opacity != 1;
     g_settings.customizeSize = g_settings.size != 1;
 }
 


### PR DESCRIPTION
* Added an option to use the system accent color.
* Fixed the color not applying on startup until the Start button is hovered.